### PR TITLE
fix(record): validate finalized iOS device MP4 before reporting record stop success

### DIFF
--- a/src/daemon/handlers/__tests__/record-trace-ios.test.ts
+++ b/src/daemon/handlers/__tests__/record-trace-ios.test.ts
@@ -4,7 +4,7 @@ import { IOS_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import type { RunnerCommand } from '../../../platforms/apple/core/runner/runner-contract.ts';
 import type { RecordTraceDeps } from '../record-trace-types.ts';
-import { startIosDeviceRecording, stopIosDeviceRecording } from '../record-trace-ios.ts';
+import { startIosDeviceRecording } from '../record-trace-ios.ts';
 
 test('startIosDeviceRecording stops stale runner recording and retries with the same request id', async () => {
   const sessionStore = makeSessionStore('agent-device-record-trace-ios-');
@@ -78,116 +78,4 @@ test('startIosDeviceRecording stops stale runner recording and retries with the 
   assert.equal(result.platform, 'ios-device-runner');
   assert.equal(result.runnerStartedAtUptimeMs, 100);
   assert.equal(result.targetAppReadyUptimeMs, 130);
-});
-
-function makeStopDeps(overrides: Partial<RecordTraceDeps>): RecordTraceDeps {
-  return {
-    runCmd: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
-    startIosSimulatorRecording: () => {
-      throw new Error('not used');
-    },
-    runAppleRunnerCommand: async () => ({}),
-    waitForRecordingTail: async () => {},
-    waitForStableFile: async () => {},
-    isPlayableVideo: async () => true,
-    trimRecordingStart: async () => {},
-    resizeRecording: async () => {},
-    overlayRecordingTouches: async () => {},
-    ...overrides,
-  };
-}
-
-const STOP_RECORDING = {
-  platform: 'ios-device-runner' as const,
-  remotePath: 'tmp/agent-device-recording.mp4',
-  outPath: '/tmp/recording.mp4',
-  startedAt: 1,
-  showTouches: false,
-  gestureEvents: [],
-};
-
-const STOP_REQ = {
-  token: 'test-token',
-  session: 'default',
-  command: 'record',
-  positionals: ['stop'],
-  flags: {},
-  meta: { requestId: 'req-stop-recording' },
-};
-
-test('stopIosDeviceRecording returns COMMAND_FAILED when the copied MP4 is not playable', async () => {
-  const activeSession = {
-    name: 'default',
-    createdAt: Date.now(),
-    actions: [],
-    device: IOS_DEVICE,
-    appBundleId: 'com.example.app',
-  };
-
-  const result = await stopIosDeviceRecording({
-    req: STOP_REQ,
-    activeSession,
-    device: IOS_DEVICE,
-    deps: makeStopDeps({ isPlayableVideo: async () => false }),
-    recording: STOP_RECORDING,
-  });
-
-  assert.ok(result && 'ok' in result, `expected a response, got: ${JSON.stringify(result)}`);
-  assert.equal(result.ok, false);
-  if (!result.ok) {
-    assert.equal(result.error.code, 'COMMAND_FAILED');
-  }
-});
-
-test('stopIosDeviceRecording reflects the runner-not-ok variant in the failure message', async () => {
-  const activeSession = {
-    name: 'default',
-    createdAt: Date.now(),
-    actions: [],
-    device: IOS_DEVICE,
-    appBundleId: 'com.example.app',
-  };
-
-  const result = await stopIosDeviceRecording({
-    req: STOP_REQ,
-    activeSession,
-    device: IOS_DEVICE,
-    deps: makeStopDeps({
-      runAppleRunnerCommand: async (_device, command) => {
-        if (command.command === 'recordStop') {
-          throw new Error('runner reported ok:false');
-        }
-        return {};
-      },
-      isPlayableVideo: async () => false,
-    }),
-    recording: STOP_RECORDING,
-  });
-
-  assert.ok(result && 'ok' in result, `expected a response, got: ${JSON.stringify(result)}`);
-  assert.equal(result.ok, false);
-  if (!result.ok) {
-    assert.equal(result.error.code, 'COMMAND_FAILED');
-    assert.match(result.error.message, /the iOS runner reported the stop did not succeed/);
-  }
-});
-
-test('stopIosDeviceRecording returns null on the happy path when the MP4 is playable', async () => {
-  const activeSession = {
-    name: 'default',
-    createdAt: Date.now(),
-    actions: [],
-    device: IOS_DEVICE,
-    appBundleId: 'com.example.app',
-  };
-
-  const result = await stopIosDeviceRecording({
-    req: STOP_REQ,
-    activeSession,
-    device: IOS_DEVICE,
-    deps: makeStopDeps({ isPlayableVideo: async () => true }),
-    recording: STOP_RECORDING,
-  });
-
-  assert.equal(result, null);
 });

--- a/src/daemon/handlers/__tests__/record-trace-ios.test.ts
+++ b/src/daemon/handlers/__tests__/record-trace-ios.test.ts
@@ -4,7 +4,7 @@ import { IOS_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import type { RunnerCommand } from '../../../platforms/apple/core/runner/runner-contract.ts';
 import type { RecordTraceDeps } from '../record-trace-types.ts';
-import { startIosDeviceRecording } from '../record-trace-ios.ts';
+import { startIosDeviceRecording, stopIosDeviceRecording } from '../record-trace-ios.ts';
 
 test('startIosDeviceRecording stops stale runner recording and retries with the same request id', async () => {
   const sessionStore = makeSessionStore('agent-device-record-trace-ios-');
@@ -78,4 +78,116 @@ test('startIosDeviceRecording stops stale runner recording and retries with the 
   assert.equal(result.platform, 'ios-device-runner');
   assert.equal(result.runnerStartedAtUptimeMs, 100);
   assert.equal(result.targetAppReadyUptimeMs, 130);
+});
+
+function makeStopDeps(overrides: Partial<RecordTraceDeps>): RecordTraceDeps {
+  return {
+    runCmd: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    startIosSimulatorRecording: () => {
+      throw new Error('not used');
+    },
+    runAppleRunnerCommand: async () => ({}),
+    waitForRecordingTail: async () => {},
+    waitForStableFile: async () => {},
+    isPlayableVideo: async () => true,
+    trimRecordingStart: async () => {},
+    resizeRecording: async () => {},
+    overlayRecordingTouches: async () => {},
+    ...overrides,
+  };
+}
+
+const STOP_RECORDING = {
+  platform: 'ios-device-runner' as const,
+  remotePath: 'tmp/agent-device-recording.mp4',
+  outPath: '/tmp/recording.mp4',
+  startedAt: 1,
+  showTouches: false,
+  gestureEvents: [],
+};
+
+const STOP_REQ = {
+  token: 'test-token',
+  session: 'default',
+  command: 'record',
+  positionals: ['stop'],
+  flags: {},
+  meta: { requestId: 'req-stop-recording' },
+};
+
+test('stopIosDeviceRecording returns COMMAND_FAILED when the copied MP4 is not playable', async () => {
+  const activeSession = {
+    name: 'default',
+    createdAt: Date.now(),
+    actions: [],
+    device: IOS_DEVICE,
+    appBundleId: 'com.example.app',
+  };
+
+  const result = await stopIosDeviceRecording({
+    req: STOP_REQ,
+    activeSession,
+    device: IOS_DEVICE,
+    deps: makeStopDeps({ isPlayableVideo: async () => false }),
+    recording: STOP_RECORDING,
+  });
+
+  assert.ok(result && 'ok' in result, `expected a response, got: ${JSON.stringify(result)}`);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, 'COMMAND_FAILED');
+  }
+});
+
+test('stopIosDeviceRecording reflects the runner-not-ok variant in the failure message', async () => {
+  const activeSession = {
+    name: 'default',
+    createdAt: Date.now(),
+    actions: [],
+    device: IOS_DEVICE,
+    appBundleId: 'com.example.app',
+  };
+
+  const result = await stopIosDeviceRecording({
+    req: STOP_REQ,
+    activeSession,
+    device: IOS_DEVICE,
+    deps: makeStopDeps({
+      runAppleRunnerCommand: async (_device, command) => {
+        if (command.command === 'recordStop') {
+          throw new Error('runner reported ok:false');
+        }
+        return {};
+      },
+      isPlayableVideo: async () => false,
+    }),
+    recording: STOP_RECORDING,
+  });
+
+  assert.ok(result && 'ok' in result, `expected a response, got: ${JSON.stringify(result)}`);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, 'COMMAND_FAILED');
+    assert.match(result.error.message, /the iOS runner reported the stop did not succeed/);
+  }
+});
+
+test('stopIosDeviceRecording returns null on the happy path when the MP4 is playable', async () => {
+  const activeSession = {
+    name: 'default',
+    createdAt: Date.now(),
+    actions: [],
+    device: IOS_DEVICE,
+    appBundleId: 'com.example.app',
+  };
+
+  const result = await stopIosDeviceRecording({
+    req: STOP_REQ,
+    activeSession,
+    device: IOS_DEVICE,
+    deps: makeStopDeps({ isPlayableVideo: async () => true }),
+    recording: STOP_RECORDING,
+  });
+
+  assert.equal(result, null);
 });

