### PR TITLE
test: stabilize iOS snapshot timeout regression

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -604,11 +604,15 @@ extension RunnerTests {
   /// assertion instead of racing a fixed-timing guess.
   private func assertBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain(
     entryPointName: String,
-    callEntryPoint: @escaping (SnapshotOptions) throws -> DataPayload
+    callEntryPoint: @escaping (XCUIApplication, SnapshotOptions) throws -> DataPayload
   ) {
-    currentApp = springboard
-    currentBundleId = Self.springboardBundleId
+    let targetBundleId = "com.callstack.agentdevice.runner.missing.snapshot-timeout-test"
+    let snapshotTarget = XCUIApplication(bundleIdentifier: targetBundleId)
+    let probeReleaseGate = DispatchSemaphore(value: 0)
+    currentApp = snapshotTarget
+    currentBundleId = targetBundleId
     defer {
+      probeReleaseGate.signal()
       currentApp = nil
       currentBundleId = nil
       systemModalProbeOverrideForTesting = nil
@@ -622,11 +626,12 @@ extension RunnerTests {
       var wasPenalizedBeforeDrain = false
     }
     let box = ResultBox()
-    // Bounded so a revert that never actually times out (nothing would ever wait on this gate)
-    // cannot hang the test -- it just leaves `box` at its false/nil defaults, below.
-    let probeReleaseGate = DispatchSemaphore(value: 0)
+    // The test owns release of the injected probe. A fixed timeout races the capture plan's
+    // independent fallback tiers on loaded CI hosts and can drain before the test records the
+    // abandoned-work state. The defer above still releases the probe if an earlier assertion or
+    // expectation fails.
     systemModalProbeOverrideForTesting = { _ in
-      _ = probeReleaseGate.wait(timeout: .now() + 8)
+      probeReleaseGate.wait()
       return nil
     }
 
@@ -636,6 +641,7 @@ extension RunnerTests {
     let drained = expectation(description: "\(entryPointName) modal probe drained")
     DispatchQueue(label: "agent-device.runner.tests.modal-probe-timeout").async {
       box.payload = try? callEntryPoint(
+        snapshotTarget,
         SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false)
       )
 
@@ -700,15 +706,15 @@ extension RunnerTests {
 
   func testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain() {
     assertBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain(entryPointName: "snapshotFast") {
-      options in
-      try self.snapshotFast(app: self.springboard, options: options)
+      target, options in
+      try self.snapshotFast(app: target, options: options)
     }
   }
 
   func testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrainForSnapshotRaw() {
     assertBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain(entryPointName: "snapshotRaw") {
-      options in
-      try self.snapshotRaw(app: self.springboard, options: options)
+      target, options in
+      try self.snapshotRaw(app: target, options: options)
     }
   }
 


### PR DESCRIPTION
## Summary

Stabilize the iOS snapshot timeout lifecycle regression tests.

The injected modal probe previously self-released after eight seconds while recovery through live SpringBoard accessibility could take roughly fifteen seconds on loaded CI hosts. The test then inspected state after the abandoned work had already drained and falsely failed its busy and retention assertions.

The test now uses a deterministic unavailable application target and keeps the injected probe blocked until it records the abandoned-work state. It then explicitly releases the probe and verifies the real drain path. Both `snapshotFast` and `snapshotRaw` still run through their production entrypoints.

## Validation

- Reproduced the original assertions locally by shortening the old self-release window.
- Ran both fixed tests for 10 iterations each: 20 tests passed.
- `pnpm format`
- `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest`
- `pnpm check:affected --base origin/main --run`
- `git diff --check`
