### PR TITLE
feat: check parent when matched element is not hittable

### DIFF
--- a/skills/agent-device/references/session-management.md
+++ b/skills/agent-device/references/session-management.md
@@ -13,7 +13,7 @@ Sessions isolate device context. A device can only be held by one session at a t
 
 - Name sessions semantically.
 - Close sessions when done.
-- Use separate devices for parallel work.
+- Use separate sessions for parallel work.
 
 ## Listing sessions
 

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -76,6 +76,7 @@ export async function dispatchCommand(
   outPath?: string,
   context?: {
     appBundleId?: string;
+    activity?: string;
     verbose?: boolean;
     logPath?: string;
     traceLogPath?: string;

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -493,7 +493,7 @@ function parseUiHierarchy(
   const scopedRoot = options.scope ? findScopeNode(tree, options.scope) : null;
   const roots = scopedRoot ? [scopedRoot] : tree.children;
 
-  const walk = (node: AndroidNode, depth: number) => {
+  const walk = (node: AndroidNode, depth: number, parentIndex?: number) => {
     if (nodes.length >= maxNodes) {
       truncated = true;
       return;
@@ -501,9 +501,11 @@ function parseUiHierarchy(
     if (depth > maxDepth) return;
 
     const include = options.raw ? true : shouldIncludeAndroidNode(node, options);
+    let currentIndex = parentIndex;
     if (include) {
+      currentIndex = nodes.length;
       nodes.push({
-        index: nodes.length,
+        index: currentIndex,
         type: node.type ?? undefined,
         label: node.label ?? undefined,
         value: node.value ?? undefined,
@@ -512,17 +514,17 @@ function parseUiHierarchy(
         enabled: node.enabled,
         hittable: node.hittable,
         depth,
-        parentIndex: node.parentIndex,
+        parentIndex,
       });
     }
     for (const child of node.children) {
-      walk(child, depth + 1);
+      walk(child, depth + 1, currentIndex);
       if (truncated) return;
     }
   };
 
   for (const root of roots) {
-    walk(root, 0);
+    walk(root, 0, undefined);
     if (truncated) break;
   }
 

--- a/website/docs/docs/selectors.md
+++ b/website/docs/docs/selectors.md
@@ -19,4 +19,4 @@ Tips:
 
 - Use `find ... wait <timeoutMs>` to wait for UI to appear.
 - Combine with scoped snapshots using `snapshot -s "<label>"` for speed.
-- If a matched node is not hittable, agent-device will click/focus the nearest hittable ancestor.
+- [Android] If a matched node is not hittable, agent-device will click/focus the nearest hittable ancestor.

--- a/website/docs/docs/selectors.md
+++ b/website/docs/docs/selectors.md
@@ -19,3 +19,4 @@ Tips:
 
 - Use `find ... wait <timeoutMs>` to wait for UI to appear.
 - Combine with scoped snapshots using `snapshot -s "<label>"` for speed.
+- If a matched node is not hittable, agent-device will click/focus the nearest hittable ancestor.


### PR DESCRIPTION
- Add find fallback to nearest hittable ancestor for Android/Compose UIs.
- Add open --activity flag for deterministic Android launches (incl. TV/Leanback).

Fixes #10 