### PR TITLE
fix(replay): resume.from now agrees with repairHint's record-and-heal continuation

### DIFF
--- a/docs/adr/0012-interactive-replay.md
+++ b/docs/adr/0012-interactive-replay.md
@@ -483,9 +483,23 @@ resuming AT it would re-diverge on the exact step just completed); for every oth
 `caution`, `manual`), `from` equals the failed step's index unchanged. This keeps the structured `resume`
 block and the `repairHint` text guidance below in agreement — a JSON/MCP-first caller that blindly resumes
 at `resume.from` gets the same continuation a text caller reads out of the rendered guidance, never a stale
-`from` that loops the caller back onto the step it just repaired. If the shifted `from` would exceed the
-plan's length (the diverged step was the plan's last), `allowed` is `false` with a reason explaining there
-is nothing left to resume into — finish the repair with `close` instead.
+`from` that loops the caller back onto the step it just repaired.
+
+If the shifted `from` equals `actions.length + 1` (the diverged step was the plan's LAST step), that is a
+legal EMPTY-TAIL resume, not an error: there is nothing left to replay, so the resumed run executes zero
+device actions and falls straight through to the normal end-of-plan completion path, correctly flipping an
+armed repair transaction COMPLETE (decision 6, R7's `close` commit gate). Rejecting this ordinal outright
+would force the agent to `close` an INCOMPLETE transaction instead, which aborts and discards the corrective
+action it just recorded. This one-past-the-end ordinal is authorized ONLY for the EXACT session and target
+that produced it — the daemon stamps a per-session watermark (`expectedFrom`, the recorded action count at
+divergence time) whenever a `record-and-heal` divergence reports `allowed: true`, and a later `--from`
+request is accepted at `actions.length + 1` only when it matches that watermark AND the session's action
+count has grown since (proof the corrective press was actually recorded) — never a blanket "one past the
+end is fine" for any session or repair kind, which would let an unrelated or blind resume silently skip the
+plan's unresolved final step and commit an incomplete repair. The same watermark match, independent of
+whether `from` lands one past the end or still inside the plan, also gates every OTHER `record-and-heal`
+continuation: resuming at the reported `from` with the action count unchanged is rejected as proof the
+corrective press never happened, rather than silently resuming past the unrepaired step.
 `planDigest` is SHA-256 over
 the canonical fully expanded plan, including each action's command, normalized inputs, control shape,
 platform-conditioned expansion, and source provenance. Concretely "normalized inputs" bind each action's

--- a/docs/adr/0012-interactive-replay.md
+++ b/docs/adr/0012-interactive-replay.md
@@ -476,6 +476,16 @@ repeat iteration label. Static includes, platform conditions, and fixed-count re
 indexing, so repeated source lines are distinguished by their plan index.
 
 Every divergence includes `resume: { allowed, from, reason?, planDigest, repairSessionHeld? }`.
+`from` is not merely the failed step's ordinal — it is the ordinal the caller should actually pass to
+`--from`, computed from the same `repairHint` carried alongside it (decision 6, R2/R3): for `record-and-heal`,
+`from` is the failed step's index **+ 1** (the agent performs that step manually before resuming, so
+resuming AT it would re-diverge on the exact step just completed); for every other hint (`state-repair`,
+`caution`, `manual`), `from` equals the failed step's index unchanged. This keeps the structured `resume`
+block and the `repairHint` text guidance below in agreement — a JSON/MCP-first caller that blindly resumes
+at `resume.from` gets the same continuation a text caller reads out of the rendered guidance, never a stale
+`from` that loops the caller back onto the step it just repaired. If the shifted `from` would exceed the
+plan's length (the diverged step was the plan's last), `allowed` is `false` with a reason explaining there
+is nothing left to resume into — finish the repair with `close` instead.
 `planDigest` is SHA-256 over
 the canonical fully expanded plan, including each action's command, normalized inputs, control shape,
 platform-conditioned expansion, and source provenance. Concretely "normalized inputs" bind each action's

--- a/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -66,7 +66,10 @@ function throwSelectorMiss(selector: string): never {
   });
 }
 
-function assertDivergenceShape(response: Awaited<ReturnType<typeof runReplayScriptFile>>): {
+function assertDivergenceShape(
+  response: Awaited<ReturnType<typeof runReplayScriptFile>>,
+  expectedResume: { allowed: boolean; from: number } = { allowed: true, from: 1 },
+): {
   divergence: Record<string, unknown>;
   targetBinding: Record<string, unknown> | undefined;
 } {
@@ -78,8 +81,8 @@ function assertDivergenceShape(response: Awaited<ReturnType<typeof runReplayScri
   expect(typeof divergence.kind).toBe('string');
 
   const resume = divergence.resume as { allowed: boolean; from?: number; planDigest?: string };
-  expect(resume.allowed).toBe(true);
-  expect(resume.from).toBe(1);
+  expect(resume.allowed).toBe(expectedResume.allowed);
+  expect(resume.from).toBe(expectedResume.from);
   expect(typeof resume.planDigest).toBe('string');
   expect((resume.planDigest ?? '').length).toBeGreaterThan(0);
 
@@ -128,11 +131,21 @@ test('(a) an ANNOTATED press whose dispatch throws a selector-miss yields REPLAY
   });
 
   expect(invoked).toEqual(['click']);
-  const { divergence } = assertDivergenceShape(response);
+  // The recorded evidence carries a real, non-empty ancestry (a nested tab
+  // button) and the post-response capture still contains that same
+  // container, so this action-failure divergence routes to `record-and-heal`
+  // (ADR 0012 decision 6, R3's container-presence test) — not the `manual`
+  // default. `resume.from` must therefore target `failedIndex + 1` (decision
+  // 6, R2), and since this is the plan's only (and last) step, there is no
+  // step 2 to resume into: `allowed: false` with an out-of-range reason.
+  const { divergence } = assertDivergenceShape(response, { allowed: false, from: 2 });
   // A thrown dispatch failure is a generic action-failure divergence — it is
   // NOT re-derived as a target-binding classification (that only happens
   // when verification's OWN pre-action check finds the mismatch).
   expect(divergence.kind).toBe('action-failure');
+  expect(divergence.repairHint).toBe('record-and-heal');
+  const resume = divergence.resume as { reason?: string };
+  expect(resume.reason).toMatch(/out of range/);
   const cause = divergence.cause as { code: string; message: string };
   expect(cause.code).toBe('COMMAND_FAILED');
   expect(cause.message).toContain('No element matched selector');

--- a/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -136,16 +136,15 @@ test('(a) an ANNOTATED press whose dispatch throws a selector-miss yields REPLAY
   // container, so this action-failure divergence routes to `record-and-heal`
   // (ADR 0012 decision 6, R3's container-presence test) — not the `manual`
   // default. `resume.from` must therefore target `failedIndex + 1` (decision
-  // 6, R2), and since this is the plan's only (and last) step, there is no
-  // step 2 to resume into: `allowed: false` with an out-of-range reason.
-  const { divergence } = assertDivergenceShape(response, { allowed: false, from: 2 });
+  // 6, R2): since this is the plan's only (and last) step, that is `from: 2`
+  // = actions.length + 1 — a legal EMPTY-TAIL resume (nothing left to run
+  // after the agent performs the corrective press), not an error.
+  const { divergence } = assertDivergenceShape(response, { allowed: true, from: 2 });
   // A thrown dispatch failure is a generic action-failure divergence — it is
   // NOT re-derived as a target-binding classification (that only happens
   // when verification's OWN pre-action check finds the mismatch).
   expect(divergence.kind).toBe('action-failure');
   expect(divergence.repairHint).toBe('record-and-heal');
-  const resume = divergence.resume as { reason?: string };
-  expect(resume.reason).toMatch(/out of range/);
   const cause = divergence.cause as { code: string; message: string };
   expect(cause.code).toBe('COMMAND_FAILED');
   expect(cause.message).toContain('No element matched selector');

--- a/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
@@ -168,3 +168,66 @@ test('a record-and-heal divergence on the LAST step resumes with an empty tail a
   expect(healedScript).toContain('article-v2');
   expect(healedScript).not.toMatch(/^click /m);
 });
+
+test('a --from one past the plan end is rejected as out of range when no record-and-heal watermark authorizes it', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-empty-tail-unauthorized-'),
+  );
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  // No target-v1 annotation: an unannotated action-failure always routes to
+  // the `manual` fail-safe (no recorded targetEvidence), so NO
+  // `pendingRecordAndHeal` watermark is ever stamped for this divergence.
+  const filePath = writeReplayFile(root, ['open "Demo" --relaunch', 'click label="Save"']);
+
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    failSteps: new Set(['click label="Save"']),
+  });
+
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const divergence = leg1.error.details?.divergence as {
+    repairHint: string;
+    resume: { allowed: boolean; from: number; planDigest: string };
+  };
+  expect(divergence.repairHint).toBe('manual');
+  // `from` stays AT the failed step (2) — never shifted, since only
+  // `record-and-heal` shifts `from`. The plan has 2 actions, so `--from 3`
+  // (one past the end) is what an EMPTY-TAIL resume would use — but this
+  // session never authorized it.
+  expect(divergence.resume.from).toBe(2);
+  const session = sessionStore.get(sessionName)!;
+  expect(session.pendingRecordAndHeal).toBeUndefined();
+
+  // --- A caller crafts `--from 3` directly — exactly the one-past-the-end
+  // ordinal a record-and-heal empty-tail resume would use, but with no
+  // matching watermark on this session. Must be rejected as out of range,
+  // never silently executed with zero steps (which would let `close`
+  // commit while the actual final "click" step remains unresolved). ---
+  const exploitAttempt = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: { saveScript: true, replayFrom: 3, replayPlanDigest: divergence.resume.planDigest },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(exploitAttempt.ok).toBe(false);
+  if (!exploitAttempt.ok) {
+    expect(exploitAttempt.error.code).toBe('INVALID_ARGS');
+    expect(exploitAttempt.error.message).toMatch(/out of range/);
+  }
+  expect(session.saveScriptComplete).toBeFalsy();
+});

