### PR TITLE
Improve Android open fallback, find ambiguity handling, and replay diagnostics

### DIFF
--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -225,6 +225,11 @@ test('replay without --update does not heal or rewrite', async () => {
 
   assert.ok(response);
   assert.equal(response.ok, false);
+  if (!response.ok) {
+    assert.match(response.error.message, /Replay failed at step 1/);
+    assert.equal(response.error.details?.step, 1);
+    assert.equal(response.error.details?.action, 'click');
+  }
   assert.equal(snapshotDispatchCalls, 0);
   assert.equal(fs.readFileSync(replayPath, 'utf8'), originalPayload);
 });

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { parseAndroidLaunchComponent } from '../index.ts';
 import { findBounds, parseUiHierarchy } from '../ui-hierarchy.ts';
 
 test('parseUiHierarchy reads double-quoted Android node attributes', () => {
@@ -71,4 +72,20 @@ test('findBounds ignores bounds-like fragments inside other attribute values', (
   ].join('');
 
   assert.deepEqual(findBounds(xml, 'target'), { x: 200, y: 350 });
+});
+
+test('parseAndroidLaunchComponent extracts final resolved component', () => {
+  const stdout = [
+    'priority=0 preferredOrder=0 match=0x108000 specificIndex=-1 isDefault=true',
+    'com.boatsgroup.boattrader/com.boatsgroup.boattrader.MainActivity',
+  ].join('\n');
+  assert.equal(
+    parseAndroidLaunchComponent(stdout),
+    'com.boatsgroup.boattrader/com.boatsgroup.boattrader.MainActivity',
+  );
+});
+
+test('parseAndroidLaunchComponent returns null when no component is present', () => {
+  const stdout = 'No activity found';
+  assert.equal(parseAndroidLaunchComponent(stdout), null);
 });

--- a/src/utils/__tests__/finders.test.ts
+++ b/src/utils/__tests__/finders.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { findBestMatchesByLocator, findNodeByLocator } from '../finders.ts';
+import type { SnapshotNode } from '../snapshot.ts';
+
+function makeNode(ref: string, label?: string, identifier?: string): SnapshotNode {
+  return {
+    index: Number(ref.replace('e', '')) || 0,
+    ref,
+    type: 'android.widget.TextView',
+    label,
+    identifier,
+    rect: { x: 0, y: 0, width: 100, height: 20 },
+  };
+}
+
+test('findBestMatchesByLocator returns all best-scored matches', () => {
+  const nodes: SnapshotNode[] = [
+    makeNode('e1', 'Continue'),
+    makeNode('e2', 'Continue'),
+    makeNode('e3', 'Continue later'),
+  ];
+  const result = findBestMatchesByLocator(nodes, 'label', 'Continue', { requireRect: true });
+  assert.equal(result.score, 2);
+  assert.equal(result.matches.length, 2);
+  assert.equal(result.matches[0]?.ref, 'e1');
+  assert.equal(result.matches[1]?.ref, 'e2');
+});
+
+test('findNodeByLocator preserves first best match behavior', () => {
+  const nodes: SnapshotNode[] = [makeNode('e1', 'Continue'), makeNode('e2', 'Continue')];
+  const match = findNodeByLocator(nodes, 'label', 'Continue', { requireRect: true });
+  assert.equal(match?.ref, 'e1');
+});

--- a/test/integration/ios.test.ts
+++ b/test/integration/ios.test.ts
@@ -30,14 +30,14 @@ test('ios settings commands', { skip: shouldSkipIos() }, async () => {
     detail: 'expected snapshot to include a nodes array',
   });
 
-  const openGeneralArgs = ['find', 'text', 'General', 'click', '--json', ...session];
+  const openGeneralArgs = ['click', 'role=cell', 'label=General', '--json', ...session];
   const openGeneral = integration.runStep('open general', openGeneralArgs);
   integration.assertResult(
     openGeneral.json?.success,
     'open general success',
     openGeneralArgs,
     openGeneral,
-    { detail: 'expected find General click to return success=true' },
+    { detail: 'expected click role=cell label=General to return success=true' },
   );
 
   const snapshotGeneralArgs = ['snapshot', '--json', ...session];


### PR DESCRIPTION
Summary:
- add Android open fallback from package launcher intent to explicit resolved component when needed
- make interactive find actions fail with AMBIGUOUS_MATCH when multiple top matches exist, including candidate refs/details
- improve replay failures with step/action/path context to make failures actionable