### PR TITLE
fix: sleep past the settle quiet deadline instead of onto it (#1306)

### DIFF
--- a/src/commands/interaction/runtime/selector-read-stable.test.ts
+++ b/src/commands/interaction/runtime/selector-read-stable.test.ts
@@ -46,7 +46,9 @@ test('runtime wait stable settles after two unchanged captures', async () => {
 // A clock whose sleep lands `undershootMs` short of what was asked, modelling
 // the real defect: `setTimeout(n)` can advance `Date.now()` by only n-1,
 // because libuv times the sleep on the monotonic loop clock while `now()` reads
-// the wall clock.
+// the wall clock. It yields to the event loop like a real sleep does, so a loop
+// that fails to terminate fails the test on its timeout rather than starving
+// the runner on microtasks.
 function createUndershootingClock(undershootMs = 1): {
   now: () => number;
   sleep: (ms: number) => Promise<void>;
@@ -56,6 +58,9 @@ function createUndershootingClock(undershootMs = 1): {
     now: () => elapsed,
     sleep: async (ms: number) => {
       elapsed += Math.max(0, ms - undershootMs);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
     },
   };
 }
@@ -139,6 +144,29 @@ test('runtime wait stable cannot settle when the budget only reaches the quiet d
       (error as { details?: { reason?: string } }).details?.reason === 'wait_stable_timeout',
   );
   assert.ok(clock.now() <= 300, `loop must not run past its budget, elapsed ${clock.now()}ms`);
+});
+
+test('runtime wait stable stops instead of spinning when an undershooting sleep meets a budget it cannot use', async () => {
+  // The two hazards combined: a budget that leaves a 1ms landing window, and a
+  // sleep that loses 1ms to skew. Asking for that 1ms buys no time, so a loop
+  // that trusts the sleep to carry it past the deadline never gets there and
+  // hammers the device with captures instead. Every delay must buy real time,
+  // and where the budget cannot afford one the loop has to stop.
+  const clock = createUndershootingClock();
+  const { device, counter } = createStableCaptureDevice(clock);
+
+  await assert.rejects(
+    () =>
+      device.selectors.wait({
+        session: 'default',
+        target: { kind: 'stable', quietMs: 300, timeoutMs: 301 },
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as { details?: { reason?: string } }).details?.reason === 'wait_stable_timeout',
+  );
+  assert.ok(counter.captures <= 3, `loop must not spin, took ${counter.captures} captures`);
+  assert.ok(clock.now() <= 301, `loop must not run past its budget, elapsed ${clock.now()}ms`);
 });
 
 test('runtime wait stable hints when it settles on a nearly-empty tree', async () => {

--- a/src/commands/interaction/runtime/selector-read-stable.test.ts
+++ b/src/commands/interaction/runtime/selector-read-stable.test.ts
@@ -43,23 +43,34 @@ test('runtime wait stable settles after two unchanged captures', async () => {
   assert.equal(captures, 3);
 });
 
-test('runtime wait stable wakes past the quiet deadline instead of onto it', async () => {
-  const snapshot = selectorReadSnapshot();
-  const sleeps: number[] = [];
+// A clock whose sleep lands `undershootMs` short of what was asked, modelling
+// the real defect: `setTimeout(n)` can advance `Date.now()` by only n-1,
+// because libuv times the sleep on the monotonic loop clock while `now()` reads
+// the wall clock.
+function createUndershootingClock(undershootMs = 1): {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+} {
   let elapsed = 0;
-  const clock = {
+  return {
     now: () => elapsed,
     sleep: async (ms: number) => {
-      sleeps.push(ms);
-      elapsed += ms;
+      elapsed += Math.max(0, ms - undershootMs);
     },
   };
-  let captures = 0;
+}
+
+function createStableCaptureDevice(clock: {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}) {
+  const snapshot = selectorReadSnapshot();
+  const counter = { captures: 0 };
   const device = createAgentDevice({
     backend: {
       platform: 'ios',
       captureSnapshot: async () => {
-        captures += 1;
+        counter.captures += 1;
         return { snapshot };
       },
     } satisfies AgentDeviceBackend,
@@ -68,9 +79,15 @@ test('runtime wait stable wakes past the quiet deadline instead of onto it', asy
     policy: localCommandPolicy(),
     clock,
   });
+  return { device, counter };
+}
 
+test('runtime wait stable settles at the second capture even when the sleep undershoots', async () => {
   // A 300ms quiet window equals the poll cadence, so the second capture is the
-  // one that decides `settled`.
+  // one that decides `settled` — and a sleep that lands 1ms short must not
+  // change the verdict (#1306).
+  const { device, counter } = createStableCaptureDevice(createUndershootingClock());
+
   const result = await device.selectors.wait({
     session: 'default',
     target: { kind: 'stable', quietMs: 300, timeoutMs: 10_000 },
@@ -78,11 +95,47 @@ test('runtime wait stable wakes past the quiet deadline instead of onto it', asy
 
   assert.equal(result.kind, 'stable');
   if (result.kind === 'stable') assert.equal(result.captures, 2);
-  // Strictly past the window, never onto it: sleeping exactly 300 would leave
-  // the verdict to ~1ms of setTimeout/Date.now() skew (#1306).
-  assert.equal(sleeps.length, 1);
-  assert.ok(sleeps[0]! > 300, `settling capture must clear the window, slept ${sleeps[0]}ms`);
-  assert.equal(captures, 2);
+  assert.equal(counter.captures, 2);
+});
+
+test('runtime wait stable still takes its settling capture when the budget barely clears the window', async () => {
+  // One millisecond of budget past the quiet window is enough to settle, and
+  // the deadline-aware sleep must not spend it on the epsilon: overshooting the
+  // deadline would drop the settling capture the plain cadence would have taken.
+  const { device, counter } = createStableCaptureDevice(createFakeClock());
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 300, timeoutMs: 301 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') {
+    assert.equal(result.captures, 2);
+    assert.ok(
+      result.waitedMs <= 301,
+      `waitedMs must stay within the budget, got ${result.waitedMs}`,
+    );
+  }
+  assert.equal(counter.captures, 2);
+});
+
+test('runtime wait stable cannot settle when the budget only reaches the quiet deadline', async () => {
+  // The other side of the boundary: the window has to ELAPSE inside the budget,
+  // so a budget equal to it leaves no instant where two captures span it. The
+  // deadline-aware sleep must not manufacture a settle here.
+  const { device } = createStableCaptureDevice(createFakeClock());
+
+  await assert.rejects(
+    () =>
+      device.selectors.wait({
+        session: 'default',
+        target: { kind: 'stable', quietMs: 300, timeoutMs: 300 },
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as { details?: { reason?: string } }).details?.reason === 'wait_stable_timeout',
+  );
 });
 
 test('runtime wait stable hints when it settles on a nearly-empty tree', async () => {

--- a/src/commands/interaction/runtime/selector-read-stable.test.ts
+++ b/src/commands/interaction/runtime/selector-read-stable.test.ts
@@ -146,26 +146,27 @@ test('runtime wait stable cannot settle when the budget only reaches the quiet d
   assert.ok(clock.now() <= 300, `loop must not run past its budget, elapsed ${clock.now()}ms`);
 });
 
-test('runtime wait stable stops instead of spinning when an undershooting sleep meets a budget it cannot use', async () => {
+test('runtime wait stable uses the final budget without spinning when sleep undershoots', async () => {
   // The two hazards combined: a budget that leaves a 1ms landing window, and a
   // sleep that loses 1ms to skew. Asking for that 1ms buys no time, so a loop
   // that trusts the sleep to carry it past the deadline never gets there and
-  // hammers the device with captures instead. Every delay must buy real time,
-  // and where the budget cannot afford one the loop has to stop.
+  // hammers the device with captures instead. Spending the full 2ms advances
+  // this clock to 300ms and earns the valid settling capture; an exact clock
+  // would land on the 301ms deadline and exit without another capture.
   const clock = createUndershootingClock();
   const { device, counter } = createStableCaptureDevice(clock);
 
-  await assert.rejects(
-    () =>
-      device.selectors.wait({
-        session: 'default',
-        target: { kind: 'stable', quietMs: 300, timeoutMs: 301 },
-      }),
-    (error: unknown) =>
-      error instanceof Error &&
-      (error as { details?: { reason?: string } }).details?.reason === 'wait_stable_timeout',
-  );
-  assert.ok(counter.captures <= 3, `loop must not spin, took ${counter.captures} captures`);
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 300, timeoutMs: 301 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') {
+    assert.equal(result.captures, 3);
+    assert.ok(result.waitedMs <= 301, `waitedMs must stay within budget, got ${result.waitedMs}`);
+  }
+  assert.equal(counter.captures, 3, `loop must not spin, took ${counter.captures} captures`);
   assert.ok(clock.now() <= 301, `loop must not run past its budget, elapsed ${clock.now()}ms`);
 });
 

--- a/src/commands/interaction/runtime/selector-read-stable.test.ts
+++ b/src/commands/interaction/runtime/selector-read-stable.test.ts
@@ -43,6 +43,48 @@ test('runtime wait stable settles after two unchanged captures', async () => {
   assert.equal(captures, 3);
 });
 
+test('runtime wait stable wakes past the quiet deadline instead of onto it', async () => {
+  const snapshot = selectorReadSnapshot();
+  const sleeps: number[] = [];
+  let elapsed = 0;
+  const clock = {
+    now: () => elapsed,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      elapsed += ms;
+    },
+  };
+  let captures = 0;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => {
+        captures += 1;
+        return { snapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  // A 300ms quiet window equals the poll cadence, so the second capture is the
+  // one that decides `settled`.
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 300, timeoutMs: 10_000 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') assert.equal(result.captures, 2);
+  // Strictly past the window, never onto it: sleeping exactly 300 would leave
+  // the verdict to ~1ms of setTimeout/Date.now() skew (#1306).
+  assert.equal(sleeps.length, 1);
+  assert.ok(sleeps[0]! > 300, `settling capture must clear the window, slept ${sleeps[0]}ms`);
+  assert.equal(captures, 2);
+});
+
 test('runtime wait stable hints when it settles on a nearly-empty tree', async () => {
   const tinySnapshot = makeSnapshotState([
     {

--- a/src/commands/interaction/runtime/selector-read-stable.test.ts
+++ b/src/commands/interaction/runtime/selector-read-stable.test.ts
@@ -123,8 +123,10 @@ test('runtime wait stable still takes its settling capture when the budget barel
 test('runtime wait stable cannot settle when the budget only reaches the quiet deadline', async () => {
   // The other side of the boundary: the window has to ELAPSE inside the budget,
   // so a budget equal to it leaves no instant where two captures span it. The
-  // deadline-aware sleep must not manufacture a settle here.
-  const { device } = createStableCaptureDevice(createFakeClock());
+  // deadline-aware sleep must neither manufacture a settle here nor run past
+  // the budget once no further capture can land inside it.
+  const clock = createFakeClock();
+  const { device } = createStableCaptureDevice(clock);
 
   await assert.rejects(
     () =>
@@ -136,6 +138,7 @@ test('runtime wait stable cannot settle when the budget only reaches the quiet d
       error instanceof Error &&
       (error as { details?: { reason?: string } }).details?.reason === 'wait_stable_timeout',
   );
+  assert.ok(clock.now() <= 300, `loop must not run past its budget, elapsed ${clock.now()}ms`);
 });
 
 test('runtime wait stable hints when it settles on a nearly-empty tree', async () => {

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -95,7 +95,10 @@ export async function runStableCaptureLoop(
       quietSinceMs = nowMs;
       lastDigest = digest;
       lastNodeCount = capture.snapshot.nodes.length;
-      await sleep(runtime, stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs }));
+      await sleep(
+        runtime,
+        stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs, deadlineMs }),
+      );
       continue;
     }
     if (digest !== lastDigest) {
@@ -112,7 +115,10 @@ export async function runStableCaptureLoop(
         lastCapture,
       };
     }
-    await sleep(runtime, stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs }));
+    await sleep(
+      runtime,
+      stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs, deadlineMs }),
+    );
   }
   return {
     settled: false,
@@ -134,16 +140,25 @@ function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boole
  * Once it is within reach, sleep to just past it instead — the capture that
  * decides `settled` then always spans the window, rather than landing on the
  * boundary where clock skew picks the answer (#1306).
+ *
+ * Bounded by the loop's own budget: it only runs again while `now < deadline`,
+ * so a wake-up past the deadline spends the very capture the epsilon exists to
+ * land. Where the budget is the tighter constraint, wake just inside it.
  */
 function stableCaptureDelayMs(params: {
   nowMs: number;
   quietSinceMs: number;
   quietMs: number;
   pollMs: number;
+  deadlineMs: number;
 }): number {
   const remainingQuietMs = params.quietSinceMs + params.quietMs - params.nowMs;
-  if (remainingQuietMs > params.pollMs) return params.pollMs;
-  return Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
+  const cadenceMs =
+    remainingQuietMs > params.pollMs
+      ? params.pollMs
+      : Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
+  const lastUsefulWakeMs = params.deadlineMs - params.nowMs - 1;
+  return lastUsefulWakeMs > 0 ? Math.min(cadenceMs, lastUsefulWakeMs) : cadenceMs;
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -148,14 +148,13 @@ function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boole
  * the window, rather than landing on the boundary where clock skew picks the
  * answer (#1306).
  *
- * The loop only runs again while `now < deadline`, so the wake-up must land
- * strictly inside the budget to be worth anything. Every returned delay is at
- * least `QUIET_DEADLINE_EPSILON_MS`, which is what makes the loop terminate:
- * the same skew this function exists to absorb means a 1ms sleep can advance
- * the clock by 0, and a delay that buys no time would spin here forever. When
- * the budget cannot afford a delay that both progresses and stays inside it,
- * there is no capture left to place — stop rather than burn captures against
- * the device at the deadline.
+ * The loop only runs again while `now < deadline`. Normally the wake-up must
+ * land strictly inside the budget to leave room for another capture. At the
+ * final skew-sized boundary, however, requesting the full remaining budget is
+ * useful: an exact clock lands on the deadline and exits, while an undershooting
+ * clock advances inside the deadline and gets the settling capture. Never
+ * request less than the epsilon — a 1ms sleep can advance the wall clock by 0
+ * and spin forever under the skew this function exists to absorb.
  */
 function stableCaptureDelayMs(params: {
   nowMs: number;
@@ -169,8 +168,11 @@ function stableCaptureDelayMs(params: {
     remainingQuietMs > params.pollMs
       ? params.pollMs
       : Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
-  const lastUsefulWakeMs = params.deadlineMs - params.nowMs - 1;
-  if (lastUsefulWakeMs < QUIET_DEADLINE_EPSILON_MS) return 0;
+  const remainingBudgetMs = params.deadlineMs - params.nowMs;
+  const lastUsefulWakeMs = remainingBudgetMs - 1;
+  if (lastUsefulWakeMs < QUIET_DEADLINE_EPSILON_MS) {
+    return remainingBudgetMs >= QUIET_DEADLINE_EPSILON_MS ? remainingBudgetMs : 0;
+  }
   return Math.min(cadenceMs, lastUsefulWakeMs);
 }
 

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -95,10 +95,15 @@ export async function runStableCaptureLoop(
       quietSinceMs = nowMs;
       lastDigest = digest;
       lastNodeCount = capture.snapshot.nodes.length;
-      await sleep(
-        runtime,
-        stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs, deadlineMs }),
-      );
+      const recoveryDelayMs = stableCaptureDelayMs({
+        nowMs,
+        quietSinceMs,
+        quietMs,
+        pollMs,
+        deadlineMs,
+      });
+      if (recoveryDelayMs <= 0) break;
+      await sleep(runtime, recoveryDelayMs);
       continue;
     }
     if (digest !== lastDigest) {
@@ -115,10 +120,9 @@ export async function runStableCaptureLoop(
         lastCapture,
       };
     }
-    await sleep(
-      runtime,
-      stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs, deadlineMs }),
-    );
+    const delayMs = stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs, deadlineMs });
+    if (delayMs <= 0) break;
+    await sleep(runtime, delayMs);
   }
   return {
     settled: false,
@@ -135,15 +139,23 @@ function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boole
 }
 
 /**
- * How long to wait before the next capture. While the quiet deadline is still
- * further away than one poll, keep the cadence so a change is noticed promptly.
- * Once it is within reach, sleep to just past it instead — the capture that
- * decides `settled` then always spans the window, rather than landing on the
- * boundary where clock skew picks the answer (#1306).
+ * How long to wait before the next capture, or 0 when there is no wait worth
+ * taking and the loop should stop.
  *
- * Bounded by the loop's own budget: it only runs again while `now < deadline`,
- * so a wake-up past the deadline spends the very capture the epsilon exists to
- * land. Where the budget is the tighter constraint, wake just inside it.
+ * While the quiet deadline is still further away than one poll, keep the
+ * cadence so a change is noticed promptly. Once it is within reach, sleep to
+ * just past it instead — the capture that decides `settled` then always spans
+ * the window, rather than landing on the boundary where clock skew picks the
+ * answer (#1306).
+ *
+ * The loop only runs again while `now < deadline`, so the wake-up must land
+ * strictly inside the budget to be worth anything. Every returned delay is at
+ * least `QUIET_DEADLINE_EPSILON_MS`, which is what makes the loop terminate:
+ * the same skew this function exists to absorb means a 1ms sleep can advance
+ * the clock by 0, and a delay that buys no time would spin here forever. When
+ * the budget cannot afford a delay that both progresses and stays inside it,
+ * there is no capture left to place — stop rather than burn captures against
+ * the device at the deadline.
  */
 function stableCaptureDelayMs(params: {
   nowMs: number;
@@ -158,12 +170,8 @@ function stableCaptureDelayMs(params: {
       ? params.pollMs
       : Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
   const lastUsefulWakeMs = params.deadlineMs - params.nowMs - 1;
-  if (lastUsefulWakeMs > 0) return Math.min(cadenceMs, lastUsefulWakeMs);
-  // No further capture can land inside the budget, so sleep out what remains of
-  // it rather than a full cadence past it: the loop is about to exit either
-  // way, and overrunning here would report a wait longer than the caller asked
-  // for.
-  return Math.max(0, params.deadlineMs - params.nowMs);
+  if (lastUsefulWakeMs < QUIET_DEADLINE_EPSILON_MS) return 0;
+  return Math.min(cadenceMs, lastUsefulWakeMs);
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -158,7 +158,12 @@ function stableCaptureDelayMs(params: {
       ? params.pollMs
       : Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
   const lastUsefulWakeMs = params.deadlineMs - params.nowMs - 1;
-  return lastUsefulWakeMs > 0 ? Math.min(cadenceMs, lastUsefulWakeMs) : cadenceMs;
+  if (lastUsefulWakeMs > 0) return Math.min(cadenceMs, lastUsefulWakeMs);
+  // No further capture can land inside the budget, so sleep out what remains of
+  // it rather than a full cadence past it: the loop is about to exit either
+  // way, and overrunning here would report a wait longer than the caller asked
+  // for.
+  return Math.max(0, params.deadlineMs - params.nowMs);
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -19,6 +19,12 @@ import {
  */
 
 const STABLE_POLL_INTERVAL_MS = 300;
+const STABLE_MIN_POLL_MS = 25;
+// Wake PAST the quiet deadline rather than exactly on it. `setTimeout(n)` can
+// advance `Date.now()` by only n-1 — libuv times the sleep on the monotonic
+// loop clock while `now()` reads the wall clock — so a capture landing on the
+// deadline decides `settled` by sub-millisecond skew rather than by the UI.
+const QUIET_DEADLINE_EPSILON_MS = 2;
 export const DEFAULT_STABLE_QUIET_MS = 500;
 export const DEFAULT_STABLE_TIMEOUT_MS = 10_000;
 // Below this node count a settled tree is suspicious: real app surfaces have
@@ -53,7 +59,7 @@ export async function runStableCaptureLoop(
   // Cadence derives from the quiet window (never slower than the default
   // poll): a caller asking for a 50ms quiet window should not be forced onto a
   // 300ms grid — and tests inject the budget instead of waiting real time.
-  const pollMs = Math.min(STABLE_POLL_INTERVAL_MS, Math.max(25, quietMs));
+  const pollMs = Math.min(STABLE_POLL_INTERVAL_MS, Math.max(STABLE_MIN_POLL_MS, quietMs));
   let captures = 0;
   let lastDigest: string | undefined;
   let lastNodeCount = 0;
@@ -89,7 +95,7 @@ export async function runStableCaptureLoop(
       quietSinceMs = nowMs;
       lastDigest = digest;
       lastNodeCount = capture.snapshot.nodes.length;
-      await sleep(runtime, pollMs);
+      await sleep(runtime, stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs }));
       continue;
     }
     if (digest !== lastDigest) {
@@ -106,7 +112,7 @@ export async function runStableCaptureLoop(
         lastCapture,
       };
     }
-    await sleep(runtime, pollMs);
+    await sleep(runtime, stableCaptureDelayMs({ nowMs, quietSinceMs, quietMs, pollMs }));
   }
   return {
     settled: false,
@@ -120,6 +126,24 @@ export async function runStableCaptureLoop(
 
 function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boolean {
   return verdict?.state === 'recovered' && verdict.backend === 'private-ax';
+}
+
+/**
+ * How long to wait before the next capture. While the quiet deadline is still
+ * further away than one poll, keep the cadence so a change is noticed promptly.
+ * Once it is within reach, sleep to just past it instead — the capture that
+ * decides `settled` then always spans the window, rather than landing on the
+ * boundary where clock skew picks the answer (#1306).
+ */
+function stableCaptureDelayMs(params: {
+  nowMs: number;
+  quietSinceMs: number;
+  quietMs: number;
+  pollMs: number;
+}): number {
+  const remainingQuietMs = params.quietSinceMs + params.quietMs - params.nowMs;
+  if (remainingQuietMs > params.pollMs) return params.pollMs;
+  return Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures


### PR DESCRIPTION
Closes #1306.

## Summary

`runStableCaptureLoop` derives its whole cadence from

```ts
const pollMs = Math.min(STABLE_POLL_INTERVAL_MS, Math.max(25, quietMs)); // 300 / 25 floor
```

so **`pollMs === quietMs` for every `quietMs` in [25, 300]**. The loop settles once two identical captures span `quietMs`, and the gap it measures at capture #2 is exactly one `sleep(pollMs)` plus capture time. Across that whole range, "settle at capture 2" rides a **0ms margin**.

Node decides that margin, not the UI. `setTimeout(n)` advances `Date.now()` by only `n-1` in **0.13% of calls idle and 0.63% under load** (measured, 4000 samples, darwin/Node 26) — libuv times the sleep on the cached monotonic loop clock while `now()` reads the wall clock (`runtime-common.ts:16-23`). On an undershoot the loop just spends a wasted extra capture + poll before settling.

## Change

The sleep is now deadline-aware. While the quiet deadline is further away than one poll, the cadence is unchanged — changes are still noticed promptly, which matters because detecting a change *early* is what starts the quiet window early. Once the deadline is within reach, the loop sleeps to just past it instead, so the capture that decides `settled` always spans the window.

```ts
const remainingQuietMs = quietSinceMs + quietMs - nowMs;
if (remainingQuietMs > pollMs) return pollMs;
return Math.max(STABLE_MIN_POLL_MS, remainingQuietMs + QUIET_DEADLINE_EPSILON_MS);
```

The `STABLE_MIN_POLL_MS` floor keeps `--settle-quiet 0` from turning into a 2ms hot capture loop against a changing UI.

## Effects

- `--settle-quiet` in [25, 300] settles at capture **2** deterministically, instead of 2-or-3 by coin flip — one capture cheaper on the 0.13–0.63% of settles that lost the flip.
- The default 500ms window settles at **~502ms instead of ~600ms**, with the same 3 captures.
- Quiet-window semantics are unchanged: still "two identical captures spanning `quietMs`". Nothing but timing moves.

Shared by `--settle` (press/fill/click/longpress) and `wait stable`, so both benefit.

## Tests

New unit test asserts the invariant directly — with `quietMs` equal to the 300ms poll cadence, the loop must sleep **strictly past** the window:

```
assert.ok(sleeps[0]! > 300, `settling capture must clear the window, slept ${sleeps[0]}ms`);
```

Verified it's a real guard: against unpatched production it fails with `settling capture must clear the window, slept 300ms`, and passes with the fix. The existing fake-clock capture-count assertions (3 and 4) are unchanged — those windows are wider than one poll, so only their `waitedMs` improves.

`src/commands/interaction/`, `src/commands/capture/`, `src/daemon/handlers/__tests__/`: 988 tests green. Typecheck, lint, format clean.

## Provenance

Surfaced while diagnosing the `settle-observation.test.ts` CI flake (#1307), where the same skew flipped a *test* assertion because the fixture scripted an exact capture count. That fix is test-only and already separate; this is the production half, deliberately not bundled with it.
