### PR TITLE
Improve integration failure diagnostics in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -54,4 +54,5 @@ jobs:
           path: |
             ${{ steps.android-agent-home.outputs.dir }}/daemon.log
             ${{ steps.android-agent-home.outputs.dir }}/sessions/**
+            test/artifacts/**
             test/screenshots/**

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -98,4 +98,5 @@ jobs:
           path: |
             ${{ steps.ios-agent-home.outputs.dir }}/daemon.log
             ${{ steps.ios-agent-home.outputs.dir }}/sessions/**
+            test/artifacts/**
             test/screenshots/**

--- a/test/integration/ios.test.ts
+++ b/test/integration/ios.test.ts
@@ -1,8 +1,7 @@
 import test from 'node:test';
-import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { formatResultDebug, runCliJson } from './test-helpers.ts';
+import { createIntegrationTestContext, runCliJson } from './test-helpers.ts';
 
 const session = ['--session', 'ios-test'];
 
@@ -11,53 +10,60 @@ test.after(() => {
 });
 
 test('ios settings commands', { skip: shouldSkipIos() }, async () => {
+  const integration = createIntegrationTestContext({
+    platform: 'ios',
+    testName: 'ios settings commands',
+  });
   const openArgs = ['open', 'com.apple.Preferences', '--platform', 'ios', '--json', ...session];
-  const open = runCliJson(openArgs);
-  assert.equal(open.status, 0, formatResultDebug('open settings', openArgs, open));
+  integration.runStep('open settings', openArgs);
 
   const outPath = path.resolve('test/screenshots/ios-settings.png');
   const shotArgs = ['screenshot', outPath, '--platform', 'ios', '--json', ...session];
-  const shot = runCliJson(shotArgs);
-  assert.equal(shot.status, 0, formatResultDebug('screenshot settings', shotArgs, shot));
-  assert.ok(existsSync(outPath), formatResultDebug('screenshot file missing', shotArgs, shot));
+  const shot = integration.runStep('screenshot settings', shotArgs);
+  integration.assertResult(existsSync(outPath), 'screenshot file missing', shotArgs, shot, {
+    detail: `expected screenshot file at ${outPath}`,
+  });
 
   const snapshotArgs = ['snapshot', '-i', '--json', ...session];
-  const snapshot = runCliJson(snapshotArgs);
-  assert.equal(snapshot.status, 0, formatResultDebug('snapshot', snapshotArgs, snapshot));
-  assert.ok(
-    Array.isArray(snapshot.json?.data?.nodes),
-    formatResultDebug('snapshot nodes', snapshotArgs, snapshot),
-  );
+  const snapshot = integration.runStep('snapshot', snapshotArgs);
+  integration.assertResult(Array.isArray(snapshot.json?.data?.nodes), 'snapshot nodes', snapshotArgs, snapshot, {
+    detail: 'expected snapshot to include a nodes array',
+  });
 
   const clickArgs = ['click', '@e21', '--json', ...session];
-  const click = runCliJson(clickArgs);
-  assert.equal(click.status, 0, formatResultDebug('click @e13', clickArgs, click));
+  integration.runStep('click @e21', clickArgs);
 
-  const snapshotGeneral = runCliJson(['snapshot', '--json', ...session]);
+  const snapshotGeneralArgs = ['snapshot', '--json', ...session];
+  const snapshotGeneral = integration.runStep('snapshot general', snapshotGeneralArgs);
   const generalDescription = 'Manage your overall setup and preferences';
   const generalNodes = Array.isArray(snapshotGeneral.json?.data?.nodes)
     ? snapshotGeneral.json.data.nodes
     : [];
-  assert.ok(
+  integration.assertResult(
     generalNodes.some(
       (node: { label?: string }) =>
         typeof node?.label === 'string' && node.label.includes(generalDescription),
     ),
-    formatResultDebug('snapshot shows general page description', snapshotArgs, snapshotGeneral),
+    'snapshot shows general page description',
+    snapshotGeneralArgs,
+    snapshotGeneral,
+    {
+      detail: `expected a node label containing ${JSON.stringify(generalDescription)}`,
+    },
   );
 
   const findTextArgs = ['find', 'text', generalDescription, 'exists', '--json', ...session];
-  const findText = runCliJson(findTextArgs);
-  assert.equal(findText.status, 0, formatResultDebug('find text', findTextArgs, findText));
-  assert.equal(
+  const findText = integration.runStep('find text', findTextArgs);
+  integration.assertResult(
     findText.json?.success,
-    true,
-    formatResultDebug('find text success', findTextArgs, findText),
+    'find text success',
+    findTextArgs,
+    findText,
+    { detail: 'expected find command to return success=true' },
   );
 
-  const backArgs = ['back', ...session];
-  const back = runCliJson(backArgs);
-  assert.equal(back.status, 0, formatResultDebug('back', backArgs, back));
+  const backArgs = ['back', '--json', ...session];
+  integration.runStep('back', backArgs);
 });
 
 function shouldSkipIos(): boolean {

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -1,3 +1,6 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { runCmdSync } from '../../src/utils/exec.ts';
 
 export type CliJsonResult = {
@@ -5,6 +8,33 @@ export type CliJsonResult = {
   json?: any;
   stdout: string;
   stderr: string;
+};
+
+type IntegrationPlatform = 'ios' | 'android';
+
+type StepRecord = {
+  step: string;
+  command: string;
+  status: number;
+  timestamp: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+type LastSnapshotState = {
+  capturedAt: string;
+  command: string;
+  nodes: any[];
+  rawJson: any;
+};
+
+type IntegrationTestContextOptions = {
+  platform: IntegrationPlatform;
+  testName: string;
+};
+
+type AssertResultOptions = {
+  detail?: string;
 };
 
 export function runCliJson(args: string[]): CliJsonResult {
@@ -41,4 +71,188 @@ export function formatResultDebug(step: string, args: string[], result: CliJsonR
     `json:`,
     jsonText,
   ].join('\n');
+}
+
+export function createIntegrationTestContext(options: IntegrationTestContextOptions) {
+  const { platform, testName } = options;
+  const stepHistory: StepRecord[] = [];
+  let lastSnapshot: LastSnapshotState | null = null;
+  let artifactDir: string | null = null;
+
+  function runStep(step: string, args: string[], expectedStatus = 0): CliJsonResult {
+    const result = runCliJson(args);
+    const errorCode =
+      typeof result.json?.error?.code === 'string' ? (result.json.error.code as string) : undefined;
+    const errorMessage =
+      typeof result.json?.error?.message === 'string' ? (result.json.error.message as string) : undefined;
+    stepHistory.push({
+      step,
+      command: `agent-device ${args.join(' ')}`,
+      status: result.status,
+      timestamp: new Date().toISOString(),
+      errorCode,
+      errorMessage,
+    });
+    maybeCaptureSnapshot(args, result);
+    if (result.status !== expectedStatus) {
+      failWithContext(step, args, result);
+    }
+    return result;
+  }
+
+  function assertResult(
+    condition: unknown,
+    step: string,
+    args: string[],
+    result: CliJsonResult,
+    opts?: AssertResultOptions,
+  ): void {
+    if (condition) {
+      return;
+    }
+    failWithContext(step, args, result, opts?.detail ?? 'assertion failed');
+  }
+
+  function failWithContext(
+    step: string,
+    args: string[],
+    result: CliJsonResult,
+    assertionDetail?: string,
+  ): never {
+    const message = buildFailureDebug(step, args, result, assertionDetail);
+    writeFailureArtifacts(step, args, result, message, assertionDetail);
+    assert.fail(message);
+  }
+
+  function maybeCaptureSnapshot(args: string[], result: CliJsonResult): void {
+    if (args[0] !== 'snapshot' || result.status !== 0) {
+      return;
+    }
+    const nodes = Array.isArray(result.json?.data?.nodes) ? result.json.data.nodes : null;
+    if (!nodes) {
+      return;
+    }
+    lastSnapshot = {
+      capturedAt: new Date().toISOString(),
+      command: `agent-device ${args.join(' ')}`,
+      nodes,
+      rawJson: result.json,
+    };
+  }
+
+  function buildFailureDebug(
+    step: string,
+    args: string[],
+    result: CliJsonResult,
+    assertionDetail?: string,
+  ): string {
+    const lines: string[] = [formatResultDebug(step, args, result)];
+    if (assertionDetail) {
+      lines.push('assertion:', assertionDetail);
+    }
+    lines.push('last snapshot context:', formatLastSnapshotContext(args));
+    lines.push('recent step history:', formatStepHistory());
+    lines.push('artifacts:', ensureArtifactDir());
+    return lines.join('\n');
+  }
+
+  function formatLastSnapshotContext(args: string[]): string {
+    if (!lastSnapshot) {
+      return '(none)';
+    }
+    const snapshotLines = [
+      `capturedAt: ${lastSnapshot.capturedAt}`,
+      `command: ${lastSnapshot.command}`,
+      `nodes: ${lastSnapshot.nodes.length}`,
+    ];
+    const refArg = args.find((arg) => arg.startsWith('@'));
+    if (refArg) {
+      const normalized = normalizeRef(refArg);
+      const refNode = lastSnapshot.nodes.find((node) => normalizeRef(String(node?.ref ?? '')) === normalized);
+      snapshotLines.push(
+        `targetRef: ${refArg}`,
+        refNode ? `targetRefInSnapshot: yes (${summarizeNode(refNode)})` : 'targetRefInSnapshot: no',
+      );
+    }
+    const preview = lastSnapshot.nodes.slice(0, 12).map((node, i) => `${i + 1}. ${summarizeNode(node)}`);
+    snapshotLines.push('nodePreview:', preview.length > 0 ? preview.join('\n') : '(empty)');
+    return snapshotLines.join('\n');
+  }
+
+  function formatStepHistory(): string {
+    const recent = stepHistory.slice(-8);
+    if (recent.length === 0) {
+      return '(empty)';
+    }
+    return recent
+      .map((stepRecord) => {
+        const error =
+          stepRecord.errorCode || stepRecord.errorMessage
+            ? ` error=${stepRecord.errorCode ?? ''}${stepRecord.errorMessage ? `:${stepRecord.errorMessage}` : ''}`
+            : '';
+        return `${stepRecord.timestamp} status=${stepRecord.status}${error} ${stepRecord.step} :: ${stepRecord.command}`;
+      })
+      .join('\n');
+  }
+
+  function ensureArtifactDir(): string {
+    if (artifactDir) {
+      return artifactDir;
+    }
+    const runId = new Date().toISOString().replaceAll(':', '-');
+    const safeTestName = sanitizeSegment(testName);
+    artifactDir = path.resolve('test/artifacts', platform, safeTestName, runId);
+    mkdirSync(artifactDir, { recursive: true });
+    return artifactDir;
+  }
+
+  function writeFailureArtifacts(
+    step: string,
+    args: string[],
+    result: CliJsonResult,
+    message: string,
+    assertionDetail?: string,
+  ): void {
+    const dir = ensureArtifactDir();
+    writeFileSync(path.join(dir, 'failed-step.txt'), message);
+    writeFileSync(
+      path.join(dir, 'failed-step.json'),
+      JSON.stringify(
+        {
+          step,
+          command: `agent-device ${args.join(' ')}`,
+          assertionDetail,
+          result,
+          occurredAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(path.join(dir, 'step-history.json'), JSON.stringify(stepHistory, null, 2));
+    if (lastSnapshot) {
+      writeFileSync(path.join(dir, 'last-snapshot.json'), JSON.stringify(lastSnapshot.rawJson, null, 2));
+    }
+  }
+
+  return {
+    runStep,
+    assertResult,
+  };
+}
+
+function sanitizeSegment(input: string): string {
+  return input.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/-+/g, '-');
+}
+
+function normalizeRef(ref: string): string {
+  return ref.trim().toLowerCase();
+}
+
+function summarizeNode(node: any): string {
+  const ref = typeof node?.ref === 'string' ? node.ref : '(no-ref)';
+  const type = typeof node?.type === 'string' ? node.type : '(no-type)';
+  const label = typeof node?.label === 'string' && node.label.length > 0 ? node.label : '(no-label)';
+  const rect = node?.rect ? JSON.stringify(node.rect) : '(no-bounds)';
+  return `${ref} type=${type} label=${JSON.stringify(label)} rect=${rect}`;
 }


### PR DESCRIPTION
## Summary
- add a shared integration test context that records step history and captures last successful snapshot
- include rich failure output (last snapshot context, target ref presence, recent step history)
- write failure artifacts under test/artifacts/<platform>/<test-name>/<timestamp>/
- migrate Android and iOS integration tests to the shared step runner
- upload test/artifacts/** in Android and iOS workflow artifacts

## Reviewer follow-up fixes
- instantiate integration context inside each test to avoid cross-test state leakage
- fix iOS click step label to match the actual command (@e21)