### PR TITLE
fix: use sh fences for .ad scripts in replay-e2e docs

### DIFF
--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -103,7 +103,7 @@ User-defined keys starting with `AD_` are rejected in `env`, `-e`, and shell imp
 
 Substitution happens inside parsed string values. It does not create extra arguments, so quote selectors or text values that contain spaces:
 
-```ad
+```sh
 env SETTINGS="label=Account || label=Profile"
 click "${SETTINGS}"
 ```
@@ -139,7 +139,7 @@ AD_VAR_WAIT_SHORT=2000 agent-device replay ./flow.ad
 
 Extract a reusable selector. Before:
 
-```ad
+```sh
 click "label=Account || label=Profile || label=User"
 wait 500
 click "label=Account || label=Profile || label=User"
@@ -147,7 +147,7 @@ click "label=Account || label=Profile || label=User"
 
 After:
 
-```ad
+```sh
 env SETTINGS="label=Account || label=Profile || label=User"
 
 click "${SETTINGS}"


### PR DESCRIPTION
Shiki's default bundle has no `ad` grammar, so rspress build failed on three code fences in replay-e2e.md. Aligns them with the rest of the file, which already uses ```sh for .ad script content.