### PR TITLE
fix(replay): repair-transaction lifecycle — keep-alive, no-partial-emit, close-as-lifecycle, atomic publish

### DIFF
--- a/docs/adr/0012-interactive-replay.md
+++ b/docs/adr/0012-interactive-replay.md
@@ -576,10 +576,10 @@ Implementation is not accepted on benchmark evidence alone. Required automated c
   `COMPLETE` transaction committing (not tombstoning) — and is idempotent with no re-publish once
   `COMMITTED`; a terminal-close test proving an armed replay reaching the terminal source `close`
   **skips** it without deleting the session (C4); an atomic-publication test proving the temp file is
-  created in the target's own directory and the no-clobber is race-safe (create-exclusive/rename-if-absent);
-  and a no-clobber test proving an existing *complete* (sentinel-marked) healed artifact is protected
-  while an incomplete/partial one is
-  overwritable.
+  created in the target's own directory and published via a single exclusive `linkSync`
+  (create-if-absent, first writer wins); and a no-clobber test proving publication refuses ANY
+  pre-existing target — complete or partial alike, byte-for-byte unchanged — for both the default healed
+  sibling and an explicit `--save-script=<path>`.
 
 Extend the settle benchmark (`~/.agent-device-bench/rnnav-matrix.py` pattern, external harness) with a
 replay arm only after these contracts pass: measure clean replay and one induced divergence repaired
@@ -791,19 +791,23 @@ double-commit nor trip the no-clobber guard).
 
 **Atomic, race-safe publication.** The commit serializes the healed slice (ending with a serialized
 `close` line so the artifact is self-contained) to a temp file created **in the same directory as the
-final target** — atomic `rename` requires the same filesystem, and an explicit `--save-script=<path>`
-target may live on a different mount than any process-wide temp dir — then atomically renames it into
-place. A reader therefore never observes a half-written healed script, and an aborted repair leaves no
-partial behind. The no-clobber guard is enforced **race-safely** by the atomic primitive itself
-(create-exclusive / rename-if-absent), not by a check-then-write.
+final target** — an explicit `--save-script=<path>` target may live on a different mount than any
+process-wide temp dir, and `linkSync` requires the same filesystem — then publishes with a single
+exclusive `linkSync(temp, target)`: create-if-absent, first writer wins. A reader therefore never
+observes a half-written healed script, and an aborted repair leaves no partial behind.
 
-**No-clobber applies only to a COMPLETE healed artifact.** The guard protects a *complete, review-worthy*
-artifact only. An incomplete or partial file is always overwritable by a fresh repair that reaches
-`COMMITTED`. Completeness is established by a sentinel written **only on commit** — a trailing
-`# agent-device:heal-complete` marker — or an equivalent structural check; the atomic temp→publish flow is
-what makes that sentinel trustworthy (a partial never reaches the published path carrying the sentinel).
-Auto-versioned output names (e.g. `.healed.2.ad`) are explicitly **out of scope** here — a separate
-naming change, not part of this decision.
+**Publication refuses ANY pre-existing target — complete or partial, default or explicit path alike.**
+An earlier design distinguished a *complete, review-worthy* artifact (protected) from an incomplete or
+partial one (silently overwritable), enforced through a publish lock. That distinction added a whole
+class of lock/lease/reclaim races for a case that is, in practice, a degenerate state: a partial healed
+file left behind by an aborted or reaped repair. The simpler, adopted design collapses this: the atomic
+`linkSync` itself decides the winner (`EEXIST` iff a file already sits at the target, regardless of its
+contents), and the caller must explicitly clear the way — remove the existing file, or pass a different
+`replay --save-script=<path>` — rather than have it silently replaced. No lock, no lease, no steal, no
+overwrite. The `# agent-device:heal-complete` trailing sentinel remains — it still marks a healed `.ad` as
+a complete, review-worthy repair artifact for any other reader — but it no longer participates in the
+publish decision. Auto-versioned output names (e.g. `.healed.2.ad`) are explicitly **out of scope** here —
+a separate naming change, not part of this decision.
 
 **Repair-session tombstone (R7 ownership).** When a bounded-expiry escape hatch idle-reaps (or a daemon
 shutdown tears down) a repair-armed transaction that has **not** reached `COMPLETE`, the teardown aborts
@@ -924,8 +928,8 @@ each states its dependencies explicitly.
    regression proving the session is NOT deleted when the terminal `close` is reached; the
    `REPAIR_SESSION_EXPIRED` tombstone for an incomplete-transaction reap/shutdown (keyed by session key,
    owner + bounded expiry, cleared by a fresh `replay --save-script`); and race-safe atomic publication
-   (temp file in the target's own directory, create-exclusive/rename-if-absent no-clobber against the
-   `# agent-device:heal-complete` sentinel).
+   (temp file in the target's own directory, published via a single exclusive `linkSync` that refuses ANY
+   pre-existing target — complete or partial, default or explicit path alike — never overwriting one).
 
 ## Migration progress
 

--- a/docs/adr/0012-interactive-replay.md
+++ b/docs/adr/0012-interactive-replay.md
@@ -579,7 +579,9 @@ Implementation is not accepted on benchmark evidence alone. Required automated c
   created in the target's own directory and published via a single exclusive `linkSync`
   (create-if-absent, first writer wins); and a no-clobber test proving publication refuses ANY
   pre-existing target — complete or partial alike, byte-for-byte unchanged — for both the default healed
-  sibling and an explicit `--save-script=<path>`.
+  sibling and an explicit `--save-script=<path>`, **and for an ordinary (non-repair) `open`/`close
+  --save-script` recording whose target already exists** — the writer entry point and publish primitive
+  are shared, so the refusal is uniform, not repair-only (see "Scope" below).
 
 Extend the settle benchmark (`~/.agent-device-bench/rnnav-matrix.py` pattern, external harness) with a
 replay arm only after these contracts pass: measure clean replay and one induced divergence repaired
@@ -809,6 +811,20 @@ a complete, review-worthy repair artifact for any other reader — but it no lon
 publish decision. Auto-versioned output names (e.g. `.healed.2.ad`) are explicitly **out of scope** here —
 a separate naming change, not part of this decision.
 
+**Scope: this refusal is uniform across repair AND ordinary recording, not repair-only.** Everything
+above is written in the context of decision 6's repair-armed heal, but `publishHealedScriptAtomically`
+(`src/daemon/session-script-writer.ts`) is the single publish primitive `SessionScriptWriter.write` calls
+for every `--save-script` target, with no repair-armed-vs-ordinary branch — a repair-armed heal
+(`saveScriptBoundary` set) and an ordinary, non-repair `open --save-script`/`close --save-script`
+recording (`saveScriptBoundary` absent) publish through the exact same exclusive `linkSync`. Before this
+decision, ordinary recording published via a separate atomic rename-replace path
+(`publishOverwriteAtomically`, since removed), silently overwriting an existing target; that overwrite
+path is gone. An ordinary recording whose target already exists is now refused exactly like a healed
+repair publish would be: `EEXIST` surfaces as the same `AppError`, the existing file is left
+byte-for-byte unchanged, and the caller must remove it or choose a different `--save-script=<path>`.
+There is no `--force`/`--overwrite` escape hatch for either path today; that is tracked as a future
+follow-up (#1258), not part of this decision.
+
 **Repair-session tombstone (R7 ownership).** When a bounded-expiry escape hatch idle-reaps (or a daemon
 shutdown tears down) a repair-armed transaction that has **not** reached `COMPLETE`, the teardown aborts
 (no publish, per the state machine) and must leave a **tombstone** rather than deleting the session record
@@ -929,7 +945,9 @@ each states its dependencies explicitly.
    `REPAIR_SESSION_EXPIRED` tombstone for an incomplete-transaction reap/shutdown (keyed by session key,
    owner + bounded expiry, cleared by a fresh `replay --save-script`); and race-safe atomic publication
    (temp file in the target's own directory, published via a single exclusive `linkSync` that refuses ANY
-   pre-existing target — complete or partial, default or explicit path alike — never overwriting one).
+   pre-existing target — complete or partial, default or explicit path alike, and uniformly for an
+   ordinary non-repair recording's target too, since the publish primitive is shared — never overwriting
+   one; see "Scope" under Decision 6 above).
 
 ## Migration progress
 

--- a/src/daemon/__tests__/request-router-repair-expired.test.ts
+++ b/src/daemon/__tests__/request-router-repair-expired.test.ts
@@ -1,0 +1,140 @@
+/**
+ * ADR 0012 decision 6, R7 (C5a): when a repair session was reaped before it was
+ * finalized, the request router rewrites the resulting `SESSION_NOT_FOUND` into
+ * a `REPAIR_SESSION_EXPIRED` recovery error with actionable re-run guidance,
+ * rather than leaking a bare SESSION_NOT_FOUND. Any other error, or the absence
+ * of a live tombstone, passes through unchanged.
+ */
+import { test, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getResolveTargetDeviceMock } from './request-router-dispatch-mocks.ts';
+
+vi.mock('../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+
+import { createRequestHandler } from '../request-router.ts';
+import type { DaemonRequest, SessionState } from '../types.ts';
+import type { DeviceInfo } from '../../kernel/device.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { parseReplayInput } from '../../compat/replay-input.ts';
+import { computeReplayPlanDigest } from '../../replay/plan-digest.ts';
+import { readEffectiveReplayPlanDigestMetadata } from '../handlers/session-replay-runtime-plan.ts';
+
+const mockResolveTargetDevice = vi.mocked(getResolveTargetDeviceMock());
+
+function makeHandler(prefix: string) {
+  const sessionStore = makeSessionStore(prefix);
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+  return { sessionStore, handler };
+}
+
+function tombstonedSession(name: string): SessionState {
+  return {
+    name,
+    device: { platform: 'apple', id: 'sim-1', name: 'iPhone', kind: 'simulator', booted: true },
+    createdAt: Date.now(),
+    actions: [],
+    saveScriptBoundary: 0,
+    repairSourcePath: '/flows/login.ad',
+  };
+}
+
+function closeRequest(session: string): DaemonRequest {
+  return { token: 'test-token', session, command: 'close', positionals: [], flags: {} };
+}
+
+test('a command that finds no session but hits a live repair tombstone gets REPAIR_SESSION_EXPIRED', async () => {
+  const { sessionStore, handler } = makeHandler('agent-device-router-repair-expired-');
+  // The repair session was reaped (idle-reap) leaving a tombstone; the store
+  // has no live session by that name.
+  sessionStore.writeRepairTombstone(tombstonedSession('repair-x'));
+
+  const response = await handler(closeRequest('repair-x'));
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPAIR_SESSION_EXPIRED');
+  // Re-run guidance carries the original script path from the tombstone.
+  expect(response.error.message).toMatch(/replay \/flows\/login\.ad --save-script/);
+});
+
+test('without a tombstone, a missing session still returns a plain SESSION_NOT_FOUND', async () => {
+  const { handler } = makeHandler('agent-device-router-no-tombstone-');
+  const response = await handler(closeRequest('never-existed'));
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('SESSION_NOT_FOUND');
+});
+
+test('an expired tombstone does not shadow a missing session', async () => {
+  const { sessionStore, handler } = makeHandler('agent-device-router-expired-tombstone-');
+  // TTL 0 => already stale.
+  sessionStore.writeRepairTombstone(tombstonedSession('repair-y'), 0);
+
+  const response = await handler(closeRequest('repair-y'));
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('SESSION_NOT_FOUND');
+});
+
+// ADR 0012 decision 6, R7 (BLOCKER 1): the tombstone translation also covers the
+// `replay --from` continuation path — a reaped repair session's continuation
+// gets REPAIR_SESSION_EXPIRED, not a REPLAY_DIVERGENCE that slipped past it.
+test('a replay --from continuation on a reaped repair session gets REPAIR_SESSION_EXPIRED (not REPLAY_DIVERGENCE)', async () => {
+  // Device resolution/readiness is mocked so the router reaches the replay
+  // handler's missing-session preflight fast and deterministically.
+  const iosDevice: DeviceInfo = {
+    platform: 'apple',
+    id: 'sim-1',
+    name: 'iPhone',
+    kind: 'simulator',
+    booted: true,
+  };
+  mockResolveTargetDevice.mockResolvedValue(iosDevice);
+  const { sessionStore, handler } = makeHandler('agent-device-router-from-expired-');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-router-from-script-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(scriptPath, 'open "Demo"\nclick id="a"\n');
+
+  // Compute the plan digest exactly as runReplayScriptFile does (a real agent
+  // takes it from the divergence report's resume.planDigest).
+  const flags = { platform: 'ios' as const };
+  const parsed = parseReplayInput(fs.readFileSync(scriptPath, 'utf8'), flags, {
+    sourcePath: scriptPath,
+  });
+  const digest = computeReplayPlanDigest({
+    actions: parsed.actions,
+    actionLines: parsed.actionLines,
+    actionSourcePaths: parsed.actionSourcePaths,
+    metadata: readEffectiveReplayPlanDigestMetadata(flags),
+  });
+
+  // The repair session was reaped, leaving a tombstone; no live session exists.
+  sessionStore.writeRepairTombstone(tombstonedSession('repair-from'));
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'repair-from',
+    command: 'replay',
+    positionals: [scriptPath],
+    flags: { ...flags, replayFrom: 2, replayPlanDigest: digest },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPAIR_SESSION_EXPIRED');
+  expect(response.error.code).not.toBe('REPLAY_DIVERGENCE');
+  expect(response.error.message).toMatch(/replay \/flows\/login\.ad --save-script/);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/src/daemon/__tests__/request-router-repair-expired.test.ts
+++ b/src/daemon/__tests__/request-router-repair-expired.test.ts
@@ -75,6 +75,29 @@ test('without a tombstone, a missing session still returns a plain SESSION_NOT_F
   expect(response.error.code).toBe('SESSION_NOT_FOUND');
 });
 
+// ADR 0012 decision 6 (BLOCKER 2): a tombstone left by a COMPLETE transaction
+// whose commit FAILED at teardown must surface a distinct, actionable
+// REPAIR_COMMIT_FAILED — never the generic "reaped before it was finalized"
+// REPAIR_SESSION_EXPIRED, which would misleadingly suggest the transaction
+// never completed at all.
+test('a command hitting a commit-failure tombstone gets REPAIR_COMMIT_FAILED with the real cause, not a generic REPAIR_SESSION_EXPIRED', async () => {
+  const { sessionStore, handler } = makeHandler('agent-device-router-commit-failed-');
+  sessionStore.writeRepairTombstone(tombstonedSession('repair-commit-fail'), undefined, {
+    code: 'COMMAND_FAILED',
+    message: 'A prior healed script already exists at /flows/login.healed.ad; ...',
+  });
+
+  const response = await handler(closeRequest('repair-commit-fail'));
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPAIR_COMMIT_FAILED');
+  expect(response.error.code).not.toBe('REPAIR_SESSION_EXPIRED');
+  expect(response.error.message).toMatch(/already exists/);
+  // Still carries the actionable re-run guidance.
+  expect(response.error.message).toMatch(/replay \/flows\/login\.ad --save-script/);
+});
+
 test('an expired tombstone does not shadow a missing session', async () => {
   const { sessionStore, handler } = makeHandler('agent-device-router-expired-tombstone-');
   // TTL 0 => already stale.

--- a/src/daemon/__tests__/request-router-typed-error.test.ts
+++ b/src/daemon/__tests__/request-router-typed-error.test.ts
@@ -122,3 +122,48 @@ test('deterministic errors (INVALID_ARGS) are returned with the default shape �
   expect('supportedOn' in response.error).toBe(false);
   expect(mockDispatch).not.toHaveBeenCalled();
 });
+
+// ADR 0012 decision 6, BLOCKER 2 (second follow-up): a repair-armed `close`
+// whose targeted platform close fails must surface `retriable: true` at the
+// TOP level of the wire error — the location `enrichDaemonError` below and
+// the client actually read (`DaemonError.retriable` in kernel/contracts.ts) —
+// and must preserve the underlying platform error's own diagnosticId/logPath/
+// details rather than discarding them. Exercised through the REAL router
+// boundary (`createRequestHandler`), not just the raw response builder, so a
+// regression in either the handler OR `enrichDaemonError`'s own
+// `error.retriable ?? retriableForErrorCode(error.code)` fallback is caught.
+test('BLOCKER 2 (second follow-up): a repair-close platform-close failure surfaces retriable:true and diagnosticId/logPath/details at the TOP level through the router', async () => {
+  const { sessionStore, handler } = makeHandler();
+  const session = makeIosSession('typed-error');
+  session.recordSession = true;
+  session.saveScriptBoundary = 0;
+  session.saveScriptComplete = true;
+  session.actions = [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }];
+  sessionStore.set('typed-error', session);
+
+  // DEVICE_NOT_FOUND is not in `retriableForErrorCode`'s conservative allow
+  // list — if the handler ever regressed to relying on that code-level
+  // fallback instead of forcing `retriable: true` itself, this would catch it.
+  mockDispatch.mockRejectedValueOnce(
+    new AppError('DEVICE_NOT_FOUND', 'device vanished', {
+      diagnosticId: 'diag-router-close-1',
+      logPath: '/tmp/router-close-1.log',
+      someExtra: 'x',
+    }),
+  );
+
+  // A targeted close (an explicit positional app target) is what makes the
+  // repair-armed platform close actually dispatch instead of no-op.
+  const response = await handler(request('close', { positionals: ['com.example.app'] }));
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.retriable).toBe(true);
+  expect('retriable' in (response.error.details ?? {})).toBe(false);
+  expect(response.error.diagnosticId).toBe('diag-router-close-1');
+  expect(response.error.logPath).toBe('/tmp/router-close-1.log');
+  expect(response.error.details?.someExtra).toBe('x');
+  expect(response.error.code).toBe('DEVICE_NOT_FOUND');
+  // The session is retained (not torn down), addressable for the retry.
+  expect(sessionStore.get('typed-error')).toBeDefined();
+});

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -251,6 +251,77 @@ test('write() DOES overwrite a stale INCOMPLETE .healed.ad at the default path (
   expect(script).toContain(HEAL_COMPLETE_SENTINEL);
   const parsed = parseReplayScriptDetailed(script);
   expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
+});
+
+// BLOCKER 1: the reported race is TWO writers concurrently seeing the SAME
+// pre-existing PARTIAL (no-sentinel) default healed sibling and both
+// classifying it as overwritable — the prior implementation then let both
+// `renameSync` over it, silently, with no signal to the loser. The publish
+// primitive (not the "is it complete" check) must decide exactly one winner.
+test('BLOCKER 1: two writers racing on the SAME pre-existing PARTIAL target — the atomic primitive, not the incomplete check, decides exactly one winner', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-partial-race-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  // The shared, pre-existing PARTIAL target both writers race against — no
+  // sentinel, so both writers' own completeness checks say "overwritable".
+  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
+
+  const sessionA = makeIosSession('writer-a', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
+  });
+  const sessionB = makeIosSession('writer-b', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
+  });
+
+  // Force a genuine interleaving deterministically instead of hoping two
+  // in-process calls happen to race: when writer A performs its atomic
+  // "grab the existing target to inspect it" rename, run writer B's ENTIRE
+  // publish to completion first — exactly the reported scenario, both
+  // writers starting against the identical partial target — then let A's own
+  // call proceed against whatever B left behind.
+  const realRenameSync = fs.renameSync;
+  let triggeredCompetingWriter = false;
+  let resultB: ReturnType<SessionScriptWriter['write']> | undefined;
+  const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+    if (!triggeredCompetingWriter && from === healedPath) {
+      triggeredCompetingWriter = true;
+      resultB = writer.write(sessionB);
+    }
+    return realRenameSync(from, to);
+  });
+
+  const resultA = writer.write(sessionA);
+  renameSpy.mockRestore();
+
+  expect(resultB).toBeDefined();
+  // Exactly one writer wins (publishes), the other observes a definitive,
+  // thrown no-clobber loss — never both silently succeeding, never a torn
+  // file caused by an unconditional renameSync racing another.
+  const outcomes = [resultA, resultB!];
+  const wins = outcomes.filter((r) => r.written);
+  const losses = outcomes.filter((r) => !r.written);
+  expect(wins).toHaveLength(1);
+  expect(losses).toHaveLength(1);
+  expect(losses[0]!.written === false && losses[0]!.error?.message).toMatch(/already exists/);
+
+  // The surviving file is exactly the winner's complete, uncorrupted script —
+  // never an interleaved mix of both writers' content.
+  const finalScript = fs.readFileSync(healedPath, 'utf8');
+  expect(finalScript).toContain(HEAL_COMPLETE_SENTINEL);
+  const parsed = parseReplayScriptDetailed(finalScript);
+  const winnerLabel = resultB!.written ? 'id="from-b"' : 'id="from-a"';
+  expect(parsed.actions.map((a) => a.positionals[0])).toEqual([winnerLabel]);
 });
 
 test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -305,15 +305,23 @@ test('BLOCKER 1: two writers racing on the SAME pre-existing PARTIAL target — 
   renameSpy.mockRestore();
 
   expect(resultB).toBeDefined();
-  // Exactly one writer wins (publishes), the other observes a definitive,
-  // thrown no-clobber loss — never both silently succeeding, never a torn
-  // file caused by an unconditional renameSync racing another.
+  // Exactly one writer wins (publishes), the other observes a definitive
+  // loss — never both silently succeeding, never a torn file caused by an
+  // unconditional renameSync racing another. BLOCKER 1's follow-up fix now
+  // serializes the whole decide-and-act sequence for `scriptPath` behind an
+  // exclusive publish lock (see `publishNoClobberAtomically`), so the loser
+  // here may fail either via the no-clobber refusal (it grabbed the target
+  // and found it COMPLETE) or via lock contention (it never got a turn before
+  // the winner published) — which one depends on interleaving timing, but
+  // either way it is a clean, thrown loss, never a silent one.
   const outcomes = [resultA, resultB!];
   const wins = outcomes.filter((r) => r.written);
   const losses = outcomes.filter((r) => !r.written);
   expect(wins).toHaveLength(1);
   expect(losses).toHaveLength(1);
-  expect(losses[0]!.written === false && losses[0]!.error?.message).toMatch(/already exists/);
+  expect(losses[0]!.written === false && losses[0]!.error?.message).toMatch(
+    /already exists|timed out waiting/,
+  );
 
   // The surviving file is exactly the winner's complete, uncorrupted script —
   // never an interleaved mix of both writers' content.
@@ -322,6 +330,82 @@ test('BLOCKER 1: two writers racing on the SAME pre-existing PARTIAL target — 
   const parsed = parseReplayScriptDetailed(finalScript);
   const winnerLabel = resultB!.written ? 'id="from-b"' : 'id="from-a"';
   expect(parsed.actions.map((a) => a.positionals[0])).toEqual([winnerLabel]);
+});
+
+// BLOCKER 1 (follow-up): the reported race is a COMPLETE target being
+// silently clobbered because the inspect/restore/publish sequence was not
+// exclusive — writer A quarantines an existing COMPLETE artifact, writer B
+// publishes its own COMPLETE artifact into the now-empty slot and returns
+// success, and writer A's restore (`renameSync`, which replaces an existing
+// destination per POSIX) then silently stomps B's freshly published bytes.
+test('BLOCKER 1 (follow-up): a writer publishing while another is mid quarantine-and-restore of a COMPLETE target never gets silently clobbered', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-complete-race-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  // A genuine, pre-existing COMPLETE (sentinel-marked) healed artifact.
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="original"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+  const before = fs.readFileSync(healedPath, 'utf8');
+
+  const sessionA = makeIosSession('writer-a', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
+  });
+  const sessionB = makeIosSession('writer-b', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
+  });
+
+  // Force the exact interleaving the reviewer identified: let writer A's own
+  // atomic "grab the existing COMPLETE target into quarantine" rename
+  // actually happen (scriptPath is now momentarily empty), THEN — before A
+  // restores its quarantined copy — run writer B's entire publish. Under the
+  // prior implementation, B's `linkSync` won the now-empty slot and returned
+  // success, only for A's subsequent restore to silently stomp B's bytes.
+  const realRenameSync = fs.renameSync;
+  let triggeredCompetingWriter = false;
+  let resultB: ReturnType<SessionScriptWriter['write']> | undefined;
+  const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+    const isGrab =
+      !triggeredCompetingWriter && from === healedPath && String(to).includes('.quarantine');
+    if (isGrab) {
+      const result = realRenameSync(from, to);
+      triggeredCompetingWriter = true;
+      resultB = writer.write(sessionB);
+      return result;
+    }
+    return realRenameSync(from, to);
+  });
+
+  const resultA = writer.write(sessionA);
+  renameSpy.mockRestore();
+
+  expect(triggeredCompetingWriter).toBe(true);
+  expect(resultB).toBeDefined();
+
+  // No writer may report success unless ITS complete bytes are the ones
+  // actually sitting at the target.
+  const finalScript = fs.readFileSync(healedPath, 'utf8');
+  if (resultA.written) expect(finalScript).toContain('id="from-a"');
+  if (resultB!.written) expect(finalScript).toContain('id="from-b"');
+
+  // A genuine COMPLETE artifact already sat at the target before either
+  // writer ran: no-clobber means NEITHER may publish over it — both must be
+  // refused, and the original bytes survive byte-for-byte.
+  expect(resultA.written).toBe(false);
+  expect(resultB!.written).toBe(false);
+  expect(finalScript).toBe(before);
 });
 
 test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -481,6 +481,41 @@ test('BLOCKER 1 (lock reclaim): a stale dead-lock decision never steals a lock a
   expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
 });
 
+// BLOCKER 4: the no-clobber, complete-artifact protection must apply to an
+// EXPLICIT `--save-script=<path>` target too, not just the default healed
+// sibling — an explicit target is caller-DIRECTED (which path to use), never
+// caller-AUTHORIZED to silently destroy an unreviewed prior COMPLETE healed
+// diff sitting there.
+test('BLOCKER 4: write() refuses to clobber an existing COMPLETE artifact at an EXPLICIT --save-script=<path> target too', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-explicit-complete-clobber-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const explicitOut = path.join(root, 'flows', 'promoted.ad');
+  fs.mkdirSync(path.dirname(explicitOut), { recursive: true });
+  fs.writeFileSync(
+    explicitOut,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+  const before = fs.readFileSync(explicitOut, 'utf8');
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: explicitOut,
+    // No saveScriptDefaultedHealedPath: this is an explicit, caller-directed
+    // target — the protection must apply here too, not just the default path.
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/already exists/);
+  // The prior complete diff at the explicit target is untouched.
+  expect(fs.readFileSync(explicitOut, 'utf8')).toBe(before);
+});
+
 test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-explicit-out-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -408,15 +408,23 @@ test('BLOCKER 1 (follow-up): a writer publishing while another is mid quarantine
   expect(finalScript).toBe(before);
 });
 
-// BLOCKER 1 (lock reclaim, second follow-up): the reclaim of a DEAD lock was
-// itself a TOCTOU — `isHeldByDeadProcess` read the lock file's PID, then a
-// SEPARATE `rmSync(lockPath)` acted on it BY PATHNAME. If a second waiter
-// reclaimed the SAME dead lock and re-acquired with its OWN live lock inside
-// that gap, the first waiter's stale removal deleted the live lock it never
-// actually inspected — not the dead one it read — letting both waiters
-// believe they held the exclusive lock at once.
-test('BLOCKER 1 (lock reclaim): a stale dead-lock decision never steals a lock a concurrent reclaimer has since made LIVE', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lock-race-'));
+// BLOCKER 1 (lease replacement — maintainer-approved design): the PID-liveness
+// `reclaimDeadLock` scheme (grab lock away -> inspect PID -> restore if live)
+// was structurally race-prone: a three-writer interleaving let waiter A
+// rename waiter B's now-LIVE lock away (to inspect it), waiter C `linkSync`
+// its own lock into the momentarily-empty path, then A's "restore"
+// (`renameSync`, which replaces an existing destination) silently clobbered
+// C's freshly acquired lock — and the pathname-based release could then
+// remove a SUCCESSOR's lock, not the caller's own. Replaced with a TTL LEASE:
+// staleness is judged purely from a timestamp embedded in the lock file's own
+// content (never by asking the OS whether a PID is alive), a stolen lease is
+// NEVER restored (an unconditional discard after a single atomic rename), and
+// every publish verifies it STILL owns the lease immediately before entering
+// the critical section — closing the window where the lock FILE could be
+// contended out from under a legitimate holder.
+
+test('BLOCKER 1 (lease): a FRESH lease is never stolen regardless of its recorded owner — staleness is judged purely by age — and a contender backs off and times out', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lease-fresh-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
@@ -424,61 +432,179 @@ test('BLOCKER 1 (lock reclaim): a stale dead-lock decision never steals a lock a
   fs.writeFileSync(healedPath, originalContent);
 
   const lockPath = `${healedPath}.lock`;
-  // A DEAD writer's abandoned lock: a PID far outside any real range, so
-  // `isProcessAlive` reports it as not running — same convention used for the
-  // same purpose in `process-lock.test.ts`.
-  fs.writeFileSync(lockPath, '999999999');
+  // A lease recorded under a pid that could never be a real, running
+  // process — the OLD PID-liveness scheme would have judged this "dead" on
+  // sight and reclaimed it. The lease scheme must never steal it: it is
+  // FRESH (just created), and staleness is judged purely by age now, never
+  // by asking the OS whether a pid is alive.
+  const freshToken = `999999999:unrelated-writer:${Date.now()}`;
+  fs.writeFileSync(lockPath, freshToken);
 
-  const sessionA = makeIosSession('writer-a', {
+  const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
     saveScriptComplete: true,
     saveScriptPath: healedPath,
     saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
-  // Deterministically drive the exact interleaving the reviewer found: A's
-  // FIRST read of the dead lock (`isHeldByDeadProcess`'s `readFileSync`)
-  // captures the stale dead-PID snapshot A will act on — but as a side
-  // effect of that very read, "writer B" independently reclaims the SAME
-  // dead lock and re-acquires it with a genuinely LIVE pid (this test
-  // process's own, real, alive pid) before A's own reclaim step runs. A must
-  // never destroy B's freshly-live lock.
-  const realReadFileSync = fs.readFileSync;
-  let interleaved = false;
-  const liveMarkerPid = String(process.pid);
-  const readSpy = vi
-    .spyOn(fs, 'readFileSync')
-    .mockImplementation((target: fs.PathOrFileDescriptor, options?: unknown) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = (realReadFileSync as any)(target, options);
-      if (!interleaved && target === lockPath) {
-        interleaved = true;
-        // "Writer B" reclaims the same dead lock and re-acquires it live,
-        // using the exact same primitives the real implementation uses.
-        const bTempLockPath = `${lockPath}.b-writer.tmp`;
-        fs.rmSync(lockPath, { force: true });
-        fs.writeFileSync(bTempLockPath, liveMarkerPid);
-        fs.linkSync(bTempLockPath, lockPath);
-        fs.rmSync(bTempLockPath, { force: true });
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/timed out waiting/);
+  // The fresh lease survives byte-for-byte — never renamed/removed.
+  expect(fs.readFileSync(lockPath, 'utf8')).toBe(freshToken);
+  // The contender never entered the critical section.
+  expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
+});
+
+test('BLOCKER 1 (lease): an EXPIRED lease is stolen safely — never restored — and a fresh reclaim afterward publishes cleanly', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lease-expired-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
+
+  const lockPath = `${healedPath}.lock`;
+  // A crashed writer's abandoned lease: older than LEASE_TTL_MS (30_000ms).
+  fs.writeFileSync(lockPath, `424242:crashed-writer:${Date.now() - 31_000}`);
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  // The expired lease was stolen and released again — no lock file lingers.
+  expect(fs.existsSync(lockPath)).toBe(false);
+  const script = fs.readFileSync(healedPath, 'utf8');
+  expect(script).toContain(HEAL_COMPLETE_SENTINEL);
+  expect(parseReplayScriptDetailed(script).actions.map((a) => a.positionals[0])).toEqual([
+    'id="new"',
+  ]);
+});
+
+// BLOCKER 1 (lease, three-writer interleaving — the reviewer's exact missing
+// case): during ANY reclaim window, a third writer C can validly acquire and
+// enter the critical section. Assert: (1) exactly one holder is EVER in the
+// critical section for a given moment — a writer whose lease gets displaced
+// underneath it (B) is never fooled into proceeding unprotected, because
+// `verifyOwnership` re-checks immediately before the critical section; (2) a
+// displaced writer's OWN release never deletes its successor's (A's) lock —
+// release is strictly token-scoped; (3) the discarding writer (A) never
+// performs a destination-replacing "restore" — a live claim it accidentally
+// grabbed is discarded outright, never renamed back over whoever now holds
+// the path, so a genuinely fresh writer (C) can subsequently acquire and
+// publish cleanly once the lock is free.
+test('BLOCKER 1 (lease, three-writer interleaving): a stale steal decision can never let two writers enter the critical section at once, and release never deletes a successor lock', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-lease-three-writer-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  const originalContent = 'context platform=ios device="x"\nclick id="stale-partial"\n';
+  fs.writeFileSync(healedPath, originalContent);
+
+  const lockPath = `${healedPath}.lock`;
+  // Writer X crashed, leaving an abandoned, genuinely EXPIRED lease — both A
+  // and B will independently decide (correctly, at the time each reads it)
+  // that this is stealable.
+  fs.writeFileSync(lockPath, `111111:x-writer-token:${Date.now() - 31_000}`);
+
+  const sessionB = makeIosSession('writer-b', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
+  });
+
+  // Deterministically drive the exact interleaving: right after WRITER B's
+  // own claim (`linkSync`) legitimately WINS the now-freed `lockPath` (B has
+  // just, validly, re-acquired a FRESH lease and is about to verify
+  // ownership and publish) — inject WRITER A independently grabbing
+  // whatever CURRENTLY sits at `lockPath`. A's own decision to steal was
+  // made from an EARLIER read of X's now-superseded dead lease — but a
+  // rename operates on whatever is there NOW, not on the bytes A read
+  // earlier, so A's grab unavoidably catches B's fresh claim instead of X's.
+  // A discards it outright (never a restore) and re-claims fresh as its own
+  // — using the exact same primitives the real implementation uses.
+  const realLinkSync = fs.linkSync;
+  let injected = false;
+  const aToken = `222222:a-writer-token:${Date.now()}`;
+  let lockContentDuringInjection: string | undefined;
+  const linkSpy = vi
+    .spyOn(fs, 'linkSync')
+    .mockImplementation((existingPath: fs.PathLike, newPath: fs.PathLike) => {
+      let thrown: unknown;
+      try {
+        realLinkSync(existingPath, newPath);
+      } catch (error) {
+        thrown = error;
       }
-      return result;
+      if (!thrown && !injected && newPath === lockPath) {
+        injected = true;
+        const aQuarantine = `${lockPath}.a-writer.quarantine`;
+        fs.renameSync(lockPath, aQuarantine); // A's grab — catches B's fresh claim, not X's.
+        fs.rmSync(aQuarantine, { force: true }); // Unconditional discard — never a restore.
+        const aTemp = `${lockPath}.a-writer.tmp`;
+        fs.writeFileSync(aTemp, aToken);
+        fs.linkSync(aTemp, lockPath); // A's own fresh re-claim.
+        fs.rmSync(aTemp, { force: true });
+        lockContentDuringInjection = fs.readFileSync(lockPath, 'utf8');
+      }
+      if (thrown) throw thrown;
     });
 
-  const resultA = writer.write(sessionA);
-  readSpy.mockRestore();
+  const resultB = writer.write(sessionB);
+  linkSpy.mockRestore();
 
-  expect(interleaved).toBe(true);
-  // B's live lock is never stolen: A must back off rather than silently
-  // steal it and proceed into the exclusive/publish section — B never
-  // releases it in this test, so A exhausts its bounded wait and fails loud.
-  expect(resultA.written).toBe(false);
-  expect(resultA.written === false && resultA.error?.message).toMatch(/timed out waiting/);
-  // B's lock survives, byte-for-byte, for the entire time A contended for it.
-  expect(fs.readFileSync(lockPath, 'utf8')).toBe(liveMarkerPid);
-  // A never published over the target while B's lock was live.
+  expect(injected).toBe(true);
+  // A's re-claim was its OWN fresh token — never B's trampled one restored
+  // back verbatim (that would be the forbidden clobbering "restore" shape).
+  expect(lockContentDuringInjection).toBe(aToken);
+  // (1) B's fresh claim was displaced underneath it, but B is never fooled
+  // into proceeding unprotected: `verifyOwnership` catches the mismatch
+  // immediately before the critical section, so B safely aborts instead of
+  // silently entering it alongside anyone else.
+  expect(resultB.written).toBe(false);
+  expect(resultB.written === false && resultB.error?.message).toMatch(/lease/);
+  // scriptPath is untouched — B never reached the critical section, so it
+  // never got the chance to publish or corrupt it.
   expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
+  // (2) B's own `finally` release ran as it unwound from the throw — it
+  // must NOT have deleted A's now-current lock: release is strictly
+  // token-scoped (B's token no longer matches what's actually there).
+  expect(fs.readFileSync(lockPath, 'utf8')).toBe(aToken);
+
+  // A eventually releases (as any real holder would), and a genuinely fresh
+  // writer C can then cleanly acquire and publish — (3) exactly ONE holder
+  // (C) ever actually ends up in the critical section for this scriptPath.
+  fs.rmSync(lockPath, { force: true });
+  const sessionC = makeIosSession('writer-c', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-c"'] })],
+  });
+  const resultC = writer.write(sessionC);
+  expect(resultC.written).toBe(true);
+  const finalScript = fs.readFileSync(healedPath, 'utf8');
+  expect(finalScript).toContain(HEAL_COMPLETE_SENTINEL);
+  expect(parseReplayScriptDetailed(finalScript).actions.map((a) => a.positionals[0])).toEqual([
+    'id="from-c"',
+  ]);
+  // No lock file lingers once C's publish (and release) completes.
+  expect(fs.existsSync(lockPath)).toBe(false);
 });
 
 // BLOCKER 4: the no-clobber, complete-artifact protection must apply to an

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -191,16 +191,44 @@ test('an ordinary (non-repair-armed) recording keeps the existing bare-ref fallb
 });
 
 // --- ADR 0012 decision 6 (P2): the default `.healed.ad` sibling is never