--- a/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
@@ -36,6 +36,7 @@ import { freshEvidence, makeRecordingReplayInvoke } from './session-replay-repai
 import {
   bottomTabsRealCaptureFixture,
   recordArticleEvidence,
+  toSnapshotNodes,
 } from './session-replay-target-classification-fixtures.ts';
 
 const mockDispatchCommand = vi.mocked(dispatchCommand);
@@ -230,4 +231,185 @@ test('a --from one past the plan end is rejected as out of range when no record-
     expect(exploitAttempt.error.message).toMatch(/out of range/);
   }
   expect(session.saveScriptComplete).toBeFalsy();
+});
+
+test('an unauthorized --from one past the plan end is rejected on an ARMED session whose last-step divergence hint is state-repair, not record-and-heal', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-empty-tail-state-repair-'),
+  );
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const evidence = recordArticleEvidence();
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    `# agent-device:target-v1 ${JSON.stringify(evidence)}`,
+    'click id="article"',
+  ]);
+
+  // The pre-action verification capture is a COMPLETELY unrelated screen —
+  // "article" resolves to matchCount 0 (selector-miss) AND the recorded
+  // container itself is absent (not merely the leaf), so this routes to
+  // `state-repair` (the app-state sub-flow), never `record-and-heal`. No
+  // `pendingRecordAndHeal` watermark is ever stamped for this session.
+  mockDispatchCommand.mockResolvedValue({
+    nodes: toSnapshotNodes([
+      {
+        index: 0,
+        type: 'Application',
+        label: 'Unrelated Screen',
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        depth: 0,
+      },
+    ]),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoke = makeRecordingReplayInvoke({ sessionStore, sessionName });
+
+  // --- The armed session diverges pre-action (target verification), never
+  // reaching `invoke` for "click" — this is the SAME repair-armed
+  // (`--save-script`) lifecycle a record-and-heal repair uses, just a
+  // different repair sub-flow. ---
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const divergence = leg1.error.details?.divergence as {
+    kind: string;
+    repairHint: string;
+    resume: { allowed: boolean; from: number; planDigest: string };
+  };
+  expect(divergence.kind).toBe('selector-miss');
+  expect(divergence.repairHint).toBe('state-repair');
+  // `state-repair` never shifts `from` — it stays AT the failed step (2).
+  expect(divergence.resume.from).toBe(2);
+  const session = sessionStore.get(sessionName)!;
+  expect(session.pendingRecordAndHeal).toBeUndefined();
+  expect(session.saveScriptBoundary).toBeDefined(); // genuinely armed
+
+  // --- Exploit attempt: `--from 3` (one past the plan's end) — exactly the
+  // ordinal a record-and-heal empty-tail resume would use — on an armed
+  // session whose divergence hint is `state-repair`. Must be rejected: no
+  // record-and-heal watermark authorizes skipping the unresolved final step,
+  // regardless of how the session's OTHER lifecycle state (armed/held)
+  // looks. ---
+  const exploitAttempt = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: { saveScript: true, replayFrom: 3, replayPlanDigest: divergence.resume.planDigest },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(exploitAttempt.ok).toBe(false);
+  if (!exploitAttempt.ok) {
+    expect(exploitAttempt.error.code).toBe('INVALID_ARGS');
+    expect(exploitAttempt.error.message).toMatch(/out of range/);
+  }
+  expect(session.saveScriptComplete).toBeFalsy();
+});
+
+test('a stale --plan-digest on an empty-tail resume is rejected WITHOUT consuming the watermark, so a subsequent correct retry still succeeds', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-empty-tail-digest-retry-'),
+  );
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const evidence = recordArticleEvidence();
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    `# agent-device:target-v1 ${JSON.stringify(evidence)}`,
+    'click id="article"',
+  ]);
+
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    failSteps: new Set(['click id="article"']),
+  });
+
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const divergence = leg1.error.details?.divergence as {
+    repairHint: string;
+    resume: { allowed: boolean; from: number; planDigest: string };
+  };
+  expect(divergence.repairHint).toBe('record-and-heal');
+  expect(divergence.resume.from).toBe(3);
+
+  const session = sessionStore.get(sessionName)!;
+  sessionStore.recordAction(session, {
+    command: 'press',
+    positionals: ['@e6'],
+    flags: {},
+    result: { selectorChain: ['id="article-v2"'] },
+    targetEvidence: freshEvidence('article-v2', 'Article V2'),
+  });
+  expect(session.pendingRecordAndHeal).toBeDefined();
+
+  // --- A resume at the correct `from` but a STALE digest is rejected — the
+  // watermark must NOT be consumed here, or a legitimate retry with the
+  // correct digest would find it already cleared and get rejected as
+  // out-of-range, permanently locking the agent out of completing the
+  // repair. ---
+  const staleDigestAttempt = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: {
+        saveScript: true,
+        replayFrom: divergence.resume.from,
+        replayPlanDigest: 'stale-digest-does-not-match',
+      },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(staleDigestAttempt.ok).toBe(false);
+  if (!staleDigestAttempt.ok) {
+    expect(staleDigestAttempt.error.code).toBe('INVALID_ARGS');
+    expect(staleDigestAttempt.error.message).toMatch(/plan digest/);
+  }
+  // The watermark survives the rejected leg untouched.
+  expect(session.pendingRecordAndHeal).toEqual({
+    expectedFrom: divergence.resume.from,
+    actionsCountAtDivergence: 1,
+  });
+
+  // --- The retry with the CORRECT digest still succeeds — never locked out. ---
+  const retry = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: {
+        saveScript: true,
+        replayFrom: divergence.resume.from,
+        replayPlanDigest: divergence.resume.planDigest,
+      },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(retry.ok).toBe(true);
+  expect(session.saveScriptComplete).toBe(true);
+  expect(session.pendingRecordAndHeal).toBeUndefined();
 });

--- a/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-empty-tail.test.ts
@@ -1,0 +1,170 @@
+/**
+ * ADR 0012 decision 6, R2/R3: two behaviors introduced alongside the
+ * `resume.from` / `repairHint` agreement fix (`session-replay-resume.ts`).
+ *
+ * 1. A `record-and-heal` divergence on the plan's LAST step reports
+ *    `resume.from = actions.length + 1` — a legal EMPTY-TAIL resume, not an
+ *    out-of-range error. The runtime must execute zero steps and reach the
+ *    normal end-of-plan completion path, flipping the repair transaction
+ *    COMPLETE so `close --save-script` actually commits the healed script
+ *    instead of discarding it (rejecting this `--from` would force the agent
+ *    into `close` on an INCOMPLETE transaction, which aborts with no publish).
+ * 2. `pendingRecordAndHeal` rejects a `--from` continuation that lands
+ *    exactly on that reported target with NO new action recorded since the
+ *    divergence — proof the agent never performed the corrective press —
+ *    instead of silently resuming past the unrepaired step.
+ */
+import { test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(async () => ({})), resolveTargetDevice: vi.fn() };
+});
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runReplayScriptFile } from '../session-replay-runtime.ts';
+import { SessionStore } from '../../session-store.ts';
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  baseReplayRequest as baseReq,
+  writeReplayFile,
+} from './session-replay-runtime.fixtures.ts';
+import { freshEvidence, makeRecordingReplayInvoke } from './session-replay-repair.fixtures.ts';
+import {
+  bottomTabsRealCaptureFixture,
+  recordArticleEvidence,
+} from './session-replay-target-classification-fixtures.ts';
+
+const mockDispatchCommand = vi.mocked(dispatchCommand);
+
+beforeEach(() => {
+  mockDispatchCommand.mockReset();
+  // The recorded container ("article", under a real nested ancestry chain)
+  // stays present throughout — this is what routes the divergence to
+  // `record-and-heal` rather than the `manual` fail-safe.
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+});
+
+test('a record-and-heal divergence on the LAST step resumes with an empty tail and commits — but only after the corrective press is actually recorded', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-empty-tail-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const evidence = recordArticleEvidence();
+  const filePath = writeReplayFile(root, [
+    'open "Demo" --relaunch',
+    `# agent-device:target-v1 ${JSON.stringify(evidence)}`,
+    'click id="article"',
+  ]);
+
+  const invoke = makeRecordingReplayInvoke({
+    sessionStore,
+    sessionName,
+    failSteps: new Set(['click id="article"']),
+  });
+
+  // --- Leg 1: open records; "click id=article" fails at dispatch. The
+  // recorded evidence's real ancestry + the still-present container routes
+  // this to `record-and-heal`, and since it is the plan's LAST step,
+  // resume.from = 3 = actions.length (2) + 1. ---
+  const leg1 = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { saveScript: true } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(leg1.ok).toBe(false);
+  if (leg1.ok) return;
+  const divergence = leg1.error.details?.divergence as {
+    kind: string;
+    repairHint: string;
+    resume: { allowed: boolean; from: number; planDigest: string };
+  };
+  expect(divergence.kind).toBe('action-failure');
+  expect(divergence.repairHint).toBe('record-and-heal');
+  expect(divergence.resume.allowed).toBe(true);
+  expect(divergence.resume.from).toBe(3);
+
+  const session = sessionStore.get(sessionName)!;
+  expect(session.actions.map((a) => a.command)).toEqual(['open']);
+  expect(session.saveScriptComplete).toBeFalsy();
+
+  // --- A blind resume at the reported target BEFORE performing the
+  // corrective press is rejected: no new action was recorded since the
+  // divergence, so nothing proves the diverged step was actually repaired. ---
+  const blindResume = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: {
+        saveScript: true,
+        replayFrom: divergence.resume.from,
+        replayPlanDigest: divergence.resume.planDigest,
+      },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(blindResume.ok).toBe(false);
+  if (!blindResume.ok) {
+    expect(blindResume.error.code).toBe('INVALID_ARGS');
+    expect(blindResume.error.message).toMatch(/no corrective action/);
+  }
+  // Rejected before touching the plan at all — never re-diverges on "click".
+  expect(session.actions.map((a) => a.command)).toEqual(['open']);
+
+  // --- Agent performs the corrective press (blessed @ref), recorded live. ---
+  sessionStore.recordAction(session, {
+    command: 'press',
+    positionals: ['@e6'],
+    flags: {},
+    result: { selectorChain: ['id="article-v2"'] },
+    targetEvidence: freshEvidence('article-v2', 'Article V2'),
+  });
+
+  // --- Leg 2: the SAME --from now succeeds — the corrective press grew
+  // session.actions, consuming the watermark. Zero steps execute (there is
+  // nothing left in the plan), and the runtime's normal end-of-plan path
+  // flips the transaction COMPLETE. ---
+  const leg2 = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [filePath],
+      flags: {
+        saveScript: true,
+        replayFrom: divergence.resume.from,
+        replayPlanDigest: divergence.resume.planDigest,
+      },
+    }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+  expect(leg2.ok).toBe(true);
+  if (leg2.ok) {
+    expect((leg2.data as { replayed: number }).replayed).toBe(0);
+  }
+  expect(session.actions.map((a) => a.command)).toEqual(['open', 'press']);
+  expect(session.saveScriptComplete).toBe(true);
+
+  // --- Commit: the transaction is COMPLETE, so the healed script actually
+  // publishes — the corrective press survives, "click" (never recorded) does
+  // not. Proves the empty-tail resume did not lead to a discarded repair. ---
+  const writeResult = sessionStore.writeSessionLog(session);
+  expect(writeResult.written).toBe(true);
+  const healedPath = path.join(root, 'flow.healed.ad');
+  expect(fs.existsSync(healedPath)).toBe(true);
+  const healedScript = fs.readFileSync(healedPath, 'utf8');
+  expect(healedScript).toContain('open');
+  expect(healedScript).toContain('article-v2');
+  expect(healedScript).not.toMatch(/^click /m);
+});

