### PR TITLE
feat: add --wait-stable for Android AX tree and --first/--last for find

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,20 @@ Minimal operating guide for AI coding agents in this repo.
 - `runner-transport.ts` must not import back from `runner-client.ts`.
 - If changing runner connect errors, retry policy, or command typing, start in `src/platforms/ios/runner-contract.ts` before touching client/transport files.
 
+## Adding a New CLI Flag
+
+A new snapshot/command flag touches up to 7 files in a fixed order. Follow this checklist:
+
+1. `src/utils/command-schema.ts`: add to `CliFlags` type, `FLAG_DEFINITIONS` array, and the relevant `*_FLAGS` constant (e.g. `SNAPSHOT_FLAGS`). Update the command's `usageOverride` string.
+2. `src/utils/snapshot.ts` (or the relevant options type): add to `SnapshotOptions` or equivalent.
+3. `src/client-types.ts`: add to `CaptureSnapshotOptions` (or equivalent public options type) **and** `InternalRequestOptions`.
+4. `src/client-normalizers.ts`: map the public option name to the internal flag name in `buildFlags`.
+5. `src/daemon/context.ts`: add to `DaemonCommandContext` type and `contextFromFlags` function.
+6. `src/core/dispatch.ts`: add to the inline context type on `dispatchCommand` and thread it to the platform call.
+7. `src/cli/commands/<command>.ts`: pass the flag from `flags.*` to the client call.
+
+Command-only flags (like `find --first`) that don't flow to the platform layer only need steps 1 and the handler file.
+
 ## Hard Rules
 - Use `runCmd`/`runCmdSync` from `src/utils/exec.ts` for process execution.
 - Use daemon session flow for interactions (`open` before interactions, `close` after).

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -17,7 +17,7 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 - Avoid speculative mutations. You may take the smallest reversible UI action needed to unblock inspection or complete the requested task, such as dismissing a popup, closing an alert, or clearing an unintended surface.
 - In React Native dev or debug builds, check early for visible warning or error overlays, tooltips, and toasts that can steal focus or intercept taps. If they are not part of the requested behavior, dismiss them and continue. If you saw them, report them in the final summary.
 - Do not browse the web or use external sources unless the user explicitly asks.
-- Re-snapshot after meaningful UI changes instead of reusing stale refs.
+- Re-snapshot after navigation, taps, or form submits instead of reusing stale refs.
 - Prefer `@ref` or selector targeting over raw coordinates.
 - Ensure the correct target is pinned and an app session is open before interacting.
 - Keep the loop short: `open` -> inspect/act -> verify if needed -> `close`.

--- a/skills/agent-device/references/debugging.md
+++ b/skills/agent-device/references/debugging.md
@@ -105,7 +105,7 @@ agent-device alert accept
 - `snapshot` returns 0 nodes: the app may no longer be foregrounded or the UI is not stable yet. Re-open the app or retry when state settles.
 - Logs are empty: confirm you opened an app session before `logs clear --restart`.
 - Android logs look stale after relaunch: retry the repro window after the process rebinds.
-- Android accessibility snapshots can lag behind visible screen transitions. If the tree looks stale after navigation, capture a `screenshot`, wait briefly, then re-run `snapshot -i`.
+- Android accessibility snapshots can lag behind visible screen transitions. If the tree looks stale after navigation, use `snapshot -i --wait-stable 2000`, or capture a `screenshot`, wait briefly, then re-run `snapshot -i`.
 - React Native dev warnings or errors keep reappearing: treat them as part of the app state, not as disposable chrome. Capture one clean repro and include them in the summary.
 - Permission prompts block the flow: wait for the alert and handle it explicitly.
 - If snapshots keep returning 0 nodes on an iOS simulator, restart Simulator and re-open the app.

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -42,19 +42,21 @@ Open this file when the app or screen is already running and you need to discove
 - `wait`
 - `keyboard dismiss` when the keyboard obscures the next target
 
-## Most common mistake to avoid
+## Common mistakes to avoid
 
-Do not treat `@ref` values as durable after navigation or dynamic updates. Re-snapshot after the UI changes, and switch to selectors when the flow must stay stable.
+**Stale refs.** Do not treat `@ref` values as durable after navigation or dynamic updates. Re-snapshot after the UI changes, and switch to selectors when the flow must stay stable.
 
-On Android after submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI for a short window. If `snapshot -i` and `screenshot` disagree, trust the screenshot as the visual source of truth, wait briefly, then take one fresh snapshot instead of looping snapshots immediately. Use `snapshot -i --wait-stable 2000` to let the command itself poll until the tree stabilizes, which avoids manual wait-then-retry loops.
+**Android AX tree lag.** After submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI. If `snapshot -i` and `screenshot` disagree:
 
