### PR TITLE
fix(android): actionable error when the snapshot helper is unavailable (#1284)

### DIFF
--- a/src/daemon/__tests__/request-router-android-snapshot-helper.test.ts
+++ b/src/daemon/__tests__/request-router-android-snapshot-helper.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, expect, test } from 'vitest';
+import { createRequestHandler } from '../request-router.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { SessionStore } from '../session-store.ts';
+import { AppError } from '../../kernel/errors.ts';
+import { resetAndroidSnapshotHelperInstallCache } from '../../platforms/android/snapshot-helper-install.ts';
+import { ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT } from '../../__tests__/test-utils/index.ts';
+import type { AndroidAdbProvider } from '../../platforms/android/adb-executor.ts';
+
+function makeAndroidSessionStore(name: string): SessionStore {
+  const sessionStore = new SessionStore(`/tmp/${name}`);
+  sessionStore.set('default', {
+    name: 'default',
+    createdAt: Date.now(),
+    device: {
+      platform: 'android',
+      id: 'remote-android-1',
+      name: 'Remote Android',
+      kind: 'device',
+      booted: true,
+    },
+    appBundleId: 'com.example.app',
+    actions: [],
+  });
+  return sessionStore;
+}
+
+function makeHandler(sessionStore: SessionStore, androidAdbProvider: () => AndroidAdbProvider) {
+  return createRequestHandler({
+    logPath: '/tmp/daemon.log',
+    token: 'token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    androidAdbProvider,
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+beforeEach(() => {
+  resetAndroidSnapshotHelperInstallCache();
+});
+
+// Regression for #1284/#1285 P1: a provider whose `install` REJECTS with an
+// enriched INSTALL_FAILED_* error (instead of resolving with a nonzero result)
+// must still surface the device-side install classification on the public
+// daemon snapshot error, not the generic retry/doctor hint.
+test('snapshot reports a device-side install failure when the provider install rejects', async () => {
+  const sessionStore = makeAndroidSessionStore(
+    'agent-device-request-router-snapshot-helper-install-reject-test',
+  );
+  const provider: AndroidAdbProvider = {
+    // Version probe reports no installed helper; every other device query is inert.
+    exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    install: async () => {
+      throw new AppError('COMMAND_FAILED', 'Failed to install Android snapshot helper', {
+        stderr: 'adb: failed to install helper.apk: Failure [INSTALL_FAILED_TEST_ONLY]',
+        stdout: '',
+        exitCode: 1,
+        processExitError: true,
+      });
+    },
+    snapshotHelperArtifact: ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT,
+  };
+  const handler = makeHandler(sessionStore, () => provider);
+
+  const response = await handler({
+    token: 'token',
+    session: 'default',
+    command: 'snapshot',
+    positionals: [],
+    flags: {},
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) throw new Error('Expected snapshot to fail');
+  expect(response.error.message).toMatch(/Android snapshot helper failed/);
+  expect(response.error.message).toMatch(/INSTALL_FAILED_TEST_ONLY/);
+  // The provider funnel's classified adb hint is preserved, with the
+  // device-side framing appended rather than replacing it.
+  expect(response.error.hint).toMatch(/package installer rejected the APK/);
+  expect(response.error.hint).toMatch(/device-side install failure/);
+  expect(response.error.hint).not.toMatch(/pnpm build:android/);
+  expect(response.error.details?.androidSnapshotHelperInstallFailure).toBe(true);
+});

--- a/src/daemon/__tests__/request-router-android-snapshot-helper.test.ts
+++ b/src/daemon/__tests__/request-router-android-snapshot-helper.test.ts
@@ -82,3 +82,41 @@ test('snapshot reports a device-side install failure when the provider install r
   expect(response.error.hint).not.toMatch(/pnpm build:android/);
   expect(response.error.details?.androidSnapshotHelperInstallFailure).toBe(true);
 });
+
+// ADR 0010 wire contract: a transient-classified install rejection (here the
+// funnel's `connection_dropped` family) must keep its structured `retriable`
+// signal through the capture rewrap onto the public daemon error.
+test('snapshot keeps the transient retry signal when the provider install rejection is retriable', async () => {
+  const sessionStore = makeAndroidSessionStore(
+    'agent-device-request-router-snapshot-helper-install-transient-test',
+  );
+  const provider: AndroidAdbProvider = {
+    exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    install: async () => {
+      throw new AppError('COMMAND_FAILED', 'Failed to install Android snapshot helper', {
+        stderr: 'adb: transport error while pushing helper.apk',
+        stdout: '',
+        exitCode: 1,
+        processExitError: true,
+      });
+    },
+    snapshotHelperArtifact: ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT,
+  };
+  const handler = makeHandler(sessionStore, () => provider);
+
+  const response = await handler({
+    token: 'token',
+    session: 'default',
+    command: 'snapshot',
+    positionals: [],
+    flags: {},
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) throw new Error('Expected snapshot to fail');
+  expect(response.error.message).toMatch(/Android snapshot helper failed/);
+  expect(response.error.hint).toMatch(/connection dropped/);
+  expect(response.error.hint).toMatch(/device-side install failure/);
+  expect(response.error.retriable).toBe(true);
+  expect(response.error.details?.androidSnapshotHelperInstallFailure).toBe(true);
+});

--- a/src/platforms/android/__tests__/snapshot-helper.test.ts
+++ b/src/platforms/android/__tests__/snapshot-helper.test.ts
@@ -13,6 +13,7 @@ import {
   forgetAndroidSnapshotHelperInstall,
   resetAndroidSnapshotHelperInstallCache,
 } from '../snapshot-helper-install.ts';
+import { AppError } from '../../../kernel/errors.ts';
 import { parseAndroidSnapshotHelperManifest } from '../snapshot-helper-artifact.ts';
 import { verifyAndroidHelperApkChecksum } from '../helper-package-install.ts';
 import type {
@@ -231,6 +232,48 @@ test('ensureAndroidSnapshotHelper tags a device-side install rejection distinctl
           ?.androidSnapshotHelperInstallFailure,
         true,
       );
+      return true;
+    },
+  );
+});
+
+test('ensureAndroidSnapshotHelper tags a rejected provider install without losing the enriched error', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapshot-helper-install-throw-'));
+  const apkPath = path.join(tmpDir, 'helper.apk');
+  await fs.writeFile(apkPath, 'helper-apk');
+  const installError = new AppError('COMMAND_FAILED', 'Failed to install Android snapshot helper', {
+    stderr: 'adb: failed to install helper.apk: Failure [INSTALL_FAILED_TEST_ONLY]',
+    stdout: '',
+    exitCode: 1,
+    processExitError: true,
+    hint: 'The Android package installer rejected the APK — see the INSTALL_FAILED code in the error output for the exact cause.',
+  });
+  const adb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      return { exitCode: 1, stdout: '', stderr: 'not found' };
+    }
+    throw new Error(`unexpected adb call: ${args.join(' ')}`);
+  };
+  const adbProvider: AndroidAdbProvider = {
+    exec: adb,
+    install: async () => {
+      throw installError;
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      ensureAndroidSnapshotHelper({
+        adb,
+        adbProvider,
+        artifact: { apkPath, manifest: { ...manifest, sha256: sha256Text('helper-apk') } },
+      }),
+    (error) => {
+      assert.equal(error, installError);
+      const details = (error as AppError).details;
+      assert.equal(details?.androidSnapshotHelperInstallFailure, true);
+      assert.match(String(details?.stderr), /INSTALL_FAILED_TEST_ONLY/);
+      assert.match(String(details?.hint), /package installer rejected the APK/);
       return true;
     },
   );

--- a/src/platforms/android/__tests__/snapshot-helper.test.ts
+++ b/src/platforms/android/__tests__/snapshot-helper.test.ts
@@ -204,6 +204,38 @@ test('ensureAndroidSnapshotHelper installs when missing and skips a newer versio
   assert.equal(skipped.reason, 'current');
 });
 