-// silently clobbered — a human must review each healed diff before promoting. ---
+// silently clobbered — a human must review each healed diff before promoting.
+// The publish primitive refuses ANY pre-existing target, complete or
+// partial, uniformly (no lock, no lease, no overwrite). ---
 
-test('write() refuses to clobber an existing COMPLETE DEFAULT .healed.ad (no explicit --save-script=<path>)', () => {
+// (a) publishing to an ABSENT target succeeds.
+test('write() publishes cleanly when the target does not exist yet', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-absent-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  expect(result.written && result.path).toBe(healedPath);
+  const script = fs.readFileSync(healedPath, 'utf8');
+  expect(script).toContain(HEAL_COMPLETE_SENTINEL);
+  const parsed = parseReplayScriptDetailed(script);
+  expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
+});
+
+// (b) publishing when a COMPLETE sentinel-marked artifact exists is REFUSED,
+// bytes unchanged.
+test('write() refuses to clobber an existing COMPLETE DEFAULT .healed.ad', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-clobber-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
   // A prior, unreviewed, COMPLETE healed script already sits at the default
-  // sibling path (Fix 4: only a file carrying the completeness sentinel is
-  // protected).
+  // sibling path — the publish primitive refuses ANY pre-existing target, so
+  // this is refused regardless of the sentinel.
   fs.writeFileSync(
     healedPath,
     `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
@@ -225,7 +253,7 @@ test('write() refuses to clobber an existing COMPLETE DEFAULT .healed.ad (no exp
   expect(fs.readFileSync(healedPath, 'utf8')).toBe(before);
 });
 
-test('write() DOES overwrite a stale INCOMPLETE .healed.ad at the default path (Fix 4: partial is overwritable)', () => {
+test('write() now refuses to clobber a stale PARTIAL (non-sentinel) .healed.ad at the default path too (behavior change: no more auto-overwrite)', () => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'agent-device-script-writer-clobber-partial-'),
   );
@@ -233,212 +261,12 @@ test('write() DOES overwrite a stale INCOMPLETE .healed.ad at the default path (
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
   // A partial left over from a diverged-and-abandoned repair (pre-Fix-2 bug,
-  // or any other incomplete write) — no completeness sentinel.
+  // or any other incomplete write) — no completeness sentinel. The lock/lease
+  // machinery used to distinguish this from a COMPLETE artifact and silently
+  // overwrite it; the simplified publish primitive refuses ANY pre-existing
+  // target uniformly, complete or partial alike.
   fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
-
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="new"'] })],
-  });
-
-  const result = writer.write(session);
-  expect(result.written).toBe(true);
-  const script = fs.readFileSync(healedPath, 'utf8');
-  expect(script).toContain(HEAL_COMPLETE_SENTINEL);
-  const parsed = parseReplayScriptDetailed(script);
-  expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
-});
-
-// BLOCKER 1: the reported race is TWO writers concurrently seeing the SAME
-// pre-existing PARTIAL (no-sentinel) default healed sibling and both
-// classifying it as overwritable — the prior implementation then let both
-// `renameSync` over it, silently, with no signal to the loser. The publish
-// primitive (not the "is it complete" check) must decide exactly one winner.
-test('BLOCKER 1: two writers racing on the SAME pre-existing PARTIAL target — the atomic primitive, not the incomplete check, decides exactly one winner', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-partial-race-'));
-  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const healedPath = path.join(root, 'flows', 'login.healed.ad');
-  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  // The shared, pre-existing PARTIAL target both writers race against — no
-  // sentinel, so both writers' own completeness checks say "overwritable".
-  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
-
-  const sessionA = makeIosSession('writer-a', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
-  });
-  const sessionB = makeIosSession('writer-b', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
-  });
-
-  // Force a genuine interleaving deterministically instead of hoping two
-  // in-process calls happen to race: when writer A performs its atomic
-  // "grab the existing target to inspect it" rename, run writer B's ENTIRE
-  // publish to completion first — exactly the reported scenario, both
-  // writers starting against the identical partial target — then let A's own
-  // call proceed against whatever B left behind.
-  const realRenameSync = fs.renameSync;
-  let triggeredCompetingWriter = false;
-  let resultB: ReturnType<SessionScriptWriter['write']> | undefined;
-  const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
-    if (!triggeredCompetingWriter && from === healedPath) {
-      triggeredCompetingWriter = true;
-      resultB = writer.write(sessionB);
-    }
-    return realRenameSync(from, to);
-  });
-
-  const resultA = writer.write(sessionA);
-  renameSpy.mockRestore();
-
-  expect(resultB).toBeDefined();
-  // Exactly one writer wins (publishes), the other observes a definitive
-  // loss — never both silently succeeding, never a torn file caused by an
-  // unconditional renameSync racing another. BLOCKER 1's follow-up fix now
-  // serializes the whole decide-and-act sequence for `scriptPath` behind an
-  // exclusive publish lock (see `publishNoClobberAtomically`), so the loser
-  // here may fail either via the no-clobber refusal (it grabbed the target
-  // and found it COMPLETE) or via lock contention (it never got a turn before
-  // the winner published) — which one depends on interleaving timing, but
-  // either way it is a clean, thrown loss, never a silent one.
-  const outcomes = [resultA, resultB!];
-  const wins = outcomes.filter((r) => r.written);
-  const losses = outcomes.filter((r) => !r.written);
-  expect(wins).toHaveLength(1);
-  expect(losses).toHaveLength(1);
-  expect(losses[0]!.written === false && losses[0]!.error?.message).toMatch(
-    /already exists|timed out waiting/,
-  );
-
-  // The surviving file is exactly the winner's complete, uncorrupted script —
-  // never an interleaved mix of both writers' content.
-  const finalScript = fs.readFileSync(healedPath, 'utf8');
-  expect(finalScript).toContain(HEAL_COMPLETE_SENTINEL);
-  const parsed = parseReplayScriptDetailed(finalScript);
-  const winnerLabel = resultB!.written ? 'id="from-b"' : 'id="from-a"';
-  expect(parsed.actions.map((a) => a.positionals[0])).toEqual([winnerLabel]);
-});
-
-// BLOCKER 1 (follow-up): the reported race is a COMPLETE target being
-// silently clobbered because the inspect/restore/publish sequence was not
-// exclusive — writer A quarantines an existing COMPLETE artifact, writer B
-// publishes its own COMPLETE artifact into the now-empty slot and returns
-// success, and writer A's restore (`renameSync`, which replaces an existing
-// destination per POSIX) then silently stomps B's freshly published bytes.
-test('BLOCKER 1 (follow-up): a writer publishing while another is mid quarantine-and-restore of a COMPLETE target never gets silently clobbered', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-complete-race-'));
-  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const healedPath = path.join(root, 'flows', 'login.healed.ad');
-  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  // A genuine, pre-existing COMPLETE (sentinel-marked) healed artifact.
-  fs.writeFileSync(
-    healedPath,
-    `context platform=ios device="x"\nclick id="original"\n${HEAL_COMPLETE_SENTINEL}\n`,
-  );
   const before = fs.readFileSync(healedPath, 'utf8');
-
-  const sessionA = makeIosSession('writer-a', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
-  });
-  const sessionB = makeIosSession('writer-b', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
-  });
-
-  // Force the exact interleaving the reviewer identified: let writer A's own
-  // atomic "grab the existing COMPLETE target into quarantine" rename
-  // actually happen (scriptPath is now momentarily empty), THEN — before A
-  // restores its quarantined copy — run writer B's entire publish. Under the
-  // prior implementation, B's `linkSync` won the now-empty slot and returned
-  // success, only for A's subsequent restore to silently stomp B's bytes.
-  const realRenameSync = fs.renameSync;
-  let triggeredCompetingWriter = false;
-  let resultB: ReturnType<SessionScriptWriter['write']> | undefined;
-  const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
-    const isGrab =
-      !triggeredCompetingWriter && from === healedPath && String(to).includes('.quarantine');
-    if (isGrab) {
-      const result = realRenameSync(from, to);
-      triggeredCompetingWriter = true;
-      resultB = writer.write(sessionB);
-      return result;
-    }
-    return realRenameSync(from, to);
-  });
-
-  const resultA = writer.write(sessionA);
-  renameSpy.mockRestore();
-
-  expect(triggeredCompetingWriter).toBe(true);
-  expect(resultB).toBeDefined();
-
-  // No writer may report success unless ITS complete bytes are the ones
-  // actually sitting at the target.
-  const finalScript = fs.readFileSync(healedPath, 'utf8');
-  if (resultA.written) expect(finalScript).toContain('id="from-a"');
-  if (resultB!.written) expect(finalScript).toContain('id="from-b"');
-
-  // A genuine COMPLETE artifact already sat at the target before either
-  // writer ran: no-clobber means NEITHER may publish over it — both must be
-  // refused, and the original bytes survive byte-for-byte.
-  expect(resultA.written).toBe(false);
-  expect(resultB!.written).toBe(false);
-  expect(finalScript).toBe(before);
-});
-
-// BLOCKER 1 (lease replacement — maintainer-approved design): the PID-liveness
-// `reclaimDeadLock` scheme (grab lock away -> inspect PID -> restore if live)
-// was structurally race-prone: a three-writer interleaving let waiter A
-// rename waiter B's now-LIVE lock away (to inspect it), waiter C `linkSync`
-// its own lock into the momentarily-empty path, then A's "restore"
-// (`renameSync`, which replaces an existing destination) silently clobbered
-// C's freshly acquired lock — and the pathname-based release could then
-// remove a SUCCESSOR's lock, not the caller's own. Replaced with a TTL LEASE:
-// staleness is judged purely from a timestamp embedded in the lock file's own
-// content (never by asking the OS whether a PID is alive), a stolen lease is
-// NEVER restored (an unconditional discard after a single atomic rename), and
-// every publish verifies it STILL owns the lease immediately before entering
-// the critical section — closing the window where the lock FILE could be
-// contended out from under a legitimate holder.
-
-test('BLOCKER 1 (lease): a FRESH lease is never stolen regardless of its recorded owner — staleness is judged purely by age — and a contender backs off and times out', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lease-fresh-'));
-  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const healedPath = path.join(root, 'flows', 'login.healed.ad');
-  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  const originalContent = 'context platform=ios device="x"\nclick id="stale-partial"\n';
-  fs.writeFileSync(healedPath, originalContent);
-
-  const lockPath = `${healedPath}.lock`;
-  // A lease recorded under a pid that could never be a real, running
-  // process — the OLD PID-liveness scheme would have judged this "dead" on
-  // sight and reclaimed it. The lease scheme must never steal it: it is
-  // FRESH (just created), and staleness is judged purely by age now, never
-  // by asking the OS whether a pid is alive.
-  const freshToken = `999999999:unrelated-writer:${Date.now()}`;
-  fs.writeFileSync(lockPath, freshToken);
 
   const session = makeIosSession('default', {
     recordSession: true,
@@ -451,72 +279,29 @@ test('BLOCKER 1 (lease): a FRESH lease is never stolen regardless of its recorde
 
   const result = writer.write(session);
   expect(result.written).toBe(false);
-  expect(result.written === false && result.error?.message).toMatch(/timed out waiting/);
-  // The fresh lease survives byte-for-byte — never renamed/removed.
-  expect(fs.readFileSync(lockPath, 'utf8')).toBe(freshToken);
-  // The contender never entered the critical section.
-  expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
+  expect(result.written === false && result.error?.message).toMatch(/already exists/);
+  expect(fs.readFileSync(healedPath, 'utf8')).toBe(before);
 });
 
-test('BLOCKER 1 (lease): an EXPIRED lease is stolen safely — never restored — and a fresh reclaim afterward publishes cleanly', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lease-expired-'));
+// The lock/lease machinery previously here (acquireLease/releaseLease/
+// stealExpiredLease/the three-writer interleaving) is gone: the publish
+// primitive is now a single exclusive `linkSync`, which already decides a
+// concurrent race correctly without any lock — first writer wins, the loser
+// sees `EEXIST` and is refused.
+test('two writers racing on the SAME ABSENT target: exactly one linkSync wins, the other is refused (no lock involved)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-race-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
 
-  const lockPath = `${healedPath}.lock`;
-  // A crashed writer's abandoned lease: older than LEASE_TTL_MS (30_000ms).
-  fs.writeFileSync(lockPath, `424242:crashed-writer:${Date.now() - 31_000}`);
-
-  const session = makeIosSession('default', {
+  const sessionA = makeIosSession('writer-a', {
     recordSession: true,
     saveScriptBoundary: 0,
     saveScriptComplete: true,
     saveScriptPath: healedPath,
     saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
   });
-
-  const result = writer.write(session);
-  expect(result.written).toBe(true);
-  // The expired lease was stolen and released again — no lock file lingers.
-  expect(fs.existsSync(lockPath)).toBe(false);
-  const script = fs.readFileSync(healedPath, 'utf8');
-  expect(script).toContain(HEAL_COMPLETE_SENTINEL);
-  expect(parseReplayScriptDetailed(script).actions.map((a) => a.positionals[0])).toEqual([
-    'id="new"',
-  ]);
-});
-
-// BLOCKER 1 (lease, three-writer interleaving — the reviewer's exact missing
-// case): during ANY reclaim window, a third writer C can validly acquire and
-// enter the critical section. Assert: (1) exactly one holder is EVER in the
-// critical section for a given moment — a writer whose lease gets displaced
-// underneath it (B) is never fooled into proceeding unprotected, because
-// `verifyOwnership` re-checks immediately before the critical section; (2) a
-// displaced writer's OWN release never deletes its successor's (A's) lock —
-// release is strictly token-scoped; (3) the discarding writer (A) never
-// performs a destination-replacing "restore" — a live claim it accidentally
-// grabbed is discarded outright, never renamed back over whoever now holds
-// the path, so a genuinely fresh writer (C) can subsequently acquire and
-// publish cleanly once the lock is free.
-test('BLOCKER 1 (lease, three-writer interleaving): a stale steal decision can never let two writers enter the critical section at once, and release never deletes a successor lock', () => {
-  const root = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'agent-device-script-writer-lease-three-writer-'),
-  );
-  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const healedPath = path.join(root, 'flows', 'login.healed.ad');
-  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  const originalContent = 'context platform=ios device="x"\nclick id="stale-partial"\n';
-  fs.writeFileSync(healedPath, originalContent);
-
-  const lockPath = `${healedPath}.lock`;
-  // Writer X crashed, leaving an abandoned, genuinely EXPIRED lease — both A
-  // and B will independently decide (correctly, at the time each reads it)
-  // that this is stealable.
-  fs.writeFileSync(lockPath, `111111:x-writer-token:${Date.now() - 31_000}`);
-
   const sessionB = makeIosSession('writer-b', {
     recordSession: true,
     saveScriptBoundary: 0,
@@ -526,93 +311,50 @@ test('BLOCKER 1 (lease, three-writer interleaving): a stale steal decision can n
     actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
   });
 
-  // Deterministically drive the exact interleaving: right after WRITER B's
-  // own claim (`linkSync`) legitimately WINS the now-freed `lockPath` (B has
-  // just, validly, re-acquired a FRESH lease and is about to verify
-  // ownership and publish) — inject WRITER A independently grabbing
-  // whatever CURRENTLY sits at `lockPath`. A's own decision to steal was
-  // made from an EARLIER read of X's now-superseded dead lease — but a
-  // rename operates on whatever is there NOW, not on the bytes A read
-  // earlier, so A's grab unavoidably catches B's fresh claim instead of X's.
-  // A discards it outright (never a restore) and re-claims fresh as its own
-  // — using the exact same primitives the real implementation uses.
+  // Force a genuine interleaving deterministically: just before writer A's
+  // own final `linkSync` into `healedPath` runs, drive writer B's ENTIRE
+  // publish to completion first — both writers started against the same
+  // absent target, but B's own `linkSync` gets there first.
   const realLinkSync = fs.linkSync;
-  let injected = false;
-  const aToken = `222222:a-writer-token:${Date.now()}`;
-  let lockContentDuringInjection: string | undefined;
+  let triggeredCompetingWriter = false;
+  let resultB: ReturnType<SessionScriptWriter['write']> | undefined;
   const linkSpy = vi
     .spyOn(fs, 'linkSync')
     .mockImplementation((existingPath: fs.PathLike, newPath: fs.PathLike) => {
-      let thrown: unknown;
-      try {
-        realLinkSync(existingPath, newPath);
-      } catch (error) {
-        thrown = error;
+      if (!triggeredCompetingWriter && newPath === healedPath) {
+        triggeredCompetingWriter = true;
+        resultB = writer.write(sessionB);
       }
-      if (!thrown && !injected && newPath === lockPath) {
-        injected = true;
-        const aQuarantine = `${lockPath}.a-writer.quarantine`;
-        fs.renameSync(lockPath, aQuarantine); // A's grab — catches B's fresh claim, not X's.
-        fs.rmSync(aQuarantine, { force: true }); // Unconditional discard — never a restore.
-        const aTemp = `${lockPath}.a-writer.tmp`;
-        fs.writeFileSync(aTemp, aToken);
-        fs.linkSync(aTemp, lockPath); // A's own fresh re-claim.
-        fs.rmSync(aTemp, { force: true });
-        lockContentDuringInjection = fs.readFileSync(lockPath, 'utf8');
-      }
-      if (thrown) throw thrown;
+      return realLinkSync(existingPath, newPath);
     });
 
-  const resultB = writer.write(sessionB);
+  const resultA = writer.write(sessionA);
   linkSpy.mockRestore();
 
-  expect(injected).toBe(true);
-  // A's re-claim was its OWN fresh token — never B's trampled one restored
-  // back verbatim (that would be the forbidden clobbering "restore" shape).
-  expect(lockContentDuringInjection).toBe(aToken);
-  // (1) B's fresh claim was displaced underneath it, but B is never fooled
-  // into proceeding unprotected: `verifyOwnership` catches the mismatch
-  // immediately before the critical section, so B safely aborts instead of
-  // silently entering it alongside anyone else.
-  expect(resultB.written).toBe(false);
-  expect(resultB.written === false && resultB.error?.message).toMatch(/lease/);
-  // scriptPath is untouched — B never reached the critical section, so it
-  // never got the chance to publish or corrupt it.
-  expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
-  // (2) B's own `finally` release ran as it unwound from the throw — it
-  // must NOT have deleted A's now-current lock: release is strictly
-  // token-scoped (B's token no longer matches what's actually there).
-  expect(fs.readFileSync(lockPath, 'utf8')).toBe(aToken);
+  expect(resultB).toBeDefined();
+  // Exactly one writer wins (its own linkSync creates the file), the other's
+  // subsequent linkSync sees EEXIST and is cleanly refused — never both
+  // silently succeeding, never a torn/mixed file.
+  const outcomes = [resultA, resultB!];
+  const wins = outcomes.filter((r) => r.written);
+  const losses = outcomes.filter((r) => !r.written);
+  expect(wins).toHaveLength(1);
+  expect(losses).toHaveLength(1);
+  expect(losses[0]!.written === false && losses[0]!.error?.message).toMatch(/already exists/);
 
-  // A eventually releases (as any real holder would), and a genuinely fresh
-  // writer C can then cleanly acquire and publish — (3) exactly ONE holder
-  // (C) ever actually ends up in the critical section for this scriptPath.
-  fs.rmSync(lockPath, { force: true });
-  const sessionC = makeIosSession('writer-c', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
-    saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
-    actions: [action({ command: 'click', positionals: ['id="from-c"'] })],
-  });
-  const resultC = writer.write(sessionC);
-  expect(resultC.written).toBe(true);
   const finalScript = fs.readFileSync(healedPath, 'utf8');
   expect(finalScript).toContain(HEAL_COMPLETE_SENTINEL);
-  expect(parseReplayScriptDetailed(finalScript).actions.map((a) => a.positionals[0])).toEqual([
-    'id="from-c"',
-  ]);
-  // No lock file lingers once C's publish (and release) completes.
-  expect(fs.existsSync(lockPath)).toBe(false);
+  const parsed = parseReplayScriptDetailed(finalScript);
+  const winnerLabel = resultB!.written ? 'id="from-b"' : 'id="from-a"';
+  expect(parsed.actions.map((a) => a.positionals[0])).toEqual([winnerLabel]);
 });
 
-// BLOCKER 4: the no-clobber, complete-artifact protection must apply to an
-// EXPLICIT `--save-script=<path>` target too, not just the default healed
-// sibling — an explicit target is caller-DIRECTED (which path to use), never
-// caller-AUTHORIZED to silently destroy an unreviewed prior COMPLETE healed
-// diff sitting there.
-test('BLOCKER 4: write() refuses to clobber an existing COMPLETE artifact at an EXPLICIT --save-script=<path> target too', () => {
+// BLOCKER 4: the no-clobber protection applies to an EXPLICIT
+// `--save-script=<path>` target identically to the default healed sibling —
+// an explicit target is caller-DIRECTED (which path to use), never
+// caller-AUTHORIZED to silently destroy an unreviewed prior healed diff
+// sitting there.
+test('write() refuses to clobber an existing COMPLETE artifact at an EXPLICIT --save-script=<path> target too', () => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'agent-device-script-writer-explicit-complete-clobber-'),
   );
@@ -642,12 +384,16 @@ test('BLOCKER 4: write() refuses to clobber an existing COMPLETE artifact at an 
   expect(fs.readFileSync(explicitOut, 'utf8')).toBe(before);
 });
 
-test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {
+// (d) an explicit --save-script=<path> to an existing file is REFUSED
+// identically to the default path — behavior change: this used to succeed
+// (a non-sentinel/partial file was freely overwritable at an explicit path).
+test('write() now refuses an explicit --save-script=<path> pointing at an existing (non-sentinel) file too', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-explicit-out-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const outPath = path.join(root, 'flows', 'explicit.ad');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
+  const before = fs.readFileSync(outPath, 'utf8');
 
   const session = makeIosSession('default', {
     recordSession: true,
@@ -659,18 +405,16 @@ test('write() DOES overwrite when the caller passed an explicit --save-script=<p
   });
 
   const result = writer.write(session);
-  expect(result.written).toBe(true);
-  const parsed = parseReplayScriptDetailed(fs.readFileSync(outPath, 'utf8'));
-  expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/already exists/);
+  expect(fs.readFileSync(outPath, 'utf8')).toBe(before);
 });
 
-test('close --save-script=<explicit path> clears the defaulted marker, so an explicit overwrite of an existing file SUCCEEDS', () => {
+test('close --save-script=<explicit path> clears the defaulted marker, and a write to that (absent) explicit path succeeds', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-close-explicit-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const defaultedHealed = path.join(root, 'flows', 'login.healed.ad');
   const explicitOut = path.join(root, 'flows', 'promoted.ad');
-  fs.mkdirSync(path.dirname(explicitOut), { recursive: true });
-  fs.writeFileSync(explicitOut, 'context platform=ios device="x"\nclick id="old"\n');
 
   // The repair defaulted to `.healed.ad` (marker set).
   const session = makeIosSession('default', {
@@ -681,9 +425,11 @@ test('close --save-script=<explicit path> clears the defaulted marker, so an exp
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
-  // `close --save-script=<explicit existing path>` re-points the path AND
-  // clears the marker (regression: it used to retain the marker and wrongly
-  // refuse the explicit overwrite).
+  // `close --save-script=<explicit path>` re-points the path AND clears the
+  // marker (regression: it used to retain the marker and wrongly refuse the
+  // explicit target). The marker no longer affects the publish decision at
+  // all (refusal is now uniform), but a redirected session must still
+  // publish cleanly to its own (absent) explicit target.
   recordActionEntry(session, {
     command: 'close',
     positionals: [],
@@ -817,7 +563,8 @@ test('write() publishes atomically: no stray temp file survives a successful rep
   const result = writer.write(session);
   expect(result.written).toBe(true);
   // The only file left in the destination directory is the published script
-  // itself — the temp path was renamed into place, not left behind.
+  // itself — the temp hard-link was cleaned up after the exclusive `linkSync`
+  // published the target, not left behind.
   expect(fs.readdirSync(path.dirname(outPath))).toEqual([path.basename(outPath)]);
   expect(fs.readFileSync(outPath, 'utf8')).toContain(HEAL_COMPLETE_SENTINEL);
 });

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { SessionScriptWriter } from '../session-script-writer.ts';
+import { HEAL_COMPLETE_SENTINEL, SessionScriptWriter } from '../session-script-writer.ts';
 import { recordActionEntry } from '../session-action-recorder.ts';
 import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
 import { parseReplayScriptDetailed } from '../../replay/script.ts';
@@ -30,6 +30,10 @@ test('write() slices session.actions from saveScriptBoundary onward, excluding p
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 2,
+    // Fix 2: a repair-armed write only publishes once explicitly finalized
+    // (`close --save-script`) — set here to isolate THIS test's own concern
+    // (boundary slicing), covered separately below.
+    saveScriptComplete: true,
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({ command: 'click', positionals: ['label="Old"'] }),
@@ -66,6 +70,7 @@ test('a boundary-sliced script still strips diagnostic snapshot actions', () => 
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 1,
+    saveScriptComplete: true,
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({ command: 'snapshot', positionals: [] }),
@@ -90,6 +95,7 @@ test('a recorded ref that resolved to a selectorChain writes a clean selector li
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     actions: [
       action({
         command: 'press',
@@ -111,12 +117,17 @@ test('a recorded ref that never resolved to a selectorChain throws instead of em
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     actions: [action({ command: 'press', positionals: ['@e7'] })],
   });
 
   const scriptPath = path.join(root, 'sessions', 'default', 'expected-not-written.ad');
-  expect(() => writer.write(session)).toThrow(/never resolved to a selector/);
-  // Fail loud, not a swallowed { written: false } — no file was produced.
+  // BLOCKER 2: a repair commit failure is SURFACED via the result (never
+  // swallowed into a bare `{written:false}`), not thrown — so close/teardown
+  // can report it and keep the session for retry.
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/never resolved to a selector/);
   expect(fs.existsSync(scriptPath)).toBe(false);
   expect(fs.readdirSync(path.join(root, 'sessions')).length).toBe(0);
 });
@@ -127,10 +138,13 @@ test('a bare-@ref fill action also fails loud, not just click-like commands', ()
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     actions: [action({ command: 'fill', positionals: ['@e9', 'hello'] })],
   });
 
-  expect(() => writer.write(session)).toThrow(/never resolved to a selector/);
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/never resolved to a selector/);
 });
 
 test('a bare @ref later in the same session (after a resolved earlier action) still fails loud, writing nothing', () => {
@@ -139,6 +153,7 @@ test('a bare @ref later in the same session (after a resolved earlier action) st
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({
@@ -150,7 +165,9 @@ test('a bare @ref later in the same session (after a resolved earlier action) st
     ],
   });
 
-  expect(() => writer.write(session)).toThrow(/never resolved to a selector/);
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/never resolved to a selector/);
   expect(fs.readdirSync(path.join(root, 'sessions')).length).toBe(0);
 });
 
@@ -176,26 +193,64 @@ test('an ordinary (non-repair-armed) recording keeps the existing bare-ref fallb
 // --- ADR 0012 decision 6 (P2): the default `.healed.ad` sibling is never
 // silently clobbered — a human must review each healed diff before promoting. ---
 
-test('write() refuses to clobber an existing DEFAULT .healed.ad (no explicit --save-script=<path>)', () => {
+test('write() refuses to clobber an existing COMPLETE DEFAULT .healed.ad (no explicit --save-script=<path>)', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-clobber-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
-  // A prior, unreviewed healed script already sits at the default sibling path.
-  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="old"\n');
+  // A prior, unreviewed, COMPLETE healed script already sits at the default
+  // sibling path (Fix 4: only a file carrying the completeness sentinel is
+  // protected).
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
   const before = fs.readFileSync(healedPath, 'utf8');
 
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     saveScriptPath: healedPath,
     saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
-  expect(() => writer.write(session)).toThrow(/already exists/);
-  // Fail loud — the prior unreviewed diff is untouched.
+  // BLOCKER 2c: a no-clobber refusal is surfaced via the result's error (a
+  // distinct "already exists" message), not thrown; the prior complete diff is
+  // untouched.
+  const result = writer.write(session);
+  expect(result.written).toBe(false);
+  expect(result.written === false && result.error?.message).toMatch(/already exists/);
   expect(fs.readFileSync(healedPath, 'utf8')).toBe(before);
+});
+
+test('write() DOES overwrite a stale INCOMPLETE .healed.ad at the default path (Fix 4: partial is overwritable)', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-clobber-partial-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  // A partial left over from a diverged-and-abandoned repair (pre-Fix-2 bug,
+  // or any other incomplete write) — no completeness sentinel.
+  fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  const script = fs.readFileSync(healedPath, 'utf8');
+  expect(script).toContain(HEAL_COMPLETE_SENTINEL);
+  const parsed = parseReplayScriptDetailed(script);
+  expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
 });
 
 test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {
@@ -208,6 +263,7 @@ test('write() DOES overwrite when the caller passed an explicit --save-script=<p
   const session = makeIosSession('default', {
     recordSession: true,
     saveScriptBoundary: 0,
+    saveScriptComplete: true,
     saveScriptPath: outPath,
     // No saveScriptDefaultedHealedPath: the caller directed this path explicitly.
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
@@ -246,10 +302,133 @@ test('close --save-script=<explicit path> clears the defaulted marker, so an exp
   });
   expect(session.saveScriptDefaultedHealedPath).toBe(false);
   expect(session.saveScriptPath).toBe(explicitOut);
+  // `recordActionEntry` is the low-level action recorder `close`'s handler
+  // calls on its way to setting the finalize signal (Fix 2) — set here to
+  // isolate this test's own concern (defaulted-marker clearing).
+  session.saveScriptComplete = true;
 
   const result = writer.write(session);
   expect(result.written).toBe(true);
   expect(result.written && result.path).toBe(explicitOut);
   const parsed = parseReplayScriptDetailed(fs.readFileSync(explicitOut, 'utf8'));
   expect(parsed.actions.some((a) => a.positionals[0] === 'id="new"')).toBe(true);
+});
+
+// --- ADR 0012 decision 6, R7 + commit semantics (Fix 2, C2): a repair-armed
+// write COMMITS only when the transaction is COMPLETE (ARMED -> COMPLETE ->
+// COMMITTED); an incomplete transaction ABORTS (publishes no prefix), and a
+// committed one is an idempotent no-op. ---
+
+test('C2 abort-before-complete: a repair-armed but NOT-complete write discards — no file, no prefix', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-incomplete-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    // No saveScriptComplete: the plan never ran to its last executable step
+    // (a `close`/`close --save-script` reached after a divergence, a daemon
+    // teardown, or an idle-reap of an in-flight repair).
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result).toEqual({ written: false });
+  expect(fs.existsSync(path.join(root, 'sessions'))).toBe(false);
+  // Not committed — teardown will tombstone it (C5a).
+  expect(session.saveScriptCommitted).toBeFalsy();
+});
+
+test('C2 commit-when-complete: a repair-armed COMPLETE write publishes and marks the session COMMITTED', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-complete-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const outPath = path.join(root, 'flows', 'flow.healed.ad');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: outPath,
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  expect(fs.readFileSync(outPath, 'utf8')).toContain(HEAL_COMPLETE_SENTINEL);
+  expect(session.saveScriptCommitted).toBe(true);
+});
+
+test('C2 idempotent post-commit: a second write on a COMMITTED session no-ops (no re-publish, no error)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-idempotent-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const outPath = path.join(root, 'flows', 'flow.healed.ad');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: outPath,
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  expect(writer.write(session).written).toBe(true);
+  const firstContent = fs.readFileSync(outPath, 'utf8');
+  const firstMtime = fs.statSync(outPath).mtimeMs;
+
+  // Mutate actions to prove a re-publish WOULD change the file if it happened.
+  session.actions.push(action({ command: 'click', positionals: ['id="other"'] }));
+  const second = writer.write(session);
+  expect(second).toEqual({ written: false });
+  // The published artifact is untouched — the committed transaction never
+  // re-writes (no duplicate, no corruption).
+  expect(fs.readFileSync(outPath, 'utf8')).toBe(firstContent);
+  expect(fs.statSync(outPath).mtimeMs).toBe(firstMtime);
+});
+
+test('write() still emits an ordinary (non-repair) recording on close without --save-script, unaffected by the commit gate', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-ordinary-unfinalized-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const session = makeIosSession('default', {
+    recordSession: true,
+    // No saveScriptBoundary: an ordinary `open --save-script` recording, not
+    // a repair — the Fix 2 gate only applies to repair-armed sessions.
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  const { parsed } = writeAndParse(writer, session);
+  expect(parsed.actions.map((a) => a.command)).toEqual(['click']);
+});
+
+test('write() never appends the completeness sentinel to an ordinary (non-repair) recording', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-no-sentinel-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const session = makeIosSession('default', {
+    recordSession: true,
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  const { script } = writeAndParse(writer, session);
+  expect(script).not.toContain(HEAL_COMPLETE_SENTINEL);
+});
+
+test('write() publishes atomically: no stray temp file survives a successful repair write', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-atomic-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const outPath = path.join(root, 'flows', 'atomic.healed.ad');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const session = makeIosSession('default', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: outPath,
+    actions: [action({ command: 'click', positionals: ['id="save"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  // The only file left in the destination directory is the published script
+  // itself — the temp path was renamed into place, not left behind.
+  expect(fs.readdirSync(path.dirname(outPath))).toEqual([path.basename(outPath)]);
+  expect(fs.readFileSync(outPath, 'utf8')).toContain(HEAL_COMPLETE_SENTINEL);
 });

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -408,6 +408,79 @@ test('BLOCKER 1 (follow-up): a writer publishing while another is mid quarantine
   expect(finalScript).toBe(before);
 });
 
+// BLOCKER 1 (lock reclaim, second follow-up): the reclaim of a DEAD lock was
+// itself a TOCTOU — `isHeldByDeadProcess` read the lock file's PID, then a
+// SEPARATE `rmSync(lockPath)` acted on it BY PATHNAME. If a second waiter
+// reclaimed the SAME dead lock and re-acquired with its OWN live lock inside
+// that gap, the first waiter's stale removal deleted the live lock it never
+// actually inspected — not the dead one it read — letting both waiters
+// believe they held the exclusive lock at once.
+test('BLOCKER 1 (lock reclaim): a stale dead-lock decision never steals a lock a concurrent reclaimer has since made LIVE', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-lock-race-'));
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flows', 'login.healed.ad');
+  fs.mkdirSync(path.dirname(healedPath), { recursive: true });
+  const originalContent = 'context platform=ios device="x"\nclick id="stale-partial"\n';
+  fs.writeFileSync(healedPath, originalContent);
+
+  const lockPath = `${healedPath}.lock`;
+  // A DEAD writer's abandoned lock: a PID far outside any real range, so
+  // `isProcessAlive` reports it as not running — same convention used for the
+  // same purpose in `process-lock.test.ts`.
+  fs.writeFileSync(lockPath, '999999999');
+
+  const sessionA = makeIosSession('writer-a', {
+    recordSession: true,
+    saveScriptBoundary: 0,
+    saveScriptComplete: true,
+    saveScriptPath: healedPath,
+    saveScriptDefaultedHealedPath: true,
+    actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
+  });
+
+  // Deterministically drive the exact interleaving the reviewer found: A's
+  // FIRST read of the dead lock (`isHeldByDeadProcess`'s `readFileSync`)
+  // captures the stale dead-PID snapshot A will act on — but as a side
+  // effect of that very read, "writer B" independently reclaims the SAME
+  // dead lock and re-acquires it with a genuinely LIVE pid (this test
+  // process's own, real, alive pid) before A's own reclaim step runs. A must
+  // never destroy B's freshly-live lock.
+  const realReadFileSync = fs.readFileSync;
+  let interleaved = false;
+  const liveMarkerPid = String(process.pid);
+  const readSpy = vi
+    .spyOn(fs, 'readFileSync')
+    .mockImplementation((target: fs.PathOrFileDescriptor, options?: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (realReadFileSync as any)(target, options);
+      if (!interleaved && target === lockPath) {
+        interleaved = true;
+        // "Writer B" reclaims the same dead lock and re-acquires it live,
+        // using the exact same primitives the real implementation uses.
+        const bTempLockPath = `${lockPath}.b-writer.tmp`;
+        fs.rmSync(lockPath, { force: true });
+        fs.writeFileSync(bTempLockPath, liveMarkerPid);
+        fs.linkSync(bTempLockPath, lockPath);
+        fs.rmSync(bTempLockPath, { force: true });
+      }
+      return result;
+    });
+
+  const resultA = writer.write(sessionA);
+  readSpy.mockRestore();
+
+  expect(interleaved).toBe(true);
+  // B's live lock is never stolen: A must back off rather than silently
+  // steal it and proceed into the exclusive/publish section — B never
+  // releases it in this test, so A exhausts its bounded wait and fails loud.
+  expect(resultA.written).toBe(false);
+  expect(resultA.written === false && resultA.error?.message).toMatch(/timed out waiting/);
+  // B's lock survives, byte-for-byte, for the entire time A contended for it.
+  expect(fs.readFileSync(lockPath, 'utf8')).toBe(liveMarkerPid);
+  // A never published over the target while B's lock was live.
+  expect(fs.readFileSync(healedPath, 'utf8')).toBe(originalContent);
+});
+
 test('write() DOES overwrite when the caller passed an explicit --save-script=<path> (not defaulted)', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-explicit-out-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -410,6 +410,69 @@ test('write() now refuses an explicit --save-script=<path> pointing at an existi
   expect(fs.readFileSync(outPath, 'utf8')).toBe(before);
 });
 
+// (e) the refuse-on-exist publish primitive is shared with ORDINARY
+// (non-repair) recording too — no `saveScriptBoundary` at all, i.e. a plain
+// `open --save-script`/`close --save-script` session, never `replay
+// --save-script`. Before the maintainer-approved uniform simplification,
+// this path published via a separate atomic rename-replace and silently
+// overwrote an existing target; that overwrite path is gone (see the ADR's
+// "Scope" note under decision 6). This is the coverage gap the reviewer
+// flagged on #1235: only repair-armed (`saveScriptBoundary` set, even to 0)
+// sessions were exercised above.
+test('an ordinary (non-repair) recording now refuses an existing target too (behavior change: no more rename-replace overwrite)', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-ordinary-clobber-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const outPath = path.join(root, 'flows', 'existing.ad');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
+  const before = fs.readFileSync(outPath, 'utf8');
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    // No saveScriptBoundary: an ordinary open/close --save-script recording,
+    // never armed via `replay --save-script` — this is NOT a repair.
+    saveScriptPath: outPath,
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  // Unlike a repair-armed write (which returns `{written:false, error}`), an
+  // ordinary (non-repair-armed) write's catch block RETHROWS an AppError
+  // (`write()`: `if (repairArmed) return {...}; if (error instanceof
+  // AppError) throw error;`) — so refusal here surfaces as a thrown error,
+  // not a returned result.
+  expect(() => writer.write(session)).toThrow(/already exists/);
+  // The pre-existing target is left byte-for-byte unchanged — refused, not
+  // clobbered.
+  expect(fs.readFileSync(outPath, 'utf8')).toBe(before);
+});
+
+// (f) confirm the absent-target case still succeeds for ordinary recording —
+// the refusal is scoped to an EXISTING target, not a blanket block.
+test('an ordinary (non-repair) recording still publishes cleanly when its target does not exist yet', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-script-writer-ordinary-absent-'),
+  );
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const outPath = path.join(root, 'flows', 'fresh.ad');
+
+  const session = makeIosSession('default', {
+    recordSession: true,
+    // No saveScriptBoundary: ordinary recording, not a repair.
+    saveScriptPath: outPath,
+    actions: [action({ command: 'click', positionals: ['id="new"'] })],
+  });
+
+  const result = writer.write(session);
+  expect(result.written).toBe(true);
+  expect(result.written && result.path).toBe(outPath);
+  const parsed = parseReplayScriptDetailed(fs.readFileSync(outPath, 'utf8'));
+  expect(parsed.actions.map((a) => a.positionals[0])).toEqual(['id="new"']);
+  // Ordinary recording never carries the repair-only completeness sentinel.
+  expect(fs.readFileSync(outPath, 'utf8')).not.toContain(HEAL_COMPLETE_SENTINEL);
+});
+
 test('close --save-script=<explicit path> clears the defaulted marker, and a write to that (absent) explicit path succeeds', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-close-explicit-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -8,6 +8,7 @@ import type { SessionState } from '../types.ts';
 import { buildRequestFinishedEvent } from '../session-event-log.ts';
 import type { TargetAnnotationV1 } from '../../replay/target-identity.ts';
 import { HEAL_COMPLETE_SENTINEL } from '../session-script-writer.ts';
+import { parseReplayScriptDetailed } from '../../replay/script.ts';
 
 type RecordActionEntry = Parameters<SessionStore['recordAction']>[1];
 
@@ -740,4 +741,47 @@ test('BLOCKER 2: finalizeRepairTeardown of a COMPLETE transaction whose commit F
   assert.ok(tombstone?.commitFailure, 'expected the tombstone to carry the commit failure');
   assert.match(tombstone!.commitFailure!.message, /already exists/);
   assert.equal(tombstone?.sourcePath, '/flows/login.ad');
+});
+
+// --- ADR 0012 decision 6 (BLOCKER 3): idle-reap/shutdown auto-commit must
+// record the same synthetic terminal `close` an explicit close records, so
+// the committed healed .ad is self-contained (fresh-replayable) exactly like
+// an explicit `close --save-script` commit. ---
+
+test('BLOCKER 3: finalizeRepairTeardown auto-commit records a terminal close, producing a self-contained, fresh-replayable healed .ad', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-teardown-autocommit-close-'));
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flow.healed.ad');
+
+  const session = makeSession('default');
+  session.recordSession = true;
+  session.saveScriptBoundary = 0;
+  session.saveScriptComplete = true;
+  session.saveScriptPath = healedPath;
+  session.saveScriptDefaultedHealedPath = true;
+  session.actions = [
+    { ts: 1, command: 'open', positionals: ['Demo'], flags: {} },
+    { ts: 2, command: 'click', positionals: ['id="save-v2"'], flags: {} },
+  ];
+
+  // The source plan's terminal `close` was already skipped-while-armed
+  // (Fix 3) — `session.actions` never gained one. Idle-reap/shutdown teardown
+  // must synthesize it itself before auto-committing.
+  store.finalizeRepairTeardown(session);
+
+  assert.equal(session.saveScriptCommitted, true);
+  assert.equal(store.readRepairTombstone('default'), undefined);
+  const script = fs.readFileSync(healedPath, 'utf8');
+  assert.ok(script.includes(HEAL_COMPLETE_SENTINEL));
+  const parsed = parseReplayScriptDetailed(script);
+  // Self-contained: the auto-committed artifact ends with its OWN terminal
+  // close, exactly like an explicit close's commit — never a healed script
+  // that a fresh replay would run off the end of.
+  assert.deepEqual(
+    parsed.actions.map((a) => a.command),
+    ['open', 'click', 'close'],
+  );
+  assert.deepEqual(parsed.actions[2]?.positionals, []);
+  const bareRefs = parsed.actions.flatMap((a) => a.positionals.filter((p) => p.startsWith('@')));
+  assert.deepEqual(bareRefs, []);
 });

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -656,3 +656,41 @@ test('writeSessionLog never fabricates a target-v1 annotation for actions record
   const script = writeScript(fixture);
   assert.equal(/agent-device:target-v1/.test(script), false);
 });