--- a/src/daemon/handlers/__tests__/session-replay-resume.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-resume.test.ts
@@ -186,22 +186,21 @@ test('buildReplayDivergenceResume with repairHint record-and-heal resumes AFTER 
   assert.deepEqual(resume, { allowed: true, from: 3, planDigest: 'abc123' });
 });
 
-test('buildReplayDivergenceResume with repairHint record-and-heal on the LAST plan step has nothing left to resume', () => {
+test('buildReplayDivergenceResume with repairHint record-and-heal on the LAST plan step is a legal empty-tail resume', () => {
   const actions: SessionAction[] = [
     action({ command: 'open', positionals: ['Demo'] }),
     action({ command: 'click', positionals: ['label="Save"'] }),
   ];
+  // failedIndex 2 (the last of 2 actions) shifts to from 3 = actions.length +
+  // 1 — there is no step 3 to run, but that is not an error: the runtime
+  // executes zero steps and reaches the normal end-of-plan completion path.
   const resume = buildReplayDivergenceResume({
     failedIndex: 2,
     actions,
     planDigest: 'abc123',
     repairHint: 'record-and-heal',
   });
-  assert.equal(resume.allowed, false);
-  assert.equal(resume.from, 3);
-  assert.equal(resume.planDigest, 'abc123');
-  if (resume.allowed) return;
-  assert.match(resume.reason, /out of range/);
+  assert.deepEqual(resume, { allowed: true, from: 3, planDigest: 'abc123' });
 });
 
 test('buildReplayDivergenceResume with repairHint record-and-heal still rejects a skipped control-flow range', () => {

--- a/src/daemon/handlers/__tests__/session-replay-resume.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-resume.test.ts
@@ -140,6 +140,7 @@ test('buildReplayDivergenceResume reports allowed:true with from/planDigest for 
     failedIndex: 2,
     actions,
     planDigest: 'abc123',
+    repairHint: 'manual',
   });
   assert.deepEqual(resume, { allowed: true, from: 2, planDigest: 'abc123' });
 });
@@ -157,10 +158,72 @@ test('buildReplayDivergenceResume reports allowed:false with from/planDigest/rea
     failedIndex: 2,
     actions,
     planDigest: 'abc123',
+    repairHint: 'manual',
   });
   assert.equal(resume.allowed, false);
   assert.equal(resume.from, 2);
   assert.equal(resume.planDigest, 'abc123');
   if (resume.allowed) return;
   assert.ok(resume.reason.length > 0);
+});
+
+// --- repairHint 'record-and-heal' shifts `from` to failedIndex + 1 (ADR 0012
+// decision 6, R2): the agent already performed the diverged step manually, so
+// resuming AT it would re-diverge on the exact same step. ---
+
+test('buildReplayDivergenceResume with repairHint record-and-heal resumes AFTER the failed step', () => {
+  const actions: SessionAction[] = [
+    action({ command: 'open', positionals: ['Demo'] }),
+    action({ command: 'click', positionals: ['label="Save"'] }),
+    action({ command: 'click', positionals: ['label="Confirm"'] }),
+  ];
+  const resume = buildReplayDivergenceResume({
+    failedIndex: 2,
+    actions,
+    planDigest: 'abc123',
+    repairHint: 'record-and-heal',
+  });
+  assert.deepEqual(resume, { allowed: true, from: 3, planDigest: 'abc123' });
+});
+
+test('buildReplayDivergenceResume with repairHint record-and-heal on the LAST plan step has nothing left to resume', () => {
+  const actions: SessionAction[] = [
+    action({ command: 'open', positionals: ['Demo'] }),
+    action({ command: 'click', positionals: ['label="Save"'] }),
+  ];
+  const resume = buildReplayDivergenceResume({
+    failedIndex: 2,
+    actions,
+    planDigest: 'abc123',
+    repairHint: 'record-and-heal',
+  });
+  assert.equal(resume.allowed, false);
+  assert.equal(resume.from, 3);
+  assert.equal(resume.planDigest, 'abc123');
+  if (resume.allowed) return;
+  assert.match(resume.reason, /out of range/);
+});
+
+test('buildReplayDivergenceResume with repairHint record-and-heal still rejects a skipped control-flow range', () => {
+  const actions: SessionAction[] = [
+    action({
+      command: 'back',
+      positionals: [],
+      replayControl: { kind: 'retry', maxRetries: 1, actions: [action({ command: 'back' })] },
+    }),
+    action({ command: 'click' }),
+    action({ command: 'click' }),
+  ];
+  // failedIndex 2 shifts to from 3, which still skips step 1's control-flow
+  // block — the shift does not bypass the existing skip-safety preflight.
+  const resume = buildReplayDivergenceResume({
+    failedIndex: 2,
+    actions,
+    planDigest: 'abc123',
+    repairHint: 'record-and-heal',
+  });
+  assert.equal(resume.allowed, false);
+  assert.equal(resume.from, 3);
+  if (resume.allowed) return;
+  assert.match(resume.reason, /control flow/);
 });

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -106,6 +106,16 @@ export async function buildReplayFailureDivergence(params: {
         })
       : [];
 
+  // ADR 0012 decision 6, R3: `action-failure`'s capture is the POST-response
+  // tree (this is the dispatch-thrown path) — the same one the container
+  // test needs. Computed before `resume` so its `from` ordinal (decision 6,
+  // R2: `record-and-heal` resumes at failedIndex + 1) agrees with the hint.
+  const repairHint = computeReplayRepairHint({
+    kind: 'action-failure',
+    targetEvidence: action.targetEvidence,
+    capture: toReplayRepairHintCapture(observation),
+  });
+
   const divergence: ReplayDivergence = {
     version: 1,
     kind: 'action-failure',
@@ -122,15 +132,9 @@ export async function buildReplayFailureDivergence(params: {
       failedIndex: index + 1,
       actions: planActions,
       planDigest,
+      repairHint,
     }),
-    // ADR 0012 decision 6, R3: `action-failure`'s capture is the POST-response
-    // tree (this is the dispatch-thrown path) — the same one the container
-    // test needs.
-    repairHint: computeReplayRepairHint({
-      kind: 'action-failure',
-      targetEvidence: action.targetEvidence,
-      capture: toReplayRepairHintCapture(observation),
-    }),
+    repairHint,
   };
 
   return boundReplayDivergenceForSession({ sessionStore, sessionName, divergence, responseLevel });

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -17,7 +17,10 @@ import {
 } from '../../selectors/index.ts';
 import { collectReplaySelectorCandidates } from './session-replay-heal.ts';
 import { collectSettleChromeRefs } from '../../core/snapshot-chrome.ts';