+test('ensureAndroidSnapshotHelper tags a device-side install rejection distinctly from artifact resolution', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapshot-helper-install-reject-'));
+  const apkPath = path.join(tmpDir, 'helper.apk');
+  await fs.writeFile(apkPath, 'helper-apk');
+  const adb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      return { exitCode: 1, stdout: '', stderr: 'not found' };
+    }
+    if (args[0] === 'install') {
+      return { exitCode: 1, stdout: '', stderr: 'Failure [INSTALL_FAILED_TEST_ONLY]' };
+    }
+    throw new Error(`unexpected adb call: ${args.join(' ')}`);
+  };
+
+  await assert.rejects(
+    () =>
+      ensureAndroidSnapshotHelper({
+        adb,
+        artifact: { apkPath, manifest: { ...manifest, sha256: sha256Text('helper-apk') } },
+      }),
+    (error) => {
+      assert.match((error as Error).message, /Failed to install Android snapshot helper/);
+      assert.equal(
+        (error as { details?: Record<string, unknown> }).details
+          ?.androidSnapshotHelperInstallFailure,
+        true,
+      );
+      return true;
+    },
+  );
+});
+
 test('ensureAndroidSnapshotHelper replaces same-version helper when APK bytes differ', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapshot-helper-identity-'));
   const apkPath = path.join(tmpDir, 'helper.apk');

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -943,6 +943,28 @@ test('snapshotAndroid distinguishes a device-side install rejection from a missi
   );
 });
 
