### PR TITLE
fix: tighten agent-device Expensify flow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,25 @@ If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browse
 The canonical loop is:
 
 ```bash
+agent-device apps --platform ios
 agent-device open SampleApp --platform ios
 agent-device snapshot -i
 agent-device press @e3
 agent-device diff snapshot -i
 agent-device fill @e5 "test"
-agent-device fill @e5 "search" --delay-ms 80
+agent-device press @e5
+agent-device type " more" --delay-ms 80
 agent-device close
 ```
 
 In practice, most work follows the same pattern:
 
-1. `open` a target app or URL.
-2. `snapshot -i` to inspect the current screen.
-3. `press`, `fill`, `scroll`, `get`, or `wait` using refs or selectors.
-4. `diff snapshot` after UI changes.
-5. `close` when the session is finished.
+1. Discover the exact app id with `apps` if the package or bundle name is uncertain.
+2. `open` a target app or URL.
+3. `snapshot -i` to inspect the current screen.
+4. `press`, `fill`, `scroll`, `get`, or `wait` using refs or selectors.
+5. `diff snapshot` or re-snapshot after UI changes.
+6. `close` when the session is finished.
 
 In non-JSON mode, core mutating commands print a short success acknowledgment so agents and humans can distinguish successful actions from dropped or silent no-ops.
 

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -10,10 +10,12 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 ## Default operating rules
 
 - Start conservative. Prefer read-only inspection before mutating the UI.
+- Start deterministic. If the app name, package, device, or session is uncertain, load bootstrap and discover them before interacting.
 - Use plain `snapshot` when the task is to verify what text or structure is currently visible on screen.
 - Use `snapshot -i` only when you need interactive refs such as `@e3` for a requested action or targeted query.
 - Prefer `diff snapshot` after a nearby mutation when you only need to know what changed.
 - Avoid speculative mutations. You may take the smallest reversible UI action needed to unblock inspection or complete the requested task, such as dismissing a popup, closing an alert, or clearing an unintended surface.
+- In React Native dev or debug builds, check early for visible warning or error overlays, tooltips, and toasts that can steal focus or intercept taps. If they are not part of the requested behavior, dismiss them and continue. If you saw them, report them in the final summary.
 - Do not browse the web or use external sources unless the user explicitly asks.
 - Re-snapshot after meaningful UI changes instead of reusing stale refs.
 - Prefer `@ref` or selector targeting over raw coordinates.
@@ -50,11 +52,13 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 - Use `get`, `is`, or `find` when they can answer the question without changing UI state.
 - Use `fill` to replace text.
 - Use `type` to append text.
+- Do not write `type @eN "text"`. Use `fill @eN "text"` to target a field directly, or `press @eN` then `type "text"` when the field already has focus and you want append semantics.
 - If the on-screen keyboard blocks the next step, prefer `keyboard dismiss` over navigation. On iOS, keep an app session open first; `keyboard status|get` remains Android-only.
 - When a task asks to "go back", use plain `back` for predictable app-owned navigation and reserve `back --system` for platform back gestures or button semantics.
 - Use `type --delay-ms` or `fill --delay-ms` for debounced search fields that drop characters when typed too quickly.
 - If there is no simulator, no app install, or no open app session yet, switch to `bootstrap-install.md` instead of improvising setup steps.
 - Use the smallest unblock action first when transient UI blocks inspection, but do not navigate, search, or enter new text just to make the UI reveal data unless the user asked for that interaction.
+- In React Native dev or debug apps, treat visible warning or error overlays as transient blockers unless the user is explicitly asking you to diagnose them. Dismiss them when safe, then continue the requested flow.
 - Do not use external lookups to compensate for missing on-screen data unless the user asked for them.
 - If the needed information is not exposed on screen, say that plainly instead of compensating with extra navigation, text entry, or web search.
 - Prefer `@ref` or selector targeting over raw coordinates.

