### PR TITLE
fix(cli): forward --no-record from every recordable command reader

### DIFF
--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
+import type { CommandName } from '../commands/command-metadata.ts';
 import type { CliFlags } from '../commands/cli-grammar/flag-types.ts';
 
 const BASE_FLAGS: CliFlags = {
@@ -136,6 +137,38 @@ test('find and is grammar decodes command action positionals', () => {
   assert.equal(isOptions.predicate, 'text');
   assert.equal(isOptions.selector, 'id=title');
   assert.equal(isOptions.value, 'Welcome');
+});
+
+// --no-record is accepted on every command (COMMON_COMMAND_SUPPORTED_FLAG_KEYS),
+// but it only reaches the daemon if the reader forwards it, so a reader that
+// never names it accepts the flag and silently ignores it. Cover every command
+// whose actions are recorded into a session script.
+test('readers forward --no-record instead of silently dropping it', () => {
+  const recordable: Array<[CommandName, string[]]> = [
+    ['press', ['@e5']],
+    ['click', ['@e5']],
+    ['fill', ['id=email', 'qa@example.com']],
+    ['longpress', ['@e5']],
+    ['swipe', ['up']],
+    ['focus', ['10', '20']],
+    ['type', ['hello']],
+    ['scroll', ['down']],
+    ['get', ['attrs', '@e5']],
+    ['is', ['visible', 'id=title']],
+    ['find', ['label', 'Continue', 'exists']],
+    ['snapshot', []],
+    ['wait', ['Continue']],
+  ];
+
+  for (const [command, positionals] of recordable) {
+    const options = readInputFromCli(command, positionals, { ...BASE_FLAGS, noRecord: true });
+    assert.equal(options.noRecord, true, `${command} dropped --no-record`);
+  }
+});
+
+test('readers omit noRecord entirely when the flag is absent', () => {
+  const options = readInputFromCli('press', ['@e5'], BASE_FLAGS);
+  assert.equal(Object.hasOwn(options, 'noRecord'), false);
 });
 
 test('is grammar accepts the selector-first form with a trailing predicate', () => {

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -2,7 +2,11 @@ import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { SNAPSHOT_FLAGS } from '../cli-grammar/flag-groups.ts';
 import { booleanField, integerField, stringField } from '../command-input.ts';
 import { defineExecutableCommand } from '../command-contract.ts';
-import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';
+import {
+  commonInputFromFlags,
+  direct,
+  recordControlInputFromFlags,
+} from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
@@ -41,6 +45,7 @@ const snapshotCliSchema = {
 
 export const snapshotCliReader: CliReader = (_positionals, flags) => ({
   ...commonInputFromFlags(flags),
+  ...recordControlInputFromFlags(flags),
   interactiveOnly: flags.snapshotInteractiveOnly,
   depth: flags.snapshotDepth,
   scope: flags.snapshotScope,

--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -16,6 +16,7 @@ import { defineExecutableCommand } from '../command-contract.ts';
 import {
   direct,
   optionalNumber,
+  recordControlInputFromFlags,
   selectionOptionsFromFlags,
   selectorSnapshotOptionsFromFlags,
 } from '../cli-grammar/common.ts';
@@ -92,6 +93,7 @@ function readWaitOptionsFromPositionals(
   const base = {
     ...selectionOptionsFromFlags(flags),
     ...selectorSnapshotOptionsFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
   };
   if (parsed.kind === 'sleep') return { ...base, durationMs: parsed.durationMs };
   if (parsed.kind === 'text') {

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -66,6 +66,16 @@ export function commonInputFromFlags(flags: CliFlags): Record<string, unknown> {
   });
 }
 
+// --no-record is a common flag, but it only takes effect if the reader forwards
+// it: command-flags.ts maps options.noRecord onto the daemon request, and
+// recordActionEntry reads it from there. A reader that never names it accepts
+// the flag and silently drops it.
+export function recordControlInputFromFlags(flags: CliFlags): Record<string, unknown> {
+  return compactRecord({
+    noRecord: flags.noRecord,
+  });
+}
+
 export function selectionOptionsFromFlags(flags: CliFlags): SelectionOptions {
   return {
     platform: flags.platform,

--- a/src/commands/interaction/interactions.ts
+++ b/src/commands/interaction/interactions.ts
@@ -23,6 +23,7 @@ import {
   optionalNumber,
   readElementTargetFromPositionals,
   readGetFormat,
+  recordControlInputFromFlags,
   request,
   requiredDaemonString,
   repeatedInputFromFlags,
@@ -35,6 +36,7 @@ import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 export const interactionCliReaders = {
   click: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
     ...repeatedInputFromFlags(flags),
     ...settleInputFromFlags(flags),
@@ -44,6 +46,7 @@ export const interactionCliReaders = {
   }),
   press: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
     ...repeatedInputFromFlags(flags),
     ...settleInputFromFlags(flags),
@@ -54,6 +57,7 @@ export const interactionCliReaders = {
     const decoded = readLongPressTargetFromPositionals(positionals);
     return {
       ...commonInputFromFlags(flags),
+      ...recordControlInputFromFlags(flags),
       ...selectorSnapshotInputFromFlags(flags),
       ...settleInputFromFlags(flags),
       target: targetInputFromClientTarget(decoded),
@@ -62,6 +66,7 @@ export const interactionCliReaders = {
   },
   swipe: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     ...swipePayloadFromPositionals(positionals, {
       count: flags.count,
       pauseMs: flags.pauseMs,
@@ -70,11 +75,13 @@ export const interactionCliReaders = {
   }),
   focus: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     x: Number(positionals[0]),
     y: Number(positionals[1]),
   }),
   type: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     text: positionals.join(' '),
     delayMs: flags.delayMs,
   }),
@@ -82,6 +89,7 @@ export const interactionCliReaders = {
     const decoded = readFillTargetFromPositionals(positionals);
     return {
       ...commonInputFromFlags(flags),
+      ...recordControlInputFromFlags(flags),
       ...selectorSnapshotInputFromFlags(flags),
       ...settleInputFromFlags(flags),
       target: targetInputFromClientTarget(decoded.target),
@@ -92,6 +100,7 @@ export const interactionCliReaders = {
   },
   scroll: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     direction: readScrollDirection(positionals[0]),
     amount: optionalCliNumber(positionals[1]),
     pixels: flags.pixels,
@@ -99,6 +108,7 @@ export const interactionCliReaders = {
   }),
   get: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
     format: readGetFormat(positionals[0]),
     target: targetInputFromClientTarget(readElementTargetFromPositionals(positionals.slice(1))),

--- a/src/commands/interaction/selectors.ts
+++ b/src/commands/interaction/selectors.ts
@@ -11,6 +11,7 @@ import {
   direct,
   optionalCliNumber,
   optionalNumber,
+  recordControlInputFromFlags,
   request,
   selectionOptionsFromFlags,
   selectorSnapshotOptionsFromFlags,
@@ -64,6 +65,7 @@ function readFindOptionsFromPositionals(positionals: string[], flags: CliFlags):
   const base = {
     ...findSnapshotOptionsFromFlags(flags),
     ...selectionOptionsFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
     first: flags.findFirst,
     last: flags.findLast,
   };
@@ -111,6 +113,7 @@ function readIsOptionsFromPositionals(positionals: string[], flags: CliFlags): I
   const base = {
     ...selectorSnapshotOptionsFromFlags(flags),
     ...selectionOptionsFromFlags(flags),
+    ...recordControlInputFromFlags(flags),
   };
   const normalized = normalizeIsPositionals(positionals);
   const predicate = normalized[0];


### PR DESCRIPTION
Closes #1304.

## The bug is wider than the issue said

#1304 described `interactionCliReaders` dropping `--no-record`. Measuring it through the **real argv path** (`parseArgs` → `readInputFromCli`) showed the gap is not local to those readers — **no** interaction or capture reader forwarded the flag:

| | `--no-record` accepted by argv | reaches options object (before) | after |
|---|---|---|---|
| press, click, fill, longpress, swipe, focus, type, scroll | ✅ 8/8 | ❌ 0/8 | ✅ 8/8 |
| get, is, find, snapshot | ✅ 4/4 | ❌ 0/4 | ✅ 4/4 |
| wait | ✅ | ❌ | ✅ |

`--no-record` is in `COMMON_COMMAND_SUPPORTED_FLAG_KEYS`, which seeds **every** command schema's `supportedFlags` (`cli-schema/command-schema.ts:24`), and it is advertised in help as *"Do not record this action"*. It parsed on all 13 commands and reached the daemon on none of them. `app` (`management/app.ts:153`) was the only command that forwarded it.

Everything downstream was already correct — `command-flags.ts:54` maps `options.noRecord` onto the request, and `recordActionEntry` (`session-action-recorder.ts:43`) reads `entry.flags?.noRecord` and skips the action. **Only the reader step was missing**, so the documented behaviour never happened.

This matters beyond repair flows: `--no-record` is how you keep a setup tap out of an ordinary `open --save-script` authoring session. It also unblocks ADR 0012 decision 6's "state-repair" sub-flow, which needs `--no-record` to work on corrective `press`/`fill`.

## Fixed at the seam, not per reader

`noRecord` is a *common* flag, so hand-copying `noRecord: flags.noRecord` into each reader just reopens the same hole for reader #14. Instead it gets a `recordControlInputFromFlags()` helper alongside the file's existing group helpers (`settleInputFromFlags`, `repeatedInputFromFlags`, `selectorSnapshotInputFromFlags`), and each recordable reader spreads it. `compactRecord` keeps the key absent when the flag isn't passed, so nothing changes for invocations that don't use it.

## What I deliberately did *not* do

#1304 also asked to add `record: flags.record` to these readers. **I left it out — on the action commands it is a provable no-op**, and #1303 says so itself:

- `session-action-recorder.ts`: `isExcludedRepairSegmentObservation` returns `false` immediately unless `entry.observationOnly` — which its own doc says is *"never set for … any mutating command."*
- `contracts/cli-flags.ts` (#1303): `record` is *"a no-op outside a repair-armed session **and on any non-observation-only command**."*
- #1303 mixes `RecordControlOptions` into `GetOptions`/`Is*Options` only — never the press/fill option types.

Plumbing it into `press` would forward a flag the daemon cannot act on: inert instead of dropped, which is no better. That leaves a real question for #1303, raised there rather than decided here: `record` is currently in `COMMON_COMMAND_SUPPORTED_FLAG_KEYS`, so `press @e5 --record` is accepted and silently inert. Scoping it to the observation-capable commands would make it fail loudly instead, matching this repo's fail-loud convention.

## Interaction with #1303

#1303 (#1271 stage 2) hand-rolls this same plumbing in four readers, each with a repeated comment. It will take a small rebase conflict here and should come out **smaller**: drop the four copies, add `record` to the shared helper.

## Verification

`tsc --noEmit`, `oxlint --deny-warnings`, `format:check`, `fallow` (exit 0), `test:integration:progress:check` (exit 0 — no new flag, nothing to classify), and 537 unit tests across `src/cli`, `src/commands`, `src/__tests__` all pass.

The regression test covers all 13 recordable commands and is **revert-sensitive** — neutering the helper fails it with `AssertionError: press dropped --no-record`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## This likely explains part of wave-3 E3's "diagnostic pollution"

E3 recorded that the heal-by-doing flow polluted healed scripts with the agent's own diagnostic reads, and concluded `--no-record` "exists but wasn't discovered". That reading was incomplete: on every reader measured here, `--no-record` **was accepted and then discarded**. An agent that did reach for it on `get attrs`/`snapshot -i` got no effect and no error — the flag was inert on precisely the commands E3 saw polluting the heal.

So E3's "0/4 hands-off" has two causes, not one: the missing guidance (fixed by #1287) and this silent drop (fixed here). Both had to be true for the foot-gun to bite. The deferred E3 redo should be measured on top of this fix, or it will re-measure a bug rather than the flow.
