### PR TITLE
feat: `replay --save-script` for self-updating e2e tests; add `it` assertions; add DSL with selectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ Minimal operating guide for AI coding agents in this repo.
 - Use daemon session flow for interactions (`open` before interactions, `close` after).
 - Do not remove shared snapshot/session model behavior without full migration.
 - If Swift runner code changes, run `pnpm build:xcuitest`.
+- Do not add command logic to `daemon.ts` — it is a thin router. Use handler modules.
+- Use `inferFillText` and `uniqueStrings` from `src/daemon/action-utils.ts`. Do not duplicate.
+- Use `evaluateIsPredicate` from `src/daemon/is-predicates.ts` for assertion logic. Do not inline.
 
 ## Architecture In One Screen
 
@@ -24,14 +27,18 @@ Minimal operating guide for AI coding agents in this repo.
 2. Daemon client transport:
    - `src/daemon-client.ts`
 3. Daemon server bootstrap/router:
-   - `src/daemon.ts`
+   - `src/daemon.ts` — thin router only, delegates to handler modules
 4. Daemon command families:
    - session/apps/appstate/open/close/replay: `src/daemon/handlers/session.ts`
+   - click/fill/get/is: `src/daemon/handlers/interaction.ts`
    - snapshot/wait/alert/settings: `src/daemon/handlers/snapshot.ts`
    - semantic find actions: `src/daemon/handlers/find.ts`
    - record/trace: `src/daemon/handlers/record-trace.ts`
 5. Daemon shared domain:
    - session state + logs: `src/daemon/session-store.ts`
+   - selector DSL (parse, resolve, build): `src/daemon/selectors.ts`
+   - `is` predicate evaluation: `src/daemon/is-predicates.ts`
+   - shared action helpers (inferFillText, uniqueStrings): `src/daemon/action-utils.ts`
    - snapshot tree shaping + label resolution: `src/daemon/snapshot-processing.ts`
    - handler context helpers: `src/daemon/context.ts`, `src/daemon/device-ready.ts`, `src/daemon/app-state.ts`
 6. Platform dispatch/backends:
@@ -55,19 +62,33 @@ Do not read both iOS and Android paths unless issue is explicitly cross-platform
 
 - `session list`, `devices`, `apps`, `appstate`, `open`, `close`, `replay`:
   - `src/daemon/handlers/session.ts`
+- `click`, `fill`, `get`, `is`:
+  - `src/daemon/handlers/interaction.ts`
 - `snapshot`, `wait`, `alert`, `settings`:
   - `src/daemon/handlers/snapshot.ts`
 - `find ...`:
   - `src/daemon/handlers/find.ts`
 - `record start|stop`, `trace start|stop`:
   - `src/daemon/handlers/record-trace.ts`
-- `click`, `fill`, `get`, generic passthrough:
-  - `src/daemon.ts` (remaining fallback logic)
+- Generic passthrough (press, scroll, type, etc.):
+  - `src/daemon.ts` (fallback after all handlers return null)
 
 ## Capability Source Of Truth
 
 - Command/device support must come from `src/core/capabilities.ts`.
 - Do not scatter new support checks across handlers.
+
+## Selector System Rules
+
+All interaction commands (`click`, `fill`, `get`, `is`) and `wait` accept selectors in addition to `@ref`.
+The selector pipeline is: **parse → resolve → act → record selectorChain → heal on replay**.
+
+- Selector DSL lives in `src/daemon/selectors.ts`. Do not duplicate parsing/matching logic elsewhere.
+- `buildSelectorChainForNode` generates fallback chains stored in action results. Always call it after resolving a node for an interaction — it powers replay healing.
+- When adding a new interaction command that targets a UI element: support both `@ref` and selector input, record `selectorChain`, and update replay healing (`healReplayAction` + `collectReplaySelectorCandidates` in `session.ts`).
+- When adding a new selector key: update `SelectorKey` type, `ALL_KEYS`/`TEXT_KEYS`/`BOOLEAN_KEYS` sets, `matchesTerm`, and `isSelectorToken` — all in `selectors.ts`.
+- When adding a new `is` predicate: update `IsPredicate` type and `evaluateIsPredicate` in `is-predicates.ts`, not in the handler.
+- `daemon.ts` must stay a thin router. Do not add command logic there — use the appropriate handler module.
 
 ## Testing Strategy
 
@@ -76,13 +97,7 @@ Do not read both iOS and Android paths unless issue is explicitly cross-platform
 - Unit tests are colocated with source files under `src/**`.
 - Use `__tests__` folders colocated with the related source folder.
 - The `test/**` tree is integration-only (including smoke integration tests).
-
-### Unit tests (default for all refactors, colocated)
-
-- `src/core/__tests__/capabilities.test.ts`
-- `src/daemon/handlers/__tests__/find.test.ts`
-- `src/daemon/__tests__/snapshot-processing.test.ts`
-- `src/daemon/__tests__/session-store.test.ts`
+- Example: tests for `src/daemon/selectors.ts` go in `src/daemon/__tests__/selectors.test.ts`.
 
 Add/extend colocated unit tests in the same PR for touched module logic.
 

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -5,6 +5,8 @@ description: Automates mobile and simulator interactions for iOS and Android dev
 
 # Mobile Automation with agent-device
 
+For agent-driven exploration: use refs. For deterministic replay scripts: use selectors.
+
 ## Quick start
 
 ```bash
@@ -26,9 +28,9 @@ npx -y agent-device
 ## Core workflow
 
 1. Open app or just boot device: `open [app]`
-2. Snapshot: `snapshot` to get full XCTest accessibility tree snapshot
+2. Snapshot: `snapshot` to get refs from accessibility tree
 3. Interact using refs (`click @ref`, `fill @ref "text"`)
-4. Re-snapshot after navigation or UI changes
+4. Re-snapshot after navigation/UI changes
 5. Close session when done
 
 ## Commands
@@ -109,6 +111,8 @@ agent-device home
 agent-device app-switcher
 agent-device wait 1000
 agent-device wait text "Settings"
+agent-device is visible 'id="settings_anchor"'  # selector assertions for deterministic checks
+agent-device is text 'id="header_title"' "Settings"
 agent-device alert get
 ```
 
@@ -119,6 +123,16 @@ agent-device get text @e1
 agent-device get attrs @e1
 agent-device screenshot out.png
 ```
+
+### Deterministic replay and updating
+
+```bash
+agent-device open App --save-script   # Save session script (.ad) on close
+agent-device replay ./session.ad      # Run deterministic replay from .ad script
+agent-device replay -u ./session.ad   # Update selector drift and rewrite .ad script in place
+```
+
+`replay` reads `.ad` recordings.
 
 ### Trace logs (AX/XCTest)
 
@@ -142,7 +156,8 @@ agent-device apps --platform android --user-installed
 ## Best practices
 
 - Pinch (`pinch <scale> [x y]`) is supported on iOS simulators and Android; scale > 1 zooms in, < 1 zooms out. On Android, pinch uses multi-touch `sendevent` injection.
-- Always snapshot right before interactions; refs invalidate on UI changes.
+- Snapshot refs are the core mechanism for interactive agent flows.
+- Use selectors for deterministic replay artifacts and assertions (e.g. in e2e test workflows).
 - Prefer `snapshot -i` to reduce output size.
 - On iOS, `xctest` is the default and does not require Accessibility permission.
 - If XCTest returns 0 nodes (foreground app changed), agent-device falls back to AX when available.
@@ -153,6 +168,7 @@ agent-device apps --platform android --user-installed
 - Use `fill` when you want clear-then-type semantics.
 - Use `type` when you want to append/enter text without clearing.
 - On Android, prefer `fill` for important fields; it verifies entered text and retries once when IME reorders characters.
+- If using deterministic replay scripts, use `replay -u` during maintenance runs to update selector drift in replay scripts. Use plain `replay` in CI.
 
 ## References
 

--- a/skills/agent-device/references/session-management.md
+++ b/skills/agent-device/references/session-management.md
@@ -14,9 +14,18 @@ Sessions isolate device context. A device can only be held by one session at a t
 - Name sessions semantically.
 - Close sessions when done.
 - Use separate sessions for parallel work.
+- For deterministic replay scripts, prefer selector-based actions and assertions.
+- Use `replay -u` to update selector drift during maintenance.
 
 ## Listing sessions
 
 ```bash
 agent-device session list
+```
+
+## Replay within sessions
+
+```bash
+agent-device replay ./session.ad --session auth
+agent-device replay -u ./session.ad --session auth
 ```

--- a/skills/agent-device/references/snapshot-refs.md
+++ b/skills/agent-device/references/snapshot-refs.md
@@ -1,8 +1,8 @@
-# Snapshot + Refs Workflow (Mobile)
+# Snapshot Refs and Selectors (Mobile)
 
 ## Purpose
 
-Refs let agents interact without repeating full UI trees. Snapshot -> refs -> click/fill.
+Refs are useful for discovery/debugging. For deterministic scripts, use selectors.
 
 ## Snapshot
 
@@ -21,17 +21,25 @@ App: com.apple.Preferences
   @e3 [button] "Privacy & Security"
 ```
 
-## Using refs
+## Using refs (discovery/debug)
 
 ```bash
 agent-device click @e2
 agent-device fill @e5 "test"
 ```
 
+## Using selectors (deterministic)
+
+```bash
+agent-device click 'id="camera_row" || label="Camera" role=button'
+agent-device fill 'id="search_input" editable=true' "test"
+agent-device is visible 'id="camera_settings_anchor"'
+```
+
 ## Ref lifecycle
 
-Refs become invalid when UI changes (navigation, modal, dynamic list updates).
-Always re-snapshot after any transition.
+Refs can become invalid when UI changes (navigation, modal, dynamic list updates).
+Re-snapshot after transitions if you keep using refs.
 
 ## Scope snapshots
 
@@ -47,3 +55,8 @@ agent-device snapshot -i -s @e3
 - Ref not found: re-snapshot.
 - AX returns Simulator window: restart Simulator and re-run.
 - AX empty: verify Accessibility permission or use `--backend xctest` (XCTest is more complete).
+
+## Replay note
+
+- Prefer selector-based actions in recorded `.ad` replays.
+- Use `agent-device replay -u <path>` to update selector drift and rewrite replay scripts in place.

--- a/skills/agent-device/references/video-recording.md
+++ b/skills/agent-device/references/video-recording.md
@@ -12,7 +12,7 @@ agent-device record start ./recordings/ios.mov
 
 # Perform actions
 agent-device open App
-agent-device snapshot
+agent-device snapshot -i
 agent-device click @e3
 agent-device close
 
@@ -30,7 +30,7 @@ agent-device record start ./recordings/android.mp4
 
 # Perform actions
 agent-device open App
-agent-device snapshot
+agent-device snapshot -i
 agent-device click @e3
 agent-device close
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,12 @@ export async function runCli(argv: string[]): Promise<void> {
           return;
         }
       }
