### PR TITLE
refactor: make request-platform-providers provider wrappers static

### DIFF
--- a/src/daemon/request-platform-providers.ts
+++ b/src/daemon/request-platform-providers.ts
@@ -1,21 +1,27 @@
 import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import { registerBuiltinPlatformPlugins } from '../core/interactors/register-builtins.ts';
 import { tryGetPlugin } from '../core/platform-plugin/plugin.ts';
-import type { AndroidAdbExecutor, AndroidAdbProvider } from '../platforms/android/adb-executor.ts';
-import type {
-  AppleRunnerCommandExecutor,
-  AppleRunnerProvider,
+import {
+  withAndroidAdbProvider,
+  type AndroidAdbExecutor,
+  type AndroidAdbProvider,
+} from '../platforms/android/adb-executor.ts';
+import {
+  withAppleRunnerProvider,
+  type AppleRunnerCommandExecutor,
+  type AppleRunnerProvider,
 } from '../platforms/apple/core/runner/runner-provider.ts';
-import type {
-  AppleToolCommandExecutor,
-  AppleToolProvider,
+import {
+  withAppleToolProvider,
+  type AppleToolCommandExecutor,
+  type AppleToolProvider,
 } from '../platforms/apple/core/tool-provider.ts';
-import type { LinuxToolProvider } from '../platforms/linux/tool-provider.ts';
-import type { WebProvider } from '../platforms/web/provider.ts';
+import { withLinuxToolProvider, type LinuxToolProvider } from '../platforms/linux/tool-provider.ts';
+import { withWebProvider, type WebProvider } from '../platforms/web/provider.ts';
 import type { DeviceInfo } from '../kernel/device.ts';
-import type { AppLogProvider } from './app-log.ts';
+import { withAppLogProvider, type AppLogProvider } from './app-log.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
-import type { RecordingProvider } from './recording-provider.ts';
+import { withRecordingProvider, type RecordingProvider } from './recording-provider.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
 import { resolveProviderDeviceResolutionIntent } from './daemon-command-registry.ts';
 
@@ -158,7 +164,7 @@ type RequestPlatformProviderDescriptor = {
   appendWrapper: (
     scopedProviders: ResolvedRequestPlatformProviders,
     wrappers: RequestPlatformProviderScopeWrapper[],
-  ) => Promise<void>;
+  ) => void;
 };
 
 const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
@@ -175,9 +181,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
       const executor = typeof provider === 'function' ? provider : provider?.exec;
       return { androidAdb: { provider, executor, serial: context.device.id } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.androidAdb?.provider) return;
-      const { withAndroidAdbProvider } = await import('../platforms/android/adb-executor.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.androidAdb, (provider, task) =>
         withAndroidAdbProvider(
           provider,
@@ -205,10 +209,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
         },
       };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.appleRunner?.provider) return;
-      const { withAppleRunnerProvider } =
-        await import('../platforms/apple/core/runner/runner-provider.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.appleRunner, (provider, task) =>
         withAppleRunnerProvider(
           provider,
@@ -229,9 +230,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
         return {};
       return { appleTool: { provider: appleToolProvider(context) } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.appleTool?.provider) return;
-      const { withAppleToolProvider } = await import('../platforms/apple/core/tool-provider.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.appleTool, withAppleToolProvider);
     },
   },
@@ -243,9 +242,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
         return {};
       return { linuxTool: { provider: linuxToolProvider(context) } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.linuxTool?.provider) return;
-      const { withLinuxToolProvider } = await import('../platforms/linux/tool-provider.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.linuxTool, withLinuxToolProvider);
     },
   },
@@ -256,9 +253,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
       if (!webProvider || !platformGatedResolverApplies('webProvider', context.device)) return {};
       return { web: { provider: webProvider(context) } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.web?.provider) return;
-      const { withWebProvider } = await import('../platforms/web/provider.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.web, withWebProvider);
     },
   },
@@ -269,9 +264,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
       if (!appLogProvider) return {};
       return { appLog: { provider: appLogProvider(context) } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.appLog?.provider) return;