--- a/skills/agent-device/references/bootstrap-install.md
+++ b/skills/agent-device/references/bootstrap-install.md
@@ -12,6 +12,8 @@ Open this file when you still need to choose the right target, start the right s
 - `open`
 - `session list`
 
+Use this exact order when you are not sure about the installed app identifier. On Android dev builds in particular, `apps` is cheaper than guessing package suffixes and retrying failed `open` calls.
+
 ## Install path
 
 - `install` or `reinstall`

--- a/skills/agent-device/references/debugging.md
+++ b/skills/agent-device/references/debugging.md
@@ -17,6 +17,8 @@ Open this file when the task turns into failure triage, logs, network inspection
 
 Do not leave logging on for normal flows or dump full log files into context. Keep debug windows short and inspect logs with `grep` or `tail`.
 
+In React Native dev or debug builds, do not dismiss visible warning or error overlays without remembering to report them later. If you close one to keep the flow moving, keep at least a screenshot or a short marked log window so the summary can name it.
+
 ## Canonical loop
 
 ```bash
@@ -39,6 +41,7 @@ Logging is off by default. Enable it only when you need a debugging window.
 - `logs doctor` checks backend and runtime readiness for the current session and device.
 - `logs mark "before tap"` inserts a timestamped marker into the app log.
 - Android `network dump` surfaces timestamps from logcat-style prefixes and can backfill status and request/response duration from adjacent GIBSDK packet lines, so check it before dumping raw log windows.
+- Marker lines are emitted with the `[agent-device][mark][...]` prefix. When you grep later, prefer a narrow pattern such as `grep -n -E "agent-device.*mark|before tap" <path>`.
 - Session app logs can contain runtime data, headers, or payload fragments. Review them before sharing.
 - `logs start` requires an active app session and appends to `app.log`.
 - `logs stop` stops streaming. `close` also stops logging.
@@ -60,8 +63,15 @@ Useful shell follow-up after `logs path`:
 
 ```bash
 grep -n -E "Error|Exception|Fatal|crash" <path>