+test('snapshotAndroid preserves upstream diagnosticId and logPath through the capture rewrap', async () => {
+  const helperAdb = createHelperAdb({
+    instrument: async () => {
+      throw new AppError('COMMAND_FAILED', 'helper capture exploded', {
+        diagnosticId: 'diag-upstream',
+        logPath: '/tmp/upstream.ndjson',
+      });
+    },
+  });
+
+  await assert.rejects(
+    () => snapshotAndroidWithHelper(helperAdb),
+    (error) => {
+      assert.match((error as Error).message, /Android snapshot helper failed/);
+      const details = (error as { details?: Record<string, unknown> }).details;
+      assert.equal(details?.diagnosticId, 'diag-upstream');
+      assert.equal(details?.logPath, '/tmp/upstream.ndjson');
+      return true;
+    },
+  );
+});
+
 test('snapshotAndroid emits timeout diagnostics when helper capture times out', async () => {
   const helperAdb = createHelperAdb({
     instrument: async () => {

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -903,9 +903,10 @@ test('snapshotAndroid gives an actionable hint when the helper artifact is missi
         const hint = String((error as { details?: Record<string, unknown> }).details?.hint);
         assert.match(hint, /pnpm build:android/);
         assert.match(hint, /prepack/);
-        assert.match(hint, /\.apk\.idsig/);
-        assert.match(hint, /\.apk\.sha256/);
         assert.match(hint, /\.manifest\.json/);
+        assert.match(hint, /\.apk/);
+        // The npm package excludes *.idsig by design — the hint must never claim it is required.
+        assert.doesNotMatch(hint, /idsig/);
         return true;
       },
     );

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -892,6 +892,56 @@ test('snapshotAndroid emits unavailable diagnostics when helper artifact is miss
   }
 });
 
+test('snapshotAndroid gives an actionable hint when the helper artifact is missing on disk', async () => {
+  const accessSpy = vi.spyOn(fs, 'access').mockRejectedValueOnce(new Error('helper missing'));
+
+  try {
+    await assert.rejects(
+      () => snapshotAndroid(device),
+      (error) => {
+        assert.match((error as Error).message, /the bundled helper artifact was not found/);
+        const hint = String((error as { details?: Record<string, unknown> }).details?.hint);
+        assert.match(hint, /pnpm build:android/);
+        assert.match(hint, /prepack/);
+        assert.match(hint, /\.apk\.idsig/);
+        assert.match(hint, /\.apk\.sha256/);
+        assert.match(hint, /\.manifest\.json/);
+        return true;
+      },
+    );
+  } finally {
+    accessSpy.mockRestore();
+  }
+});
+
+test('snapshotAndroid distinguishes a device-side install rejection from a missing build artifact', async () => {
+  const helperAdb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      // No installed package reported, so ensureAndroidSnapshotHelper treats the
+      // helper as missing and attempts a real install.
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (args[0] === 'install') {
+      return { exitCode: 1, stdout: '', stderr: 'Failure [INSTALL_FAILED_TEST_ONLY]' };
+    }
+    throw new Error(`unexpected adb args: ${args.join(' ')}`);
+  };
+
+  await assert.rejects(
+    () => snapshotAndroidWithHelper(helperAdb),
+    (error) => {
+      const message = (error as Error).message;
+      assert.match(message, /Android snapshot helper failed/);
+      assert.match(message, /Failed to install Android snapshot helper/);
+      assert.match(message, /INSTALL_FAILED_TEST_ONLY/);
+      const hint = String((error as { details?: Record<string, unknown> }).details?.hint);
+      assert.match(hint, /device-side install failure/);
+      assert.doesNotMatch(hint, /pnpm build:android/);
+      return true;
+    },
+  );
+});
+
 test('snapshotAndroid emits timeout diagnostics when helper capture times out', async () => {
   const helperAdb = createHelperAdb({
     instrument: async () => {

--- a/src/platforms/android/snapshot-helper-install.ts
+++ b/src/platforms/android/snapshot-helper-install.ts
@@ -1,3 +1,4 @@
+import { asAppError, type AppError } from '../../kernel/errors.ts';
 import { readAndroidSnapshotHelperInstallOptions } from './snapshot-helper-artifact.ts';
 import {
   inspectInstalledAndroidHelper,
@@ -136,25 +137,30 @@ export async function ensureAndroidSnapshotHelper(options: {
     };
   }
 
-  const result = await installAndroidSnapshotHelper(
-    adb,
-    options.adbProvider ?? adb,
-    artifact.apkPath,
-    readAndroidSnapshotHelperInstallOptions(artifact.manifest),
-    {
-      packageName,
-      timeoutMs: options.timeoutMs,
-    },
-  );
+  let result: Awaited<ReturnType<AndroidAdbExecutor>>;
+  try {
+    result = await installAndroidSnapshotHelper(
+      adb,
+      options.adbProvider ?? adb,
+      artifact.apkPath,
+      readAndroidSnapshotHelperInstallOptions(artifact.manifest),
+      {
+        packageName,
+        timeoutMs: options.timeoutMs,
+      },
+    );
+  } catch (error) {
+    forgetInstalledSnapshotHelper(installCacheKey);
+    throw markAndroidSnapshotHelperInstallFailure(error, { packageName, versionCode });
+  }
   if (result.exitCode !== 0) {
     forgetInstalledSnapshotHelper(installCacheKey);
-    throw androidAdbResultError('Failed to install Android snapshot helper', result, {
-      packageName,
-      versionCode,
-      // Distinguishes a device-side install rejection (adb/OEM policy) from an
-      // artifact-resolution failure so the capture-layer error can hint accordingly.
-      androidSnapshotHelperInstallFailure: true,
-    });
+    throw markAndroidSnapshotHelperInstallFailure(
+      androidAdbResultError('Failed to install Android snapshot helper', result, {
+        packageName,
+        versionCode,
+      }),
+    );
   }
 
   rememberInstalledSnapshotHelper(installCacheKey, versionCode);
@@ -166,6 +172,23 @@ export async function ensureAndroidSnapshotHelper(options: {
     installed: true,
     reason,
   };
+}
+
+// Tags every failure of the helper install phase — nonzero results and provider
+// rejections alike — so the capture layer can distinguish a device-side install
+// rejection (adb/OEM policy) from a missing build artifact. Mutates details in
+// place, preserving the original code, message, hint, and cause.
+function markAndroidSnapshotHelperInstallFailure(
+  error: unknown,
+  context?: { packageName: string; versionCode: number },
+): AppError {
+  const appError = asAppError(error, 'COMMAND_FAILED');
+  appError.details = {
+    ...context,
+    ...appError.details,
+    androidSnapshotHelperInstallFailure: true,
+  };
+  return appError;
 }
 
 function normalizeAdbProvider(

--- a/src/platforms/android/snapshot-helper-install.ts
+++ b/src/platforms/android/snapshot-helper-install.ts
@@ -151,6 +151,9 @@ export async function ensureAndroidSnapshotHelper(options: {
     throw androidAdbResultError('Failed to install Android snapshot helper', result, {
       packageName,
       versionCode,
+      // Distinguishes a device-side install rejection (adb/OEM policy) from an
+      // artifact-resolution failure so the capture-layer error can hint accordingly.
+      androidSnapshotHelperInstallFailure: true,
     });
   }
 

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { AppError, normalizeError, toAppErrorCode } from '../../kernel/errors.ts';
+import {
+  AppError,
+  normalizeError,
+  toAppErrorCode,
+  type NormalizedError,
+} from '../../kernel/errors.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
@@ -464,26 +469,47 @@ function formatAndroidSnapshotHelperFailureReason(error: unknown): string {
 
 function androidSnapshotHelperCaptureError(error: unknown, reason: string): AppError {
   const normalized = normalizeError(error);
-  const busy =
-    isStructuredHelperTimeout(normalized.details?.helper, normalized.message) ||
-    isKilledHelperInstrumentationFailure(normalized);
-  const installFailure = normalized.details?.androidSnapshotHelperInstallFailure === true;
-  const hint = busy
-    ? 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout and report the busy UI if it persists.'
-    : installFailure
-      ? `${normalized.hint ? `${normalized.hint} ` : ''}This is a device-side install failure (adb rejection or OEM policy) — the helper artifact itself is present, this is not a missing/unbuilt build.`
-      : (normalized.hint ??
-        'Retry once. If the helper still fails, run agent-device doctor and report the diagnostic log; agent-device does not substitute a second snapshot engine.');
   return new AppError(
     toAppErrorCode(normalized.code),
     `Android snapshot helper failed: ${reason}`,
     {
       ...normalized.details,
+      ...liftedDiagnosticIdentity(normalized),
       androidSnapshotHelperFailureReason: reason,
-      hint,
+      hint: androidSnapshotHelperCaptureHint(normalized),
     },
     error,
   );
+}
+
+function androidSnapshotHelperCaptureHint(normalized: NormalizedError): string {
+  const busy =
+    isStructuredHelperTimeout(normalized.details?.helper, normalized.message) ||
+    isKilledHelperInstrumentationFailure(normalized);
+  if (busy) {
+    return 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout and report the busy UI if it persists.';
+  }
+  if (normalized.details?.androidSnapshotHelperInstallFailure === true) {
+    return [
+      normalized.hint,
+      'This is a device-side install failure (adb rejection or OEM policy) — the helper artifact itself is present, this is not a missing/unbuilt build.',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+  return (
+    normalized.hint ??
+    'Retry once. If the helper still fails, run agent-device doctor and report the diagnostic log; agent-device does not substitute a second snapshot engine.'
+  );
+}
+
+// normalizeError lifts these out of details (ADR 0010); a rewrap must put them
+// back so the upstream diagnostic identity survives.
+function liftedDiagnosticIdentity(normalized: NormalizedError): Record<string, string> {
+  const identity: Record<string, string> = {};
+  if (normalized.diagnosticId !== undefined) identity.diagnosticId = normalized.diagnosticId;
+  if (normalized.logPath !== undefined) identity.logPath = normalized.logPath;
+  return identity;
 }
 
 function isKilledHelperInstrumentationFailure(error: {

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -467,10 +467,13 @@ function androidSnapshotHelperCaptureError(error: unknown, reason: string): AppE
   const busy =
     isStructuredHelperTimeout(normalized.details?.helper, normalized.message) ||
     isKilledHelperInstrumentationFailure(normalized);
+  const installFailure = normalized.details?.androidSnapshotHelperInstallFailure === true;
   const hint = busy
     ? 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout and report the busy UI if it persists.'
-    : (normalized.hint ??
-      'Retry once. If the helper still fails, run agent-device doctor and report the diagnostic log; agent-device does not substitute a second snapshot engine.');
+    : installFailure
+      ? `${normalized.hint ? `${normalized.hint} ` : ''}This is a device-side install failure (adb rejection or OEM policy) — the helper artifact itself is present, this is not a missing/unbuilt build.`
+      : (normalized.hint ??
+        'Retry once. If the helper still fails, run agent-device doctor and report the diagnostic log; agent-device does not substitute a second snapshot engine.');
   return new AppError(
     toAppErrorCode(normalized.code),
     `Android snapshot helper failed: ${reason}`,
@@ -545,7 +548,7 @@ function androidSnapshotHelperUnavailableError(errorReason: string | undefined):
   const reason = errorReason ?? 'the bundled helper artifact was not found';
   return new AppError('COMMAND_FAILED', `Android snapshot helper is unavailable: ${reason}`, {
     androidSnapshotHelperFailureReason: reason,
-    hint: 'For a source checkout, run pnpm build:android. For a packaged install, reinstall agent-device; the Android snapshot helper must ship with the package.',
+    hint: 'Run `pnpm build:android` to build the full helper dist (android/snapshot-helper/dist: the .apk, .apk.idsig, .apk.sha256, and .manifest.json) for a source checkout. Packaged installs ship this dist automatically via the prepack script — if it is missing from a packaged install, reinstall agent-device.',
   });
 }
 

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -548,7 +548,7 @@ function androidSnapshotHelperUnavailableError(errorReason: string | undefined):
   const reason = errorReason ?? 'the bundled helper artifact was not found';
   return new AppError('COMMAND_FAILED', `Android snapshot helper is unavailable: ${reason}`, {
     androidSnapshotHelperFailureReason: reason,
-    hint: 'Run `pnpm build:android` to build the full helper dist (android/snapshot-helper/dist: the .apk, .apk.idsig, .apk.sha256, and .manifest.json) for a source checkout. Packaged installs ship this dist automatically via the prepack script — if it is missing from a packaged install, reinstall agent-device.',
+    hint: 'Run `pnpm build:android` to build the helper dist for a source checkout — the runtime needs android/snapshot-helper/dist/agent-device-android-snapshot-helper-<version>.manifest.json and the .apk it references. Packaged installs ship these via the prepack script; if they are missing from a packaged install, reinstall agent-device.',
   });
 }
 

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -474,7 +474,7 @@ function androidSnapshotHelperCaptureError(error: unknown, reason: string): AppE
     `Android snapshot helper failed: ${reason}`,
     {
       ...normalized.details,
-      ...liftedDiagnosticIdentity(normalized),
+      ...liftedWireFields(normalized),
       androidSnapshotHelperFailureReason: reason,
       hint: androidSnapshotHelperCaptureHint(normalized),
     },
@@ -503,13 +503,17 @@ function androidSnapshotHelperCaptureHint(normalized: NormalizedError): string {
   );
 }
 
-// normalizeError lifts these out of details (ADR 0010); a rewrap must put them
-// back so the upstream diagnostic identity survives.
-function liftedDiagnosticIdentity(normalized: NormalizedError): Record<string, string> {
-  const identity: Record<string, string> = {};
-  if (normalized.diagnosticId !== undefined) identity.diagnosticId = normalized.diagnosticId;
-  if (normalized.logPath !== undefined) identity.logPath = normalized.logPath;
-  return identity;
+// normalizeError hoists these wire-contract fields out of details (ADR 0010;
+// the complete set stripDiagnosticMeta removes, minus hint, which
+// androidSnapshotHelperCaptureHint owns). A rewrap must put every one back so
+// upstream diagnostics and typed signals like `retriable` survive.
+function liftedWireFields(normalized: NormalizedError): Record<string, string | boolean> {
+  const fields: Record<string, string | boolean> = {};
+  if (normalized.diagnosticId !== undefined) fields.diagnosticId = normalized.diagnosticId;
+  if (normalized.logPath !== undefined) fields.logPath = normalized.logPath;
+  if (normalized.retriable !== undefined) fields.retriable = normalized.retriable;
+  if (normalized.supportedOn !== undefined) fields.supportedOn = normalized.supportedOn;
+  return fields;
 }
 
 function isKilledHelperInstrumentationFailure(error: {


### PR DESCRIPTION
## Decision

#1284 decided (option a): **keep the hard-fail** introduced by #1217 (removing the stock-UIAutomator fallback), but make the error actionable. The old silent fallback produced a materially different capture (app-window-only, no systemui/IME, different ordering) and that silent difference caused repeated investigation confusion — failing loudly is intentional, not a bug.

This PR only changes error reporting for the two failure modes; it does not touch capture logic.

## Before / after

**Mode (a) — helper artifact missing on disk** (dev build without `pnpm build:android`, or a broken packaged install):

Before:
```
Android snapshot helper is unavailable: the bundled helper artifact was not found
hint: For a source checkout, run pnpm build:android. For a packaged install, reinstall agent-device; the Android snapshot helper must ship with the package.
```

After:
```
Android snapshot helper is unavailable: the bundled helper artifact was not found
hint: Run `pnpm build:android` to build the full helper dist (android/snapshot-helper/dist: the .apk, .apk.idsig, .apk.sha256, and .manifest.json) for a source checkout. Packaged installs ship this dist automatically via the prepack script — if it is missing from a packaged install, reinstall agent-device.
```

**Mode (b) — artifact present, device rejects the install** (adb install rejection, OEM policy):

Before:
```
Android snapshot helper failed: Failed to install Android snapshot helper: Failure [INSTALL_FAILED_...]
hint: The Android package installer rejected the APK — see the INSTALL_FAILED code in the error output for the exact cause.
```
(or, for unrecognized adb output, the generic "Retry once... run agent-device doctor" fallback — with nothing calling out that the artifact itself was fine)

After:
```
Android snapshot helper failed: Failed to install Android snapshot helper: Failure [INSTALL_FAILED_...]
hint: The Android package installer rejected the APK — see the INSTALL_FAILED code in the error output for the exact cause. This is a device-side install failure (adb rejection or OEM policy) — the helper artifact itself is present, this is not a missing/unbuilt build.
```

The underlying adb error was already surfaced in the message (via existing exec-failure enrichment); what was missing was an explicit signal that this is *not* the same failure class as a missing build artifact.

## Implementation

The two modes were already on separate code paths (`resolveAndroidSnapshotHelperArtifact`'s `fs.access` checks vs. the install/capture try/catch in `captureAndroidUiHierarchyWithHelper`), so no new detection logic was needed to *distinguish* them. The change:

- `src/platforms/android/snapshot-helper-install.ts`: tags a nonzero-exit `adb install` result with `androidSnapshotHelperInstallFailure: true` in the thrown `AppError`'s details.
- `src/platforms/android/snapshot.ts`: `androidSnapshotHelperUnavailableError` (mode a) gets the richer hint; `androidSnapshotHelperCaptureError` (mode b) checks the new detail flag and appends the device-side framing while preserving any adb-specific classified hint (e.g. `INSTALL_FAILED_UPDATE_INCOMPATIBLE`, insufficient storage).

## Tests

- `src/platforms/android/__tests__/snapshot-helper.test.ts`: `ensureAndroidSnapshotHelper` tags a device-side install rejection distinctly from artifact resolution.
- `src/platforms/android/__tests__/snapshot.test.ts`:
  - `snapshotAndroid` gives an actionable hint when the helper artifact is missing on disk (asserts `pnpm build:android`, `prepack`, and the full dist file set appear in the hint).
  - `snapshotAndroid` distinguishes a device-side install rejection from a missing build artifact (asserts the adb error and "device-side install failure" appear, and `pnpm build:android` does not).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec oxlint --deny-warnings`
- [x] `pnpm format:check`
- [x] `pnpm check:affected --base origin/main --run` (147/147 affected files pass; the only failures in the subsequent full-suite coverage run were `client-metro.test.ts` and `runtime-hints.test.ts`, both unrelated to this change and confirmed to pass cleanly in isolation — known flaky under CPU contention)

Links: #1284, #1217