-In React Native dev or debug builds, do not ignore visible warning or error overlays. They can block taps, change the focused element, or hide the real UI state. Check for them near app open and after major transitions.
+1. Trust the screenshot as visual truth.
+2. Use `snapshot -i --wait-stable 2000` to let the command poll until the tree settles.
+3. If you cannot use `--wait-stable`, wait briefly, then take one fresh snapshot. Do not loop snapshots immediately.
 
-Default rule:
+**React Native dev overlays.** In dev or debug builds, warning or error overlays can block taps, change focus, or hide the real UI. Check for them near app open and after major transitions.
 
-- If the overlay is not part of the requested behavior, dismiss it and continue.
-- If it is blocking, recurring, or likely related to the task, switch to [debugging.md](debugging.md) and collect a short evidence window.
-- If you saw a visible warning or error at any point, mention it in the final summary even if you dismissed it.
+- Not blocking the task: dismiss and continue.
+- Blocking or recurring: switch to [debugging.md](debugging.md) and collect evidence.
+- Seen at any point: mention in the final summary even if dismissed.
 
 ## Common example loops
 
@@ -212,7 +214,7 @@ Avoid this escalation path for visible-text questions:
 
 - Do not jump from `snapshot -i` to `get text @ref`, then to web search, then to typing into a search box just to force the app to reveal the answer.
 - Start with `snapshot`. If the text is not visible or exposed, report that directly.
-- After Android submit or navigation-heavy actions, prefer this recovery order when the UI looks wrong: `screenshot`, then `snapshot -i --wait-stable 2000` to let the tree settle, or short `wait` then one fresh `snapshot -i`.
+- After Android submit or navigation-heavy actions when the UI looks wrong: `screenshot` first, then `snapshot -i --wait-stable 2000`.
 
 Canonical QA loop:
 

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -46,7 +46,7 @@ Open this file when the app or screen is already running and you need to discove
 
 Do not treat `@ref` values as durable after navigation or dynamic updates. Re-snapshot after the UI changes, and switch to selectors when the flow must stay stable.
 
-On Android after submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI for a short window. If `snapshot -i` and `screenshot` disagree, trust the screenshot as the visual source of truth, wait briefly, then take one fresh snapshot instead of looping snapshots immediately.
+On Android after submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI for a short window. If `snapshot -i` and `screenshot` disagree, trust the screenshot as the visual source of truth, wait briefly, then take one fresh snapshot instead of looping snapshots immediately. Use `snapshot -i --wait-stable 2000` to let the command itself poll until the tree stabilizes, which avoids manual wait-then-retry loops.
 
 In React Native dev or debug builds, do not ignore visible warning or error overlays. They can block taps, change the focused element, or hide the real UI state. Check for them near app open and after major transitions.
 
@@ -173,6 +173,7 @@ Use this rule of thumb:
 - Use `is` for assertions.
 - Use `wait` when the UI needs time to settle after a mutation.
 - Use `find "<query>" click --json` when you need search-driven targeting plus matched-target metadata.
+- Use `find "<query>" click --first` or `--last` when ambiguous matches are expected and you want the first or last occurrence without falling back to raw coordinates.
 - If you are forced onto raw coordinates, open [coordinate-system.md](coordinate-system.md) first.
 
 Example:
@@ -211,7 +212,7 @@ Avoid this escalation path for visible-text questions:
 
 - Do not jump from `snapshot -i` to `get text @ref`, then to web search, then to typing into a search box just to force the app to reveal the answer.
 - Start with `snapshot`. If the text is not visible or exposed, report that directly.
-- After Android submit or navigation-heavy actions, prefer this recovery order when the UI looks wrong: `screenshot`, short `wait`, one fresh `snapshot -i`.
+- After Android submit or navigation-heavy actions, prefer this recovery order when the UI looks wrong: `screenshot`, then `snapshot -i --wait-stable 2000` to let the tree settle, or short `wait` then one fresh `snapshot -i`.
 
 Canonical QA loop:
 

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -11,6 +11,7 @@ export const snapshotCommand: ClientCommandHandler = async ({ flags, client }) =
     depth: flags.snapshotDepth,
     scope: flags.snapshotScope,
     raw: flags.snapshotRaw,
+    waitStableMs: flags.snapshotWaitStableMs,
   });
   const data = serializeSnapshotResult(result);
   writeCommandOutput(flags, data, () =>

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -266,6 +266,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     snapshotDepth: options.depth,
     snapshotScope: options.scope,
     snapshotRaw: options.raw,
+    snapshotWaitStableMs: options.waitStableMs,
     overlayRefs: options.overlayRefs,
     verbose: options.debug,
   }) as CommandFlags;

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -247,6 +247,7 @@ export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
     depth?: number;
     scope?: string;
     raw?: boolean;