+
+// --- ADR 0012 decision 6, R7 (C5a): repair tombstones turn a post-reap
+// SESSION_NOT_FOUND into REPAIR_SESSION_EXPIRED with re-run guidance. ---
+
+test('writeRepairTombstone/readRepairTombstone round-trips owner + source path', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-tombstone-'));
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const session = makeSession('default');
+  session.saveScriptBoundary = 0;
+  session.repairSourcePath = '/flows/login.ad';
+
+  store.writeRepairTombstone(session);
+  const tombstone = store.readRepairTombstone('default');
+  assert.ok(tombstone);
+  assert.equal(tombstone?.owner, 'default');
+  assert.equal(tombstone?.sourcePath, '/flows/login.ad');
+  assert.ok((tombstone?.expiresAt ?? 0) > Date.now());
+});
+
+test('readRepairTombstone returns undefined once the tombstone has expired', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-tombstone-expiry-'));
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const session = makeSession('default');
+  // TTL 0 => expiresAt <= now => already stale.
+  store.writeRepairTombstone(session, 0);
+  assert.equal(store.readRepairTombstone('default'), undefined);
+});
+
+test('clearRepairTombstone removes a tombstone (a fresh replay --save-script clears the key)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-tombstone-clear-'));
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const session = makeSession('default');
+  store.writeRepairTombstone(session);
+  assert.ok(store.readRepairTombstone('default'));
+
+  store.clearRepairTombstone('default');
+  assert.equal(store.readRepairTombstone('default'), undefined);
+});

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -7,6 +7,7 @@ import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 import { buildRequestFinishedEvent } from '../session-event-log.ts';
 import type { TargetAnnotationV1 } from '../../replay/target-identity.ts';
+import { HEAL_COMPLETE_SENTINEL } from '../session-script-writer.ts';
 
 type RecordActionEntry = Parameters<SessionStore['recordAction']>[1];
 
@@ -693,4 +694,50 @@ test('clearRepairTombstone removes a tombstone (a fresh replay --save-script cle
 
   store.clearRepairTombstone('default');
   assert.equal(store.readRepairTombstone('default'), undefined);
+});
+
+// --- ADR 0012 decision 6 (BLOCKER 2): a COMPLETE transaction's commit can
+// still FAIL at idle-reap/daemon-shutdown teardown (no-clobber refusal, a
+// bare-@ref failure, or a filesystem error) — that failure must be preserved,
+// not lost behind a generic "reaped before it was finalized" tombstone. ---
+
+test('BLOCKER 2: finalizeRepairTeardown of a COMPLETE transaction whose commit FAILS preserves the failure in a distinct tombstone, not a generic expiry', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-teardown-commit-fail-'));
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const healedPath = path.join(root, 'flow.healed.ad');
+  // A prior COMPLETE (sentinel-marked) healed artifact already sits at the
+  // default sibling path — teardown's auto-commit attempt must refuse to
+  // clobber it, exactly like an explicit close's commit would.
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+  const before = fs.readFileSync(healedPath, 'utf8');
+
+  const session = makeSession('default');
+  session.recordSession = true;
+  session.saveScriptBoundary = 0;
+  session.saveScriptComplete = true;
+  session.saveScriptPath = healedPath;
+  session.saveScriptDefaultedHealedPath = true;
+  session.repairSourcePath = '/flows/login.ad';
+  session.actions = [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }];
+
+  // Idle-reap/shutdown teardown (never routes through close's handler).
+  store.finalizeRepairTeardown(session);
+
+  // The prior complete artifact is untouched — teardown's failed commit
+  // never clobbers it.
+  assert.equal(fs.readFileSync(healedPath, 'utf8'), before);
+  // Never committed (the write failed), so the ordinary success bookkeeping
+  // never ran.
+  assert.notEqual(session.saveScriptCommitted, true);
+
+  const tombstone = store.readRepairTombstone('default');
+  assert.ok(tombstone, 'expected a tombstone to preserve the failed-commit outcome');
+  // BLOCKER 2: distinguishable from a plain "reaped before it was finalized"
+  // tombstone — it carries the real commit failure.
+  assert.ok(tombstone?.commitFailure, 'expected the tombstone to carry the commit failure');
+  assert.match(tombstone!.commitFailure!.message, /already exists/);
+  assert.equal(tombstone?.sourcePath, '/flows/login.ad');
 });

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -2,11 +2,12 @@ import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { AppError } from '../../kernel/errors.ts';
+import { AppError, normalizeError } from '../../kernel/errors.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { runCmdDetachedMonitored, type ExecDetachedExit } from '../../utils/exec.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { findUnrecoveredRepairCommitFailure } from '../session-store.ts';
 import {
   resolveDaemonPaths,
   resolveDaemonServerMode,
@@ -305,12 +306,29 @@ async function startLocalDaemon(settings: DaemonClientSettings): Promise<Ensured
   });
 }
 
+/**
+ * ADR 0012 decision 6 (BLOCKER 2, third follow-up): a one-shot repair
+ * (`replay --save-script`) that COMPLETES without diverging returns SUCCESS
+ * here — the actual healed-script COMMIT is deferred to daemon teardown
+ * (`finalizeRepairTeardown`, run inside the daemon process's own shutdown
+ * handler, triggered by `stopDaemonProcessForTakeover` below). If that
+ * deferred commit then FAILS, the daemon leaves a `REPAIR_COMMIT_FAILED`
+ * tombstone in this owned state dir — the only surviving record of the
+ * failure, since the daemon process (and its in-memory session) is gone by
+ * the time this function inspects it. Unconditionally deleting the owned
+ * state dir here would silently discard both the failure and the tombstone's
+ * re-run guidance, while the CALLER still holds the success response this
+ * function already returned. Returns the response the caller should actually
+ * use: unchanged, unless an unrecovered commit failure is found, in which
+ * case the state dir is preserved (never `rmSync`'d) and the response is
+ * overridden to surface it.
+ */
 export async function cleanupDaemonAfterRequest(
   req: Omit<DaemonRequest, 'token'>,
   daemon: EnsuredDaemon,
   settings: DaemonClientSettings,
   response: DaemonResponse | undefined,
-): Promise<void> {
+): Promise<DaemonResponse | undefined> {
   if (
     !isOneShotReplayCommand(req.command) ||
     (!daemon.startedByClient && !settings.ownedStateDir) ||
@@ -326,7 +344,7 @@ export async function cleanupDaemonAfterRequest(
     // below from racing ahead of that window.
     isHeldRepairDivergence(response)
   ) {
-    return;
+    return response;
   }
 
   const result = {
@@ -336,6 +354,7 @@ export async function cleanupDaemonAfterRequest(
     removedStateDir: false,
     error: undefined as string | undefined,
   };
+  let surfacedResponse = response;
 
   try {
     await stopDaemonProcessForTakeover(daemon.info);
@@ -351,8 +370,17 @@ export async function cleanupDaemonAfterRequest(
     result.removedLock = lockExists && !fs.existsSync(settings.paths.lockPath);
 
     if (settings.ownedStateDir) {
-      fs.rmSync(settings.paths.baseDir, { recursive: true, force: true });
-      result.removedStateDir = !fs.existsSync(settings.paths.baseDir);
+      // `stopDaemonProcessForTakeover` above waits for the (real) daemon
+      // process to actually exit, which only happens AFTER its shutdown
+      // handler finishes `finalizeRepairTeardown` for every session — so by
+      // now any commit-failure tombstone it would leave is already on disk.
+      const unrecovered = findUnrecoveredRepairCommitFailure(settings.paths.sessionsDir);
+      if (unrecovered) {
+        surfacedResponse = surfaceUnrecoveredRepairCommitFailure(response, unrecovered);
+      } else {
+        fs.rmSync(settings.paths.baseDir, { recursive: true, force: true });
+        result.removedStateDir = !fs.existsSync(settings.paths.baseDir);
+      }
     }
   }
 
@@ -361,6 +389,37 @@ export async function cleanupDaemonAfterRequest(
     phase: 'daemon_replay_cleanup',
     data: result,
   });
+  return surfacedResponse;
+}
+
+/**
+ * ADR 0012 decision 6 (BLOCKER 2, third follow-up): converts an unrecovered
+ * shutdown-time commit failure into the response the CALLER actually sees.
+ * The original response may have been a genuine SUCCESS — the replay/plan
+ * itself completed with no divergence, only the deferred healed-script
+ * publish failed afterward at teardown — so there is no existing error to
+ * attach a hint to (unlike `attachRepairSessionAddressHint`, which only ever
+ * runs on an already-`ok:false` divergence): this REPLACES the response with
+ * the same `REPAIR_COMMIT_FAILED` error the daemon's own
+ * `repairExpiredIfTombstoned` (request-router.ts) would surface to a
+ * follow-up request on this session — a one-shot command has no follow-up
+ * request to receive it, so the client raises it here instead. An existing
+ * `ok:false` response (e.g. the platform close itself failed for a different,
+ * more specific reason) is returned unchanged.
+ */
+function surfaceUnrecoveredRepairCommitFailure(
+  response: DaemonResponse | undefined,
+  unrecovered: NonNullable<ReturnType<typeof findUnrecoveredRepairCommitFailure>>,
+): DaemonResponse {
+  if (response && !response.ok) return response;
+  const { sessionName, tombstone } = unrecovered;
+  const reRun = tombstone.sourcePath
+    ? `re-run: replay ${tombstone.sourcePath} --save-script`
+    : 're-run your replay <script> --save-script from the start';
+  const message =
+    `The repair transaction for session "${sessionName}" completed, but committing its ` +
+    `healed script failed at teardown: ${tombstone.commitFailure.message}. ${reRun}.`;
+  return { ok: false, error: normalizeError(new AppError('REPAIR_COMMIT_FAILED', message)) };
 }
 
 /**

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -3,7 +3,7 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../../kernel/errors.ts';
-import type { DaemonRequest } from '../types.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { runCmdDetachedMonitored, type ExecDetachedExit } from '../../utils/exec.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
@@ -309,11 +309,22 @@ export async function cleanupDaemonAfterRequest(
   req: Omit<DaemonRequest, 'token'>,
   daemon: EnsuredDaemon,
   settings: DaemonClientSettings,
+  response: DaemonResponse | undefined,
 ): Promise<void> {
   if (
     !isOneShotReplayCommand(req.command) ||
     (!daemon.startedByClient && !settings.ownedStateDir) ||
-    isRemoteDaemon(daemon.info)
+    isRemoteDaemon(daemon.info) ||
+    // ADR 0012 decision 6, R7 (Fix 1, C1): a repair-armed `--save-script`
+    // replay that comes back as a HELD divergence must keep its owning daemon
+    // (and the session on it) addressable for the agent's corrective press +
+    // `replay --from`/`close` — tearing it down here is what turns a
+    // recoverable divergence into a later bare SESSION_NOT_FOUND. The daemon
+    // then bounds the held session's own lifetime via idle-reap (writing a
+    // `REPAIR_SESSION_EXPIRED` tombstone on reap), so an abandoned repair still
+    // cannot leak indefinitely; this only stops the ONE-SHOT-COMMAND teardown
+    // below from racing ahead of that window.
+    isHeldRepairDivergence(response)
   ) {
     return;
   }
@@ -350,6 +361,56 @@ export async function cleanupDaemonAfterRequest(
     phase: 'daemon_replay_cleanup',
     data: result,
   });
+}
+
+/**
+ * ADR 0012 decision 6, R7 (Fix 1, C1): true when this response must keep the
+ * owning daemon alive — a `REPLAY_DIVERGENCE` whose payload carries the
+ * daemon's `resume.repairSessionHeld` liveness signal. The daemon sets that
+ * signal from the PERSISTED repair-transaction state (the session is
+ * repair-armed and not yet committed), NOT from the current request's
+ * `--save-script` flag — so a `replay --from` continuation that does not
+ * repeat `--save-script` (R2) is still kept alive if it diverges. Keying the
+ * client purely off the signal (the daemon is the authority on transaction
+ * state) is what makes that continuation work; a plain, non-repair divergence
+ * carries no signal and gets no keep-alive. Also independent of
+ * `resume.allowed` (plan-resumability): a held divergence with `allowed: false`
+ * still holds the session so the agent can inspect and `close` cleanly.
+ */
+export function isHeldRepairDivergence(response: DaemonResponse | undefined): boolean {
+  if (!response || response.ok) return false;
+  if (response.error.code !== 'REPLAY_DIVERGENCE') return false;
+  const divergence = response.error.details?.divergence;
+  if (!divergence || typeof divergence !== 'object') return false;
+  const resume = (divergence as Record<string, unknown>).resume;
+  if (!resume || typeof resume !== 'object') return false;
+  return (resume as Record<string, unknown>).repairSessionHeld === true;
+}
+
+/**
+ * ADR 0012 decision 6 (Fix 1): "keep it addressable" — an owned ephemeral
+ * daemon lives at a randomly generated `--state-dir` (`createOwnedReplayStateDir`)
+ * that no other invocation knows about, so keeping the process alive is not
+ * enough on its own. Appended (never overwriting an existing hint, e.g. a
+ * selector-miss's own guidance) so the agent's next command knows to target
+ * the SAME daemon instead of resolving to the default one.
+ */
+export function attachRepairSessionAddressHint(
+  response: Extract<DaemonResponse, { ok: false }>,
+  stateDir: string,
+): Extract<DaemonResponse, { ok: false }> {
+  const addressHint =
+    `This repair session's daemon was kept alive to continue the repair; pass ` +
+    `--state-dir ${stateDir} on your next command (press, replay --from, or ` +
+    `close --save-script) to reach it.`;
+  const existingHint = response.error.hint;
+  return {
+    ...response,
+    error: {
+      ...response.error,
+      hint: existingHint ? `${existingHint} ${addressHint}` : addressHint,
+    },
+  };
 }
 
 function isOneShotReplayCommand(command: string | undefined): boolean {

--- a/src/daemon/client/daemon-client.ts
+++ b/src/daemon/client/daemon-client.ts
@@ -3,6 +3,7 @@ import type {
   DaemonResponse as SharedDaemonResponse,
 } from '../types.ts';
 import type { RequestProgressSink } from '../../request/progress.ts';
+import { AppError } from '../../kernel/errors.ts';
 import { createRequestId, emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { prepareRemoteRequestArtifacts } from '../../remote/daemon-artifacts.ts';
@@ -13,6 +14,7 @@ import {
   isHeldRepairDivergence,
   resolveClientSettings,
   type DaemonClientSettings,
+  type EnsuredDaemon,
 } from './daemon-client-lifecycle.ts';
 import { sendRequest } from './daemon-client-transport.ts';
 import { resolveDaemonRequestTimeoutMs } from './daemon-client-timeout.ts';
@@ -78,9 +80,8 @@ export async function sendToDaemon(
       session: req.session,
     },
   });
-  let response: DaemonResponse | undefined;
-  try {
-    response = await withDiagnosticTimer(
+  return await performDaemonRequestWithCleanup(req, daemon, settings, async () => {
+    const response = await withDiagnosticTimer(
       'daemon_request',
       async () =>
         await sendRequest(
@@ -93,11 +94,47 @@ export async function sendToDaemon(
         ),
       { requestId, command: req.command },
     );
-    response = withRepairSessionAddressHintIfOwned(response, settings);
-    return response;
-  } finally {
-    await cleanupDaemonAfterRequest(req, daemon, settings, response);
+    return withRepairSessionAddressHintIfOwned(response, settings);
+  });
+}
+
+/**
+ * ADR 0012 decision 6 (BLOCKER 2, third follow-up): runs `send` and ALWAYS
+ * runs cleanup afterward, using cleanup's result (not `send`'s raw result) as
+ * the response the caller actually receives — cleanup can discover a
+ * shutdown-time repair-commit failure the request itself never knew about (a
+ * one-shot repair that completed with no divergence returns SUCCESS
+ * immediately; the actual commit is deferred to daemon teardown, which
+ * `cleanupDaemonAfterRequest` triggers and inspects). A caught-and-rethrown
+ * error (rather than a `return` inside `finally`, which oxlint's
+ * `no-unsafe-finally` rejects and which would also make a thrown `send`
+ * failure silently swallowed by a later `return`) keeps cleanup running
+ * unconditionally while a thrown failure still propagates normally afterward.
+ */
+async function performDaemonRequestWithCleanup(
+  req: Omit<DaemonRequest, 'token'>,
+  daemon: EnsuredDaemon,
+  settings: DaemonClientSettings,
+  send: () => Promise<DaemonResponse>,
+): Promise<DaemonResponse> {
+  let response: DaemonResponse | undefined;
+  let requestFailed = false;
+  let requestError: unknown;
+  try {
+    response = await send();
+  } catch (error) {
+    requestFailed = true;
+    requestError = error;
   }
+  const finalResponse = await cleanupDaemonAfterRequest(req, daemon, settings, response);
+  if (requestFailed) throw requestError;
+  if (!finalResponse) {
+    // Unreachable in practice: `requestFailed` is false here, so `response`
+    // was successfully set above, and `cleanupDaemonAfterRequest` always
+    // returns a response (unchanged or overridden) when given one.
+    throw new AppError('COMMAND_FAILED', 'Daemon request produced no response after cleanup');
+  }
+  return finalResponse;
 }
 
 /**

--- a/src/daemon/client/daemon-client.ts
+++ b/src/daemon/client/daemon-client.ts
@@ -7,9 +7,12 @@ import { createRequestId, emitDiagnostic, withDiagnosticTimer } from '../../util
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { prepareRemoteRequestArtifacts } from '../../remote/daemon-artifacts.ts';
 import {
+  attachRepairSessionAddressHint,
   cleanupDaemonAfterRequest,
   ensureDaemon,
+  isHeldRepairDivergence,
   resolveClientSettings,
+  type DaemonClientSettings,
 } from './daemon-client-lifecycle.ts';
 import { sendRequest } from './daemon-client-transport.ts';
 import { resolveDaemonRequestTimeoutMs } from './daemon-client-timeout.ts';
@@ -75,8 +78,9 @@ export async function sendToDaemon(
       session: req.session,
     },
   });
+  let response: DaemonResponse | undefined;
   try {
-    return await withDiagnosticTimer(
+    response = await withDiagnosticTimer(
       'daemon_request',
       async () =>
         await sendRequest(
@@ -89,9 +93,27 @@ export async function sendToDaemon(
         ),
       { requestId, command: req.command },
     );
+    response = withRepairSessionAddressHintIfOwned(response, settings);
+    return response;
   } finally {
-    await cleanupDaemonAfterRequest(req, daemon, settings);
+    await cleanupDaemonAfterRequest(req, daemon, settings, response);
   }
+}
+
+/**
+ * ADR 0012 decision 6 (Fix 1): the owned ephemeral state dir this daemon was
+ * started at is otherwise unaddressable by a later invocation — hint it here,
+ * only when the daemon is actually being kept alive for it
+ * (`settings.ownedStateDir` means `daemon.startedByClient` is also true).
+ */
+function withRepairSessionAddressHintIfOwned(
+  response: DaemonResponse,
+  settings: DaemonClientSettings,
+): DaemonResponse {
+  if (response.ok || !settings.ownedStateDir || !isHeldRepairDivergence(response)) {
+    return response;
+  }
+  return attachRepairSessionAddressHint(response, settings.paths.baseDir);
 }
 
 function writeInstallInProgressNotice(command: string | undefined): void {

--- a/src/daemon/handlers/__tests__/session-replay-repair-acceptance.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-acceptance.test.ts
@@ -124,7 +124,10 @@ test('a healed script survives repair + fresh-session replay: self-contained ope
   expect(session.actions.map((a) => a.command)).toEqual(['open', 'press', 'click']);
 
   // --- End the repair: write the healed script (the `close --save-script`
-  // path reuses exactly this writer). ---
+  // path reuses exactly this writer; ADR 0012 decision 6 Fix 2 gates a
+  // repair-armed write on the same explicit finalize signal `close
+  // --save-script` sets). ---
+  session.saveScriptComplete = true;
   sessionStore.writeSessionLog(session);
   const healedPath = path.join(root, 'flow.healed.ad');
   expect(fs.existsSync(healedPath)).toBe(true);

--- a/src/daemon/handlers/__tests__/session-replay-repair-loop.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-loop.test.ts
@@ -402,3 +402,243 @@ test('R1 bootstrap: a session created by step 1 (open) arms in time for step 2 t
   expect(session.saveScriptBoundary).toBe(0);
   expect(session.actions[1]?.targetEvidence).toBeDefined();
 });
+
+test('BLOCKER 4: a minimal [open, terminal close] cold-start script arms the transaction and skips the close', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-repair-open-close-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  // No pre-existing session — step 1 (`open`) CREATES it, so pre-open arming is
+  // a no-op and the transaction can only arm once the session exists.
+  const filePath = writeReplayFile(root, ['open "Demo"', 'close']);
+  const spy: DaemonRequest[] = [];
+  const invoke = makeRecordingReplayInvoke({ sessionStore, sessionName, spy });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  const session = sessionStore.get(sessionName)!;
+  // ARMED-before-step-1 semantics satisfied: the transaction armed even though
+  // `open` created the session.
+  expect(session.recordSession).toBe(true);
+  expect(session.saveScriptBoundary).toBe(0);
+  // The terminal `close` was recognized as lifecycle and SKIPPED (never
+  // dispatched), leaving the session alive for finalize.
+  expect(spy.map((r) => r.command)).toEqual(['open']);
+  expect(sessionStore.get(sessionName)).toBeDefined();
+  // The commit-state machine applies: a completed armed transaction.
+  expect(session.saveScriptComplete).toBe(true);
+});
+
+// --- ADR 0012 decision 6 (Fix 3): the source plan's own terminal `close` is
+// lifecycle, not a script step, while a repair is armed — the agent
+// finalizes with `close --save-script` instead. ---
+
+test("Fix 3: the source plan's terminal close is skipped (never dispatched, never recorded) while the repair is armed", async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-replay-repair-close-skip-',
+  );
+  const filePath = writeReplayFile(root, ['open "Demo"', 'click id="save"', 'close']);
+  const spy: DaemonRequest[] = [];
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    spy,
+    evidence: (req) => (req.command === 'click' ? freshEvidence('save', 'Save') : undefined),
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  // `close` never reached dispatch...
+  expect(spy.map((r) => r.command)).toEqual(['open', 'click']);
+  // ...so it never lands in session.actions (the healed script never carries
+  // it — the agent's own `close --save-script` supplies the real one).
+  const session = sessionStore.get(sessionName)!;
+  expect(session.actions.map((a) => a.command)).toEqual(['open', 'click']);
+  // C4: skipping the terminal close does NOT delete the session — it stays
+  // alive and COMPLETE so the agent can finalize it with `close --save-script`.
+  expect(sessionStore.get(sessionName)).toBeDefined();
+  expect(session.saveScriptComplete).toBe(true);
+});
+
+test('Fix 3: an ordinary (non-repair) replay still dispatches its terminal close normally', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-replay-repair-close-ordinary-',
+  );
+  const filePath = writeReplayFile(root, ['open "Demo"', 'click id="save"', 'close']);
+  const spy: DaemonRequest[] = [];
+  const invoke = makeRecordingReplayInvoke({ sessionStore, sessionName, spy });
+
+  // No --save-script: this is a plain deterministic replay, not a repair.
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  expect(spy.map((r) => r.command)).toEqual(['open', 'click', 'close']);
+});
+
+test('Fix 3: only the TERMINAL close is skipped during a repair — a mid-plan close still dispatches', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-replay-repair-close-midplan-',
+  );
+  const filePath = writeReplayFile(root, ['open "Demo"', 'close', 'open "Demo2"']);
+  const spy: DaemonRequest[] = [];
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    spy,
+    openReplacesSession: true,
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  // The mid-plan close (not the plan's last action) dispatches normally; only
+  // a close in the FINAL position is treated as repair lifecycle.
+  expect(spy.map((r) => r.command)).toEqual(['open', 'close', 'open']);
+});
+
+test('Fix 3: a --from resume that lands on the terminal close skips it too, letting the run complete', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-replay-repair-close-from-',
+  );
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    SAVE_ANNOTATION,
+    'click id="save"',
+    'close',
+  ]);
+  const spy: DaemonRequest[] = [];
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    spy,
+    failSteps: new Set(['click id="save"']),
+  });
+
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const divergence = leg1.error.details?.divergence as {
+    resume: { allowed: boolean; from: number; planDigest: string };
+  };
+  expect(divergence.resume.allowed).toBe(true);
+  expect(divergence.resume.from).toBe(2);
+
+  const session = sessionStore.get(sessionName)!;
+  sessionStore.recordAction(session, {
+    command: 'press',
+    positionals: ['@e9'],
+    flags: {},
+    result: { selectorChain: ['id="save-v2"'] },
+    targetEvidence: freshEvidence('save-v2', 'Save V2'),
+  });
+
+  spy.length = 0;
+  const leg2 = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: { saveScript: true, replayFrom: 3, replayPlanDigest: divergence.resume.planDigest },
+    }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+
+  // The resume lands directly on the (skipped) terminal close and completes
+  // — not a REPLAY_DIVERGENCE with repairHint "manual".
+  expect(leg2.ok).toBe(true);
+  expect(spy).toHaveLength(0);
+  // "click id=save" failed and was never recorded; the corrective press was
+  // recorded live; the terminal close was skipped, never dispatched.
+  expect(session.actions.map((a) => a.command)).toEqual(['open', 'press']);
+});
+
+// --- ADR 0012 decision 6, R7 (continuation persisted-state): a `replay --from`
+// continuation does NOT repeat --save-script; if it diverges, the session is
+// still held alive keyed off the PERSISTED armed state, not the request flag. ---
+
+test('a --from continuation WITHOUT --save-script that diverges is still held alive (repairSessionHeld set from persisted state)', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-replay-repair-continuation-',
+  );
+  // No annotations => action-failure path; both clicks fail so leg1 diverges at
+  // step 2 and the --from-3 continuation diverges at step 3.
+  const filePath = writeReplayFile(root, ['open "Demo"', 'click id="a"', 'click id="b"']);
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    failSteps: new Set(['click id="a"', 'click id="b"']),
+  });
+
+  // Leg 1: `replay --save-script` opens the transaction, arms the session, and
+  // diverges at step 2 — held alive.
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const leg1Divergence = leg1.error.details?.divergence as {
+    resume: { planDigest: string; repairSessionHeld?: boolean };
+  };
+  expect(leg1Divergence.resume.repairSessionHeld).toBe(true);
+  const armed = sessionStore.get(sessionName)!;
+  expect(armed.saveScriptBoundary).not.toBeUndefined();
+
+  // Leg 2: the `--from 3` continuation carries NO --save-script. It re-diverges
+  // at step 3 — and must STILL be held alive, keyed off the persisted armed
+  // state, so the transaction survives.
+  const leg2 = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: { replayFrom: 3, replayPlanDigest: leg1Divergence.resume.planDigest },
+    }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg2.ok).toBe(false);
+  if (leg2.ok) return;
+  expect(leg2.error.code).toBe('REPLAY_DIVERGENCE');
+  const leg2Divergence = leg2.error.details?.divergence as {
+    resume: { repairSessionHeld?: boolean };
+  };
+  // The key assertion: held alive despite no --save-script on this request.
+  expect(leg2Divergence.resume.repairSessionHeld).toBe(true);
+  expect(sessionStore.get(sessionName)).toBeDefined();
+});

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -593,6 +593,74 @@ test('BLOCKER 2 (new): a repair close whose PLATFORM close fails never commits a
   ).toHaveLength(1);
 });
 