+grep -n -E "agent-device.*mark|before tap" <path>
 tail -50 <path>
 ```
+
+If the app showed a visible warning or error overlay during the flow:
+
+- Prefer a narrow grep window around your `logs mark` lines instead of loading the whole file.
+- Mention the surfaced warning or error in the final summary even if it did not block completion.
+- If the overlay kept returning, call that out as a stability issue instead of treating it as operator noise.
 
 ## Alerts and permissions
 
@@ -95,6 +105,8 @@ agent-device alert accept
 - `snapshot` returns 0 nodes: the app may no longer be foregrounded or the UI is not stable yet. Re-open the app or retry when state settles.
 - Logs are empty: confirm you opened an app session before `logs clear --restart`.
 - Android logs look stale after relaunch: retry the repro window after the process rebinds.
+- Android accessibility snapshots can lag behind visible screen transitions. If the tree looks stale after navigation, capture a `screenshot`, wait briefly, then re-run `snapshot -i`.
+- React Native dev warnings or errors keep reappearing: treat them as part of the app state, not as disposable chrome. Capture one clean repro and include them in the summary.
 - Permission prompts block the flow: wait for the alert and handle it explicitly.
 - If snapshots keep returning 0 nodes on an iOS simulator, restart Simulator and re-open the app.
 - If a macOS snapshot looks incomplete, compare with `snapshot --raw --platform macos` to separate collector filtering from missing AX content.

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -20,6 +20,7 @@ Open this file when the app or screen is already running and you need to discove
 - User asks what is visible on screen: `snapshot`
 - User asks for exact text from a known target: `get text`
 - User asks you to tap, type, or choose an element: `snapshot -i`, then act
+- React Native dev or debug build shows warning/error UI: capture enough evidence to identify it, dismiss it if it is not the requested behavior, then continue the flow and report it in the summary
 - The on-screen keyboard is blocking the next step: `keyboard dismiss`; on iOS do this only while an app session is active, and use `keyboard status|get` only on Android
 - UI does not expose the answer: say so plainly; do not browse or force the app into a new state unless asked
 
@@ -44,6 +45,16 @@ Open this file when the app or screen is already running and you need to discove
 ## Most common mistake to avoid
 
 Do not treat `@ref` values as durable after navigation or dynamic updates. Re-snapshot after the UI changes, and switch to selectors when the flow must stay stable.
+
+On Android after submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI for a short window. If `snapshot -i` and `screenshot` disagree, trust the screenshot as the visual source of truth, wait briefly, then take one fresh snapshot instead of looping snapshots immediately.
+
+In React Native dev or debug builds, do not ignore visible warning or error overlays. They can block taps, change the focused element, or hide the real UI state. Check for them near app open and after major transitions.
+
+Default rule:
+
+- If the overlay is not part of the requested behavior, dismiss it and continue.
+- If it is blocking, recurring, or likely related to the task, switch to [debugging.md](debugging.md) and collect a short evidence window.
+- If you saw a visible warning or error at any point, mention it in the final summary even if you dismissed it.
 
 ## Common example loops
 
@@ -129,9 +140,30 @@ When `press @ref` fails:
 
 - Use `fill` to replace text in an editable field.
 - Use `type` to append text to the current insertion point.
+- Use `fill @ref "text"` when you need to target a field directly by ref.
+- Use `press @ref`, then `type "text"` when the field is already focused and you need append semantics.
+- Do not write `type @ref "text"`; `type` only accepts text and will not target that ref for you.
 - If the keyboard blocks the next control after text entry, prefer `keyboard dismiss` instead of backing out of the screen.
 - On iOS, `keyboard dismiss` depends on the active app session to keep the target app foregrounded, so do not rely on selector-only dismiss calls after closing or without `open`.
 - Do not use `fill` or `type` just to make the app reveal information that is not currently visible unless the user asked for that interaction.
+
+## React Native dev or debug overlays
+
+Use this loop for React Native dev clients, Metro-backed builds, and local debug sessions where warnings or errors may appear as tooltips, banners, toasts, or modal overlays.
+
+1. After `open`, inspect the visible UI for warning or error surfaces before relying on the next tap.
+2. If a warning or error is visible, capture enough evidence to identify it:
+   - preferred: `screenshot`
+   - optional: `logs mark "warning visible"` or `logs mark "error visible"` if you are already in a debug window
+3. If the overlay is not the thing the user asked you to investigate, dismiss or close it with the smallest reversible action.
+4. Re-check the intended screen before continuing the task.
+5. Report any visible warnings or errors in the final summary, even if the flow succeeded after dismissal.
+
+Use this rule of thumb:
+
+- Warning overlay that does not block the task: dismiss and keep going.
+- Error overlay that does not block the task: dismiss, keep going, and report it.
+- Error overlay that blocks the task or keeps returning: stop treating it as noise and switch to [debugging.md](debugging.md).
 
 ## Query and sync rules
 
@@ -165,6 +197,7 @@ Preferred mapping:
 Notes:
 
 - `wait text` is useful for synchronizing on text presence, but it is not the same as `is visible`.
+- After a nearby navigation or submit on Android, prefer `screenshot`, then `wait 500` or `wait 1000`, then one fresh `snapshot -i` if the accessibility tree seems stale.
 
 Anti-hallucination rules:
 
@@ -222,6 +255,18 @@ agent-device batch --session sim --platform ios --steps-file /tmp/batch-steps.js
 - Keep batch size moderate, roughly 5 to 20 steps.
 - Add `wait` or `is exists` guards after mutating steps.
 - Do not use `batch` for highly dynamic flows that need replanning after each step.
+
+Example: known chat-send flow
+
+```json
+[
+  { "command": "open", "positionals": ["ChatApp"], "flags": { "platform": "android" } },
+  { "command": "click", "positionals": ["label=\"Travel chat\""], "flags": {} },
+  { "command": "wait", "positionals": ["label=\"Message\"", "3000"], "flags": {} },
+  { "command": "fill", "positionals": ["label=\"Message\"", "Filed the expense"], "flags": {} },
+  { "command": "press", "positionals": ["label=\"Send\""], "flags": {} }
+]
+```
 
 Step payload contract:
 

--- a/src/core/__tests__/dispatch-type.test.ts
+++ b/src/core/__tests__/dispatch-type.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { dispatchCommand } from '../dispatch.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+
+const IOS_DEVICE: DeviceInfo = {
+  platform: 'ios',
+  id: 'sim-1',
+  name: 'iPhone 17 Pro',
+  kind: 'simulator',
+  booted: true,
+};
+
+test('dispatch type rejects ref-looking first positional with a repair hint', async () => {
+  await assert.rejects(
+    () => dispatchCommand(IOS_DEVICE, 'type', ['@e52', 'filed the expense']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /does not accept a target ref/i.test(error.message) &&
+      /Use fill @e52 "text".*press @e52 then type "text"/i.test(error.details?.hint ?? ''),
+  );
+});

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -381,6 +381,16 @@ export async function dispatchCommand(
           return { x, y, ...successText(`Focused (${x}, ${y})`) };
         }
         case 'type': {
+          const mistargetedRef = findMistargetedTypeRef(positionals);
+          if (mistargetedRef) {
+            throw new AppError(
+              'INVALID_ARGS',
+              `type does not accept a target ref like "${mistargetedRef}"`,
+              {
+                hint: `Use fill ${mistargetedRef} "text" to replace text, or press ${mistargetedRef} then type "text" to append.`,
+              },
+            );
+          }
           const text = positionals.join(' ');
           if (!text) throw new AppError('INVALID_ARGS', 'type requires text');
           const delayMs = requireIntInRange(context?.delayMs ?? 0, 'delay-ms', 0, 10_000);
@@ -782,6 +792,12 @@ function formatSwipeMessage(count: number, pattern: 'one-way' | 'ping-pong'): st
 
 function formatTextLengthMessage(action: 'Typed' | 'Filled', text: string): string {
   return `${action} ${Array.from(text).length} chars`;
+}
+
+function findMistargetedTypeRef(positionals: string[]): string | null {
+  const first = positionals[0]?.trim();
+  if (!first || !/^@e\d+$/i.test(first)) return null;
+  return first;
 }
 
 function readResultMessage(result: Record<string, unknown>): string | undefined {

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -215,7 +215,9 @@ test('dumpUiHierarchy reads fallback XML when dump exits non-zero', async () => 
   });
 
   const result = await dumpUiHierarchy(device);
-  const dumpCall = mockRunCmd.mock.calls.find(([, args]) => args.includes('/sdcard/window_dump.xml'));
+  const dumpCall = mockRunCmd.mock.calls.find(([, args]) =>
+    args.includes('/sdcard/window_dump.xml'),
+  );
   const catCall = mockRunCmd.mock.calls.find(
     ([, args]) => args.includes('cat') && args.includes('/sdcard/window_dump.xml'),
   );
@@ -226,8 +228,7 @@ test('dumpUiHierarchy reads fallback XML when dump exits non-zero', async () => 
 });
 
 test('dumpUiHierarchy retries when fallback dump file is temporarily missing', async () => {
-  const xml =
-    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="retried"/></hierarchy>';
+  const xml = '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="retried"/></hierarchy>';
   let catAttempts = 0;
 
   mockRunCmd.mockImplementation(async (_cmd, args) => {

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -81,3 +81,13 @@ test('asAppError wraps unknown errors', () => {
   assert.equal(err.code, 'UNKNOWN');
   assert.equal(err.message, 'unexpected');
 });
+
+test('normalizeError provides app discovery guidance for app-not-installed errors', () => {
+  const normalized = normalizeError(
+    new AppError('APP_NOT_INSTALLED', 'No package found matching "chat"'),
+  );
+  assert.match(
+    normalized.hint ?? '',
+    /Run apps to discover the exact installed package or bundle id/i,
+  );
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -125,6 +125,8 @@ function defaultHintForCode(code: string): string | undefined {
       return 'Install required platform tooling and ensure it is available in PATH.';
     case 'DEVICE_NOT_FOUND':
       return 'Verify the target device is booted/connected and selectors match.';
+    case 'APP_NOT_INSTALLED':
+      return 'Run apps to discover the exact installed package or bundle id, or install the app before open.';
     case 'UNSUPPORTED_OPERATION':
       return 'This command is not available for the selected platform/device.';
     case 'COMMAND_FAILED':

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -244,6 +244,7 @@ agent-device pinch 0.5 200 400 # zoom out at coordinates (Apple simulator or mac
 ```
 
 `fill` clears then types. `type` does not clear.
