### PR TITLE
fix: harden iOS runner snapshot retry and modal probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ agent-device press 300 500 --count 12 --interval-ms 45
 agent-device press 300 500 --count 6 --hold-ms 120 --interval-ms 30 --jitter-px 2
 agent-device press @e5 --count 5 --double-tap
 agent-device swipe 540 1500 540 500 120 --count 8 --pause-ms 30 --pattern ping-pong
+agent-device scrollintoview "Sign in"
+agent-device scrollintoview @e42
 ```
 
 ## Command Index
@@ -180,6 +182,7 @@ Swipe timing:
 - `swipe` accepts optional `durationMs` (default `250`, range `16..10000`).
 - Android uses requested swipe duration directly.
 - iOS uses a safe normalized duration to avoid longpress side effects.
+- `scrollintoview` accepts either plain text or a snapshot ref (`@eN`); ref mode uses geometry-based scrolling.
 
 ## Skills
 Install the automation skills listed in [SKILL.md](skills/agent-device/SKILL.md).

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -33,6 +33,7 @@ final class RunnerTests: XCTestCase {
   private let maxSnapshotElements = 600
   private let fastSnapshotLimit = 300
   private let mainThreadExecutionTimeout: TimeInterval = 30
+  private let appExistenceTimeout: TimeInterval = 30
   private let retryCooldown: TimeInterval = 0.2
   private let postSnapshotInteractionDelay: TimeInterval = 0.2
   private let firstInteractionAfterActivateDelay: TimeInterval = 0.25
@@ -327,10 +328,10 @@ final class RunnerTests: XCTestCase {
       activeApp = app
     }
 
-    if !activeApp.waitForExistence(timeout: 5) {
+    if !activeApp.waitForExistence(timeout: appExistenceTimeout) {
       if let bundleId = requestedBundleId {
         activeApp = activateTarget(bundleId: bundleId, reason: "missing_after_wait")
-        guard activeApp.waitForExistence(timeout: 5) else {
+        guard activeApp.waitForExistence(timeout: appExistenceTimeout) else {
           return Response(ok: false, error: ErrorPayload(message: "app '\(bundleId)' is not available"))
         }
       } else {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -1044,7 +1044,7 @@ final class RunnerTests: XCTestCase {
       if disableSafeProbe {
         return fetch()
       }
-      return safeElementsQuery(fetch)
+      return self.safeElementsQuery(fetch)
     }
 
     let alerts = queryElements {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -77,6 +77,7 @@ export async function dispatchCommand(
   positionals: string[],
   outPath?: string,
   context?: {
+    requestId?: string;
     appBundleId?: string;
     activity?: string;
     verbose?: boolean;
@@ -97,6 +98,7 @@ export async function dispatchCommand(
   },
 ): Promise<Record<string, unknown> | void> {
   const runnerCtx: RunnerContext = {
+    requestId: context?.requestId,
     appBundleId: context?.appBundleId,
     verbose: context?.verbose,
     logPath: context?.logPath,

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -184,7 +184,12 @@ export async function dispatchCommand(
             doubleTap,
             appBundleId: context?.appBundleId,
           },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { x, y, count, intervalMs, holdMs, jitterPx, doubleTap, timingMode: 'runner-series' };
       }
@@ -237,7 +242,12 @@ export async function dispatchCommand(
             pattern,
             appBundleId: context?.appBundleId,
           },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return {
           x1,
@@ -334,7 +344,12 @@ export async function dispatchCommand(
       await runIosRunnerCommand(
         device,
         { command: 'pinch', scale, x, y, appBundleId: context?.appBundleId },
-        { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+        {
+          verbose: context?.verbose,
+          logPath: context?.logPath,
+          traceLogPath: context?.traceLogPath,
+          requestId: context?.requestId,
+        },
       );
       return { scale, x, y };
     }
@@ -350,7 +365,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'back', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'back' };
       }
@@ -362,7 +382,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'home', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'home' };
       }
@@ -374,7 +399,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'appSwitcher', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'app-switcher' };
       }
@@ -415,7 +445,12 @@ export async function dispatchCommand(
                 scope: context?.snapshotScope,
                 raw: context?.snapshotRaw,
               },
-              { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+              {
+                verbose: context?.verbose,
+                logPath: context?.logPath,
+                traceLogPath: context?.traceLogPath,
+                requestId: context?.requestId,
+              },
             ),
           {
             backend: 'xctest',

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,7 +7,7 @@ import { dispatchCommand, type CommandFlags } from './core/dispatch.ts';
 import { isCommandSupportedOnDevice } from './core/capabilities.ts';
 import { asAppError, AppError, normalizeError } from './utils/errors.ts';
 import { readVersion } from './utils/version.ts';
-import { stopAllIosRunnerSessions } from './platforms/ios/runner-client.ts';
+import { abortAllIosRunnerSessions, stopAllIosRunnerSessions } from './platforms/ios/runner-client.ts';
 import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
 import { SessionStore } from './daemon/session-store.ts';
 import { contextFromFlags as contextFromFlagsWithLog, type DaemonCommandContext } from './daemon/context.ts';
@@ -305,8 +305,8 @@ function start(): void {
         },
       });
       // Best effort: if client disconnects mid-request (for example on Ctrl+C),
-      // stop runner sessions so xcodebuild/log streaming does not continue detached.
-      void stopAllIosRunnerSessions();
+      // immediately abort runner sessions so xcodebuild/log streaming stops fast.
+      void abortAllIosRunnerSessions();
     };
     socket.setEncoding('utf8');
     socket.on('close', cancelInFlightRunnerSessions);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -329,7 +329,7 @@ function start(): void {
         } catch (err) {
           response = { ok: false, error: normalizeError(err) };
         } finally {
-          inFlightRequests = Math.max(0, inFlightRequests - 1);
+          inFlightRequests -= 1;
         }
         if (!socket.destroyed) {
           socket.write(`${JSON.stringify(response)}\n`);

--- a/src/daemon/__tests__/scroll-planner.test.ts
+++ b/src/daemon/__tests__/scroll-planner.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { type RawSnapshotNode } from '../../utils/snapshot.ts';
+import {
+  buildScrollIntoViewPlan,
+  isRectWithinSafeViewportBand,
+  resolveViewportRect,
+} from '../scroll-planner.ts';
+
+function makeNode(index: number, type: string, rect?: RawSnapshotNode['rect']): RawSnapshotNode {
+  return { index, type, rect };
+}
+
+test('resolveViewportRect picks containing application/window viewport', () => {
+  const targetRect = { x: 20, y: 1700, width: 120, height: 40 };
+  const nodes: RawSnapshotNode[] = [
+    makeNode(0, 'Application', { x: 0, y: 0, width: 390, height: 844 }),
+    makeNode(1, 'Window', { x: 0, y: 0, width: 390, height: 844 }),
+    makeNode(2, 'Cell', targetRect),
+  ];
+  const viewport = resolveViewportRect(nodes, targetRect);
+  assert.deepEqual(viewport, { x: 0, y: 0, width: 390, height: 844 });
+});
+
+test('resolveViewportRect returns null when no valid viewport can be inferred', () => {
+  const targetRect = { x: 20, y: 100, width: 120, height: 40 };
+  const nodes: RawSnapshotNode[] = [makeNode(0, 'Cell', undefined)];
+  const viewport = resolveViewportRect(nodes, targetRect);
+  assert.equal(viewport, null);
+});
+
+test('buildScrollIntoViewPlan computes downward content scroll when target is below safe band', () => {
+  const targetRect = { x: 20, y: 2100, width: 120, height: 40 };
+  const viewportRect = { x: 0, y: 0, width: 390, height: 844 };
+  const plan = buildScrollIntoViewPlan(targetRect, viewportRect);
+  assert.ok(plan);
+  assert.equal(plan?.direction, 'down');
+  assert.ok((plan?.count ?? 0) > 1);
+});
+
+test('buildScrollIntoViewPlan returns null when already in safe viewport band', () => {
+  const targetRect = { x: 20, y: 320, width: 120, height: 40 };
+  const viewportRect = { x: 0, y: 0, width: 390, height: 844 };
+  const plan = buildScrollIntoViewPlan(targetRect, viewportRect);
+  assert.equal(plan, null);
+  assert.equal(isRectWithinSafeViewportBand(targetRect, viewportRect), true);
+});

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,4 +1,5 @@
 import type { CommandFlags } from '../core/dispatch.ts';
+import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
 
 export type DaemonCommandContext = {
   requestId?: string;
@@ -28,8 +29,9 @@ export function contextFromFlags(
   traceLogPath?: string,
   requestId?: string,
 ): DaemonCommandContext {
+  const effectiveRequestId = requestId ?? getDiagnosticsMeta().requestId;
   return {
-    requestId,
+    requestId: effectiveRequestId,
     appBundleId,
     activity: flags?.activity,
     verbose: flags?.verbose,

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,6 +1,7 @@
 import type { CommandFlags } from '../core/dispatch.ts';
 
 export type DaemonCommandContext = {
+  requestId?: string;
   appBundleId?: string;
   activity?: string;
   verbose?: boolean;
@@ -25,8 +26,10 @@ export function contextFromFlags(
   flags: CommandFlags | undefined,
   appBundleId?: string,
   traceLogPath?: string,
+  requestId?: string,
 ): DaemonCommandContext {
   return {
+    requestId,
     appBundleId,
     activity: flags?.activity,
     verbose: flags?.verbose,

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -185,3 +185,117 @@ test('press coordinates does not treat extra trailing args as selector', async (
   assert.deepEqual(dispatchCalls[0]?.positionals, ['100', '200']);
   assert.equal(sessionStore.get(sessionName)?.actions.length, 1);
 });
+
+test('scrollintoview @ref dispatches geometry-based swipe series', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'default';
+  const session = makeSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+      },
+      {
+        index: 1,
+        type: 'XCUIElementTypeStaticText',
+        label: 'Far item',
+        rect: { x: 20, y: 2600, width: 120, height: 40 },
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  sessionStore.set(sessionName, session);
+
+  const dispatchCalls: Array<{
+    command: string;
+    positionals: string[];
+    context: Record<string, unknown> | undefined;
+  }> = [];
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'scrollintoview',
+      positionals: ['@e2'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+    dispatch: async (_device, command, positionals, _out, context) => {
+      dispatchCalls.push({ command, positionals, context: context as Record<string, unknown> | undefined });
+      return { ok: true };
+    },
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, true);
+  assert.equal(dispatchCalls.length, 1);
+  assert.equal(dispatchCalls[0]?.command, 'swipe');
+  assert.equal(dispatchCalls[0]?.positionals.length, 5);
+  assert.equal(dispatchCalls[0]?.context?.pattern, 'one-way');
+  assert.equal(dispatchCalls[0]?.context?.pauseMs, 0);
+  assert.equal(typeof dispatchCalls[0]?.context?.count, 'number');
+  assert.ok((dispatchCalls[0]?.context?.count as number) > 1);
+
+  const stored = sessionStore.get(sessionName);
+  assert.ok(stored);
+  assert.equal(stored?.actions.length, 1);
+  assert.equal(stored?.actions[0]?.command, 'scrollintoview');
+  const result = (stored?.actions[0]?.result ?? {}) as Record<string, unknown>;
+  assert.equal(result.ref, 'e2');
+  assert.equal(result.strategy, 'ref-geometry');
+});
+
+test('scrollintoview @ref returns immediately when target is already in viewport safe band', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'default';
+  const session = makeSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+      },
+      {
+        index: 1,
+        type: 'XCUIElementTypeStaticText',
+        label: 'Visible item',
+        rect: { x: 20, y: 320, width: 120, height: 40 },
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  sessionStore.set(sessionName, session);
+
+  const dispatchCalls: Array<{ command: string }> = [];
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'scrollintoview',
+      positionals: ['@e2'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+    dispatch: async (_device, command) => {
+      dispatchCalls.push({ command });
+      return { ok: true };
+    },
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, true);
+  assert.equal(dispatchCalls.length, 0);
+  if (response.ok) {
+    assert.equal(response.data?.attempts, 0);
+    assert.equal(response.data?.alreadyVisible, true);
+  }
+});

--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -234,7 +234,12 @@ export async function handleSnapshotCommands(params: {
           const result = (await runIosRunnerCommand(
             device,
             { command: 'findText', text, appBundleId: session?.appBundleId },
-            { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+            {
+              verbose: req.flags?.verbose,
+              logPath,
+              traceLogPath: session?.trace?.outPath,
+              requestId: req.meta?.requestId,
+            },
           )) as { found?: boolean };
           if (result?.found) {
             recordIfSession(sessionStore, session, req, { text, waitedMs: Date.now() - start });
@@ -277,7 +282,12 @@ export async function handleSnapshotCommands(params: {
             const data = await runIosRunnerCommand(
               device,
               { command: 'alert', action: 'get', appBundleId: session?.appBundleId },
-              { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+              {
+                verbose: req.flags?.verbose,
+                logPath,
+                traceLogPath: session?.trace?.outPath,
+                requestId: req.meta?.requestId,
+              },
             );
             recordIfSession(sessionStore, session, req, data as Record<string, unknown>);
             return { ok: true, data };
@@ -296,7 +306,12 @@ export async function handleSnapshotCommands(params: {
             action === 'accept' || action === 'dismiss' ? (action as 'accept' | 'dismiss') : 'get',
           appBundleId: session?.appBundleId,
         },
-        { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+        {
+          verbose: req.flags?.verbose,
+          logPath,
+          traceLogPath: session?.trace?.outPath,
+          requestId: req.meta?.requestId,
+        },
       );
       recordIfSession(sessionStore, session, req, data as Record<string, unknown>);
       return { ok: true, data };

--- a/src/daemon/request-cancel.ts
+++ b/src/daemon/request-cancel.ts
@@ -1,0 +1,16 @@
+const canceledRequestIds = new Set<string>();
+
+export function markRequestCanceled(requestId: string | undefined): void {
+  if (!requestId) return;
+  canceledRequestIds.add(requestId);
+}
+
+export function clearRequestCanceled(requestId: string | undefined): void {
+  if (!requestId) return;
+  canceledRequestIds.delete(requestId);
+}
+
+export function isRequestCanceled(requestId: string | undefined): boolean {
+  if (!requestId) return false;
+  return canceledRequestIds.has(requestId);
+}

--- a/src/daemon/scroll-planner.ts
+++ b/src/daemon/scroll-planner.ts
@@ -1,0 +1,113 @@
+import { centerOfRect, type RawSnapshotNode, type Rect } from '../utils/snapshot.ts';
+
+export type ScrollIntoViewPlan = {
+  x: number;
+  startY: number;
+  endY: number;
+  count: number;
+  direction: 'up' | 'down';
+};
+
+export function resolveViewportRect(nodes: RawSnapshotNode[], targetRect: Rect): Rect | null {
+  const targetCenter = centerOfRect(targetRect);
+  const rectNodes = nodes.filter((node) => hasValidRect(node.rect));
+  const viewportNodes = rectNodes.filter((node) => {
+    const type = (node.type ?? '').toLowerCase();
+    return type.includes('application') || type.includes('window');
+  });
+
+  const containingViewport = pickLargestRect(
+    viewportNodes
+      .map((node) => node.rect as Rect)
+      .filter((rect) => containsPoint(rect, targetCenter.x, targetCenter.y)),
+  );
+  if (containingViewport) return containingViewport;
+
+  const viewportFallback = pickLargestRect(viewportNodes.map((node) => node.rect as Rect));
+  if (viewportFallback) return viewportFallback;
+
+  const genericContaining = pickLargestRect(
+    rectNodes
+      .map((node) => node.rect as Rect)
+      .filter((rect) => containsPoint(rect, targetCenter.x, targetCenter.y)),
+  );
+  if (genericContaining) return genericContaining;
+
+  return null;
+}
+
+export function buildScrollIntoViewPlan(targetRect: Rect, viewportRect: Rect): ScrollIntoViewPlan | null {
+  const viewportHeight = Math.max(1, viewportRect.height);
+  const viewportTop = viewportRect.y;
+  const viewportBottom = viewportRect.y + viewportHeight;
+  const safeTop = viewportTop + viewportHeight * 0.25;
+  const safeBottom = viewportBottom - viewportHeight * 0.25;
+  const targetCenterY = targetRect.y + targetRect.height / 2;
+
+  if (targetCenterY >= safeTop && targetCenterY <= safeBottom) {
+    return null;
+  }
+
+  const x = Math.round(viewportRect.x + viewportRect.width / 2);
+  const dragUpStartY = Math.round(viewportTop + viewportHeight * 0.78);
+  const dragUpEndY = Math.round(viewportTop + viewportHeight * 0.22);
+  const dragDownStartY = dragUpEndY;
+  const dragDownEndY = dragUpStartY;
+  const swipeStepPx = Math.max(1, Math.abs(dragUpStartY - dragUpEndY) * 0.9);
+
+  if (targetCenterY > safeBottom) {
+    const delta = targetCenterY - safeBottom;
+    return {
+      x,
+      startY: dragUpStartY,
+      endY: dragUpEndY,
+      count: clampInt(Math.ceil(delta / swipeStepPx), 1, 50),
+      direction: 'down',
+    };
+  }
+
+  const delta = safeTop - targetCenterY;
+  return {
+    x,
+    startY: dragDownStartY,
+    endY: dragDownEndY,
+    count: clampInt(Math.ceil(delta / swipeStepPx), 1, 50),
+    direction: 'up',
+  };
+}
+
+export function isRectWithinSafeViewportBand(targetRect: Rect, viewportRect: Rect): boolean {
+  const viewportHeight = Math.max(1, viewportRect.height);
+  const viewportTop = viewportRect.y;
+  const viewportBottom = viewportRect.y + viewportHeight;
+  const safeTop = viewportTop + viewportHeight * 0.25;
+  const safeBottom = viewportBottom - viewportHeight * 0.25;
+  const targetCenterY = targetRect.y + targetRect.height / 2;
+  return targetCenterY >= safeTop && targetCenterY <= safeBottom;
+}
+
+function hasValidRect(rect: Rect | undefined): rect is Rect {
+  if (!rect) return false;
+  return Number.isFinite(rect.x) && Number.isFinite(rect.y) && Number.isFinite(rect.width) && Number.isFinite(rect.height);
+}
+
+function containsPoint(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
+}
+
+function pickLargestRect(rects: Rect[]): Rect | null {
+  let best: Rect | null = null;
+  let bestArea = -1;
+  for (const rect of rects) {
+    const area = rect.width * rect.height;
+    if (area > bestArea) {
+      best = rect;
+      bestArea = area;
+    }
+  }
+  return best;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -74,7 +74,7 @@ const RUNNER_STARTUP_TIMEOUT_MS = resolveTimeoutMs(
 );
 const RUNNER_COMMAND_TIMEOUT_MS = resolveTimeoutMs(
   process.env.AGENT_DEVICE_RUNNER_COMMAND_TIMEOUT_MS,
-  15_000,
+  45_000,
   1_000,
 );
 const RUNNER_CONNECT_ATTEMPT_INTERVAL_MS = resolveTimeoutMs(
@@ -94,7 +94,7 @@ const RUNNER_CONNECT_RETRY_MAX_DELAY_MS = resolveTimeoutMs(
 );
 const RUNNER_CONNECT_REQUEST_TIMEOUT_MS = resolveTimeoutMs(
   process.env.AGENT_DEVICE_RUNNER_CONNECT_REQUEST_TIMEOUT_MS,
-  5_000,
+  20_000,
   250,
 );
 const RUNNER_DEVICE_INFO_TIMEOUT_MS = resolveTimeoutMs(

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -453,10 +453,12 @@ async function ensureXctestrun(
 async function stopAllRunnerPrepProcesses(): Promise<void> {
   const prepProcesses = Array.from(runnerPrepProcesses);
   await Promise.allSettled(prepProcesses.map(async (child) => {
-    await killRunnerProcessTree(child.pid, 'SIGTERM');
-  }));
-  await Promise.allSettled(prepProcesses.map(async (child) => {
-    await killRunnerProcessTree(child.pid, 'SIGKILL');
+    try {
+      await killRunnerProcessTree(child.pid, 'SIGTERM');
+      await killRunnerProcessTree(child.pid, 'SIGKILL');
+    } finally {
+      runnerPrepProcesses.delete(child);
+    }
   }));
 }
 

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -483,8 +483,10 @@ export const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: [],
   },
   scrollintoview: {
-    description: 'Scroll until text appears',
-    positionalArgs: ['text'],
+    usageOverride: 'scrollintoview <text|@ref>',
+    description: 'Scroll until text appears or a snapshot ref is brought into view',
+    positionalArgs: ['target'],
+    allowsExtraPositionals: true,
     allowedFlags: [],
   },
   pinch: {

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -15,6 +15,7 @@ export type ExecOptions = {
   binaryStdout?: boolean;
   stdin?: string | Buffer;
   timeoutMs?: number;
+  detached?: boolean;
 };
 
 export type ExecStreamOptions = ExecOptions & {
@@ -38,6 +39,7 @@ export async function runCmd(
       cwd: options.cwd,
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: options.detached,
     });
 
     let stdout = '';
@@ -200,6 +202,7 @@ export async function runCmdStreaming(
       cwd: options.cwd,
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: options.detached,
     });
     options.onSpawn?.(child);
 
@@ -271,6 +274,7 @@ export function runCmdBackground(
     cwd: options.cwd,
     env: options.env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    detached: options.detached,
   });
 
   let stdout = '';

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -20,6 +20,7 @@ export type ExecOptions = {
 export type ExecStreamOptions = ExecOptions & {
   onStdoutChunk?: (chunk: string) => void;
   onStderrChunk?: (chunk: string) => void;
+  onSpawn?: (child: ReturnType<typeof spawn>) => void;
 };
 
 export type ExecBackgroundResult = {
@@ -200,6 +201,7 @@ export async function runCmdStreaming(
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+    options.onSpawn?.(child);
 
     let stdout = '';
     let stderr = '';

--- a/src/utils/interactors.ts
+++ b/src/utils/interactors.ts
@@ -87,7 +87,12 @@ type IoRunnerOverrides = Pick<
 >;
 
 function iosRunnerOverrides(device: DeviceInfo, ctx: RunnerContext): IoRunnerOverrides {
-  const runnerOpts = { verbose: ctx.verbose, logPath: ctx.logPath, traceLogPath: ctx.traceLogPath };
+  const runnerOpts = {
+    verbose: ctx.verbose,
+    logPath: ctx.logPath,
+    traceLogPath: ctx.traceLogPath,
+    requestId: ctx.requestId,
+  };
   const throwIfCanceled = () => {
     if (!isRequestCanceled(ctx.requestId)) return;
     throw new AppError('COMMAND_FAILED', 'request canceled');

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -56,6 +56,8 @@ agent-device swipe 540 1500 540 500 120
 agent-device swipe 540 1500 540 500 120 --count 8 --pause-ms 30 --pattern ping-pong
 agent-device longpress 300 500 800
 agent-device scroll down 0.5
+agent-device scrollintoview "Sign in"
+agent-device scrollintoview @e42
 agent-device pinch 2.0          # zoom in 2x (iOS simulator)
 agent-device pinch 0.5 200 400 # zoom out at coordinates (iOS simulator)
 ```
@@ -64,6 +66,7 @@ agent-device pinch 0.5 200 400 # zoom out at coordinates (iOS simulator)
 On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
 `swipe` accepts an optional `durationMs` argument (default `250ms`, range `16..10000`).
 On iOS, swipe timing uses a safe normalized duration to avoid longpress side effects.
+`scrollintoview` accepts plain text or a snapshot ref (`@eN`); ref mode uses geometry-based scrolling.
 `longpress` is supported on iOS and Android.
 `pinch` is iOS simulator-only.
 


### PR DESCRIPTION
## Summary

Superseded by split PRs for safer review and rollback.

- Runner resilience + cancellation hardening: #85
- `scrollintoview @ref` optimization + verification: #86

This PR can be closed after the split PRs are reviewed.

## Validation

Validation is tracked on the split PRs.
