### PR TITLE
fix: clean daemon metadata in integration teardown

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -52,7 +52,7 @@ type DaemonClientSettings = {
 };
 
 const REQUEST_TIMEOUT_MS = resolveDaemonRequestTimeoutMs();
-const DAEMON_STARTUP_TIMEOUT_MS = 5000;
+const DAEMON_STARTUP_TIMEOUT_MS = resolveDaemonStartupTimeoutMs();
 const DAEMON_TAKEOVER_TERM_TIMEOUT_MS = 3000;
 const DAEMON_TAKEOVER_KILL_TIMEOUT_MS = 1000;
 const IOS_RUNNER_XCODEBUILD_KILL_PATTERNS = [
@@ -647,6 +647,15 @@ export function resolveDaemonRequestTimeoutMs(raw: string | undefined = process.
   if (!raw) return 90000;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return 90000;
+  return Math.max(1000, Math.floor(parsed));
+}
+
+export function resolveDaemonStartupTimeoutMs(
+  raw: string | undefined = process.env.AGENT_DEVICE_DAEMON_STARTUP_TIMEOUT_MS,
+): number {
+  if (!raw) return 15000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return 15000;
   return Math.max(1000, Math.floor(parsed));
 }
 

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -4,7 +4,12 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { computeDaemonCodeSignature, resolveDaemonRequestTimeoutMs, resolveDaemonStartupHint } from '../../daemon-client.ts';
+import {
+  computeDaemonCodeSignature,
+  resolveDaemonRequestTimeoutMs,
+  resolveDaemonStartupHint,
+  resolveDaemonStartupTimeoutMs,
+} from '../../daemon-client.ts';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
 import {
   isProcessAlive,
@@ -21,6 +26,16 @@ test('resolveDaemonRequestTimeoutMs enforces minimum timeout', () => {
   assert.equal(resolveDaemonRequestTimeoutMs('100'), 1000);
   assert.equal(resolveDaemonRequestTimeoutMs('2500'), 2500);
   assert.equal(resolveDaemonRequestTimeoutMs('invalid'), 90000);
+});
+
+test('resolveDaemonStartupTimeoutMs defaults to 15000', () => {
+  assert.equal(resolveDaemonStartupTimeoutMs(undefined), 15000);
+});
+
+test('resolveDaemonStartupTimeoutMs enforces minimum timeout', () => {
+  assert.equal(resolveDaemonStartupTimeoutMs('100'), 1000);
+  assert.equal(resolveDaemonStartupTimeoutMs('20000'), 20000);
+  assert.equal(resolveDaemonStartupTimeoutMs('invalid'), 15000);
 });
 
 test('resolveDaemonStartupHint prefers stale lock guidance when lock exists without info', () => {

--- a/test/integration/android.test.ts
+++ b/test/integration/android.test.ts
@@ -1,7 +1,9 @@
 import test from 'node:test';
-import { cleanupDefaultDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
+import path from 'node:path';
+import { cleanupDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
 
-const session = ['--session', 'android-test'];
+const stateDir = path.resolve('test/.state/android-integration');
+const session = ['--session', 'android-test', '--state-dir', stateDir];
 const settingsSectionLabels = [
   'Apps',
   'Apps & notifications',
@@ -22,9 +24,13 @@ const settingsCrashDialogSelector = settingsCrashDialogLabels
   .map((label) => (label.includes(' ') ? `label="${label}"` : `label=${label}`))
   .join(' || ');
 
+test.before(() => {
+  cleanupDaemonMetadata(stateDir);
+});
+
 test.after(() => {
   runCliJson(['close', '--platform', 'android', ...session]);
-  cleanupDefaultDaemonMetadata();
+  cleanupDaemonMetadata(stateDir);
 });
 
 test('android settings commands', () => {

--- a/test/integration/android.test.ts
+++ b/test/integration/android.test.ts
@@ -1,5 +1,5 @@
 import test from 'node:test';
-import { createIntegrationTestContext, runCliJson } from './test-helpers.ts';
+import { cleanupDefaultDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
 
 const session = ['--session', 'android-test'];
 const settingsSectionLabels = [
@@ -24,6 +24,7 @@ const settingsCrashDialogSelector = settingsCrashDialogLabels
 
 test.after(() => {
   runCliJson(['close', '--platform', 'android', ...session]);
+  cleanupDefaultDaemonMetadata();
 });
 
 test('android settings commands', () => {

--- a/test/integration/ios.test.ts
+++ b/test/integration/ios.test.ts
@@ -1,19 +1,35 @@
 import test from 'node:test';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { cleanupDefaultDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
+import { cleanupDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
 
-const session = ['--session', 'ios-test'];
+const stateDir = path.resolve('test/.state/ios-integration');
+const daemonState = ['--state-dir', stateDir];
+const session = ['--session', 'ios-test', ...daemonState];
 const iosTarget = ['--platform', 'ios'];
 const iosPhysicalUdid = process.env.IOS_UDID?.trim();
 let didRunIosPhysicalSession = false;
 
+test.before(() => {
+  cleanupDaemonMetadata(stateDir);
+});
+
 test.after(() => {
   runCliJson(['close', ...iosTarget, '--json', ...session]);
   if (iosPhysicalUdid && didRunIosPhysicalSession) {
-    runCliJson(['close', '--platform', 'ios', '--udid', iosPhysicalUdid, '--json', '--session', 'ios-device-test']);
+    runCliJson([
+      'close',
+      '--platform',
+      'ios',
+      '--udid',
+      iosPhysicalUdid,
+      '--json',
+      '--session',
+      'ios-device-test',
+      ...daemonState,
+    ]);
   }
-  cleanupDefaultDaemonMetadata();
+  cleanupDaemonMetadata(stateDir);
 });
 
 test('ios settings commands', { skip: shouldSkipIos() }, async () => {
@@ -100,7 +116,7 @@ test('ios physical device core lifecycle', { skip: shouldSkipIosPhysicalDevice()
     platform: 'ios',
     testName: 'ios physical device core lifecycle',
   });
-  const deviceSession = ['--session', 'ios-device-test'];
+  const deviceSession = ['--session', 'ios-device-test', ...daemonState];
   const target = ['--platform', 'ios', '--udid', iosPhysicalUdid as string];
   didRunIosPhysicalSession = true;
 

--- a/test/integration/ios.test.ts
+++ b/test/integration/ios.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { createIntegrationTestContext, runCliJson } from './test-helpers.ts';
+import { cleanupDefaultDaemonMetadata, createIntegrationTestContext, runCliJson } from './test-helpers.ts';
 
 const session = ['--session', 'ios-test'];
 const iosTarget = ['--platform', 'ios'];
@@ -13,6 +13,7 @@ test.after(() => {
   if (iosPhysicalUdid && didRunIosPhysicalSession) {
     runCliJson(['close', '--platform', 'ios', '--udid', iosPhysicalUdid, '--json', '--session', 'ios-device-test']);
   }
+  cleanupDefaultDaemonMetadata();
 });
 
 test('ios settings commands', { skip: shouldSkipIos() }, async () => {

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { resolveDaemonPaths } from '../../src/daemon/config.ts';
 import { runCmdSync } from '../../src/utils/exec.ts';
 
 export type CliJsonResult = {
@@ -71,6 +72,16 @@ export function formatResultDebug(step: string, args: string[], result: CliJsonR
     `json:`,
     jsonText,
   ].join('\n');
+}
+
+export function cleanupDefaultDaemonMetadata(): void {
+  const { infoPath, lockPath } = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR);
+  if (existsSync(infoPath)) {
+    rmSync(infoPath, { force: true });
+  }
+  if (existsSync(lockPath)) {
+    rmSync(lockPath, { force: true });
+  }
 }
 
 export function createIntegrationTestContext(options: IntegrationTestContextOptions) {

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -75,7 +75,11 @@ export function formatResultDebug(step: string, args: string[], result: CliJsonR
 }
 
 export function cleanupDefaultDaemonMetadata(): void {
-  const { infoPath, lockPath } = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR);
+  cleanupDaemonMetadata(process.env.AGENT_DEVICE_STATE_DIR);
+}
+
+export function cleanupDaemonMetadata(stateDir?: string): void {
+  const { infoPath, lockPath } = resolveDaemonPaths(stateDir);
   if (existsSync(infoPath)) {
     rmSync(infoPath, { force: true });
   }


### PR DESCRIPTION
## Summary
Clean up stale daemon metadata after mobile integration tests so subsequent CI tests do not inherit stale daemon state.
Added shared `cleanupDefaultDaemonMetadata()` in integration test helpers and invoked it in iOS/Android `test.after` hooks.
Touched files: 3. Scope stayed within integration tests and did not expand beyond initial test teardown change.

## Validation
pnpm typecheck