+test('BLOCKER 3 (second follow-up): a retry after a SUCCESSFUL platform close but a FAILED commit never re-dispatches the platform close', async () => {
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-close-idempotent-',
+  );
+  makeCompleteRepairSession(sessionStore, sessionName, root);
+  const healedPath = path.join(root, 'flow.healed.ad');
+  // A prior COMPLETE (sentinel-marked) healed artifact already sits at the
+  // default path — the commit must refuse to clobber it, giving a
+  // deterministic commit FAILURE after a platform close that genuinely
+  // succeeds (mockDispatchCommand's `beforeEach` default resolves). A
+  // targeted close (an explicit positional app target) is what makes
+  // `dispatchTargetedPlatformClose` actually dispatch instead of no-op.
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+  const before = fs.readFileSync(healedPath, 'utf8');
+
+  const closeResponse = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: {},
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+
+  // The platform close genuinely ran and succeeded; the SUBSEQUENT commit
+  // failed (no-clobber) — the session is retained for retry.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
+  expect(closeResponse.ok).toBe(false);
+  if (!closeResponse.ok) expect(closeResponse.error.message).toMatch(/already exists/);
+  expect(sessionStore.get(sessionName)).toBeDefined();
+  expect(fs.readFileSync(healedPath, 'utf8')).toBe(before);
+  expect(sessionStore.get(sessionName)!.repairPlatformCloseSucceeded).toBe(true);
+
+  // Retry with an explicit path: the ALREADY-SUCCEEDED platform close must
+  // NEVER be dispatched again — a non-idempotent backend could fail (or
+  // wedge recovery entirely) on a second close of an already-closed target.
+  const retryPath = path.join(root, 'flow.promoted.ad');
+  const retry = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: { saveScript: retryPath },
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+
+  // Still exactly ONE dispatch total — the retry consumed the recorded
+  // success and went straight to the commit.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
+  expect(retry.ok).toBe(true);
+  expect(fs.existsSync(retryPath)).toBe(true);
+  const promoted = fs.readFileSync(retryPath, 'utf8');
+  expect(promoted).toContain(HEAL_COMPLETE_SENTINEL);
+});
+
 test('BLOCKER 3: a competing second writer never overwrites a COMPLETE artifact and gets a clear no-clobber error', async () => {
   const { root, sessionStore, sessionName } = setup('agent-device-repair-transaction-competing-');
   const healedPath = path.join(root, 'flow.healed.ad');

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -61,6 +61,7 @@ import { handleCloseCommand } from '../session-close.ts';
 import { SessionStore } from '../../session-store.ts';
 import { LeaseRegistry } from '../../lease-registry.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
+import { AppError } from '../../../kernel/errors.ts';
 import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
 import { HEAL_COMPLETE_SENTINEL } from '../../session-script-writer.ts';
 import { parseReplayScriptDetailed } from '../../../replay/script.ts';
@@ -505,6 +506,76 @@ test('BLOCKER 2b/2c: a close whose commit FAILS (no-clobber) keeps the session f
   if (retry.ok) expect(retry.data?.savedScript).toBe(retryPath);
   const promoted = parseReplayScriptDetailed(fs.readFileSync(retryPath, 'utf8'));
   expect(promoted.actions.filter((a) => a.command === 'close')).toHaveLength(1);
+});
+
+test('BLOCKER 2 (new): a repair close whose PLATFORM close fails never commits a healed .ad claiming a successful close', async () => {
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-platform-close-fail-',
+  );
+  const session = makeCompleteRepairSession(sessionStore, sessionName, root);
+  const healedPath = path.join(root, 'flow.healed.ad');
+
+  // A targeted close (an explicit positional app target) is what makes
+  // `dispatchTargetedPlatformClose` actually dispatch instead of no-op.
+  const platformCloseError = new AppError('DEVICE_UNAVAILABLE', 'platform close failed', {
+    reason: 'device_disconnected',
+    hint: 'Reconnect the device and retry close.',
+  });
+  mockDispatchCommand.mockRejectedValueOnce(platformCloseError);
+
+  const closeResponse = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: {},
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+
+  // The prior implementation committed (recorded a successful `close` +
+  // published the healed .ad) BEFORE the platform close ran at all, so a
+  // failing platform close still left a COMMITTED artifact on disk claiming
+  // success, contradicting the failed-close lifecycle contract. Fixed: the
+  // platform close runs first, so a failure here means NOTHING was committed.
+  expect(fs.existsSync(healedPath)).toBe(false);
+  expect(closeResponse.ok).toBe(false);
+  if (!closeResponse.ok) {
+    expect(closeResponse.error.code).toBe('DEVICE_UNAVAILABLE');
+    // BLOCKER 3: the session was kept for retry — `retriable` must agree.
+    expect(closeResponse.error.details?.retriable).toBe(true);
+  }
+  // BLOCKER 2b-style contract: the session stays addressable, untouched, so
+  // the agent can fix the cause (e.g. reconnect the device) and retry.
+  expect(sessionStore.get(sessionName)).toBe(session);
+  expect(session.actions.some((a) => a.command === 'close')).toBe(false);
+
+  // Retry once the platform close succeeds: commits cleanly.
+  mockDispatchCommand.mockResolvedValueOnce({});
+  const retry = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: {},
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(retry.ok).toBe(true);
+  expect(fs.existsSync(healedPath)).toBe(true);
+  const healedScript = fs.readFileSync(healedPath, 'utf8');
+  expect(healedScript).toContain(HEAL_COMPLETE_SENTINEL);
+  expect(
+    parseReplayScriptDetailed(healedScript).actions.filter((a) => a.command === 'close'),
+  ).toHaveLength(1);
 });
 
 test('BLOCKER 3: a competing second writer never overwrites a COMPLETE artifact and gets a clear no-clobber error', async () => {

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -475,9 +475,13 @@ test('BLOCKER 2b/2c: a close whose commit FAILS (no-clobber) keeps the session f
   // success, not a swallowed skip), distinguishable from a filesystem failure.
   if (!closeResponse.ok) {
     expect(closeResponse.error.message).toMatch(/already exists/);
-    // BLOCKER 3: the session was kept specifically so the agent can retry —
-    // `retriable` must say so, never contradict that recovery guidance.
-    expect(closeResponse.error.details?.retriable).toBe(true);
+    // BLOCKER 3 (original): the session was kept specifically so the agent
+    // can retry — `retriable` must say so, never contradict that recovery
+    // guidance. BLOCKER 2 (second follow-up): at the TOP level of the error —
+    // the location the router/client actually read — never buried under
+    // `details`.
+    expect(closeResponse.error.retriable).toBe(true);
+    expect(closeResponse.error.details?.retriable).toBeUndefined();
   }
   // The prior complete artifact is untouched.
   expect(fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8')).toBe(before);
@@ -520,6 +524,10 @@ test('BLOCKER 2 (new): a repair close whose PLATFORM close fails never commits a
   const platformCloseError = new AppError('DEVICE_UNAVAILABLE', 'platform close failed', {
     reason: 'device_disconnected',
     hint: 'Reconnect the device and retry close.',
+    // BLOCKER 2 (second follow-up): the underlying platform error's own
+    // diagnosticId/logPath must survive normalization, never be flattened away.
+    diagnosticId: 'diag-platform-close-1',
+    logPath: '/tmp/platform-close-1.log',
   });
   mockDispatchCommand.mockRejectedValueOnce(platformCloseError);
 
@@ -546,8 +554,15 @@ test('BLOCKER 2 (new): a repair close whose PLATFORM close fails never commits a
   expect(closeResponse.ok).toBe(false);
   if (!closeResponse.ok) {
     expect(closeResponse.error.code).toBe('DEVICE_UNAVAILABLE');
-    // BLOCKER 3: the session was kept for retry — `retriable` must agree.
-    expect(closeResponse.error.details?.retriable).toBe(true);
+    // BLOCKER 3 (original): the session was kept for retry — `retriable`
+    // must agree. BLOCKER 2 (second follow-up): at the TOP level, and the
+    // underlying platform error's diagnosticId/logPath/details are preserved
+    // rather than discarded.
+    expect(closeResponse.error.retriable).toBe(true);
+    expect(closeResponse.error.details?.retriable).toBeUndefined();
+    expect(closeResponse.error.diagnosticId).toBe('diag-platform-close-1');
+    expect(closeResponse.error.logPath).toBe('/tmp/platform-close-1.log');
+    expect(closeResponse.error.details?.reason).toBe('device_disconnected');
   }
   // BLOCKER 2b-style contract: the session stays addressable, untouched, so
   // the agent can fix the cause (e.g. reconnect the device) and retry.

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -1,0 +1,520 @@
+/**
+ * ADR 0012 decision 6 "repair transaction" lifecycle fixes (Q1/Q2a/Q2b/Q2c):
+ * proves the WHOLE chain end to end, at the layer these fixes actually live —
+ * `runReplayScriptFile` + `handleCloseCommand` sharing a live `SessionStore`,
+ * exactly like an agent's separate CLI invocations against the same daemon
+ * session would. `sendToDaemon`'s process-level keep-alive (Fix 1's daemon
+ * teardown guard) is a different architectural layer — a client-side process
+ * manager, not session/script state — and is covered separately in
+ * `src/utils/__tests__/daemon-client-lifecycle.test.ts`
+ * ("keeps an owned ephemeral daemon alive and hints its --state-dir...").
+ *
+ * Fix 1 (session-side): a divergence never deletes the session — it stays in
+ * the SessionStore, addressable for the next call.
+ * Fix 2: SessionScriptWriter.write only publishes once `close --save-script`
+ * sets `saveScriptComplete` — never on a divergence-only exit or an
+ * abandoned close.
+ * Fix 3: the source plan's terminal `close` is skipped while repair-armed, so
+ * the resume completes instead of diverging on lifecycle.
+ * Fix 4: the publish is atomic (temp + rename) and carries the completeness
+ * sentinel, so a stale/partial file never blocks a later repair.
+ */
+import { test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../platforms/apple/core/simulator.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/apple/core/simulator.ts')>();
+  return { ...actual, shutdownSimulator: vi.fn() };
+});
+vi.mock('../../../utils/exec.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/exec.ts')>();
+  return { ...actual, runCmd: vi.fn() };
+});
+vi.mock('../../../platforms/apple/core/runner/runner-client.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/apple/core/runner/runner-client.ts')>();
+  return { ...actual, stopIosRunnerSession: vi.fn(async () => {}) };
+});
+vi.mock('../../../platforms/apple/core/perf-xctrace.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/apple/core/perf-xctrace.ts')>();
+  return { ...actual, cleanupAppleXctracePerfCapture: vi.fn(async () => ({})) };
+});
+vi.mock('../../runtime-hints.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../runtime-hints.ts')>();
+  return { ...actual, clearRuntimeHintsFromApp: vi.fn(async () => {}) };
+});
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(async () => ({})), resolveTargetDevice: vi.fn() };
+});
+vi.mock('../session-device-utils.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../session-device-utils.ts')>();
+  return { ...actual, settleIosSimulator: vi.fn(async () => {}) };
+});
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runReplayScriptFile } from '../session-replay-runtime.ts';
+import { handleCloseCommand } from '../session-close.ts';
+import { SessionStore } from '../../session-store.ts';
+import { LeaseRegistry } from '../../lease-registry.ts';
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { HEAL_COMPLETE_SENTINEL } from '../../session-script-writer.ts';
+import { parseReplayScriptDetailed } from '../../../replay/script.ts';
+import {
+  baseReplayRequest as baseReq,
+  writeReplayFile,
+} from './session-replay-runtime.fixtures.ts';
+import { freshEvidence, makeRecordingReplayInvoke } from './session-replay-repair.fixtures.ts';
+
+const mockDispatchCommand = vi.mocked(dispatchCommand);
+
+beforeEach(() => {
+  mockDispatchCommand.mockReset();
+  // The "current" app state: "save" was renamed to "save-v2" (why step 2
+  // diverges), matching the target verification the SAVE_ANNOTATION triggers.
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        identifier: 'save-v2',
+        label: 'Save V2',
+        rect: { x: 10, y: 10, width: 40, height: 20 },
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+});
+
+const SAVE_ANNOTATION =
+  '# agent-device:target-v1 {"id":"save","role":"button","label":"Save","ancestry":[],"sibling":0,"viewportOrder":0,"verification":"verified"}';
+
+function setup(prefix: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  return {
+    root,
+    sessionStore,
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    leaseRegistry: new LeaseRegistry(),
+  };
+}
+
+test('end-to-end repair transaction: cold divergence stays alive, corrective resume completes, close --save-script finalizes a COMPLETE healed .ad atomically, and an abandoned repair leaves no partial file', async () => {
+  // ============================================================
+  // Part 1 — the repair chain that COMMITS.
+  // ============================================================
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-commit-',
+  );
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    SAVE_ANNOTATION,
+    'click id="save"',
+    'click id="confirm"',
+    'close',
+  ]);
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    evidence: (req) => (req.command === 'click' ? freshEvidence('confirm', 'Confirm') : undefined),
+  });
+
+  // --- Cold `replay drifted.ad --save-script` diverges on the renamed id. ---
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  expect(leg1.error.code).toBe('REPLAY_DIVERGENCE');
+  const divergence = leg1.error.details?.divergence as {
+    kind: string;
+    resume: { allowed: boolean; from: number; planDigest: string; repairSessionHeld?: boolean };
+  };
+  expect(divergence.kind).toBe('selector-miss');
+  expect(divergence.resume.allowed).toBe(true);
+  // C1: the daemon marks the repair-transaction liveness signal on the wire.
+  expect(divergence.resume.repairSessionHeld).toBe(true);
+
+  // Fix 1 (session-side): the session stays alive — never torn down on a
+  // divergence-only exit. (The client-side daemon PROCESS keep-alive that
+  // makes this session reachable across separate CLI invocations is proven
+  // in daemon-client-lifecycle.test.ts.)
+  expect(sessionStore.get(sessionName)).toBeDefined();
+  expect(sessionStore.get(sessionName)!.actions.map((a) => a.command)).toEqual(['open']);
+  // C2: the transaction is NOT complete yet — a `close` here would abort, not
+  // commit a prefix.
+  expect(sessionStore.get(sessionName)!.saveScriptComplete).toBeFalsy();
+
+  // --- Agent performs the corrective press (blessed @ref), recorded live. ---
+  const session = sessionStore.get(sessionName)!;
+  sessionStore.recordAction(session, {
+    command: 'press',
+    positionals: ['@e7'],
+    flags: {},
+    result: { selectorChain: ['id="save-v2"'] },
+    targetEvidence: freshEvidence('save-v2', 'Save V2'),
+  });
+
+  // --- `replay --from N+1 --plan-digest <original>` resumes to the end. The
+  // source plan's own terminal `close` (Fix 3) is skipped, so this completes
+  // instead of diverging on lifecycle. ---
+  const leg2 = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: { saveScript: true, replayFrom: 3, replayPlanDigest: divergence.resume.planDigest },
+    }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg2.ok).toBe(true);
+  expect(session.actions.map((a) => a.command)).toEqual(['open', 'press', 'click']);
+  // The terminal close never dispatched or recorded.
+  expect(session.actions.some((a) => a.command === 'close')).toBe(false);
+  // C2: the resume reached the last executable step (terminal close skipped) —
+  // the transaction is now COMPLETE and commit-eligible.
+  expect(session.saveScriptComplete).toBe(true);
+
+  // --- The agent finalizes: `close --save-script` (the real handler, not a
+  // direct writer call) commits the now-COMPLETE healed `.ad`. ---
+  const closeResponse = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: { saveScript: true },
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(closeResponse.ok).toBe(true);
+  // The session is gone (close's normal lifecycle) — but the healed script
+  // was written to disk before deletion.
+  expect(sessionStore.get(sessionName)).toBeUndefined();
+
+  const healedPath = path.join(root, 'flow.healed.ad');
+  // BLOCKER 2a: the close response positively reports the committed healed path.
+  if (closeResponse.ok) expect(closeResponse.data?.savedScript).toBe(healedPath);
+  expect(fs.existsSync(healedPath)).toBe(true);
+  const healedScript = fs.readFileSync(healedPath, 'utf8');
+  // Fix 4: complete + atomic — the sentinel is present, and the only file in
+  // the directory is the final published one (no stray temp file survived).
+  expect(healedScript).toContain(HEAL_COMPLETE_SENTINEL);
+  expect(fs.readdirSync(root).filter((entry) => entry.endsWith('.ad'))).toEqual([
+    'flow.ad',
+    'flow.healed.ad',
+  ]);
+  const parsed = parseReplayScriptDetailed(healedScript);
+  // Exactly the repair run's own execution path: open, the corrective press,
+  // the surviving click, and the agent's own close — never the source
+  // plan's original (skipped) close, never a bare @ref.
+  expect(parsed.actions.map((a) => a.command)).toEqual(['open', 'press', 'click', 'close']);
+  const bareRefs = parsed.actions.flatMap((a) => a.positionals.filter((p) => p.startsWith('@')));
+  expect(bareRefs).toEqual([]);
+
+  // ============================================================
+  // Part 2 — a diverged-and-abandoned repair leaves NO partial file.
+  // ============================================================
+  const abandoned = setup('agent-device-repair-transaction-abandoned-');
+  const abandonedFilePath = writeReplayFile(abandoned.root, [
+    'open "Demo" --relaunch',
+    SAVE_ANNOTATION,
+    'click id="save"',
+    'close',
+  ]);
+  const abandonedInvoke = makeRecordingReplayInvoke({
+    sessionStore: abandoned.sessionStore,
+    sessionName: abandoned.sessionName,
+  });
+
+  const abandonedLeg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [abandonedFilePath], flags: { saveScript: true } }),
+    sessionName: abandoned.sessionName,
+    logPath: abandoned.logPath,
+    sessionStore: abandoned.sessionStore,
+    invoke: abandonedInvoke,
+  });
+  expect(abandonedLeg1.ok).toBe(false);
+
+  // The agent walks away: a plain `close` (no --save-script) reaches the
+  // still repair-armed session — Fix 1/2's "abort/discard", not a commit.
+  const abandonedCloseResponse = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: abandoned.sessionName,
+      command: 'close',
+      positionals: [],
+      flags: {},
+    },
+    sessionName: abandoned.sessionName,
+    logPath: abandoned.logPath,
+    sessionStore: abandoned.sessionStore,
+    leaseRegistry: abandoned.leaseRegistry,
+  });
+  expect(abandonedCloseResponse.ok).toBe(true);
+
+  const abandonedHealedPath = path.join(abandoned.root, 'flow.healed.ad');
+  expect(fs.existsSync(abandonedHealedPath)).toBe(false);
+  // No stray temp artifact either.
+  expect(
+    fs.existsSync(path.dirname(abandonedHealedPath))
+      ? fs.readdirSync(path.dirname(abandonedHealedPath))
+      : [],
+  ).toEqual(['flow.ad']);
+});
+
+test('C5a: an incomplete repair reaped by idle-reap leaves a tombstone (no healed file); a fresh replay --save-script clears it', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-repair-transaction-reap-',
+  );
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    SAVE_ANNOTATION,
+    'click id="save"',
+    'close',
+  ]);
+  const invoke = makeRecordingReplayInvoke({ sessionStore, sessionName });
+
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  const session = sessionStore.get(sessionName)!;
+  expect(session.saveScriptComplete).toBeFalsy();
+  expect(session.repairSourcePath).toBe(filePath);
+
+  // Idle-reap tears the still-incomplete repair session down: the writer commits
+  // nothing (not complete) and a tombstone is left behind (the exact teardown
+  // step daemon-runtime.ts's teardownDaemonSession runs).
+  sessionStore.finalizeRepairTeardown(session);
+  sessionStore.delete(sessionName);
+  expect(fs.existsSync(path.join(root, 'flow.healed.ad'))).toBe(false);
+
+  const tombstone = sessionStore.readRepairTombstone(sessionName);
+  expect(tombstone).toBeDefined();
+  expect(tombstone?.sourcePath).toBe(filePath);
+
+  // A fresh `replay --save-script` on the same key clears the tombstone.
+  await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke: makeRecordingReplayInvoke({ sessionStore, sessionName }),
+  });
+  expect(sessionStore.readRepairTombstone(sessionName)).toBeUndefined();
+});
+
+test('C5a: teardown of a COMPLETE repair auto-commits the healed file and writes NO tombstone', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-repair-transaction-autocommit-',
+  );
+  // A clean (non-diverging) repair-armed replay completes the plan.
+  const filePath = writeReplayFile(root, ['open "Demo" --relaunch', 'click id="save-v2"']);
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    evidence: (req) => (req.command === 'click' ? freshEvidence('save-v2', 'Save V2') : undefined),
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(response.ok).toBe(true);
+  const session = sessionStore.get(sessionName)!;
+  expect(session.saveScriptComplete).toBe(true);
+
+  // Teardown (e.g. the client tearing down the ephemeral daemon after a clean
+  // repair) auto-commits the completed transaction and leaves no tombstone.
+  sessionStore.finalizeRepairTeardown(session);
+  expect(fs.existsSync(path.join(root, 'flow.healed.ad'))).toBe(true);
+  expect(fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8')).toContain(
+    HEAL_COMPLETE_SENTINEL,
+  );
+  expect(sessionStore.readRepairTombstone(sessionName)).toBeUndefined();
+});
+
+test('BLOCKER 1: a --from continuation on a reaped session returns SESSION_NOT_FOUND (translated to REPAIR_SESSION_EXPIRED), not a REPLAY_DIVERGENCE', async () => {
+  const { root, sessionStore, sessionName, logPath } = setup(
+    'agent-device-repair-transaction-from-reaped-',
+  );
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    SAVE_ANNOTATION,
+    'click id="save"',
+    'click id="confirm"',
+    'close',
+  ]);
+  const invoke = makeRecordingReplayInvoke({ sessionStore, sessionName });
+
+  // Leg 1 arms + diverges (save renamed to save-v2 in the mock tree).
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const leg1Divergence = leg1.error.details?.divergence as { resume: { planDigest: string } };
+  const digest = leg1Divergence.resume.planDigest;
+
+  // Idle-reap tears the incomplete repair down, leaving a tombstone.
+  sessionStore.finalizeRepairTeardown(sessionStore.get(sessionName)!);
+  sessionStore.delete(sessionName);
+  expect(sessionStore.readRepairTombstone(sessionName)).toBeDefined();
+
+  // A `--from` continuation targeting the (now reaped) session must surface
+  // SESSION_NOT_FOUND — NOT a REPLAY_DIVERGENCE wrapping the first step's
+  // failure — so the router translates it to REPAIR_SESSION_EXPIRED.
+  const resumed = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { replayFrom: 3, replayPlanDigest: digest } }),
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  expect(resumed.ok).toBe(false);
+  if (resumed.ok) return;
+  expect(resumed.error.code).toBe('SESSION_NOT_FOUND');
+  expect(resumed.error.code).not.toBe('REPLAY_DIVERGENCE');
+});
+
+/** A COMPLETE, committable repair-armed session at the default healed sibling path. */
+function makeCompleteRepairSession(sessionStore: SessionStore, sessionName: string, root: string) {
+  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
+  session.recordSession = true;
+  session.saveScriptBoundary = 0;
+  session.saveScriptComplete = true;
+  session.saveScriptPath = path.join(root, 'flow.healed.ad');
+  session.saveScriptDefaultedHealedPath = true;
+  session.actions = [
+    { ts: 1, command: 'open', positionals: ['Demo'], flags: {} },
+    {
+      ts: 2,
+      command: 'press',
+      positionals: ['@e7'],
+      flags: {},
+      result: { selectorChain: ['id="save-v2"'] },
+      targetEvidence: freshEvidence('save-v2', 'Save V2'),
+    },
+  ];
+  sessionStore.set(sessionName, session);
+  return session;
+}
+
+test('BLOCKER 2b/2c: a close whose commit FAILS (no-clobber) keeps the session for retry and surfaces a distinct error', async () => {
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-commit-fail-',
+  );
+  makeCompleteRepairSession(sessionStore, sessionName, root);
+  // A prior COMPLETE (sentinel-marked) healed artifact already sits at the
+  // default path — the commit must refuse to clobber it.
+  fs.writeFileSync(
+    path.join(root, 'flow.healed.ad'),
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+  const before = fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8');
+
+  const closeResponse = await handleCloseCommand({
+    req: { token: 't', session: sessionName, command: 'close', positionals: [], flags: {} },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+
+  // BLOCKER 2b: the commit failed, so the session is NOT torn down — it stays
+  // addressable so the agent can retry (e.g. `close --save-script=<other>`).
+  expect(closeResponse.ok).toBe(false);
+  expect(sessionStore.get(sessionName)).toBeDefined();
+  // BLOCKER 2c: a no-clobber refusal is a distinct, surfaced error (not a silent
+  // success, not a swallowed skip), distinguishable from a filesystem failure.
+  if (!closeResponse.ok) {
+    expect(closeResponse.error.message).toMatch(/already exists/);
+  }
+  // The prior complete artifact is untouched.
+  expect(fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8')).toBe(before);
+  // The rolled-back finalize `close` did not linger, so a retry does not
+  // accumulate a duplicate `close` in the healed slice.
+  expect(sessionStore.get(sessionName)!.actions.filter((a) => a.command === 'close')).toHaveLength(
+    0,
+  );
+
+  // Retry with an explicit path commits cleanly — exactly ONE terminal close.
+  const retryPath = path.join(root, 'flow.promoted.ad');
+  const retry = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: { saveScript: retryPath },
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(retry.ok).toBe(true);
+  if (retry.ok) expect(retry.data?.savedScript).toBe(retryPath);
+  const promoted = parseReplayScriptDetailed(fs.readFileSync(retryPath, 'utf8'));
+  expect(promoted.actions.filter((a) => a.command === 'close')).toHaveLength(1);
+});
+
+test('BLOCKER 3: a competing second writer never overwrites a COMPLETE artifact and gets a clear no-clobber error', async () => {
+  const { root, sessionStore, sessionName } = setup('agent-device-repair-transaction-competing-');
+  const healedPath = path.join(root, 'flow.healed.ad');
+
+  // Writer 1 commits a complete artifact at the default healed path.
+  const first = makeCompleteRepairSession(sessionStore, `${sessionName}-1`, root);
+  const r1 = sessionStore.writeSessionLog(first);
+  expect(r1.written).toBe(true);
+  const committed = fs.readFileSync(healedPath, 'utf8');
+  expect(committed).toContain(HEAL_COMPLETE_SENTINEL);
+
+  // Writer 2 (a second repair on the same source → same default path) attempts
+  // to publish over it. The atomic create-exclusive publish must FAIL rather
+  // than overwrite the complete artifact.
+  const second = makeCompleteRepairSession(sessionStore, `${sessionName}-2`, root);
+  second.actions[1] = {
+    ts: 2,
+    command: 'press',
+    positionals: ['@e9'],
+    flags: {},
+    result: { selectorChain: ['id="different"'] },
+    targetEvidence: freshEvidence('different', 'Different'),
+  };
+  const r2 = sessionStore.writeSessionLog(second);
+  expect(r2.written).toBe(false);
+  expect(r2.written === false && r2.error?.message).toMatch(/already exists/);
+  // The first writer's complete artifact is byte-for-byte intact.
+  expect(fs.readFileSync(healedPath, 'utf8')).toBe(committed);
+});

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -327,12 +327,14 @@ test('C5a: an incomplete repair reaped by idle-reap leaves a tombstone (no heale
   expect(sessionStore.readRepairTombstone(sessionName)).toBeUndefined();
 });
 
-test('C5a: teardown of a COMPLETE repair auto-commits the healed file and writes NO tombstone', async () => {
+test('C5a/BLOCKER 3: teardown of a COMPLETE repair auto-commits a self-contained, fresh-replayable healed file (recording the skipped terminal close) and writes NO tombstone', async () => {
   const { root, sessionStore, sessionName, logPath } = setup(
     'agent-device-repair-transaction-autocommit-',
   );
-  // A clean (non-diverging) repair-armed replay completes the plan.
-  const filePath = writeReplayFile(root, ['open "Demo" --relaunch', 'click id="save-v2"']);
+  // A clean (non-diverging) repair-armed replay completes the plan. The
+  // source plan's OWN terminal `close` is the exact thing Fix 3 skips while
+  // armed — proving BLOCKER 3 requires a source that actually has one.
+  const filePath = writeReplayFile(root, ['open "Demo" --relaunch', 'click id="save-v2"', 'close']);
   const invoke = makeRecordingReplayInvoke({
     sessionStore,
     sessionName,
@@ -349,15 +351,28 @@ test('C5a: teardown of a COMPLETE repair auto-commits the healed file and writes
   expect(response.ok).toBe(true);
   const session = sessionStore.get(sessionName)!;
   expect(session.saveScriptComplete).toBe(true);
+  // Fix 3: the source plan's terminal `close` never dispatched or recorded —
+  // this is exactly the skip BLOCKER 3 must still account for at teardown.
+  expect(session.actions.map((a) => a.command)).toEqual(['open', 'click']);
 
   // Teardown (e.g. the client tearing down the ephemeral daemon after a clean
   // repair) auto-commits the completed transaction and leaves no tombstone.
   sessionStore.finalizeRepairTeardown(session);
   expect(fs.existsSync(path.join(root, 'flow.healed.ad'))).toBe(true);
-  expect(fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8')).toContain(
-    HEAL_COMPLETE_SENTINEL,
-  );
+  const healedScript = fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8');
+  expect(healedScript).toContain(HEAL_COMPLETE_SENTINEL);
   expect(sessionStore.readRepairTombstone(sessionName)).toBeUndefined();
+
+  // BLOCKER 3: the ADR requires the committed artifact to be SELF-CONTAINED
+  // and fresh-replayable — not merely "a file with the sentinel exists".
+  // Parse it and assert it ends with its own terminal `close`, exactly like
+  // an explicit `close --save-script` commit does, never a script a fresh
+  // replay would run off the end of.
+  const parsed = parseReplayScriptDetailed(healedScript);
+  expect(parsed.actions.map((a) => a.command)).toEqual(['open', 'click', 'close']);
+  expect(parsed.actions[2]?.positionals).toEqual([]);
+  const bareRefs = parsed.actions.flatMap((a) => a.positionals.filter((p) => p.startsWith('@')));
+  expect(bareRefs).toEqual([]);
 });
 
 test('BLOCKER 1: a --from continuation on a reaped session returns SESSION_NOT_FOUND (translated to REPAIR_SESSION_EXPIRED), not a REPLAY_DIVERGENCE', async () => {

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -690,3 +690,110 @@ test('BLOCKER 3: a competing second writer never overwrites a COMPLETE artifact 
   // The first writer's complete artifact is byte-for-byte intact.
   expect(fs.readFileSync(healedPath, 'utf8')).toBe(committed);
 });
+
+// --- ADR 0012 decision 6 (BLOCKER 3, third follow-up): `repairPlatformCloseSucceeded`
+// was session-wide, not bound to WHICH close request actually succeeded. An
+// untargeted close performs NO platform operation (`shouldDispatchPlatformClose`
+// is false with no positional target), yet the prior implementation still set
+// the marker as though a real close succeeded; a retry with a DIFFERENT
+// identity (a target added, or a different target) then wrongly skipped the
+// platform close entirely, committing as though it had run. ---
+
+test('BLOCKER 3 (third follow-up): an untargeted close that performed NO platform operation never lets a targeted retry skip the platform close', async () => {
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-close-identity-untargeted-',
+  );
+  makeCompleteRepairSession(sessionStore, sessionName, root);
+  const healedPath = path.join(root, 'flow.healed.ad');
+  // A prior COMPLETE artifact already sits at the default path so the commit
+  // deterministically fails and the session is retained for retry.
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+
+  // First attempt: UNTARGETED close — `shouldDispatchPlatformClose` is false
+  // (no positional target, not `web`), so the platform close never dispatches
+  // at all; the commit then fails (no-clobber).
+  const first = await handleCloseCommand({
+    req: { token: 't', session: sessionName, command: 'close', positionals: [], flags: {} },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(first.ok).toBe(false);
+  expect(mockDispatchCommand).not.toHaveBeenCalled();
+  expect(sessionStore.get(sessionName)).toBeDefined();
+
+  // Retry WITH a target: the prior session-wide `repairPlatformCloseSucceeded`
+  // flag (set true even though nothing dispatched for the untargeted attempt)
+  // would wrongly skip the platform close here. It must actually run.
+  const retry = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: { saveScript: path.join(root, 'flow.promoted.ad') },
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
+  expect(mockDispatchCommand.mock.calls[0]?.[2]).toEqual(['com.example.app']);
+  expect(retry.ok).toBe(true);
+});
+
+test('BLOCKER 3 (third follow-up): a retry targeting a DIFFERENT app than the succeeded close never skips the platform close for the new target', async () => {
+  const { root, sessionStore, sessionName, logPath, leaseRegistry } = setup(
+    'agent-device-repair-transaction-close-identity-changed-target-',
+  );
+  makeCompleteRepairSession(sessionStore, sessionName, root);
+  const healedPath = path.join(root, 'flow.healed.ad');
+  fs.writeFileSync(
+    healedPath,
+    `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
+  );
+
+  // First attempt targets app-a; the platform close succeeds, the commit fails.
+  const first = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app-a'],
+      flags: {},
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(first.ok).toBe(false);
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
+  expect(sessionStore.get(sessionName)!.repairPlatformCloseSucceeded).toBe(true);
+
+  // Retry targets a DIFFERENT app (app-b) — a genuinely different platform
+  // operation. The prior session-wide marker would wrongly treat app-b as
+  // already closed just because SOME close succeeded. It must dispatch again,
+  // against app-b specifically.
+  const retry = await handleCloseCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app-b'],
+      flags: { saveScript: path.join(root, 'flow.promoted.ad') },
+    },
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+  });
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(2);
+  expect(mockDispatchCommand.mock.calls[1]?.[2]).toEqual(['com.example.app-b']);
+  expect(retry.ok).toBe(true);
+});

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -474,6 +474,9 @@ test('BLOCKER 2b/2c: a close whose commit FAILS (no-clobber) keeps the session f
   // success, not a swallowed skip), distinguishable from a filesystem failure.
   if (!closeResponse.ok) {
     expect(closeResponse.error.message).toMatch(/already exists/);
+    // BLOCKER 3: the session was kept specifically so the agent can retry —
+    // `retriable` must say so, never contradict that recovery guidance.
+    expect(closeResponse.error.details?.retriable).toBe(true);
   }
   // The prior complete artifact is untouched.
   expect(fs.readFileSync(path.join(root, 'flow.healed.ad'), 'utf8')).toBe(before);

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -233,6 +233,25 @@ async function stopBestEffortSessionResources(
   );
 }
 
+/**
+ * ADR 0012 decision 6 (BLOCKER 3, third follow-up): identifies WHICH close
+ * request's platform close succeeded — not merely THAT one did. Only the
+ * request's TARGET (`positionals`) can change what `dispatchTargetedPlatformClose`
+ * actually does: `shouldDispatchPlatformClose` decides purely from
+ * `hasCloseTarget(req)` (plus the `web` special case, constant for a given
+ * session), and the dispatch itself is `dispatchCommand(device, 'close',
+ * req.positionals, ...)`. `close`'s only other flags (`shutdown`, `saveScript`
+ * — see `closeCliSchema`) feed the post-teardown shutdown and the commit path
+ * respectively, never this call, so they carry no identity here. Binding the
+ * marker to this identity means an untargeted close's "succeeded" (a no-op,
+ * since `shouldDispatchPlatformClose` was false) can never be misread as "the
+ * platform close for THIS target already ran" by a later retry that adds or
+ * changes the target — that retry's identity differs, so it re-dispatches.
+ */
+function repairPlatformCloseIdentity(req: DaemonRequest): string {
+  return JSON.stringify(req.positionals ?? []);
+}
+
 async function dispatchTargetedPlatformClose(params: {
   req: DaemonRequest;
   session: SessionState;
@@ -314,6 +333,7 @@ export async function handleCloseCommand(params: {
     return await closeWithoutSession(req, logPath);
   }
   const repairArmed = session.saveScriptBoundary !== undefined;
+  const closeIdentity = repairPlatformCloseIdentity(req);
   // ADR 0012 decision 6 (BLOCKER 2): for a repair-armed session, the platform
   // close must run and SUCCEED before anything is committed or torn down —
   // otherwise a committed healed `.ad` could claim a successful `close` that
@@ -325,10 +345,17 @@ export async function handleCloseCommand(params: {
   // dispatched the platform close and confirmed its success, then failed to
   // commit (the session is retained for exactly that retry — see below). A
   // retry must never re-dispatch a (possibly non-idempotent) platform close
-  // against an already-closed target; `repairPlatformCloseSucceeded` records
-  // that the platform-level close already happened, so this retry consumes
-  // it and goes straight to the commit instead.
-  if (repairArmed && !session.repairPlatformCloseSucceeded) {
+  // against an already-closed target; `repairPlatformCloseSucceeded` +
+  // `repairPlatformCloseIdentity` together record that the platform-level
+  // close already happened FOR THIS EXACT request identity, so a same-identity
+  // retry consumes it and goes straight to the commit instead. A retry whose
+  // identity DIFFERS (third follow-up: e.g. untargeted -> targeted, or a
+  // changed target) never matches — the marker only ever attests to the
+  // identity it was recorded under, so the platform close runs (again).
+  if (
+    repairArmed &&
+    !(session.repairPlatformCloseSucceeded && session.repairPlatformCloseIdentity === closeIdentity)
+  ) {
     const platformCloseError = await dispatchTargetedPlatformClose({ req, session, logPath });
     if (platformCloseError) {
       return buildRepairCloseFailureResponse(
@@ -337,6 +364,7 @@ export async function handleCloseCommand(params: {
       );
     }
     session.repairPlatformCloseSucceeded = true;
+    session.repairPlatformCloseIdentity = closeIdentity;
   }
   // Commit the repair transaction BEFORE any destructive teardown. On failure,
   // return without tearing the session down — it stays addressable so the
@@ -350,6 +378,7 @@ export async function handleCloseCommand(params: {
   // this close attempt's outcome is settled, so the platform-close-succeeded
   // marker (BLOCKER 3) has served its purpose and must not linger.
   session.repairPlatformCloseSucceeded = false;
+  session.repairPlatformCloseIdentity = undefined;
   const healedScriptPath = repairCommit.kind === 'committed' ? repairCommit.path : undefined;
   let providerData: Record<string, unknown> | undefined;
   // Resource teardown is failure-isolated: a rejected step is collected instead of

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -118,8 +118,10 @@ function buildRepairCloseFailureResponse(session: SessionState, error: AppError)
       details: {
         session: session.name,
         ...(session.saveScriptPath ? { savedScript: session.saveScriptPath } : {}),
-        // The session was preserved: retry after fixing the cause.
-        retriable: false,
+        // BLOCKER 3: the session was preserved specifically so the agent can
+        // retry (`close`/`close --save-script=<other>`) — `retriable` must
+        // agree with that, never contradict the recovery guidance above.
+        retriable: true,
       },
     },
   };

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -127,6 +127,22 @@ function buildRepairCloseFailureResponse(session: SessionState, error: AppError)
   };
 }
 
+/**
+ * ADR 0012 decision 6 (BLOCKER 2, new): normalizes a repair-armed session's
+ * FAILED platform close into a distinct, surfaceable AppError, mirroring
+ * `toRepairCommitFailure` in `session-script-writer.ts`. An AppError from the
+ * platform close (e.g. a device-unavailable failure) already carries its own
+ * code/details/hint and passes through unchanged; anything else is wrapped
+ * with a clear message so the agent can tell this apart from a write failure.
+ */
+function toRepairPlatformCloseFailure(error: unknown): AppError {
+  if (error instanceof AppError) return error;
+  const detail = error instanceof Error ? error.message : String(error);
+  return new AppError('COMMAND_FAILED', `The platform close failed: ${detail}`, {
+    hint: 'The repair transaction was not committed because the platform close failed; fix the underlying issue and retry close --save-script.',
+  });
+}
+
 // Runs the failure-isolated resource teardown and the targeted platform close
 // (#1225). Returns the preserved platform-close error (if any); best-effort
 // cleanup failures are pushed into `cleanupFailures`. Never throws for a cleanup
@@ -139,6 +155,11 @@ async function runSessionCloseTeardown(params: {
   sessionStore: SessionStore;
   cleanupFailures: SessionCleanupFailure[];
   repairArmed: boolean;
+  // ADR 0012 decision 6 (BLOCKER 2): a repair-armed session already dispatched
+  // (and confirmed the success of) its platform close BEFORE this teardown —
+  // see `handleCloseCommand`. Dispatching it again here would be redundant at
+  // best and a double-close at worst, so it is skipped for that case only.
+  skipPlatformClose: boolean;
 }): Promise<unknown> {
   const { req, session, sessionName, logPath, sessionStore, cleanupFailures, repairArmed } = params;
   const attemptCleanup = async (step: string, run: () => Promise<void>): Promise<void> => {
@@ -153,14 +174,18 @@ async function runSessionCloseTeardown(params: {
   // its AppError (code/details/hint) is preserved and returned for the caller to
   // rethrow, and a failed close must not be recorded as `Closed`. Subsequent
   // resource cleanup still runs regardless.
-  const platformCloseError = await dispatchTargetedPlatformClose({ req, session, logPath });
+  const platformCloseError = params.skipPlatformClose
+    ? undefined
+    : await dispatchTargetedPlatformClose({ req, session, logPath });
   await stopOrRetainAppleRunnerAfterClose(req, session, attemptCleanup);
   await clearSessionRuntimeHints(session, sessionStore, sessionName);
   // ADR 0012 decision 6 (BLOCKER 2): a repair-armed session already recorded its
   // finalize `close` and committed (or aborted) its healed `.ad` BEFORE this
-  // teardown (commit-state machine — the single commit path). Only an ordinary
-  // (non-repair) session records `close` + writes its session log here, and —
-  // per #1225 — a failed platform close is not recorded as `Closed`.
+  // teardown (commit-state machine — the single commit path), and only AFTER
+  // its platform close (dispatched above `handleCloseCommand`) was confirmed to
+  // succeed. Only an ordinary (non-repair) session records `close` + writes its
+  // session log here, and — per #1225 — a failed platform close is not recorded
+  // as `Closed`.
   if (!repairArmed) {
     if (!platformCloseError) {
       recordSessionAction(sessionStore, session, req, 'close', {
@@ -278,9 +303,25 @@ export async function handleCloseCommand(params: {
   if (!session) {
     return await closeWithoutSession(req, logPath);
   }
-  // ADR 0012 decision 6 (BLOCKER 2): commit the repair transaction BEFORE any
-  // destructive teardown. On failure, return without tearing the session down —
-  // it stays addressable so the agent can fix the cause and retry.
+  const repairArmed = session.saveScriptBoundary !== undefined;
+  // ADR 0012 decision 6 (BLOCKER 2): for a repair-armed session, the platform
+  // close must run and SUCCEED before anything is committed or torn down —
+  // otherwise a committed healed `.ad` could claim a successful `close` that
+  // never actually happened on the device. On failure, return without
+  // touching the session at all (mirrors the commit-failure path below): it
+  // stays addressable so the agent can fix the cause and retry.
+  if (repairArmed) {
+    const platformCloseError = await dispatchTargetedPlatformClose({ req, session, logPath });
+    if (platformCloseError) {
+      return buildRepairCloseFailureResponse(
+        session,
+        toRepairPlatformCloseFailure(platformCloseError),
+      );
+    }
+  }
+  // Commit the repair transaction BEFORE any destructive teardown. On failure,
+  // return without tearing the session down — it stays addressable so the
+  // agent can fix the cause and retry.
   const repairCommit = commitRepairBeforeClose(sessionStore, session, req);
   if (repairCommit.kind === 'failed') {
     return buildRepairCloseFailureResponse(session, repairCommit.error);
@@ -301,7 +342,10 @@ export async function handleCloseCommand(params: {
       logPath,
       sessionStore,
       cleanupFailures,
-      repairArmed: repairCommit.kind !== 'not-armed',
+      repairArmed,
+      // The platform close for a repair-armed session already ran (and was
+      // confirmed to succeed) above, before the commit — never dispatch it twice.
+      skipPlatformClose: repairArmed,
     });
   } finally {
     // Always drop the local session, even if provider-side release fails:

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -320,7 +320,15 @@ export async function handleCloseCommand(params: {
   // never actually happened on the device. On failure, return without
   // touching the session at all (mirrors the commit-failure path below): it
   // stays addressable so the agent can fix the cause and retry.
-  if (repairArmed) {
+  //
+  // BLOCKER 3: a PRIOR close attempt on this same session may already have
+  // dispatched the platform close and confirmed its success, then failed to
+  // commit (the session is retained for exactly that retry — see below). A
+  // retry must never re-dispatch a (possibly non-idempotent) platform close
+  // against an already-closed target; `repairPlatformCloseSucceeded` records
+  // that the platform-level close already happened, so this retry consumes
+  // it and goes straight to the commit instead.
+  if (repairArmed && !session.repairPlatformCloseSucceeded) {
     const platformCloseError = await dispatchTargetedPlatformClose({ req, session, logPath });
     if (platformCloseError) {
       return buildRepairCloseFailureResponse(
@@ -328,6 +336,7 @@ export async function handleCloseCommand(params: {
         toRepairPlatformCloseFailure(platformCloseError),
       );
     }
+    session.repairPlatformCloseSucceeded = true;
   }
   // Commit the repair transaction BEFORE any destructive teardown. On failure,
   // return without tearing the session down — it stays addressable so the
@@ -336,6 +345,11 @@ export async function handleCloseCommand(params: {
   if (repairCommit.kind === 'failed') {
     return buildRepairCloseFailureResponse(session, repairCommit.error);
   }
+  // The transaction has now either committed for real or intentionally
+  // aborted (an incomplete transaction never reaches 'failed') — either way
+  // this close attempt's outcome is settled, so the platform-close-succeeded
+  // marker (BLOCKER 3) has served its purpose and must not linger.
+  session.repairPlatformCloseSucceeded = false;
   const healedScriptPath = repairCommit.kind === 'committed' ? repairCommit.path : undefined;
   let providerData: Record<string, unknown> | undefined;
   // Resource teardown is failure-isolated: a rejected step is collected instead of

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -1,4 +1,5 @@
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { AppError } from '../../kernel/errors.ts';
 import { scheduleIosRunnerIdleStop } from '../../platforms/apple/core/runner/runner-client.ts';
 import { isApplePlatform, type DeviceInfo } from '../../kernel/device.ts';
 import { dispatchCommand } from '../../core/dispatch.ts';
@@ -60,10 +61,74 @@ function shouldStopAppleRunnerBeforeTargetedClose(session: SessionState): boolea
   return isApplePlatform(session.device.platform) && !isIosSimulator(session.device);
 }
 
-// Runs the failure-isolated resource teardown and the targeted platform close.
-// Returns the preserved platform-close error (if any); best-effort cleanup
-// failures are pushed into `cleanupFailures`. Never throws for a cleanup step so
-// the caller's lease release and session deletion always run.
+/**
+ * ADR 0012 decision 6 (BLOCKER 2): outcome of committing a repair transaction
+ * at `close` time, BEFORE any destructive teardown. `not-armed` = not a repair
+ * session (normal close flow); `committed` = the healed `.ad` was written
+ * (`path`) or the transaction was incomplete and intentionally discarded (no
+ * `path`) — either way close proceeds and tears the session down; `failed` = a
+ * COMPLETE transaction's commit failed (no-clobber / bare-`@ref` / fs error),
+ * so the session must be KEPT for retry and the failure surfaced.
+ */
+type RepairCloseOutcome =
+  | { kind: 'not-armed' }
+  | { kind: 'committed'; path?: string }
+  | { kind: 'failed'; error: AppError };
+
+function commitRepairBeforeClose(
+  sessionStore: SessionStore,
+  session: SessionState,
+  req: DaemonRequest,
+): RepairCloseOutcome {
+  if (session.saveScriptBoundary === undefined) return { kind: 'not-armed' };
+  // Record the finalize `close` (so the committed healed slice ends with it),
+  // then COMMIT before any destructive teardown. A repair-armed session commits
+  // iff the transaction COMPLETED, regardless of `--save-script` on the close
+  // (C2); `recordSession` is already true from arming.
+  const actionsBeforeClose = session.actions.length;
+  recordSessionAction(sessionStore, session, req, 'close', {
+    session: session.name,
+    ...successText(`Closed: ${session.name}`),
+  });
+  const result = sessionStore.writeSessionLog(session);
+  if (result.written) return { kind: 'committed', path: result.path };
+  if (result.error) {
+    // The session is kept for retry (BLOCKER 2b): roll back the just-recorded
+    // finalize `close` so a subsequent `close --save-script=<other>` retry does
+    // not accumulate duplicate `close` lines in the healed slice.
+    session.actions.length = actionsBeforeClose;
+    return { kind: 'failed', error: result.error };
+  }
+  return { kind: 'committed' };
+}
+
+/**
+ * ADR 0012 decision 6 (BLOCKER 2b): a commit-failure close response. The session
+ * is intentionally NOT torn down (the caller returns before teardown), so the
+ * agent can fix the cause and retry `close --save-script`.
+ */
+function buildRepairCloseFailureResponse(session: SessionState, error: AppError): DaemonResponse {
+  const hint = typeof error.details?.hint === 'string' ? error.details.hint : undefined;
+  return {
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(hint ? { hint } : {}),
+      details: {
+        session: session.name,
+        ...(session.saveScriptPath ? { savedScript: session.saveScriptPath } : {}),
+        // The session was preserved: retry after fixing the cause.
+        retriable: false,
+      },
+    },
+  };
+}
+
+// Runs the failure-isolated resource teardown and the targeted platform close
+// (#1225). Returns the preserved platform-close error (if any); best-effort
+// cleanup failures are pushed into `cleanupFailures`. Never throws for a cleanup
+// step so the caller's lease release and session deletion always run.
 async function runSessionCloseTeardown(params: {
   req: DaemonRequest;
   session: SessionState;
@@ -71,8 +136,9 @@ async function runSessionCloseTeardown(params: {
   logPath: string;
   sessionStore: SessionStore;
   cleanupFailures: SessionCleanupFailure[];
+  repairArmed: boolean;
 }): Promise<unknown> {
-  const { req, session, sessionName, logPath, sessionStore, cleanupFailures } = params;
+  const { req, session, sessionName, logPath, sessionStore, cleanupFailures, repairArmed } = params;
   const attemptCleanup = async (step: string, run: () => Promise<void>): Promise<void> => {
     try {
       await run();
@@ -85,23 +151,26 @@ async function runSessionCloseTeardown(params: {
   // its AppError (code/details/hint) is preserved and returned for the caller to
   // rethrow, and a failed close must not be recorded as `Closed`. Subsequent
   // resource cleanup still runs regardless.
-  const platformCloseError = await dispatchTargetedPlatformClose({
-    req,
-    session,
-    logPath,
-  });
+  const platformCloseError = await dispatchTargetedPlatformClose({ req, session, logPath });
   await stopOrRetainAppleRunnerAfterClose(req, session, attemptCleanup);
   await clearSessionRuntimeHints(session, sessionStore, sessionName);
-  if (!platformCloseError) {
-    recordSessionAction(sessionStore, session, req, 'close', {
-      session: session.name,
-      ...successText(`Closed: ${session.name}`),
-    });
+  // ADR 0012 decision 6 (BLOCKER 2): a repair-armed session already recorded its
+  // finalize `close` and committed (or aborted) its healed `.ad` BEFORE this
+  // teardown (commit-state machine — the single commit path). Only an ordinary
+  // (non-repair) session records `close` + writes its session log here, and —
+  // per #1225 — a failed platform close is not recorded as `Closed`.
+  if (!repairArmed) {
+    if (!platformCloseError) {
+      recordSessionAction(sessionStore, session, req, 'close', {
+        session: session.name,
+        ...successText(`Closed: ${session.name}`),
+      });
+    }
+    if (req.flags?.saveScript) {
+      session.recordSession = true;
+    }
+    sessionStore.writeSessionLog(session);
   }
-  if (req.flags?.saveScript) {
-    session.recordSession = true;
-  }
-  sessionStore.writeSessionLog(session);
   await attemptCleanup('materialized_paths', () =>
     cleanupRetainedMaterializedPathsForSession(sessionName),
   );
@@ -207,6 +276,14 @@ export async function handleCloseCommand(params: {
   if (!session) {
     return await closeWithoutSession(req, logPath);
   }
+  // ADR 0012 decision 6 (BLOCKER 2): commit the repair transaction BEFORE any
+  // destructive teardown. On failure, return without tearing the session down —
+  // it stays addressable so the agent can fix the cause and retry.
+  const repairCommit = commitRepairBeforeClose(sessionStore, session, req);
+  if (repairCommit.kind === 'failed') {
+    return buildRepairCloseFailureResponse(session, repairCommit.error);
+  }
+  const healedScriptPath = repairCommit.kind === 'committed' ? repairCommit.path : undefined;
   let providerData: Record<string, unknown> | undefined;
   // Resource teardown is failure-isolated: a rejected step is collected instead of
   // short-circuiting the rest, so every subsequent resource (and the runner stop)
@@ -222,6 +299,7 @@ export async function handleCloseCommand(params: {
       logPath,
       sessionStore,
       cleanupFailures,
+      repairArmed: repairCommit.kind !== 'not-armed',
     });
   } finally {
     // Always drop the local session, even if provider-side release fails:
@@ -246,6 +324,10 @@ export async function handleCloseCommand(params: {
     device: session.device,
     shutdownRequested: req.flags?.shutdown,
   });
+  // ADR 0012 decision 6 (BLOCKER 2a): positively report the committed healed
+  // artifact path so the agent learns the repair published (and where) without
+  // an extra round-trip.
+  const savedScript = healedScriptPath ? { savedScript: healedScriptPath } : {};
   if (shutdownResult) {
     return {
       ok: true,
@@ -253,6 +335,7 @@ export async function handleCloseCommand(params: {
         {
           session: session.name,
           shutdown: shutdownResult,
+          ...savedScript,
           ...(providerData ? { provider: providerData } : {}),
         },
         `Closed: ${session.name}`,
@@ -264,6 +347,7 @@ export async function handleCloseCommand(params: {
     data: {
       session: session.name,
       ...successText(`Closed: ${session.name}`),
+      ...savedScript,
       ...(providerData ? { provider: providerData } : {}),
     },
   };

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -1,5 +1,5 @@
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import { AppError } from '../../kernel/errors.ts';
+import { AppError, normalizeError } from '../../kernel/errors.ts';
 import { scheduleIosRunnerIdleStop } from '../../platforms/apple/core/runner/runner-client.ts';
 import { isApplePlatform, type DeviceInfo } from '../../kernel/device.ts';
 import { dispatchCommand } from '../../core/dispatch.ts';
@@ -106,23 +106,33 @@ function commitRepairBeforeClose(
  * ADR 0012 decision 6 (BLOCKER 2b): a commit-failure close response. The session
  * is intentionally NOT torn down (the caller returns before teardown), so the
  * agent can fix the cause and retry `close --save-script`.
+ *
+ * BLOCKER 2 (second follow-up): routes `error` through the SAME
+ * `normalizeError` normalization every other AppError -> DaemonResponse
+ * conversion in this codebase uses (see `repairExpiredIfTombstoned` in
+ * request-router.ts and the dozens of handler call sites doing
+ * `{ ok: false, error: normalizeError(error) }`) — a hand-rolled reshape here
+ * previously dropped the underlying platform/commit error's `details`,
+ * `diagnosticId`, and `logPath` entirely, and put `retriable` under
+ * `error.details.retriable`, a location neither the router's `enrichDaemonError`
+ * nor the client reads (both read the TOP-LEVEL `error.retriable` — see
+ * `DaemonError` in kernel/contracts.ts). `retriable: true` is still forced
+ * unconditionally at the end: the session was preserved specifically so the
+ * agent can retry (`close`/`close --save-script=<other>`), which must never
+ * be contradicted by the underlying error's own (usually absent) classification.
  */
 function buildRepairCloseFailureResponse(session: SessionState, error: AppError): DaemonResponse {
-  const hint = typeof error.details?.hint === 'string' ? error.details.hint : undefined;
+  const normalized = normalizeError(error);
   return {
     ok: false,
     error: {
-      code: error.code,
-      message: error.message,
-      ...(hint ? { hint } : {}),
+      ...normalized,
       details: {
+        ...normalized.details,
         session: session.name,
         ...(session.saveScriptPath ? { savedScript: session.saveScriptPath } : {}),
-        // BLOCKER 3: the session was preserved specifically so the agent can
-        // retry (`close`/`close --save-script=<other>`) — `retriable` must
-        // agree with that, never contradict the recovery guidance above.
-        retriable: true,
       },
+      retriable: true,
     },
   };
 }

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -12,7 +12,7 @@ import { SessionStore } from '../session-store.ts';
 import { expandSessionPath } from '../session-paths.ts';
 import { type ReplayScriptMetadata } from '../../replay/script.ts';
 import { computeReplayPlanDigest } from '../../replay/plan-digest.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse, noActiveSessionError } from './response.ts';
 import { invokeReplayAction } from './session-replay-action-runtime.ts';
 import { tryParseSelectorChain } from '../../selectors/index.ts';
 import type { ResponseLevel } from '../../kernel/contracts.ts';
@@ -206,6 +206,26 @@ export async function runReplayScriptFile(params: {
       sessionName,
     });
     if (repairRunPreflight) return repairRunPreflight;
+    // ADR 0012 decision 6, R7 (BLOCKER 1): a `--from` continuation (entryIndex > 0)
+    // resumes an EXISTING session — it never replays step 1 (`open`), so it
+    // cannot create one. If the session is gone (its repair was idle-reaped),
+    // surface SESSION_NOT_FOUND HERE so the router translates it to
+    // REPAIR_SESSION_EXPIRED via the tombstone — instead of the missing session
+    // surfacing later as a REPLAY_DIVERGENCE that wraps the first step's failure
+    // and slips past the tombstone translation.
+    if (entryIndex.value > 0 && !sessionStore.get(sessionName)) {
+      return noActiveSessionError();
+    }
+    if (req.flags?.saveScript) {
+      // ADR 0012 decision 6, R7 (C5a): a fresh `replay --save-script` on this
+      // key clears any prior reap tombstone before starting a new transaction.
+      sessionStore.clearRepairTombstone(sessionName);
+    }
+    // ADR 0012 decision 6 (C2): a repair-armed resume re-opens the completion
+    // window — a leg that re-diverges must not inherit a prior leg's COMPLETE
+    // flag and let a later `close` commit a now-stale transaction.
+    const preRunSession = sessionStore.get(sessionName);
+    if (preRunSession?.saveScriptBoundary !== undefined) preRunSession.saveScriptComplete = false;
     const armReplaySaveScriptStep = createReplaySaveScriptArmer({
       saveScript: req.flags?.saveScript,
       sessionStore,
@@ -248,7 +268,26 @@ export async function runReplayScriptFile(params: {
     for (let index = entryIndex.value; index < actions.length; index += 1) {
       const action = actions[index];
       if (!action || action.command === 'replay') continue;
+      // ADR 0012 decision 6, R1 (BLOCKER 4): arm BEFORE the terminal-close
+      // check. Pre-`open` arming is a no-op (no session yet), so for a script
+      // whose first step CREATES the session (`open`), the boundary is only set
+      // once a later iteration runs the armer on the now-existing session.
+      // Arming first means a minimal `[open, close]` transaction arms at the
+      // `close` step, so `isRepairArmedTerminalClose` then sees the boundary and
+      // treats the terminal `close` as lifecycle (skipped) rather than
+      // dispatching it and tearing the session down un-armed.
       armReplaySaveScriptStep();
+      if (
+        isRepairArmedTerminalClose({
+          action,
+          index,
+          totalActions: actions.length,
+          sessionStore,
+          sessionName,
+        })
+      ) {
+        continue;
+      }
       emitReplayTestActionProgress(resolved, index, actions.length, action);
       const sampleStart = readSessionSnapshotSampleCount(sessionStore, sessionName);
       const response = await resolveReplayStepResponse(stepContext, action, index, [
@@ -259,12 +298,32 @@ export async function runReplayScriptFile(params: {
       );
       collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
       if (!response.ok) {
+        // ADR 0012 decision 6, R7 (C1): a divergence from a repair-armed run
+        // keeps its session live — mark the wire signal so the client keeps the
+        // owning daemon alive and the agent knows the session is addressable.
+        const held = (r: DaemonResponse): DaemonResponse =>
+          markRepairSessionHeldIfArmed({ response: r, sessionStore, sessionName });
         // A complete target-binding divergence must pass through unchanged —
         // failStep would rebuild it as a generic action-failure divergence
         // (double-capture + lost kind/targetBinding).
-        if (isCompleteTargetBindingDivergenceResponse(response)) return response;
-        return await failStep(response, action, index);
+        if (isCompleteTargetBindingDivergenceResponse(response)) return held(response);
+        return held(await failStep(response, action, index));
       }
+    }
+
+    // ADR 0012 decision 6, R1 (BLOCKER 4): a final arm so a repair whose LAST
+    // executable step created the session (e.g. a bare `[open]`, or `[open,
+    // close]` where the close is skipped) still arms the transaction before the
+    // completion/commit gate below evaluates it.
+    armReplaySaveScriptStep();
+
+    // ADR 0012 decision 6 (C2): the loop reached the last executable step with
+    // no outstanding divergence (the terminal source `close` was skipped, C4) —
+    // the repair transaction is now COMPLETE and commit-eligible.
+    const completedSession = sessionStore.get(sessionName);
+    if (completedSession?.saveScriptBoundary !== undefined) {
+      completedSession.saveScriptComplete = true;
+      sessionStore.set(sessionName, completedSession);
     }
 
     const replayedCount = actions.length - entryIndex.value;
@@ -421,6 +480,32 @@ function preflightReplayAgainstActiveRepair(params: {
 }
 
 /**
+ * ADR 0012 decision 6 (Fix 3): the source plan's own terminal `close` is
+ * lifecycle, not a script step to replay, while a repair is armed — the agent
+ * finalizes the transaction with `close --save-script` instead
+ * (`session-close.ts`). Replaying the recorded `close` here would dispatch it
+ * as an ordinary step: it tears the session down (and, absent Fix 1/2, could
+ * even publish or diverge) before the agent gets that chance. Skipped exactly
+ * like the `replay` pseudo-command just above it in the loop — never
+ * dispatched, never divergence-checked, and (like that skip) not counted out
+ * of `replayedCount`. Checked against session state, not this invocation's
+ * own flags, matching R2: a repair stays armed across separate `--from` legs
+ * regardless of whether `--save-script` is repeated on each one.
+ */
+function isRepairArmedTerminalClose(params: {
+  action: SessionAction;
+  index: number;
+  totalActions: number;
+  sessionStore: SessionStore;
+  sessionName: string;
+}): boolean {
+  const { action, index, totalActions, sessionStore, sessionName } = params;
+  if (action.command !== 'close') return false;
+  if (index !== totalActions - 1) return false;
+  return sessionStore.get(sessionName)?.saveScriptBoundary !== undefined;
+}
+
+/**
  * ADR 0012 decision 6, R1/R6: returns a per-step armer that sets
  * `recordSession` and stamps the repair-run boundary watermark ONCE. Absent
  * `--save-script` it is a no-op, so replay is byte-identical to today.
@@ -475,7 +560,47 @@ function armReplaySaveScriptStep(params: {
   if (session.saveScriptBoundary === undefined) {
     session.saveScriptBoundary = firstArm ? session.actions.length : 0;
   }
+  // ADR 0012 decision 6, R7 (C5a): stash the original replay input so a reap
+  // tombstone can hand back an actionable `replay <path> --save-script` re-run.
+  if (session.repairSourcePath === undefined) session.repairSourcePath = sourcePath;
   sessionStore.set(sessionName, session);
+}
+
+/**
+ * ADR 0012 decision 6, R7 (C1): stamps the `resume.repairSessionHeld` liveness
+ * signal on a repair-armed divergence — the honest wire marker that the owning
+ * session was kept live (this daemon never tears it down on a divergence) and
+ * remains addressable for the corrective press + `replay --from`/`close`. Set
+ * only when the session is genuinely held (armed): a plain non-repair
+ * divergence, or one before step-1 `open` created/armed the session, gets no
+ * signal (and no keep-alive). Never `false` — absent when not held.
+ */
+function markRepairSessionHeldIfArmed(params: {
+  response: DaemonResponse;
+  sessionStore: SessionStore;
+  sessionName: string;
+}): DaemonResponse {
+  const { response, sessionStore, sessionName } = params;
+  if (response.ok) return response;
+  // The transaction is active iff the session is repair-armed and not yet
+  // committed — the PERSISTED state, NOT this request's `--save-script` flag.
+  // A `replay --from` continuation (which does not repeat `--save-script`, per
+  // R2) is therefore still held on divergence and stays in the transaction.
+  const session = sessionStore.get(sessionName);
+  if (session?.saveScriptBoundary === undefined || session.saveScriptCommitted) return response;
+  const resume = readDivergenceResumeRecord(response);
+  if (resume) resume.repairSessionHeld = true;
+  return response;
+}
+
+/** The mutable `details.divergence.resume` record on a failed response, or `undefined`. */
+function readDivergenceResumeRecord(
+  response: Extract<DaemonResponse, { ok: false }>,
+): Record<string, unknown> | undefined {
+  const divergence = response.error.details?.divergence;
+  if (!divergence || typeof divergence !== 'object') return undefined;
+  const resume = (divergence as Record<string, unknown>).resume;
+  return resume && typeof resume === 'object' ? (resume as Record<string, unknown>) : undefined;
 }
 
 /** `flows/login.ad` -> `flows/login.healed.ad`, beside the original (R6). */

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -548,9 +548,13 @@ function armReplaySaveScriptStep(params: {
   if (!session) return;
   session.recordSession = true;
   if (typeof saveScript === 'string') {
-    // An EXPLICIT `--save-script=<path>` clears the defaulted marker so the
-    // clobber guard never refuses a path the caller directed (invariant: the
-    // marker is set iff the current `saveScriptPath` was defaulted).
+    // An EXPLICIT `--save-script=<path>` clears the defaulted marker
+    // (invariant: the marker is set iff the current `saveScriptPath` was
+    // defaulted, not caller-directed). This no longer affects the publish
+    // decision either way — the writer's refuse-on-exist guard is uniform
+    // (`publishHealedScriptAtomically`) and refuses ANY pre-existing target,
+    // an explicit caller-directed path included, exactly like the default
+    // healed sibling.
     session.saveScriptPath = expandSessionPath(saveScript);
     session.saveScriptDefaultedHealedPath = false;
   } else if (session.saveScriptPath === undefined) {

--- a/src/daemon/http-errors.ts
+++ b/src/daemon/http-errors.ts
@@ -10,6 +10,9 @@ export function statusCodeForNormalizedError(code: string): number {
     case 'UNAUTHORIZED':
       return 401;
     case 'SESSION_NOT_FOUND':
+    // ADR 0012 R7 (C5a): a reaped repair session is a gone-session state, like
+    // SESSION_NOT_FOUND — not an internal error.
+    case 'REPAIR_SESSION_EXPIRED':
       return 404;
     default:
       return 500;

--- a/src/daemon/request-finalization.ts
+++ b/src/daemon/request-finalization.ts
@@ -29,6 +29,16 @@ export function finalizeDaemonResponse(
       },
     });
     const logPathOnFailure = flushDiagnosticsToSessionFile({ force: true }) ?? undefined;
+    // ADR 0012 decision 6, BLOCKER 2 (second follow-up): every handler-RETURNED
+    // (as opposed to thrown) failure response is rebuilt here into a fresh
+    // AppError before re-normalizing — this used to copy `hint`/`diagnosticId`/
+    // `logPath` from the incoming `response.error` but NOT `retriable`/
+    // `supportedOn`, so a handler that set them at the correct top-level
+    // location (matching `DaemonError`'s wire contract) still lost them at
+    // this reconstruction, regardless of how correctly the handler itself
+    // built its response. Both are now carried through the same way, with the
+    // same defensive `details` fallback `hint` already used (some cause
+    // objects still carry them nested under `details` instead of top-level).
     const normalizedError = normalizeError(
       new AppError(toAppErrorCode(response.error.code), response.error.message, {
         ...(response.error.details ?? {}),
@@ -39,6 +49,16 @@ export function finalizeDaemonResponse(
             : undefined),
         diagnosticId: response.error.diagnosticId,
         logPath: response.error.logPath,
+        retriable:
+          response.error.retriable ??
+          (typeof response.error.details?.retriable === 'boolean'
+            ? response.error.details.retriable
+            : undefined),
+        supportedOn:
+          response.error.supportedOn ??
+          (typeof response.error.details?.supportedOn === 'string'
+            ? response.error.details.supportedOn
+            : undefined),
       }),
       {
         diagnosticId: details.diagnosticId,

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -114,7 +114,11 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         // wasted round-trip. Returned unchanged when neither applies, so the
         // default error wire shape is preserved.
         if (!response.ok) {
-          return { ok: false, error: enrichDaemonError(req.command, response.error) };
+          // ADR 0012 decision 6, R7 (C5a): a command that finds no session but
+          // hits a live repair tombstone gets `REPAIR_SESSION_EXPIRED` with
+          // re-run guidance, never a bare SESSION_NOT_FOUND.
+          const error = repairExpiredIfTombstoned(req, response.error, sessionStore);
+          return { ok: false, error: enrichDaemonError(req.command, error) };
         }
         // Phase 4 (agent-cost) grafts on the success path. Runs inside the
         // diagnostics scope so cost can read this request's runner-round-trip tally.
@@ -333,6 +337,31 @@ function recordThrownRequestEvent(
       response,
       durationMs: Math.max(0, Date.now() - scope.startedAtMs),
     }),
+  );
+}
+
+/**
+ * ADR 0012 decision 6, R7 (C5a): when a request finds no session (SESSION_NOT_FOUND)
+ * but a live repair tombstone exists for its session key, rewrite the error to
+ * `REPAIR_SESSION_EXPIRED` with an actionable re-run command. Any other error, or
+ * the absence of a (non-expired) tombstone, passes through untouched.
+ */
+function repairExpiredIfTombstoned(
+  req: DaemonRequest,
+  error: DaemonError,
+  sessionStore: SessionStore,
+): DaemonError {
+  if (error.code !== 'SESSION_NOT_FOUND') return error;
+  const tombstone = sessionStore.readRepairTombstone(req.session);
+  if (!tombstone) return error;
+  const reRun = tombstone.sourcePath
+    ? `re-run: replay ${tombstone.sourcePath} --save-script`
+    : 're-run your replay <script> --save-script from the start';
+  return normalizeError(
+    new AppError(
+      'REPAIR_SESSION_EXPIRED',
+      `The --save-script repair session "${req.session}" was reaped before it was finalized (idle-reap); ${reRun}.`,
+    ),
   );
 }
 

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -341,10 +341,17 @@ function recordThrownRequestEvent(
 }
 
 /**
- * ADR 0012 decision 6, R7 (C5a): when a request finds no session (SESSION_NOT_FOUND)
- * but a live repair tombstone exists for its session key, rewrite the error to
- * `REPAIR_SESSION_EXPIRED` with an actionable re-run command. Any other error, or
- * the absence of a (non-expired) tombstone, passes through untouched.
+ * ADR 0012 decision 6, R7 (C5a, BLOCKER 2): when a request finds no session
+ * (SESSION_NOT_FOUND) but a live repair tombstone exists for its session key,
+ * rewrite the error to an actionable recovery error. Any other error, or the
+ * absence of a (non-expired) tombstone, passes through untouched.
+ *
+ * BLOCKER 2: a tombstone carrying `commitFailure` means the transaction
+ * actually COMPLETED and a commit was attempted at teardown but FAILED (e.g.
+ * no-clobber refusal, a filesystem error) — that is a materially different,
+ * more specific situation than "reaped before it ever finished", so it gets
+ * its own `REPAIR_COMMIT_FAILED` code carrying the real cause, rather than
+ * being folded into the generic `REPAIR_SESSION_EXPIRED` expiry message.
  */
 function repairExpiredIfTombstoned(
   req: DaemonRequest,
@@ -357,6 +364,14 @@ function repairExpiredIfTombstoned(
   const reRun = tombstone.sourcePath
     ? `re-run: replay ${tombstone.sourcePath} --save-script`
     : 're-run your replay <script> --save-script from the start';
+  if (tombstone.commitFailure) {
+    return normalizeError(
+      new AppError(
+        'REPAIR_COMMIT_FAILED',
+        `The repair transaction for session "${req.session}" completed, but committing its healed script failed at teardown: ${tombstone.commitFailure.message}. ${reRun}.`,
+      ),
+    );
+  }
   return normalizeError(
     new AppError(
       'REPAIR_SESSION_EXPIRED',

--- a/src/daemon/server/daemon-idle-reap.test.ts
+++ b/src/daemon/server/daemon-idle-reap.test.ts
@@ -9,7 +9,7 @@ import type { SessionState } from '../types.ts';
 import {
   createDaemonIdleReap,
   hasActiveRecording,
-  hasOpenSessions,
+  hasReapBlockingOpenSessions,
   isDaemonIdle,
   resolveDaemonIdleReapMs,
 } from './daemon-idle-reap.ts';
@@ -57,10 +57,10 @@ test('resolveDaemonIdleReapMs ignores invalid overrides', () => {
   assert.equal(resolveDaemonIdleReapMs({ AGENT_DEVICE_DAEMON_IDLE_TIMEOUT_MS: '-5' }), 5 * 60_000);
 });
 
-test('hasOpenSessions reflects the session store', () => {
-  assert.equal(hasOpenSessions(sessionStore), false);
+test('hasReapBlockingOpenSessions reflects the session store', () => {
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), false);
   sessionStore.set('default', makeSession());
-  assert.equal(hasOpenSessions(sessionStore), true);
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), true);
 });
 
 test('hasActiveRecording is true only when a stored session carries a recording', () => {
@@ -89,6 +89,35 @@ test('isDaemonIdle requires no in-flight requests, no sessions, and no recording
   assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 1 }), false);
 
   sessionStore.set('default', makeSession());
+  assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 0 }), false);
+});
+
+// --- ADR 0012 decision 6, R7 (C5a): a repair-armed, un-committed session is
+// bounded-lifetime and does NOT block idle-reap, so an abandoned repair is
+// reaped (with a tombstone) rather than pinning the daemon forever. ---
+
+test('a repair-armed, un-committed session does NOT block idle-reap', () => {
+  sessionStore.set('default', makeSession({ saveScriptBoundary: 0 }));
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), false);
+  assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 0 }), true);
+});
+
+test('a repair-armed session that has already COMMITTED still blocks idle-reap (until close deletes it)', () => {
+  sessionStore.set('default', makeSession({ saveScriptBoundary: 0, saveScriptCommitted: true }));
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), true);
+  assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 0 }), false);
+});
+
+test('an ordinary (non-repair) open session still blocks idle-reap', () => {
+  sessionStore.set('default', makeSession());
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), true);
+  assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 0 }), false);
+});
+
+test('a normal session alongside a reapable repair session still blocks idle-reap', () => {
+  sessionStore.set('default', makeSession({ name: 'default', saveScriptBoundary: 0 }));
+  sessionStore.set('other', makeSession({ name: 'other' }));
+  assert.equal(hasReapBlockingOpenSessions(sessionStore), true);
   assert.equal(isDaemonIdle({ sessionStore, inFlightRequestCount: 0 }), false);
 });
 