--- a/src/daemon/handlers/__tests__/record-trace.test.ts
+++ b/src/daemon/handlers/__tests__/record-trace.test.ts
@@ -802,7 +802,7 @@ test('record start does not stop recording owned by another session during desyn
   expect(sessionStore.get(ownerSessionName)?.recording?.platform).toBe('ios-device-runner');
 });
 
-test('record stop clears iOS runner recording state when runner stop fails', async () => {
+test('record stop reports iOS runner stop failure after copying and clears recording state', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-device-stop-fail';
   sessionStore.set(sessionName, {
@@ -835,8 +835,9 @@ test('record stop clears iOS runner recording state when runner stop fails', asy
     positionals: ['stop'],
   });
 
-  expect(response?.ok).toBe(true);
-  expect((response as any).data?.recording).toBe('stopped');
+  expect(response?.ok).toBe(false);
+  expect((response as any).error?.code).toBe('COMMAND_FAILED');
+  expect((response as any).error?.message).toMatch(/runner reported recordStop did not succeed/);
   expect(runCmdCalls.length).toBe(1);
   expect(sessionStore.get(sessionName)?.recording).toBeUndefined();
 });

--- a/src/daemon/handlers/record-trace-ios.ts
+++ b/src/daemon/handlers/record-trace-ios.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { isIosFamily } from '../../kernel/device.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
@@ -65,7 +66,7 @@ async function stopRunnerRecordingBestEffort(params: {
   device: SessionState['device'];
   logPath?: string;
   deps: RecordTraceDeps;
-}): Promise<void> {
+}): Promise<boolean> {
   const { req, activeSession, device, logPath, deps } = params;
   const appBundleId = normalizeAppBundleId(activeSession);
 
@@ -75,6 +76,7 @@ async function stopRunnerRecordingBestEffort(params: {
       { command: 'recordStop', appBundleId },
       getIosRunnerOptions(req, logPath, activeSession),
     );
+    return true;
   } catch (error) {
     emitDiagnostic({
       level: 'warn',
@@ -87,6 +89,15 @@ async function stopRunnerRecordingBestEffort(params: {
         error: formatRecordTraceError(error),
       },
     });
+    return false;
+  }
+}
+
+function readRecordingFileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
   }
 }
 
