### PR TITLE
fix: support physical iOS close with Xcode 26

### DIFF
--- a/src/platforms/apple/core/__tests__/app-launch-close.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-close.test.ts
@@ -51,7 +51,7 @@ test('closeIosApp terminates a physical iOS app by its resolved process ID', asy
   });
 
   const terminateCall = calls.at(-1);
-  assert.deepEqual(terminateCall?.slice(0, 7), [
+  assert.deepEqual(terminateCall?.slice(0, 8), [
     'device',
     'process',
     'terminate',
@@ -59,6 +59,7 @@ test('closeIosApp terminates a physical iOS app by its resolved process ID', asy
     IOS_DEVICE.id,
     '--pid',
     '421',
+    '--kill',
   ]);
   assert.equal(terminateCall?.includes('--json-output'), true);
   assert.equal(terminateCall?.includes(APP_BUNDLE_ID), false);

--- a/src/platforms/apple/core/__tests__/app-launch-close.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-close.test.ts
@@ -38,6 +38,8 @@ test('closeIosApp terminates a physical iOS app by its resolved process ID', asy
               ],
             },
           });
+        } else if (args.includes('terminate')) {
+          await writeJsonOutput(args, { info: { outcome: 'success' } });
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       },
@@ -48,7 +50,8 @@ test('closeIosApp terminates a physical iOS app by its resolved process ID', asy
     await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
   });
 