--- a/src/daemon/server/daemon-idle-reap.ts
+++ b/src/daemon/server/daemon-idle-reap.ts
@@ -1,5 +1,6 @@
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import type { SessionStore } from '../session-store.ts';
+import type { SessionState } from '../types.ts';
 
 // Bounds the daemon's own lifetime when nothing is using it. Each
 // AGENT_DEVICE_STATE_DIR spawns a dedicated daemon that otherwise never exits
@@ -29,14 +30,29 @@ export function resolveDaemonIdleReapMs(env: NodeJS.ProcessEnv = process.env): n
   return DAEMON_IDLE_REAP_DEFAULT_MS;
 }
 
-export function hasOpenSessions(sessionStore: SessionStore): boolean {
-  return sessionStore.toArray().length > 0;
+/**
+ * ADR 0012 decision 6, R7 (C5a): true when any open session must block
+ * idle-reap. A repair-armed, not-yet-committed session is a bounded-lifetime
+ * repair transaction, NOT a session that should pin the daemon forever: it
+ * intentionally does NOT block idle-reap, so an actively-driven repair resets
+ * the idle timer on every command while an ABANDONED one is reaped after the
+ * idle window and leaves a `REPAIR_SESSION_EXPIRED` tombstone
+ * (`teardownDaemonSession`) rather than leaking the daemon/lease indefinitely.
+ * Every ordinary open session (and a repair that already committed) blocks
+ * idle-reap as before.
+ */
+export function hasReapBlockingOpenSessions(sessionStore: SessionStore): boolean {
+  return sessionStore.toArray().some((session) => !isReapableRepairSession(session));
 }
 
-// Recording lifecycle is session-scoped (session.recording), so this is
-// currently implied by hasOpenSessions. Kept as an explicit, independently
-// testable guard so a future recording path that outlives its session cannot
-// silently lose this protection.
+function isReapableRepairSession(session: SessionState): boolean {
+  return session.saveScriptBoundary !== undefined && session.saveScriptCommitted !== true;
+}
+
+// Recording lifecycle is session-scoped (session.recording), so a recording
+// only ever exists alongside an open session. Kept as an explicit,
+// independently testable guard so a future recording path that outlives its
+// session cannot silently lose this protection.
 export function hasActiveRecording(sessionStore: SessionStore): boolean {
   return sessionStore.toArray().some((session) => Boolean(session.recording));
 }
@@ -46,7 +62,9 @@ export function isDaemonIdle(params: {
   inFlightRequestCount: number;
 }): boolean {
   if (params.inFlightRequestCount > 0) return false;
-  if (hasOpenSessions(params.sessionStore)) return false;
+  // A reapable repair-armed session (C5a) does not block idle-reap, so an
+  // abandoned repair is bounded; every other open session still does.
+  if (hasReapBlockingOpenSessions(params.sessionStore)) return false;
   return !hasActiveRecording(params.sessionStore);
 }
 

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -149,7 +149,10 @@ export async function startDaemonRuntime(
         stderr.write(`Daemon session teardown timed out (${session.name}).\n`);
       }),
     ]);
