### PR TITLE
fix: write Android debug_http_host to the RN default-preferences file

### DIFF
--- a/src/commands/cli-grammar/flag-definitions-target.ts
+++ b/src/commands/cli-grammar/flag-definitions-target.ts
@@ -77,7 +77,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 1,
     max: 65535,
     usageLabel: '--metro-port <port>',
-    usageDescription: 'Session-scoped Metro/debug port hint',
+    usageDescription:
+      'Session-scoped Metro/debug port hint; on an emulator/simulator the host defaults to the loopback alias, physical devices still need --metro-host',
   },
   {
     key: 'metroProjectRoot',

--- a/src/commands/management/app.ts
+++ b/src/commands/management/app.ts
@@ -46,10 +46,13 @@ const openCommandMetadata = defineFieldCommandMetadata(
     ),
     noRecord: booleanField('Do not record this action.'),
     metroHost: stringField('Session-scoped Metro/debug host hint applied to the opened app.'),
-    metroPort: integerField('Session-scoped Metro/debug port hint applied to the opened app.', {
-      min: 1,
-      max: 65535,
-    }),
+    metroPort: integerField(
+      'Session-scoped Metro/debug port hint applied to the opened app. On an emulator/simulator the host defaults to the loopback alias (Android 10.0.2.2, iOS 127.0.0.1) when --metro-host is omitted; physical devices still require an explicit --metro-host.',
+      {
+        min: 1,
+        max: 65535,
+      },
+    ),
     bundleUrl: stringField('Session-scoped bundle URL hint applied to the opened app.'),
     launchUrl: stringField('Session-scoped launch URL hint applied to the opened app.'),
   },

--- a/src/daemon/__tests__/runtime-hints.test.ts
+++ b/src/daemon/__tests__/runtime-hints.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../../kernel/errors.ts';
 import { applyRuntimeHintsToApp, clearRuntimeHintsFromApp } from '../runtime-hints.ts';
+import { applyDeviceDefaultMetroHost } from '../handlers/session-runtime.ts';
 import { resolveRuntimeTransportHints } from '../../utils/runtime-transport.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
 
@@ -295,6 +296,52 @@ test('applyRuntimeHintsToApp also writes the legacy ReactNativeDevPrefs.xml path
     assert.match(legacyPayload ?? '', /<string name="keep_legacy">legacy-value<\/string>/);
     assert.match(legacyPayload ?? '', /<string name="debug_http_host">10\.0\.0\.10:8082<\/string>/);
     assert.match(legacyPayload ?? '', /<boolean name="dev_server_https" value="true" \/>/);
+  });
+});
+
+test('port-only hint on an Android emulator defaults host to 10.0.2.2 and writes the dev-server pref', async () => {
+  await withMockedAdb(async ({ device, readWrittenPrefsFile }) => {
+    const packageName = 'com.example.demo';
+    const runtime = applyDeviceDefaultMetroHost({ platform: 'android', metroPort: 8084 }, device);
+    assert.equal(runtime?.metroHost, '10.0.2.2');
+
+    await applyRuntimeHintsToApp({ device, appId: packageName, runtime });
+
+    const defaultPayload = await readWrittenPrefsFile(defaultPrefsPath(packageName));
+    assert.ok(defaultPayload, 'expected a write to the default RN preferences file');
+    assert.match(defaultPayload ?? '', /<string name="debug_http_host">10\.0\.2\.2:8084<\/string>/);
+  });
+});
+
+test('port-only hint on a physical Android device stays ambiguous and writes nothing', async () => {
+  await withMockedAdb(async ({ device, argsLogPath, readWrittenPrefsFile }) => {
+    const physicalDevice: DeviceInfo = { ...device, id: 'R5CN30', kind: 'device' };
+    const runtime = applyDeviceDefaultMetroHost(
+      { platform: 'android', metroPort: 8084 },
+      physicalDevice,
+    );
+    assert.equal(runtime?.metroHost, undefined);
+
+    await applyRuntimeHintsToApp({ device: physicalDevice, appId: 'com.example.demo', runtime });
+
+    const loggedArgs = await fs.readFile(argsLogPath, 'utf8').catch(() => '');
+    assert.doesNotMatch(loggedArgs, /tee/);
+    assert.equal(await readWrittenPrefsFile(defaultPrefsPath('com.example.demo')), undefined);
+  });
+});
+
+test('port-only hint on an iOS simulator defaults host to 127.0.0.1', async () => {
+  await withMockedXcrun(async ({ device, argsLogPath }) => {
+    const runtime = applyDeviceDefaultMetroHost({ platform: 'ios', metroPort: 8084 }, device);
+    assert.equal(runtime?.metroHost, '127.0.0.1');
+
+    await applyRuntimeHintsToApp({ device, appId: 'com.example.demo', runtime });
+
+    const loggedArgs = await fs.readFile(argsLogPath, 'utf8');
+    assert.match(
+      loggedArgs,
+      /simctl spawn sim-1 defaults write com\.example\.demo RCT_jsLocation -string 127\.0\.0\.1:8084/,
+    );
   });
 });
 