-  assert.deepEqual(calls.at(-1), [
+  const terminateCall = calls.at(-1);
+  assert.deepEqual(terminateCall?.slice(0, 7), [
     'device',
     'process',
     'terminate',
@@ -57,7 +60,28 @@ test('closeIosApp terminates a physical iOS app by its resolved process ID', asy
     '--pid',
     '421',
   ]);
-  assert.equal(calls.at(-1)?.includes(APP_BUNDLE_ID), false);
+  assert.equal(terminateCall?.includes('--json-output'), true);
+  assert.equal(terminateCall?.includes(APP_BUNDLE_ID), false);
+});
+
+test('closeIosApp tolerates the process exiting after PID resolution', async () => {
+  await withAppleToolProvider(createTerminateFailureProvider(3), async () => {
+    await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
+  });
+});
+
+test('closeIosApp preserves termination failures other than an exited process', async () => {
+  await assert.rejects(
+    () =>
+      withAppleToolProvider(createTerminateFailureProvider(1), async () => {
+        await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.message, 'Failed to terminate iOS app');
+      return true;
+    },
+  );
 });
 
 test('closeIosApp reports the required devicectl process-list API', async () => {
@@ -139,4 +163,39 @@ async function writeJsonOutput(args: string[], payload: unknown): Promise<void> 
   const outputPath = args[outputIndex + 1];
   assert.ok(outputPath);
   await fs.writeFile(outputPath, JSON.stringify(payload), 'utf8');
+}
+
+function createTerminateFailureProvider(underlyingCode: number) {
+  return createLocalAppleToolProvider({
+    devicectl: {
+      run: async (args) => {
+        if (args.slice(0, 4).join(' ') === 'device info apps --device') {
+          await writeJsonOutput(args, {
+            result: {
+              apps: [{ bundleIdentifier: APP_BUNDLE_ID, name: 'Demo', url: APP_BUNDLE_URL }],
+            },
+          });
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (args.slice(0, 4).join(' ') === 'device info processes --device') {
+          await writeJsonOutput(args, {
+            result: {
+              runningProcesses: [{ executable: `${APP_BUNDLE_URL}Demo`, processIdentifier: 421 }],
+            },
+          });
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        await writeJsonOutput(args, {
+          error: {
+            userInfo: {
+              NSUnderlyingError: {
+                error: { code: underlyingCode, domain: 'NSPOSIXErrorDomain' },
+              },
+            },
+          },
+        });
+        return { exitCode: 1, stdout: '', stderr: 'Process termination failed.' };
+      },
+    },
+  });
 }

--- a/src/platforms/apple/core/__tests__/app-launch-close.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-close.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+
+import { test } from 'vitest';
+
+import { IOS_DEVICE } from '../../../../__tests__/test-utils/index.ts';
+import { AppError } from '../../../../kernel/errors.ts';
+import { closeIosApp } from '../app-launch.ts';
+import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
+
+const APP_BUNDLE_ID = 'com.example.demo';
+const APP_BUNDLE_URL = 'file:///private/var/containers/Bundle/Application/ABC123/Demo.app/';
+
+test('closeIosApp terminates a physical iOS app by its resolved process ID', async () => {
+  const calls: string[][] = [];
+  const provider = createLocalAppleToolProvider({
+    devicectl: {
+      run: async (args) => {
+        calls.push(args);
+        if (args.slice(0, 4).join(' ') === 'device info apps --device') {
+          await writeJsonOutput(args, {
+            result: {
+              apps: [{ bundleIdentifier: APP_BUNDLE_ID, name: 'Demo', url: APP_BUNDLE_URL }],
+            },
+          });
+        } else if (args.slice(0, 4).join(' ') === 'device info processes --device') {
+          await writeJsonOutput(args, {
+            result: {
+              runningProcesses: [
+                {
+                  executable: `${APP_BUNDLE_URL}PlugIns/Share.appex/Share`,
+                  processIdentifier: 422,
+                },
+                {
+                  executable: `${APP_BUNDLE_URL}Demo`,
+                  processIdentifier: 421,
+                },
+              ],
+            },
+          });
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+  });
+
+  await withAppleToolProvider(provider, async () => {
+    await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
+  });
+
+  assert.deepEqual(calls.at(-1), [
+    'device',
+    'process',
+    'terminate',
+    '--device',
+    IOS_DEVICE.id,
+    '--pid',
+    '421',
+  ]);
+  assert.equal(calls.at(-1)?.includes(APP_BUNDLE_ID), false);
+});
+
+test('closeIosApp reports the required devicectl process-list API', async () => {
+  const provider = createLocalAppleToolProvider({
+    devicectl: {
+      run: async (args) => {
+        if (args.slice(0, 4).join(' ') === 'device info apps --device') {
+          await writeJsonOutput(args, {
+            result: {
+              apps: [{ bundleIdentifier: APP_BUNDLE_ID, name: 'Demo', url: APP_BUNDLE_URL }],
+            },
+          });
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        return {
+          exitCode: 64,
+          stdout: '',
+          stderr: "Error: Unknown subcommand 'processes'",
+        };
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      withAppleToolProvider(provider, async () => {
+        await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.message, 'Failed to list iOS processes');
+      assert.match(String(error.details?.hint), /devicectl device info processes/);
+      assert.match(String(error.details?.stderr), /Unknown subcommand 'processes'/);
+      return true;
+    },
+  );
+});
+
+test('closeIosApp fails closed when devicectl changes the process-list response shape', async () => {
+  const calls: string[][] = [];
+  const provider = createLocalAppleToolProvider({
+    devicectl: {
+      run: async (args) => {
+        calls.push(args);
+        if (args.slice(0, 4).join(' ') === 'device info apps --device') {
+          await writeJsonOutput(args, {
+            result: {
+              apps: [{ bundleIdentifier: APP_BUNDLE_ID, name: 'Demo', url: APP_BUNDLE_URL }],
+            },
+          });
+        } else if (args.slice(0, 4).join(' ') === 'device info processes --device') {
+          await writeJsonOutput(args, { result: { processes: [] } });
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      withAppleToolProvider(provider, async () => {
+        await closeIosApp(IOS_DEVICE, APP_BUNDLE_ID);
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.message, 'Unsupported iOS process list response');
+      assert.match(String(error.details?.hint), /JSON runningProcesses/);
+      return true;
+    },
+  );
+  assert.equal(
+    calls.some((args) => args.includes('terminate')),
+    false,
+  );
+});
+
+async function writeJsonOutput(args: string[], payload: unknown): Promise<void> {
+  const outputIndex = args.indexOf('--json-output');
+  const outputPath = args[outputIndex + 1];
+  assert.ok(outputPath);
+  await fs.writeFile(outputPath, JSON.stringify(payload), 'utf8');
+}

--- a/src/platforms/apple/core/app-launch.ts
+++ b/src/platforms/apple/core/app-launch.ts
@@ -15,7 +15,7 @@ import {
   resolveIosDeviceDeepLinkBundleId,
 } from '../../../contracts/open-target.ts';
 import { IOS_APP_LAUNCH_TIMEOUT_MS, IOS_SIMULATOR_TERMINATE_TIMEOUT_MS } from './config.ts';
-import { runIosDevicectl } from './devicectl.ts';
+import { runIosDevicectl, terminateIosDeviceApp } from './devicectl.ts';
 import {
   isSimulatorLaunchFBSError,
   probeSimulatorLaunchContext,
@@ -170,10 +170,7 @@ export async function closeIosApp(device: DeviceInfo, app: string): Promise<void
     return;
   }
 
-  await runIosDevicectl(['device', 'process', 'terminate', '--device', device.id, bundleId], {
-    action: 'terminate iOS app',
-    deviceId: device.id,
-  });
+  await terminateIosDeviceApp(device, bundleId);
 }
 
 async function launchIosSimulatorApp(

--- a/src/platforms/apple/core/devicectl.ts
+++ b/src/platforms/apple/core/devicectl.ts
@@ -40,6 +40,19 @@ type IosDeviceProcessesPayload = {
   };
 };
 
+type IosDevicectlErrorPayload = {
+  error?: {
+    userInfo?: {
+      NSUnderlyingError?: {
+        error?: {
+          code?: unknown;
+          domain?: unknown;
+        };
+      };
+    };
+  };
+};
+
 export async function runIosDevicectl(
   args: string[],
   context: { action: string; deviceId: string },
@@ -106,19 +119,30 @@ async function listIosDeviceProcesses(device: DeviceInfo): Promise<IosDeviceProc
 
 export async function terminateIosDeviceApp(device: DeviceInfo, bundleId: string): Promise<void> {
   const { appBundleUrl, processes } = await resolveIosDeviceAppProcesses(device, bundleId);
+  // Extensions share the app bundle URL, but closing the app targets its shallowest main process.
   const process = processes.sort(
     (left, right) => processPathDepth(left, appBundleUrl) - processPathDepth(right, appBundleUrl),
   )[0];
-  // Close is idempotent: no matching process means the installed app is not running.
+  // No match means the installed app is already closed.
   if (!process) return;
 
-  await runIosDevicectl(
-    ['device', 'process', 'terminate', '--device', device.id, '--pid', String(process.pid)],
-    {
-      action: 'terminate iOS app',
-      deviceId: device.id,
-    },
-  );
+  await runIosDevicectlJsonCommand(device, {
+    jsonPrefix: 'agent-device-ios-process-terminate',
+    args: [
+      'devicectl',
+      'device',
+      'process',
+      'terminate',
+      '--device',
+      device.id,
+      '--pid',
+      String(process.pid),
+    ],
+    failureMessage: 'Failed to terminate iOS app',
+    parseFailureMessage: 'Failed to parse iOS process termination response',
+    // The process may exit after discovery but before CoreDevice sends the signal.
+    tolerateFailurePayload: isMissingIosDeviceProcessPayload,
+  });
 }
 
 export async function resolveIosDeviceAppProcesses(
@@ -158,6 +182,7 @@ async function runIosDevicectlJsonCommand(
     failureMessage: string;
     parseFailureMessage: string;
     fallbackHint?: string;
+    tolerateFailurePayload?: (payload: unknown) => boolean;
   },
 ): Promise<unknown> {
   const jsonPath = path.join(
@@ -173,6 +198,12 @@ async function runIosDevicectlJsonCommand(
   try {
     if (result.exitCode !== 0) {
       const { stdout, stderr } = result;
+      if (options.tolerateFailurePayload) {
+        const failurePayload = await readJsonFile(jsonPath).catch(() => undefined);
+        if (failurePayload !== undefined && options.tolerateFailurePayload(failurePayload)) {
+          return failurePayload;
+        }
+      }
       throw new AppError(
         'COMMAND_FAILED',
         options.failureMessage,
@@ -189,7 +220,7 @@ async function runIosDevicectlJsonCommand(
         }),
       );
     }
-    return JSON.parse(await fs.readFile(jsonPath, 'utf8'));
+    return await readJsonFile(jsonPath);
   } catch (error) {
     if (error instanceof AppError) throw error;
     throw new AppError('COMMAND_FAILED', options.parseFailureMessage, {
@@ -201,6 +232,10 @@ async function runIosDevicectlJsonCommand(
   }
 }
 
+async function readJsonFile(jsonPath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(jsonPath, 'utf8'));
+}
+
 function processPathDepth(process: IosDeviceProcessInfo, appBundleUrl: string): number {
   return process.executable.slice(appBundleUrl.length + 1).split('/').length;
 }
@@ -209,6 +244,12 @@ function isIosDeviceProcessesPayload(payload: unknown): payload is IosDeviceProc
   return Array.isArray(
     (payload as IosDeviceProcessesPayload | null | undefined)?.result?.runningProcesses,
   );
+}
+
+function isMissingIosDeviceProcessPayload(payload: unknown): boolean {
+  const underlyingError = (payload as IosDevicectlErrorPayload | null | undefined)?.error?.userInfo
+    ?.NSUnderlyingError?.error;
+  return underlyingError?.domain === 'NSPOSIXErrorDomain' && underlyingError.code === 3;
 }
 
 export function parseIosDeviceAppsPayload(payload: unknown): IosAppInfo[] {

--- a/src/platforms/apple/core/devicectl.ts
+++ b/src/platforms/apple/core/devicectl.ts
@@ -137,6 +137,7 @@ export async function terminateIosDeviceApp(device: DeviceInfo, bundleId: string
       device.id,
       '--pid',
       String(process.pid),
+      '--kill',
     ],
     failureMessage: 'Failed to terminate iOS app',
     parseFailureMessage: 'Failed to parse iOS process termination response',

--- a/src/platforms/apple/core/devicectl.ts
+++ b/src/platforms/apple/core/devicectl.ts
@@ -26,6 +26,11 @@ export type IosDeviceProcessInfo = {
   pid: number;
 };
 
+export type IosDeviceAppProcesses = {
+  appBundleUrl: string;
+  processes: IosDeviceProcessInfo[];
+};
+
 type IosDeviceProcessesPayload = {
   result?: {
     runningProcesses?: Array<{
@@ -82,7 +87,7 @@ export async function listIosDeviceApps(
   return filterIosDeviceApps(parseIosDeviceAppsPayload(payload), filter);
 }
 
-export async function listIosDeviceProcesses(device: DeviceInfo): Promise<IosDeviceProcessInfo[]> {
+async function listIosDeviceProcesses(device: DeviceInfo): Promise<IosDeviceProcessInfo[]> {
   const payload = await runIosDevicectlJsonCommand(device, {
     jsonPrefix: 'agent-device-ios-processes',
     args: ['devicectl', 'device', 'info', 'processes', '--device', device.id],
@@ -100,7 +105,11 @@ export async function listIosDeviceProcesses(device: DeviceInfo): Promise<IosDev
 }
 
 export async function terminateIosDeviceApp(device: DeviceInfo, bundleId: string): Promise<void> {
-  const process = await resolveIosDeviceAppProcess(device, bundleId);
+  const { appBundleUrl, processes } = await resolveIosDeviceAppProcesses(device, bundleId);
+  const process = processes.sort(
+    (left, right) => processPathDepth(left, appBundleUrl) - processPathDepth(right, appBundleUrl),
+  )[0];
+  // Close is idempotent: no matching process means the installed app is not running.
   if (!process) return;
 
   await runIosDevicectl(
@@ -112,10 +121,10 @@ export async function terminateIosDeviceApp(device: DeviceInfo, bundleId: string
   );
 }
 
-async function resolveIosDeviceAppProcess(
+export async function resolveIosDeviceAppProcesses(
   device: DeviceInfo,
   bundleId: string,
-): Promise<IosDeviceProcessInfo | undefined> {
+): Promise<IosDeviceAppProcesses> {
   const app = (await listIosDeviceApps(device, 'all')).find(
     (candidate) => candidate.bundleId === bundleId,
   );
@@ -126,20 +135,19 @@ async function resolveIosDeviceAppProcess(
     });
   }
   if (!app.url) {
-    throw new AppError('COMMAND_FAILED', `Cannot resolve the process ID for ${bundleId}`, {
+    throw new AppError('COMMAND_FAILED', `Missing app bundle URL for ${bundleId}`, {
       appBundleId: bundleId,
       deviceId: device.id,
-      hint: 'Installed-app metadata from devicectl did not include a bundle URL, so agent-device cannot map this app to the PID required for termination. Use an Xcode/CoreDevice toolchain that reports app URLs, or close the app manually.',
+      hint: 'Installed-app metadata from devicectl did not include the bundle URL required to match running processes. Use an Xcode/CoreDevice toolchain that reports app URLs.',
     });
   }
 
   const appBundleUrl = app.url.replace(/\/+$/, '');
-  const matches = (await listIosDeviceProcesses(device)).filter((process) =>
+  // CoreDevice reports app URLs and process executables in the same file-URL form.
+  const processes = (await listIosDeviceProcesses(device)).filter((process) =>
     process.executable.startsWith(`${appBundleUrl}/`),
   );
-  return matches.sort(
-    (left, right) => processPathDepth(left, appBundleUrl) - processPathDepth(right, appBundleUrl),
-  )[0];
+  return { appBundleUrl, processes };
 }
 
 async function runIosDevicectlJsonCommand(

--- a/src/platforms/apple/core/devicectl.ts
+++ b/src/platforms/apple/core/devicectl.ts
@@ -83,14 +83,63 @@ export async function listIosDeviceApps(
 }
 
 export async function listIosDeviceProcesses(device: DeviceInfo): Promise<IosDeviceProcessInfo[]> {
-  return parseIosDeviceProcessesPayload(
-    await runIosDevicectlJsonCommand(device, {
-      jsonPrefix: 'agent-device-ios-processes',
-      args: ['devicectl', 'device', 'info', 'processes', '--device', device.id],
-      failureMessage: 'Failed to list iOS processes',
-      parseFailureMessage: 'Failed to parse iOS process list',
-    }),
+  const payload = await runIosDevicectlJsonCommand(device, {
+    jsonPrefix: 'agent-device-ios-processes',
+    args: ['devicectl', 'device', 'info', 'processes', '--device', device.id],
+    failureMessage: 'Failed to list iOS processes',
+    parseFailureMessage: 'Failed to parse iOS process list',
+    fallbackHint: IOS_DEVICE_PROCESS_LIST_HINT,
+  });
+  if (!isIosDeviceProcessesPayload(payload)) {
+    throw new AppError('COMMAND_FAILED', 'Unsupported iOS process list response', {
+      deviceId: device.id,
+      hint: IOS_DEVICE_PROCESS_LIST_HINT,
+    });
+  }
+  return parseIosDeviceProcessesPayload(payload);
+}
+
+export async function terminateIosDeviceApp(device: DeviceInfo, bundleId: string): Promise<void> {
+  const process = await resolveIosDeviceAppProcess(device, bundleId);
+  if (!process) return;
+
+  await runIosDevicectl(
+    ['device', 'process', 'terminate', '--device', device.id, '--pid', String(process.pid)],
+    {
+      action: 'terminate iOS app',
+      deviceId: device.id,
+    },
   );
+}
+
+async function resolveIosDeviceAppProcess(
+  device: DeviceInfo,
+  bundleId: string,
+): Promise<IosDeviceProcessInfo | undefined> {
+  const app = (await listIosDeviceApps(device, 'all')).find(
+    (candidate) => candidate.bundleId === bundleId,
+  );
+  if (!app) {
+    throw new AppError('APP_NOT_INSTALLED', `No iOS device app found for ${bundleId}`, {
+      appBundleId: bundleId,
+      deviceId: device.id,
+    });
+  }
+  if (!app.url) {
+    throw new AppError('COMMAND_FAILED', `Cannot resolve the process ID for ${bundleId}`, {
+      appBundleId: bundleId,
+      deviceId: device.id,
+      hint: 'Installed-app metadata from devicectl did not include a bundle URL, so agent-device cannot map this app to the PID required for termination. Use an Xcode/CoreDevice toolchain that reports app URLs, or close the app manually.',
+    });
+  }
+
+  const appBundleUrl = app.url.replace(/\/+$/, '');
+  const matches = (await listIosDeviceProcesses(device)).filter((process) =>
+    process.executable.startsWith(`${appBundleUrl}/`),
+  );
+  return matches.sort(
+    (left, right) => processPathDepth(left, appBundleUrl) - processPathDepth(right, appBundleUrl),
+  )[0];
 }
 
 async function runIosDevicectlJsonCommand(
@@ -100,6 +149,7 @@ async function runIosDevicectlJsonCommand(
     args: string[];
     failureMessage: string;
     parseFailureMessage: string;
+    fallbackHint?: string;
   },
 ): Promise<unknown> {
   const jsonPath = path.join(
@@ -124,7 +174,10 @@ async function runIosDevicectlJsonCommand(
           stdout,
           stderr,
           deviceId: device.id,
-          hint: resolveIosDevicectlHint(stdout, stderr) ?? IOS_DEVICECTL_DEFAULT_HINT,
+          hint:
+            resolveIosDevicectlHint(stdout, stderr) ??
+            options.fallbackHint ??
+            IOS_DEVICECTL_DEFAULT_HINT,
         }),
       );
     }
@@ -138,6 +191,16 @@ async function runIosDevicectlJsonCommand(
   } finally {
     await fs.unlink(jsonPath).catch(() => {});
   }
+}
+
+function processPathDepth(process: IosDeviceProcessInfo, appBundleUrl: string): number {
+  return process.executable.slice(appBundleUrl.length + 1).split('/').length;
+}
+
+function isIosDeviceProcessesPayload(payload: unknown): payload is IosDeviceProcessesPayload {
+  return Array.isArray(
+    (payload as IosDeviceProcessesPayload | null | undefined)?.result?.runningProcesses,
+  );
 }
 
 export function parseIosDeviceAppsPayload(payload: unknown): IosAppInfo[] {
@@ -184,6 +247,9 @@ function filterIosDeviceApps(apps: IosAppInfo[], filter: 'user-installed' | 'all
 
 export const IOS_DEVICECTL_DEFAULT_HINT =
   'Ensure the iOS device is unlocked, trusted, and available in Xcode > Devices, then retry.';
+
+const IOS_DEVICE_PROCESS_LIST_HINT =
+  "This Xcode/CoreDevice toolchain must support 'devicectl device info processes' with JSON runningProcesses so agent-device can resolve app process IDs. Inspect diagnostics for the exact devicectl API failure.";
 
 export function resolveIosDevicectlHint(stdout: string, stderr: string): string | null {
   const text = `${stdout}\n${stderr}`.toLowerCase();

--- a/src/platforms/apple/core/perf.ts
+++ b/src/platforms/apple/core/perf.ts
@@ -16,8 +16,7 @@ import { roundPercent } from '../../perf-utils.ts';
 import { uniqueStrings } from '../../../kernel/collections.ts';
 import {
   IOS_DEVICECTL_DEFAULT_HINT,
-  listIosDeviceApps,
-  listIosDeviceProcesses,
+  resolveIosDeviceAppProcesses,
   resolveIosDevicectlHint,
   type IosDeviceProcessInfo,
 } from './devicectl.ts';
@@ -846,26 +845,8 @@ export async function resolveIosDevicePerfTarget(
   device: DeviceInfo,
   appBundleId: string,
 ): Promise<IosDeviceProcessInfo[]> {
-  const apps = await listIosDeviceApps(device, 'all');
-  const app = apps.find((candidate) => candidate.bundleId === appBundleId);
-  if (!app) {
-    throw new AppError('APP_NOT_INSTALLED', `No iOS device app found for ${appBundleId}`, {
-      appBundleId,
-      deviceId: device.id,
-    });
-  }
-  if (!app.url) {
-    throw new AppError('COMMAND_FAILED', `Missing app bundle URL for ${appBundleId}`, {
-      appBundleId,
-      deviceId: device.id,
-    });
-  }
-
-  const appBundleUrl = app.url.replace(/\/$/, '');
+  const { appBundleUrl, processes } = await resolveIosDeviceAppProcesses(device, appBundleId);
   const appBundlePath = fileURLToPath(appBundleUrl);
-  const processes = (await listIosDeviceProcesses(device)).filter((process) =>
-    process.executable.startsWith(`${appBundleUrl}/`),
-  );
   if (processes.length === 0) {
     throw new AppError('COMMAND_FAILED', `No running process found for ${appBundleId}`, {
       appBundleId,


### PR DESCRIPTION
## Summary

Fix physical iOS app close on current CoreDevice by resolving the app's running PID and invoking `devicectl device process terminate --pid`.

Keep CoreDevice command grammar behind the devicectl module, validate process-list JSON at the trust boundary, and fail with an actionable compatibility hint when the required API or response shape is unavailable.

Consume terminate's supported JSON output and tolerate only structured `NSPOSIXErrorDomain` code 3 (`ESRCH`) when the resolved process exits before CoreDevice sends the signal.

Share app-to-process resolution with physical-device perf so app lookup, bundle URL normalization, and executable matching have one owner.

Closes #1230

## Validation

- `pnpm check:affected --base origin/main --run` (static gates, build, and 1,170 related tests passed; full coverage remained host-contention-limited, with unrelated failures passing in isolation)
- `pnpm test:coverage` (post-change runs completed coverage but exited nonzero on unrelated host-load failures; the four named failing files passed all 150 tests in isolation)
- `pnpm test:integration:provider`
- Physical iPhone: opened the native Light Meter app on `thymikee-iphone`, confirmed its app state, and closed it through the JSON-backed public CLI path; a CoreDevice process query confirmed no remaining process.
- Physical iPhone: probed termination of a guaranteed-missing PID and confirmed CoreDevice reports the stable structured `NSPOSIXErrorDomain` code 3 used by the race handler.