-      const { withAppLogProvider } = await import('./app-log.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.appLog, withAppLogProvider);
     },
   },
@@ -282,9 +275,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
       if (!recordingProvider) return {};
       return { recording: { provider: recordingProvider(context) } };
     },
-    async appendWrapper(scopedProviders, wrappers) {
-      if (!scopedProviders.recording?.provider) return;
-      const { withRecordingProvider } = await import('./recording-provider.ts');
+    appendWrapper(scopedProviders, wrappers) {
       appendRequestProviderWrapper(wrappers, scopedProviders.recording, withRecordingProvider);
     },
   },
@@ -298,7 +289,7 @@ export async function withRequestPlatformProviderScope<T>(
   const scope: RequestPlatformProviderScope = {
     androidAdbExecutor: scopedProviders.androidAdb?.executor,
   };
-  const wrappers = await requestPlatformProviderScopeWrappers(scopedProviders);
+  const wrappers = requestPlatformProviderScopeWrappers(scopedProviders);
 
   return await runRequestPlatformProviderScopes(wrappers, async () => await task(scope));
 }
@@ -355,12 +346,12 @@ async function resolveScopedProviderDevice(
   }
 }
 
-async function requestPlatformProviderScopeWrappers(
+function requestPlatformProviderScopeWrappers(
   scopedProviders: ResolvedRequestPlatformProviders,
-): Promise<RequestPlatformProviderScopeWrapper[]> {
+): RequestPlatformProviderScopeWrapper[] {
   const wrappers: RequestPlatformProviderScopeWrapper[] = [];
   for (const descriptor of REQUEST_PLATFORM_PROVIDER_DESCRIPTORS) {
-    await descriptor.appendWrapper(scopedProviders, wrappers);
+    descriptor.appendWrapper(scopedProviders, wrappers);
   }
   return wrappers;
 }


### PR DESCRIPTION
## Problem

`pnpm build` warned:

```
[INEFFECTIVE_DYNAMIC_IMPORT] src/daemon/app-log.ts is dynamically imported by
src/daemon/request-platform-providers.ts but also statically imported by
session-observability.ts, session-teardown.ts — dynamic import will not move
module into another chunk.
```

## Fix

`request-platform-providers.ts` builds the per-request provider scope from a
table of descriptors, each of which did `await import('…provider')` inside
`appendWrapper`. But the file is **daemon-only** (imported solely by
`request-router`), and the daemon serves every platform, so all seven of those
dynamic imports defer nothing — each provider module is already loaded eagerly
in the daemon entry chunk. The `app-log` one additionally collides with the
static imports in `session-observability` / `session-teardown`, which is what
rolldown flagged.

The `R3 platforms-seam` layering rule already permits `src/daemon/**` to import
`platforms/**` statically (the seam only constrains `src/core/` outside
`core/interactors/`), so this is allowed. So:

- Hoist every `with*Provider` import to the top as a static import.
- Collapse `appendWrapper` to a uniform **synchronous** one-liner per descriptor.
- Drop the redundant per-descriptor provider guards — `appendRequestProviderWrapper`
  already short-circuits when the provider is absent.

Net **−13 lines**, one file.

## Why runner-client's warning is intentionally left

Fixing the `app-log` collision unmasks a separate `INEFFECTIVE_DYNAMIC_IMPORT`
for `runner-client.ts` (rolldown only reports a subset at a time). That one is
**not** vestigial: `runner-client` is dynamically imported by
`src/core/dispatch.ts` / `dispatch-interactions.ts`, which is the **mandated R3
cold-start seam** (`core → platforms` must cross via `import()` / type-only to
keep it out of the CLI's eager closure). It is also statically imported by ~20
daemon modules, so rolldown can't hoist it into its own chunk. The dynamic
import is *correct and required*; the warning is inherent to the seam. Rather
than paper over it with a build-config suppression, it's left visible.

## Verification

- **Layering Guard passes** (was the failing check).
- Typecheck, lint, and provider + dispatch tests pass; build succeeds.
- The CLI eager closure is unchanged — this file isn't in the CLI graph, so
  there's no cold-start impact.