### PR TITLE
fix: iOS snapshot not showing password fields

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -33,6 +33,7 @@ final class RunnerTests: XCTestCase {
     .switch,
     .tabBar,
     .textField,
+    .secureTextField,
     .textView,
   ]
 


### PR DESCRIPTION
Fixes #28 