+    waitStableMs?: number;
   };
 
 export type CaptureSnapshotResult = {
@@ -291,6 +292,7 @@ export type InternalRequestOptions = AgentDeviceClientConfig &
     depth?: number;
     scope?: string;
     raw?: boolean;
+    waitStableMs?: number;
     installSource?: DaemonInstallSource;
     retainMaterializedPaths?: boolean;
     materializedPathRetentionMs?: number;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -63,6 +63,7 @@ export async function dispatchCommand(
     snapshotDepth?: number;
     snapshotScope?: string;
     snapshotRaw?: boolean;
+    snapshotWaitStableMs?: number;
     screenshotFullscreen?: boolean;
     count?: number;
     intervalMs?: number;
@@ -712,6 +713,7 @@ export async function dispatchCommand(
                 depth: context?.snapshotDepth,
                 scope: context?.snapshotScope,
                 raw: context?.snapshotRaw,
+                waitStableMs: context?.snapshotWaitStableMs,
               }),
             {
               backend: 'android',

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -15,6 +15,7 @@ export type DaemonCommandContext = {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotWaitStableMs?: number;
   screenshotFullscreen?: boolean;
   count?: number;
   intervalMs?: number;
@@ -51,6 +52,7 @@ export function contextFromFlags(
     snapshotDepth: flags?.snapshotDepth,
     snapshotScope: flags?.snapshotScope,
     snapshotRaw: flags?.snapshotRaw,
+    snapshotWaitStableMs: flags?.snapshotWaitStableMs,
     screenshotFullscreen: flags?.screenshotFullscreen,
     count: flags?.count,
     intervalMs: flags?.intervalMs,

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -122,7 +122,13 @@ export async function handleFindCommands(params: {
   });
 
   if (requiresRect && bestMatches.matches.length > 1) {
-    return buildAmbiguousMatchError(bestMatches.matches, locator, query);
+    if (req.flags?.findFirst) {
+      bestMatches.matches.length = 1;
+    } else if (req.flags?.findLast) {
+      bestMatches.matches = [bestMatches.matches[bestMatches.matches.length - 1]];
+    } else {
+      return buildAmbiguousMatchError(bestMatches.matches, locator, query);
+    }
   }
 
   const node = bestMatches.matches[0] ?? null;

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -123,7 +123,7 @@ export async function handleFindCommands(params: {
 
   if (requiresRect && bestMatches.matches.length > 1) {
     if (req.flags?.findFirst) {
-      bestMatches.matches.length = 1;
+      bestMatches.matches = [bestMatches.matches[0]];
     } else if (req.flags?.findLast) {
       bestMatches.matches = [bestMatches.matches[bestMatches.matches.length - 1]];
     } else {

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -14,8 +14,30 @@ export async function snapshotAndroid(
   truncated?: boolean;
   analysis: AndroidSnapshotAnalysis;
 }> {
-  const xml = await dumpUiHierarchy(device);
+  const xml = options.waitStableMs
+    ? await dumpUiHierarchyStable(device, options.waitStableMs)
+    : await dumpUiHierarchy(device);
   return parseUiHierarchy(xml, 800, options);
+}
+
+/**
+ * Poll until the AX tree stabilizes: two consecutive dumps produce identical XML,
+ * or the timeout is reached. Returns the last captured XML.
+ */
+async function dumpUiHierarchyStable(device: DeviceInfo, timeoutMs: number): Promise<string> {
+  const POLL_INTERVAL = 200;
+  const start = Date.now();
+  let previousXml = await dumpUiHierarchy(device);
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+    const currentXml = await dumpUiHierarchy(device);
+    if (currentXml === previousXml) {
+      return currentXml;
+    }
+    previousXml = currentXml;
+  }
+  // Timeout reached — return the last dump even though it may still be changing.
+  return previousXml;
 }
 
 export async function dumpUiHierarchy(device: DeviceInfo): Promise<string> {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -150,7 +150,6 @@ const SELECTOR_SNAPSHOT_FLAGS = [
 ] as const satisfies readonly FlagKey[];
 
 const FIND_SNAPSHOT_FLAGS = ['snapshotDepth', 'snapshotRaw'] as const satisfies readonly FlagKey[];
-const FIND_DISAMBIGUATE_FLAGS = ['findFirst', 'findLast'] as const satisfies readonly FlagKey[];
 
 const AGENT_SKILLS = [
   { label: 'agent-device', description: 'Canonical mobile automation flows' },
@@ -879,8 +878,7 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 0,
     max: 10000,
     usageLabel: '--wait-stable <ms>',
-    usageDescription:
-      'Snapshot: poll until AX tree stabilizes (Android). Retries until two consecutive dumps match or timeout.',
+    usageDescription: 'Snapshot: wait for AX tree to stabilize (Android)',
   },
   {
     key: 'findFirst',
@@ -1301,7 +1299,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     summary: 'Find an element and act',
     positionalArgs: ['query', 'action', 'value?'],
     allowsExtraPositionals: true,
-    allowedFlags: [...FIND_SNAPSHOT_FLAGS, ...FIND_DISAMBIGUATE_FLAGS],
+    allowedFlags: [...FIND_SNAPSHOT_FLAGS, 'findFirst', 'findLast'],
   },
   is: {
     helpDescription: 'Assert UI state (visible|hidden|exists|editable|selected|text)',

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -53,6 +53,7 @@ export type CliFlags = {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotWaitStableMs?: number;
   networkInclude?: 'summary' | 'headers' | 'body' | 'all';
   overlayRefs?: boolean;
   screenshotFullscreen?: boolean;
@@ -92,6 +93,8 @@ export type CliFlags = {
   reportJunit?: string;
   steps?: string;
   stepsFile?: string;
+  findFirst?: boolean;
+  findLast?: boolean;
   batchOnError?: 'stop';
   batchMaxSteps?: number;
   batchSteps?: Array<{
@@ -137,6 +140,7 @@ const SNAPSHOT_FLAGS = [
   'snapshotDepth',
   'snapshotScope',
   'snapshotRaw',
+  'snapshotWaitStableMs',
 ] as const satisfies readonly FlagKey[];
 
 const SELECTOR_SNAPSHOT_FLAGS = [
@@ -146,6 +150,7 @@ const SELECTOR_SNAPSHOT_FLAGS = [
 ] as const satisfies readonly FlagKey[];
 
 const FIND_SNAPSHOT_FLAGS = ['snapshotDepth', 'snapshotRaw'] as const satisfies readonly FlagKey[];
+const FIND_DISAMBIGUATE_FLAGS = ['findFirst', 'findLast'] as const satisfies readonly FlagKey[];
 
 const AGENT_SKILLS = [
   { label: 'agent-device', description: 'Canonical mobile automation flows' },
@@ -868,6 +873,30 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription: 'Snapshot: raw node output',
   },
   {
+    key: 'snapshotWaitStableMs',
+    names: ['--wait-stable'],
+    type: 'int',
+    min: 0,
+    max: 10000,
+    usageLabel: '--wait-stable <ms>',
+    usageDescription:
+      'Snapshot: poll until AX tree stabilizes (Android). Retries until two consecutive dumps match or timeout.',
+  },
+  {
+    key: 'findFirst',
+    names: ['--first'],
+    type: 'boolean',
+    usageLabel: '--first',
+    usageDescription: 'Find: pick the first match when ambiguous',
+  },
+  {
+    key: 'findLast',
+    names: ['--last'],
+    type: 'boolean',
+    usageLabel: '--last',
+    usageDescription: 'Find: pick the last match when ambiguous',
+  },
+  {
     key: 'out',
     names: ['--out'],
     type: 'string',
@@ -980,7 +1009,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: [],
   },
   snapshot: {
-    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw]',
+    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw] [--wait-stable <ms>]',
     helpDescription: 'Capture accessibility tree or diff against the previous session baseline',
     positionalArgs: [],
     allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS],
@@ -1267,12 +1296,12 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: ['networkInclude'],
   },
   find: {
-    usageOverride: 'find <locator|text> <action> [value]',
+    usageOverride: 'find <locator|text> <action> [value] [--first|--last]',
     helpDescription: 'Find by text/label/value/role/id and run action',
     summary: 'Find an element and act',
     positionalArgs: ['query', 'action', 'value?'],
     allowsExtraPositionals: true,
-    allowedFlags: [...FIND_SNAPSHOT_FLAGS],
+    allowedFlags: [...FIND_SNAPSHOT_FLAGS, ...FIND_DISAMBIGUATE_FLAGS],
   },
   is: {
     helpDescription: 'Assert UI state (visible|hidden|exists|editable|selected|text)',

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -16,6 +16,7 @@ export type SnapshotOptions = {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  waitStableMs?: number;
 };
 
 export type RawSnapshotNode = {


### PR DESCRIPTION
Address the #1 token efficiency issue on Android: stale accessibility
trees after navigation. `snapshot --wait-stable <ms>` polls until two
consecutive uiautomator dumps match (tree stabilized) or the timeout
expires, eliminating retry loops caused by AX lag after screen transitions.

Also adds `find --first` / `find --last` flags to disambiguate when
multiple elements match, avoiding the fallback to raw snapshot +
coordinate taps that burned 4-6 extra tool calls.

https://claude.ai/code/session_01FzX5t9qATyT9iWnYjssShC