### PR TITLE
feat: normalize Android snapshots

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ export async function runCli(argv: string[]): Promise<void> {
         process.stdout.write(
           formatSnapshotText((response.data ?? {}) as Record<string, unknown>, {
             raw: flags.snapshotRaw,
+            flatten: flags.snapshotInteractiveOnly,
           }),
         );
         if (logTailStopper) logTailStopper();

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -28,9 +28,10 @@ type SnapshotNode = {
 
 export function formatSnapshotText(
   data: Record<string, unknown>,
-  options: { raw?: boolean } = {},
+  options: { raw?: boolean; flatten?: boolean } = {},
 ): string {
-  const nodes = (data.nodes ?? []) as SnapshotNode[];
+  const rawNodes = data.nodes;
+  const nodes = Array.isArray(rawNodes) ? (rawNodes as SnapshotNode[]) : [];
   const truncated = Boolean(data.truncated);
   const appName = typeof data.appName === 'string' ? data.appName : undefined;
   const appBundleId = typeof data.appBundleId === 'string' ? data.appBundleId : undefined;
@@ -39,12 +40,16 @@ export function formatSnapshotText(
   if (appBundleId) meta.push(`App: ${appBundleId}`);
   const header = `Snapshot: ${nodes.length} nodes${truncated ? ' (truncated)' : ''}`;
   const prefix = meta.length > 0 ? `${meta.join('\n')}\n` : '';
-  if (!Array.isArray(nodes) || nodes.length === 0) {
+  if (nodes.length === 0) {
     return `${prefix}${header}\n`;
   }
   if (options.raw) {
     const rawLines = nodes.map((node) => JSON.stringify(node));
     return `${prefix}${header}\n${rawLines.join('\n')}\n`;
+  }
+  if (options.flatten) {
+    const flatLines = nodes.map((node) => formatSnapshotLine(node, 0, false));
+    return `${prefix}${header}\n${flatLines.join('\n')}\n`;
   }
   const hiddenGroupDepths: number[] = [];
   const lines: string[] = [];
@@ -62,28 +67,59 @@ export function formatSnapshotText(
     const adjustedDepth = isHiddenGroup
       ? depth
       : Math.max(0, depth - hiddenGroupDepths.length);
-    const indent = '  '.repeat(adjustedDepth);
-    const ref = node.ref ? `@${node.ref}` : '';
-    const flags = [
-      node.enabled === false ? 'disabled' : null,
-    ]
-      .filter(Boolean)
-      .join(', ');
-    const flagText = flags ? ` [${flags}]` : '';
-    const textPart = label ? ` "${label}"` : '';
-    if (isHiddenGroup) {
-      lines.push(`${indent}${ref} [${type}]${flagText}`.trimEnd());
-      continue;
-    }
-    lines.push(`${indent}${ref} [${type}]${textPart}${flagText}`.trimEnd());
+    lines.push(formatSnapshotLine(node, adjustedDepth, isHiddenGroup));
   }
   return `${prefix}${header}\n${lines.join('\n')}\n`;
 }
 
+function formatSnapshotLine(node: SnapshotNode, depth: number, hiddenGroup: boolean): string {
+  const type = formatRole(node.type ?? 'Element');
+  const label = displayLabel(node, type);
+  const indent = '  '.repeat(depth);
+  const ref = node.ref ? `@${node.ref}` : '';
+  const flags = [node.enabled === false ? 'disabled' : null].filter(Boolean).join(', ');
+  const flagText = flags ? ` [${flags}]` : '';
+  const textPart = label ? ` "${label}"` : '';
+  if (hiddenGroup) {
+    return `${indent}${ref} [${type}]${flagText}`.trimEnd();
+  }
+  return `${indent}${ref} [${type}]${textPart}${flagText}`.trimEnd();
+}
+
+function displayLabel(node: SnapshotNode, type: string): string {
+  const label = node.label?.trim();
+  if (label) return label;
+  const value = node.value?.trim();
+  if (value) return value;
+  const identifier = node.identifier?.trim();
+  if (!identifier) return '';
+  if (isGenericResourceId(identifier) && (type === 'group' || type === 'image' || type === 'list' || type === 'collection')) {
+    return '';
+  }
+  return identifier;
+}
+
+function isGenericResourceId(value: string): boolean {
+  return /^[\w.]+:id\/[\w.-]+$/i.test(value);
+}
+
 function formatRole(type: string): string {
+  const raw = type;
   let normalized = type.replace(/XCUIElementType/gi, '').toLowerCase();
-  if (normalized.startsWith("ax")) {
-    normalized = normalized.replace(/^ax/, "");
+  const isAndroidClass =
+    raw.includes('.') &&
+    (raw.startsWith('android.') || raw.startsWith('androidx.') || raw.startsWith('com.'));
+  if (normalized.startsWith('ax')) {
+    normalized = normalized.replace(/^ax/, '');
+  }
+  if (normalized.includes('.')) {
+    normalized = normalized
+      .replace(/^android\.widget\./, '')
+      .replace(/^android\.view\./, '')
+      .replace(/^android\.webkit\./, '')
+      .replace(/^androidx\./, '')
+      .replace(/^com\.google\.android\./, '')
+      .replace(/^com\.android\./, '');
   }
   switch (normalized) {
     case 'application':
@@ -93,24 +129,40 @@ function formatRole(type: string): string {
     case 'tabbar':
       return 'tab-bar';
     case 'button':
+    case 'imagebutton':
       return 'button';
     case 'link':
       return 'link';
     case 'cell':
       return 'cell';
     case 'statictext':
+    case 'checkedtextview':
       return 'text';
     case 'textfield':
+    case 'edittext':
       return 'text-field';
     case 'textview':
+      return isAndroidClass ? 'text' : 'text-view';
+    case 'textarea':
       return 'text-view';
     case 'switch':
       return 'switch';
     case 'slider':
       return 'slider';
     case 'image':
+    case 'imageview':
       return 'image';
-    case 'table':
+    case 'webview':
+      return 'webview';
+    case 'framelayout':
+    case 'linearlayout':
+    case 'relativelayout':
+    case 'constraintlayout':
+    case 'viewgroup':
+    case 'view':
+      return 'group';
+    case 'listview':
+    case 'recyclerview':
       return 'list';
     case 'collectionview':
       return 'collection';
@@ -122,12 +174,6 @@ function formatRole(type: string): string {
       return 'group';
     case 'window':
       return 'window';
-    case 'statictext':
-      return 'text';
-    case 'textfield':
-      return 'text-field';
-    case 'textarea':
-      return 'text-view';
     case 'checkbox':
       return 'checkbox';
     case 'radio':
@@ -137,6 +183,8 @@ function formatRole(type: string): string {
     case 'toolbar':
       return 'toolbar';
     case 'scrollarea':
+    case 'scrollview':
+    case 'nestedscrollview':
       return 'scroll-area';
     case 'table':
       return 'table';


### PR DESCRIPTION
## Summary

Normalizes Android snapshot output to reduce structural noise and improve actionability.
Flattens snapshot -i rendering so interactive snapshots are easier to scan.
Improves role/type mapping for Android classes and suppresses generic resource-id labels on structural nodes.

- snapshot -i now displays as a flat list (no deep indentation).
- Android snapshot inclusion heuristics now favor meaningful, actionable elements over container-heavy output.
- Output formatter now handles malformed nodes safely and renders cleaner labels/types.

before: 
```
@e10 [android.view.View]           
  @e11 [android.widget.TextView]
```

after:
```
@e10 [group]           
  @e11 [text]
```

## Impact

- Better agent readability and lower token noise in interactive snapshots.
- Less trial-and-error for common UI actions, especially on Android.