### PR TITLE
docs: remove ready-for-human guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Issues and PRDs live in GitHub Issues for `callstack/agent-device`; external PRs
 
 ### Triage labels
 
-Follow the issue label workflow in `docs/agents/triage-labels.md`, including `ready-for-agent` and `ready-for-human`.
+Follow the issue label workflow in `docs/agents/triage-labels.md`, including `ready-for-agent`.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,13 +1,12 @@
 # Issue Label Workflow
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual GitHub labels used in this repo.
+The skills speak in terms of four canonical triage roles. This file maps those roles to the actual GitHub labels used in this repo.
 
 | Skill role | GitHub label | Meaning |
 | --- | --- | --- |
 | `needs-triage` | `needs-triage` | New or unreviewed issue; maintainer needs to evaluate it |
 | `needs-info` | `needs-info` | Waiting on reporter or external input |
 | `ready-for-agent` | `ready-for-agent` | Fully specified, AFK-ready for an agent to pick up |
-| `ready-for-human` | `ready-for-human` | Valid work, but needs human implementation or judgment |
 | `wontfix` | `wontfix` | Will not be actioned after an explicit maintainer decision |
 
 Default flow:
@@ -16,5 +15,4 @@ Default flow:
 2. Remove `needs-triage` once the issue is understood and valid.
 3. Add `needs-info` when reporter or external input is required.
 4. Add `ready-for-agent` when the issue is fully specified and can be picked up by an AFK agent with no extra human context.
-5. Add `ready-for-human` when the issue is valid but needs human implementation, product judgment, or maintainer ownership.
-6. Add `wontfix` only after an explicit maintainer decision.
+5. Add `wontfix` only after an explicit maintainer decision.


### PR DESCRIPTION
## Summary

Remove `ready-for-human` from agent and issue-triage documentation.
Keep the remaining four documented triage roles and workflow coherent.

## Validation

Docs-only change; `git diff --check` passes.