+`type` accepts text only. Do not pass `@ref` to `type`; use `fill @ref "text"` to target a field directly, or `press @ref` then `type "text"` to append in the focused field.
 Use `--delay-ms` on `type` or `fill` for debounced search fields and search-as-you-type inputs that miss characters when text is injected too quickly.
 Delayed typing prefers paced character entry over clipboard-style fallbacks so the target field still receives incremental updates.
 On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
@@ -568,6 +569,7 @@ agent-device logs path
 # Then grep the path; -n adds line numbers for reference
 grep -n "Error\|Exception\|Fatal" ~/.agent-device/sessions/default/app.log
 grep -n -E "Error|Exception|Fatal|crash" ~/.agent-device/sessions/default/app.log
+grep -n -E "agent-device.*mark|before submit" ~/.agent-device/sessions/default/app.log
 
 # Last 50 lines only (bounded context)
 tail -50 ~/.agent-device/sessions/default/app.log
@@ -575,6 +577,7 @@ tail -50 ~/.agent-device/sessions/default/app.log
 
 - Use `-n` to include line numbers. Use `-E` for extended regex and `|` without escaping in the pattern.
 - Prefer targeted patterns (e.g. `Error`, `Exception`, your log tags) over reading the whole file.
+- `logs mark "before submit"` lines are prefixed with `[agent-device][mark][...]`, so grep for `agent-device.*mark` when you need timing markers back quickly.
 
 - iOS `record` works on simulators and physical devices.
 - iOS simulator recording uses native `simctl io ... recordVideo`.

