### PR TITLE
fix: make fill clear input and progressively fill the input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,19 +26,16 @@ Instructions for AI coding agents working with this codebase.
 2) Daemon (`src/daemon.ts`) resolves device, tracks session state, and calls `dispatchCommand`.
 3) `dispatchCommand` selects platform interactor.
 4) iOS simulator path:
-   - Prefer `simctl` input when available (`simctlSupportsInput`).
-   - Snapshot default backend: AX (`snapshotAx`), fallback to iOS runner if AX is unavailable.
-   - Fallback to iOS runner via `runIosRunnerCommand` for tap/type/swipe/list.
+   - Snapshot default backend: XCTest for everything, fallback to AX if XCTest returns 0 nodes.
 5) iOS runner uses xcodebuild `test-without-building` with an injected `.xctestrun`,
    starts an `NWListener` HTTP server inside the UI test bundle, and executes UI actions.
 
 ## Key commands (local)
 
-- Build iOS runner: `xcodebuild build-for-testing -project ios-runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj -scheme AgentDeviceRunner -destination "platform=iOS Simulator,id=<UDID>" -derivedDataPath ~/.agent-device/ios-runner/derived`
-- Build AX snapshot tool: `swift build -c release` in `ios-runner/AXSnapshot`
+- Build iOS runner: `pnpm build:xcuitest`
+- Build AX snapshot tool: `pnpm build:axsnapshot`
 - Build everything: `pnpm build:all`
-- Run command: `node bin/agent-device.mjs --platform ios --udid <UDID> open settings --verbose`
-- Scroll: `node bin/agent-device.mjs --platform ios --udid <UDID> scroll down 0.5 --verbose`
+- Run command: `pnpm ad`
 
 ## Run and Test
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ Find (semantic):
 - `find text|label|value|role|id <value> <action> [value]` for specific locators.
 - Actions: `click` (default), `fill`, `type`, `focus`, `get text`, `get attrs`, `wait [timeout]`, `exists`.
 