@@ -318,7 +329,13 @@ export async function stopIosDeviceRecording(params: {
   recording: Extract<NonNullable<SessionState['recording']>, { platform: 'ios-device-runner' }>;
 }): Promise<DaemonResponse | null> {
   const { req, activeSession, device, logPath, deps, recording } = params;
-  await stopRunnerRecordingBestEffort({ req, activeSession, device, logPath, deps });
+  const runnerStopOk = await stopRunnerRecordingBestEffort({
+    req,
+    activeSession,
+    device,
+    logPath,
+    deps,
+  });
 
   let copyResult = { stdout: '', stderr: '', exitCode: 1 };
   for (const bundleId of IOS_RUNNER_CONTAINER_BUNDLE_IDS) {
@@ -353,6 +370,28 @@ export async function stopIosDeviceRecording(params: {
       copyResult.stdout.trim() ||
       `devicectl exited with code ${copyResult.exitCode}`;
     return errorResponse('COMMAND_FAILED', `failed to copy recording from device: ${copyError}`);
+  }
+
+  await deps.waitForStableFile(recording.outPath);
+  const playable = await deps.isPlayableVideo(recording.outPath);
+  if (!playable) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'record_stop_ios_invalid_video',
+      data: {
+        deviceId: device.id,
+        session: activeSession.name,
+        outPath: recording.outPath,
+        runnerStopOk,
+        fileSize: readRecordingFileSize(recording.outPath),
+      },
+    });
+    return errorResponse(
+      'COMMAND_FAILED',
+      runnerStopOk
+        ? `failed to stop recording: ${recording.outPath} was not finalized into a playable video`
+        : `failed to stop recording: the iOS runner reported the stop did not succeed and ${recording.outPath} is not a finalized, playable MP4`,
+    );
   }
 
   const trimStartMs = resolveIosRecordingTrimStartMs(recording);