--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -7,26 +7,31 @@ title: Quick Start
 Every device automation follows this pattern:
 
 ```bash
-# 1. Navigate
+# 1. Discover the installed app identifier when needed
+agent-device apps --platform ios # or android
+
+# 2. Navigate
 agent-device open SampleApp --platform ios # or android
 
-# 2. Snapshot to get element refs
+# 3. Snapshot to get element refs
 agent-device snapshot -i
 # Output:
 # @e1 [heading] "Sample App"
 # @e2 [button] "Settings"
 
-# 3. Interact using refs
+# 4. Interact using refs
 agent-device click @e2
 
-# 4. Re-snapshot before next interactions
+# 5. Re-snapshot before next interactions
 agent-device snapshot -i
 
-# 5. Optional: see structural changes since last baseline
+# 6. Optional: see structural changes since last baseline
 agent-device diff snapshot
 # or, from snapshot-focused help/examples:
 agent-device snapshot --diff
 ```
+
+React Native dev or debug builds often show warning or error overlays that can intercept taps or hide the real UI state. Check for them near app open and after major transitions. If they are not the requested behavior, dismiss them and continue, but mention them in your summary if you saw them.
 
 Boot target if there is no ready device/simulator:
 
@@ -41,12 +46,14 @@ agent-device boot --platform android --device Pixel_9_Pro_XL --headless
 ## Common commands
 
 ```bash
+agent-device apps --platform android    # Discover the exact package name when unsure
 agent-device open SampleApp
 agent-device snapshot -i                 # Get interactive elements with refs
 agent-device diff snapshot               # Preferred exploration form for structural deltas
 agent-device click @e2                   # Click by ref
 agent-device fill @e3 "test@example.com" # Clear then type (Android verifies and retries once if needed)
-agent-device fill @e3 "search" --delay-ms 80 # Pace typing for debounced search fields
+agent-device press @e3
+agent-device type " more" --delay-ms 80  # Append into the already focused field
 agent-device get text @e1                # Get text content
 agent-device screenshot page.png         # Save to specific path
 agent-device install com.example.app ./build/app.apk     # Install app binary in-place
@@ -63,6 +70,7 @@ agent-device close
 - `.ipa` installs extract `Payload/*.app`; if multiple app bundles exist, `<app>` selects the target by bundle id or bundle name.
 
 If `open` fails because no booted simulator/emulator/device is available, run `boot --platform ios|android` and retry.
+If `open` fails because the app id is wrong or missing, run `apps` and retry with the discovered package or bundle id instead of guessing.
 
 ## Fast batching
 
@@ -73,6 +81,18 @@ agent-device batch \
   --platform ios \
   --steps-file /tmp/batch-steps.json \
   --json
+```
+
+Example batch payload for a known chat flow:
+
+```json
+[
+  { "command": "open", "positionals": ["ChatApp"], "flags": { "platform": "android" } },
+  { "command": "click", "positionals": ["label=\"Travel chat\""], "flags": {} },
+  { "command": "wait", "positionals": ["label=\"Message\"", "3000"], "flags": {} },
+  { "command": "fill", "positionals": ["label=\"Message\"", "Filed the expense"], "flags": {} },
+  { "command": "press", "positionals": ["label=\"Send\""], "flags": {} }
+]
 ```
 
 See [Batching](/docs/batching) for payload format, failure handling, and best practices.

--- a/website/docs/docs/selectors.md
+++ b/website/docs/docs/selectors.md
@@ -10,7 +10,8 @@ Use `find` to locate elements by semantic attributes instead of raw refs.
 agent-device find "Settings" click
 agent-device find text "Sign In" click
 agent-device find label "Email" fill "user@example.com"
-agent-device find value "Search" type "query"
+agent-device find value "Search" click
+agent-device type "query"
 agent-device find role button click
 agent-device find id "com.example:id/login" click
 ```
@@ -20,6 +21,7 @@ Tips:
 - Use `find ... wait <timeoutMs>` to wait for UI to appear.
 - Combine with scoped snapshots using `snapshot -s "<label>"` for speed.
 - [Android] If a matched node is not hittable, agent-device will click/focus the nearest hittable ancestor.
+- Use `fill` when you want find-plus-targeted text replacement in one step. Use `click` or `press` plus `type` when you need append semantics in the focused field.
 
 ## Response shape (click)
 

--- a/website/docs/docs/snapshots.md
+++ b/website/docs/docs/snapshots.md
@@ -33,6 +33,7 @@ It does not automatically switch to AX.
 - Add `-s "<label>"` (or `-s @ref`) to keep results screen-local.
 - Add `-d <depth>` when you only need upper hierarchy layers.
 - Re-snapshot after any UI mutation before reusing refs.
+- On Android after navigation or submit, if `snapshot -i` disagrees with the visible screen, trust `screenshot`, wait briefly, then take one fresh snapshot instead of looping stale snapshots.
 - Use `diff snapshot` between mutations to validate structural changes with lower output volume.
 - Use `snapshot --diff` when you discover the feature from snapshot help, but keep `diff snapshot` as the default exploration command.
 - Keep `--raw` for troubleshooting only.


### PR DESCRIPTION
## Summary

- fail fast when `type` is mistakenly given an `@ref`, with a repair hint for `fill @ref` vs `press @ref` then `type`
- improve app discovery hints and agent-device docs/skills for discovery-first Android flows, stale post-navigation snapshots, and React Native warning-overlay handling
- add regression coverage and update public docs for the safer Expensify-style chat flow

Touched files: 14
Scope expanded beyond the initial `type` command fix into docs/skills and shared error hints.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm format`
- `pnpm check:quick`
- `pnpm check:unit`
- Manual: reran the Expensify Android flow with local `agent-device` and `agent-react-devtools`