+Android fill reliability:
+- `fill` clears the current value, then enters text.
+- `type` enters text into the focused field without clearing.
+- `fill` now verifies the entered value on Android.
+- If value does not match, agent-device clears the field and retries once with slower typing.
+- This reduces IME-related character swaps on long strings (e.g. emails and IDs).
+
 Settings helpers (simulators):
 - `settings wifi on|off`
 - `settings airplane on|off`

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -97,8 +97,8 @@ agent-device apps --metadata --platform android
 ```bash
 agent-device click @e1
 agent-device focus @e2
-agent-device fill @e2 "text"           # Tap then type
-agent-device type "text"               # Type into focused field
+agent-device fill @e2 "text"           # Clear then type (Android: verifies value and retries once on mismatch)
+agent-device type "text"               # Type into focused field without clearing
 agent-device press 300 500             # Tap by coordinates
 agent-device long-press 300 500 800    # Long press (where supported)
 agent-device scroll down 0.5
@@ -150,6 +150,9 @@ agent-device apps --platform android --user-installed
 - If AX returns the Simulator window or empty tree, restart Simulator or use `--backend xctest`.
 - Use `--session <name>` for parallel sessions; avoid device contention.
 - Use `--activity <component>` on Android to launch a specific activity (e.g. TV apps with LEANBACK).
+- Use `fill` when you want clear-then-type semantics.
+- Use `type` when you want to append/enter text without clearing.
+- On Android, prefer `fill` for important fields; it verifies entered text and retries once when IME reorders characters.
 
 ## References
 

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -174,7 +174,7 @@ export async function dispatchCommand(
         );
         await runIosRunnerCommand(
           device,
-          { command: 'type', text, appBundleId: context?.appBundleId },
+          { command: 'type', text, clearFirst: true, appBundleId: context?.appBundleId },
           { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
         );
       } else {

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -176,10 +176,9 @@ async function ensureRunnerSession(
   await ensureBooted(device.id);
   const xctestrun = await ensureXctestrun(device.id, options);
   const port = await getFreePort();
-  const runnerTimeout = process.env.AGENT_DEVICE_RUNNER_TIMEOUT ?? '0';
   const { xctestrunPath, jsonPath } = await prepareXctestrunWithEnv(
     xctestrun,
-    { AGENT_DEVICE_RUNNER_PORT: String(port), AGENT_DEVICE_RUNNER_TIMEOUT: runnerTimeout },
+    { AGENT_DEVICE_RUNNER_PORT: String(port) },
     `session-${device.id}-${port}`,
   );
   const testPromise = runCmdStreaming(
@@ -189,6 +188,8 @@ async function ensureRunnerSession(
       '-only-testing',
       'AgentDeviceRunnerUITests/RunnerTests/testCommand',
       '-parallel-testing-enabled',
+      'NO',
+      '-test-timeouts-enabled',
       'NO',
       '-maximum-concurrent-test-simulator-destinations',
       '1',
@@ -205,7 +206,7 @@ async function ensureRunnerSession(
         logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
       },
       allowFailure: true,
-      env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(port), AGENT_DEVICE_RUNNER_TIMEOUT: runnerTimeout },
+      env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(port) },
     },
   );
 

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -34,6 +34,7 @@ export type RunnerCommand = {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  clearFirst?: boolean;
 };
 
 export type RunnerSession = {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -88,8 +88,14 @@ function formatSnapshotLine(node: SnapshotNode, depth: number, hiddenGroup: bool
 
 function displayLabel(node: SnapshotNode, type: string): string {
   const label = node.label?.trim();
-  if (label) return label;
   const value = node.value?.trim();
+  if (isEditableRole(type)) {
+    // For inputs, prefer current value over placeholder/accessibility label.
+    if (value) return value;
+    if (label) return label;
+  } else if (label) {
+    return label;
+  }
   if (value) return value;
   const identifier = node.identifier?.trim();
   if (!identifier) return '';
@@ -97,6 +103,10 @@ function displayLabel(node: SnapshotNode, type: string): string {
     return '';
   }
   return identifier;
+}
+
+function isEditableRole(type: string): boolean {
+  return type === 'text-field' || type === 'text-view' || type === 'search';
 }
 
 function isGenericResourceId(value: string): boolean {

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -29,14 +29,17 @@ agent-device get attrs @e1
 ```bash
 agent-device click @e1
 agent-device focus @e2
-agent-device fill @e2 "text"
-agent-device type "text"
+agent-device fill @e2 "text"          # Clear then type
+agent-device type "text"              # Type into focused field without clearing
 agent-device press 300 500
 agent-device long-press 300 500 800
 agent-device scroll down 0.5
 agent-device pinch 2.0          # zoom in 2x
 agent-device pinch 0.5 200 400 # zoom out at coordinates
 ```
+
+`fill` clears then types. `type` does not clear.
+On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
 
 ## Find (semantic)
 

--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -29,7 +29,7 @@ agent-device snapshot -i
 agent-device open SampleApp
 agent-device snapshot -i                 # Get interactive elements with refs
 agent-device click @e2                   # Click by ref
-agent-device fill @e3 "test@example.com" # Fill input by ref
+agent-device fill @e3 "test@example.com" # Clear then type (Android verifies and retries once if needed)
 agent-device get text @e1                # Get text content
 agent-device screenshot --out page.png   # Save to specific path
 agent-device close


### PR DESCRIPTION
Refactors and stabilizes fill behavior across platforms while keeping type as non-clearing input.

Fixes #8 

- Unified Android fill into a single attempt loop: focus -> clear -> type -> verify; fast first pass + one safer retry pass
- Fast chunked typing instead of pasting
- Removed extra pre-typing hierarchy dump on happy path
- Simplified daemon flow: removed iOS-specific `fill @ref` special case; all `fill @ref` now route through the same `dispatchCommand('fill')` path
- Added iOS runner support for clear-first typing
- Cleaned up Android parsing helpers by centralizing attribute extraction.

Behavior now aligns better with `agent-browser`:
- `fill`: clears existing text, then types.
- `type`: types into focused field without clearing.
- Android `fill` verifies final text and retries once on mismatch.

Updated skills.