### PR TITLE
fix: refresh Android snapshots after in-place ComposeView content swaps (#1254)

### DIFF
--- a/android-snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/SnapshotInstrumentation.java
+++ b/android-snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/SnapshotInstrumentation.java
@@ -341,6 +341,7 @@ public final class SnapshotInstrumentation extends Instrumentation {
         // Busy or animated apps can still expose a usable root; capture whatever is available.
       }
     }
+    clearAccessibilityCache(automation);
 
     CaptureStats stats = new CaptureStats();
     StringBuilder xml = new StringBuilder();
@@ -365,6 +366,38 @@ public final class SnapshotInstrumentation extends Instrumentation {
     xml.append("</hierarchy>");
     return new CaptureResult(
         xml.toString(), windowCount > 0, captureMode, windowCount, stats.nodeCount, stats.truncated);
+  }
+
+  private static void clearAccessibilityCache(UiAutomation automation) {
+    // Navigation 3 and any in-place content swap that keeps the same window/Activity render every
+    // destination inside one AndroidComposeView. A persistent helper session reuses a single
+    // UiAutomation connection across captures, and its per-connection accessibility node cache is
+    // not always invalidated by such a swap, so getWindows()/getRootInActiveWindow() can keep
+    // returning the previous screen. Drop the cache before each traversal so every capture re-reads
+    // the live tree, the way a fresh `uiautomator dump` (new connection, empty cache) does.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      try {
+        automation.clearCache();
+        return;
+      } catch (RuntimeException ignored) {
+        // Fall back to the setServiceInfo() flush below if the platform rejects the public API.
+      }
+    }
+    clearAccessibilityCacheViaServiceInfo(automation);
+  }
+
+  private static void clearAccessibilityCacheViaServiceInfo(UiAutomation automation) {
+    // Platforms before API 34 lack UiAutomation.clearCache(). Re-applying the current service info
+    // is the supported public-API way to drop the cache there: UiAutomation.setServiceInfo() calls
+    // AccessibilityInteractionClient.clearCache() before forwarding the config (verified in AOSP
+    // from API 24 through 33). Reflecting the internal clearCache() directly is not an option — it
+    // is a blocklisted non-SDK member, so hidden-API enforcement makes it unreachable from the
+    // helper process. Best-effort: if the flush fails the capture proceeds with the current tree.
+    try {
+      automation.setServiceInfo(automation.getServiceInfo());
+    } catch (RuntimeException ignored) {
+      // No reliable cache reset on this platform; leave capture behavior unchanged.
+    }
   }
 
   private UiAutomation getConnectedUiAutomation(long timeoutMs) throws TimeoutException {


### PR DESCRIPTION
## Summary

Fixes #1254 — after the **second** Jetpack Navigation 3 navigation, `agent-device snapshot` keeps returning the *previous* screen. Every selector on the new screen then fails to match (`click`, `fill`, `is`, `wait`, `find`) even though the app has actually moved on. `adb shell uiautomator dump` at the same instant shows the correct screen, so it's the helper's snapshot that is stale, not the app or device.

## Root cause

The snapshot helper keeps a single `UiAutomation` connection hot across captures in a persistent session (a deliberate "keep the runner hot" optimization). That connection's per-connection **accessibility node cache** is not reliably invalidated by an in-place content swap that keeps the same window/Activity — which is exactly what Navigation 3 does: every destination is rendered inside one `AndroidComposeView`, with no new Activity or window (`mCurrentFocus` never changes). So `getWindows()` / `getRootInActiveWindow()` keep serving the cached subtree from the earlier navigation.

`uiautomator dump` is unaffected because each invocation uses a *fresh* connection with an empty cache.

The [#861 recovery](https://github.com/callstack/agent-device/commit/df490ee85) only rescues **empty / system-only / content-poor** helper output and falls back to a stock `uiautomator dump`. Here the stale tree is a rich, plausible foreground-app screen (16 nodes from the app package), so it slips past every heuristic.

## Fix

Clear the accessibility cache before every traversal so each capture re-reads the live tree — the same effect a fresh `uiautomator dump` gets for free:

- **API 34+**: `UiAutomation.clearCache()` (public since Android 14).
- **older**: best-effort reflection into `AccessibilityInteractionClient` (all failures swallowed; capture proceeds unchanged if unavailable).

The change is confined to the on-device helper (`SnapshotInstrumentation.java`); the npm-bundled APK is rebuilt from source at `prepack`.

## Verification

Reproduced end-to-end with the reporter's minimal repro (`antFrancon/nav3-agent-device-snapshot-repro`) on an Android emulator (API 36).

**Before** (unpatched helper):
```
snapshot after click id=to-screen3  ->  "Screen 2" + to-screen3   (STALE)
uiautomator dump (same instant)     ->  screen3-title, screen3-field (correct)
```

**After** (patched helper) — `Home -> Screen 2 -> Screen 3`, snapshot correctly lands on Screen 3 (`screen3-field`, "Type here"):
```
run 1: PASS (Screen 3)
run 2: PASS (Screen 3)
run 3: PASS (Screen 3)
```

Home and the first navigation continued to capture correctly, and the Android content-recovery unit tests still pass.