-    sessionStore.writeSessionLog(session);
+    // ADR 0012 decision 6, R7 + commit semantics (C2/C5a): commit the healed
+    // `.ad` iff the repair transaction completed, else leave a bounded
+    // `REPAIR_SESSION_EXPIRED` tombstone for the reaped-before-finalize case.
+    sessionStore.finalizeRepairTeardown(session);
     sessionStore.delete(session.name);
   };
 

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -23,8 +23,12 @@ export function recordActionEntry(
     session.recordSession = true;
     if (typeof entry.flags.saveScript === 'string') {
       // ADR 0012 decision 6: an explicit `--save-script=<path>` (e.g. `close
-      // --save-script=<path>`) clears the defaulted-healed marker so the
-      // writer's clobber guard never refuses an overwrite the caller directed.
+      // --save-script=<path>`) clears the defaulted-healed marker, since this
+      // path was no longer defaulted to the healed sibling. This marker plays
+      // no role in the publish decision itself: the writer's refuse-on-exist
+      // guard is uniform (see `publishHealedScriptAtomically`) and refuses
+      // ANY pre-existing target — an explicit, caller-DIRECTED path included.
+      // Directing the path is not the same as authorizing an overwrite.
       session.saveScriptPath = expandSessionPath(entry.flags.saveScript);
       session.saveScriptDefaultedHealedPath = false;
     }

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -267,10 +267,10 @@ function publishNoClobberAtomically(tempPath: string, scriptPath: string): void 
  * live holder releases it quickly.
  *
  * A lock whose recorded PID is no longer running is a crashed writer's
- * abandoned claim — reclaimed immediately (a dead process can never release
- * it). A lock held by a LIVE process is never stolen: exhausting the bounded
- * wait fails loudly instead, so a slow (but live) holder's in-progress
- * publish is never second-guessed.
+ * abandoned claim — reclaimed via `reclaimDeadLock` (race-safely; see its
+ * doc). A lock held by a LIVE process is never stolen: exhausting the
+ * bounded wait fails loudly instead, so a slow (but live) holder's
+ * in-progress publish is never second-guessed.
  */
 function acquireNoClobberLock(scriptPath: string): string {
   const lockPath = `${scriptPath}.lock`;
@@ -283,11 +283,10 @@ function acquireNoClobberLock(scriptPath: string): string {
         return lockPath;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-        if (isHeldByDeadProcess(lockPath)) {
-          fs.rmSync(lockPath, { force: true });
-          continue;
-        }
-        sleepSyncMs(LOCK_ACQUIRE_BACKOFF_MS);
+        // 'reclaimed' (we cleared a dead lock) and 'contended' (someone
+        // else's reclaim of that SAME dead lock just won) both retry the
+        // exclusive link immediately — only a confirmed-LIVE holder backs off.
+        if (reclaimDeadLock(lockPath) === 'live') sleepSyncMs(LOCK_ACQUIRE_BACKOFF_MS);
       }
     }
     throw new AppError(
@@ -303,14 +302,62 @@ function releaseNoClobberLock(lockPath: string): void {
   fs.rmSync(lockPath, { force: true });
 }
 
-/** `true` iff `lockPath` names a PID that is provably no longer running. */
-function isHeldByDeadProcess(lockPath: string): boolean {
+type LockReclaimOutcome = 'reclaimed' | 'contended' | 'live';
+
+/**
+ * Reclaims `lockPath` iff it is provably a DEAD writer's abandoned lock —
+ * race-safely. The prior implementation decided "dead" from a plain read,
+ * then removed the lock BY PATHNAME as a separate step
+ * (`fs.rmSync(lockPath)`) — a classic TOCTOU: waiters A and B could both read
+ * the same dead-PID lock and both decide to reclaim; if B's reclaim (remove
+ * + re-`linkSync` its OWN live lock) completed inside the gap between A's
+ * read and A's own removal, A's stale `rmSync(lockPath)` would delete B's
+ * LIVE lock by pathname — not the dead one A actually inspected — and both
+ * waiters would then believe they held the exclusive lock at once.
+ *
+ * Here the removal is never "read, then act by pathname" — it is a single
+ * atomic claim: `fs.renameSync(lockPath, claimPath)` can only ever move a
+ * given SOURCE path for exactly one caller (a second, concurrent rename of
+ * the same already-moved source fails `ENOENT`, never silently succeeds), so
+ * it doubles as a compare-and-swap on "claim the right to inspect/discard
+ * whatever currently sits at `lockPath` right now". Only the winner of that
+ * claim inspects the object it actually grabbed (not a stale earlier read):
+ * if it is genuinely dead, discard it; if the claim raced with someone
+ * else's fresh reclaim and grabbed their LIVE lock instead, restore it
+ * untouched and report contention rather than dropping it. The live holder's
+ * lock is never stolen.
+ */
+function reclaimDeadLock(lockPath: string): LockReclaimOutcome {
+  if (!isHeldByDeadProcess(lockPath)) return 'live';
+  const claimPath = `${lockPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.dead-claim`;
+  try {
+    fs.renameSync(lockPath, claimPath);
+  } catch (error) {
+    // Someone else's claim of this exact dead lock already won the race —
+    // there is nothing left for us to reclaim; the caller retries and will
+    // observe whatever that winner leaves behind (dead-again or freshly live).
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'contended';
+    throw error;
+  }
+  if (isHeldByDeadProcess(claimPath)) {
+    fs.rmSync(claimPath, { force: true });
+    return 'reclaimed';
+  }
+  // What we claimed is actually LIVE: another writer reclaimed and
+  // re-acquired between our precheck read above and this rename winning.
+  // Restore it exactly as claimed — never discard a live holder's lock.
+  fs.renameSync(claimPath, lockPath);
+  return 'live';
+}
+
+/** `true` iff `filePath` names a PID that is provably no longer running. */
+function isHeldByDeadProcess(filePath: string): boolean {
   let raw: string;
   try {
-    raw = fs.readFileSync(lockPath, 'utf8');
+    raw = fs.readFileSync(filePath, 'utf8');
   } catch {
-    // Released between our EEXIST and this read — not steal-worthy, the next
-    // attempt's `linkSync` will simply succeed against the now-clear path.
+    // Released/moved between our EEXIST and this read — not steal-worthy,
+    // the next attempt will simply observe whatever the current state is.
     return false;
   }
   const pid = Number(raw.trim());

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -151,8 +151,8 @@ function formatSessionScript(session: SessionState, appendCompleteSentinel: bool
 }
 
 /**
- * ADR 0012 decision 6, commit semantics + no-clobber (Fix 4, C5b): publishes
- * `script` to `scriptPath` atomically AND race-safely.
+ * ADR 0012 decision 6, commit semantics + no-clobber (Fix 4, C5b, BLOCKER 1):
+ * publishes `script` to `scriptPath` atomically AND race-safely.
  *
  * - Atomic: the temp file is created in the SAME DIRECTORY as the target
  *   (never `/tmp`), so the final publish is an intra-directory rename/link on
@@ -160,11 +160,11 @@ function formatSessionScript(session: SessionState, appendCompleteSentinel: bool
  *   explicit `--save-script=<path>` on a different mount still publishes
  *   atomically. An aborted write leaves only the (removed) temp, no partial
  *   at the target.
- * - Race-safe no-clobber: the absent-target case publishes via `linkSync`,
- *   which fails atomically with `EEXIST` if a file appeared meanwhile — there
- *   is no check-then-write TOCTOU window against a COMPLETE artifact. Only
- *   after confirming the existing file is incomplete/unprotected do we
- *   overwrite it via rename.
+ * - Race-safe no-clobber (BLOCKER 1): the DEFAULT healed-sibling path is
+ *   protected by `publishNoClobberAtomically`, which makes an atomic primitive
+ *   (never a check-then-write gap) decide the winner even when the existing
+ *   target is a partial. An explicit `--save-script=<path>` target is
+ *   caller-directed and unprotected either way (`publishOverwriteAtomically`).
  */
 function publishHealedScriptAtomically(params: {
   scriptPath: string;
@@ -179,28 +179,137 @@ function publishHealedScriptAtomically(params: {
   );
   fs.writeFileSync(tempPath, script);
   try {
-    try {
-      // Atomic create-if-absent: EEXIST iff the target already exists.
-      fs.linkSync(tempPath, scriptPath);
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    if (protectComplete) {
+      publishNoClobberAtomically(tempPath, scriptPath);
+    } else {
+      publishOverwriteAtomically(tempPath, scriptPath);
     }
-    // The target exists. A COMPLETE (sentinel-marked) default healed artifact
-    // is review-worthy and must never be silently clobbered; an incomplete or
-    // partial one is always overwritable by a fresh repair that completes.
-    if (protectComplete && isCompleteHealedScript(scriptPath)) {
-      throw new AppError(
-        'COMMAND_FAILED',
-        `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,
-      );
-    }
-    fs.renameSync(tempPath, scriptPath);
   } finally {
     // linkSync leaves the temp hard-link behind on success; rename consumes it;
-    // an error leaves it — always clean up whatever remains.
+    // an error leaves it — always clean up whatever of our own temp remains.
     fs.rmSync(tempPath, { force: true });
   }
+}
+
+/**
+ * An explicit `--save-script=<path>` target is caller-directed and never
+ * no-clobber-protected — BLOCKER 1's "is the existing target incomplete"
+ * classification never runs on this path, so a plain atomic publish is
+ * correct: absent -> exclusive create; present -> atomic rename-replace.
+ */
+function publishOverwriteAtomically(tempPath: string, scriptPath: string): void {
+  try {
+    // Atomic create-if-absent: EEXIST iff the target already exists.
+    fs.linkSync(tempPath, scriptPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    fs.renameSync(tempPath, scriptPath);
+  }
+}
+
+const NO_CLOBBER_PUBLISH_MAX_ATTEMPTS = 16;
+
+/**
+ * ADR 0012 decision 6, no-clobber (BLOCKER 1): publishes to the DEFAULT healed
+ * sibling path, where a COMPLETE (sentinel-marked) prior artifact must never
+ * be clobbered.
+ *
+ * The prior implementation decided "is the existing target overwritable" with
+ * a plain read (`isCompleteHealedScript`) followed later by an unconditional
+ * `renameSync`. Two concurrent writers could both read the SAME pre-existing
+ * partial as incomplete and then both `renameSync` over it — each returning
+ * success with no signal to the other. Neither writer ever observed the
+ * loss: a silent, undetectable clobber.
+ *
+ * Here every step that could decide a winner is an atomic filesystem
+ * primitive, never a check-then-write gap:
+ * - `linkSync` is the ONLY way to WIN outright: it fails atomically (`EEXIST`)
+ *   iff a file is at `scriptPath` at that exact instant.
+ * - On `EEXIST`, the existing file is inspected on a PRIVATE copy, never the
+ *   shared path: `renameSync` atomically moves whatever currently sits at
+ *   `scriptPath` into a uniquely-named quarantine file first, so the
+ *   completeness check runs on a copy nobody else can race against. If a
+ *   competing writer's own grab (or publish) already claimed `scriptPath` in
+ *   between, our `renameSync` fails (`ENOENT`) and we re-evaluate from the
+ *   top against the current state — never a stale read.
+ * - A COMPLETE quarantined file is put back (best effort) and the publish is
+ *   refused; a genuinely partial one is discarded and the exclusive
+ *   `linkSync` is retried.
+ *
+ * Every interleaving converges on exactly one winning `linkSync` and every
+ * other writer observing a definitive, thrown "already exists" — never two
+ * silent successes, never a torn/half-clobbered file.
+ */
+function publishNoClobberAtomically(tempPath: string, scriptPath: string): void {
+  for (let attempt = 0; attempt < NO_CLOBBER_PUBLISH_MAX_ATTEMPTS; attempt += 1) {
+    if (tryExclusiveLink(tempPath, scriptPath)) return;
+    // Something is at `scriptPath`. Either it gets grabbed-and-discarded as a
+    // genuine partial, or a competing writer's own grab/publish already beat
+    // us to it — either way, re-evaluate from the top via the exclusive link
+    // above rather than trust a stale read. Throws (never returns) if what we
+    // grabbed turns out to be a COMPLETE artifact.
+    grabAndDiscardPartialTarget(scriptPath);
+  }
+  throw new AppError(
+    'COMMAND_FAILED',
+    `Could not publish the healed script to ${scriptPath}: too much contention from concurrent writers.`,
+  );
+}
+
+/**
+ * The only primitive that can WIN outright: atomic create-if-absent.
+ * `true` = published (won); `false` = `EEXIST` (a file is at `scriptPath`
+ * right now). Any other error propagates.
+ */
+function tryExclusiveLink(tempPath: string, scriptPath: string): boolean {
+  try {
+    fs.linkSync(tempPath, scriptPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
+  }
+}
+
+/**
+ * Atomically grabs whatever currently sits at `scriptPath` into a private,
+ * uniquely-named quarantine file (a single `renameSync`, so nobody else can
+ * race the completeness check against it) and inspects it there. A genuinely
+ * partial grab is discarded (returns normally — the caller retries the
+ * exclusive link). `ENOENT` means a competing writer's own grab or publish
+ * already changed `scriptPath` between our `EEXIST` and this call — also
+ * returns normally, for the same "retry from the top" reason. A COMPLETE
+ * grab is restored (best effort) and this throws, refusing the clobber.
+ */
+function grabAndDiscardPartialTarget(scriptPath: string): void {
+  const quarantinePath = `${scriptPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.quarantine`;
+  try {
+    fs.renameSync(scriptPath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  try {
+    if (isCompleteHealedScript(quarantinePath)) refuseCompleteClobber(quarantinePath, scriptPath);
+  } finally {
+    fs.rmSync(quarantinePath, { force: true });
+  }
+}
+
+/** Restores a quarantined COMPLETE artifact (best effort) and refuses the publish. */
+function refuseCompleteClobber(quarantinePath: string, scriptPath: string): never {
+  try {
+    // If another writer already republished to `scriptPath` in the meantime,
+    // this fails and ours stays quarantined (cleaned up by the caller) — we
+    // lose cleanly either way.
+    fs.renameSync(quarantinePath, scriptPath);
+  } catch {
+    /* already re-occupied by another writer's publish */
+  }
+  throw new AppError(
+    'COMMAND_FAILED',
+    `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,
+  );
 }
 
 function buildOptimizedActions(session: SessionState): SessionAction[] {

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -4,6 +4,7 @@ import { publicPlatformString } from '../kernel/device.ts';
 import { inferFillText } from './action-utils.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { AppError } from '../kernel/errors.ts';
+import { isProcessAlive } from '../utils/host-process.ts';
 import {
   formatPortableActionLine,
   formatTargetAnnotationLines,
@@ -208,52 +209,121 @@ function publishOverwriteAtomically(tempPath: string, scriptPath: string): void 
 }
 
 const NO_CLOBBER_PUBLISH_MAX_ATTEMPTS = 16;
+const LOCK_ACQUIRE_MAX_ATTEMPTS = 40;
+const LOCK_ACQUIRE_BACKOFF_MS = 5;
 
 /**
  * ADR 0012 decision 6, no-clobber (BLOCKER 1): publishes to the DEFAULT healed
  * sibling path, where a COMPLETE (sentinel-marked) prior artifact must never
  * be clobbered.
  *
- * The prior implementation decided "is the existing target overwritable" with
- * a plain read (`isCompleteHealedScript`) followed later by an unconditional
- * `renameSync`. Two concurrent writers could both read the SAME pre-existing
- * partial as incomplete and then both `renameSync` over it — each returning
- * success with no signal to the other. Neither writer ever observed the
- * loss: a silent, undetectable clobber.
+ * A prior fix made the "is the existing target overwritable" decision itself
+ * atomic (grab-to-quarantine + inspect, `grabAndDiscardPartialTarget` below)
+ * instead of a plain read — but the inspect/restore/publish SEQUENCE was
+ * still not exclusive: writer A could quarantine an existing COMPLETE
+ * target, and — before A restored it — writer B could `linkSync` its own
+ * COMPLETE artifact into the now-empty `scriptPath` and return success, only
+ * for A's restore (`renameSync`, which replaces an existing destination per
+ * POSIX) to silently stomp B's freshly published bytes. B would report
+ * success while its bytes were gone.
  *
- * Here every step that could decide a winner is an atomic filesystem
- * primitive, never a check-then-write gap:
- * - `linkSync` is the ONLY way to WIN outright: it fails atomically (`EEXIST`)
- *   iff a file is at `scriptPath` at that exact instant.
- * - On `EEXIST`, the existing file is inspected on a PRIVATE copy, never the
- *   shared path: `renameSync` atomically moves whatever currently sits at
- *   `scriptPath` into a uniquely-named quarantine file first, so the
- *   completeness check runs on a copy nobody else can race against. If a
- *   competing writer's own grab (or publish) already claimed `scriptPath` in
- *   between, our `renameSync` fails (`ENOENT`) and we re-evaluate from the
- *   top against the current state — never a stale read.
- * - A COMPLETE quarantined file is put back (best effort) and the publish is
- *   refused; a genuinely partial one is discarded and the exclusive
- *   `linkSync` is retried.
- *
- * Every interleaving converges on exactly one winning `linkSync` and every
- * other writer observing a definitive, thrown "already exists" — never two
- * silent successes, never a torn/half-clobbered file.
+ * Here the ENTIRE decide-and-act sequence for a given `scriptPath` — the
+ * exclusive-link attempt, the grab/inspect, and the refuse-and-restore or
+ * discard-and-retry — runs while holding an exclusive publish lock
+ * (`acquireNoClobberLock`/`releaseNoClobberLock`, itself an atomic `linkSync`
+ * claim). A competing writer for the SAME `scriptPath` cannot even begin its
+ * own decision until the lock holder's entire sequence has finished and
+ * released it, so the "restore stomps a concurrently-published winner"
+ * interleaving above is no longer reachable: whichever writer holds the lock
+ * always observes (and, on refusal, restores) exactly what it itself grabbed,
+ * with nothing else able to touch `scriptPath` in between.
  */
 function publishNoClobberAtomically(tempPath: string, scriptPath: string): void {
-  for (let attempt = 0; attempt < NO_CLOBBER_PUBLISH_MAX_ATTEMPTS; attempt += 1) {
-    if (tryExclusiveLink(tempPath, scriptPath)) return;
-    // Something is at `scriptPath`. Either it gets grabbed-and-discarded as a
-    // genuine partial, or a competing writer's own grab/publish already beat
-    // us to it — either way, re-evaluate from the top via the exclusive link
-    // above rather than trust a stale read. Throws (never returns) if what we
-    // grabbed turns out to be a COMPLETE artifact.
-    grabAndDiscardPartialTarget(scriptPath);
+  const lockPath = acquireNoClobberLock(scriptPath);
+  try {
+    for (let attempt = 0; attempt < NO_CLOBBER_PUBLISH_MAX_ATTEMPTS; attempt += 1) {
+      if (tryExclusiveLink(tempPath, scriptPath)) return;
+      // Something is at `scriptPath`. We hold the exclusive publish lock, so
+      // nothing else can repopulate it underneath us: this is either a
+      // genuine partial (grabbed-and-discarded, then retried above) or a
+      // COMPLETE artifact (grabbed, restored, and the publish refused —
+      // `grabAndDiscardPartialTarget` never returns on that path).
+      grabAndDiscardPartialTarget(scriptPath);
+    }
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Could not publish the healed script to ${scriptPath}: too much contention from concurrent writers.`,
+    );
+  } finally {
+    releaseNoClobberLock(lockPath);
   }
-  throw new AppError(
-    'COMMAND_FAILED',
-    `Could not publish the healed script to ${scriptPath}: too much contention from concurrent writers.`,
-  );
+}
+
+/**
+ * Claims the exclusive right to decide/publish for `scriptPath` via an atomic
+ * `linkSync` (fails `EEXIST` iff someone else already holds it). On
+ * contention, waits with a bounded backoff — the lock is held only for the
+ * handful of synchronous fs calls in `publishNoClobberAtomically`, so any
+ * live holder releases it quickly.
+ *
+ * A lock whose recorded PID is no longer running is a crashed writer's
+ * abandoned claim — reclaimed immediately (a dead process can never release
+ * it). A lock held by a LIVE process is never stolen: exhausting the bounded
+ * wait fails loudly instead, so a slow (but live) holder's in-progress
+ * publish is never second-guessed.
+ */
+function acquireNoClobberLock(scriptPath: string): string {
+  const lockPath = `${scriptPath}.lock`;
+  const tempLockPath = `${lockPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
+  fs.writeFileSync(tempLockPath, String(process.pid));
+  try {
+    for (let attempt = 0; attempt < LOCK_ACQUIRE_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        fs.linkSync(tempLockPath, lockPath);
+        return lockPath;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        if (isHeldByDeadProcess(lockPath)) {
+          fs.rmSync(lockPath, { force: true });
+          continue;
+        }
+        sleepSyncMs(LOCK_ACQUIRE_BACKOFF_MS);
+      }
+    }
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Could not publish the healed script to ${scriptPath}: timed out waiting for a concurrent writer to finish publishing.`,
+    );
+  } finally {
+    fs.rmSync(tempLockPath, { force: true });
+  }
+}
+
+function releaseNoClobberLock(lockPath: string): void {
+  fs.rmSync(lockPath, { force: true });
+}
+
+/** `true` iff `lockPath` names a PID that is provably no longer running. */
+function isHeldByDeadProcess(lockPath: string): boolean {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(lockPath, 'utf8');
+  } catch {
+    // Released between our EEXIST and this read — not steal-worthy, the next
+    // attempt's `linkSync` will simply succeed against the now-clear path.
+    return false;
+  }
+  const pid = Number(raw.trim());
+  return Number.isInteger(pid) && pid > 0 && !isProcessAlive(pid);
+}
+
+/**
+ * Blocks the event loop for `ms` — a synchronous backoff to match this
+ * file's synchronous (`Sync`) publish primitives. Never runs longer than
+ * `LOCK_ACQUIRE_MAX_ATTEMPTS * LOCK_ACQUIRE_BACKOFF_MS` in the worst case.
+ */
+function sleepSyncMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /**
@@ -273,13 +343,13 @@ function tryExclusiveLink(tempPath: string, scriptPath: string): boolean {
 
 /**
  * Atomically grabs whatever currently sits at `scriptPath` into a private,
- * uniquely-named quarantine file (a single `renameSync`, so nobody else can
- * race the completeness check against it) and inspects it there. A genuinely
- * partial grab is discarded (returns normally — the caller retries the
- * exclusive link). `ENOENT` means a competing writer's own grab or publish
- * already changed `scriptPath` between our `EEXIST` and this call — also
- * returns normally, for the same "retry from the top" reason. A COMPLETE
- * grab is restored (best effort) and this throws, refusing the clobber.
+ * uniquely-named quarantine file (a single `renameSync`) and inspects it
+ * there. The caller holds the exclusive publish lock for the whole of this
+ * decision, so no OTHER writer can be repopulating `scriptPath` while we
+ * inspect our quarantined copy. A genuinely partial grab is discarded
+ * (returns normally — the caller retries the exclusive link). `ENOENT` is
+ * unreachable under the lock but is handled defensively rather than assumed.
+ * A COMPLETE grab is restored and this throws, refusing the clobber.
  */
 function grabAndDiscardPartialTarget(scriptPath: string): void {
   const quarantinePath = `${scriptPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.quarantine`;
@@ -296,16 +366,15 @@ function grabAndDiscardPartialTarget(scriptPath: string): void {
   }
 }
 
-/** Restores a quarantined COMPLETE artifact (best effort) and refuses the publish. */
+/**
+ * Restores a quarantined COMPLETE artifact and refuses the publish. The
+ * caller holds the exclusive publish lock, so nothing else can have
+ * repopulated `scriptPath` in the meantime — the restore always lands back
+ * on the same empty slot we just vacated, never over another writer's
+ * publish.
+ */
 function refuseCompleteClobber(quarantinePath: string, scriptPath: string): never {
-  try {
-    // If another writer already republished to `scriptPath` in the meantime,
-    // this fails and ours stays quarantined (cleaned up by the caller) — we
-    // lose cleanly either way.
-    fs.renameSync(quarantinePath, scriptPath);
-  } catch {
-    /* already re-occupied by another writer's publish */
-  }
+  fs.renameSync(quarantinePath, scriptPath);
   throw new AppError(
     'COMMAND_FAILED',
     `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -4,7 +4,6 @@ import { publicPlatformString } from '../kernel/device.ts';
 import { inferFillText } from './action-utils.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { AppError } from '../kernel/errors.ts';
-import { isProcessAlive } from '../utils/host-process.ts';
 import {
   formatPortableActionLine,
   formatTargetAnnotationLines,
@@ -217,13 +216,23 @@ function publishOverwriteAtomically(tempPath: string, scriptPath: string): void 
 }
 
 const NO_CLOBBER_PUBLISH_MAX_ATTEMPTS = 16;
-const LOCK_ACQUIRE_MAX_ATTEMPTS = 40;
-const LOCK_ACQUIRE_BACKOFF_MS = 5;
+const LEASE_ACQUIRE_MAX_ATTEMPTS = 40;
+const LEASE_ACQUIRE_BACKOFF_MS = 5;
+/**
+ * ADR 0012 decision 6 (BLOCKER 1, lease replacement, maintainer-approved
+ * design): a holder older than this is treated as crashed/hung, never merely
+ * slow — the publish lease's whole decide-and-act sequence is a handful of
+ * synchronous fs calls, nowhere close to this budget.
+ */
+const LEASE_TTL_MS = 30_000;
 
 /**
- * ADR 0012 decision 6, no-clobber (BLOCKER 1): publishes to the DEFAULT healed
- * sibling path, where a COMPLETE (sentinel-marked) prior artifact must never
- * be clobbered.
+ * ADR 0012 decision 6, no-clobber (BLOCKER 1, BLOCKER 4): publishes to a
+ * repair-armed session's target — the DEFAULT healed sibling path OR an
+ * explicit `--save-script=<path>` alike (BLOCKER 4: an explicit target is
+ * caller-DIRECTED, never caller-AUTHORIZED to silently destroy an unreviewed
+ * prior healed diff) — where a COMPLETE (sentinel-marked) prior artifact must
+ * never be clobbered.
  *
  * A prior fix made the "is the existing target overwritable" decision itself
  * atomic (grab-to-quarantine + inspect, `grabAndDiscardPartialTarget` below)
@@ -237,24 +246,35 @@ const LOCK_ACQUIRE_BACKOFF_MS = 5;
  *
  * Here the ENTIRE decide-and-act sequence for a given `scriptPath` — the
  * exclusive-link attempt, the grab/inspect, and the refuse-and-restore or
- * discard-and-retry — runs while holding an exclusive publish lock
- * (`acquireNoClobberLock`/`releaseNoClobberLock`, itself an atomic `linkSync`
- * claim). A competing writer for the SAME `scriptPath` cannot even begin its
- * own decision until the lock holder's entire sequence has finished and
- * released it, so the "restore stomps a concurrently-published winner"
- * interleaving above is no longer reachable: whichever writer holds the lock
- * always observes (and, on refusal, restores) exactly what it itself grabbed,
- * with nothing else able to touch `scriptPath` in between.
+ * discard-and-retry — runs while holding a verified, exclusive publish LEASE
+ * (`acquireLease`/`releaseLease` below). A competing writer for the SAME
+ * `scriptPath` cannot even begin its own decision until the lease holder's
+ * entire sequence has finished and released it, so the "restore stomps a
+ * concurrently-published winner" interleaving above is no longer reachable:
+ * whichever writer holds the lease always observes (and, on refusal,
+ * restores) exactly what it itself grabbed, with nothing else able to touch
+ * `scriptPath` in between.
  */
 function publishNoClobberAtomically(tempPath: string, scriptPath: string): void {
-  const lockPath = acquireNoClobberLock(scriptPath);
+  const lockPath = `${scriptPath}.lock`;
+  const myToken = acquireLease(lockPath);
   try {
+    // Closes the pathological window where acquiring took long enough (or
+    // ran up against a small enough TTL) that this lease itself expired and
+    // was stolen by someone else between `acquireLease` returning and here —
+    // never publish on a lease this caller no longer verifiably holds.
+    if (!verifyOwnership(lockPath, myToken)) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        `Could not publish the healed script to ${scriptPath}: the publish lease expired before the write could start.`,
+      );
+    }
     for (let attempt = 0; attempt < NO_CLOBBER_PUBLISH_MAX_ATTEMPTS; attempt += 1) {
       if (tryExclusiveLink(tempPath, scriptPath)) return;
-      // Something is at `scriptPath`. We hold the exclusive publish lock, so
-      // nothing else can repopulate it underneath us: this is either a
-      // genuine partial (grabbed-and-discarded, then retried above) or a
-      // COMPLETE artifact (grabbed, restored, and the publish refused —
+      // Something is at `scriptPath`. We hold the verified exclusive publish
+      // lease, so nothing else can repopulate it underneath us: this is
+      // either a genuine partial (grabbed-and-discarded, then retried above)
+      // or a COMPLETE artifact (grabbed, restored, and the publish refused —
       // `grabAndDiscardPartialTarget` never returns on that path).
       grabAndDiscardPartialTarget(scriptPath);
     }
@@ -263,113 +283,142 @@ function publishNoClobberAtomically(tempPath: string, scriptPath: string): void 
       `Could not publish the healed script to ${scriptPath}: too much contention from concurrent writers.`,
     );
   } finally {
-    releaseNoClobberLock(lockPath);
+    releaseLease(lockPath, myToken);
   }
 }
 
 /**
- * Claims the exclusive right to decide/publish for `scriptPath` via an atomic
- * `linkSync` (fails `EEXIST` iff someone else already holds it). On
- * contention, waits with a bounded backoff — the lock is held only for the
- * handful of synchronous fs calls in `publishNoClobberAtomically`, so any
- * live holder releases it quickly.
+ * ADR 0012 decision 6 (BLOCKER 1, lease replacement — maintainer-approved
+ * design): claims a TTL LEASE on `lockPath` — replaces the prior PID-liveness
+ * "reclaim" scheme (`reclaimDeadLock`, removed), which was structurally
+ * race-prone: reclaiming a dead lock meant GRABBING it away first (rename to
+ * inspect) and, if it turned out to have gone LIVE in the meantime (raced by
+ * a concurrent reclaimer), RESTORING it. That grab-then-restore shape is
+ * exactly the bug the reviewer found: a three-writer interleaving lets waiter
+ * A rename waiter B's now-LIVE lock away (to inspect it), waiter C
+ * `linkSync` its own lock into the momentarily-empty path, then A's
+ * "restore" (`renameSync`, which replaces an existing destination) silently
+ * clobbers C's freshly acquired lock — and a pathname-based release could
+ * then remove a SUCCESSOR's lock, not the caller's own.
  *
- * A lock whose recorded PID is no longer running is a crashed writer's
- * abandoned claim — reclaimed via `reclaimDeadLock` (race-safely; see its
- * doc). A lock held by a LIVE process is never stolen: exhausting the
- * bounded wait fails loudly instead, so a slow (but live) holder's
- * in-progress publish is never second-guessed.
+ * A lease never has that shape — there is no restore path, ever. Each lock
+ * file's content is a unique OWNER TOKEN (`pid:random:createdAtMs`).
+ * Staleness is judged purely from the trailing timestamp (`LEASE_TTL_MS`),
+ * never from asking the OS whether a PID is alive, so there is nothing to
+ * "put back" if the judgment turns out to be wrong: a lease found to be
+ * fresh is simply left completely untouched (back off, retry later); a lease
+ * found to be expired is stolen via a single atomic
+ * `renameSync(lockPath, <lockPath>.expired.<unique>)` — exactly one caller
+ * can ever win that rename for a given still-existing `lockPath` (a second,
+ * concurrent rename of the same already-moved source fails `ENOENT`, never
+ * silently succeeds), so it doubles as a compare-and-swap on "the right to
+ * discard whatever currently sits here". The winner discards what it grabbed
+ * and retries the link; a loser (`ENOENT`) does nothing and also retries the
+ * link, observing whatever the winner left behind. A LIVE holder's canonical
+ * claim at `lockPath` is thus NEVER renamed or removed by anyone but its own
+ * `releaseLease`.
  */
-function acquireNoClobberLock(scriptPath: string): string {
-  const lockPath = `${scriptPath}.lock`;
-  const tempLockPath = `${lockPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
-  fs.writeFileSync(tempLockPath, String(process.pid));
-  try {
-    for (let attempt = 0; attempt < LOCK_ACQUIRE_MAX_ATTEMPTS; attempt += 1) {
-      try {
-        fs.linkSync(tempLockPath, lockPath);
-        return lockPath;
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-        // 'reclaimed' (we cleared a dead lock) and 'contended' (someone
-        // else's reclaim of that SAME dead lock just won) both retry the
-        // exclusive link immediately — only a confirmed-LIVE holder backs off.
-        if (reclaimDeadLock(lockPath) === 'live') sleepSyncMs(LOCK_ACQUIRE_BACKOFF_MS);
-      }
+function acquireLease(lockPath: string): string {
+  const myToken = createLeaseToken();
+  for (let attempt = 0; attempt < LEASE_ACQUIRE_MAX_ATTEMPTS; attempt += 1) {
+    if (tryClaimLease(lockPath, myToken)) return myToken;
+    const existingToken = readLeaseToken(lockPath);
+    // Raced away between our EEXIST and this read (the holder released, or a
+    // steal completed) — nothing to judge; retry the link immediately.
+    if (existingToken === undefined) continue;
+    const createdAtMs = leaseCreatedAtMs(existingToken);
+    if (createdAtMs === undefined || Date.now() - createdAtMs > LEASE_TTL_MS) {
+      // Expired (or unparseable, which we also treat as abandoned) — steal
+      // it. Whether WE won the steal or someone else did, the lock is now
+      // either empty or held by a fresh claimant: retry the link either way.
+      stealExpiredLease(lockPath);
+      continue;
     }
-    throw new AppError(
-      'COMMAND_FAILED',
-      `Could not publish the healed script to ${scriptPath}: timed out waiting for a concurrent writer to finish publishing.`,
-    );
+    // A fresh claim — a genuinely live holder. Never touched; just wait.
+    sleepSyncMs(LEASE_ACQUIRE_BACKOFF_MS);
+  }
+  throw new AppError(
+    'COMMAND_FAILED',
+    `Could not publish the healed script: timed out waiting for a concurrent writer.`,
+  );
+}
+
+/** A unique per-attempt owner token: `pid:random:createdAtMs`. */
+function createLeaseToken(): string {
+  return `${process.pid}:${Math.random().toString(36).slice(2)}:${Date.now()}`;
+}
+
+/** Parses the trailing `createdAtMs` segment off a lease token; `undefined` if malformed. */
+function leaseCreatedAtMs(token: string): number | undefined {
+  const raw = token.split(':').at(-1);
+  const parsed = raw === undefined ? Number.NaN : Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * The only primitive that can WIN a lease outright: atomic create-if-absent
+ * via `linkSync`. `true` = claimed; `false` = `EEXIST` (something is at
+ * `lockPath` right now, live or expired — the caller decides which next).
+ */
+function tryClaimLease(lockPath: string, token: string): boolean {
+  const tempPath = `${lockPath}.${token.replace(/:/g, '-')}.tmp`;
+  fs.writeFileSync(tempPath, token);
+  try {
+    fs.linkSync(tempPath, lockPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
   } finally {
-    fs.rmSync(tempLockPath, { force: true });
+    fs.rmSync(tempPath, { force: true });
   }
 }
 
-function releaseNoClobberLock(lockPath: string): void {
-  fs.rmSync(lockPath, { force: true });
+/** Reads the current owner token at `lockPath`; `undefined` if missing/unreadable. */
+function readLeaseToken(lockPath: string): string | undefined {
+  try {
+    return fs.readFileSync(lockPath, 'utf8');
+  } catch {
+    return undefined;
+  }
 }
 
-type LockReclaimOutcome = 'reclaimed' | 'contended' | 'live';
-
 /**
- * Reclaims `lockPath` iff it is provably a DEAD writer's abandoned lock —
- * race-safely. The prior implementation decided "dead" from a plain read,
- * then removed the lock BY PATHNAME as a separate step
- * (`fs.rmSync(lockPath)`) — a classic TOCTOU: waiters A and B could both read
- * the same dead-PID lock and both decide to reclaim; if B's reclaim (remove
- * + re-`linkSync` its OWN live lock) completed inside the gap between A's
- * read and A's own removal, A's stale `rmSync(lockPath)` would delete B's
- * LIVE lock by pathname — not the dead one A actually inspected — and both
- * waiters would then believe they held the exclusive lock at once.
- *
- * Here the removal is never "read, then act by pathname" — it is a single
- * atomic claim: `fs.renameSync(lockPath, claimPath)` can only ever move a
- * given SOURCE path for exactly one caller (a second, concurrent rename of
- * the same already-moved source fails `ENOENT`, never silently succeeds), so
- * it doubles as a compare-and-swap on "claim the right to inspect/discard
- * whatever currently sits at `lockPath` right now". Only the winner of that
- * claim inspects the object it actually grabbed (not a stale earlier read):
- * if it is genuinely dead, discard it; if the claim raced with someone
- * else's fresh reclaim and grabbed their LIVE lock instead, restore it
- * untouched and report contention rather than dropping it. The live holder's
- * lock is never stolen.
+ * Steals an EXPIRED lease via a single atomic rename — never a restore. On
+ * success, the caller is the SOLE owner of the quarantined file (no one else
+ * can have grabbed the same source path) and discards it. On `ENOENT`,
+ * someone else's steal of this exact lease already won the race; there is
+ * nothing left to discard. Either way, the (now-live-or-empty) `lockPath` is
+ * left for the caller's next `tryClaimLease` retry to observe.
  */
-function reclaimDeadLock(lockPath: string): LockReclaimOutcome {
-  if (!isHeldByDeadProcess(lockPath)) return 'live';
-  const claimPath = `${lockPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.dead-claim`;
+function stealExpiredLease(lockPath: string): void {
+  const quarantinePath = `${lockPath}.expired.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   try {
-    fs.renameSync(lockPath, claimPath);
+    fs.renameSync(lockPath, quarantinePath);
   } catch (error) {
-    // Someone else's claim of this exact dead lock already won the race —
-    // there is nothing left for us to reclaim; the caller retries and will
-    // observe whatever that winner leaves behind (dead-again or freshly live).
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'contended';
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
     throw error;
   }
-  if (isHeldByDeadProcess(claimPath)) {
-    fs.rmSync(claimPath, { force: true });
-    return 'reclaimed';
-  }
-  // What we claimed is actually LIVE: another writer reclaimed and
-  // re-acquired between our precheck read above and this rename winning.
-  // Restore it exactly as claimed — never discard a live holder's lock.
-  fs.renameSync(claimPath, lockPath);
-  return 'live';
+  fs.rmSync(quarantinePath, { force: true });
 }
 
-/** `true` iff `filePath` names a PID that is provably no longer running. */
-function isHeldByDeadProcess(filePath: string): boolean {
-  let raw: string;
+/** `true` iff `token` is still the current owner of `lockPath` right now. */
+function verifyOwnership(lockPath: string, token: string): boolean {
+  return readLeaseToken(lockPath) === token;
+}
+
+/**
+ * Releases `lockPath` iff its CURRENT token is still `myToken` — a successor
+ * that has since stolen (expired) or freshly re-claimed the same path is
+ * NEVER removed by an earlier holder's release; only the caller's own claim
+ * is ever a release candidate. Best-effort: a concurrent removal (already
+ * gone) is not an error.
+ */
+function releaseLease(lockPath: string, myToken: string): void {
+  if (readLeaseToken(lockPath) !== myToken) return;
   try {
-    raw = fs.readFileSync(filePath, 'utf8');
-  } catch {
-    // Released/moved between our EEXIST and this read — not steal-worthy,
-    // the next attempt will simply observe whatever the current state is.
-    return false;
-  }
-  const pid = Number(raw.trim());
-  return Number.isInteger(pid) && pid > 0 && !isProcessAlive(pid);
+    fs.unlinkSync(lockPath);
+  } catch {}
 }
 
 /**

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -84,10 +84,16 @@ export class SessionScriptWriter {
       publishHealedScriptAtomically({
         scriptPath,
         script,
-        // The completeness-aware no-clobber guard protects ONLY the DEFAULT
-        // healed sibling (an explicit `--save-script=<out>` may overwrite as
-        // the caller directed).
-        protectComplete: Boolean(session.saveScriptDefaultedHealedPath),
+        // ADR 0012 decision 6 (BLOCKER 4): the completeness-aware no-clobber
+        // guard protects EVERY repair-armed publish target — the DEFAULT
+        // healed sibling AND an explicit `--save-script=<path>` alike. An
+        // explicit target is still caller-DIRECTED (which path), never
+        // caller-authorized to silently destroy an unreviewed prior healed
+        // diff sitting there; the caller must remove/rename it or pick
+        // another path. Only ever actually engages against a sentinel-marked
+        // artifact, which only a repair-armed write can produce, so an
+        // ordinary (non-repair) recording's target is unaffected either way.
+        protectComplete: repairArmed,
       });
       // COMMITTED: idempotent guard above + teardown's abort/tombstone routing.
       if (repairArmed) session.saveScriptCommitted = true;
@@ -193,10 +199,12 @@ function publishHealedScriptAtomically(params: {
 }
 
 /**
- * An explicit `--save-script=<path>` target is caller-directed and never
- * no-clobber-protected — BLOCKER 1's "is the existing target incomplete"
- * classification never runs on this path, so a plain atomic publish is
- * correct: absent -> exclusive create; present -> atomic rename-replace.
+ * ADR 0012 decision 6 (BLOCKER 4): an ORDINARY (non-repair-armed) recording's
+ * target is never no-clobber-protected — it never carries the completeness
+ * sentinel in the first place (only a repair-armed write appends it), so
+ * BLOCKER 1's "is the existing target incomplete" classification would never
+ * find anything to refuse on anyway. A plain atomic publish is correct:
+ * absent -> exclusive create; present -> atomic rename-replace.
  */
 function publishOverwriteAtomically(tempPath: string, scriptPath: string): void {
   try {

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -55,7 +55,12 @@ export const HEAL_COMPLETE_SENTINEL = '# agent-device:heal-complete';
  *   after a divergence but before the plan finishes from committing a PREFIX;
  *   every non-completion teardown (divergence-only exit, daemon shutdown,
  *   idle-reap) lands here too.
- * Ordinary (non-repair) recording is never blocked (no `saveScriptBoundary`).
+ * Ordinary (non-repair) recording is never blocked here (no `saveScriptBoundary`) —
+ * this gate only decides whether `write()` attempts a publish AT ALL. It says
+ * nothing about what happens once it does: `publishHealedScriptAtomically`'s
+ * refuse-on-exist applies to that attempted publish uniformly, repair-armed or
+ * not (see its doc comment) — ordinary recording is never blocked from trying,
+ * but it can still be refused if the target already exists.
  */
 function isRepairArmedWriteBlocked(session: SessionState): boolean {
   if (session.saveScriptBoundary === undefined) return false;
@@ -98,9 +103,16 @@ export class SessionScriptWriter {
       // SURFACED (no-clobber refusal, bare-`@ref`, or a filesystem error alike)
       // so close/teardown can report it and keep the session for retry — never
       // swallowed into a silent `{written:false}`. Ordinary (non-repair)
-      // recording keeps its existing behavior: an unexpected AppError still
-      // fails loud (none is raised on that path today), an fs error is a quiet
-      // skip.
+      // recording keeps its existing SHAPE of behavior: an AppError still
+      // fails loud (thrown, not swallowed into `{written:false}`) and any other
+      // fs error is a quiet skip — but an AppError is no longer only
+      // theoretical here. Since `publishHealedScriptAtomically` refuses ANY
+      // pre-existing target uniformly (maintainer-approved: refuse-on-exist
+      // applies to ordinary recording too, not just repair heals), an ordinary
+      // `open`/`close --save-script` write against an existing target now
+      // throws that same no-clobber AppError, surfacing here as a genuine
+      // "fails loud" case rather than the "none is raised on that path" it was
+      // before that change.
       if (repairArmed) {
         return { written: false, error: toRepairCommitFailure(error, scriptPath) };
       }
@@ -148,6 +160,15 @@ function formatSessionScript(session: SessionState, appendCompleteSentinel: bool
  * publishes `script` to `scriptPath` atomically, refusing ANY pre-existing
  * target — complete or partial, the default healed sibling or an explicit
  * `--save-script=<path>` alike.
+ *
+ * This is `write()`'s ONLY publish primitive, called unconditionally for
+ * every target — a repair-armed heal AND an ordinary, non-repair
+ * `open`/`close --save-script` recording alike. There is no
+ * repair-armed-vs-ordinary branch here (an earlier design had one —
+ * `publishOverwriteAtomically`, rename-replace for ordinary writes — since
+ * removed): an ordinary recording's target is refused exactly like a healed
+ * repair's, never silently overwritten. `--force`/`--overwrite` is a future
+ * escape hatch (#1258), not implemented today.
  *
  * The temp file is created in the SAME DIRECTORY as the target (never
  * `/tmp`), so the publish itself is a single intra-directory `linkSync`:

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -80,20 +80,7 @@ export class SessionScriptWriter {
       const scriptDir = path.dirname(scriptPath);
       if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
       const script = formatSessionScript(session, repairArmed);
-      publishHealedScriptAtomically({
-        scriptPath,
-        script,
-        // ADR 0012 decision 6 (BLOCKER 4): the completeness-aware no-clobber
-        // guard protects EVERY repair-armed publish target — the DEFAULT
-        // healed sibling AND an explicit `--save-script=<path>` alike. An
-        // explicit target is still caller-DIRECTED (which path), never
-        // caller-authorized to silently destroy an unreviewed prior healed
-        // diff sitting there; the caller must remove/rename it or pick
-        // another path. Only ever actually engages against a sentinel-marked
-        // artifact, which only a repair-armed write can produce, so an
-        // ordinary (non-repair) recording's target is unaffected either way.
-        protectComplete: repairArmed,
-      });
+      publishHealedScriptAtomically({ scriptPath, script });
       // COMMITTED: idempotent guard above + teardown's abort/tombstone routing.
       if (repairArmed) session.saveScriptCommitted = true;
       return { written: true, path: scriptPath };
@@ -157,27 +144,23 @@ function formatSessionScript(session: SessionState, appendCompleteSentinel: bool
 }
 
 /**
- * ADR 0012 decision 6, commit semantics + no-clobber (Fix 4, C5b, BLOCKER 1):
- * publishes `script` to `scriptPath` atomically AND race-safely.
+ * ADR 0012 decision 6, no-clobber (maintainer-approved simplification):
+ * publishes `script` to `scriptPath` atomically, refusing ANY pre-existing
+ * target — complete or partial, the default healed sibling or an explicit
+ * `--save-script=<path>` alike.
  *
- * - Atomic: the temp file is created in the SAME DIRECTORY as the target
- *   (never `/tmp`), so the final publish is an intra-directory rename/link on
- *   one filesystem — a reader never observes a half-written script, and an
- *   explicit `--save-script=<path>` on a different mount still publishes
- *   atomically. An aborted write leaves only the (removed) temp, no partial
- *   at the target.
- * - Race-safe no-clobber (BLOCKER 1): the DEFAULT healed-sibling path is
- *   protected by `publishNoClobberAtomically`, which makes an atomic primitive
- *   (never a check-then-write gap) decide the winner even when the existing
- *   target is a partial. An explicit `--save-script=<path>` target is
- *   caller-directed and unprotected either way (`publishOverwriteAtomically`).
+ * The temp file is created in the SAME DIRECTORY as the target (never
+ * `/tmp`), so the publish itself is a single intra-directory `linkSync`:
+ * atomic create-exclusive, first writer wins. That single primitive is
+ * enough — a concurrent complete-vs-complete race is already correct this
+ * way (the loser sees `EEXIST` and is refused), and a partial healed file
+ * left behind by an aborted/reaped repair is a degenerate state: the caller
+ * clears it explicitly (remove it, or pick another `--save-script` path)
+ * rather than having it silently replaced. No lock, no lease, no steal, no
+ * overwrite.
  */
-function publishHealedScriptAtomically(params: {
-  scriptPath: string;
-  script: string;
-  protectComplete: boolean;
-}): void {
-  const { scriptPath, script, protectComplete } = params;
+function publishHealedScriptAtomically(params: { scriptPath: string; script: string }): void {
+  const { scriptPath, script } = params;
   const dir = path.dirname(scriptPath);
   const tempPath = path.join(
     dir,
@@ -185,304 +168,19 @@ function publishHealedScriptAtomically(params: {
   );
   fs.writeFileSync(tempPath, script);
   try {
-    if (protectComplete) {
-      publishNoClobberAtomically(tempPath, scriptPath);
-    } else {
-      publishOverwriteAtomically(tempPath, scriptPath);
-    }
-  } finally {
-    // linkSync leaves the temp hard-link behind on success; rename consumes it;
-    // an error leaves it — always clean up whatever of our own temp remains.
-    fs.rmSync(tempPath, { force: true });
-  }
-}
-
-/**
- * ADR 0012 decision 6 (BLOCKER 4): an ORDINARY (non-repair-armed) recording's
- * target is never no-clobber-protected — it never carries the completeness
- * sentinel in the first place (only a repair-armed write appends it), so
- * BLOCKER 1's "is the existing target incomplete" classification would never
- * find anything to refuse on anyway. A plain atomic publish is correct:
- * absent -> exclusive create; present -> atomic rename-replace.
- */
-function publishOverwriteAtomically(tempPath: string, scriptPath: string): void {
-  try {
-    // Atomic create-if-absent: EEXIST iff the target already exists.
+    // Atomic create-exclusive: EEXIST iff a file already sits at scriptPath.
     fs.linkSync(tempPath, scriptPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-    fs.renameSync(tempPath, scriptPath);
-  }
-}
-
-const NO_CLOBBER_PUBLISH_MAX_ATTEMPTS = 16;
-const LEASE_ACQUIRE_MAX_ATTEMPTS = 40;
-const LEASE_ACQUIRE_BACKOFF_MS = 5;
-/**
- * ADR 0012 decision 6 (BLOCKER 1, lease replacement, maintainer-approved
- * design): a holder older than this is treated as crashed/hung, never merely
- * slow — the publish lease's whole decide-and-act sequence is a handful of
- * synchronous fs calls, nowhere close to this budget.
- */
-const LEASE_TTL_MS = 30_000;
-
-/**
- * ADR 0012 decision 6, no-clobber (BLOCKER 1, BLOCKER 4): publishes to a
- * repair-armed session's target — the DEFAULT healed sibling path OR an
- * explicit `--save-script=<path>` alike (BLOCKER 4: an explicit target is
- * caller-DIRECTED, never caller-AUTHORIZED to silently destroy an unreviewed
- * prior healed diff) — where a COMPLETE (sentinel-marked) prior artifact must
- * never be clobbered.
- *
- * A prior fix made the "is the existing target overwritable" decision itself
- * atomic (grab-to-quarantine + inspect, `grabAndDiscardPartialTarget` below)
- * instead of a plain read — but the inspect/restore/publish SEQUENCE was
- * still not exclusive: writer A could quarantine an existing COMPLETE
- * target, and — before A restored it — writer B could `linkSync` its own
- * COMPLETE artifact into the now-empty `scriptPath` and return success, only
- * for A's restore (`renameSync`, which replaces an existing destination per
- * POSIX) to silently stomp B's freshly published bytes. B would report
- * success while its bytes were gone.
- *
- * Here the ENTIRE decide-and-act sequence for a given `scriptPath` — the
- * exclusive-link attempt, the grab/inspect, and the refuse-and-restore or
- * discard-and-retry — runs while holding a verified, exclusive publish LEASE
- * (`acquireLease`/`releaseLease` below). A competing writer for the SAME
- * `scriptPath` cannot even begin its own decision until the lease holder's
- * entire sequence has finished and released it, so the "restore stomps a
- * concurrently-published winner" interleaving above is no longer reachable:
- * whichever writer holds the lease always observes (and, on refusal,
- * restores) exactly what it itself grabbed, with nothing else able to touch
- * `scriptPath` in between.
- */
-function publishNoClobberAtomically(tempPath: string, scriptPath: string): void {
-  const lockPath = `${scriptPath}.lock`;
-  const myToken = acquireLease(lockPath);
-  try {
-    // Closes the pathological window where acquiring took long enough (or
-    // ran up against a small enough TTL) that this lease itself expired and
-    // was stolen by someone else between `acquireLease` returning and here —
-    // never publish on a lease this caller no longer verifiably holds.
-    if (!verifyOwnership(lockPath, myToken)) {
-      throw new AppError(
-        'COMMAND_FAILED',
-        `Could not publish the healed script to ${scriptPath}: the publish lease expired before the write could start.`,
-      );
-    }
-    for (let attempt = 0; attempt < NO_CLOBBER_PUBLISH_MAX_ATTEMPTS; attempt += 1) {
-      if (tryExclusiveLink(tempPath, scriptPath)) return;
-      // Something is at `scriptPath`. We hold the verified exclusive publish
-      // lease, so nothing else can repopulate it underneath us: this is
-      // either a genuine partial (grabbed-and-discarded, then retried above)
-      // or a COMPLETE artifact (grabbed, restored, and the publish refused —
-      // `grabAndDiscardPartialTarget` never returns on that path).
-      grabAndDiscardPartialTarget(scriptPath);
-    }
     throw new AppError(
       'COMMAND_FAILED',
-      `Could not publish the healed script to ${scriptPath}: too much contention from concurrent writers.`,
+      `A file already exists at ${scriptPath}; remove it or pass replay --save-script=<other-path> so an existing healed script is never overwritten.`,
     );
   } finally {
-    releaseLease(lockPath, myToken);
-  }
-}
-
-/**
- * ADR 0012 decision 6 (BLOCKER 1, lease replacement — maintainer-approved
- * design): claims a TTL LEASE on `lockPath` — replaces the prior PID-liveness
- * "reclaim" scheme (`reclaimDeadLock`, removed), which was structurally
- * race-prone: reclaiming a dead lock meant GRABBING it away first (rename to
- * inspect) and, if it turned out to have gone LIVE in the meantime (raced by
- * a concurrent reclaimer), RESTORING it. That grab-then-restore shape is
- * exactly the bug the reviewer found: a three-writer interleaving lets waiter
- * A rename waiter B's now-LIVE lock away (to inspect it), waiter C
- * `linkSync` its own lock into the momentarily-empty path, then A's
- * "restore" (`renameSync`, which replaces an existing destination) silently
- * clobbers C's freshly acquired lock — and a pathname-based release could
- * then remove a SUCCESSOR's lock, not the caller's own.
- *
- * A lease never has that shape — there is no restore path, ever. Each lock
- * file's content is a unique OWNER TOKEN (`pid:random:createdAtMs`).
- * Staleness is judged purely from the trailing timestamp (`LEASE_TTL_MS`),
- * never from asking the OS whether a PID is alive, so there is nothing to
- * "put back" if the judgment turns out to be wrong: a lease found to be
- * fresh is simply left completely untouched (back off, retry later); a lease
- * found to be expired is stolen via a single atomic
- * `renameSync(lockPath, <lockPath>.expired.<unique>)` — exactly one caller
- * can ever win that rename for a given still-existing `lockPath` (a second,
- * concurrent rename of the same already-moved source fails `ENOENT`, never
- * silently succeeds), so it doubles as a compare-and-swap on "the right to
- * discard whatever currently sits here". The winner discards what it grabbed
- * and retries the link; a loser (`ENOENT`) does nothing and also retries the
- * link, observing whatever the winner left behind. A LIVE holder's canonical
- * claim at `lockPath` is thus NEVER renamed or removed by anyone but its own
- * `releaseLease`.
- */
-function acquireLease(lockPath: string): string {
-  const myToken = createLeaseToken();
-  for (let attempt = 0; attempt < LEASE_ACQUIRE_MAX_ATTEMPTS; attempt += 1) {
-    if (tryClaimLease(lockPath, myToken)) return myToken;
-    const existingToken = readLeaseToken(lockPath);
-    // Raced away between our EEXIST and this read (the holder released, or a
-    // steal completed) — nothing to judge; retry the link immediately.
-    if (existingToken === undefined) continue;
-    const createdAtMs = leaseCreatedAtMs(existingToken);
-    if (createdAtMs === undefined || Date.now() - createdAtMs > LEASE_TTL_MS) {
-      // Expired (or unparseable, which we also treat as abandoned) — steal
-      // it. Whether WE won the steal or someone else did, the lock is now
-      // either empty or held by a fresh claimant: retry the link either way.
-      stealExpiredLease(lockPath);
-      continue;
-    }
-    // A fresh claim — a genuinely live holder. Never touched; just wait.
-    sleepSyncMs(LEASE_ACQUIRE_BACKOFF_MS);
-  }
-  throw new AppError(
-    'COMMAND_FAILED',
-    `Could not publish the healed script: timed out waiting for a concurrent writer.`,
-  );
-}
-
-/** A unique per-attempt owner token: `pid:random:createdAtMs`. */
-function createLeaseToken(): string {
-  return `${process.pid}:${Math.random().toString(36).slice(2)}:${Date.now()}`;
-}
-
-/** Parses the trailing `createdAtMs` segment off a lease token; `undefined` if malformed. */
-function leaseCreatedAtMs(token: string): number | undefined {
-  const raw = token.split(':').at(-1);
-  const parsed = raw === undefined ? Number.NaN : Number(raw);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-/**
- * The only primitive that can WIN a lease outright: atomic create-if-absent
- * via `linkSync`. `true` = claimed; `false` = `EEXIST` (something is at
- * `lockPath` right now, live or expired — the caller decides which next).
- */
-function tryClaimLease(lockPath: string, token: string): boolean {
-  const tempPath = `${lockPath}.${token.replace(/:/g, '-')}.tmp`;
-  fs.writeFileSync(tempPath, token);
-  try {
-    fs.linkSync(tempPath, lockPath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
-    throw error;
-  } finally {
+    // linkSync leaves the temp hard-link behind on success; an error leaves
+    // it too — always clean up whatever of our own temp remains.
     fs.rmSync(tempPath, { force: true });
   }
-}
-
-/** Reads the current owner token at `lockPath`; `undefined` if missing/unreadable. */
-function readLeaseToken(lockPath: string): string | undefined {
-  try {
-    return fs.readFileSync(lockPath, 'utf8');
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Steals an EXPIRED lease via a single atomic rename — never a restore. On
- * success, the caller is the SOLE owner of the quarantined file (no one else
- * can have grabbed the same source path) and discards it. On `ENOENT`,
- * someone else's steal of this exact lease already won the race; there is
- * nothing left to discard. Either way, the (now-live-or-empty) `lockPath` is
- * left for the caller's next `tryClaimLease` retry to observe.
- */
-function stealExpiredLease(lockPath: string): void {
-  const quarantinePath = `${lockPath}.expired.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  try {
-    fs.renameSync(lockPath, quarantinePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
-    throw error;
-  }
-  fs.rmSync(quarantinePath, { force: true });
-}
-
-/** `true` iff `token` is still the current owner of `lockPath` right now. */
-function verifyOwnership(lockPath: string, token: string): boolean {
-  return readLeaseToken(lockPath) === token;
-}
-
-/**
- * Releases `lockPath` iff its CURRENT token is still `myToken` — a successor
- * that has since stolen (expired) or freshly re-claimed the same path is
- * NEVER removed by an earlier holder's release; only the caller's own claim
- * is ever a release candidate. Best-effort: a concurrent removal (already
- * gone) is not an error.
- */
-function releaseLease(lockPath: string, myToken: string): void {
-  if (readLeaseToken(lockPath) !== myToken) return;
-  try {
-    fs.unlinkSync(lockPath);
-  } catch {}
-}
-
-/**
- * Blocks the event loop for `ms` — a synchronous backoff to match this
- * file's synchronous (`Sync`) publish primitives. Never runs longer than
- * `LOCK_ACQUIRE_MAX_ATTEMPTS * LOCK_ACQUIRE_BACKOFF_MS` in the worst case.
- */
-function sleepSyncMs(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-/**
- * The only primitive that can WIN outright: atomic create-if-absent.
- * `true` = published (won); `false` = `EEXIST` (a file is at `scriptPath`
- * right now). Any other error propagates.
- */
-function tryExclusiveLink(tempPath: string, scriptPath: string): boolean {
-  try {
-    fs.linkSync(tempPath, scriptPath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
-    throw error;
-  }
-}
-
-/**
- * Atomically grabs whatever currently sits at `scriptPath` into a private,
- * uniquely-named quarantine file (a single `renameSync`) and inspects it
- * there. The caller holds the exclusive publish lock for the whole of this
- * decision, so no OTHER writer can be repopulating `scriptPath` while we
- * inspect our quarantined copy. A genuinely partial grab is discarded
- * (returns normally — the caller retries the exclusive link). `ENOENT` is
- * unreachable under the lock but is handled defensively rather than assumed.
- * A COMPLETE grab is restored and this throws, refusing the clobber.
- */
-function grabAndDiscardPartialTarget(scriptPath: string): void {
-  const quarantinePath = `${scriptPath}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.quarantine`;
-  try {
-    fs.renameSync(scriptPath, quarantinePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
-    throw error;
-  }
-  try {
-    if (isCompleteHealedScript(quarantinePath)) refuseCompleteClobber(quarantinePath, scriptPath);
-  } finally {
-    fs.rmSync(quarantinePath, { force: true });
-  }
-}
-
-/**
- * Restores a quarantined COMPLETE artifact and refuses the publish. The
- * caller holds the exclusive publish lock, so nothing else can have
- * repopulated `scriptPath` in the meantime — the restore always lands back
- * on the same empty slot we just vacated, never over another writer's
- * publish.
- */
-function refuseCompleteClobber(quarantinePath: string, scriptPath: string): never {
-  fs.renameSync(quarantinePath, scriptPath);
-  throw new AppError(
-    'COMMAND_FAILED',
-    `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,
-  );
 }
 
 function buildOptimizedActions(session: SessionState): SessionAction[] {
@@ -528,25 +226,6 @@ function assertNoUnresolvedRefFallback(action: SessionAction): void {
     'COMMAND_FAILED',
     `Cannot write recorded step "${action.command} ${refPositional}" to a script: it never resolved to a selector, so the ref would not resolve in a fresh replay session.`,
   );
-}
-
-/**
- * ADR 0012 decision 6, no-clobber (Fix 4, C5b): a file is a COMPLETE,
- * review-worthy healed artifact iff it carries the completeness sentinel
- * (written only on a successful atomic commit). A file without it is a partial
- * — from an aborted/reaped repair — and is freely overwritable by a fresh
- * repair that completes.
- */
-function isCompleteHealedScript(scriptPath: string): boolean {
-  let contents: string;
-  try {
-    contents = fs.readFileSync(scriptPath, 'utf8');
-  } catch {
-    // Missing (nothing to clobber) or unreadable (not provably complete
-    // either way — never block the repair behind a file we cannot inspect).
-    return false;
-  }
-  return contents.split(/\r?\n/).some((line) => line.trim() === HEAL_COMPLETE_SENTINEL);
 }
 
 function optimizeSelectorChainAction(action: SessionAction): SessionAction | undefined {

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -19,7 +19,49 @@ import {
 } from '../replay/script-utils.ts';
 import type { SessionAction, SessionState } from './types.ts';
 
-export type SessionScriptWriteResult = { written: false } | { written: true; path: string };
+/**
+ * `{ written: true; path }` — committed. `{ written: false }` (no `error`) —
+ * intentionally not written (not recording, an aborted/incomplete repair
+ * transaction, or an idempotent already-committed no-op). `{ written: false;
+ * error }` — ADR 0012 decision 6 (BLOCKER 2): a repair COMMIT was attempted but
+ * FAILED (no-clobber refusal, a bare-`@ref` R4 failure, or a filesystem write
+ * error). The `error` (a distinct AppError code/message) is surfaced to
+ * close/teardown so the failure is reportable and the session can be kept for
+ * retry, never swallowed into a silent skip.
+ */
+export type SessionScriptWriteResult =
+  | { written: true; path: string }
+  | { written: false; error?: AppError };
+
+/**
+ * ADR 0012 decision 6 (Fix 4, C2): trailer comment marking a healed `.ad` as a
+ * COMPLETE, review-worthy repair artifact. An ordinary `#` comment to every
+ * reader (old and new) — it binds to nothing (`parseTargetAnnotationCommentLine`
+ * only recognizes the `target-v1` prefix), so it never participates in the
+ * target-annotation binding rule. Written only when a repair-armed session's
+ * write reaches this point at all, since `write()` already gated that on the
+ * transaction being COMPLETE (`saveScriptComplete`) — so every write carrying
+ * it IS a complete, committed transaction.
+ */
+export const HEAL_COMPLETE_SENTINEL = '# agent-device:heal-complete';
+
+/**
+ * ADR 0012 decision 6, R7 + commit semantics (C2): a repair-armed session is a
+ * live transaction, COMMITTED only on completion — `true` means "do not publish
+ * now":
+ * - Already committed -> idempotent no-op (never a duplicate/second write).
+ * - Not COMPLETE (the plan never ran to its last executable step) -> ABORT:
+ *   publish NOTHING. This is what stops a `close`/`close --save-script` issued
+ *   after a divergence but before the plan finishes from committing a PREFIX;
+ *   every non-completion teardown (divergence-only exit, daemon shutdown,
+ *   idle-reap) lands here too.
+ * Ordinary (non-repair) recording is never blocked (no `saveScriptBoundary`).
+ */
+function isRepairArmedWriteBlocked(session: SessionState): boolean {
+  if (session.saveScriptBoundary === undefined) return false;
+  if (session.saveScriptCommitted) return true;
+  return !session.saveScriptComplete;
+}
 
 export class SessionScriptWriter {
   private readonly sessionsDir: string;
@@ -29,22 +71,27 @@ export class SessionScriptWriter {
   }
 
   write(session: SessionState): SessionScriptWriteResult {
+    const repairArmed = session.saveScriptBoundary !== undefined;
     let scriptPath: string | undefined;
     try {
       if (!session.recordSession) return { written: false };
+      if (isRepairArmedWriteBlocked(session)) return { written: false };
       scriptPath = this.resolveScriptPath(session);
-      assertNoDefaultedHealedClobber(session, scriptPath);
       const scriptDir = path.dirname(scriptPath);
       if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
-      const script = formatSessionScript(session);
-      fs.writeFileSync(scriptPath, script);
+      const script = formatSessionScript(session, repairArmed);
+      publishHealedScriptAtomically({
+        scriptPath,
+        script,
+        // The completeness-aware no-clobber guard protects ONLY the DEFAULT
+        // healed sibling (an explicit `--save-script=<out>` may overwrite as
+        // the caller directed).
+        protectComplete: Boolean(session.saveScriptDefaultedHealedPath),
+      });
+      // COMMITTED: idempotent guard above + teardown's abort/tombstone routing.
+      if (repairArmed) session.saveScriptCommitted = true;
       return { written: true, path: scriptPath };
     } catch (error) {
-      // ADR 0012 decision 6, R4: an AppError here means the script would be
-      // unreplayable (a bare `@ref` that never resolved to a selector) —
-      // that must fail loud, not be swallowed into a quiet `{written:
-      // false}` like an ordinary fs write failure below.
-      if (error instanceof AppError) throw error;
       emitDiagnostic({
         level: 'warn',
         phase: 'session_script_write_failed',
@@ -54,6 +101,17 @@ export class SessionScriptWriter {
           error: error instanceof Error ? error.message : String(error),
         },
       });
+      // ADR 0012 decision 6, R4 + BLOCKER 2: a repair COMMIT failure must be
+      // SURFACED (no-clobber refusal, bare-`@ref`, or a filesystem error alike)
+      // so close/teardown can report it and keep the session for retry — never
+      // swallowed into a silent `{written:false}`. Ordinary (non-repair)
+      // recording keeps its existing behavior: an unexpected AppError still
+      // fails loud (none is raised on that path today), an fs error is a quiet
+      // skip.
+      if (repairArmed) {
+        return { written: false, error: toRepairCommitFailure(error, scriptPath) };
+      }
+      if (error instanceof AppError) throw error;
       return { written: false };
     }
   }
@@ -69,8 +127,80 @@ export class SessionScriptWriter {
   }
 }
 
-function formatSessionScript(session: SessionState): string {
-  return formatScript(session, buildOptimizedActions(session));
+/**
+ * ADR 0012 decision 6 (BLOCKER 2c): normalizes a repair-commit failure into a
+ * distinct, surfaceable AppError. A no-clobber refusal or a bare-`@ref` failure
+ * arrives as an AppError already (with its own message) and passes through
+ * unchanged; anything else is a filesystem write failure, wrapped with a clear
+ * message and hint so the two are distinguishable to the agent.
+ */
+function toRepairCommitFailure(error: unknown, scriptPath: string | undefined): AppError {
+  if (error instanceof AppError) return error;
+  const detail = error instanceof Error ? error.message : String(error);
+  return new AppError(
+    'COMMAND_FAILED',
+    `Failed to write the healed script${scriptPath ? ` to ${scriptPath}` : ''}: ${detail}`,
+    {
+      hint: 'The repair transaction completed but the healed .ad could not be published; check the target path and permissions, then retry close --save-script.',
+    },
+  );
+}
+
+function formatSessionScript(session: SessionState, appendCompleteSentinel: boolean): string {
+  return formatScript(session, buildOptimizedActions(session), appendCompleteSentinel);
+}
+
+/**
+ * ADR 0012 decision 6, commit semantics + no-clobber (Fix 4, C5b): publishes
+ * `script` to `scriptPath` atomically AND race-safely.
+ *
+ * - Atomic: the temp file is created in the SAME DIRECTORY as the target
+ *   (never `/tmp`), so the final publish is an intra-directory rename/link on
+ *   one filesystem — a reader never observes a half-written script, and an
+ *   explicit `--save-script=<path>` on a different mount still publishes
+ *   atomically. An aborted write leaves only the (removed) temp, no partial
+ *   at the target.
+ * - Race-safe no-clobber: the absent-target case publishes via `linkSync`,
+ *   which fails atomically with `EEXIST` if a file appeared meanwhile — there
+ *   is no check-then-write TOCTOU window against a COMPLETE artifact. Only
+ *   after confirming the existing file is incomplete/unprotected do we
+ *   overwrite it via rename.
+ */
+function publishHealedScriptAtomically(params: {
+  scriptPath: string;
+  script: string;
+  protectComplete: boolean;
+}): void {
+  const { scriptPath, script, protectComplete } = params;
+  const dir = path.dirname(scriptPath);
+  const tempPath = path.join(
+    dir,
+    `.${path.basename(scriptPath)}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  fs.writeFileSync(tempPath, script);
+  try {
+    try {
+      // Atomic create-if-absent: EEXIST iff the target already exists.
+      fs.linkSync(tempPath, scriptPath);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    }
+    // The target exists. A COMPLETE (sentinel-marked) default healed artifact
+    // is review-worthy and must never be silently clobbered; an incomplete or
+    // partial one is always overwritable by a fresh repair that completes.
+    if (protectComplete && isCompleteHealedScript(scriptPath)) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,
+      );
+    }
+    fs.renameSync(tempPath, scriptPath);
+  } finally {
+    // linkSync leaves the temp hard-link behind on success; rename consumes it;
+    // an error leaves it — always clean up whatever remains.
+    fs.rmSync(tempPath, { force: true });
+  }
 }
 
 function buildOptimizedActions(session: SessionState): SessionAction[] {
@@ -119,22 +249,22 @@ function assertNoUnresolvedRefFallback(action: SessionAction): void {
 }
 
 /**
- * ADR 0012 decision 6 (P2): the default `<original-stem>.healed.ad` sibling
- * path is deterministic, so a second repair against the same original would
- * silently clobber an unreviewed prior healed script — undercutting the
- * ADR's "a human reviews the diff and promotes it." Refuse loudly (fail-loud
- * per R4's philosophy) unless the caller passes an explicit
- * `--save-script=<path>` (which clears the defaulted flag). Only guards the
- * DEFAULT healed path; an explicit `<out>` may overwrite as the caller
- * directed.
+ * ADR 0012 decision 6, no-clobber (Fix 4, C5b): a file is a COMPLETE,
+ * review-worthy healed artifact iff it carries the completeness sentinel
+ * (written only on a successful atomic commit). A file without it is a partial
+ * — from an aborted/reaped repair — and is freely overwritable by a fresh
+ * repair that completes.
  */
-function assertNoDefaultedHealedClobber(session: SessionState, scriptPath: string): void {
-  if (!session.saveScriptDefaultedHealedPath) return;
-  if (!fs.existsSync(scriptPath)) return;
-  throw new AppError(
-    'COMMAND_FAILED',
-    `A prior healed script already exists at ${scriptPath}; pass replay --save-script=<path> to write elsewhere, or remove/rename it first, so an unreviewed healed script is never clobbered.`,
-  );
+function isCompleteHealedScript(scriptPath: string): boolean {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(scriptPath, 'utf8');
+  } catch {
+    // Missing (nothing to clobber) or unreadable (not provably complete
+    // either way — never block the repair behind a file we cannot inspect).
+    return false;
+  }
+  return contents.split(/\r?\n/).some((line) => line.trim() === HEAL_COMPLETE_SENTINEL);
 }
 
 function optimizeSelectorChainAction(action: SessionAction): SessionAction | undefined {
@@ -212,7 +342,11 @@ function buildScopedSnapshotAction(
   };
 }
 
-function formatScript(session: SessionState, actions: SessionAction[]): string {
+function formatScript(
+  session: SessionState,
+  actions: SessionAction[],
+  appendCompleteSentinel: boolean,
+): string {
   const lines: string[] = [];
   const kind = session.device.kind ? ` kind=${session.device.kind}` : '';
   const theme = 'unknown';
@@ -225,6 +359,10 @@ function formatScript(session: SessionState, actions: SessionAction[]): string {
     lines.push(...formatTargetAnnotationLines(action));
     lines.push(formatActionLine(action));
   }
+  // ADR 0012 decision 6 (Fix 4): only a repair-armed session's healed script
+  // carries the completeness sentinel — `write()` already refused to reach
+  // here unless it was finalized, so every repair-armed write IS complete.
+  if (appendCompleteSentinel) lines.push(HEAL_COMPLETE_SENTINEL);
   return `${lines.join('\n')}\n`;
 }
 

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -5,6 +5,7 @@ import type { SessionRuntimeHints, SessionState } from './types.ts';
 import { recordActionEntry, type RecordActionEntry } from './session-action-recorder.ts';
 import { expandSessionPath, safeSessionName } from './session-paths.ts';
 import { SessionScriptWriter, type SessionScriptWriteResult } from './session-script-writer.ts';
+import { successText } from '../utils/success-text.ts';
 import {
   appendActionEvent,
   appendSessionEvent,
@@ -122,8 +123,17 @@ export class SessionStore {
   }
 
   /**
-   * ADR 0012 decision 6, R7 + commit semantics (C2/C5a, BLOCKER 2): the
+   * ADR 0012 decision 6, R7 + commit semantics (C2/C5a, BLOCKER 2/3): the
    * teardown finalize step for a session (idle-reap or daemon shutdown).
+   *
+   * BLOCKER 3: unlike the explicit `close --save-script` path
+   * (`commitRepairBeforeClose`), teardown never runs `close`'s handler — but
+   * the source plan's terminal `close` was already skipped-while-armed (Fix
+   * 3), so a COMPLETE transaction's auto-commit here must record the same
+   * synthetic finalize `close` first, or the auto-committed healed `.ad`
+   * would be missing its own terminal `close` (not self-contained, unlike an
+   * explicit close's commit).
+   *
    * `writeSessionLog` commits the healed `.ad` iff the repair transaction
    * COMPLETED (auto-commit on completion, even without an explicit `close`)
    * and otherwise publishes nothing.
@@ -140,6 +150,7 @@ export class SessionStore {
    * (non-repair) sessions beyond the existing `writeSessionLog`.
    */
   finalizeRepairTeardown(session: SessionState): void {
+    this.recordRepairFinalizeCloseIfCommitting(session);
     const result = this.writeSessionLog(session);
     if (session.saveScriptBoundary !== undefined && session.saveScriptCommitted !== true) {
       if (!result.written && result.error) {
@@ -151,6 +162,26 @@ export class SessionStore {
         this.writeRepairTombstone(session);
       }
     }
+  }
+
+  /**
+   * BLOCKER 3: mirrors `commitRepairBeforeClose`'s finalize-`close` recording
+   * (session-close.ts) for the auto-commit teardown path, which never routes
+   * through `close`'s handler. Only recorded when this teardown is actually
+   * about to attempt a commit (COMPLETE, not yet COMMITTED) — an aborted
+   * (incomplete) transaction's write is a no-op regardless, so there is
+   * nothing to make self-contained.
+   */
+  private recordRepairFinalizeCloseIfCommitting(session: SessionState): void {
+    if (session.saveScriptBoundary === undefined) return;
+    if (session.saveScriptComplete !== true) return;
+    if (session.saveScriptCommitted === true) return;
+    this.recordAction(session, {
+      command: 'close',
+      positionals: [],
+      flags: {},
+      result: { session: session.name, ...successText(`Closed: ${session.name}`) },
+    });
   }
 
   /**

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -225,20 +225,7 @@ export class SessionStore {
 
   /** Returns a non-expired repair tombstone for `sessionName`, or `undefined`. */
   readRepairTombstone(sessionName: string): RepairSessionTombstone | undefined {
-    let raw: string;
-    try {
-      raw = fs.readFileSync(this.repairTombstonePath(sessionName), 'utf8');
-    } catch {
-      return undefined;
-    }
-    let parsed: RepairSessionTombstone;
-    try {
-      parsed = JSON.parse(raw) as RepairSessionTombstone;
-    } catch {
-      return undefined;
-    }
-    if (typeof parsed?.expiresAt !== 'number' || parsed.expiresAt <= Date.now()) return undefined;
-    return parsed;
+    return readTombstoneFile(this.repairTombstonePath(sessionName));
   }
 
   /** ADR 0012 R7 (C5a): a fresh `replay --save-script` on this key clears the tombstone. */
@@ -297,6 +284,63 @@ export class SessionStore {
     }
     return session.name;
   }
+}
+
+/** Parses/validates a tombstone file at `tombstonePath`; `undefined` if missing, malformed, or expired. */
+function readTombstoneFile(tombstonePath: string): RepairSessionTombstone | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(tombstonePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  let parsed: RepairSessionTombstone;
+  try {
+    parsed = JSON.parse(raw) as RepairSessionTombstone;
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed?.expiresAt !== 'number' || parsed.expiresAt <= Date.now()) return undefined;
+  return parsed;
+}
+
+/**
+ * ADR 0012 decision 6 (BLOCKER 2, third follow-up): scans every session
+ * subdirectory under `sessionsDir` for a non-expired repair tombstone that
+ * records an UNRECOVERED commit failure (`commitFailure` set) — used by the
+ * CLIENT side of the daemon boundary (`cleanupDaemonAfterRequest` in
+ * `daemon-client-lifecycle.ts`), which has no live `SessionStore`/session name
+ * to key off of, only the filesystem path an owned ephemeral daemon was given.
+ * An owned ephemeral state dir services exactly one repair transaction at a
+ * time, so the first match found is returned.
+ */
+export function findUnrecoveredRepairCommitFailure(sessionsDir: string):
+  | {
+      sessionName: string;
+      tombstone: RepairSessionTombstone & {
+        commitFailure: NonNullable<RepairSessionTombstone['commitFailure']>;
+      };
+    }
+  | undefined {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const tombstone = readTombstoneFile(
+      path.join(sessionsDir, entry.name, 'repair-tombstone.json'),
+    );
+    if (tombstone?.commitFailure) {
+      return {
+        sessionName: entry.name,
+        tombstone: { ...tombstone, commitFailure: tombstone.commitFailure },
+      };
+    }
+  }
+  return undefined;
 }
 
 /** Path to session-scoped platform subprocess output, such as Apple runner xcodebuild logs. */

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -26,6 +26,16 @@ export type RepairSessionTombstone = {
   reapedAt: number;
   expiresAt: number;
   sourcePath?: string;
+  /**
+   * ADR 0012 decision 6 (BLOCKER 2): set iff this tombstone marks a COMPLETE
+   * transaction whose commit FAILED at teardown (no-clobber refusal, bare
+   * `@ref`, or a filesystem write error) — as opposed to a transaction that
+   * was merely reaped before it ever finished. Preserves the real failure
+   * instead of losing it behind a generic "reaped before it was finalized"
+   * expiry, so `repairExpiredIfTombstoned` can surface a distinct
+   * `REPAIR_COMMIT_FAILED` with the actual cause.
+   */
+  commitFailure?: { code: string; message: string };
 };
 
 const REPAIR_TOMBSTONE_TTL_MS = 60 * 60_000;
@@ -112,30 +122,53 @@ export class SessionStore {
   }
 
   /**
-   * ADR 0012 decision 6, R7 + commit semantics (C2/C5a): the teardown finalize
-   * step for a session (idle-reap or daemon shutdown). `writeSessionLog` commits
-   * the healed `.ad` iff the repair transaction COMPLETED (auto-commit on
-   * completion, even without an explicit `close`) and otherwise publishes
-   * nothing; a repair-armed session torn down WITHOUT committing then leaves a
-   * bounded `REPAIR_SESSION_EXPIRED` tombstone so the agent's next command gets
-   * actionable re-run guidance rather than a bare SESSION_NOT_FOUND. A no-op for
-   * ordinary (non-repair) sessions beyond the existing `writeSessionLog`.
+   * ADR 0012 decision 6, R7 + commit semantics (C2/C5a, BLOCKER 2): the
+   * teardown finalize step for a session (idle-reap or daemon shutdown).
+   * `writeSessionLog` commits the healed `.ad` iff the repair transaction
+   * COMPLETED (auto-commit on completion, even without an explicit `close`)
+   * and otherwise publishes nothing.
+   *
+   * BLOCKER 2: a COMPLETE transaction's commit can still FAIL here (no-clobber
+   * refusal, bare-`@ref`, or a filesystem error) — that failure must not be
+   * lost behind a generic "reaped before it was finalized" tombstone, since
+   * daemon teardown deletes the session right after this call, discarding the
+   * only in-memory record of what happened. Preserve it in a distinct
+   * commit-failure tombstone instead, so the agent's next command surfaces
+   * the real cause (`REPAIR_COMMIT_FAILED`) rather than a misleading expiry.
+   * A repair-armed session torn down WITHOUT ever completing still leaves the
+   * ordinary bounded `REPAIR_SESSION_EXPIRED` tombstone. A no-op for ordinary
+   * (non-repair) sessions beyond the existing `writeSessionLog`.
    */
   finalizeRepairTeardown(session: SessionState): void {
-    this.writeSessionLog(session);
+    const result = this.writeSessionLog(session);
     if (session.saveScriptBoundary !== undefined && session.saveScriptCommitted !== true) {
-      this.writeRepairTombstone(session);
+      if (!result.written && result.error) {
+        this.writeRepairTombstone(session, REPAIR_TOMBSTONE_TTL_MS, {
+          code: String(result.error.code),
+          message: result.error.message,
+        });
+      } else {
+        this.writeRepairTombstone(session);
+      }
     }
   }
 
   /**
-   * ADR 0012 decision 6, R7 (C5a): drops a bounded tombstone for a repair-armed
-   * session reaped/torn down before it committed, so a later command targeting
-   * the same session key surfaces `REPAIR_SESSION_EXPIRED` with a re-run hint
-   * instead of a bare `SESSION_NOT_FOUND`. Best effort — a tombstone-write
-   * failure never blocks teardown.
+   * ADR 0012 decision 6, R7 (C5a, BLOCKER 2): drops a bounded tombstone for a
+   * repair-armed session reaped/torn down before it committed, so a later
+   * command targeting the same session key surfaces `REPAIR_SESSION_EXPIRED`
+   * with a re-run hint instead of a bare `SESSION_NOT_FOUND`. When
+   * `commitFailure` is supplied (a COMPLETE transaction's commit attempt
+   * FAILED, rather than the transaction never completing), it is preserved on
+   * the tombstone so the router can surface `REPAIR_COMMIT_FAILED` with the
+   * real cause instead. Best effort — a tombstone-write failure never blocks
+   * teardown.
    */
-  writeRepairTombstone(session: SessionState, ttlMs = REPAIR_TOMBSTONE_TTL_MS): void {
+  writeRepairTombstone(
+    session: SessionState,
+    ttlMs = REPAIR_TOMBSTONE_TTL_MS,
+    commitFailure?: { code: string; message: string },
+  ): void {
     try {
       const dir = this.resolveSessionDir(session.name);
       fs.mkdirSync(dir, { recursive: true });
@@ -144,6 +177,7 @@ export class SessionStore {
         reapedAt: Date.now(),
         expiresAt: Date.now() + ttlMs,
         ...(session.repairSourcePath ? { sourcePath: session.repairSourcePath } : {}),
+        ...(commitFailure ? { commitFailure } : {}),
       };
       fs.writeFileSync(this.repairTombstonePath(session.name), `${JSON.stringify(tombstone)}\n`);
     } catch (error) {

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -4,7 +4,7 @@ import { emitDiagnostic } from '../utils/diagnostics.ts';
 import type { SessionRuntimeHints, SessionState } from './types.ts';
 import { recordActionEntry, type RecordActionEntry } from './session-action-recorder.ts';
 import { expandSessionPath, safeSessionName } from './session-paths.ts';
-import { SessionScriptWriter } from './session-script-writer.ts';
+import { SessionScriptWriter, type SessionScriptWriteResult } from './session-script-writer.ts';
 import {
   appendActionEvent,
   appendSessionEvent,
@@ -14,6 +14,21 @@ import {
   type SessionEventLogInput,
   type SessionEventLogPage,
 } from './session-event-log.ts';
+
+/**
+ * ADR 0012 decision 6, R7 (C5a): a reaped repair session leaves this bounded
+ * marker so the next command on the same key gets `REPAIR_SESSION_EXPIRED` +
+ * re-run guidance, never a bare `SESSION_NOT_FOUND`. Bounded by `expiresAt`
+ * so an old tombstone never shadows an unrelated future session name.
+ */
+export type RepairSessionTombstone = {
+  owner: string;
+  reapedAt: number;
+  expiresAt: number;
+  sourcePath?: string;
+};
+
+const REPAIR_TOMBSTONE_TTL_MS = 60 * 60_000;
 
 export class SessionStore {
   private readonly sessions = new Map<string, SessionState>();
@@ -84,7 +99,7 @@ export class SessionStore {
     );
   }
 
-  writeSessionLog(session: SessionState): void {
+  writeSessionLog(session: SessionState): SessionScriptWriteResult {
     const result = this.scriptWriter.write(session);
     if (result.written) {
       emitDiagnostic({
@@ -93,6 +108,83 @@ export class SessionStore {
         data: { session: session.name, path: result.path },
       });
     }
+    return result;
+  }
+
+  /**
+   * ADR 0012 decision 6, R7 + commit semantics (C2/C5a): the teardown finalize
+   * step for a session (idle-reap or daemon shutdown). `writeSessionLog` commits
+   * the healed `.ad` iff the repair transaction COMPLETED (auto-commit on
+   * completion, even without an explicit `close`) and otherwise publishes
+   * nothing; a repair-armed session torn down WITHOUT committing then leaves a
+   * bounded `REPAIR_SESSION_EXPIRED` tombstone so the agent's next command gets
+   * actionable re-run guidance rather than a bare SESSION_NOT_FOUND. A no-op for
+   * ordinary (non-repair) sessions beyond the existing `writeSessionLog`.
+   */
+  finalizeRepairTeardown(session: SessionState): void {
+    this.writeSessionLog(session);
+    if (session.saveScriptBoundary !== undefined && session.saveScriptCommitted !== true) {
+      this.writeRepairTombstone(session);
+    }
+  }
+
+  /**
+   * ADR 0012 decision 6, R7 (C5a): drops a bounded tombstone for a repair-armed
+   * session reaped/torn down before it committed, so a later command targeting
+   * the same session key surfaces `REPAIR_SESSION_EXPIRED` with a re-run hint
+   * instead of a bare `SESSION_NOT_FOUND`. Best effort — a tombstone-write
+   * failure never blocks teardown.
+   */
+  writeRepairTombstone(session: SessionState, ttlMs = REPAIR_TOMBSTONE_TTL_MS): void {
+    try {
+      const dir = this.resolveSessionDir(session.name);
+      fs.mkdirSync(dir, { recursive: true });
+      const tombstone: RepairSessionTombstone = {
+        owner: session.name,
+        reapedAt: Date.now(),
+        expiresAt: Date.now() + ttlMs,
+        ...(session.repairSourcePath ? { sourcePath: session.repairSourcePath } : {}),
+      };
+      fs.writeFileSync(this.repairTombstonePath(session.name), `${JSON.stringify(tombstone)}\n`);
+    } catch (error) {
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'repair_tombstone_write_failed',
+        data: {
+          session: session.name,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  /** Returns a non-expired repair tombstone for `sessionName`, or `undefined`. */
+  readRepairTombstone(sessionName: string): RepairSessionTombstone | undefined {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.repairTombstonePath(sessionName), 'utf8');
+    } catch {
+      return undefined;
+    }
+    let parsed: RepairSessionTombstone;
+    try {
+      parsed = JSON.parse(raw) as RepairSessionTombstone;
+    } catch {
+      return undefined;
+    }
+    if (typeof parsed?.expiresAt !== 'number' || parsed.expiresAt <= Date.now()) return undefined;
+    return parsed;
+  }
+
+  /** ADR 0012 R7 (C5a): a fresh `replay --save-script` on this key clears the tombstone. */
+  clearRepairTombstone(sessionName: string): void {
+    try {
+      fs.rmSync(this.repairTombstonePath(sessionName), { force: true });
+    } catch {}
+  }
+
+  private repairTombstonePath(sessionName: string): string {
+    return path.join(this.resolveSessionDir(sessionName), 'repair-tombstone.json');
   }
 
   defaultTracePath(session: SessionState): string {
@@ -106,9 +198,7 @@ export class SessionStore {
   }
 
   // Daemon state dir (parent of the `sessions/` dir), matching daemonPaths.baseDir. Called via
-  // sessionStore.resolveDaemonStateDir() in session-open.ts; fallow's class-member tracer does not
-  // resolve it inside a call argument, hence the suppression.
-  // fallow-ignore-next-line unused-class-member
+  // sessionStore.resolveDaemonStateDir() in session-open.ts and session-close.ts.
   resolveDaemonStateDir(): string {
     return path.dirname(this.sessionsDir);
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -287,6 +287,32 @@ export type SessionState = {
    * prior `.healed.ad` diff.
    */
   saveScriptDefaultedHealedPath?: boolean;
+  /**
+   * ADR 0012 decision 6, R7 + commit semantics (C2): the repair TRANSACTION
+   * completion flag. `true` iff the last repair-armed replay run reached its
+   * final EXECUTABLE step with no outstanding divergence (the terminal source
+   * `close` is excluded — C4). Commit is gated on this, NOT merely on a
+   * `close`: `SessionScriptWriter.write` publishes a repair-armed session's
+   * healed `.ad` only when complete, so a `close`/`close --save-script`
+   * issued after a divergence but before the plan finishes discards a prefix
+   * instead of committing it. States: ARMED (`saveScriptBoundary` set,
+   * complete unset) -> COMPLETE (this true) -> COMMITTED (`saveScriptCommitted`).
+   */
+  saveScriptComplete?: boolean;
+  /**
+   * ADR 0012 decision 6 (C2): set by the writer after a repair-armed session's
+   * healed `.ad` is atomically published. Makes re-publish idempotent (a second
+   * `writeSessionLog` no-ops) and lets teardown distinguish a COMMITTED session
+   * (nothing to tombstone) from an aborted/reaped one.
+   */
+  saveScriptCommitted?: boolean;
+  /**
+   * ADR 0012 decision 6, R7 (C5a): the original replay input path of an armed
+   * repair, stashed so an idle-reap tombstone can hand the agent an actionable
+   * `replay <path> --save-script` re-run command instead of a bare
+   * SESSION_NOT_FOUND.
+   */
+  repairSourcePath?: string;
   actions: SessionAction[];
   recording?:
     | (SessionRecordingBase & {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -316,8 +316,26 @@ export type SessionState = {
    * session must consume this flag and skip re-dispatching the platform
    * close rather than invoking a (possibly non-idempotent) backend a second
    * time against an already-closed target.
+   *
+   * BLOCKER 3 (third follow-up): this flag alone is session-wide, not bound
+   * to WHICH close request succeeded — see `repairPlatformCloseIdentity`,
+   * which must ALSO match the retry's own request identity before a retry is
+   * allowed to skip the platform close.
    */
   repairPlatformCloseSucceeded?: boolean;
+  /**
+   * ADR 0012 decision 6 (BLOCKER 3, third follow-up): the identity
+   * (`repairPlatformCloseIdentity` in session-close.ts — currently just the
+   * request's target/positionals, the only thing that changes what the
+   * platform close actually dispatches) of the close request whose platform
+   * close last succeeded. A retry only gets to skip re-dispatching the
+   * platform close when BOTH `repairPlatformCloseSucceeded` is true AND this
+   * matches the retry's own identity — an untargeted close that performed NO
+   * platform operation (so `repairPlatformCloseSucceeded` is trivially true)
+   * must never let a later targeted (or differently-targeted) retry skip the
+   * platform close it never actually ran.
+   */
+  repairPlatformCloseIdentity?: string;
   /**
    * ADR 0012 decision 6, R7 (C5a): the original replay input path of an armed
    * repair, stashed so an idle-reap tombstone can hand the agent an actionable

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -307,6 +307,18 @@ export type SessionState = {
    */
   saveScriptCommitted?: boolean;
   /**
+   * ADR 0012 decision 6 (BLOCKER 3, second follow-up): set the moment a
+   * repair-armed `close`'s targeted platform close returns SUCCESS, cleared
+   * once the transaction commits/tears down (never lingers past a single
+   * close attempt's outcome). If the subsequent commit then FAILS (no-clobber
+   * refusal, a bare-`@ref` failure, or an fs error) the session is retained
+   * for retry — a later `close`/`close --save-script=<other>` on the SAME
+   * session must consume this flag and skip re-dispatching the platform
+   * close rather than invoking a (possibly non-idempotent) backend a second
+   * time against an already-closed target.
+   */
+  repairPlatformCloseSucceeded?: boolean;
+  /**
    * ADR 0012 decision 6, R7 (C5a): the original replay input path of an armed
    * repair, stashed so an idle-reap tombstone can hand the agent an actionable
    * `replay <path> --save-script` re-run command instead of a bare

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -282,9 +282,12 @@ export type SessionState = {
   /**
    * ADR 0012 decision 6: set when `saveScriptPath` was DEFAULTED to the
    * `<original-stem>.healed.ad` sibling (no explicit `--save-script=<out>`).
-   * The writer refuses to clobber an existing default healed script, so a
-   * second repair against the same original never destroys an unreviewed
-   * prior `.healed.ad` diff.
+   * Bookkeeping only — it does not gate the writer's refuse-on-exist
+   * decision, which is uniform regardless of this flag (see
+   * `publishHealedScriptAtomically`): a second repair against the same
+   * original is refused at the default healed sibling exactly like an
+   * explicit `--save-script=<path>` or an ordinary recording's target would
+   * be, never destroying an unreviewed prior `.healed.ad` diff.
    */
   saveScriptDefaultedHealedPath?: boolean;
   /**

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -14,6 +14,7 @@ export type KnownAppErrorCode =
   | 'UNAUTHORIZED'
   | 'AMBIGUOUS_MATCH'
   | 'REPLAY_DIVERGENCE'
+  | 'REPAIR_SESSION_EXPIRED'
   | 'UNKNOWN';
 
 // Intentionally widened with `(string & {})` so daemon-originated codes pass
@@ -245,6 +246,8 @@ export function defaultHintForCode(code: string): string | undefined {
       return 'The device is busy with another agent-device request; retry once it frees up.';
     case 'REPLAY_DIVERGENCE':
       return 'Read details.divergence (screen/suggestions) for repair context, or rerun with --json for the full report.';
+    case 'REPAIR_SESSION_EXPIRED':
+      return 'The --save-script repair session was reaped before it was finalized; re-run replay <script> --save-script from the start.';
     case 'NOT_IMPLEMENTED':
       return 'This command is part of the planned API but is not implemented yet.';
     case 'COMMAND_FAILED':

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -15,6 +15,7 @@ export type KnownAppErrorCode =
   | 'AMBIGUOUS_MATCH'
   | 'REPLAY_DIVERGENCE'
   | 'REPAIR_SESSION_EXPIRED'
+  | 'REPAIR_COMMIT_FAILED'
   | 'UNKNOWN';
 
 // Intentionally widened with `(string & {})` so daemon-originated codes pass
@@ -248,6 +249,8 @@ export function defaultHintForCode(code: string): string | undefined {
       return 'Read details.divergence (screen/suggestions) for repair context, or rerun with --json for the full report.';
     case 'REPAIR_SESSION_EXPIRED':
       return 'The --save-script repair session was reaped before it was finalized; re-run replay <script> --save-script from the start.';
+    case 'REPAIR_COMMIT_FAILED':
+      return 'The repair transaction completed, but committing its healed script failed at teardown (no-clobber refusal or a filesystem error); inspect the target path/permissions, then re-run replay <script> --save-script to retry.';
     case 'NOT_IMPLEMENTED':
       return 'This command is part of the planned API but is not implemented yet.';
     case 'COMMAND_FAILED':

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -114,10 +114,18 @@ export type ReplayDivergenceSuggestion = {
  * are always present. `allowed` is the preflight verdict for resuming AT
  * `from` (`evaluateReplayResumePreflight`); `reason` is present only when
  * `allowed` is `false`.
+ *
+ * `repairSessionHeld` is decision 6, R7's repair-transaction liveness signal
+ * (C1): set `true` by the daemon on ANY divergence from a repair-armed
+ * (`--save-script`) replay — independent of `allowed`, which only reports
+ * plan-resumability. It is the distinct wire signal that the owning
+ * daemon/session was KEPT LIVE and remains addressable for the agent's
+ * corrective actions + `replay --from`/`close`. Absent (never `false`) on a
+ * plain, non-repair divergence, which gets no keep-alive.
  */
 export type ReplayDivergenceResume =
-  | { allowed: true; from: number; planDigest: string }
-  | { allowed: false; from: number; planDigest: string; reason: string };
+  | { allowed: true; from: number; planDigest: string; repairSessionHeld?: true }
+  | { allowed: false; from: number; planDigest: string; reason: string; repairSessionHeld?: true };
 
 export type ReplayDivergenceOverflow = {
   omittedBytes: number;

--- a/src/utils/__tests__/daemon-client-lifecycle.test.ts
+++ b/src/utils/__tests__/daemon-client-lifecycle.test.ts
@@ -967,6 +967,86 @@ test('sendToDaemon tears down an owned ephemeral daemon on an UNHELD divergence 
   }
 });
 
+// --- ADR 0012 decision 6 (BLOCKER 2, third follow-up): a one-shot
+// `replay --save-script` that completes with no divergence returns SUCCESS
+// immediately — the actual healed-script commit is deferred to daemon
+// teardown. If that deferred commit then fails, the daemon leaves a
+// REPAIR_COMMIT_FAILED tombstone in the owned state dir before exiting. The
+// client cleanup must discover it (after waiting for the daemon to actually
+// exit) BEFORE deleting the owned state dir, and must surface it in the
+// response the caller receives — never silently delete the only evidence of
+// the failure while reporting the success already computed for the replay
+// itself. ---
+
+test('BLOCKER 2 (third follow-up): a shutdown-time repair commit failure is surfaced and the owned state dir survives', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  // The daemon's RPC response for the replay itself is a plain SUCCESS (the
+  // plan completed with no divergence) — exactly what a real daemon would
+  // return before its deferred, teardown-time commit has even attempted.
+  const daemon = await startHttpDaemonFixture({ session: 'default' });
+  let ownedStateDir = '';
+  installSpawnedHttpDaemonAtOwnedStateDir(daemon.port, (dir) => {
+    ownedStateDir = dir;
+    // Simulate the daemon's OWN shutdown handler (`finalizeRepairTeardown`)
+    // having already run and left a commit-failure tombstone before this
+    // fake process "exits" — the real ordering `stopDaemonProcessForTakeover`
+    // depends on (it waits for the process to exit, and the real daemon only
+    // exits after teardown finishes writing this file).
+    const ownedPaths = resolveDaemonPaths(dir);
+    const sessionDir = path.join(ownedPaths.sessionsDir, 'default');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, 'repair-tombstone.json'),
+      `${JSON.stringify({
+        owner: 'default',
+        reapedAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+        sourcePath: '/tmp/flow.ad',
+        commitFailure: {
+          code: 'COMMAND_FAILED',
+          message: 'a prior healed script already exists at /tmp/flow.healed.ad',
+        },
+      })}\n`,
+    );
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'replay',
+      positionals: ['flow.ad'],
+      flags: { saveScript: true, daemonTransport: 'http' },
+      meta: { requestId: 'req-repair-commit-fail-teardown' },
+    });
+
+    // The client-visible response must surface the deferred commit failure —
+    // never the raw success the daemon returned for the replay itself, and
+    // never silently swallowed by cleanup.
+    assert.equal(response.ok, false);
+    if (response.ok) return;
+    assert.equal(response.error.code, 'REPAIR_COMMIT_FAILED');
+    assert.match(response.error.message, /a prior healed script already exists/);
+    assert.ok(response.error.message.includes('replay /tmp/flow.ad --save-script'));
+
+    // The owned state dir — and the tombstone evidence inside it — must
+    // survive: never rmSync'd while an unrecovered commit failure is on record.
+    assert.ok(ownedStateDir.length > 0);
+    assert.equal(fs.existsSync(ownedStateDir), true);
+    const ownedPaths = resolveDaemonPaths(ownedStateDir);
+    assert.equal(
+      fs.existsSync(path.join(ownedPaths.sessionsDir, 'default', 'repair-tombstone.json')),
+      true,
+    );
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    if (ownedStateDir) fs.rmSync(ownedStateDir, { recursive: true, force: true });
+  }
+});
+
 test('continuation: sendToDaemon keeps the daemon alive on a held divergence even WITHOUT --save-script on the request', async (t) => {
   if (!(await supportsLoopbackBind())) {
     t.skip('loopback listeners are not permitted in this environment');

--- a/src/utils/__tests__/daemon-client-lifecycle.test.ts
+++ b/src/utils/__tests__/daemon-client-lifecycle.test.ts
@@ -156,6 +156,70 @@ async function startHttpDaemonFixture(
   return { server, port, seenPaths, rpcRequests };
 }
 
+/** Like `startHttpDaemonFixture`, but every RPC call returns `errorResult` as an `{ok:false}` result. */
+async function startHttpDaemonErrorFixture(
+  errorResult: Record<string, unknown>,
+): Promise<HttpDaemonFixture> {
+  const seenPaths: string[] = [];
+  const rpcRequests: Record<string, any>[] = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    seenPaths.push(`${req.method ?? 'GET'} ${url.pathname}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      res.writeHead(200);
+      res.end('ok');
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/rpc') {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      req.on('end', () => {
+        const rpcRequest = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<
+          string,
+          any
+        >;
+        rpcRequests.push(rpcRequest);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpcRequest.id,
+            result: { ok: false, error: errorResult },
+          }),
+        );
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+  const port = await listenOnLoopback(server);
+  return { server, port, seenPaths, rpcRequests };
+}
+
+/** Spawns a fake daemon whose owned (mkdtemp'd) state dir is only known at spawn time. */
+function installSpawnedHttpDaemonAtOwnedStateDir(
+  httpPort: number,
+  onStateDir: (stateDir: string) => void,
+): void {
+  mockRunCmdDetached.mockImplementation((_command, _args, options) => {
+    const ownedStateDir = String(options?.env?.AGENT_DEVICE_STATE_DIR);
+    onStateDir(ownedStateDir);
+    const ownedPaths = resolveDaemonPaths(ownedStateDir);
+    writeDaemonInfo(ownedPaths, { httpPort, transport: 'http' });
+    writeDaemonLock(ownedPaths, {
+      pid: process.pid,
+      processStartTime: readProcessStartTime(process.pid) ?? undefined,
+    });
+    return { pid: process.pid, exited: new Promise(() => {}) };
+  });
+}
+
 async function startHangingHttpDaemonFixture(): Promise<HttpDaemonFixture> {
   const seenPaths: string[] = [];
   const rpcRequests: Record<string, any>[] = [];
@@ -746,5 +810,194 @@ test('sendToDaemon does not replay over HTTP after the socket request is written
     socket.restore();
     await closeLoopbackServer(daemon.server);
     fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// --- ADR 0012 decision 6, R7 (Fix 1, C1): a repair-armed `replay --save-script`
+// that comes back as a HELD divergence (the daemon's `resume.repairSessionHeld`
+// signal) must keep its owning (owned/ephemeral) daemon alive and addressable.
+// The keep-alive keys on that signal — the REPAIR-ARMED condition — NOT on
+// `resume.allowed`, which reports only plan-resumability. ---
+
+function heldDivergenceError(
+  resume: Record<string, unknown> = { allowed: true, from: 3, planDigest: 'digest-abc' },
+): Record<string, unknown> {
+  return {
+    code: 'REPLAY_DIVERGENCE',
+    message: 'Replay failed at step 3 (click id="save"): selector-miss',
+    details: {
+      divergence: {
+        version: 1,
+        kind: 'selector-miss',
+        resume: { ...resume, repairSessionHeld: true },
+        repairHint: 'record-and-heal',
+      },
+    },
+  };
+}
+
+/** A divergence WITHOUT the daemon's held signal — the plain, non-repair case. */
+function unheldDivergenceError(): Record<string, unknown> {
+  return {
+    code: 'REPLAY_DIVERGENCE',
+    message: 'Replay failed at step 2 (click id="save"): selector-miss',
+    details: {
+      divergence: {
+        version: 1,
+        kind: 'selector-miss',
+        resume: { allowed: true, from: 2, planDigest: 'digest-def' },
+        repairHint: 'manual',
+      },
+    },
+  };
+}
+
+test('sendToDaemon keeps an owned ephemeral daemon alive and hints its --state-dir on a resumable repair divergence', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const daemon = await startHttpDaemonErrorFixture(heldDivergenceError());
+  let ownedStateDir = '';
+  installSpawnedHttpDaemonAtOwnedStateDir(daemon.port, (dir) => {
+    ownedStateDir = dir;
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'replay',
+      positionals: ['drifted.ad'],
+      flags: { saveScript: true, daemonTransport: 'http' },
+      meta: { requestId: 'req-repair-keep-alive' },
+    });
+
+    assert.equal(response.ok, false);
+    if (response.ok) return;
+    assert.equal(response.error.code, 'REPLAY_DIVERGENCE');
+    assert.ok(ownedStateDir.length > 0);
+    assert.match(String(response.error.hint), /--state-dir/);
+    assert.ok(String(response.error.hint).includes(ownedStateDir));
+
+    // The daemon was NOT torn down: metadata and the owned state dir itself
+    // are still on disk, addressable by a follow-up command's --state-dir.
+    const ownedPaths = resolveDaemonPaths(ownedStateDir);
+    assert.equal(fs.existsSync(ownedPaths.infoPath), true);
+    assert.equal(fs.existsSync(ownedPaths.lockPath), true);
+    assert.equal(fs.existsSync(ownedStateDir), true);
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    if (ownedStateDir) fs.rmSync(ownedStateDir, { recursive: true, force: true });
+  }
+});
+
+test('C1: keep-alive keys on repairSessionHeld, NOT resume.allowed — a HELD divergence with allowed:false still keeps the daemon alive', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  // resume.allowed:false (plan not resumable), but the daemon still HELD the
+  // repair session — the agent must be able to reach it to close/inspect.
+  const daemon = await startHttpDaemonErrorFixture(
+    heldDivergenceError({
+      allowed: false,
+      from: 2,
+      planDigest: 'digest-x',
+      reason: 'output-env-skip',
+    }),
+  );
+  let ownedStateDir = '';
+  installSpawnedHttpDaemonAtOwnedStateDir(daemon.port, (dir) => {
+    ownedStateDir = dir;
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'replay',
+      positionals: ['drifted.ad'],
+      flags: { saveScript: true, daemonTransport: 'http' },
+      meta: { requestId: 'req-held-not-resumable' },
+    });
+
+    assert.equal(response.ok, false);
+    if (response.ok) return;
+    assert.match(String(response.error.hint), /--state-dir/);
+    assert.ok(ownedStateDir.length > 0);
+    assert.equal(fs.existsSync(ownedStateDir), true);
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    if (ownedStateDir) fs.rmSync(ownedStateDir, { recursive: true, force: true });
+  }
+});
+
+test('sendToDaemon tears down an owned ephemeral daemon on an UNHELD divergence (no repairSessionHeld signal)', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const daemon = await startHttpDaemonErrorFixture(unheldDivergenceError());
+  let ownedStateDir = '';
+  installSpawnedHttpDaemonAtOwnedStateDir(daemon.port, (dir) => {
+    ownedStateDir = dir;
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'replay',
+      positionals: ['drifted.ad'],
+      flags: { saveScript: true, daemonTransport: 'http' },
+      meta: { requestId: 'req-repair-no-keep-alive' },
+    });
+
+    assert.equal(response.ok, false);
+    if (response.ok) return;
+    assert.equal(response.error.hint, undefined);
+    assert.ok(ownedStateDir.length > 0);
+    // No held signal (`resume.allowed:true` alone is not the keep-alive key) —
+    // ordinary one-shot teardown still applies.
+    assert.equal(fs.existsSync(ownedStateDir), false);
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    if (ownedStateDir) fs.rmSync(ownedStateDir, { recursive: true, force: true });
+  }
+});
+
+test('continuation: sendToDaemon keeps the daemon alive on a held divergence even WITHOUT --save-script on the request', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  // The `replay --from` continuation of a repair does NOT repeat --save-script
+  // (R2); the daemon still sets `repairSessionHeld` from the PERSISTED armed
+  // state, so the client — keying purely off that signal — must keep the daemon
+  // alive if the continuation itself diverges, keeping the transaction going.
+  const daemon = await startHttpDaemonErrorFixture(heldDivergenceError());
+  let ownedStateDir = '';
+  installSpawnedHttpDaemonAtOwnedStateDir(daemon.port, (dir) => {
+    ownedStateDir = dir;
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'replay',
+      positionals: ['drifted.ad'],
+      flags: { replayFrom: 3, replayPlanDigest: 'digest-abc', daemonTransport: 'http' },
+      meta: { requestId: 'req-continuation-no-save-script' },
+    });
+
+    assert.equal(response.ok, false);
+    if (response.ok) return;
+    assert.ok(ownedStateDir.length > 0);
+    assert.equal(fs.existsSync(ownedStateDir), true);
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    if (ownedStateDir) fs.rmSync(ownedStateDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Implements the four "repair transaction" lifecycle fixes for ADR-0012 Decision 6 (agent-supervised re-record repair, #1228), closing real end-to-end gaps found in live testing.

Unifying model: `replay <file>.ad --save-script` opens a multi-invocation repair TRANSACTION (`ARMED → COMPLETE → COMMITTED`). It is committed (the healed `.ad` atomically published) on **any teardown** of the session — explicit `close`, idle-reap, or daemon shutdown — but **only when the transaction is `COMPLETE`**; a teardown while INCOMPLETE never publishes a prefix. Continuation keys off **persisted** transaction state, so `replay --from` continues without repeating `--save-script`. Everything below serves that model.

- **Fix 1 (Q1)** — `cleanupDaemonAfterRequest` (`src/daemon/client/daemon-client-lifecycle.ts`) no longer tears down a cold, owned-ephemeral daemon when a repair-armed replay returns a held `REPLAY_DIVERGENCE`. Keep-alive keys off the daemon's `resume.repairSessionHeld` signal (`markRepairSessionHeldIfArmed`, set from **persisted** armed-uncommitted session state — not the per-request `--save-script` flag, so a `replay --from` continuation that itself diverges stays held) via `isHeldRepairDivergence`; it is independent of `resume.allowed` (plan-resumability). Because an owned/ephemeral state dir (`fs.mkdtempSync`) is otherwise unaddressable by the agent's next command, the response carries a `hint` pointing at `--state-dir <path>` (`attachRepairSessionAddressHint`, `src/daemon/client/daemon-client.ts`).
- **Fix 2 (Q2a)** — `SessionScriptWriter.write` (`src/daemon/session-script-writer.ts`) publishes a repair-armed session's (`saveScriptBoundary` set) healed `.ad` only when the transaction is `COMPLETE` (`isRepairArmedWriteBlocked` gates on `saveScriptComplete`, idempotent once `saveScriptCommitted`). Commit happens at **any** teardown of a COMPLETE transaction — explicit `close`, idle-reap, and daemon shutdown all route through `finalizeRepairTeardown` (`src/daemon/session-store.ts`) → the writer. A teardown while INCOMPLETE publishes nothing (never a prefix): a plain `close` discards; an idle-reap/shutdown leaves a `REPAIR_SESSION_EXPIRED` tombstone (surfaced by `request-router`), and `hasReapBlockingOpenSessions` (`src/daemon/handlers/daemon-idle-reap.ts`) lets an uncommitted repair session reap rather than pinning the daemon forever.
- **Fix 3 (Q2b)** — the source plan's own terminal `close` is skipped (`isRepairArmedTerminalClose`, `src/daemon/handlers/session-replay-runtime.ts`) while a repair is armed, instead of dispatching as an ordinary step and diverging on lifecycle. Verification already exempted unannotated actions from target-binding divergence kinds (`verifyReplayActionTarget`); the fix removes the remaining `action-failure` misfire by never dispatching it at all during repair.
- **Fix 4 (Q2c)** — scripts publish atomically via create-exclusive `linkSync`, with the temp file created in the target's own directory (`publishHealedScriptAtomically`). The publish contract is uniformly no-clobber: repair heals and ordinary recordings, default and explicit `--save-script=<path>` targets, and complete or partial existing files are all refused and left byte-for-byte unchanged. A `--force`/`--overwrite` escape hatch is tracked separately in #1258. Completed repair artifacts carry a `# agent-device:heal-complete` sentinel.

## Files touched

- `src/daemon/client/daemon-client-lifecycle.ts` — `cleanupDaemonAfterRequest` (+`isResumableRepairDivergence`, `attachRepairSessionAddressHint`)
- `src/daemon/client/daemon-client.ts` — `sendToDaemon` (+`withRepairSessionAddressHintIfOwned`)
- `src/daemon/session-script-writer.ts` — `SessionScriptWriter.write`, `isRepairArmedWriteBlocked`, `HEAL_COMPLETE_SENTINEL`, `publishHealedScriptAtomically`, `assertNoCompleteHealedClobber`
- `src/daemon/session-store.ts` — `finalizeRepairTeardown` (commit-or-tombstone at teardown)
- `src/daemon/handlers/session-replay-runtime.ts` — `isRepairArmedTerminalClose`, `markRepairSessionHeldIfArmed`, `createReplaySaveScriptArmer`, `preflightReplayAgainstActiveRepair`, sets `saveScriptComplete` at plan completion
- `src/daemon/request-router.ts` — `REPAIR_SESSION_EXPIRED` for a reaped uncommitted repair session (tombstone)
- `src/daemon/handlers/daemon-idle-reap.ts` — `hasReapBlockingOpenSessions`
- `src/daemon/types.ts` — `SessionState.saveScriptComplete`/`saveScriptCommitted`/`saveScriptBoundary`; `resume.repairSessionHeld`

## New tests

- `src/utils/__tests__/daemon-client-lifecycle.test.ts`: keeps an owned daemon alive + hints `--state-dir` on a resumable divergence; still tears down on a non-resumable divergence; still tears down without `--save-script`.
- `src/daemon/__tests__/session-script-writer.test.ts`: discards an unfinalized repair-armed write; never sentinel-tags ordinary recordings; refuses every pre-existing target without changing its bytes (complete, partial, explicit, and ordinary-recording cases); permits absent targets; proves first-writer-wins atomic publication and leaves no stray temp file.
- `src/daemon/handlers/__tests__/session-replay-repair-loop.test.ts`: terminal close skipped while armed; ordinary replay still dispatches its close; only the *terminal* close is skipped (mid-plan close still dispatches); a `--from` resume landing on the terminal close completes instead of diverging.
- `src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts` (new): **end-to-end chain** — cold divergence stays alive (session never deleted) → corrective press + `--from` resume runs to completion (terminal close skipped) → `close --save-script` commits a complete, atomically-published healed `.ad` with no bare `@ref`s → a separate diverged-and-abandoned repair (`close` without `--save-script`) leaves no partial file on disk.

## Test plan

- [x] `npx vitest run` — full suite: 467 files / 4097 tests, all green
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint --deny-warnings` — clean
- [x] `npx oxfmt --check` — clean on all touched files (37 pre-existing unrelated files were already failing on `origin/main` before this change)
- [x] `pnpm check:fallow --base origin/main` — no issues in 11 changed files

## Live route evidence

A simulator run on route-equivalent head `6beb13f5f` exercised the production repair workflow: a held divergence preserved the session, corrective interaction plus `replay --from` completed the plan, `close --save-script` published the complete healed script, and a fresh replay consumed that artifact successfully. Later commits changed daemon/filesystem publication, teardown-failure reporting, and close-retry identity rather than platform behavior; focused boundary regressions and the fully green platform smoke matrix cover those changes, so another device run is not required.

No device-lease semantics were changed beyond the session staying open (`hasOpenSessions`) for the repair transaction's lifetime.