+      if (command === 'is') {
+        const predicate = (response.data as any)?.predicate ?? 'assertion';
+        process.stdout.write(`Passed: is ${predicate}\n`);
+        if (logTailStopper) logTailStopper();
+        return;
+      }
       if (command === 'click') {
         const ref = (response.data as any)?.ref ?? '';
         const x = (response.data as any)?.x;

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -25,6 +25,7 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   find: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   focus: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   get: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
+  is: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   home: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   'long-press': { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   open: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -33,8 +33,8 @@ export type CommandFlags = {
   snapshotScope?: string;
   snapshotRaw?: boolean;
   snapshotBackend?: 'ax' | 'xctest';
+  saveScript?: boolean;
   noRecord?: boolean;
-  recordJson?: boolean;
   appsFilter?: 'launchable' | 'user-installed' | 'all';
   appsMetadata?: boolean;
   replayUpdate?: boolean;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -37,6 +37,7 @@ export type CommandFlags = {
   recordJson?: boolean;
   appsFilter?: 'launchable' | 'user-installed' | 'all';
   appsMetadata?: boolean;
+  replayUpdate?: boolean;
 };
 
 export async function resolveTargetDevice(flags: CommandFlags): Promise<DeviceInfo> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,16 +7,15 @@ import { fileURLToPath } from 'node:url';
 import { dispatchCommand, type CommandFlags } from './core/dispatch.ts';
 import { isCommandSupportedOnDevice } from './core/capabilities.ts';
 import { asAppError, AppError } from './utils/errors.ts';
-import { centerOfRect, findNodeByRef, normalizeRef } from './utils/snapshot.ts';
 import { stopIosRunnerSession } from './platforms/ios/runner-client.ts';
 import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
 import { SessionStore } from './daemon/session-store.ts';
-import { contextFromFlags as contextFromFlagsWithLog } from './daemon/context.ts';
+import { contextFromFlags as contextFromFlagsWithLog, type DaemonCommandContext } from './daemon/context.ts';
 import { handleSessionCommands } from './daemon/handlers/session.ts';
 import { handleSnapshotCommands } from './daemon/handlers/snapshot.ts';
 import { handleFindCommands } from './daemon/handlers/find.ts';
 import { handleRecordTraceCommands } from './daemon/handlers/record-trace.ts';
-import { findNodeByLabel, isFillableType, resolveRefLabel } from './daemon/snapshot-processing.ts';
+import { handleInteractionCommands } from './daemon/handlers/interaction.ts';
 import { assertSessionSelectorMatches } from './daemon/session-selector.ts';
 import { resolveEffectiveSessionName } from './daemon/session-routing.ts';
 
@@ -33,19 +32,7 @@ function contextFromFlags(
   flags: CommandFlags | undefined,
   appBundleId?: string,
   traceLogPath?: string,
-): {
-  appBundleId?: string;
-  activity?: string;
-  verbose?: boolean;
-  logPath?: string;
-  traceLogPath?: string;
-  snapshotInteractiveOnly?: boolean;
-  snapshotCompact?: boolean;
-  snapshotDepth?: number;
-  snapshotScope?: string;
-  snapshotBackend?: 'ax' | 'xctest';
-  snapshotRaw?: boolean;
-} {
+): DaemonCommandContext {
   return contextFromFlagsWithLog(logPath, flags, appBundleId, traceLogPath);
 }
 
@@ -94,139 +81,13 @@ async function handleRequest(req: DaemonRequest): Promise<DaemonResponse> {
   });
   if (findResponse) return findResponse;
 
-  if (command === 'click') {
-    const session = sessionStore.get(sessionName);
-    if (!session?.snapshot) {
-      return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
-    }
-    const refInput = req.positionals?.[0] ?? '';
-    const ref = normalizeRef(refInput);
-    if (!ref) {
-      return { ok: false, error: { code: 'INVALID_ARGS', message: 'click requires a ref like @e2' } };
-    }
-    let node = findNodeByRef(session.snapshot.nodes, ref);
-    if (!node?.rect && req.positionals.length > 1) {
-      const fallbackLabel = req.positionals.slice(1).join(' ').trim();
-      if (fallbackLabel.length > 0) {
-        node = findNodeByLabel(session.snapshot.nodes, fallbackLabel);
-      }
-    }
-    if (!node?.rect) {
-      return { ok: false, error: { code: 'COMMAND_FAILED', message: `Ref ${refInput} not found or has no bounds` } };
-    }
-    const refLabel = resolveRefLabel(node, session.snapshot.nodes);
-    const { x, y } = centerOfRect(node.rect);
-    await dispatchCommand(session.device, 'press', [String(x), String(y)], req.flags?.out, {
-      ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
-    });
-    sessionStore.recordAction(session, {
-      command,
-      positionals: req.positionals ?? [],
-      flags: req.flags ?? {},
-      result: { ref, x, y, refLabel },
-    });
-    return { ok: true, data: { ref, x, y } };
-  }
-
-  if (command === 'fill') {
-    const session = sessionStore.get(sessionName);
-    if (req.positionals?.[0]?.startsWith('@')) {
-      if (!session?.snapshot) {
-        return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
-      }
-      const ref = normalizeRef(req.positionals[0]);
-      if (!ref) {
-        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires a ref like @e2' } };
-      }
-      const labelCandidate = req.positionals.length >= 3 ? req.positionals[1] : '';
-      const text = req.positionals.length >= 3 ? req.positionals.slice(2).join(' ') : req.positionals.slice(1).join(' ');
-      if (!text) {
-        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires text after ref' } };
-      }
-      let node = findNodeByRef(session.snapshot.nodes, ref);
-      if (!node?.rect && labelCandidate) {
-        node = findNodeByLabel(session.snapshot.nodes, labelCandidate);
-      }
-      if (!node?.rect) {
-        return { ok: false, error: { code: 'COMMAND_FAILED', message: `Ref ${req.positionals[0]} not found or has no bounds` } };
-      }
-      const nodeType = node.type ?? '';
-      const fillWarning =
-        nodeType && !isFillableType(nodeType, session.device.platform)
-          ? `fill target ${req.positionals[0]} resolved to "${nodeType}", attempting fill anyway.`
-          : undefined;
-      const refLabel = resolveRefLabel(node, session.snapshot.nodes);
-      const { x, y } = centerOfRect(node.rect);
-      const data = await dispatchCommand(
-        session.device,
-        'fill',
-        [String(x), String(y), text],
-        req.flags?.out,
-        {
-          ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
-        },
-      );
-      const resultPayload: Record<string, unknown> = {
-        ...(data ?? { ref, x, y }),
-      };
-      if (fillWarning) {
-        resultPayload.warning = fillWarning;
-      }
-      sessionStore.recordAction(session, {
-        command,
-        positionals: req.positionals ?? [],
-        flags: req.flags ?? {},
-        result: { ...resultPayload, refLabel },
-      });
-      return { ok: true, data: resultPayload };
-    }
-  }
-
-  if (command === 'get') {
-    const sub = req.positionals?.[0];
-    const refInput = req.positionals?.[1];
-    if (sub !== 'text' && sub !== 'attrs') {
-      return { ok: false, error: { code: 'INVALID_ARGS', message: 'get only supports text or attrs' } };
-    }
-    const session = sessionStore.get(sessionName);
-    if (!session?.snapshot) {
-      return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
-    }
-    const ref = normalizeRef(refInput ?? '');
-    if (!ref) {
-      return { ok: false, error: { code: 'INVALID_ARGS', message: 'get text requires a ref like @e2' } };
-    }
-    let node = findNodeByRef(session.snapshot.nodes, ref);
-    if (!node && req.positionals.length > 2) {
-      const labelCandidate = req.positionals.slice(2).join(' ').trim();
-      if (labelCandidate.length > 0) {
-        node = findNodeByLabel(session.snapshot.nodes, labelCandidate);
-      }
-    }
-    if (!node) {
-      return { ok: false, error: { code: 'COMMAND_FAILED', message: `Ref ${refInput} not found` } };
-    }
-    if (sub === 'attrs') {
-      sessionStore.recordAction(session, {
-        command,
-        positionals: req.positionals ?? [],
-        flags: req.flags ?? {},
-        result: { ref },
-      });
-      return { ok: true, data: { ref, node } };
-    }
-    const candidates = [node.label, node.value, node.identifier]
-      .map((value) => (typeof value === 'string' ? value.trim() : ''))
-      .filter((value) => value.length > 0);
-    const text = candidates[0] ?? '';
-    sessionStore.recordAction(session, {
-      command,
-      positionals: req.positionals ?? [],
-      flags: req.flags ?? {},
-      result: { ref, text, refLabel: text || undefined },
-    });
-    return { ok: true, data: { ref, text, node } };
-  }
+  const interactionResponse = await handleInteractionCommands({
+    req,
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+  if (interactionResponse) return interactionResponse;
 
 
   const session = sessionStore.get(sessionName);

--- a/src/daemon/__tests__/is-predicates.test.ts
+++ b/src/daemon/__tests__/is-predicates.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateIsPredicate, isSupportedPredicate } from '../is-predicates.ts';
+
+const baseNode = {
+  ref: 'e1',
+  index: 0,
+  type: 'XCUIElementTypeTextField',
+  label: 'Email',
+  value: '',
+  identifier: 'login_email',
+  rect: { x: 0, y: 0, width: 100, height: 40 },
+  enabled: true,
+  hittable: true,
+};
+
+test('isSupportedPredicate validates supported predicates', () => {
+  assert.equal(isSupportedPredicate('visible'), true);
+  assert.equal(isSupportedPredicate('text'), true);
+  assert.equal(isSupportedPredicate('checked'), false);
+});
+
+test('evaluateIsPredicate visible and hidden', () => {
+  const visible = evaluateIsPredicate({
+    predicate: 'visible',
+    node: baseNode,
+    platform: 'ios',
+  });
+  const hidden = evaluateIsPredicate({
+    predicate: 'hidden',
+    node: { ...baseNode, rect: { ...baseNode.rect, width: 0 }, hittable: false },
+    platform: 'ios',
+  });
+  assert.equal(visible.pass, true);
+  assert.equal(hidden.pass, true);
+});
+
+test('evaluateIsPredicate editable and selected', () => {
+  const editable = evaluateIsPredicate({
+    predicate: 'editable',
+    node: baseNode,
+    platform: 'ios',
+  });
+  const selected = evaluateIsPredicate({
+    predicate: 'selected',
+    node: { ...baseNode, selected: true },
+    platform: 'ios',
+  });
+  assert.equal(editable.pass, true);
+  assert.equal(selected.pass, true);
+});
+
+test('evaluateIsPredicate text uses equality', () => {
+  const match = evaluateIsPredicate({
+    predicate: 'text',
+    node: baseNode,
+    expectedText: 'Email',
+    platform: 'ios',
+  });
+  const mismatch = evaluateIsPredicate({
+    predicate: 'text',
+    node: baseNode,
+    expectedText: 'email',
+    platform: 'ios',
+  });
+  assert.equal(match.pass, true);
+  assert.equal(mismatch.pass, false);
+});

--- a/src/daemon/__tests__/selectors.test.ts
+++ b/src/daemon/__tests__/selectors.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { SnapshotState } from '../../utils/snapshot.ts';
+import {
+  buildSelectorChainForNode,
+  findSelectorChainMatch,
+  isSelectorToken,
+  parseSelectorChain,
+  resolveSelectorChain,
+  splitSelectorFromArgs,
+} from '../selectors.ts';
+
+const nodes: SnapshotState['nodes'] = [
+  {
+    ref: 'e1',
+    index: 0,
+    type: 'XCUIElementTypeTextField',
+    label: 'Email',
+    value: '',
+    identifier: 'login_email',
+    rect: { x: 0, y: 0, width: 200, height: 44 },
+    enabled: true,
+    hittable: true,
+  },
+  {
+    ref: 'e2',
+    index: 1,
+    type: 'XCUIElementTypeButton',
+    label: 'Continue',
+    identifier: 'auth_continue',
+    rect: { x: 0, y: 80, width: 200, height: 44 },
+    enabled: true,
+    hittable: true,
+  },
+  {
+    ref: 'e3',
+    index: 2,
+    type: 'XCUIElementTypeButton',
+    label: 'Continue',
+    identifier: 'secondary_continue',
+    rect: { x: 0, y: 140, width: 200, height: 44 },
+    enabled: true,
+    hittable: true,
+  },
+];
+
+test('parseSelectorChain parses fallback and boolean terms', () => {
+  const chain = parseSelectorChain('id=auth_continue || role=button label="Continue" visible=true');
+  assert.equal(chain.selectors.length, 2);
+  assert.equal(chain.selectors[0].terms[0].key, 'id');
+  assert.equal(chain.selectors[1].terms[2].key, 'visible');
+});
+
+test('resolveSelectorChain resolves unique match', () => {
+  const chain = parseSelectorChain('id=login_email');
+  const resolved = resolveSelectorChain(nodes, chain, {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+  assert.ok(resolved);
+  assert.equal(resolved.node.ref, 'e1');
+});
+
+test('resolveSelectorChain falls back when first selector is ambiguous', () => {
+  const chain = parseSelectorChain('label="Continue" || id=auth_continue');
+  const resolved = resolveSelectorChain(nodes, chain, {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+  assert.ok(resolved);
+  assert.equal(resolved.selectorIndex, 1);
+  assert.equal(resolved.node.ref, 'e2');
+});
+
+test('findSelectorChainMatch returns first matching selector for existence checks', () => {
+  const chain = parseSelectorChain('label="Continue" || id=auth_continue');
+  const match = findSelectorChainMatch(nodes, chain, {
+    platform: 'ios',
+  });
+  assert.ok(match);
+  assert.equal(match.selectorIndex, 0);
+  assert.equal(match.matches, 2);
+});
+
+test('splitSelectorFromArgs extracts selector prefix and trailing value', () => {
+  const split = splitSelectorFromArgs(['id=login_email', 'editable=true', 'qa@example.com']);
+  assert.ok(split);
+  assert.equal(split.selectorExpression, 'id=login_email editable=true');
+  assert.deepEqual(split.rest, ['qa@example.com']);
+});
+
+test('parseSelectorChain rejects unknown keys and malformed quotes', () => {
+  assert.throws(() => parseSelectorChain('foo=bar'), /Unknown selector key/i);
+  assert.throws(() => parseSelectorChain('label="unclosed'), /Unclosed quote/i);
+  assert.throws(() => parseSelectorChain(''), /cannot be empty/i);
+});
+
+test('isSelectorToken only accepts known keys for key=value tokens', () => {
+  assert.equal(isSelectorToken('id=foo'), true);
+  assert.equal(isSelectorToken('editable=true'), true);
+  assert.equal(isSelectorToken('foo=bar'), false);
+  assert.equal(isSelectorToken('a=b'), false);
+});
+
+test('text selector matches extractNodeText semantics (first non-empty field)', () => {
+  const chainByLabel = parseSelectorChain('text=Email');
+  const chainById = parseSelectorChain('text=login_email');
+  const resolvedLabel = resolveSelectorChain(nodes, chainByLabel, {
+    platform: 'ios',
+    requireUnique: true,
+  });
+  const resolvedId = resolveSelectorChain(nodes, chainById, {
+    platform: 'ios',
+    requireUnique: true,
+  });
+  assert.ok(resolvedLabel);
+  assert.equal(resolvedLabel.node.ref, 'e1');
+  assert.equal(resolvedId, null);
+});
+
+test('buildSelectorChainForNode prefers id and adds editable for fill action', () => {
+  const target = nodes[0];
+  const chain = buildSelectorChainForNode(target, 'ios', { action: 'fill' });
+  assert.ok(chain.some((entry) => entry.includes('id=')));
+  assert.ok(chain.some((entry) => entry.includes('editable=true')));
+});

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { SessionStore } from '../session-store.ts';
@@ -53,4 +54,42 @@ test('defaultTracePath sanitizes session name', () => {
   const tracePath = store.defaultTracePath(session);
   assert.match(tracePath, /session_with_spaces/);
   assert.match(tracePath, /\.trace\.log$/);
+});
+
+test('writeSessionLog writes .ad only when recording is enabled', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-disabled-'));
+  const store = new SessionStore(root);
+  const session = makeSession('default');
+  store.recordAction(session, {
+    command: 'open',
+    positionals: ['Settings'],
+    flags: { platform: 'ios' },
+    result: {},
+  });
+
+  store.writeSessionLog(session);
+  const files = fs.readdirSync(root);
+  assert.equal(files.filter((file) => file.endsWith('.ad')).length, 0);
+});
+
+test('saveScript flag enables .ad session log writing', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-enabled-'));
+  const store = new SessionStore(root);
+  const session = makeSession('default');
+  store.recordAction(session, {
+    command: 'open',
+    positionals: ['Settings'],
+    flags: { platform: 'ios', saveScript: true },
+    result: {},
+  });
+  store.recordAction(session, {
+    command: 'close',
+    positionals: [],
+    flags: { platform: 'ios' },
+    result: {},
+  });
+
+  store.writeSessionLog(session);
+  const files = fs.readdirSync(root);
+  assert.equal(files.filter((file) => file.endsWith('.ad')).length, 1);
 });

--- a/src/daemon/action-utils.ts
+++ b/src/daemon/action-utils.ts
@@ -1,0 +1,29 @@
+import type { SessionAction } from './types.ts';
+
+export function inferFillText(action: SessionAction): string {
+  const resultText = action.result?.text;
+  if (typeof resultText === 'string' && resultText.trim().length > 0) {
+    return resultText;
+  }
+  const positionals = action.positionals ?? [];
+  if (positionals.length === 0) return '';
+  if (positionals[0].startsWith('@')) {
+    if (positionals.length >= 3) return positionals.slice(2).join(' ').trim();
+    return positionals.slice(1).join(' ').trim();
+  }
+  if (positionals.length >= 3 && !Number.isNaN(Number(positionals[0])) && !Number.isNaN(Number(positionals[1]))) {
+    return positionals.slice(2).join(' ').trim();
+  }
+  return positionals.slice(1).join(' ').trim();
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    output.push(value);
+  }
+  return output;
+}

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,11 +1,6 @@
 import type { CommandFlags } from '../core/dispatch.ts';
 
-export function contextFromFlags(
-  logPath: string,
-  flags: CommandFlags | undefined,
-  appBundleId?: string,
-  traceLogPath?: string,
-): {
+export type DaemonCommandContext = {
   appBundleId?: string;
   activity?: string;
   verbose?: boolean;
@@ -17,7 +12,14 @@ export function contextFromFlags(
   snapshotScope?: string;
   snapshotBackend?: 'ax' | 'xctest';
   snapshotRaw?: boolean;
-} {
+};
+
+export function contextFromFlags(
+  logPath: string,
+  flags: CommandFlags | undefined,
+  appBundleId?: string,
+  traceLogPath?: string,
+): DaemonCommandContext {
   return {
     appBundleId,
     activity: flags?.activity,

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -30,28 +30,64 @@ function makeSession(name: string): SessionState {
 }
 
 function writeReplayFile(filePath: string, action: SessionAction) {
-  const payload = {
-    optimizedActions: [action],
-  };
-  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+  const args = action.positionals.map((value) => JSON.stringify(value)).join(' ');
+  fs.writeFileSync(filePath, `${action.command}${args.length > 0 ? ` ${args}` : ''}\n`);
 }
 
 function readReplaySelector(filePath: string, command: string): string {
-  const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
-    optimizedActions?: Array<{ command?: string; positionals?: string[] }>;
-  };
-  const action = payload.optimizedActions?.find((entry) => entry.command === command);
-  if (!action) return '';
+  const lines = fs
+    .readFileSync(filePath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const line = lines.find((entry) => entry.startsWith(`${command} `) || entry === command);
+  if (!line) return '';
+  const args = tokenizeReplayLine(line).slice(1);
   if (command === 'is') {
-    return action.positionals?.[1] ?? '';
+    return args[1] ?? '';
   }
-  return action.positionals?.[0] ?? '';
+  return args[0] ?? '';
+}
+
+function tokenizeReplayLine(line: string): string[] {
+  const tokens: string[] = [];
+  let cursor = 0;
+  while (cursor < line.length) {
+    while (cursor < line.length && /\s/.test(line[cursor])) {
+      cursor += 1;
+    }
+    if (cursor >= line.length) break;
+    if (line[cursor] === '"') {
+      let end = cursor + 1;
+      let escaped = false;
+      while (end < line.length) {
+        const char = line[end];
+        if (char === '"' && !escaped) break;
+        escaped = char === '\\' && !escaped;
+        if (char !== '\\') escaped = false;
+        end += 1;
+      }
+      if (end >= line.length) {
+        throw new Error(`Invalid replay script line: ${line}`);
+      }
+      tokens.push(JSON.parse(line.slice(cursor, end + 1)) as string);
+      cursor = end + 1;
+      continue;
+    }
+    let end = cursor;
+    while (end < line.length && !/\s/.test(line[end])) {
+      end += 1;
+    }
+    tokens.push(line.slice(cursor, end));
+    cursor = end;
+  }
+  return tokens;
 }
 
 test('replay --update heals selector and rewrites replay file', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-'));
   const sessionsDir = path.join(tempRoot, 'sessions');
-  const replayPath = path.join(tempRoot, 'replay.json');
+  const replayPath = path.join(tempRoot, 'replay.ad');
   const sessionStore = new SessionStore(sessionsDir);
   const sessionName = 'heal-session';
   sessionStore.set(sessionName, makeSession(sessionName));
@@ -59,12 +95,9 @@ test('replay --update heals selector and rewrites replay file', async () => {
   writeReplayFile(replayPath, {
     ts: Date.now(),
     command: 'click',
-    positionals: ['id="old_continue"'],
+    positionals: ['id="old_continue" || label="Continue"'],
     flags: {},
-    result: {
-      refLabel: 'Continue',
-      selectorChain: ['id="old_continue"', 'label="Continue"'],
-    },
+    result: {},
   });
 
   const invokeCalls: string[] = [];
@@ -128,7 +161,7 @@ test('replay --update heals selector and rewrites replay file', async () => {
   });
 
   assert.ok(response);
-  assert.equal(response.ok, true);
+  assert.equal(response.ok, true, JSON.stringify(response));
   if (response.ok) {
     assert.equal(response.data?.healed, 1);
     assert.equal(response.data?.replayed, 1);
@@ -145,7 +178,7 @@ test('replay --update heals selector and rewrites replay file', async () => {
 test('replay without --update does not heal or rewrite', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-noheal-'));
   const sessionsDir = path.join(tempRoot, 'sessions');
-  const replayPath = path.join(tempRoot, 'replay.json');
+  const replayPath = path.join(tempRoot, 'replay.ad');
   const sessionStore = new SessionStore(sessionsDir);
   const sessionName = 'noheal-session';
   sessionStore.set(sessionName, makeSession(sessionName));
@@ -153,12 +186,9 @@ test('replay without --update does not heal or rewrite', async () => {
   writeReplayFile(replayPath, {
     ts: Date.now(),
     command: 'click',
-    positionals: ['id="old_continue"'],
+    positionals: ['id="old_continue" || label="Continue"'],
     flags: {},
-    result: {
-      refLabel: 'Continue',
-      selectorChain: ['id="old_continue"', 'label="Continue"'],
-    },
+    result: {},
   });
   const originalPayload = fs.readFileSync(replayPath, 'utf8');
 
@@ -202,7 +232,7 @@ test('replay without --update does not heal or rewrite', async () => {
 test('replay --update heals selector in is command', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-is-'));
   const sessionsDir = path.join(tempRoot, 'sessions');
-  const replayPath = path.join(tempRoot, 'replay.json');
+  const replayPath = path.join(tempRoot, 'replay.ad');
   const sessionStore = new SessionStore(sessionsDir);
   const sessionName = 'heal-is-session';
   sessionStore.set(sessionName, makeSession(sessionName));
@@ -210,12 +240,9 @@ test('replay --update heals selector in is command', async () => {
   writeReplayFile(replayPath, {
     ts: Date.now(),
     command: 'is',
-    positionals: ['visible', 'id="old_continue"'],
+    positionals: ['visible', 'id="old_continue" || label="Continue"'],
     flags: {},
-    result: {
-      selectorChain: ['id="old_continue"', 'label="Continue"'],
-      refLabel: 'Continue',
-    },
+    result: {},
   });
 
   const invoke = async (request: DaemonRequest): Promise<DaemonResponse> => {
@@ -266,10 +293,72 @@ test('replay --update heals selector in is command', async () => {
   });
 
   assert.ok(response);
-  assert.equal(response.ok, true);
+  assert.equal(response.ok, true, JSON.stringify(response));
   if (response.ok) {
     assert.equal(response.data?.healed, 1);
   }
   const rewrittenSelector = readReplaySelector(replayPath, 'is');
   assert.ok(rewrittenSelector.includes('auth_continue'));
+});
+
+test('replay rejects legacy JSON payload files', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-json-rejected-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const replayPath = path.join(tempRoot, 'replay.json');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'json-rejected-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+  fs.writeFileSync(replayPath, JSON.stringify({ optimizedActions: [] }, null, 2));
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(tempRoot, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, false);
+  if (!response.ok) {
+    assert.equal(response.error.code, 'INVALID_ARGS');
+    assert.match(response.error.message, /\.ad script files/);
+  }
+});
+
+test('replay rejects malformed .ad lines with unclosed quotes', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-invalid-ad-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const replayPath = path.join(tempRoot, 'replay.ad');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'invalid-ad-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+  fs.writeFileSync(replayPath, 'click "id=\\"broken\\"\n');
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(tempRoot, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, false);
+  if (!response.ok) {
+    assert.equal(response.error.code, 'INVALID_ARGS');
+    assert.match(response.error.message, /Invalid replay script line/);
+  }
 });

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -1,0 +1,275 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { CommandFlags } from '../../../core/dispatch.ts';
+import { handleSessionCommands } from '../session.ts';
+import { SessionStore } from '../../session-store.ts';
+import type { DaemonRequest, DaemonResponse, SessionAction, SessionState } from '../../types.ts';
+import type { DeviceInfo } from '../../../utils/device.ts';
+
+function makeDevice(): DeviceInfo {
+  return {
+    platform: 'ios',
+    id: 'sim-1',
+    name: 'iPhone Test',
+    kind: 'simulator',
+    booted: true,
+  };
+}
+
+function makeSession(name: string): SessionState {
+  return {
+    name,
+    device: makeDevice(),
+    createdAt: Date.now(),
+    appBundleId: 'com.example.app',
+    actions: [],
+  };
+}
+
+function writeReplayFile(filePath: string, action: SessionAction) {
+  const payload = {
+    optimizedActions: [action],
+  };
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+}
+
+function readReplaySelector(filePath: string, command: string): string {
+  const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+    optimizedActions?: Array<{ command?: string; positionals?: string[] }>;
+  };
+  const action = payload.optimizedActions?.find((entry) => entry.command === command);
+  if (!action) return '';
+  if (command === 'is') {
+    return action.positionals?.[1] ?? '';
+  }
+  return action.positionals?.[0] ?? '';
+}
+
+test('replay --update heals selector and rewrites replay file', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const replayPath = path.join(tempRoot, 'replay.json');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'heal-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+
+  writeReplayFile(replayPath, {
+    ts: Date.now(),
+    command: 'click',
+    positionals: ['id="old_continue"'],
+    flags: {},
+    result: {
+      refLabel: 'Continue',
+      selectorChain: ['id="old_continue"', 'label="Continue"'],
+    },
+  });
+
+  const invokeCalls: string[] = [];
+  const invoke = async (request: DaemonRequest): Promise<DaemonResponse> => {
+    if (request.command !== 'click') {
+      return { ok: false, error: { code: 'INVALID_ARGS', message: `unexpected command ${request.command}` } };
+    }
+    const selector = request.positionals?.[0] ?? '';
+    invokeCalls.push(selector);
+    if (selector.includes('old_continue')) {
+      return { ok: false, error: { code: 'COMMAND_FAILED', message: 'selector no longer exists' } };
+    }
+    if (selector.includes('auth_continue')) {
+      return { ok: true, data: { clicked: true } };
+    }
+    return { ok: false, error: { code: 'COMMAND_FAILED', message: 'unexpected selector' } };
+  };
+
+  let snapshotDispatchCalls = 0;
+  const dispatch = async (
+    _device: DeviceInfo,
+    command: string,
+    _positionals: string[],
+    _out?: string,
+    _context?: CommandFlags,
+  ): Promise<Record<string, unknown> | void> => {
+    if (command !== 'snapshot') {
+      throw new Error(`unexpected dispatch command: ${command}`);
+    }
+    snapshotDispatchCalls += 1;
+    return {
+      nodes: [
+        {
+          index: 0,
+          type: 'XCUIElementTypeButton',
+          label: 'Continue',
+          identifier: 'auth_continue',
+          rect: { x: 10, y: 10, width: 100, height: 44 },
+          enabled: true,
+          hittable: true,
+        },
+      ],
+      truncated: false,
+      backend: 'xctest',
+    };
+  };
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'replay',
+      positionals: [replayPath],
+      flags: { replayUpdate: true },
+    },
+    sessionName,
+    logPath: path.join(tempRoot, 'daemon.log'),
+    sessionStore,
+    invoke,
+    dispatch,
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, true);
+  if (response.ok) {
+    assert.equal(response.data?.healed, 1);
+    assert.equal(response.data?.replayed, 1);
+  }
+  assert.equal(snapshotDispatchCalls, 1);
+  assert.equal(invokeCalls.length, 2);
+  assert.ok(invokeCalls[0].includes('old_continue'));
+  assert.ok(invokeCalls[1].includes('auth_continue'));
+  const rewrittenSelector = readReplaySelector(replayPath, 'click');
+  assert.ok(rewrittenSelector.includes('auth_continue'));
+  assert.ok(!rewrittenSelector.includes('old_continue'));
+});
+
+test('replay without --update does not heal or rewrite', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-noheal-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const replayPath = path.join(tempRoot, 'replay.json');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'noheal-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+
+  writeReplayFile(replayPath, {
+    ts: Date.now(),
+    command: 'click',
+    positionals: ['id="old_continue"'],
+    flags: {},
+    result: {
+      refLabel: 'Continue',
+      selectorChain: ['id="old_continue"', 'label="Continue"'],
+    },
+  });
+  const originalPayload = fs.readFileSync(replayPath, 'utf8');
+
+  const invoke = async (_request: DaemonRequest): Promise<DaemonResponse> => {
+    return { ok: false, error: { code: 'COMMAND_FAILED', message: 'selector no longer exists' } };
+  };
+
+  let snapshotDispatchCalls = 0;
+  const dispatch = async (
+    _device: DeviceInfo,
+    _command: string,
+    _positionals: string[],
+    _out?: string,
+    _context?: CommandFlags,
+  ): Promise<Record<string, unknown> | void> => {
+    snapshotDispatchCalls += 1;
+    return {};
+  };
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(tempRoot, 'daemon.log'),
+    sessionStore,
+    invoke,
+    dispatch,
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, false);
+  assert.equal(snapshotDispatchCalls, 0);
+  assert.equal(fs.readFileSync(replayPath, 'utf8'), originalPayload);
+});
+
+test('replay --update heals selector in is command', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-is-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const replayPath = path.join(tempRoot, 'replay.json');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'heal-is-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+
+  writeReplayFile(replayPath, {
+    ts: Date.now(),
+    command: 'is',
+    positionals: ['visible', 'id="old_continue"'],
+    flags: {},
+    result: {
+      selectorChain: ['id="old_continue"', 'label="Continue"'],
+      refLabel: 'Continue',
+    },
+  });
+
+  const invoke = async (request: DaemonRequest): Promise<DaemonResponse> => {
+    if (request.command !== 'is') {
+      return { ok: false, error: { code: 'INVALID_ARGS', message: `unexpected command ${request.command}` } };
+    }
+    const selector = request.positionals?.[1] ?? '';
+    if (selector.includes('old_continue')) {
+      return { ok: false, error: { code: 'COMMAND_FAILED', message: 'selector stale' } };
+    }
+    if (selector.includes('auth_continue')) {
+      return { ok: true, data: { predicate: 'visible', pass: true } };
+    }
+    return { ok: false, error: { code: 'COMMAND_FAILED', message: 'unexpected selector' } };
+  };
+
+  const dispatch = async (): Promise<Record<string, unknown> | void> => {
+    return {
+      nodes: [
+        {
+          index: 0,
+          type: 'XCUIElementTypeButton',
+          label: 'Continue',
+          identifier: 'auth_continue',
+          rect: { x: 10, y: 10, width: 100, height: 44 },
+          enabled: true,
+          hittable: true,
+        },
+      ],
+      truncated: false,
+      backend: 'xctest',
+    };
+  };
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'replay',
+      positionals: [replayPath],
+      flags: { replayUpdate: true },
+    },
+    sessionName,
+    logPath: path.join(tempRoot, 'daemon.log'),
+    sessionStore,
+    invoke,
+    dispatch,
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, true);
+  if (response.ok) {
+    assert.equal(response.data?.healed, 1);
+  }
+  const rewrittenSelector = readReplaySelector(replayPath, 'is');
+  assert.ok(rewrittenSelector.includes('auth_continue'));
+});

--- a/src/daemon/handlers/__tests__/snapshot.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot.test.ts
@@ -87,6 +87,31 @@ test('parseWaitArgs parses bare text with timeout', () => {
   assert.deepEqual(result, { kind: 'text', text: 'Hello', timeoutMs: 5000 });
 });
 
+test('parseWaitArgs parses selector expression', () => {
+  const result = parseWaitArgs(['id=login_email']);
+  assert.ok(result);
+  assert.equal(result.kind, 'selector');
+  if (result.kind === 'selector') {
+    assert.equal(result.selectorExpression, 'id=login_email');
+    assert.equal(result.timeoutMs, null);
+  }
+});
+
+test('parseWaitArgs parses selector expression with timeout', () => {
+  const result = parseWaitArgs(['id=login_email', '5000']);
+  assert.ok(result);
+  assert.equal(result.kind, 'selector');
+  if (result.kind === 'selector') {
+    assert.equal(result.selectorExpression, 'id=login_email');
+    assert.equal(result.timeoutMs, 5000);
+  }
+});
+
+test('parseWaitArgs falls back to text when selector-like token is invalid', () => {
+  const result = parseWaitArgs(['foo=bar', '5000']);
+  assert.deepEqual(result, { kind: 'text', text: 'foo=bar', timeoutMs: 5000 });
+});
+
 test('parseWaitArgs parses bare multi-word text', () => {
   const result = parseWaitArgs(['Sign', 'In']);
   assert.deepEqual(result, { kind: 'text', text: 'Sign In', timeoutMs: null });

--- a/src/daemon/handlers/interaction.ts
+++ b/src/daemon/handlers/interaction.ts
@@ -1,0 +1,510 @@
+import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
+import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
+import { attachRefs, centerOfRect, findNodeByRef, normalizeRef, type RawSnapshotNode } from '../../utils/snapshot.ts';
+import type { DaemonCommandContext } from '../context.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import { SessionStore } from '../session-store.ts';
+import { evaluateIsPredicate, isSupportedPredicate } from '../is-predicates.ts';
+import { extractNodeText, findNodeByLabel, isFillableType, pruneGroupNodes, resolveRefLabel } from '../snapshot-processing.ts';
+import {
+  buildSelectorChainForNode,
+  findSelectorChainMatch,
+  formatSelectorFailure,
+  parseSelectorChain,
+  resolveSelectorChain,
+  splitSelectorFromArgs,
+} from '../selectors.ts';
+
+type ContextFromFlags = (
+  flags: CommandFlags | undefined,
+  appBundleId?: string,
+  traceLogPath?: string,
+) => DaemonCommandContext;
+
+export async function handleInteractionCommands(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  sessionStore: SessionStore;
+  contextFromFlags: ContextFromFlags;
+}): Promise<DaemonResponse | null> {
+  const { req, sessionName, sessionStore, contextFromFlags } = params;
+  const command = req.command;
+
+  if (command === 'click') {
+    const session = sessionStore.get(sessionName);
+    if (!session) {
+      return {
+        ok: false,
+        error: { code: 'SESSION_NOT_FOUND', message: 'No active session. Run open first.' },
+      };
+    }
+    const refInput = req.positionals?.[0] ?? '';
+    if (refInput.startsWith('@')) {
+      if (!session.snapshot) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
+      }
+      const ref = normalizeRef(refInput);
+      if (!ref) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'click requires a ref like @e2' } };
+      }
+      let node = findNodeByRef(session.snapshot.nodes, ref);
+      if (!node?.rect && req.positionals.length > 1) {
+        const fallbackLabel = req.positionals.slice(1).join(' ').trim();
+        if (fallbackLabel.length > 0) {
+          node = findNodeByLabel(session.snapshot.nodes, fallbackLabel);
+        }
+      }
+      if (!node?.rect) {
+        return {
+          ok: false,
+          error: { code: 'COMMAND_FAILED', message: `Ref ${refInput} not found or has no bounds` },
+        };
+      }
+      const refLabel = resolveRefLabel(node, session.snapshot.nodes);
+      const selectorChain = buildSelectorChainForNode(node, session.device.platform, { action: 'click' });
+      const { x, y } = centerOfRect(node.rect);
+      await dispatchCommand(session.device, 'press', [String(x), String(y)], req.flags?.out, {
+        ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
+      });
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: { ref, x, y, refLabel, selectorChain },
+      });
+      return { ok: true, data: { ref, x, y } };
+    }
+
+    const selectorExpression = (req.positionals ?? []).join(' ').trim();
+    if (!selectorExpression) {
+      return {
+        ok: false,
+        error: { code: 'INVALID_ARGS', message: 'click requires @ref or selector expression' },
+      };
+    }
+    const chain = parseSelectorChain(selectorExpression);
+    const snapshot = await captureSnapshotForSession(session, req.flags, sessionStore, contextFromFlags, {
+      interactiveOnly: true,
+    });
+    const resolved = resolveSelectorChain(snapshot.nodes, chain, {
+      platform: session.device.platform,
+      requireRect: true,
+      requireUnique: true,
+    });
+    if (!resolved || !resolved.node.rect) {
+      return {
+        ok: false,
+        error: {
+          code: 'COMMAND_FAILED',
+          message: formatSelectorFailure(chain, resolved?.diagnostics ?? [], { unique: true }),
+        },
+      };
+    }
+    const { x, y } = centerOfRect(resolved.node.rect);
+    await dispatchCommand(session.device, 'press', [String(x), String(y)], req.flags?.out, {
+      ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
+    });
+    const selectorChain = buildSelectorChainForNode(resolved.node, session.device.platform, { action: 'click' });
+    const refLabel = resolveRefLabel(resolved.node, snapshot.nodes);
+    sessionStore.recordAction(session, {
+      command,
+      positionals: req.positionals ?? [],
+      flags: req.flags ?? {},
+      result: {
+        x,
+        y,
+        selector: resolved.selector.raw,
+        selectorChain,
+        refLabel,
+      },
+    });
+    return { ok: true, data: { selector: resolved.selector.raw, x, y } };
+  }
+
+  if (command === 'fill') {
+    const session = sessionStore.get(sessionName);
+    if (req.positionals?.[0]?.startsWith('@')) {
+      if (!session?.snapshot) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
+      }
+      const ref = normalizeRef(req.positionals[0]);
+      if (!ref) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires a ref like @e2' } };
+      }
+      const labelCandidate = req.positionals.length >= 3 ? req.positionals[1] : '';
+      const text = req.positionals.length >= 3 ? req.positionals.slice(2).join(' ') : req.positionals.slice(1).join(' ');
+      if (!text) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires text after ref' } };
+      }
+      let node = findNodeByRef(session.snapshot.nodes, ref);
+      if (!node?.rect && labelCandidate) {
+        node = findNodeByLabel(session.snapshot.nodes, labelCandidate);
+      }
+      if (!node?.rect) {
+        return { ok: false, error: { code: 'COMMAND_FAILED', message: `Ref ${req.positionals[0]} not found or has no bounds` } };
+      }
+      const nodeType = node.type ?? '';
+      const fillWarning =
+        nodeType && !isFillableType(nodeType, session.device.platform)
+          ? `fill target ${req.positionals[0]} resolved to "${nodeType}", attempting fill anyway.`
+          : undefined;
+      const refLabel = resolveRefLabel(node, session.snapshot.nodes);
+      const selectorChain = buildSelectorChainForNode(node, session.device.platform, { action: 'fill' });
+      const { x, y } = centerOfRect(node.rect);
+      const data = await dispatchCommand(
+        session.device,
+        'fill',
+        [String(x), String(y), text],
+        req.flags?.out,
+        {
+          ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
+        },
+      );
+      const resultPayload: Record<string, unknown> = {
+        ...(data ?? { ref, x, y }),
+      };
+      if (fillWarning) {
+        resultPayload.warning = fillWarning;
+      }
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: { ...resultPayload, refLabel, selectorChain },
+      });
+      return { ok: true, data: resultPayload };
+    }
+    if (!session) {
+      return {
+        ok: false,
+        error: { code: 'SESSION_NOT_FOUND', message: 'No active session. Run open first.' },
+      };
+    }
+    const selectorArgs = splitSelectorFromArgs(req.positionals ?? []);
+    if (selectorArgs) {
+      if (selectorArgs.rest.length === 0) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires text after selector' } };
+      }
+      const text = selectorArgs.rest.join(' ').trim();
+      if (!text) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'fill requires text after selector' } };
+      }
+      const chain = parseSelectorChain(selectorArgs.selectorExpression);
+      const snapshot = await captureSnapshotForSession(session, req.flags, sessionStore, contextFromFlags, {
+        interactiveOnly: true,
+      });
+      const resolved = resolveSelectorChain(snapshot.nodes, chain, {
+        platform: session.device.platform,
+        requireRect: true,
+        requireUnique: true,
+      });
+      if (!resolved || !resolved.node.rect) {
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: formatSelectorFailure(chain, resolved?.diagnostics ?? [], { unique: true }),
+          },
+        };
+      }
+      const node = resolved.node;
+      const nodeType = node.type ?? '';
+      const fillWarning =
+        nodeType && !isFillableType(nodeType, session.device.platform)
+          ? `fill target ${resolved.selector.raw} resolved to "${nodeType}", attempting fill anyway.`
+          : undefined;
+      const { x, y } = centerOfRect(resolved.node.rect);
+      const data = await dispatchCommand(session.device, 'fill', [String(x), String(y), text], req.flags?.out, {
+        ...contextFromFlags(req.flags, session.appBundleId, session.trace?.outPath),
+      });
+      const selectorChain = buildSelectorChainForNode(node, session.device.platform, { action: 'fill' });
+      const resultPayload: Record<string, unknown> = {
+        ...(data ?? { x, y, text }),
+        selector: resolved.selector.raw,
+        selectorChain,
+        refLabel: resolveRefLabel(node, snapshot.nodes),
+      };
+      if (fillWarning) {
+        resultPayload.warning = fillWarning;
+      }
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: resultPayload,
+      });
+      return { ok: true, data: resultPayload };
+    }
+    return {
+      ok: false,
+      error: { code: 'INVALID_ARGS', message: 'fill requires x y text, @ref text, or selector text' },
+    };
+  }
+
+  if (command === 'get') {
+    const sub = req.positionals?.[0];
+    if (sub !== 'text' && sub !== 'attrs') {
+      return { ok: false, error: { code: 'INVALID_ARGS', message: 'get only supports text or attrs' } };
+    }
+    const session = sessionStore.get(sessionName);
+    if (!session) {
+      return {
+        ok: false,
+        error: { code: 'SESSION_NOT_FOUND', message: 'No active session. Run open first.' },
+      };
+    }
+    const refInput = req.positionals?.[1] ?? '';
+    if (refInput.startsWith('@')) {
+      if (!session.snapshot) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'No snapshot in session. Run snapshot first.' } };
+      }
+      const ref = normalizeRef(refInput ?? '');
+      if (!ref) {
+        return { ok: false, error: { code: 'INVALID_ARGS', message: 'get text requires a ref like @e2' } };
+      }
+      let node = findNodeByRef(session.snapshot.nodes, ref);
+      if (!node && req.positionals.length > 2) {
+        const labelCandidate = req.positionals.slice(2).join(' ').trim();
+        if (labelCandidate.length > 0) {
+          node = findNodeByLabel(session.snapshot.nodes, labelCandidate);
+        }
+      }
+      if (!node) {
+        return { ok: false, error: { code: 'COMMAND_FAILED', message: `Ref ${refInput} not found` } };
+      }
+      const selectorChain = buildSelectorChainForNode(node, session.device.platform, { action: 'get' });
+      if (sub === 'attrs') {
+        sessionStore.recordAction(session, {
+          command,
+          positionals: req.positionals ?? [],
+          flags: req.flags ?? {},
+          result: { ref, selectorChain },
+        });
+        return { ok: true, data: { ref, node } };
+      }
+      const text = extractNodeText(node);
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: { ref, text, refLabel: text || undefined, selectorChain },
+      });
+      return { ok: true, data: { ref, text, node } };
+    }
+
+    const selectorExpression = req.positionals.slice(1).join(' ').trim();
+    if (!selectorExpression) {
+      return {
+        ok: false,
+        error: { code: 'INVALID_ARGS', message: 'get requires @ref or selector expression' },
+      };
+    }
+    const chain = parseSelectorChain(selectorExpression);
+    const snapshot = await captureSnapshotForSession(session, req.flags, sessionStore, contextFromFlags, {
+      interactiveOnly: false,
+    });
+    const resolved = resolveSelectorChain(snapshot.nodes, chain, {
+      platform: session.device.platform,
+      requireRect: false,
+      requireUnique: true,
+    });
+    if (!resolved) {
+      return {
+        ok: false,
+        error: {
+          code: 'COMMAND_FAILED',
+          message: formatSelectorFailure(chain, [], { unique: true }),
+        },
+      };
+    }
+    const node = resolved.node;
+    const selectorChain = buildSelectorChainForNode(node, session.device.platform, { action: 'get' });
+    if (sub === 'attrs') {
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: { selector: resolved.selector.raw, selectorChain },
+      });
+      return { ok: true, data: { selector: resolved.selector.raw, node } };
+    }
+    const text = extractNodeText(node);
+    sessionStore.recordAction(session, {
+      command,
+      positionals: req.positionals ?? [],
+      flags: req.flags ?? {},
+      result: {
+        text,
+        refLabel: text || undefined,
+        selector: resolved.selector.raw,
+        selectorChain,
+      },
+    });
+    return { ok: true, data: { selector: resolved.selector.raw, text, node } };
+  }
+
+  if (command === 'is') {
+    const predicate = (req.positionals?.[0] ?? '').toLowerCase();
+    if (!isSupportedPredicate(predicate)) {
+      return {
+        ok: false,
+        error: {
+          code: 'INVALID_ARGS',
+          message: 'is requires predicate: visible|hidden|exists|editable|selected|text',
+        },
+      };
+    }
+    const session = sessionStore.get(sessionName);
+    if (!session) {
+      return {
+        ok: false,
+        error: { code: 'SESSION_NOT_FOUND', message: 'No active session. Run open first.' },
+      };
+    }
+    if (!isCommandSupportedOnDevice('is', session.device)) {
+      return {
+        ok: false,
+        error: { code: 'UNSUPPORTED_OPERATION', message: 'is is not supported on this device' },
+      };
+    }
+    const selectorArgs = req.positionals.slice(1);
+    const split = splitSelectorFromArgs(selectorArgs);
+    if (!split) {
+      return {
+        ok: false,
+        error: {
+          code: 'INVALID_ARGS',
+          message: 'is requires a selector expression',
+        },
+      };
+    }
+    const expectedText = split.rest.join(' ').trim();
+    if (predicate === 'text' && !expectedText) {
+      return {
+        ok: false,
+        error: {
+          code: 'INVALID_ARGS',
+          message: 'is text requires expected text value',
+        },
+      };
+    }
+    if (predicate !== 'text' && split.rest.length > 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'INVALID_ARGS',
+          message: `is ${predicate} does not accept trailing values`,
+        },
+      };
+    }
+    const chain = parseSelectorChain(split.selectorExpression);
+    const snapshot = await captureSnapshotForSession(session, req.flags, sessionStore, contextFromFlags, {
+      interactiveOnly: false,
+    });
+    if (predicate === 'exists') {
+      const matched = findSelectorChainMatch(snapshot.nodes, chain, {
+        platform: session.device.platform,
+      });
+      if (!matched) {
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: formatSelectorFailure(chain, [], { unique: false }),
+          },
+        };
+      }
+      sessionStore.recordAction(session, {
+        command,
+        positionals: req.positionals ?? [],
+        flags: req.flags ?? {},
+        result: {
+          predicate,
+          selector: matched.selector.raw,
+          selectorChain: chain.selectors.map((entry) => entry.raw),
+          pass: true,
+          matches: matched.matches,
+        },
+      });
+      return { ok: true, data: { predicate, pass: true, selector: matched.selector.raw, matches: matched.matches } };
+    }
+
+    const resolved = resolveSelectorChain(snapshot.nodes, chain, {
+      platform: session.device.platform,
+      requireUnique: true,
+    });
+    if (!resolved) {
+      return {
+        ok: false,
+        error: {
+          code: 'COMMAND_FAILED',
+          message: formatSelectorFailure(chain, [], { unique: true }),
+        },
+      };
+    }
+    const result = evaluateIsPredicate({
+      predicate,
+      node: resolved.node,
+      expectedText,
+      platform: session.device.platform,
+    });
+    if (!result.pass) {
+      return {
+        ok: false,
+        error: {
+          code: 'COMMAND_FAILED',
+          message: `is ${predicate} failed for selector ${resolved.selector.raw}: ${result.details}`,
+        },
+      };
+    }
+    sessionStore.recordAction(session, {
+      command,
+      positionals: req.positionals ?? [],
+      flags: req.flags ?? {},
+      result: {
+        predicate,
+        selector: resolved.selector.raw,
+        selectorChain: chain.selectors.map((entry) => entry.raw),
+        pass: true,
+        text: predicate === 'text' ? result.actualText : undefined,
+      },
+    });
+    return { ok: true, data: { predicate, pass: true, selector: resolved.selector.raw } };
+  }
+
+  return null;
+}
+
+async function captureSnapshotForSession(
+  session: SessionState,
+  flags: CommandFlags | undefined,
+  sessionStore: SessionStore,
+  contextFromFlags: ContextFromFlags,
+  options: { interactiveOnly: boolean },
+) {
+  const data = (await dispatchCommand(session.device, 'snapshot', [], flags?.out, {
+    ...contextFromFlags(
+      {
+        ...(flags ?? {}),
+        snapshotInteractiveOnly: options.interactiveOnly,
+        snapshotCompact: options.interactiveOnly,
+      },
+      session.appBundleId,
+      session.trace?.outPath,
+    ),
+  })) as {
+    nodes?: RawSnapshotNode[];
+    truncated?: boolean;
+    backend?: 'ax' | 'xctest' | 'android';
+  };
+  const rawNodes = data?.nodes ?? [];
+  const nodes = attachRefs(flags?.snapshotRaw ? rawNodes : pruneGroupNodes(rawNodes));
+  session.snapshot = {
+    nodes,
+    truncated: data?.truncated,
+    createdAt: Date.now(),
+    backend: data?.backend,
+  };
+  sessionStore.set(session.name, session);
+  return session.snapshot;
+}

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -9,6 +9,10 @@ import { contextFromFlags } from '../context.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 import { resolveIosAppStateFromSnapshots } from '../app-state.ts';
 import { stopIosRunnerSession } from '../../platforms/ios/runner-client.ts';
