### PR TITLE
fix: support TouchableOpacity as [other] on iOS when has content

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -704,7 +704,7 @@ final class RunnerTests: XCTestCase {
     if options.interactiveOnly {
       if interactiveTypes.contains(type) { return true }
       if element.isHittable && type != .other { return true }
-      if hasContent && type != .other { return true }
+      if hasContent { return true }
       return false
     }
     if options.compact {
@@ -728,7 +728,7 @@ final class RunnerTests: XCTestCase {
     if options.interactiveOnly {
       if interactiveTypes.contains(type) { return true }
       if snapshotHittable(snapshot) && type != .other { return true }
-      if hasContent && type != .other { return true }
+      if hasContent { return true }
       return false
     }
     if options.compact {

--- a/test/integration/ios.test.ts
+++ b/test/integration/ios.test.ts
@@ -29,7 +29,7 @@ test('ios settings commands', { skip: shouldSkipIos() }, async () => {
     formatResultDebug('snapshot nodes', snapshotArgs, snapshot),
   );
 
-  const clickArgs = ['click', '@e13', '--json', ...session];
+  const clickArgs = ['click', '@e15', '--json', ...session];
   const click = runCliJson(clickArgs);
   assert.equal(click.status, 0, formatResultDebug('click @e13', clickArgs, click));
 


### PR DESCRIPTION
Fixes `TouchableOpacity` from React Native not being visible in iOS snapshots.

Example:
```sh
@e1 [application] "Rock83Brownfield"
@e2 [window]
@e3 [other] "Hello World"
@e4 [text] "Hello World"
@e5 [button] "Click me"
@e6 [other] "TouchableOpacity"  # this is now shown
```

This means that the snapshots show more data, which is a breaking change in the output and will require updating tests (if created)

Fixes #30 

Tested locally as CI tests are timing out.