--- a/src/daemon/__tests__/runtime-hints.test.ts
+++ b/src/daemon/__tests__/runtime-hints.test.ts
@@ -8,19 +8,31 @@ import { applyRuntimeHintsToApp, clearRuntimeHintsFromApp } from '../runtime-hin
 import { resolveRuntimeTransportHints } from '../../utils/runtime-transport.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
 
+const LEGACY_PREFS_PATH = 'shared_prefs/ReactNativeDevPrefs.xml';
+
+function defaultPrefsPath(packageName: string): string {
+  return `shared_prefs/${packageName}_preferences.xml`;
+}
+
+function prefsKey(prefsPath: string): string {
+  return prefsPath.replaceAll('/', '_');
+}
+
 async function withMockedAdb(
   run: (ctx: {
     device: DeviceInfo;
     argsLogPath: string;
-    readFilePath: string;
-    stdinFilePath: string;
+    seedPrefsFile: (prefsPath: string, xml: string) => Promise<void>;
+    readWrittenPrefsFile: (prefsPath: string) => Promise<string | undefined>;
   }) => Promise<void>,
 ): Promise<void> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-runtime-hints-android-'));
   const adbPath = path.join(tmpDir, 'adb');
   const argsLogPath = path.join(tmpDir, 'args.log');