+import { attachRefs, type RawSnapshotNode, type SnapshotState } from '../../utils/snapshot.ts';
+import { pruneGroupNodes } from '../snapshot-processing.ts';
+import { buildSelectorChainForNode, parseSelectorChain, resolveSelectorChain, splitSelectorFromArgs } from '../selectors.ts';
+import { inferFillText, uniqueStrings } from '../action-utils.ts';
 
 export async function handleSessionCommands(params: {
   req: DaemonRequest;
@@ -16,8 +20,10 @@ export async function handleSessionCommands(params: {
   logPath: string;
   sessionStore: SessionStore;
   invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  dispatch?: typeof dispatchCommand;
 }): Promise<DaemonResponse | null> {
-  const { req, sessionName, logPath, sessionStore, invoke } = params;
+  const { req, sessionName, logPath, sessionStore, invoke, dispatch: dispatchOverride } = params;
+  const dispatch = dispatchOverride ?? dispatchCommand;
   const command = req.command;
 
   if (command === 'session_list') {
@@ -167,7 +173,7 @@ export async function handleSessionCommands(params: {
           appBundleId = undefined;
         }
       }
-      await dispatchCommand(session.device, 'open', req.positionals ?? [], req.flags?.out, {
+      await dispatch(session.device, 'open', req.positionals ?? [], req.flags?.out, {
         ...contextFromFlags(logPath, req.flags, appBundleId),
       });
       const nextSession: SessionState = {
@@ -208,7 +214,7 @@ export async function handleSessionCommands(params: {
         appBundleId = undefined;
       }
     }
-    await dispatchCommand(device, 'open', req.positionals ?? [], req.flags?.out, {
+    await dispatch(device, 'open', req.positionals ?? [], req.flags?.out, {
       ...contextFromFlags(logPath, req.flags, appBundleId),
     });
     const session: SessionState = {
@@ -241,17 +247,47 @@ export async function handleSessionCommands(params: {
         optimizedActions?: SessionAction[];
       };
       const actions = payload.optimizedActions ?? payload.actions ?? [];
-      for (const action of actions) {
+      const shouldUpdate = req.flags?.replayUpdate === true;
+      let healed = 0;
+      for (let index = 0; index < actions.length; index += 1) {
+        const action = actions[index];
         if (!action || action.command === 'replay') continue;
-        await invoke({
+        let response = await invoke({
           token: req.token,
           session: sessionName,
           command: action.command,
           positionals: action.positionals ?? [],
           flags: action.flags ?? {},
         });
+        if (response.ok) continue;
+        if (!shouldUpdate) return response;
+        const nextAction = await healReplayAction({
+          action,
+          sessionName,
+          logPath,
+          sessionStore,
+          dispatch,
+        });
+        if (!nextAction) {
+          return response;
+        }
+        actions[index] = nextAction;
+        response = await invoke({
+          token: req.token,
+          session: sessionName,
+          command: nextAction.command,
+          positionals: nextAction.positionals ?? [],
+          flags: nextAction.flags ?? {},
+        });
+        if (!response.ok) {
+          return response;
+        }
+        healed += 1;
       }
-      return { ok: true, data: { replayed: actions.length, session: sessionName } };
+      if (shouldUpdate && healed > 0) {
+        writeReplayPayload(resolved, payload);
+      }
+      return { ok: true, data: { replayed: actions.length, healed, session: sessionName } };
     } catch (err) {
       const appErr = asAppError(err);
       return { ok: false, error: { code: appErr.code, message: appErr.message } };
@@ -264,7 +300,7 @@ export async function handleSessionCommands(params: {
       return { ok: false, error: { code: 'SESSION_NOT_FOUND', message: 'No active session' } };
     }
     if (req.positionals && req.positionals.length > 0) {
-      await dispatchCommand(session.device, 'close', req.positionals ?? [], req.flags?.out, {
+      await dispatch(session.device, 'close', req.positionals ?? [], req.flags?.out, {
         ...contextFromFlags(logPath, req.flags, session.appBundleId, session.trace?.outPath),
       });
     }
@@ -283,4 +319,202 @@ export async function handleSessionCommands(params: {
   }
 
   return null;
+}
+
+async function healReplayAction(params: {
+  action: SessionAction;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  dispatch: typeof dispatchCommand;
+}): Promise<SessionAction | null> {
+  const { action, sessionName, logPath, sessionStore, dispatch } = params;
+  if (!['click', 'fill', 'get', 'is', 'wait'].includes(action.command)) return null;
+  const session = sessionStore.get(sessionName);
+  if (!session) return null;
+  const requiresRect = action.command === 'click' || action.command === 'fill';
+  const snapshot = await captureSnapshotForReplay(session, action, logPath, requiresRect, dispatch, sessionStore);
+  const selectorCandidates = collectReplaySelectorCandidates(action);
+  for (const candidate of selectorCandidates) {
+    const chain = parseSelectorChain(candidate);
+    const resolved = resolveSelectorChain(snapshot.nodes, chain, {
+      platform: session.device.platform,
+      requireRect: requiresRect,
+      requireUnique: true,
+    });
+    if (!resolved) continue;
+    const selectorChain = buildSelectorChainForNode(resolved.node, session.device.platform, {
+      action: action.command === 'click' ? 'click' : action.command === 'fill' ? 'fill' : 'get',
+    });
+    const selectorExpression = selectorChain.join(' || ');
+    if (action.command === 'click') {
+      return {
+        ...action,
+        positionals: [selectorExpression],
+      };
+    }
+    if (action.command === 'fill') {
+      const fillText = inferFillText(action);
+      if (!fillText) continue;
+      return {
+        ...action,
+        positionals: [selectorExpression, fillText],
+      };
+    }
+    if (action.command === 'get') {
+      const sub = action.positionals?.[0];
+      if (sub !== 'text' && sub !== 'attrs') continue;
+      return {
+        ...action,
+        positionals: [sub, selectorExpression],
+      };
+    }
+    if (action.command === 'is') {
+      const predicate = action.positionals?.[0];
+      if (!predicate) continue;
+      const split = splitSelectorFromArgs(action.positionals.slice(1));
+      const expectedText = split?.rest.join(' ').trim() ?? '';
+      const nextPositionals = [predicate, selectorExpression];
+      if (predicate === 'text' && expectedText.length > 0) {
+        nextPositionals.push(expectedText);
+      }
+      return {
+        ...action,
+        positionals: nextPositionals,
+      };
+    }
+    if (action.command === 'wait') {
+      const { selectorTimeout } = parseSelectorWaitPositionals(action.positionals ?? []);
+      const nextPositionals = [selectorExpression];
+      if (selectorTimeout) {
+        nextPositionals.push(selectorTimeout);
+      }
+      return {
+        ...action,
+        positionals: nextPositionals,
+      };
+    }
+  }
+  return null;
+}
+
+async function captureSnapshotForReplay(
+  session: SessionState,
+  action: SessionAction,
+  logPath: string,
+  interactiveOnly: boolean,
+  dispatch: typeof dispatchCommand,
+  sessionStore: SessionStore,
+): Promise<SnapshotState> {
+  const data = (await dispatch(session.device, 'snapshot', [], action.flags?.out, {
+    ...contextFromFlags(
+      logPath,
+      {
+        ...(action.flags ?? {}),
+        snapshotInteractiveOnly: interactiveOnly,
+        snapshotCompact: interactiveOnly,
+      },
+      session.appBundleId,
+      session.trace?.outPath,
+    ),
+  })) as {
+    nodes?: RawSnapshotNode[];
+    truncated?: boolean;
+    backend?: 'ax' | 'xctest' | 'android';
+  };
+  const rawNodes = data?.nodes ?? [];
+  const nodes = attachRefs(action.flags?.snapshotRaw ? rawNodes : pruneGroupNodes(rawNodes));
+  const snapshot: SnapshotState = {
+    nodes,
+    truncated: data?.truncated,
+    createdAt: Date.now(),
+    backend: data?.backend,
+  };
+  session.snapshot = snapshot;
+  sessionStore.set(session.name, session);
+  return snapshot;
+}
+
+function collectReplaySelectorCandidates(action: SessionAction): string[] {
+  const result: string[] = [];
+  const explicitChain =
+    Array.isArray(action.result?.selectorChain) &&
+    action.result?.selectorChain.every((entry) => typeof entry === 'string')
+      ? (action.result.selectorChain as string[])
+      : [];
+  result.push(...explicitChain);
+
+  if (action.command === 'click') {
+    const first = action.positionals?.[0] ?? '';
+    if (first && !first.startsWith('@')) {
+      result.push(action.positionals.join(' '));
+    }
+  }
+  if (action.command === 'fill') {
+    const first = action.positionals?.[0] ?? '';
+    if (first && !first.startsWith('@') && Number.isNaN(Number(first))) {
+      result.push(first);
+    }
+  }
+  if (action.command === 'get') {
+    const selector = action.positionals?.[1] ?? '';
+    if (selector && !selector.startsWith('@')) {
+      result.push(action.positionals.slice(1).join(' '));
+    }
+  }
+  if (action.command === 'is') {
+    const split = splitSelectorFromArgs(action.positionals.slice(1));
+    if (split) {
+      result.push(split.selectorExpression);
+    }
+  }
+  if (action.command === 'wait') {
+    const { selectorExpression } = parseSelectorWaitPositionals(action.positionals ?? []);
+    if (selectorExpression) {
+      result.push(selectorExpression);
+    }
+  }
+
+  const refLabel = typeof action.result?.refLabel === 'string' ? action.result.refLabel.trim() : '';
+  if (refLabel.length > 0) {
+    const quoted = JSON.stringify(refLabel);
+    if (action.command === 'fill') {
+      result.push(`id=${quoted} editable=true`);
+      result.push(`label=${quoted} editable=true`);
+      result.push(`text=${quoted} editable=true`);
+      result.push(`value=${quoted} editable=true`);
+    } else {
+      result.push(`id=${quoted}`);
+      result.push(`label=${quoted}`);
+      result.push(`text=${quoted}`);
+      result.push(`value=${quoted}`);
+    }
+  }
+
+  return uniqueStrings(result).filter((entry) => entry.trim().length > 0);
+}
+
+function parseSelectorWaitPositionals(positionals: string[]): {
+  selectorExpression: string | null;
+  selectorTimeout: string | null;
+} {
+  if (positionals.length === 0) return { selectorExpression: null, selectorTimeout: null };
+  const maybeTimeout = positionals[positionals.length - 1];
+  const hasTimeout = /^\d+$/.test(maybeTimeout ?? '');
+  const selectorTokens = hasTimeout ? positionals.slice(0, -1) : positionals.slice();
+  const split = splitSelectorFromArgs(selectorTokens);
+  if (!split || split.rest.length > 0) {
+    return { selectorExpression: null, selectorTimeout: null };
+  }
+  return {
+    selectorExpression: split.selectorExpression,
+    selectorTimeout: hasTimeout ? maybeTimeout : null,
+  };
+}
+
+function writeReplayPayload(filePath: string, payload: { actions?: SessionAction[]; optimizedActions?: SessionAction[] }) {
+  const serialized = JSON.stringify(payload, null, 2);
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, serialized);
+  fs.renameSync(tmpPath, filePath);
 }

--- a/src/daemon/is-predicates.ts
+++ b/src/daemon/is-predicates.ts
@@ -1,0 +1,46 @@
+import type { SnapshotState } from '../utils/snapshot.ts';
+import { extractNodeText } from './snapshot-processing.ts';
+import { isNodeEditable, isNodeVisible } from './selectors.ts';
+
+export type IsPredicate = 'visible' | 'hidden' | 'exists' | 'editable' | 'selected' | 'text';
+
+export function isSupportedPredicate(input: string): input is IsPredicate {
+  return ['visible', 'hidden', 'exists', 'editable', 'selected', 'text'].includes(input);
+}
+
+export function evaluateIsPredicate(params: {
+  predicate: Exclude<IsPredicate, 'exists'>;
+  node: SnapshotState['nodes'][number];
+  expectedText?: string;
+  platform: 'ios' | 'android';
+}): { pass: boolean; actualText: string; details: string } {
+  const { predicate, node, expectedText, platform } = params;
+  const actualText = extractNodeText(node);
+  let pass = false;
+  switch (predicate) {
+    case 'visible':
+      pass = isNodeVisible(node);
+      break;
+    case 'hidden':
+      pass = !isNodeVisible(node);
+      break;
+    case 'editable':
+      pass = isNodeEditable(node, platform);
+      break;
+    case 'selected':
+      pass = node.selected === true;
+      break;
+    case 'text':
+      pass = actualText === (expectedText ?? '');
+      break;
+  }
+  const details =
+    predicate === 'text'
+      ? `expected="${expectedText ?? ''}" actual="${actualText}"`
+      : `actual=${JSON.stringify({
+          visible: isNodeVisible(node),
+          editable: isNodeEditable(node, platform),
+          selected: node.selected === true,
+        })}`;
+  return { pass, actualText, details };
+}

--- a/src/daemon/selectors.ts
+++ b/src/daemon/selectors.ts
@@ -1,0 +1,423 @@
+import { AppError } from '../utils/errors.ts';
+import type { SnapshotNode, SnapshotState } from '../utils/snapshot.ts';
+import { extractNodeText, isFillableType, normalizeType } from './snapshot-processing.ts';
+import { uniqueStrings } from './action-utils.ts';
+
+type SelectorKey =
+  | 'id'
+  | 'role'
+  | 'text'
+  | 'label'
+  | 'value'
+  | 'visible'
+  | 'hidden'
+  | 'editable'
+  | 'selected'
+  | 'enabled'
+  | 'hittable';
+
+type SelectorTerm = {
+  key: SelectorKey;
+  value: string | boolean;
+};
+
+export type Selector = {
+  raw: string;
+  terms: SelectorTerm[];
+};
+
+export type SelectorChain = {
+  raw: string;
+  selectors: Selector[];
+};
+
+export type SelectorDiagnostics = {
+  selector: string;
+  matches: number;
+};
+
+export type SelectorResolution = {
+  node: SnapshotNode;
+  selector: Selector;
+  selectorIndex: number;
+  matches: number;
+  diagnostics: SelectorDiagnostics[];
+};
+
+const TEXT_KEYS = new Set<SelectorKey>(['id', 'role', 'text', 'label', 'value']);
+const BOOLEAN_KEYS = new Set<SelectorKey>([
+  'visible',
+  'hidden',
+  'editable',
+  'selected',
+  'enabled',
+  'hittable',
+]);
+const ALL_KEYS = new Set<SelectorKey>([...TEXT_KEYS, ...BOOLEAN_KEYS]);
+
+export function parseSelectorChain(expression: string): SelectorChain {
+  const raw = expression.trim();
+  if (!raw) {
+    throw new AppError('INVALID_ARGS', 'Selector expression cannot be empty');
+  }
+  const segments = splitByFallback(raw);
+  if (segments.length === 0) {
+    throw new AppError('INVALID_ARGS', 'Selector expression cannot be empty');
+  }
+  return {
+    raw,
+    selectors: segments.map((segment) => parseSelector(segment)),
+  };
+}
+
+export function tryParseSelectorChain(expression: string): SelectorChain | null {
+  try {
+    return parseSelectorChain(expression);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveSelectorChain(
+  nodes: SnapshotState['nodes'],
+  chain: SelectorChain,
+  options: {
+    platform: 'ios' | 'android';
+    requireRect?: boolean;
+    requireUnique?: boolean;
+  },
+): SelectorResolution | null {
+  const requireRect = options.requireRect ?? false;
+  const requireUnique = options.requireUnique ?? true;
+  const diagnostics: SelectorDiagnostics[] = [];
+  for (let i = 0; i < chain.selectors.length; i += 1) {
+    const selector = chain.selectors[i];
+    const matches = nodes.filter((node) => {
+      if (requireRect && !node.rect) return false;
+      return matchesSelector(node, selector, options.platform);
+    });
+    diagnostics.push({ selector: selector.raw, matches: matches.length });
+    if (matches.length === 0) continue;
+    if (requireUnique && matches.length !== 1) continue;
+    return {
+      node: matches[0],
+      selector,
+      selectorIndex: i,
+      matches: matches.length,
+      diagnostics,
+    };
+  }
+  return null;
+}
+
+export function findSelectorChainMatch(
+  nodes: SnapshotState['nodes'],
+  chain: SelectorChain,
+  options: {
+    platform: 'ios' | 'android';
+    requireRect?: boolean;
+  },
+): { selectorIndex: number; selector: Selector; matches: number; diagnostics: SelectorDiagnostics[] } | null {
+  const requireRect = options.requireRect ?? false;
+  const diagnostics: SelectorDiagnostics[] = [];
+  for (let i = 0; i < chain.selectors.length; i += 1) {
+    const selector = chain.selectors[i];
+    const matches = nodes.filter((node) => {
+      if (requireRect && !node.rect) return false;
+      return matchesSelector(node, selector, options.platform);
+    });
+    diagnostics.push({ selector: selector.raw, matches: matches.length });
+    if (matches.length > 0) {
+      return { selectorIndex: i, selector, matches: matches.length, diagnostics };
+    }
+  }
+  return null;
+}
+
+export function formatSelectorFailure(
+  chain: SelectorChain,
+  diagnostics: SelectorDiagnostics[],
+  options: { unique?: boolean },
+): string {
+  const unique = options.unique ?? true;
+  if (diagnostics.length === 0) {
+    return `Selector did not match: ${chain.raw}`;
+  }
+  const summary = diagnostics.map((entry) => `${entry.selector} -> ${entry.matches}`).join(', ');
+  if (unique) {
+    return `Selector did not resolve uniquely (${summary})`;
+  }
+  return `Selector did not match (${summary})`;
+}
+
+export function isSelectorToken(token: string): boolean {
+  const trimmed = token.trim();
+  if (!trimmed) return false;
+  if (trimmed === '||') return true;
+  const equalsIdx = trimmed.indexOf('=');
+  if (equalsIdx !== -1) {
+    const key = trimmed.slice(0, equalsIdx).trim().toLowerCase() as SelectorKey;
+    return ALL_KEYS.has(key);
+  }
+  return ALL_KEYS.has(trimmed.toLowerCase() as SelectorKey);
+}
+
+export function splitSelectorFromArgs(args: string[]): { selectorExpression: string; rest: string[] } | null {
+  if (args.length === 0) return null;
+  let i = 0;
+  while (i < args.length && isSelectorToken(args[i])) {
+    i += 1;
+  }
+  if (i === 0) return null;
+  const selectorExpression = args.slice(0, i).join(' ').trim();
+  if (!selectorExpression) return null;
+  return {
+    selectorExpression,
+    rest: args.slice(i),
+  };
+}
+
+export function isNodeVisible(node: SnapshotNode): boolean {
+  if (node.hittable === true) return true;
+  if (!node.rect) return false;
+  return node.rect.width > 0 && node.rect.height > 0;
+}
+
+export function isNodeEditable(node: SnapshotNode, platform: 'ios' | 'android'): boolean {
+  const type = node.type ?? '';
+  return isFillableType(type, platform) && node.enabled !== false;
+}
+
+export function buildSelectorChainForNode(
+  node: SnapshotNode,
+  platform: 'ios' | 'android',
+  options: { action?: 'click' | 'fill' | 'get' } = {},
+): string[] {
+  const chain: string[] = [];
+  const role = normalizeType(node.type ?? '');
+  const id = normalizeSelectorText(node.identifier);
+  const label = normalizeSelectorText(node.label);
+  const value = normalizeSelectorText(node.value);
+  const text = normalizeSelectorText(extractNodeText(node));
+  const requireEditable = options.action === 'fill';
+
+  if (id) {
+    chain.push(`id=${quoteSelectorValue(id)}`);
+  }
+  if (role && label) {
+    chain.push(
+      requireEditable
+        ? `role=${quoteSelectorValue(role)} label=${quoteSelectorValue(label)} editable=true`
+        : `role=${quoteSelectorValue(role)} label=${quoteSelectorValue(label)}`,
+    );
+  }
+  if (label) {
+    chain.push(requireEditable ? `label=${quoteSelectorValue(label)} editable=true` : `label=${quoteSelectorValue(label)}`);
+  }
+  if (value) {
+    chain.push(requireEditable ? `value=${quoteSelectorValue(value)} editable=true` : `value=${quoteSelectorValue(value)}`);
+  }
+  if (text && text !== label && text !== value) {
+    chain.push(requireEditable ? `text=${quoteSelectorValue(text)} editable=true` : `text=${quoteSelectorValue(text)}`);
+  }
+  if (role && requireEditable && !chain.some((entry) => entry.includes('editable=true'))) {
+    chain.push(`role=${quoteSelectorValue(role)} editable=true`);
+  }
+
+  const deduped = uniqueStrings(chain);
+  if (deduped.length === 0 && role) {
+    deduped.push(requireEditable ? `role=${quoteSelectorValue(role)} editable=true` : `role=${quoteSelectorValue(role)}`);
+  }
+  if (deduped.length === 0) {
+    const visible = isNodeVisible(node);
+    if (visible) deduped.push('visible=true');
+  }
+  return deduped;
+}
+
+function parseSelector(segment: string): Selector {
+  const raw = segment.trim();
+  if (!raw) throw new AppError('INVALID_ARGS', 'Selector segment cannot be empty');
+  const tokens = tokenize(raw);
+  if (tokens.length === 0) {
+    throw new AppError('INVALID_ARGS', `Invalid selector segment: ${segment}`);
+  }
+  const terms = tokens.map(parseTerm);
+  return { raw, terms };
+}
+
+function parseTerm(token: string): SelectorTerm {
+  const normalized = token.trim();
+  if (!normalized) {
+    throw new AppError('INVALID_ARGS', 'Empty selector term');
+  }
+  const equalsIdx = normalized.indexOf('=');
+  if (equalsIdx === -1) {
+    const key = normalized.toLowerCase() as SelectorKey;
+    if (!BOOLEAN_KEYS.has(key)) {
+      throw new AppError('INVALID_ARGS', `Invalid selector term "${token}", expected key=value`);
+    }
+    return { key, value: true };
+  }
+  const keyRaw = normalized.slice(0, equalsIdx).trim().toLowerCase() as SelectorKey;
+  const valueRaw = normalized.slice(equalsIdx + 1).trim();
+  if (!ALL_KEYS.has(keyRaw)) {
+    throw new AppError('INVALID_ARGS', `Unknown selector key: ${keyRaw}`);
+  }
+  if (!valueRaw) {
+    throw new AppError('INVALID_ARGS', `Missing selector value for key: ${keyRaw}`);
+  }
+  if (BOOLEAN_KEYS.has(keyRaw)) {
+    const parsedBoolean = parseBoolean(valueRaw);
+    if (parsedBoolean === null) {
+      throw new AppError('INVALID_ARGS', `Invalid boolean value for ${keyRaw}: ${valueRaw}`);
+    }
+    return { key: keyRaw, value: parsedBoolean };
+  }
+  return { key: keyRaw, value: unquote(valueRaw) };
+}
+
+function matchesSelector(node: SnapshotNode, selector: Selector, platform: 'ios' | 'android'): boolean {
+  return selector.terms.every((term) => matchesTerm(node, term, platform));
+}
+
+function matchesTerm(node: SnapshotNode, term: SelectorTerm, platform: 'ios' | 'android'): boolean {
+  switch (term.key) {
+    case 'id':
+      return textEquals(node.identifier, String(term.value));
+    case 'role':
+      return roleEquals(node.type, String(term.value));
+    case 'label':
+      return textEquals(node.label, String(term.value));
+    case 'value':
+      return textEquals(node.value, String(term.value));
+    case 'text': {
+      const query = normalizeText(String(term.value));
+      return normalizeText(extractNodeText(node)) === query;
+    }
+    case 'visible':
+      return isNodeVisible(node) === Boolean(term.value);
+    case 'hidden':
+      return (!isNodeVisible(node)) === Boolean(term.value);
+    case 'editable':
+      return isNodeEditable(node, platform) === Boolean(term.value);
+    case 'selected':
+      return Boolean(node.selected === true) === Boolean(term.value);
+    case 'enabled':
+      return Boolean(node.enabled !== false) === Boolean(term.value);
+    case 'hittable':
+      return Boolean(node.hittable === true) === Boolean(term.value);
+    default:
+      return false;
+  }
+}
+
+function splitByFallback(expression: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < expression.length; i += 1) {
+    const ch = expression[i];
+    if ((ch === '"' || ch === "'") && expression[i - 1] !== '\\') {
+      if (!quote) {
+        quote = ch;
+      } else if (quote === ch) {
+        quote = null;
+      }
+      current += ch;
+      continue;
+    }
+    if (!quote && ch === '|' && expression[i + 1] === '|') {
+      const segment = current.trim();
+      if (!segment) {
+        throw new AppError('INVALID_ARGS', `Invalid selector fallback expression: ${expression}`);
+      }
+      segments.push(segment);
+      current = '';
+      i += 1;
+      continue;
+    }
+    current += ch;
+  }
+  const finalSegment = current.trim();
+  if (!finalSegment) {
+    throw new AppError('INVALID_ARGS', `Invalid selector fallback expression: ${expression}`);
+  }
+  segments.push(finalSegment);
+  return segments;
+}
+
+function tokenize(segment: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < segment.length; i += 1) {
+    const ch = segment[i];
+    if ((ch === '"' || ch === "'") && segment[i - 1] !== '\\') {
+      if (!quote) {
+        quote = ch;
+      } else if (quote === ch) {
+        quote = null;
+      }
+      current += ch;
+      continue;
+    }
+    if (!quote && /\s/.test(ch)) {
+      if (current.trim().length > 0) {
+        tokens.push(current.trim());
+      }
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (quote) {
+    throw new AppError('INVALID_ARGS', `Unclosed quote in selector: ${segment}`);
+  }
+  if (current.trim().length > 0) {
+    tokens.push(current.trim());
+  }
+  return tokens;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1).replace(/\\(["'])/g, '$1');
+  }
+  return trimmed;
+}
+
+function parseBoolean(value: string): boolean | null {
+  const normalized = unquote(value).toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  return null;
+}
+
+function textEquals(value: string | undefined, query: string): boolean {
+  return normalizeText(value ?? '') === normalizeText(query);
+}
+
+function roleEquals(value: string | undefined, query: string): boolean {
+  return normalizeRole(value ?? '') === normalizeRole(query);
+}
+
+function normalizeText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function normalizeRole(value: string): string {
+  return normalizeType(value);
+}
+
+function quoteSelectorValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+function normalizeSelectorText(value: string | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -26,6 +26,7 @@ export type SessionState = {
     outPath: string;
     startedAt: number;
   };
+  recordSession?: boolean;
   actions: SessionAction[];
   recording?: {
     platform: 'ios' | 'android';
@@ -47,8 +48,8 @@ export type SessionAction = {
     snapshotScope?: string;
     snapshotRaw?: boolean;
     snapshotBackend?: 'ax' | 'xctest';
+    saveScript?: boolean;
     noRecord?: boolean;
-    recordJson?: boolean;
   };
   result?: Record<string, unknown>;
 };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -23,6 +23,7 @@ export type ParsedArgs = {
     activity?: string;
     noRecord?: boolean;
     recordJson?: boolean;
+    replayUpdate?: boolean;
     help: boolean;
   };
 };
@@ -63,6 +64,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === '--record-json') {
       flags.recordJson = true;
+      continue;
+    }
+    if (arg === '--update' || arg === '-u') {
+      flags.replayUpdate = true;
       continue;
     }
     if (arg === '--user-installed') {
@@ -180,17 +185,19 @@ Commands:
   back                                      Navigate back (where supported)
   home                                      Go to home screen (where supported)
   app-switcher                              Open app switcher (where supported)
-  wait <ms>|text <text>|@ref [timeoutMs]     Wait for duration or text to appear
+  wait <ms>|text <text>|@ref|<selector> [timeoutMs]
+                                             Wait for duration, text, ref, or selector to appear
   alert [get|accept|dismiss|wait] [timeout] Inspect or handle alert (iOS simulator)
-  click <@ref>                               Click element by snapshot ref
-  get text <@ref>                            Return element text by ref
-  get attrs <@ref>                           Return element attributes by ref
-  replay <path>                              Replay a recorded session
+  click <@ref|selector>                      Click element by snapshot ref or selector
+  get text <@ref|selector>                   Return element text by ref or selector
+  get attrs <@ref|selector>                  Return element attributes by ref or selector
+  replay <path> [--update|-u]                Replay a recorded session
   press <x> <y>                              Tap at coordinates
   long-press <x> <y> [durationMs]            Long press (where supported)
   focus <x> <y>                              Focus input at coordinates
   type <text>                                Type text in focused field
-  fill <x> <y> <text> | fill <@ref> <text>   Tap then type
+  fill <x> <y> <text> | fill <@ref|selector> <text>
+                                             Tap then type
   scroll <direction> [amount]                Scroll in direction (0-1 amount)
   scrollintoview <text>                      Scroll until text appears (Android only)
   screenshot [path]                          Capture screenshot
@@ -204,6 +211,7 @@ Commands:
   find value <value> <action> [value]        Find by value
   find role <role> <action> [value]          Find by role/type
   find id <id> <action> [value]              Find by identifier/resource-id
+  is <predicate> <selector> [value]          Assert UI state (visible|hidden|exists|editable|selected|text)
   settings <wifi|airplane|location> <on|off> Toggle OS settings (simulators)
   session list                               List active sessions
 
@@ -218,6 +226,7 @@ Flags:
   --json                                     JSON output
   --no-record                                Do not record this action
   --record-json                              Record JSON session log
+  --update, -u                               Replay: heal selectors and update replay file in place
   --user-installed                           Apps: list user-installed packages (Android only)
   --all                                      Apps: list all packages (Android only)
 `;

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -21,8 +21,8 @@ export type ParsedArgs = {
     appsFilter?: 'launchable' | 'user-installed' | 'all';
     appsMetadata?: boolean;
     activity?: string;
+    saveScript?: boolean;
     noRecord?: boolean;
-    recordJson?: boolean;
     replayUpdate?: boolean;
     help: boolean;
   };
@@ -62,8 +62,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       flags.noRecord = true;
       continue;
     }
-    if (arg === '--record-json') {
-      flags.recordJson = true;
+    if (arg === '--save-script') {
+      flags.saveScript = true;
       continue;
     }
     if (arg === '--update' || arg === '-u') {
@@ -224,9 +224,9 @@ Flags:
   --session <name>                           Named session
   --verbose                                  Stream daemon/runner logs
   --json                                     JSON output
+  --save-script                             Save session script (.ad) on close
   --no-record                                Do not record this action
-  --record-json                              Record JSON session log
-  --update, -u                               Replay: heal selectors and update replay file in place
+  --update, -u                               Replay: update selectors and rewrite replay file in place
   --user-installed                           Apps: list user-installed packages (Android only)
   --all                                      Apps: list all packages (Android only)
 `;

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -21,6 +21,7 @@ export type RawSnapshotNode = {
   identifier?: string;
   rect?: Rect;
   enabled?: boolean;
+  selected?: boolean;
   hittable?: boolean;
   depth?: number;
   parentIndex?: number;

--- a/website/docs/docs/_meta.json
+++ b/website/docs/docs/_meta.json
@@ -30,6 +30,11 @@
     "label": "Sessions"
   },
   {
+    "name": "replay-e2e",
+    "type": "file",
+    "label": "Replay & E2E (Experimental)"
+  },
+  {
     "name": "snapshots",
     "type": "file",
     "label": "Snapshots"

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -49,6 +49,18 @@ agent-device find label "Email" fill "user@example.com"
 agent-device find role button click
 ```
 
+## Replay
+
+```bash
+agent-device replay ./session.ad      # Run deterministic replay from .ad script
+agent-device replay -u ./session.ad   # Update selector drift and rewrite .ad script in place
+```
+
+- `replay` runs deterministic `.ad` scripts.
+- `replay -u` updates stale recorded actions and rewrites the same script.
+
+See [Replay & E2E (Experimental)](/docs/replay-e2e) for recording and CI workflow details.
+
 ## Settings helpers
 
 ```bash

--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -35,7 +35,7 @@ agent-device screenshot page.png         # Save to specific path
 agent-device close
 ```
 
-## Semantic selectors
+## Semantic discovery
 
 Use `find` for human-readable targeting without refs:
 
@@ -44,6 +44,10 @@ agent-device find "Sign In" click
 agent-device find label "Email" fill "user@example.com"
 agent-device find role button click
 ```
+
+## Replay (experimental)
+
+For deterministic replay scripts and E2E guidance, see [Replay & E2E (Experimental)](/docs/replay-e2e).
 
 ## Scrolling
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -1,0 +1,95 @@
+---
+title: Replay & E2E Testing (Experimental)
+---
+
+# Replay & E2E Testing (Experimental)
+
+Agents use refs for exploration and authoring. Replay scripts are deterministic runs that can be used for E2E testing.
+
+## Core model
+
+Two-pass workflow:
+
+1. Agent pass: discover and interact with refs (`snapshot` -> `click @e..` / `fill @e..`).
+2. Deterministic pass: run recorded `.ad` script with `replay`.
+
+## Record a replay script
+
+Enable recording during a session:
+
+```bash
+agent-device open Settings --platform ios --session e2e --save-script
+agent-device snapshot -i --session e2e
+agent-device click @e13 --session e2e
+agent-device close --session e2e
+```
+
+On `close`, a replay script is written to:
+
+```text
+~/.agent-device/sessions/<session>-<timestamp>.ad
+```
+
+## Run replay
+
+```bash
+agent-device replay ~/.agent-device/sessions/e2e-2026-02-09T12-00-00-000Z.ad --session e2e-run
+```
+
+- Replay reads `.ad` scripts.
+
+## Update stale selectors in replay scripts
+
+```bash
+agent-device replay -u ~/.agent-device/sessions/e2e-2026-02-09T12-00-00-000Z.ad --session e2e-run
+```
+
+When a replay step fails, update can:
+
+- Take a fresh snapshot.
+- Resolve a stable replacement target.
+- Retry the step.
+- Rewrite the failing line in the same `.ad` file.
+
+Current update targets:
+
+- `click`
+- `fill`
+- `get`
+- `is`
+- `wait`
+
+## `replay -u` before/after examples
+
+Example 1: stale selector rewritten in place
+
+```sh
+# Before
+click "id=\"old_continue\" || label=\"Continue\""
+
+# After `replay -u`
+click "id=\"auth_continue\" || label=\"Continue\""
+```
+
+Example 2: stale ref-based action upgraded to selector form
+
+```sh
+# Before
+snapshot -i -c -s "Continue"
+click @e13 "Continue"
+
+# After `replay -u`
+snapshot -i -c -s "Continue"
+click "id=\"auth_continue\" || label=\"Continue\""
+```
+
+Use `replay -u` locally during maintenance, review the rewritten `.ad` lines, then commit the updated script.
+
+## Troubleshooting
+
+- Replay fails after UI/layout changes:
+  - Run `replay -u` locally and review the rewritten lines.
+- Updating cannot resolve a unique target:
+  - Re-record that flow (`--save-script`) from a fresh exploratory pass.
+- Replay file parse error:
+  - Validate quoting in `.ad` lines (unclosed quotes are rejected).

--- a/website/docs/docs/sessions.md
+++ b/website/docs/docs/sessions.md
@@ -25,3 +25,5 @@ Notes:
 
 - `open <app>` within an existing session switches the active app and updates the session bundle id.
 - Use `--session <name>` to run multiple sessions in parallel.
+
+For replay scripts and deterministic E2E guidance, see [Replay & E2E (Experimental)](/docs/replay-e2e).


### PR DESCRIPTION
## Summary
Adds deterministic replay-first E2E workflows while keeping refs as the default agent interaction model.

## What changed
- Added selector DSL support for deterministic targeting and fallback chains.
- Added `is` command predicates: `visible|hidden|exists|editable|selected|text`.
- Added initial approach to deterministic E2E tests with replay updating via `replay -u` / `replay --update`:
  - On failure: re-snapshot, resolve updated target, retry, rewrite failing `.ad` line in place.
  - Targets: `click`, `fill`, `get`, `is`, `wait`.
- Switched replay to `.ad`-only input (JSON replay payloads rejected).
- Made session script capture explicit with `--save-script` (not automatic).
- Kept refs as the primary workflow for agent exploration; replay/update is the deterministic maintenance path.

Added relevant tests and docs.