-import { buildReplayDivergenceResume } from './session-replay-resume.ts';
+import {
+  buildReplayDivergenceResume,
+  stampPendingRecordAndHealWatermark,
+} from './session-replay-resume.ts';
 import { formatDivergenceActionLabel, isTouchTargetCommand } from '../../replay/script-utils.ts';
 import {
   computeReplayRepairHint,
@@ -116,6 +119,14 @@ export async function buildReplayFailureDivergence(params: {
     capture: toReplayRepairHintCapture(observation),
   });
 
+  const resume = buildReplayDivergenceResume({
+    failedIndex: index + 1,
+    actions: planActions,
+    planDigest,
+    repairHint,
+  });
+  if (session) stampPendingRecordAndHealWatermark({ session, resume, repairHint });
+
   const divergence: ReplayDivergence = {
     version: 1,
     kind: 'action-failure',
@@ -128,12 +139,7 @@ export async function buildReplayFailureDivergence(params: {
     screen,
     suggestions: suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT),
     suggestionCount: suggestions.length,
-    resume: buildReplayDivergenceResume({
-      failedIndex: index + 1,
-      actions: planActions,
-      planDigest,
-      repairHint,
-    }),
+    resume,
     repairHint,
   };
 

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -125,7 +125,10 @@ export async function buildReplayFailureDivergence(params: {
     planDigest,
     repairHint,
   });
-  if (session) stampPendingRecordAndHealWatermark({ session, resume, repairHint });
+  if (session) {
+    stampPendingRecordAndHealWatermark({ session, resume, repairHint });
+    sessionStore.set(sessionName, session);
+  }
 
   const divergence: ReplayDivergence = {
     version: 1,

--- a/src/daemon/handlers/session-replay-resume.ts
+++ b/src/daemon/handlers/session-replay-resume.ts
@@ -1,5 +1,5 @@
 import { MAESTRO_RUNTIME_COMMAND } from '../../compat/maestro/runtime-commands.ts';
-import type { SessionAction } from '../types.ts';
+import type { SessionAction, SessionState } from '../types.ts';
 import type { ReplayDivergenceResume, ReplayRepairHint } from '../../replay/divergence.ts';
 
 /**
@@ -71,6 +71,19 @@ function producesOutputEnv(action: SessionAction): boolean {
  * `failedIndex` unchanged. This must agree with the text guidance rendered by
  * `formatReplayDivergenceReport` (`src/replay/divergence.ts`) — both are
  * derived from the same computed `from` value.
+ *
+ * `failedIndex` is always a valid 1-based index into `actions` (both call
+ * sites resolve it from the plan they are actively executing), so the shifted
+ * `from` is at most `actions.length + 1` — never further out of range. That
+ * boundary case (`record-and-heal` diverged on the plan's LAST step) is a
+ * legal EMPTY-TAIL resume, not an error: `evaluateReplayResumePreflight`
+ * already proves it safe (it only checks whether the SKIPPED range 1..from-1
+ * is safe to skip; there is no `from`-th step to reject), and the runtime
+ * loop (`runReplayScriptFile`) executes zero steps and reaches the normal
+ * end-of-plan completion path, correctly flipping a repair transaction
+ * COMPLETE. Rejecting it here would send the agent to `close` instead —
+ * which discards the just-recorded corrective action, since commit is gated
+ * on that same COMPLETE flag.
  */
 export function buildReplayDivergenceResume(params: {
   failedIndex: number; // 1-based
@@ -80,18 +93,35 @@ export function buildReplayDivergenceResume(params: {
 }): ReplayDivergenceResume {
   const { failedIndex, actions, planDigest, repairHint } = params;
   const from = repairHint === 'record-and-heal' ? failedIndex + 1 : failedIndex;
-  if (from > actions.length) {
-    return {
-      allowed: false,
-      from,
-      planDigest,
-      reason:
-        `replay --from ${from} would be out of range for this ${actions.length}-step plan; ` +
-        'the corrective action already completes the script, so finish the repair with close instead of --from.',
-    };
-  }
   const preflight = evaluateReplayResumePreflight({ from, actions });
   return preflight.allowed
     ? { allowed: true, from, planDigest }
     : { allowed: false, from, planDigest, reason: preflight.reason };
+}
+
+/**
+ * ADR 0012 decision 6, R2/R3: a `record-and-heal` divergence's `resume.from`
+ * assumes the agent performs the diverged step manually before continuing —
+ * nothing else enforces that. Stamps a watermark on the LIVE session so a
+ * later `--from` request that lands exactly on the expected target with NO
+ * new action recorded since (proof the corrective press never happened) can
+ * be rejected by `rejectUnperformedRecordAndHeal` instead of silently
+ * resuming past the unrepaired step and, if the tail then completes,
+ * committing a healed script with a hole at the diverged step.
+ *
+ * Called at every divergence site (not only `record-and-heal` ones) so a
+ * stale watermark from an earlier divergence never survives an unrelated
+ * later one: a non-`record-and-heal` hint, or a `record-and-heal` hint whose
+ * `resume` was not `allowed`, clears the field.
+ */
+export function stampPendingRecordAndHealWatermark(params: {
+  session: SessionState;
+  resume: ReplayDivergenceResume;
+  repairHint: ReplayRepairHint;
+}): void {
+  const { session, resume, repairHint } = params;
+  session.pendingRecordAndHeal =
+    repairHint === 'record-and-heal' && resume.allowed
+      ? { expectedFrom: resume.from, actionsCountAtDivergence: session.actions.length }
+      : undefined;
 }

--- a/src/daemon/handlers/session-replay-resume.ts
+++ b/src/daemon/handlers/session-replay-resume.ts
@@ -1,6 +1,6 @@
 import { MAESTRO_RUNTIME_COMMAND } from '../../compat/maestro/runtime-commands.ts';
 import type { SessionAction } from '../types.ts';
-import type { ReplayDivergenceResume } from '../../replay/divergence.ts';
+import type { ReplayDivergenceResume, ReplayRepairHint } from '../../replay/divergence.ts';
 
 /**
  * ADR 0012 decision 4 / migration step 5: resume does not reconstruct
@@ -60,15 +60,38 @@ function producesOutputEnv(action: SessionAction): boolean {
   return action.command === OUTPUT_ENV_PRODUCING_COMMAND;
 }
 
-/** Builds the `resume` object attached to every divergence report. */
+/**
+ * Builds the `resume` object attached to every divergence report. `from` is
+ * the ordinal the agent should actually pass to `--from`, not merely the
+ * failed step's index: per ADR 0012 decision 6, R2, a `record-and-heal`
+ * repair has the agent perform the diverged step manually before this report
+ * is acted on, so the correct continuation is `failedIndex + 1` (re-running
+ * `failedIndex` would re-diverge on the step the agent already performed).
+ * Every other repair hint (including a plain `action-failure`) resumes AT
+ * `failedIndex` unchanged. This must agree with the text guidance rendered by
+ * `formatReplayDivergenceReport` (`src/replay/divergence.ts`) — both are
+ * derived from the same computed `from` value.
+ */
 export function buildReplayDivergenceResume(params: {
   failedIndex: number; // 1-based
   actions: SessionAction[];
   planDigest: string;
+  repairHint: ReplayRepairHint;
 }): ReplayDivergenceResume {
-  const { failedIndex, actions, planDigest } = params;
-  const preflight = evaluateReplayResumePreflight({ from: failedIndex, actions });
+  const { failedIndex, actions, planDigest, repairHint } = params;
+  const from = repairHint === 'record-and-heal' ? failedIndex + 1 : failedIndex;
+  if (from > actions.length) {
+    return {
+      allowed: false,
+      from,
+      planDigest,
+      reason:
+        `replay --from ${from} would be out of range for this ${actions.length}-step plan; ` +
+        'the corrective action already completes the script, so finish the repair with close instead of --from.',
+    };
+  }
+  const preflight = evaluateReplayResumePreflight({ from, actions });
   return preflight.allowed
-    ? { allowed: true, from: failedIndex, planDigest }
-    : { allowed: false, from: failedIndex, planDigest, reason: preflight.reason };
+    ? { allowed: true, from, planDigest }
+    : { allowed: false, from, planDigest, reason: preflight.reason };
 }

--- a/src/daemon/handlers/session-replay-runtime-plan.ts
+++ b/src/daemon/handlers/session-replay-runtime-plan.ts
@@ -66,7 +66,14 @@ function validateReplayResumeRequest(params: {
   actions: SessionAction[];
 }): string | undefined {
   const { from, digest, planDigest, actionCount, actions } = params;
-  if (!Number.isInteger(from) || from < 1 || from > actionCount) {
+  // `from === actionCount + 1` is a legal EMPTY-TAIL resume (ADR 0012 decision
+  // 6, R2): a `record-and-heal` divergence on the plan's LAST step reports
+  // exactly this `resume.from`, since the agent performs that step manually
+  // and there is nothing left to replay. The loop then executes zero steps
+  // and falls through to the normal end-of-plan completion path
+  // (`runReplayScriptFile`), correctly flipping an armed repair transaction
+  // COMPLETE. `from > actionCount + 1` has no addressable target at all.
+  if (!Number.isInteger(from) || from < 1 || from > actionCount + 1) {
     return `replay --from ${from} is out of range for a ${actionCount}-step plan.`;
   }
   if (digest !== planDigest) {

--- a/src/daemon/handlers/session-replay-runtime-plan.ts
+++ b/src/daemon/handlers/session-replay-runtime-plan.ts
@@ -32,15 +32,31 @@ export function readEffectiveReplayPlanDigestMetadata(
 
 type ReplayEntryIndexResult = { ok: true; value: number } | { ok: false; response: DaemonResponse };
 
+/** The session-side state that gates an EMPTY-TAIL resume (`--from actionCount + 1`). */
+export type PendingRecordAndHeal = { expectedFrom: number; actionsCountAtDivergence: number };
+
 /**
  * Resolves `--from`/`--plan-digest` into a 0-based loop entry index before
  * any device action. `--from` is 1-based and matches divergence step indices.
+ *
+ * `pendingRecordAndHeal`/`sessionActionsLength` gate the ONE ordinal beyond
+ * the plan's end (`actionCount + 1`): ADR 0012 decision 6, R2's `record-and-heal`
+ * repair resumes past the plan's LAST step once the agent performs the
+ * diverged step manually, and that resume must execute zero device actions
+ * before reaching the normal completion path. That allowance is scoped to
+ * the EXACT session + target that actually produced it (`stampPendingRecordAndHealWatermark`,
+ * `session-replay-resume.ts`), and only once a new action proves the
+ * corrective press happened — never a blanket "one past the end is fine" for
+ * any session, which would let an unrelated or blind `--from actionCount + 1`
+ * silently skip the plan's tail and commit an unfinished repair.
  */
 export function resolveReplayEntryIndex(
   flags: CommandFlags | undefined,
   actionCount: number,
   planDigest: string,
   actions: SessionAction[],
+  pendingRecordAndHeal: PendingRecordAndHeal | undefined,
+  sessionActionsLength: number,
 ): ReplayEntryIndexResult {
   const from = flags?.replayFrom;
   const digest = flags?.replayPlanDigest;
@@ -50,7 +66,15 @@ export function resolveReplayEntryIndex(
       'replay --from requires --plan-digest (and --plan-digest requires --from).',
     );
   }
-  const message = validateReplayResumeRequest({ from, digest, planDigest, actionCount, actions });
+  const message = validateReplayResumeRequest({
+    from,
+    digest,
+    planDigest,
+    actionCount,
+    actions,
+    pendingRecordAndHeal,
+    sessionActionsLength,
+  });
   return message ? invalidReplayEntryIndex(message) : { ok: true, value: from - 1 };
 }
 
@@ -64,17 +88,39 @@ function validateReplayResumeRequest(params: {
   planDigest: string;
   actionCount: number;
   actions: SessionAction[];
+  pendingRecordAndHeal: PendingRecordAndHeal | undefined;
+  sessionActionsLength: number;
 }): string | undefined {
-  const { from, digest, planDigest, actionCount, actions } = params;
-  // `from === actionCount + 1` is a legal EMPTY-TAIL resume (ADR 0012 decision
-  // 6, R2): a `record-and-heal` divergence on the plan's LAST step reports
-  // exactly this `resume.from`, since the agent performs that step manually
-  // and there is nothing left to replay. The loop then executes zero steps
-  // and falls through to the normal end-of-plan completion path
-  // (`runReplayScriptFile`), correctly flipping an armed repair transaction
-  // COMPLETE. `from > actionCount + 1` has no addressable target at all.
-  if (!Number.isInteger(from) || from < 1 || from > actionCount + 1) {
+  const { from, digest, planDigest, actionCount, actions, pendingRecordAndHeal, sessionActionsLength } =
+    params;
+  // `actionCount + 1` (one past the plan's end) is a legal EMPTY-TAIL resume
+  // ONLY when it matches THIS session's own `record-and-heal` divergence
+  // watermark (`stampPendingRecordAndHealWatermark`, `session-replay-resume.ts`)
+  // — never a blanket "one past the end is fine" for any session or repair
+  // kind. Absent a matching watermark, `actionCount + 1` is exactly as
+  // out-of-range as any other ordinal beyond the plan.
+  const isAuthorizedEmptyTail =
+    from === actionCount + 1 &&
+    pendingRecordAndHeal !== undefined &&
+    pendingRecordAndHeal.expectedFrom === from;
+  if (!Number.isInteger(from) || from < 1 || (from > actionCount && !isAuthorizedEmptyTail)) {
     return `replay --from ${from} is out of range for a ${actionCount}-step plan.`;
+  }
+  // A `from` matching a pending `record-and-heal` watermark — in-range
+  // (mid-plan) or the empty-tail boundary above — requires proof the agent
+  // actually performed the diverged step: the session's recorded action
+  // count must have grown since the divergence. Without that proof, this
+  // would silently resume past an unrepaired step instead of rejecting.
+  if (
+    pendingRecordAndHeal?.expectedFrom === from &&
+    sessionActionsLength === pendingRecordAndHeal.actionsCountAtDivergence
+  ) {
+    return (
+      `replay --from ${from} continues a record-and-heal repair, but no corrective action has been ` +
+      'recorded on this session since that divergence; press the correct control via a blessed @ref ' +
+      "from the divergence's screen.refs (recorded, no --no-record) before resuming with " +
+      `--from ${from}.`
+    );
   }
   if (digest !== planDigest) {
     return (

--- a/src/daemon/handlers/session-replay-runtime-plan.ts
+++ b/src/daemon/handlers/session-replay-runtime-plan.ts
@@ -82,6 +82,9 @@ function invalidReplayEntryIndex(message: string): ReplayEntryIndexResult {
   return { ok: false, response: errorResponse('INVALID_ARGS', message) };
 }
 
+/** A single sub-check of a `--from` resume request; `undefined` means "no objection". */
+type ReplayResumeCheck = () => string | undefined;
+
 function validateReplayResumeRequest(params: {
   from: number;
   digest: string;
@@ -91,44 +94,91 @@ function validateReplayResumeRequest(params: {
   pendingRecordAndHeal: PendingRecordAndHeal | undefined;
   sessionActionsLength: number;
 }): string | undefined {
-  const { from, digest, planDigest, actionCount, actions, pendingRecordAndHeal, sessionActionsLength } =
-    params;
-  // `actionCount + 1` (one past the plan's end) is a legal EMPTY-TAIL resume
-  // ONLY when it matches THIS session's own `record-and-heal` divergence
-  // watermark (`stampPendingRecordAndHealWatermark`, `session-replay-resume.ts`)
-  // — never a blanket "one past the end is fine" for any session or repair
-  // kind. Absent a matching watermark, `actionCount + 1` is exactly as
-  // out-of-range as any other ordinal beyond the plan.
+  const {
+    from,
+    digest,
+    planDigest,
+    actionCount,
+    actions,
+    pendingRecordAndHeal,
+    sessionActionsLength,
+  } = params;
+  const checks: ReplayResumeCheck[] = [
+    () => describeOutOfRangeResumeFrom({ from, actionCount, pendingRecordAndHeal }),
+    () => describeUnperformedRecordAndHeal({ from, pendingRecordAndHeal, sessionActionsLength }),
+    () => describeStaleResumeDigest(digest, planDigest),
+    () => describeUnsafeResumePreflight(from, actions),
+  ];
+  for (const check of checks) {
+    const message = check();
+    if (message) return message;
+  }
+  return undefined;
+}
+
+/**
+ * `actionCount + 1` (one past the plan's end) is a legal EMPTY-TAIL resume
+ * ONLY when it matches THIS session's own `record-and-heal` divergence
+ * watermark (`stampPendingRecordAndHealWatermark`, `session-replay-resume.ts`)
+ * — never a blanket "one past the end is fine" for any session or repair
+ * kind. Absent a matching watermark, `actionCount + 1` is exactly as
+ * out-of-range as any other ordinal beyond the plan.
+ */
+function describeOutOfRangeResumeFrom(params: {
+  from: number;
+  actionCount: number;
+  pendingRecordAndHeal: PendingRecordAndHeal | undefined;
+}): string | undefined {
+  const { from, actionCount, pendingRecordAndHeal } = params;
   const isAuthorizedEmptyTail =
     from === actionCount + 1 &&
     pendingRecordAndHeal !== undefined &&
     pendingRecordAndHeal.expectedFrom === from;
-  if (!Number.isInteger(from) || from < 1 || (from > actionCount && !isAuthorizedEmptyTail)) {
-    return `replay --from ${from} is out of range for a ${actionCount}-step plan.`;
-  }
-  // A `from` matching a pending `record-and-heal` watermark — in-range
-  // (mid-plan) or the empty-tail boundary above — requires proof the agent
-  // actually performed the diverged step: the session's recorded action
-  // count must have grown since the divergence. Without that proof, this
-  // would silently resume past an unrepaired step instead of rejecting.
+  const inRange =
+    Number.isInteger(from) && from >= 1 && (from <= actionCount || isAuthorizedEmptyTail);
+  return inRange
+    ? undefined
+    : `replay --from ${from} is out of range for a ${actionCount}-step plan.`;
+}
+
+/**
+ * A `from` matching a pending `record-and-heal` watermark — in-range
+ * (mid-plan) or the empty-tail boundary the range check above authorizes —
+ * requires proof the agent actually performed the diverged step: the
+ * session's recorded action count must have grown since the divergence.
+ * Without that proof, this would silently resume past an unrepaired step
+ * instead of rejecting.
+ */
+function describeUnperformedRecordAndHeal(params: {
+  from: number;
+  pendingRecordAndHeal: PendingRecordAndHeal | undefined;
+  sessionActionsLength: number;
+}): string | undefined {
+  const { from, pendingRecordAndHeal, sessionActionsLength } = params;
   if (
-    pendingRecordAndHeal?.expectedFrom === from &&
-    sessionActionsLength === pendingRecordAndHeal.actionsCountAtDivergence
+    pendingRecordAndHeal?.expectedFrom !== from ||
+    sessionActionsLength !== pendingRecordAndHeal.actionsCountAtDivergence
   ) {
-    return (
-      `replay --from ${from} continues a record-and-heal repair, but no corrective action has been ` +
-      'recorded on this session since that divergence; press the correct control via a blessed @ref ' +
-      "from the divergence's screen.refs (recorded, no --no-record) before resuming with " +
-      `--from ${from}.`
-    );
+    return undefined;
   }
-  if (digest !== planDigest) {
-    return (
-      'replay --plan-digest does not match the current plan digest; the script, its includes, or its ' +
-      'platform-conditioned expansion changed since the divergence report was generated. Run a fresh full ' +
-      'replay to get a new digest.'
-    );
-  }
+  return (
+    `replay --from ${from} continues a record-and-heal repair, but no corrective action has been ` +
+    'recorded on this session since that divergence; press the correct control via a blessed @ref ' +
+    "from the divergence's screen.refs (recorded, no --no-record) before resuming with " +
+    `--from ${from}.`
+  );
+}
+
+function describeStaleResumeDigest(digest: string, planDigest: string): string | undefined {
+  if (digest === planDigest) return undefined;
+  return (
+    'replay --plan-digest does not match the current plan digest; the script, its includes, or its ' +
+    'platform-conditioned expansion changed since the divergence report was generated. Run a fresh full ' +
+    'replay to get a new digest.'
+  );
+}
+
+function describeUnsafeResumePreflight(from: number, actions: SessionAction[]): string | undefined {
   const preflight = evaluateReplayResumePreflight({ from, actions });
   return preflight.allowed ? undefined : `replay --from ${from} cannot resume: ${preflight.reason}`;
 }

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -177,8 +177,19 @@ export async function runReplayScriptFile(params: {
     });
     // ADR 0012 decision 4 / migration step 5: resume preflight, entirely
     // before any device action. `test` never reaches here with either flag
-    // set (rejected earlier, in handleSessionReplayCommands).
-    const entryIndex = resolveReplayEntryIndex(req.flags, actions.length, planDigest, actions);
+    // set (rejected earlier, in handleSessionReplayCommands). Fetched before
+    // any mutation below so the pending record-and-heal watermark (decision
+    // 6, R2/R3) reflects this session's state AT REQUEST START, scoping the
+    // one-past-the-plan `--from` ordinal to the exact session that produced it.
+    const preEntrySession = sessionStore.get(sessionName);
+    const entryIndex = resolveReplayEntryIndex(
+      req.flags,
+      actions.length,
+      planDigest,
+      actions,
+      preEntrySession?.pendingRecordAndHeal,
+      preEntrySession?.actions.length ?? 0,
+    );
     if (!entryIndex.ok) return entryIndex.response;
     const scope = buildReplayVarScope({
       builtins: buildReplayBuiltinVars({
@@ -216,17 +227,16 @@ export async function runReplayScriptFile(params: {
     if (entryIndex.value > 0 && !sessionStore.get(sessionName)) {
       return noActiveSessionError();
     }
-    // ADR 0012 decision 6, R2/R3: a `record-and-heal` divergence's reported
-    // `resume.from` assumes the agent performed the diverged step manually
-    // before resuming. Reject a `--from` that lands exactly on that expected
-    // target with no new action recorded since — the corrective press never
-    // happened — instead of silently skipping the unrepaired step.
-    const recordAndHealGuard = rejectUnperformedRecordAndHeal({
-      from: req.flags?.replayFrom,
-      sessionStore,
-      sessionName,
-    });
-    if (recordAndHealGuard) return recordAndHealGuard;
+    // ADR 0012 decision 6, R2/R3: `resolveReplayEntryIndex` already proved (or
+    // this `from` never matched the watermark at all) that a `record-and-heal`
+    // continuation is either not this session's pending target, or that a new
+    // action was recorded since the divergence — the corrective press
+    // happened. Consume the watermark on the latter so it can never be
+    // re-checked against a later, unrelated request.
+    if (preEntrySession && preEntrySession.pendingRecordAndHeal?.expectedFrom === req.flags?.replayFrom) {
+      preEntrySession.pendingRecordAndHeal = undefined;
+      sessionStore.set(sessionName, preEntrySession);
+    }
     if (req.flags?.saveScript) {
       // ADR 0012 decision 6, R7 (C5a): a fresh `replay --save-script` on this
       // key clears any prior reap tombstone before starting a new transaction.
@@ -488,40 +498,6 @@ function preflightReplayAgainstActiveRepair(params: {
     'INVALID_ARGS',
     'This session has an active --save-script repair run; continue it with replay --from <n> --plan-digest <sha256>, or finish with close, before starting a fresh full replay.',
   );
-}
-
-/**
- * ADR 0012 decision 6, R2/R3: `stampPendingRecordAndHealWatermark`
- * (`session-replay-resume.ts`) marks a `record-and-heal` divergence's
- * expected `--from` target and the session's recorded action count at that
- * moment. If a `--from` request matching that exact target arrives while the
- * action count is UNCHANGED, no corrective action was ever recorded — the
- * agent (or a JSON/MCP-first caller blindly following `resume.from`) skipped
- * straight past the diverged step instead of performing it. Reject rather
- * than silently resuming past it, since a completed tail would then commit a
- * healed script with a hole at that step. Once a request observes the count
- * having grown, the watermark is consumed (cleared) so it can never fire
- * against a later, unrelated request.
- */
-function rejectUnperformedRecordAndHeal(params: {
-  from: number | undefined;
-  sessionStore: SessionStore;
-  sessionName: string;
-}): DaemonResponse | undefined {
-  const { from, sessionStore, sessionName } = params;
-  if (from === undefined) return undefined;
-  const session = sessionStore.get(sessionName);
-  const pending = session?.pendingRecordAndHeal;
-  if (!session || !pending || pending.expectedFrom !== from) return undefined;
-  if (session.actions.length === pending.actionsCountAtDivergence) {
-    return errorResponse(
-      'INVALID_ARGS',
-      `replay --from ${from} continues a record-and-heal repair, but no corrective action has been recorded on this session since that divergence; press the correct control via a blessed @ref from the divergence's screen.refs (recorded, no --no-record) before resuming with --from ${from}.`,
-    );
-  }
-  session.pendingRecordAndHeal = undefined;
-  sessionStore.set(sessionName, session);
-  return undefined;
 }
 
 /**

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -216,6 +216,17 @@ export async function runReplayScriptFile(params: {
     if (entryIndex.value > 0 && !sessionStore.get(sessionName)) {
       return noActiveSessionError();
     }
+    // ADR 0012 decision 6, R2/R3: a `record-and-heal` divergence's reported
+    // `resume.from` assumes the agent performed the diverged step manually
+    // before resuming. Reject a `--from` that lands exactly on that expected
+    // target with no new action recorded since — the corrective press never
+    // happened — instead of silently skipping the unrepaired step.
+    const recordAndHealGuard = rejectUnperformedRecordAndHeal({
+      from: req.flags?.replayFrom,
+      sessionStore,
+      sessionName,
+    });
+    if (recordAndHealGuard) return recordAndHealGuard;
     if (req.flags?.saveScript) {
       // ADR 0012 decision 6, R7 (C5a): a fresh `replay --save-script` on this
       // key clears any prior reap tombstone before starting a new transaction.
@@ -477,6 +488,40 @@ function preflightReplayAgainstActiveRepair(params: {
     'INVALID_ARGS',
     'This session has an active --save-script repair run; continue it with replay --from <n> --plan-digest <sha256>, or finish with close, before starting a fresh full replay.',
   );
+}
+
+/**
+ * ADR 0012 decision 6, R2/R3: `stampPendingRecordAndHealWatermark`
+ * (`session-replay-resume.ts`) marks a `record-and-heal` divergence's
+ * expected `--from` target and the session's recorded action count at that
+ * moment. If a `--from` request matching that exact target arrives while the
+ * action count is UNCHANGED, no corrective action was ever recorded — the
+ * agent (or a JSON/MCP-first caller blindly following `resume.from`) skipped
+ * straight past the diverged step instead of performing it. Reject rather
+ * than silently resuming past it, since a completed tail would then commit a
+ * healed script with a hole at that step. Once a request observes the count
+ * having grown, the watermark is consumed (cleared) so it can never fire
+ * against a later, unrelated request.
+ */
+function rejectUnperformedRecordAndHeal(params: {
+  from: number | undefined;
+  sessionStore: SessionStore;
+  sessionName: string;
+}): DaemonResponse | undefined {
+  const { from, sessionStore, sessionName } = params;
+  if (from === undefined) return undefined;
+  const session = sessionStore.get(sessionName);
+  const pending = session?.pendingRecordAndHeal;
+  if (!session || !pending || pending.expectedFrom !== from) return undefined;
+  if (session.actions.length === pending.actionsCountAtDivergence) {
+    return errorResponse(
+      'INVALID_ARGS',
+      `replay --from ${from} continues a record-and-heal repair, but no corrective action has been recorded on this session since that divergence; press the correct control via a blessed @ref from the divergence's screen.refs (recorded, no --no-record) before resuming with --from ${from}.`,
+    );
+  }
+  session.pendingRecordAndHeal = undefined;
+  sessionStore.set(sessionName, session);
+  return undefined;
 }
 
 /**

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -233,7 +233,10 @@ export async function runReplayScriptFile(params: {
     // action was recorded since the divergence — the corrective press
     // happened. Consume the watermark on the latter so it can never be
     // re-checked against a later, unrelated request.
-    if (preEntrySession && preEntrySession.pendingRecordAndHeal?.expectedFrom === req.flags?.replayFrom) {
+    if (
+      preEntrySession &&
+      preEntrySession.pendingRecordAndHeal?.expectedFrom === req.flags?.replayFrom
+    ) {
       preEntrySession.pendingRecordAndHeal = undefined;
       sessionStore.set(sessionName, preEntrySession);
     }

--- a/src/daemon/handlers/session-replay-target-verification.ts
+++ b/src/daemon/handlers/session-replay-target-verification.ts
@@ -36,7 +36,10 @@ import {
   type ReplayRepairHintCapture,
 } from './session-replay-repair-hint.ts';
 import { buildReplayDivergenceFailureResponse } from './session-replay-runtime-failure-response.ts';
-import { buildReplayDivergenceResume } from './session-replay-resume.ts';
+import {
+  buildReplayDivergenceResume,
+  stampPendingRecordAndHealWatermark,
+} from './session-replay-resume.ts';
 import {
   classifyReplayTarget,
   identityFieldMismatches,
@@ -132,6 +135,14 @@ function buildTargetBindingDivergenceResponse(
     targetEvidence: recorded,
     capture: built.repairCapture,
   });
+  const resume = buildReplayDivergenceResume({
+    failedIndex: step,
+    actions: planActions,
+    planDigest,
+    repairHint,
+  });
+  const session = sessionStore.get(sessionName);
+  if (session) stampPendingRecordAndHealWatermark({ session, resume, repairHint });
 
   const divergence: ReplayDivergence = {
     version: 1,
@@ -155,12 +166,7 @@ function buildTargetBindingDivergenceResponse(
     // preflight as an action-failure divergence (allowed unless a skipped
     // step produces outputEnv or the range crosses runtime control flow).
     // This is the only resume site for target-binding divergences.
-    resume: buildReplayDivergenceResume({
-      failedIndex: step,
-      actions: planActions,
-      planDigest,
-      repairHint,
-    }),
+    resume,
     repairHint,
     targetBinding,
   };

--- a/src/daemon/handlers/session-replay-target-verification.ts
+++ b/src/daemon/handlers/session-replay-target-verification.ts
@@ -142,7 +142,10 @@ function buildTargetBindingDivergenceResponse(
     repairHint,
   });
   const session = sessionStore.get(sessionName);
-  if (session) stampPendingRecordAndHealWatermark({ session, resume, repairHint });
+  if (session) {
+    stampPendingRecordAndHealWatermark({ session, resume, repairHint });
+    sessionStore.set(sessionName, session);
+  }
 
   const divergence: ReplayDivergence = {
     version: 1,

--- a/src/daemon/handlers/session-replay-target-verification.ts
+++ b/src/daemon/handlers/session-replay-target-verification.ts
@@ -125,6 +125,14 @@ function buildTargetBindingDivergenceResponse(
     mismatches: built.mismatches.slice(0, 5).map((entry) => sanitize(entry)),
     candidates: built.candidateNodes.slice(0, 5).map((node) => describeCandidate(node, sanitize)),
   };
+  // Computed before `resume` so its `from` ordinal (decision 6, R2:
+  // `record-and-heal` resumes at `step + 1`) agrees with the hint.
+  const repairHint = computeReplayRepairHint({
+    kind: built.kind,
+    targetEvidence: recorded,
+    capture: built.repairCapture,
+  });
+
   const divergence: ReplayDivergence = {
     version: 1,
     kind: built.kind,
@@ -141,20 +149,19 @@ function buildTargetBindingDivergenceResponse(
     // ADR 0012 migration step 5 (PR #1211 machinery): a target-binding
     // divergence fires PRE-ACTION, so the failed step itself was never
     // executed — resuming AT `step` re-runs exactly the action that did not
-    // send. `buildReplayDivergenceResume` runs the same skip-safety preflight
-    // as an action-failure divergence (allowed unless a skipped step produces
-    // outputEnv or the range crosses runtime control flow). This is the only
-    // resume site for target-binding divergences.
+    // send (unless `repairHint` is `record-and-heal`, in which case the agent
+    // performs it manually and `buildReplayDivergenceResume` targets `step +
+    // 1` instead). `buildReplayDivergenceResume` runs the same skip-safety
+    // preflight as an action-failure divergence (allowed unless a skipped
+    // step produces outputEnv or the range crosses runtime control flow).
+    // This is the only resume site for target-binding divergences.
     resume: buildReplayDivergenceResume({
       failedIndex: step,
       actions: planActions,
       planDigest,
+      repairHint,
     }),
-    repairHint: computeReplayRepairHint({
-      kind: built.kind,
-      targetEvidence: recorded,
-      capture: built.repairCapture,
-    }),
+    repairHint,
     targetBinding,
   };
   const bounded = boundReplayDivergenceForSession({

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -346,6 +346,20 @@ export type SessionState = {
    * SESSION_NOT_FOUND.
    */
   repairSourcePath?: string;
+  /**
+   * ADR 0012 decision 6, R2/R3: set whenever a `record-and-heal` divergence's
+   * `resume` reports `allowed: true` — its `from` (the failed step's index +
+   * 1) assumes the agent performs the diverged step manually before
+   * continuing, and nothing else enforces that. A later `--from` request that
+   * matches `expectedFrom` while `session.actions.length` is still exactly
+   * `actionsCountAtDivergence` (no new action recorded since) is rejected —
+   * proof the corrective press never happened, so the resume would silently
+   * skip the unrepaired step instead of healing it. Overwritten by the next
+   * divergence (cleared to `undefined` for any non-`record-and-heal` hint),
+   * and cleared once a `--from` request observes the action count having
+   * grown, so it never fires against an unrelated later request.
+   */
+  pendingRecordAndHeal?: { expectedFrom: number; actionsCountAtDivergence: number };
   actions: SessionAction[];
   recording?:
     | (SessionRecordingBase & {

--- a/src/replay/__tests__/divergence.test.ts
+++ b/src/replay/__tests__/divergence.test.ts
@@ -470,3 +470,84 @@ test('formatReplayDivergenceReport lists candidates for an identity-unverifiable
   assert.match(report!, /2 candidate\(s\) shared the recorded identity/);
   assert.match(report!, /@e1 \[button\] "Row"/);
 });
+
+// --- ADR 0012 decision 6: the `repairHint` text guidance embeds the
+// concrete `resume.from`/`planDigest` command ONLY when `resume.allowed` is
+// true, and never renders a `--from` command a structured caller would be
+// refused — it surfaces `resume.reason` instead. ---
+
+test('formatReplayDivergenceReport embeds the concrete resume command for an allowed record-and-heal divergence', async () => {
+  const { formatReplayDivergenceReport } = await import('../divergence.ts');
+  const report = formatReplayDivergenceReport({
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 2, source: { path: '/tmp/flow.ad', line: 3 } },
+      action: 'click id="article"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: { state: 'available', refsGeneration: 1, refs: [{ ref: 'e1', role: 'button' }] },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: { allowed: true, from: 3, planDigest: 'deadbeef' },
+      repairHint: 'record-and-heal',
+    },
+  });
+  assert.ok(report);
+  assert.match(report!, /Repair hint: record-and-heal — press the correct control/);
+  // The LITERAL next command, computed from this exact `resume` — never the
+  // generic `<step\+1>` placeholder — so a text-only caller reads the same
+  // continuation a JSON\/MCP-first caller would follow mechanically.
+  assert.match(report!, /then replay --from 3 --plan-digest deadbeef\./);
+  assert.doesNotMatch(report!, /<step/);
+});
+
+test('formatReplayDivergenceReport never renders a --from command when resume is NOT allowed, surfacing the reason instead', async () => {
+  const { formatReplayDivergenceReport } = await import('../divergence.ts');
+  const report = formatReplayDivergenceReport({
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 2, source: { path: '/tmp/flow.ad', line: 3 } },
+      action: 'click id="article"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: { state: 'available', refsGeneration: 1, refs: [{ ref: 'e1', role: 'button' }] },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: {
+        allowed: false,
+        from: 3,
+        planDigest: 'deadbeef',
+        reason: 'step 1 is inside runtime control flow (retry); skipping it cannot be proven safe.',
+      },
+      repairHint: 'record-and-heal',
+    },
+  });
+  assert.ok(report);
+  assert.match(report!, /Repair hint: record-and-heal/);
+  // A text caller must never be told to run a --from a structured caller
+  // (reading the same `resume.allowed:false`) would be refused.
+  assert.doesNotMatch(report!, /replay --from/);
+  assert.match(report!, /cannot currently be resumed automatically/);
+  assert.match(report!, /step 1 is inside runtime control flow \(retry\)/);
+});
+
+test('formatReplayDivergenceReport falls back to a generic non-resumable sentence when resume carries no reason', async () => {
+  const { formatReplayDivergenceReport } = await import('../divergence.ts');
+  const report = formatReplayDivergenceReport({
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 2, source: { path: '/tmp/flow.ad', line: 3 } },
+      action: 'click id="article"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: { state: 'unavailable', reason: 'sparse-snapshot', hint: 'run snapshot -i.' },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: { allowed: false, reason: 'resume not yet supported' },
+      repairHint: 'state-repair',
+    },
+  });
+  assert.ok(report);
+  assert.doesNotMatch(report!, /replay --from/);
+  assert.match(report!, /cannot currently be resumed automatically \(resume not yet supported\)/);
+});

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -339,7 +339,7 @@ export function formatReplayDivergenceReport(
   const lines = [
     ...divergenceStepLine(record.step),
     ...divergenceTargetBindingLines(record.kind, record.targetBinding),
-    ...divergenceRepairHintLine(record.repairHint),
+    ...divergenceRepairHintLine(record.repairHint, record.resume),
     ...divergenceScreenLine(record.screen),
     ...divergenceSuggestionLines(record.suggestions, record.suggestionCount),
     ...divergenceOverflowLine(record.overflow, record.artifactUnavailable),
@@ -351,21 +351,48 @@ export function formatReplayDivergenceReport(
  * ADR 0012 decision 6: the repair-routing hint rendered on every text
  * surface (CLI, MCP text, `test` failures) — the same field that rides
  * `structuredContent`/JSON, so a text-only caller still learns which repair
- * sub-flow applies.
+ * sub-flow applies. `record-and-heal`/`state-repair` guidance embeds the
+ * CONCRETE `resume.from`/`planDigest` values (computed by
+ * `buildReplayDivergenceResume`, decision 6 R2) rather than a placeholder, so
+ * a text-only or JSON/MCP-first caller reads the identical next command
+ * instead of deriving it (and potentially disagreeing with `resume.from`).
+ * Falls back to a placeholder only when `resume` carries no usable ordinal
+ * (e.g. `allowed: false`, or a divergence shape without one).
  */
-const REPAIR_HINT_GUIDANCE: Record<string, string> = {
-  'record-and-heal':
-    'press the correct control via a blessed @ref from screen.refs (recorded), then replay --from <step+1>.',
-  'state-repair': 'fix app state with --no-record actions, then replay --from <step> to re-run it.',
-  caution:
-    'something already matches the recorded selector; a blind re-press may repeat the mistake.',
-  manual: 'no safe automated repair could be proven; inspect the screen and repair by hand.',
-};
-
-function divergenceRepairHintLine(repairHint: unknown): string[] {
+function divergenceRepairHintLine(repairHint: unknown, resume: unknown): string[] {
   if (typeof repairHint !== 'string') return [];
-  const guidance = REPAIR_HINT_GUIDANCE[repairHint];
+  const guidance = buildRepairHintGuidance(repairHint, resume);
   return [`Repair hint: ${repairHint}${guidance ? ` — ${guidance}` : ''}`];
+}
+
+function buildRepairHintGuidance(repairHint: string, resume: unknown): string | undefined {
+  const resumeCommand = formatResumeCommand(resume);
+  switch (repairHint) {
+    case 'record-and-heal':
+      return (
+        'press the correct control via a blessed @ref from screen.refs (recorded), then ' +
+        `${resumeCommand ?? 'replay --from <step+1>'}.`
+      );
+    case 'state-repair':
+      return `fix app state with --no-record actions, then ${resumeCommand ?? 'replay --from <step>'} to re-run it.`;
+    case 'caution':
+      return 'something already matches the recorded selector; a blind re-press may repeat the mistake.';
+    case 'manual':
+      return 'no safe automated repair could be proven; inspect the screen and repair by hand.';
+    default:
+      return undefined;
+  }
+}
+
+/** `replay --from <n> --plan-digest <sha>` from a resolved `resume`, only when it is actually resumable. */
+function formatResumeCommand(resume: unknown): string | undefined {
+  const record = resume as Record<string, unknown> | undefined;
+  if (!record || record.allowed !== true) return undefined;
+  const { from, planDigest } = record;
+  if (typeof from !== 'number' || typeof planDigest !== 'string' || planDigest.length === 0) {
+    return undefined;
+  }
+  return `replay --from ${from} --plan-digest ${planDigest}`;
 }
 
 function divergenceTargetBindingLines(kind: unknown, targetBinding: unknown): string[] {

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -389,14 +389,19 @@ function divergenceRepairHintLine(repairHint: unknown, resume: unknown): string[
   return [`Repair hint: ${repairHint}${guidance ? ` — ${guidance}` : ''}`];
 }
 
-type ResumeGuidance = { allowed: true; command: string } | { allowed: false; reason: string | undefined };
+type ResumeGuidance =
+  | { allowed: true; command: string }
+  | { allowed: false; reason: string | undefined };
 
 /** Reads the parts of `resume` the repair-hint guidance needs; `undefined` when the shape is unreadable. */
 function readResumeGuidance(resume: unknown): ResumeGuidance | undefined {
   const record = resume as Record<string, unknown> | undefined;
   if (!record || typeof record.allowed !== 'boolean') return undefined;
   if (!record.allowed) {
-    return { allowed: false, reason: typeof record.reason === 'string' ? record.reason : undefined };
+    return {
+      allowed: false,
+      reason: typeof record.reason === 'string' ? record.reason : undefined,
+    };
   }
   const { from, planDigest } = record;
   if (typeof from !== 'number' || typeof planDigest !== 'string' || planDigest.length === 0) {

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -108,12 +108,34 @@ export type ReplayDivergenceSuggestion = {
 };
 
 /**
- * ADR 0012 decision 4 / migration step 5. `from` is the failed step's 1-based
- * plan index and `planDigest` is the SHA-256 digest of the canonical fully
- * expanded plan (`computeReplayPlanDigest`) that produced this report — both
- * are always present. `allowed` is the preflight verdict for resuming AT
- * `from` (`evaluateReplayResumePreflight`); `reason` is present only when
- * `allowed` is `false`.
+ * ADR 0012 decision 4 / migration step 5, refined by decision 6, R2. `from`
+ * is the 1-based plan ordinal the caller should actually pass to `--from` —
+ * NOT always the failed step's own index. It depends on the divergence's
+ * `repairHint` (`ReplayRepairHint`, below): for `record-and-heal`, the agent
+ * performs the diverged step manually before this report is acted on, so
+ * `from` is the failed step's index **+ 1** (resuming AT the failed step
+ * would re-diverge on the exact step just repaired); for every other hint
+ * (`state-repair`, `caution`, `manual`, and a plain `action-failure`), `from`
+ * equals the failed step's index unchanged. When the diverged step was the
+ * plan's LAST step, a `record-and-heal` `from` can equal `actions.length + 1`
+ * — a legal EMPTY-TAIL resume (there is nothing left to replay; the runtime
+ * executes zero steps and reaches the normal end-of-plan completion path),
+ * not an out-of-range error. That one-past-the-end ordinal is authorized
+ * ONLY for the exact session + target that produced it (the daemon tracks a
+ * per-session watermark, `session.pendingRecordAndHeal`) and only once a new
+ * action proves the corrective press actually happened — never a general
+ * "one past the end is fine" for any session.
+ *
+ * `planDigest` is the SHA-256 digest of the canonical fully expanded plan
+ * (`computeReplayPlanDigest`) that produced this report — always present.
+ * `allowed` is the preflight verdict for resuming AT `from`
+ * (`evaluateReplayResumePreflight`, plus the same-session/action-count
+ * authorization above when `from` is one past the plan's end); `reason` is
+ * present only when `allowed` is `false`. This must agree with the
+ * `repairHint` text guidance rendered by `formatReplayDivergenceReport`
+ * (below) — both are derived from the same computed `from`, and when
+ * `allowed` is `false` the text guidance never renders a `--from` command,
+ * surfacing `reason` instead.
  *
  * `repairSessionHeld` is decision 6, R7's repair-transaction liveness signal
  * (C1): set `true` by the daemon on ANY divergence from a repair-armed
@@ -353,11 +375,13 @@ export function formatReplayDivergenceReport(
  * `structuredContent`/JSON, so a text-only caller still learns which repair
  * sub-flow applies. `record-and-heal`/`state-repair` guidance embeds the
  * CONCRETE `resume.from`/`planDigest` values (computed by
- * `buildReplayDivergenceResume`, decision 6 R2) rather than a placeholder, so
- * a text-only or JSON/MCP-first caller reads the identical next command
- * instead of deriving it (and potentially disagreeing with `resume.from`).
- * Falls back to a placeholder only when `resume` carries no usable ordinal
- * (e.g. `allowed: false`, or a divergence shape without one).
+ * `buildReplayDivergenceResume`, decision 6 R2) when `resume.allowed` is
+ * true, so a text-only or JSON/MCP-first caller reads the identical next
+ * command instead of deriving it. When `resume.allowed` is false (a skipped
+ * step crosses runtime control flow or would produce unavailable
+ * `outputEnv`), a resume command is never rendered — a text caller must not
+ * be told to run a `--from` a structured caller would be refused — and the
+ * reported `reason` is surfaced instead.
  */
 function divergenceRepairHintLine(repairHint: unknown, resume: unknown): string[] {
   if (typeof repairHint !== 'string') return [];
@@ -365,16 +389,33 @@ function divergenceRepairHintLine(repairHint: unknown, resume: unknown): string[
   return [`Repair hint: ${repairHint}${guidance ? ` — ${guidance}` : ''}`];
 }
 
+type ResumeGuidance = { allowed: true; command: string } | { allowed: false; reason: string | undefined };
+
+/** Reads the parts of `resume` the repair-hint guidance needs; `undefined` when the shape is unreadable. */
+function readResumeGuidance(resume: unknown): ResumeGuidance | undefined {
+  const record = resume as Record<string, unknown> | undefined;
+  if (!record || typeof record.allowed !== 'boolean') return undefined;
+  if (!record.allowed) {
+    return { allowed: false, reason: typeof record.reason === 'string' ? record.reason : undefined };
+  }
+  const { from, planDigest } = record;
+  if (typeof from !== 'number' || typeof planDigest !== 'string' || planDigest.length === 0) {
+    return undefined;
+  }
+  return { allowed: true, command: `replay --from ${from} --plan-digest ${planDigest}` };
+}
+
 function buildRepairHintGuidance(repairHint: string, resume: unknown): string | undefined {
-  const resumeCommand = formatResumeCommand(resume);
+  const guidance = readResumeGuidance(resume);
   switch (repairHint) {
     case 'record-and-heal':
-      return (
-        'press the correct control via a blessed @ref from screen.refs (recorded), then ' +
-        `${resumeCommand ?? 'replay --from <step+1>'}.`
-      );
+      return guidance?.allowed
+        ? `press the correct control via a blessed @ref from screen.refs (recorded), then ${guidance.command}.`
+        : `press the correct control via a blessed @ref from screen.refs (recorded). ${resumeUnavailableSentence(guidance)}`;
     case 'state-repair':
-      return `fix app state with --no-record actions, then ${resumeCommand ?? 'replay --from <step>'} to re-run it.`;
+      return guidance?.allowed
+        ? `fix app state with --no-record actions, then ${guidance.command} to re-run it.`
+        : `fix app state with --no-record actions. ${resumeUnavailableSentence(guidance)}`;
     case 'caution':
       return 'something already matches the recorded selector; a blind re-press may repeat the mistake.';
     case 'manual':
@@ -384,15 +425,12 @@ function buildRepairHintGuidance(repairHint: string, resume: unknown): string | 
   }
 }
 
-/** `replay --from <n> --plan-digest <sha>` from a resolved `resume`, only when it is actually resumable. */
-function formatResumeCommand(resume: unknown): string | undefined {
-  const record = resume as Record<string, unknown> | undefined;
-  if (!record || record.allowed !== true) return undefined;
-  const { from, planDigest } = record;
-  if (typeof from !== 'number' || typeof planDigest !== 'string' || planDigest.length === 0) {
-    return undefined;
+/** Never renders a `--from` command — only reached when `resume.allowed` is false (or unreadable). */
+function resumeUnavailableSentence(guidance: ResumeGuidance | undefined): string {
+  if (guidance && !guidance.allowed && guidance.reason) {
+    return `This step cannot currently be resumed automatically (${guidance.reason}) — run a fresh full replay instead.`;
   }
-  return `replay --from ${from} --plan-digest ${planDigest}`;
+  return 'This step cannot currently be resumed automatically — run a fresh full replay instead.';
 }
 
 function divergenceTargetBindingLines(kind: unknown, targetBinding: unknown): string[] {


### PR DESCRIPTION
## Summary

- `buildReplayDivergenceResume` always reported `resume.from` as the failed step's index, but the rendered text guidance for `repairHint: 'record-and-heal'` told the agent to continue at `step+1` (the corrective action is performed manually, so re-running the original step re-diverges). A JSON/MCP-first agent that follows `resume.from` mechanically would loop on the same divergence forever — this is exactly what stumbled the #1235 evidence run (ADR-0012 decisions 4 + 6).
- `resume.from` is now derived from the same `repairHint` value the divergence already carries: `failedIndex + 1` for `record-and-heal`, `failedIndex` unchanged for `state-repair`/`caution`/`manual`. Also handles the shifted index running past the plan's end (diverged on the last step) by reporting `allowed: false` with an explanatory reason rather than an unusable ordinal.
- The text renderer (`formatReplayDivergenceReport`) now embeds the concrete `replay --from <n> --plan-digest <sha>` command computed from this same value instead of the old `<step+1>`/`<step>` placeholders, so text-only and structured (JSON/MCP) callers always agree on the exact next command.
- Amended ADR-0012's wire-contract wording to document that `from`'s value depends on `repairHint`.

## Why

Per the handoff note: text and structure disagreed for `record-and-heal` divergences, so a small/JSON-first model following the structured `resume.from` field would repeatedly re-diverge on the exact step it just repaired manually.

## Notable finding while fixing

One existing test (`session-replay-dispatch-selector-miss.test.ts`, test "(a)") was silently exercising the bug: its script has a single annotated step with real (non-empty) ancestry evidence, which genuinely computes `repairHint: 'record-and-heal'` — but the shared assertion helper hardcoded `resume.allowed: true, resume.from: 1`, the pre-fix (wrong) value. Updated it to assert the corrected `allowed: false, from: 2` (out of range, since it's a 1-step plan) with the new explanatory reason.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] Full `src/daemon`, `src/mcp`, `src/cli`, `src/utils`, `src/replay` suites — 1789+ tests pass
- [x] Added targeted unit tests in `session-replay-resume.test.ts` for the `record-and-heal` shift and the new last-step out-of-range case