--- a/src/daemon/handlers/record-trace-ios.ts
+++ b/src/daemon/handlers/record-trace-ios.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import { isIosFamily } from '../../kernel/device.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
@@ -66,7 +65,7 @@ async function stopRunnerRecordingBestEffort(params: {
   device: SessionState['device'];
   logPath?: string;
   deps: RecordTraceDeps;
-}): Promise<boolean> {
+}): Promise<void> {
   const { req, activeSession, device, logPath, deps } = params;
   const appBundleId = normalizeAppBundleId(activeSession);
 
@@ -76,7 +75,6 @@ async function stopRunnerRecordingBestEffort(params: {
       { command: 'recordStop', appBundleId },
       getIosRunnerOptions(req, logPath, activeSession),
     );
-    return true;
   } catch (error) {
     emitDiagnostic({
       level: 'warn',
@@ -89,15 +87,6 @@ async function stopRunnerRecordingBestEffort(params: {
         error: formatRecordTraceError(error),
       },
     });
-    return false;
-  }
-}
-
-function readRecordingFileSize(filePath: string): number {
-  try {
-    return fs.statSync(filePath).size;
-  } catch {
-    return 0;
   }
 }
 
@@ -329,13 +318,7 @@ export async function stopIosDeviceRecording(params: {
   recording: Extract<NonNullable<SessionState['recording']>, { platform: 'ios-device-runner' }>;
 }): Promise<DaemonResponse | null> {
   const { req, activeSession, device, logPath, deps, recording } = params;
-  const runnerStopOk = await stopRunnerRecordingBestEffort({
-    req,
-    activeSession,
-    device,
-    logPath,
-    deps,
-  });
+  await stopRunnerRecordingBestEffort({ req, activeSession, device, logPath, deps });
 
   let copyResult = { stdout: '', stderr: '', exitCode: 1 };
   for (const bundleId of IOS_RUNNER_CONTAINER_BUNDLE_IDS) {
@@ -375,22 +358,9 @@ export async function stopIosDeviceRecording(params: {
   await deps.waitForStableFile(recording.outPath);
   const playable = await deps.isPlayableVideo(recording.outPath);
   if (!playable) {
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'record_stop_ios_invalid_video',
-      data: {
-        deviceId: device.id,
-        session: activeSession.name,
-        outPath: recording.outPath,
-        runnerStopOk,
-        fileSize: readRecordingFileSize(recording.outPath),
-      },
-    });
     return errorResponse(
       'COMMAND_FAILED',
-      runnerStopOk
-        ? `failed to stop recording: ${recording.outPath} was not finalized into a playable video`
-        : `failed to stop recording: the iOS runner reported the stop did not succeed and ${recording.outPath} is not a finalized, playable MP4`,
+      `failed to stop recording: ${recording.outPath} was not finalized into a playable video`,
     );
   }
 

--- a/src/daemon/handlers/record-trace-ios.ts
+++ b/src/daemon/handlers/record-trace-ios.ts
@@ -65,7 +65,7 @@ async function stopRunnerRecordingBestEffort(params: {
   device: SessionState['device'];
   logPath?: string;
   deps: RecordTraceDeps;
-}): Promise<void> {
+}): Promise<boolean> {
   const { req, activeSession, device, logPath, deps } = params;
   const appBundleId = normalizeAppBundleId(activeSession);
 
@@ -75,6 +75,7 @@ async function stopRunnerRecordingBestEffort(params: {
       { command: 'recordStop', appBundleId },
       getIosRunnerOptions(req, logPath, activeSession),
     );
+    return true;
   } catch (error) {
     emitDiagnostic({
       level: 'warn',
@@ -87,6 +88,7 @@ async function stopRunnerRecordingBestEffort(params: {
         error: formatRecordTraceError(error),
       },
     });
+    return false;
   }
 }
 
@@ -318,7 +320,13 @@ export async function stopIosDeviceRecording(params: {
   recording: Extract<NonNullable<SessionState['recording']>, { platform: 'ios-device-runner' }>;
 }): Promise<DaemonResponse | null> {
   const { req, activeSession, device, logPath, deps, recording } = params;
-  await stopRunnerRecordingBestEffort({ req, activeSession, device, logPath, deps });
+  const runnerStopOk = await stopRunnerRecordingBestEffort({
+    req,
+    activeSession,
+    device,
+    logPath,
+    deps,
+  });
 
   let copyResult = { stdout: '', stderr: '', exitCode: 1 };
   for (const bundleId of IOS_RUNNER_CONTAINER_BUNDLE_IDS) {
@@ -361,6 +369,12 @@ export async function stopIosDeviceRecording(params: {
     return errorResponse(
       'COMMAND_FAILED',
       `failed to stop recording: ${recording.outPath} was not finalized into a playable video`,
+    );
+  }
+  if (!runnerStopOk) {
+    return errorResponse(
+      'COMMAND_FAILED',
+      'failed to stop recording: the iOS runner reported recordStop did not succeed',
     );
   }
 

--- a/test/integration/provider-scenarios/ios-record-trace.test.ts
+++ b/test/integration/provider-scenarios/ios-record-trace.test.ts
@@ -29,20 +29,26 @@ test('Provider-backed integration iOS physical recording flow uses runner and de
       const tracePath = path.join(tmpDir, 'trace.adtrace');
       const finalTracePath = path.join(tmpDir, 'trace-final.adtrace');
       const recordingPath = path.join(tmpDir, 'recording.mp4');
-      const runnerTranscript = createProviderTranscript([
+      const invalidRecordingPath = path.join(tmpDir, 'invalid-recording.mp4');
+      let copiedRecording = likelyPlayableMp4Container();
+      const recordingTranscriptEntries = [
         {
           command: 'ios.runner.recordStart',
           deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
-          platform: 'apple',
+          platform: 'apple' as const,
           result: {},
         },
         {
           command: 'ios.runner.recordStop',
           deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
-          platform: 'apple',
+          platform: 'apple' as const,
           request: { command: 'recordStop', appBundleId: 'com.apple.Preferences' },
           result: {},
         },
+      ];
+      const runnerTranscript = createProviderTranscript([
+        ...recordingTranscriptEntries,
+        ...recordingTranscriptEntries,
       ]);
       const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
         runnerTranscript,
@@ -51,7 +57,7 @@ test('Provider-backed integration iOS physical recording flow uses runner and de
       const appleTool = createRecordingAppleToolProvider({
         devicectl: async (args) => {
           writeJsonOutputIfRequested(args);
-          writeCopiedRecordingIfRequested(args);
+          writeCopiedRecordingIfRequested(args, copiedRecording);
           return { stdout: '', stderr: '', exitCode: 0 };
         },
       });
@@ -60,6 +66,10 @@ test('Provider-backed integration iOS physical recording flow uses runner and de
         appleToolProvider: () => appleTool.provider,
         deviceInventoryProvider: async () => [PROVIDER_SCENARIO_IOS_DEVICE],
       });
+      const previousPath = process.env.PATH;
+      const previousSwiftCacheDir = process.env.AGENT_DEVICE_SWIFT_CACHE_DIR;
+      process.env.PATH = tmpDir;
+      process.env.AGENT_DEVICE_SWIFT_CACHE_DIR = path.join(tmpDir, 'swift-cache');
 
       try {
         const open = await daemon.callCommand('open', ['com.apple.Preferences'], {
@@ -93,6 +103,22 @@ test('Provider-backed integration iOS physical recording flow uses runner and de
           { meta: { requestId: 'ios-physical-record-stop' } },
         );
         assertRecordingStopped(recordStop, recordingPath, { showTouches: false });
+
+        copiedRecording = Buffer.from('unfinalized-recording');
+        const invalidRecordStart = await daemon.callCommand(
+          'record',
+          ['start', invalidRecordingPath],
+          { hideTouches: true },
+        );
+        assertRecordingStarted(invalidRecordStart, { showTouches: false });
+        const invalidRecordStop = await daemon.callCommand('record', ['stop']);
+        assert.equal(invalidRecordStop.statusCode, 200, JSON.stringify(invalidRecordStop.json));
+        assert.equal(invalidRecordStop.json?.result, undefined);
+        assert.equal(invalidRecordStop.json?.error?.data?.code, 'COMMAND_FAILED');
+        assert.match(
+          String(invalidRecordStop.json?.error?.data?.message),
+          /was not finalized into a playable video/,
+        );
 
         const traceStop = await daemon.callCommand('trace', ['stop', finalTracePath]);
         assert.equal(traceStop.statusCode, 200, JSON.stringify(traceStop.json));
@@ -151,6 +177,8 @@ test('Provider-backed integration iOS physical recording flow uses runner and de
         ]);
       } finally {
         await daemon.close();
+        restoreEnv('PATH', previousPath);
+        restoreEnv('AGENT_DEVICE_SWIFT_CACHE_DIR', previousSwiftCacheDir);
       }
     },
   );
@@ -264,9 +292,9 @@ function writeJsonOutputIfRequested(args: string[]): void {
   );
 }
 
-function writeCopiedRecordingIfRequested(args: string[]): void {
+function writeCopiedRecordingIfRequested(args: string[], contents: Buffer): void {
   const destinationIndex = args.indexOf('--destination');
   const destination = destinationIndex >= 0 ? args[destinationIndex + 1] : undefined;
   if (!destination) return;
-  fs.writeFileSync(destination, 'provider-scenario-recording');
+  fs.writeFileSync(destination, contents);
 }

--- a/test/integration/provider-scenarios/ios-record-trace.test.ts
+++ b/test/integration/provider-scenarios/ios-record-trace.test.ts
@@ -23,166 +23,187 @@ import {
 import { createProviderTranscript } from './transcript.ts';
 
 test('Provider-backed integration iOS physical recording flow uses runner and devicectl providers', async () => {
-  await withProviderScenarioTempDir(
-    'agent-device-provider-scenario-ios-record-',
-    async (tmpDir) => {
-      const tracePath = path.join(tmpDir, 'trace.adtrace');
-      const finalTracePath = path.join(tmpDir, 'trace-final.adtrace');
-      const recordingPath = path.join(tmpDir, 'recording.mp4');
-      const invalidRecordingPath = path.join(tmpDir, 'invalid-recording.mp4');
-      let copiedRecording = likelyPlayableMp4Container();
-      const recordingTranscriptEntries = [
-        {
-          command: 'ios.runner.recordStart',
-          deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
-          platform: 'apple' as const,
-          result: {},
-        },
-        {
-          command: 'ios.runner.recordStop',
-          deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
-          platform: 'apple' as const,
-          request: { command: 'recordStop', appBundleId: 'com.apple.Preferences' },
-          result: {},
-        },
-      ];
-      const runnerTranscript = createProviderTranscript([
-        ...recordingTranscriptEntries,
-        ...recordingTranscriptEntries,
-      ]);
-      const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
-        runnerTranscript,
-        'ios.runner',
-      );
-      const appleTool = createRecordingAppleToolProvider({
-        devicectl: async (args) => {
-          writeJsonOutputIfRequested(args);
-          writeCopiedRecordingIfRequested(args, copiedRecording);
-          return { stdout: '', stderr: '', exitCode: 0 };
-        },
-      });
-      const daemon = await createProviderScenarioHarness({
-        appleRunnerProvider: () => appleRunnerProvider,
-        appleToolProvider: () => appleTool.provider,
-        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_IOS_DEVICE],
-      });
-      const previousPath = process.env.PATH;
-      const previousSwiftCacheDir = process.env.AGENT_DEVICE_SWIFT_CACHE_DIR;
-      process.env.PATH = tmpDir;
-      process.env.AGENT_DEVICE_SWIFT_CACHE_DIR = path.join(tmpDir, 'swift-cache');
-
-      try {
-        const open = await daemon.callCommand('open', ['com.apple.Preferences'], {
-          platform: 'ios',
-          udid: PROVIDER_SCENARIO_IOS_DEVICE.id,
-        });
-        assert.equal(open.statusCode, 200, JSON.stringify(open.json));
-        assert.equal(open.json?.result?.data?.device_udid, PROVIDER_SCENARIO_IOS_DEVICE.id);
-
-        const traceStart = await daemon.callCommand('trace', ['start', tracePath]);
-        assert.equal(traceStart.statusCode, 200, JSON.stringify(traceStart.json));
-        assert.equal(traceStart.json?.result?.data?.trace, 'started');
-
-        const recordStart = await daemon.callCommand(
-          'record',
-          ['start', recordingPath],
-          {
-            fps: 30,
-            screenshotMaxSize: 720,
-            quality: 'high',
-            hideTouches: true,
-          },
-          { meta: { requestId: 'ios-physical-record-start' } },
-        );
-        assertRecordingStarted(recordStart, { showTouches: false });
-
-        const recordStop = await daemon.callCommand(
-          'record',
-          ['stop'],
-          {},
-          { meta: { requestId: 'ios-physical-record-stop' } },
-        );
-        assertRecordingStopped(recordStop, recordingPath, { showTouches: false });
-
-        copiedRecording = Buffer.from('unfinalized-recording');
-        const invalidRecordStart = await daemon.callCommand(
-          'record',
-          ['start', invalidRecordingPath],
-          { hideTouches: true },
-        );
-        assertRecordingStarted(invalidRecordStart, { showTouches: false });
-        const invalidRecordStop = await daemon.callCommand('record', ['stop']);
-        assert.equal(invalidRecordStop.statusCode, 200, JSON.stringify(invalidRecordStop.json));
-        assert.equal(invalidRecordStop.json?.result, undefined);
-        assert.equal(invalidRecordStop.json?.error?.data?.code, 'COMMAND_FAILED');
-        assert.match(
-          String(invalidRecordStop.json?.error?.data?.message),
-          /was not finalized into a playable video/,
-        );
-
-        const traceStop = await daemon.callCommand('trace', ['stop', finalTracePath]);
-        assert.equal(traceStop.statusCode, 200, JSON.stringify(traceStop.json));
-        assert.equal(traceStop.json?.result?.data?.trace, 'stopped');
-        assert.equal(traceStop.json?.result?.data?.outPath, finalTracePath);
-
-        runnerTranscript.assertComplete();
-        const recordStartCall = runnerTranscript.calls.find(
-          (call) => call.command === 'ios.runner.recordStart',
-        );
-        assert.deepEqual(
-          {
-            command: (recordStartCall?.request as { command?: unknown } | undefined)?.command,
-            fps: (recordStartCall?.request as { fps?: unknown } | undefined)?.fps,
-            maxSize: (recordStartCall?.request as { maxSize?: unknown } | undefined)?.maxSize,
-            appBundleId: (recordStartCall?.request as { appBundleId?: unknown } | undefined)
-              ?.appBundleId,
-          },
-          {
-            command: 'recordStart',
-            fps: 30,
-            maxSize: 720,
-            appBundleId: 'com.apple.Preferences',
-          },
-        );
-        assert.match(
-          String((recordStartCall?.request as { outPath?: unknown } | undefined)?.outPath),
-          /^agent-device-recording-\d+\.mp4$/,
-        );
-        assert.equal(fs.existsSync(recordingPath), true);
-        assert.equal(fs.existsSync(finalTracePath), true);
-        assertFlatToolCallStartsWith(appleTool.calls, [
-          'devicectl',
-          'device',
-          'info',
-          'details',
-          '--device',
-          PROVIDER_SCENARIO_IOS_DEVICE.id,
-        ]);
-        assertFlatToolCallStartsWith(appleTool.calls, [
-          'devicectl',
-          'device',
-          'process',
-          'launch',
-          '--device',
-          PROVIDER_SCENARIO_IOS_DEVICE.id,
-          'com.apple.Preferences',
-        ]);
-        assertFlatToolCallStartsWith(appleTool.calls, [
-          'devicectl',
-          'device',
-          'copy',
-          'from',
-          '--device',
-          PROVIDER_SCENARIO_IOS_DEVICE.id,
-        ]);
-      } finally {
-        await daemon.close();
-        restoreEnv('PATH', previousPath);
-        restoreEnv('AGENT_DEVICE_SWIFT_CACHE_DIR', previousSwiftCacheDir);
-      }
-    },
+  await withProviderScenarioTempDir('agent-device-provider-scenario-ios-record-', (tmpDir) =>
+    runPhysicalRecordingScenario(tmpDir),
   );
 });
+
+type ScenarioDaemon = Awaited<ReturnType<typeof createProviderScenarioHarness>>;
+
+async function runPhysicalRecordingScenario(tmpDir: string): Promise<void> {
+  const tracePath = path.join(tmpDir, 'trace.adtrace');
+  const finalTracePath = path.join(tmpDir, 'trace-final.adtrace');
+  const recordingPath = path.join(tmpDir, 'recording.mp4');
+  const invalidRecordingPath = path.join(tmpDir, 'invalid-recording.mp4');
+  const runnerFailurePath = path.join(tmpDir, 'runner-failure.mp4');
+  const harness = await createPhysicalRecordingHarness();
+  const previousPath = process.env.PATH;
+  const previousSwiftCacheDir = process.env.AGENT_DEVICE_SWIFT_CACHE_DIR;
+  process.env.PATH = tmpDir;
+  process.env.AGENT_DEVICE_SWIFT_CACHE_DIR = path.join(tmpDir, 'swift-cache');
+
+  try {
+    await openPhysicalSettings(harness.daemon);
+    const traceStart = await harness.daemon.callCommand('trace', ['start', tracePath]);
+    assert.equal(traceStart.json?.result?.data?.trace, 'started');
+    await recordPhysicalHappyPath(harness.daemon, recordingPath);
+    harness.setCopiedRecording(Buffer.from('unfinalized-recording'));
+    await recordAndExpectFailure(harness.daemon, invalidRecordingPath, /not finalized/);
+    harness.setCopiedRecording(likelyPlayableMp4Container());
+    await recordAndExpectFailure(harness.daemon, runnerFailurePath, /runner reported recordStop/);
+    const traceStop = await harness.daemon.callCommand('trace', ['stop', finalTracePath]);
+    assert.equal(traceStop.json?.result?.data?.trace, 'stopped');
+    assertPhysicalRecordingEvidence(harness, recordingPath, finalTracePath);
+  } finally {
+    await harness.daemon.close();
+    restoreEnv('PATH', previousPath);
+    restoreEnv('AGENT_DEVICE_SWIFT_CACHE_DIR', previousSwiftCacheDir);
+  }
+}
+
+async function createPhysicalRecordingHarness() {
+  let copiedRecording = likelyPlayableMp4Container();
+  const runnerStartEntry = {
+    command: 'ios.runner.recordStart',
+    deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
+    platform: 'apple' as const,
+    result: {},
+  };
+  const runnerStopEntry = {
+    command: 'ios.runner.recordStop',
+    deviceId: PROVIDER_SCENARIO_IOS_DEVICE.id,
+    platform: 'apple' as const,
+    request: { command: 'recordStop', appBundleId: 'com.apple.Preferences' },
+    result: {},
+  };
+  const runnerTranscript = createProviderTranscript([
+    runnerStartEntry,
+    runnerStopEntry,
+    runnerStartEntry,
+    runnerStopEntry,
+    runnerStartEntry,
+    { ...runnerStopEntry, result: undefined, error: 'runner reported recordStop ok:0' },
+  ]);
+  const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
+    runnerTranscript,
+    'ios.runner',
+  );
+  const appleTool = createRecordingAppleToolProvider({
+    devicectl: async (args) => {
+      writeJsonOutputIfRequested(args);
+      writeCopiedRecordingIfRequested(args, copiedRecording);
+      return { stdout: '', stderr: '', exitCode: 0 };
+    },
+  });
+  const daemon = await createProviderScenarioHarness({
+    appleRunnerProvider: () => appleRunnerProvider,
+    appleToolProvider: () => appleTool.provider,
+    deviceInventoryProvider: async () => [PROVIDER_SCENARIO_IOS_DEVICE],
+  });
+  return {
+    daemon,
+    runnerTranscript,
+    appleTool,
+    setCopiedRecording(contents: Buffer) {
+      copiedRecording = contents;
+    },
+  };
+}
+
+async function openPhysicalSettings(daemon: ScenarioDaemon): Promise<void> {
+  const open = await daemon.callCommand('open', ['com.apple.Preferences'], {
+    platform: 'ios',
+    udid: PROVIDER_SCENARIO_IOS_DEVICE.id,
+  });
+  assert.equal(open.statusCode, 200, JSON.stringify(open.json));
+  assert.equal(open.json?.result?.data?.device_udid, PROVIDER_SCENARIO_IOS_DEVICE.id);
+}
+
+async function recordPhysicalHappyPath(daemon: ScenarioDaemon, outPath: string): Promise<void> {
+  const start = await daemon.callCommand(
+    'record',
+    ['start', outPath],
+    { fps: 30, screenshotMaxSize: 720, quality: 'high', hideTouches: true },
+    { meta: { requestId: 'ios-physical-record-start' } },
+  );
+  assertRecordingStarted(start, { showTouches: false });
+  const stop = await daemon.callCommand(
+    'record',
+    ['stop'],
+    {},
+    { meta: { requestId: 'ios-physical-record-stop' } },
+  );
+  assertRecordingStopped(stop, outPath, { showTouches: false });
+}
+
+async function recordAndExpectFailure(
+  daemon: ScenarioDaemon,
+  outPath: string,
+  message: RegExp,
+): Promise<void> {
+  const start = await daemon.callCommand('record', ['start', outPath], { hideTouches: true });
+  assertRecordingStarted(start, { showTouches: false });
+  const stop = await daemon.callCommand('record', ['stop']);
+  assert.equal(stop.statusCode, 200, JSON.stringify(stop.json));
+  assert.equal(stop.json?.result, undefined);
+  assert.equal(stop.json?.error?.data?.code, 'COMMAND_FAILED');
+  assert.match(String(stop.json?.error?.data?.message), message);
+  assert.equal(fs.existsSync(outPath), true);
+}
+
+function assertPhysicalRecordingEvidence(
+  harness: Awaited<ReturnType<typeof createPhysicalRecordingHarness>>,
+  recordingPath: string,
+  finalTracePath: string,
+): void {
+  harness.runnerTranscript.assertComplete();
+  const recordStartCall = harness.runnerTranscript.calls.find(
+    (call) => call.command === 'ios.runner.recordStart',
+  );
+  const request = recordStartCall?.request as Record<string, unknown> | undefined;
+  assert.deepEqual(
+    {
+      command: request?.command,
+      fps: request?.fps,
+      maxSize: request?.maxSize,
+      appBundleId: request?.appBundleId,
+    },
+    {
+      command: 'recordStart',
+      fps: 30,
+      maxSize: 720,
+      appBundleId: 'com.apple.Preferences',
+    },
+  );
+  assert.match(String(request?.outPath), /^agent-device-recording-\d+\.mp4$/);
+  assert.equal(fs.existsSync(recordingPath), true);
+  assert.equal(fs.existsSync(finalTracePath), true);
+  assertFlatToolCallStartsWith(harness.appleTool.calls, [
+    'devicectl',
+    'device',
+    'info',
+    'details',
+    '--device',
+    PROVIDER_SCENARIO_IOS_DEVICE.id,
+  ]);
+  assertFlatToolCallStartsWith(harness.appleTool.calls, [
+    'devicectl',
+    'device',
+    'process',
+    'launch',
+    '--device',
+    PROVIDER_SCENARIO_IOS_DEVICE.id,
+    'com.apple.Preferences',
+  ]);
+  assertFlatToolCallStartsWith(harness.appleTool.calls, [
+    'devicectl',
+    'device',
+    'copy',
+    'from',
+    '--device',
+    PROVIDER_SCENARIO_IOS_DEVICE.id,
+  ]);
+}
 
 test('Provider-backed integration iOS simulator recording flow uses semantic recording provider', async () => {
   await withProviderScenarioTempDir(


### PR DESCRIPTION
## Summary

On a physical iPhone, agent-device record stop using the runner AVAssetWriter backend could report a successful screen-recording artifact even when the runner reported recordStop ok:0 or the copied MP4 was never finalized.

The physical-iOS stop path previously treated runner stop as best-effort and trusted a successful devicectl copy, but devicectl can exit successfully while copying an unfinalized MP4. This change now:

- Records whether the runner-side recordStop command succeeded while still attempting to copy and validate the recording.
- Waits for the copied local file to stabilize.
- Validates the copied output with isPlayableVideo before trim or touch-overlay processing.
- Returns COMMAND_FAILED without publishing a screen-recording artifact when the video is not playable.
- Also returns COMMAND_FAILED when the runner reported recordStop failure even if the copied MP4 is technically playable.
- Leaves the playable-video plus successful-runner path and other recording backends unchanged.

The validation reuses waitForStableFile and isPlayableVideo already present on RecordTraceDeps, with no new runtime dependency. isPlayableVideo uses AVFoundation when available and falls back to checking for the required ftyp and moov container atoms, directly covering the reported unfinalized-file failure.

## Validation

- Provider-backed physical-iOS scenario covers three production-route outcomes: playable plus runner success, invalid copied MP4, and playable copied MP4 plus runner recordStop failure.
- The existing unit contract verifies runner-stop failure is user-visible after copy and that daemon recording state is cleared.
- iOS simulator provider recording remains green.
- pnpm check:affected --base origin/main --run passes: formatting, lint, typecheck, layering, fallow, build, and 482 related tests.
- A live app-scoped runner AVAssetWriter recording on thymikee-iphone previously produced a playable 16.4-second MP4. Exact-head reruns on b491ede80 were attempted after the runner-failure change, but Xcode could not establish the physical-device runner connection and the retry timed out before record start; all attempted sessions and runner processes were cleaned up.

## Scope

This PR addresses MP4 finalization validation and user-visible runner recordStop failure. Structured validation metadata, raw-video recovery after runner restart, and daemon signing-configuration diagnostics remain follow-up work.

Addresses #1229