-  const readFilePath = path.join(tmpDir, 'existing.xml');
-  const stdinFilePath = path.join(tmpDir, 'write-stdin.xml');
+  const seedDir = path.join(tmpDir, 'seed');
+  const stdinDir = path.join(tmpDir, 'stdin');
+  await fs.mkdir(seedDir, { recursive: true });
+  await fs.mkdir(stdinDir, { recursive: true });
   await fs.writeFile(
     adbPath,
     [
@@ -31,8 +43,9 @@ async function withMockedAdb(
       'fi',
       'printf "%s\\n" "$*" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
       'if [ "$1" = "shell" ] && [ "$2" = "run-as" ] && [ "$4" = "cat" ]; then',
-      '  if [ -f "$AGENT_DEVICE_TEST_READ_FILE" ]; then',
-      '    cat "$AGENT_DEVICE_TEST_READ_FILE"',
+      '  key=$(printf "%s" "$5" | tr "/" "_")',
+      '  if [ -f "$AGENT_DEVICE_TEST_SEED_DIR/$key" ]; then',
+      '    cat "$AGENT_DEVICE_TEST_SEED_DIR/$key"',
       '    exit 0',
       '  fi',
       '  exit 1',
@@ -57,8 +70,9 @@ async function withMockedAdb(
       '  fi',
       '  exit "${AGENT_DEVICE_TEST_RUN_AS_MKDIR_EXIT_CODE:-0}"',
       'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "run-as" ] && [ "$4" = "tee" ] && [ "$5" = "shared_prefs/ReactNativeDevPrefs.xml" ]; then',
-      '  cat > "$AGENT_DEVICE_TEST_STDIN_FILE"',
+      'if [ "$1" = "shell" ] && [ "$2" = "run-as" ] && [ "$4" = "tee" ]; then',
+      '  key=$(printf "%s" "$5" | tr "/" "_")',
+      '  cat > "$AGENT_DEVICE_TEST_STDIN_DIR/$key"',
       '  if [ -n "$AGENT_DEVICE_TEST_RUN_AS_WRITE_STDOUT" ]; then',
       '    printf "%s" "$AGENT_DEVICE_TEST_RUN_AS_WRITE_STDOUT"',
       '  fi',
@@ -80,8 +94,8 @@ async function withMockedAdb(
 
   const previousPath = process.env.PATH;
   const previousArgsFile = process.env.AGENT_DEVICE_TEST_ARGS_FILE;
-  const previousReadFile = process.env.AGENT_DEVICE_TEST_READ_FILE;
-  const previousStdinFile = process.env.AGENT_DEVICE_TEST_STDIN_FILE;
+  const previousSeedDir = process.env.AGENT_DEVICE_TEST_SEED_DIR;
+  const previousStdinDir = process.env.AGENT_DEVICE_TEST_STDIN_DIR;
   const previousRunAsIdExitCode = process.env.AGENT_DEVICE_TEST_RUN_AS_ID_EXIT_CODE;
   const previousRunAsIdStdout = process.env.AGENT_DEVICE_TEST_RUN_AS_ID_STDOUT;
   const previousRunAsIdStderr = process.env.AGENT_DEVICE_TEST_RUN_AS_ID_STDERR;
@@ -93,8 +107,8 @@ async function withMockedAdb(
   const previousRunAsWriteStderr = process.env.AGENT_DEVICE_TEST_RUN_AS_WRITE_STDERR;
   process.env.PATH = `${tmpDir}${path.delimiter}${previousPath ?? ''}`;
   process.env.AGENT_DEVICE_TEST_ARGS_FILE = argsLogPath;
-  process.env.AGENT_DEVICE_TEST_READ_FILE = readFilePath;
-  process.env.AGENT_DEVICE_TEST_STDIN_FILE = stdinFilePath;
+  process.env.AGENT_DEVICE_TEST_SEED_DIR = seedDir;
+  process.env.AGENT_DEVICE_TEST_STDIN_DIR = stdinDir;
 
   const device: DeviceInfo = {
     platform: 'android',
@@ -104,13 +118,24 @@ async function withMockedAdb(
     booted: true,
   };
 
+  const seedPrefsFile = async (prefsPath: string, xml: string): Promise<void> => {
+    await fs.writeFile(path.join(seedDir, prefsKey(prefsPath)), xml, 'utf8');
+  };
+  const readWrittenPrefsFile = async (prefsPath: string): Promise<string | undefined> => {
+    try {
+      return await fs.readFile(path.join(stdinDir, prefsKey(prefsPath)), 'utf8');
+    } catch {
+      return undefined;
+    }
+  };
+
   try {
-    await run({ device, argsLogPath, readFilePath, stdinFilePath });
+    await run({ device, argsLogPath, seedPrefsFile, readWrittenPrefsFile });
   } finally {
     process.env.PATH = previousPath;
     restoreEnv('AGENT_DEVICE_TEST_ARGS_FILE', previousArgsFile);
-    restoreEnv('AGENT_DEVICE_TEST_READ_FILE', previousReadFile);
-    restoreEnv('AGENT_DEVICE_TEST_STDIN_FILE', previousStdinFile);
+    restoreEnv('AGENT_DEVICE_TEST_SEED_DIR', previousSeedDir);
+    restoreEnv('AGENT_DEVICE_TEST_STDIN_DIR', previousStdinDir);
     restoreEnv('AGENT_DEVICE_TEST_RUN_AS_ID_EXIT_CODE', previousRunAsIdExitCode);
     restoreEnv('AGENT_DEVICE_TEST_RUN_AS_ID_STDOUT', previousRunAsIdStdout);
     restoreEnv('AGENT_DEVICE_TEST_RUN_AS_ID_STDERR', previousRunAsIdStderr);
@@ -188,23 +213,23 @@ test('resolveRuntimeTransportHints derives host, port, and scheme from bundle UR
   );
 });
 
-test('applyRuntimeHintsToApp writes React Native Android dev prefs', async () => {
-  await withMockedAdb(async ({ device, argsLogPath, readFilePath, stdinFilePath }) => {
-    await fs.writeFile(
-      readFilePath,
+test('applyRuntimeHintsToApp writes debug_http_host to the RN default-preferences file React Native actually reads', async () => {
+  await withMockedAdb(async ({ device, argsLogPath, seedPrefsFile, readWrittenPrefsFile }) => {
+    const packageName = 'com.example.demo';
+    await seedPrefsFile(
+      defaultPrefsPath(packageName),
       [
         '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>',
         '<map>',
-        '  <string name="keep">value</string>',
+        '  <string name="keep_default">default-value</string>',
         '</map>',
         '',
       ].join('\n'),
-      'utf8',
     );
 
     await applyRuntimeHintsToApp({
       device,
-      appId: 'com.example.demo',
+      appId: packageName,
       runtime: {
         platform: 'android',
         bundleUrl: 'https://10.0.0.10:8082/index.bundle?platform=android',
@@ -212,19 +237,64 @@ test('applyRuntimeHintsToApp writes React Native Android dev prefs', async () =>
     });
 
     const loggedArgs = await fs.readFile(argsLogPath, 'utf8');
-    const stdinPayload = await fs.readFile(stdinFilePath, 'utf8');
+    assert.match(
+      loggedArgs,
+      /shell run-as com\.example\.demo cat shared_prefs\/com\.example\.demo_preferences\.xml/,
+    );
+    assert.match(
+      loggedArgs,
+      /shell run-as com\.example\.demo tee shared_prefs\/com\.example\.demo_preferences\.xml/,
+    );
+
+    const defaultPayload = await readWrittenPrefsFile(defaultPrefsPath(packageName));
+    assert.ok(defaultPayload, 'expected a write to the default RN preferences file');
+    assert.match(defaultPayload ?? '', /<string name="keep_default">default-value<\/string>/);
+    assert.match(
+      defaultPayload ?? '',
+      /<string name="debug_http_host">10\.0\.0\.10:8082<\/string>/,
+    );
+    assert.match(defaultPayload ?? '', /<boolean name="dev_server_https" value="true" \/>/);
+  });
+});
+
+test('applyRuntimeHintsToApp also writes the legacy ReactNativeDevPrefs.xml path for back-compat', async () => {
+  await withMockedAdb(async ({ device, argsLogPath, seedPrefsFile, readWrittenPrefsFile }) => {
+    const packageName = 'com.example.demo';
+    await seedPrefsFile(
+      LEGACY_PREFS_PATH,
+      [
+        '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>',
+        '<map>',
+        '  <string name="keep_legacy">legacy-value</string>',
+        '</map>',
+        '',
+      ].join('\n'),
+    );
+
+    await applyRuntimeHintsToApp({
+      device,
+      appId: packageName,
+      runtime: {
+        platform: 'android',
+        bundleUrl: 'https://10.0.0.10:8082/index.bundle?platform=android',
+      },
+    });
+
+    const loggedArgs = await fs.readFile(argsLogPath, 'utf8');
     assert.match(
       loggedArgs,
       /shell run-as com\.example\.demo cat shared_prefs\/ReactNativeDevPrefs\.xml/,
     );
-    assert.match(loggedArgs, /shell run-as com\.example\.demo mkdir -p shared_prefs/);
     assert.match(
       loggedArgs,
       /shell run-as com\.example\.demo tee shared_prefs\/ReactNativeDevPrefs\.xml/,
     );
-    assert.match(stdinPayload, /<string name="keep">value<\/string>/);
-    assert.match(stdinPayload, /<string name="debug_http_host">10\.0\.0\.10:8082<\/string>/);
-    assert.match(stdinPayload, /<boolean name="dev_server_https" value="true" \/>/);
+
+    const legacyPayload = await readWrittenPrefsFile(LEGACY_PREFS_PATH);
+    assert.ok(legacyPayload, 'expected a write to the legacy ReactNativeDevPrefs.xml file');
+    assert.match(legacyPayload ?? '', /<string name="keep_legacy">legacy-value<\/string>/);
+    assert.match(legacyPayload ?? '', /<string name="debug_http_host">10\.0\.0\.10:8082<\/string>/);
+    assert.match(legacyPayload ?? '', /<boolean name="dev_server_https" value="true" \/>/);
   });
 });
 
@@ -349,7 +419,7 @@ test('applyRuntimeHintsToApp preserves write failures after a successful run-as 
   await withMockedAdb(async ({ device }) => {
     process.env.AGENT_DEVICE_TEST_RUN_AS_WRITE_EXIT_CODE = '1';
     process.env.AGENT_DEVICE_TEST_RUN_AS_WRITE_STDERR =
-      "sh: can't create shared_prefs/ReactNativeDevPrefs.xml: Permission denied";
+      "sh: can't create shared_prefs/com.example.demo_preferences.xml: Permission denied";
     try {
       await assert.rejects(
         applyRuntimeHintsToApp({
@@ -366,7 +436,7 @@ test('applyRuntimeHintsToApp preserves write failures after a successful run-as 
           assert.equal(error.message, 'Failed to write Android runtime hints for com.example.demo');
           assert.equal(
             error.details?.hint,
-            'adb run-as succeeded, but writing ReactNativeDevPrefs.xml failed. Inspect stderr/details for the failing shell command.',
+            'adb run-as succeeded, but writing the React Native dev-server preference file failed. Inspect stderr/details for the failing shell command.',
           );
           assert.equal(error.details?.phase, 'write-runtime-hints');
           assert.equal(error.details?.exitCode, 1);
@@ -381,31 +451,38 @@ test('applyRuntimeHintsToApp preserves write failures after a successful run-as 
   });
 });
 
-test('clearRuntimeHintsFromApp removes managed Android runtime prefs but preserves unrelated entries', async () => {
-  await withMockedAdb(async ({ device, readFilePath, stdinFilePath }) => {
-    await fs.writeFile(
-      readFilePath,
+test('clearRuntimeHintsFromApp removes managed Android runtime prefs from both files but preserves unrelated entries', async () => {
+  await withMockedAdb(async ({ device, seedPrefsFile, readWrittenPrefsFile }) => {
+    const packageName = 'com.example.demo';
+    const seeded = (keepKey: string, keepValue: string): string =>
       [
         '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>',
         '<map>',
-        '  <string name="keep">value</string>',
+        `  <string name="${keepKey}">${keepValue}</string>`,
         '  <string name="debug_http_host">10.0.0.10:8081</string>',
         '  <boolean name="dev_server_https" value="true" />',
         '</map>',
         '',
-      ].join('\n'),
-      'utf8',
-    );
+      ].join('\n');
+    await seedPrefsFile(defaultPrefsPath(packageName), seeded('keep_default', 'default-value'));
+    await seedPrefsFile(LEGACY_PREFS_PATH, seeded('keep_legacy', 'legacy-value'));
 
     await clearRuntimeHintsFromApp({
       device,
-      appId: 'com.example.demo',
+      appId: packageName,
     });
 
-    const stdinPayload = await fs.readFile(stdinFilePath, 'utf8');
-    assert.match(stdinPayload, /<string name="keep">value<\/string>/);
-    assert.doesNotMatch(stdinPayload, /debug_http_host/);
-    assert.doesNotMatch(stdinPayload, /dev_server_https/);
+    const defaultPayload = await readWrittenPrefsFile(defaultPrefsPath(packageName));
+    assert.ok(defaultPayload, 'expected the default RN preferences file to be rewritten');
+    assert.match(defaultPayload ?? '', /<string name="keep_default">default-value<\/string>/);
+    assert.doesNotMatch(defaultPayload ?? '', /debug_http_host/);
+    assert.doesNotMatch(defaultPayload ?? '', /dev_server_https/);
+
+    const legacyPayload = await readWrittenPrefsFile(LEGACY_PREFS_PATH);
+    assert.ok(legacyPayload, 'expected the legacy ReactNativeDevPrefs.xml file to be rewritten');
+    assert.match(legacyPayload ?? '', /<string name="keep_legacy">legacy-value<\/string>/);
+    assert.doesNotMatch(legacyPayload ?? '', /debug_http_host/);
+    assert.doesNotMatch(legacyPayload ?? '', /dev_server_https/);
   });
 });
 

--- a/src/daemon/handlers/__tests__/session-open-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-runtime.test.ts
@@ -516,6 +516,118 @@ test('open runtime payload does not persist replacement when launch fails', asyn
   });
 });
 
+test('open --metro-port alone defaults the host to 10.0.2.2 on an Android emulator', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'runtime-open-port-only-android';
+  const runtimeApplyCalls: Array<{ host?: string; port?: number }> = [];
+
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'android',
+    id: 'emulator-5556',
+    name: 'Pixel',
+    kind: 'emulator',
+    booted: true,
+  });
+  mockResolveAndroidPackage.mockResolvedValue('com.example.demo');
+  mockApplyRuntimeHints.mockImplementation(async ({ runtime }) => {
+    runtimeApplyCalls.push({ host: runtime?.metroHost, port: runtime?.metroPort });
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'open',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+      runtime: { metroPort: 8084 },
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(runtimeApplyCalls).toEqual([{ host: '10.0.2.2', port: 8084 }]);
+  expect(sessionStore.getRuntimeHints(sessionName)?.metroHost).toBe('10.0.2.2');
+  expect(sessionStore.getRuntimeHints(sessionName)?.metroPort).toBe(8084);
+});
+
+test('open --metro-port alone defaults the host to 127.0.0.1 on an iOS simulator', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'runtime-open-port-only-ios';
+  const runtimeApplyCalls: Array<{ host?: string; port?: number }> = [];
+
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'apple',
+    id: 'sim-1',
+    name: 'iPhone 17 Pro',
+    kind: 'simulator',
+    booted: true,
+  });
+  mockApplyRuntimeHints.mockImplementation(async ({ runtime }) => {
+    runtimeApplyCalls.push({ host: runtime?.metroHost, port: runtime?.metroPort });
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'open',
+      positionals: ['Demo'],
+      flags: { platform: 'ios' },
+      runtime: { metroPort: 8084 },
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(runtimeApplyCalls).toEqual([{ host: '127.0.0.1', port: 8084 }]);
+  expect(sessionStore.getRuntimeHints(sessionName)?.metroHost).toBe('127.0.0.1');
+});
+
+test('open --metro-port alone stays host-ambiguous on a physical Android device', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'runtime-open-port-only-physical';
+  const runtimeApplyCalls: Array<{ host?: string; port?: number }> = [];
+
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'android',
+    id: 'R5CN30',
+    name: 'Galaxy',
+    kind: 'device',
+    booted: true,
+  });
+  mockResolveAndroidPackage.mockResolvedValue('com.example.demo');
+  mockApplyRuntimeHints.mockImplementation(async ({ runtime }) => {
+    runtimeApplyCalls.push({ host: runtime?.metroHost, port: runtime?.metroPort });
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'open',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+      runtime: { metroPort: 8084 },
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(runtimeApplyCalls).toEqual([{ host: undefined, port: 8084 }]);
+  expect(sessionStore.getRuntimeHints(sessionName)?.metroHost).toBeUndefined();
+  expect(sessionStore.getRuntimeHints(sessionName)?.metroPort).toBe(8084);
+});
+
 test('open --relaunch allows Android package names ending with apk-like suffix', async () => {
   const sessionStore = makeSessionStore();
   const dispatchCalls: Array<{ command: string; positionals: string[] }> = [];

--- a/src/daemon/handlers/session-runtime.ts
+++ b/src/daemon/handlers/session-runtime.ts
@@ -8,7 +8,12 @@ import {
   hasRuntimeTransportHints,
   trimRuntimeValue,
 } from '../runtime-hints.ts';
+import { isAndroidEmulator, isIosSimulator } from '../device-targets.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
+
+// Loopback aliases an emulator/simulator app uses to reach the dev server on the host machine.
+const ANDROID_EMULATOR_LOOPBACK_HOST = '10.0.2.2';
+const IOS_SIMULATOR_LOOPBACK_HOST = '127.0.0.1';
 
 const RUNTIME_HINT_FIELD_NAMES = [
   'platform',
@@ -112,6 +117,28 @@ export function mergeRuntimeHints(
   };
 }
 
+function defaultMetroHostForDevice(device: DeviceInfo): string | undefined {
+  if (isAndroidEmulator(device)) return ANDROID_EMULATOR_LOOPBACK_HOST;
+  if (isIosSimulator(device)) return IOS_SIMULATOR_LOOPBACK_HOST;
+  return undefined;
+}
+
+// A port-only hint (`--metro-port` without `--metro-host`) otherwise writes no dev-server pref.
+// Emulator/simulator hosts are unambiguous, so fill in the loopback alias; physical devices stay
+// ambiguous and still require an explicit `--metro-host`.
+export function applyDeviceDefaultMetroHost(
+  runtime: SessionRuntimeHints | undefined,
+  device: DeviceInfo,
+): SessionRuntimeHints | undefined {
+  if (!runtime) return runtime;
+  if (trimRuntimeValue(runtime.metroHost)) return runtime;
+  if (trimRuntimeValue(runtime.bundleUrl)) return runtime; // bundleUrl carries its own host
+  if (runtime.metroPort === undefined) return runtime;
+  const host = defaultMetroHostForDevice(device);
+  if (!host) return runtime;
+  return { ...runtime, metroHost: host };
+}
+
 function normalizeExplicitRuntimeHints(params: {
   runtime: unknown;
   sessionName: string;
@@ -202,16 +229,21 @@ function resolveOpenRuntimeHints(params: {
   });
   if (req.runtime === undefined) {
     return {
-      runtime: resolveSessionRuntimeHints(sessionStore, sessionName, device),
+      runtime: applyDeviceDefaultMetroHost(
+        resolveSessionRuntimeHints(sessionStore, sessionName, device),
+        device,
+      ),
       previousRuntime,
       replacedStoredRuntime: false,
     };
   }
   return {
-    runtime:
+    runtime: applyDeviceDefaultMetroHost(
       explicitRuntime && countConfiguredRuntimeHints(explicitRuntime) > 0
         ? explicitRuntime
         : undefined,
+      device,
+    ),
     previousRuntime,
     replacedStoredRuntime: true,
   };

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -15,7 +15,12 @@ import { buildSimctlArgsForDevice } from '../platforms/apple/core/simctl.ts';
 import { runXcrun } from '../platforms/apple/core/tool-provider.ts';
 import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 
-const ANDROID_DEV_PREFS_PATH = 'shared_prefs/ReactNativeDevPrefs.xml';
+// React Native's PackagerConnectionSettings/DevInternalSettings read debug_http_host via
+// PreferenceManager.getDefaultSharedPreferences(context), which resolves to
+// `<packageName>_preferences.xml`, not a React Native-specific file. We write both that file
+// and the legacy ReactNativeDevPrefs.xml path (kept in case some RN fork/version reads it) so
+// the hint reaches the app either way.
+const ANDROID_LEGACY_DEV_PREFS_PATH = 'shared_prefs/ReactNativeDevPrefs.xml';
 const ANDROID_DEBUG_HOST_KEY = 'debug_http_host';
 const ANDROID_HTTPS_KEY = 'dev_server_https';
 const IOS_JS_LOCATION_KEY = 'RCT_jsLocation';
@@ -23,7 +28,7 @@ const IOS_PACKAGER_SCHEME_KEY = 'RCT_packager_scheme';
 const ANDROID_RUN_AS_HINT =
   'React Native runtime hints require adb run-as access to the app sandbox. Verify the app is debuggable and the selected package/device are correct.';
 const ANDROID_WRITE_HINT =
-  'adb run-as succeeded, but writing ReactNativeDevPrefs.xml failed. Inspect stderr/details for the failing shell command.';
+  'adb run-as succeeded, but writing the React Native dev-server preference file failed. Inspect stderr/details for the failing shell command.';
 const ANDROID_PROBE_HINT =
   'adb shell run-as probe failed. Check adb connectivity and that the device is reachable. Inspect stderr/details for more information.';
 const DEFAULT_ANDROID_PREFS_XML = [
@@ -77,37 +82,47 @@ export async function clearRuntimeHintsFromApp(params: {
   }
 }
 
+function androidDevPrefsPaths(packageName: string): string[] {
+  return [`shared_prefs/${packageName}_preferences.xml`, ANDROID_LEGACY_DEV_PREFS_PATH];
+}
+
 async function applyAndroidRuntimeHints(
   device: DeviceInfo,
   packageName: string,
   transport: ResolvedRuntimeTransport,
 ): Promise<void> {
   assertAndroidRuntimePackageName(packageName);
-  const currentXml = await readAndroidDevPrefs(device, packageName);
-  let nextXml = upsertAndroidStringPref(
-    currentXml,
-    ANDROID_DEBUG_HOST_KEY,
-    `${transport.host}:${transport.port}`,
-  );
-  nextXml = upsertAndroidBooleanPref(nextXml, ANDROID_HTTPS_KEY, transport.scheme === 'https');
-  await writeAndroidDevPrefs(device, packageName, nextXml);
+  for (const prefsPath of androidDevPrefsPaths(packageName)) {
+    const currentXml = await readAndroidDevPrefs(device, packageName, prefsPath);
+    let nextXml = upsertAndroidStringPref(
+      currentXml,
+      ANDROID_DEBUG_HOST_KEY,
+      `${transport.host}:${transport.port}`,
+    );
+    nextXml = upsertAndroidBooleanPref(nextXml, ANDROID_HTTPS_KEY, transport.scheme === 'https');
+    await writeAndroidDevPrefs(device, packageName, prefsPath, nextXml);
+  }
 }
 
 async function clearAndroidRuntimeHints(device: DeviceInfo, packageName: string): Promise<void> {
   assertAndroidRuntimePackageName(packageName);
-  const currentXml = await readAndroidDevPrefs(device, packageName);
-  const withoutHost = removeAndroidPrefEntry(currentXml, ANDROID_DEBUG_HOST_KEY);
-  const withoutHttps = removeAndroidPrefEntry(withoutHost, ANDROID_HTTPS_KEY);
-  if (withoutHttps === currentXml) return;
-  await writeAndroidDevPrefs(device, packageName, withoutHttps);
+  for (const prefsPath of androidDevPrefsPaths(packageName)) {
+    const currentXml = await readAndroidDevPrefs(device, packageName, prefsPath);
+    const withoutHost = removeAndroidPrefEntry(currentXml, ANDROID_DEBUG_HOST_KEY);
+    const withoutHttps = removeAndroidPrefEntry(withoutHost, ANDROID_HTTPS_KEY);
+    if (withoutHttps === currentXml) continue;
+    await writeAndroidDevPrefs(device, packageName, prefsPath, withoutHttps);
+  }
 }
 
-async function readAndroidDevPrefs(device: DeviceInfo, packageName: string): Promise<string> {
-  const result = await runAndroidAdb(
-    device,
-    ['shell', 'run-as', packageName, 'cat', ANDROID_DEV_PREFS_PATH],
-    { allowFailure: true },
-  );
+async function readAndroidDevPrefs(
+  device: DeviceInfo,
+  packageName: string,
+  prefsPath: string,
+): Promise<string> {
+  const result = await runAndroidAdb(device, ['shell', 'run-as', packageName, 'cat', prefsPath], {
+    allowFailure: true,
+  });
   if (result.exitCode !== 0) return DEFAULT_ANDROID_PREFS_XML;
   return normalizeAndroidPrefsXml(result.stdout);
 }
@@ -115,6 +130,7 @@ async function readAndroidDevPrefs(device: DeviceInfo, packageName: string): Pro
 async function writeAndroidDevPrefs(
   device: DeviceInfo,
   packageName: string,
+  prefsPath: string,
   xml: string,
 ): Promise<void> {
   const probeArgs = ['shell', 'run-as', packageName, 'id'];
@@ -137,7 +153,7 @@ async function writeAndroidDevPrefs(
 
   try {
     await runAndroidAdb(device, ['shell', 'run-as', packageName, 'mkdir', '-p', 'shared_prefs']);
-    await runAndroidAdb(device, ['shell', 'run-as', packageName, 'tee', ANDROID_DEV_PREFS_PATH], {
+    await runAndroidAdb(device, ['shell', 'run-as', packageName, 'tee', prefsPath], {
       stdin: xml.trimEnd(),
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

Two gaps kept `open --metro-port`/`--bundle-url` and `metro prepare`/`reload` from actually pointing modern React Native Android apps at the chosen dev server. Both were verified live.

### 1. Wrong SharedPreferences file (filename fix)

- The Android runtime-hints path only wrote `debug_http_host`/`dev_server_https` into `shared_prefs/ReactNativeDevPrefs.xml`. React Native's `PackagerConnectionSettings`/`DevInternalSettings` (verified in RN 0.76–0.85 source) read `debug_http_host` via `PreferenceManager.getDefaultSharedPreferences(context)`, which resolves to `shared_prefs/<packageName>_preferences.xml` — not `ReactNativeDevPrefs.xml`. So the write silently had no effect on modern (new-arch) RN Android apps.
- Verified live (org.reactnavigation.playground, new arch): the `ReactNativeDevPrefs.xml` write was ignored (app kept its default host); writing `debug_http_host` into `<packageName>_preferences.xml` made the app immediately request the chosen port.
- Fix: read-merge-write **both** `shared_prefs/<packageName>_preferences.xml` (the file RN actually reads) and `shared_prefs/ReactNativeDevPrefs.xml` (kept for back-compat — no evidence any RN 0.76–0.85 version reads it, but written defensively). Both preserve unrelated existing keys; the `clear` path removes the managed keys from both.

### 2. Port-only hint wrote nothing (host-defaulting fix)

- `--metro-port <port>` **without** `--metro-host` resolved to no transport (`resolveRuntimeTransportHints` requires both host and port), so `applyRuntimeHintsToApp` bailed and nothing was written — the app kept its built-in default host. The filename fix above only took effect when both flags were passed.
- Verified live: `open --metro-host 10.0.2.2 --metro-port 8084` wrote `debug_http_host=10.0.2.2:8084` and the app requested 8084; `--metro-port 8084` alone wrote nothing.
- Fix: default the Metro host in the device-aware layer (`resolveOpenRuntimeHints`, which has `DeviceInfo`) via `applyDeviceDefaultMetroHost` — **Android emulator → `10.0.2.2`**, **iOS simulator → `127.0.0.1`**. The default is baked into the resolved runtime, so it flows to both the app-pref write and the stored session dev-server binding. **Physical devices stay host-ambiguous and still require an explicit `--metro-host`** (no LAN-IP guessing). `bundleUrl` hints carry their own host and are left untouched. `--metro-port` help text updated to match.

## Test plan

- [x] `src/daemon/__tests__/runtime-hints.test.ts`: write targets `<packageName>_preferences.xml` and preserves an unrelated key; legacy `ReactNativeDevPrefs.xml` write also happens and preserves its own key; `clear` scrubs the managed keys from both files. New: port-only on emulator defaults host to `10.0.2.2` and writes `10.0.2.2:<port>`; port-only on iOS simulator writes `127.0.0.1:<port>`; port-only on a physical device writes nothing.
- [x] `src/daemon/handlers/__tests__/session-open-runtime.test.ts`: `open --metro-port` alone through the full open flow defaults host to `10.0.2.2` (emulator) / `127.0.0.1` (iOS sim) in both the applied runtime and the stored session hints; a physical device stays host-undefined.
- [x] `npx tsc --noEmit`, `npx oxlint --deny-warnings`, `npx oxfmt --check`
- [x] `fallow audit --base origin/main`, `npm run check:layering`
- [x] `npx vitest run src/daemon src/platforms/android src/utils` (203 files / 1782 tests passed)