### PR TITLE
fix(remote): preserve tenant scope for proxy artifact downloads

### DIFF
--- a/src/daemon/__tests__/http-contract.test.ts
+++ b/src/daemon/__tests__/http-contract.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   buildDaemonHttpAuthHeaders,
   buildDaemonHttpBaseUrl,
+  buildDaemonHttpTenantHeaders,
   buildDaemonHttpUrl,
 } from '../http-contract.ts';
 
@@ -34,4 +35,11 @@ test('buildDaemonHttpAuthHeaders writes both supported daemon auth headers', () 
     'x-agent-device-token': 'token-1',
   });
   assert.deepEqual(buildDaemonHttpAuthHeaders(''), {});
+});
+
+test('buildDaemonHttpTenantHeaders omits blank tenant identities', () => {
+  assert.deepEqual(buildDaemonHttpTenantHeaders(' tenant-a '), {
+    'x-agent-device-tenant': 'tenant-a',
+  });
+  assert.deepEqual(buildDaemonHttpTenantHeaders(''), {});
 });

--- a/src/daemon/http-contract.ts
+++ b/src/daemon/http-contract.ts
@@ -1,4 +1,5 @@
 export const DAEMON_HTTP_BASE_PATH = '/agent-device';
+export const DAEMON_HTTP_TENANT_HEADER = 'x-agent-device-tenant';
 
 export function buildDaemonHttpBaseUrl(baseUrl: string): string {
   return buildDaemonHttpUrl(baseUrl, DAEMON_HTTP_BASE_PATH);
@@ -16,4 +17,10 @@ export function buildDaemonHttpAuthHeaders(token: string | undefined): Record<st
     authorization: `Bearer ${normalizedToken}`,
     'x-agent-device-token': normalizedToken,
   };
+}
+
+export function buildDaemonHttpTenantHeaders(tenantId: string | undefined): Record<string, string> {
+  const normalizedTenantId = tenantId?.trim();
+  if (!normalizedTenantId) return {};
+  return { [DAEMON_HTTP_TENANT_HEADER]: normalizedTenantId };
 }

--- a/src/daemon/http-health.ts
+++ b/src/daemon/http-health.ts
@@ -1,7 +1,7 @@
 import { readVersion } from '../utils/version.ts';
 
 // See docs/adr/0006-daemon-rpc-protocol-version.md before changing this value.
-export const DAEMON_RPC_PROTOCOL_VERSION = 1;
+export const DAEMON_RPC_PROTOCOL_VERSION = 2;
 
 export type DaemonHealthPayload = {
   ok: true;

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -792,6 +792,8 @@ async function authorizeAuxiliaryHttpRequest(params: {
     return null;
   }
 
+  // Auth-hook identity remains authoritative. The header fallback only preserves the
+  // client-declared tenant used by RPC when a deployment does not derive tenant scope in its hook.
   return { tenantId: authResult.tenantId ?? tenantId };
 }
 

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -26,6 +26,7 @@ import {
   shouldStreamRequestProgress,
 } from '../request-progress-protocol.ts';
 import { buildDaemonHealthPayload } from '../http-health.ts';
+import { DAEMON_HTTP_TENANT_HEADER } from '../http-contract.ts';
 import { sendRestJsonError, statusCodeForNormalizedError } from '../http-errors.ts';
 import { tryHandleUploadHttpRoute } from '../upload-http.ts';
 import { tryHandleDownloadableArtifactHttpRoute } from '../downloadable-artifact-http.ts';
@@ -753,6 +754,7 @@ async function authorizeAuxiliaryHttpRequest(params: {
 }): Promise<{ tenantId?: string } | null> {
   const { req, res, authHook, expectedToken, daemonRequest } = params;
   const token = resolveToken({}, req.headers);
+  const tenantId = normalizeTenantId(readHeaderValue(req.headers, DAEMON_HTTP_TENANT_HEADER));
   const tokenError = enforceDaemonToken(token, expectedToken);
   if (tokenError) {
     sendRestJsonError(res, tokenError);
@@ -772,6 +774,7 @@ async function authorizeAuxiliaryHttpRequest(params: {
       session: 'default',
       command: daemonRequest.command,
       positionals: daemonRequest.positionals,
+      ...(tenantId ? { meta: { tenantId } } : {}),
     },
   });
   if (!authResult.ok) {
@@ -789,7 +792,12 @@ async function authorizeAuxiliaryHttpRequest(params: {
     return null;
   }
 
-  return { tenantId: authResult.tenantId };
+  return { tenantId: authResult.tenantId ?? tenantId };
+}
+
+function readHeaderValue(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const value = headers[name];
+  return typeof value === 'string' ? value : undefined;
 }
 
 function enforceDaemonToken(

--- a/src/remote/daemon-artifacts.ts
+++ b/src/remote/daemon-artifacts.ts
@@ -314,8 +314,7 @@ export async function materializeRemoteArtifacts(
       token: info.token,
       artifactId: artifact.artifactId,
       destinationPath: localPath,
-      requestId: req.meta?.requestId,
-      tenantId: req.meta?.tenantId,
+      requestScope: req.meta,
     });
     nextData[artifact.field] = localPath;
     nextArtifacts.push({
@@ -344,8 +343,7 @@ type DownloadRemoteArtifactParams = {
   token: string;
   artifactId: string;
   destinationPath: string;
-  requestId?: string;
-  tenantId?: string;
+  requestScope: DaemonRequest['meta'];
   timeoutMs?: number;
 };
 
@@ -375,7 +373,7 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
         path: artifactUrl.pathname + artifactUrl.search,
         headers: {
           ...buildDaemonHttpAuthHeaders(params.token),
-          ...buildDaemonHttpTenantHeaders(params.tenantId),
+          ...buildDaemonHttpTenantHeaders(params.requestScope?.tenantId),
         },
       },
       (res) => {
@@ -390,7 +388,7 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
               new AppError('COMMAND_FAILED', 'Failed to download remote artifact', {
                 artifactId: params.artifactId,
                 statusCode: res.statusCode,
-                requestId: params.requestId,
+                requestId: params.requestScope?.requestId,
                 body,
               }),
             );
@@ -401,7 +399,7 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
           settle(
             new AppError('COMMAND_FAILED', 'Remote artifact download was interrupted', {
               artifactId: params.artifactId,
-              requestId: params.requestId,
+              requestId: params.requestScope?.requestId,
             }),
           );
         });
@@ -414,7 +412,7 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
     const timeoutHandle = setTimeout(() => {
       const timeoutError = new AppError('COMMAND_FAILED', 'Remote artifact download timed out', {
         artifactId: params.artifactId,
-        requestId: params.requestId,
+        requestId: params.requestScope?.requestId,
         timeoutMs,
       });
       settle(timeoutError);
@@ -431,7 +429,7 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
           'Failed to download remote artifact',
           {
             artifactId: params.artifactId,
-            requestId: params.requestId,
+            requestId: params.requestScope?.requestId,
             timeoutMs,
           },
           error instanceof Error ? error : undefined,

--- a/src/remote/daemon-artifacts.ts
+++ b/src/remote/daemon-artifacts.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../kernel/errors.ts';
 import type { DaemonArtifact, DaemonRequest, DaemonResponse } from '../daemon/types.ts';
-import { buildDaemonHttpAuthHeaders } from '../daemon/http-contract.ts';
+import {
+  buildDaemonHttpAuthHeaders,
+  buildDaemonHttpTenantHeaders,
+} from '../daemon/http-contract.ts';
 import {
   appendRecordingExtensionWhenMissing,
   recordingExtensionForPlatform,
@@ -312,6 +315,7 @@ export async function materializeRemoteArtifacts(
       artifactId: artifact.artifactId,
       destinationPath: localPath,
       requestId: req.meta?.requestId,
+      tenantId: req.meta?.tenantId,
     });
     nextData[artifact.field] = localPath;
     nextArtifacts.push({
@@ -341,6 +345,7 @@ type DownloadRemoteArtifactParams = {
   artifactId: string;
   destinationPath: string;
   requestId?: string;
+  tenantId?: string;
   timeoutMs?: number;
 };
 
@@ -368,7 +373,10 @@ export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParam
         port: artifactUrl.port,
         method: 'GET',
         path: artifactUrl.pathname + artifactUrl.search,
-        headers: buildDaemonHttpAuthHeaders(params.token),
+        headers: {
+          ...buildDaemonHttpAuthHeaders(params.token),
+          ...buildDaemonHttpTenantHeaders(params.tenantId),
+        },
       },
       (res) => {
         if ((res.statusCode ?? 500) >= 400) {

--- a/src/remote/daemon-proxy.ts
+++ b/src/remote/daemon-proxy.ts
@@ -7,6 +7,7 @@ import { readNodeHttpRequestBody } from '../utils/node-http.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
 import {
   DAEMON_HTTP_BASE_PATH,
+  DAEMON_HTTP_TENANT_HEADER,
   buildDaemonHttpAuthHeaders,
   buildDaemonHttpUrl,
 } from '../daemon/http-contract.ts';
@@ -31,6 +32,7 @@ const FORWARDED_REQUEST_HEADERS = [
   'x-artifact-filename',
   'x-artifact-hash',
   'x-artifact-hash-algorithm',
+  DAEMON_HTTP_TENANT_HEADER,
 ];
 const FORWARDED_RESPONSE_HEADERS = ['content-type', 'content-disposition', 'x-request-id'];
 

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1460,7 +1460,7 @@ test('downloadRemoteArtifact downloads daemon artifact URL', async (t) => {
       token: 'remote-secret',
       artifactId: 'artifact-download',
       destinationPath,
-      requestId: 'req-remote-artifact-download',
+      requestScope: { requestId: 'req-remote-artifact-download' },
     });
     assert.equal(seenUrl, '/agent-device/artifacts/artifact-download');
     assert.equal(seenAuth, 'Bearer remote-secret');
@@ -1497,7 +1497,7 @@ test('downloadRemoteArtifact times out stalled artifact responses and removes pa
           token: 'remote-secret',
           artifactId: 'artifact-timeout',
           destinationPath,
-          requestId: 'req-remote-artifact-timeout',
+          requestScope: { requestId: 'req-remote-artifact-timeout' },
           timeoutMs: 50,
         }),
       (error: unknown) => {
@@ -1541,7 +1541,7 @@ test('downloadRemoteArtifact removes partial files after mid-stream aborts', asy
           token: 'remote-secret',
           artifactId: 'artifact-abort',
           destinationPath,
-          requestId: 'req-remote-artifact-abort',
+          requestScope: { requestId: 'req-remote-artifact-abort' },
           timeoutMs: 1_000,
         }),
       (error: unknown) => {

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -20,6 +20,7 @@ import {
   resolveDaemonStartupHint,
 } from '../../daemon/client/daemon-client-metadata.ts';
 import { canConnectSocket } from '../../daemon/client/daemon-client-transport.ts';
+import { DAEMON_RPC_PROTOCOL_VERSION } from '../../daemon/http-health.ts';
 import {
   resolveDaemonRequestTimeoutMs,
   shouldResetDaemonAfterRequestTimeout,
@@ -985,59 +986,68 @@ test('sendToDaemon uses explicit remote daemon base URL and auth token', async (
   }
 });
 
-test('sendToDaemon rejects remote daemon RPC protocol mismatches before RPC', async () => {
-  const seenPaths: string[] = [];
-  let rpcCalled = false;
-  const restoreHttpRequest = mockEventHttpRequest(({ options, res }) => {
-    seenPaths.push(String(options.path ?? ''));
-    if (options.method === 'GET') {
-      res.emit(
-        'data',
-        JSON.stringify({
-          ok: true,
-          service: 'agent-device-proxy',
-          version: '99.0.0',
-          rpcProtocolVersion: 999,
-        }),
-      );
-      res.emit('end');
-      return;
-    }
-
-    rpcCalled = true;
-    emitJsonRpcResult(res, 'req-incompatible', { ok: true, data: {} });
-  });
-
-  try {
-    await withRemoteDaemonEnv(async () => {
-      let error: unknown;
-      try {
-        await sendToDaemon({
-          session: 'default',
-          command: 'remote-smoke',
-          positionals: ['ping'],
-          flags: {},
-          meta: { requestId: 'req-incompatible' },
-        });
-      } catch (caught) {
-        error = caught;
+test.each([
+  ['older', DAEMON_RPC_PROTOCOL_VERSION - 1],
+  ['newer', DAEMON_RPC_PROTOCOL_VERSION + 1],
+] as const)(
+  'sendToDaemon rejects %s remote daemon RPC protocols before RPC',
+  async (_skew, remoteProtocolVersion) => {
+    const seenPaths: string[] = [];
+    let rpcCalled = false;
+    const restoreHttpRequest = mockEventHttpRequest(({ options, res }) => {
+      seenPaths.push(String(options.path ?? ''));
+      if (options.method === 'GET') {
+        res.emit(
+          'data',
+          JSON.stringify({
+            ok: true,
+            service: 'agent-device-proxy',
+            version: '99.0.0',
+            rpcProtocolVersion: remoteProtocolVersion,
+          }),
+        );
+        res.emit('end');
+        return;
       }
 
-      assert.ok(error instanceof Error);
-      assert.equal((error as any).code, 'COMMAND_FAILED');
-      assert.match(error.message, /Remote daemon RPC protocol is incompatible/);
-      assert.equal((error as any).details?.remoteService, 'agent-device-proxy');
-      assert.equal((error as any).details?.remoteVersion, '99.0.0');
-      assert.equal((error as any).details?.remoteRpcProtocolVersion, 999);
-      assert.equal(typeof (error as any).details?.supportedRpcProtocolVersion, 'number');
+      rpcCalled = true;
+      emitJsonRpcResult(res, 'req-incompatible', { ok: true, data: {} });
     });
 
-    assert.deepEqual(seenPaths, ['/agent-device/health']);
-    assert.equal(rpcCalled, false);
-  } finally {
-    restoreHttpRequest();
-  }
-});
+    try {
+      await withRemoteDaemonEnv(async () => {
+        let error: unknown;
+        try {
+          await sendToDaemon({
+            session: 'default',
+            command: 'remote-smoke',
+            positionals: ['ping'],
+            flags: {},
+            meta: { requestId: 'req-incompatible' },
+          });
+        } catch (caught) {
+          error = caught;
+        }
+
+        assert.ok(error instanceof Error);
+        assert.equal((error as any).code, 'COMMAND_FAILED');
+        assert.match(error.message, /Remote daemon RPC protocol is incompatible/);
+        assert.equal((error as any).details?.remoteService, 'agent-device-proxy');
+        assert.equal((error as any).details?.remoteVersion, '99.0.0');
+        assert.equal((error as any).details?.remoteRpcProtocolVersion, remoteProtocolVersion);
+        assert.equal(
+          (error as any).details?.supportedRpcProtocolVersion,
+          DAEMON_RPC_PROTOCOL_VERSION,
+        );
+      });
+
+      assert.deepEqual(seenPaths, ['/agent-device/health']);
+      assert.equal(rpcCalled, false);
+    } finally {
+      restoreHttpRequest();
+    }
+  },
+);
 
 test('sendToDaemon hints to disconnect when a remote daemon is unavailable', async () => {
   const restoreHttpRequest = mockEventHttpRequest(({ res }) => {

--- a/test/integration/provider-scenarios/remote-proxy-artifact-tenant.test.ts
+++ b/test/integration/provider-scenarios/remote-proxy-artifact-tenant.test.ts
@@ -71,9 +71,9 @@ test('Provider-backed integration local proxy materializes tenant-scoped screens
         await downloadRemoteArtifact({
           baseUrl: daemonBaseUrl,
           token: 'proxy-token',
-          tenantId: OTHER_TENANT,
           artifactId: protectedArtifactId,
           destinationPath: rejectedScreenshotPath,
+          requestScope: { tenantId: OTHER_TENANT },
         }),
       (error: unknown) => {
         const normalized = normalizeAgentDeviceError(error);

--- a/test/integration/provider-scenarios/remote-proxy-artifact-tenant.test.ts
+++ b/test/integration/provider-scenarios/remote-proxy-artifact-tenant.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { createAgentDeviceClient } from '../../../src/agent-device-client.ts';
+import {
+  cleanupDownloadableArtifact,
+  trackDownloadableArtifact,
+} from '../../../src/daemon/artifact-tracking.ts';
+import { finalizeDaemonResponse } from '../../../src/daemon/request-finalization.ts';
+import { createDaemonHttpServer } from '../../../src/daemon/server/http-server.ts';
+import { normalizeAgentDeviceError } from '../../../src/kernel/errors.ts';
+import { downloadRemoteArtifact } from '../../../src/remote/daemon-artifacts.ts';
+import { createDaemonProxyServer } from '../../../src/remote/daemon-proxy.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../../src/__tests__/test-utils/loopback.ts';
+
+const TENANT = 'local-proxy-tenant';
+const OTHER_TENANT = 'other-tenant';
+
+test('Provider-backed integration local proxy materializes tenant-scoped screenshots', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t, 'local proxy artifact tenant coverage')) return;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-proxy-artifact-tenant-'));
+  const remoteScreenshotPath = path.join(tempDir, 'remote-shot.png');
+  const localScreenshotPath = path.join(tempDir, 'local-shot.png');
+  const rejectedScreenshotPath = path.join(tempDir, 'rejected-shot.png');
+  fs.writeFileSync(remoteScreenshotPath, 'tenant-scoped-png');
+  const artifactIds: string[] = [];
+  const upstream = await createDaemonHttpServer({
+    token: 'upstream-token',
+    handleRequest: async (req) => {
+      assert.equal(req.command, 'screenshot');
+      assert.equal(req.meta?.tenantId, TENANT);
+      assert.equal(req.meta?.runId, 'local-proxy-run');
+      assert.equal(req.meta?.sessionIsolation, 'tenant');
+      return finalizeDaemonResponse(
+        req,
+        { ok: true, data: { path: remoteScreenshotPath } },
+        (artifact) => {
+          const artifactId = trackDownloadableArtifact(artifact);
+          artifactIds.push(artifactId);
+          return artifactId;
+        },
+      );
+    },
+  });
+  const protectedArtifactId = trackDownloadableArtifact({
+    artifactPath: remoteScreenshotPath,
+    tenantId: TENANT,
+    artifactType: 'screenshot',
+    fileName: 'remote-shot.png',
+  });
+  artifactIds.push(protectedArtifactId);
+  const proxy = createDaemonProxyServer({
+    upstreamBaseUrl: `http://127.0.0.1:${await listenOnLoopback(upstream)}`,
+    upstreamToken: 'upstream-token',
+    clientToken: 'proxy-token',
+  });
+
+  try {
+    const proxyPort = await listenOnLoopback(proxy);
+    const daemonBaseUrl = `http://127.0.0.1:${proxyPort}/agent-device`;
+
+    await assert.rejects(
+      async () =>
+        await downloadRemoteArtifact({
+          baseUrl: daemonBaseUrl,
+          token: 'proxy-token',
+          tenantId: OTHER_TENANT,
+          artifactId: protectedArtifactId,
+          destinationPath: rejectedScreenshotPath,
+        }),
+      (error: unknown) => {
+        const normalized = normalizeAgentDeviceError(error);
+        assert.equal(normalized.details?.statusCode, 401);
+        assert.match(String(normalized.details?.body), /different tenant/i);
+        return true;
+      },
+    );
+    assert.equal(fs.existsSync(rejectedScreenshotPath), false);
+
+    const client = createAgentDeviceClient({
+      daemonBaseUrl,
+      daemonAuthToken: 'proxy-token',
+      tenant: TENANT,
+      runId: 'local-proxy-run',
+      sessionIsolation: 'tenant',
+      stateDir: tempDir,
+    });
+    const screenshot = await client.capture.screenshot({ path: localScreenshotPath });
+
+    assert.equal(screenshot.path, localScreenshotPath);
+    assert.equal(fs.readFileSync(localScreenshotPath, 'utf8'), 'tenant-scoped-png');
+  } finally {
+    for (const artifactId of artifactIds) cleanupDownloadableArtifact(artifactId);
+    await closeLoopbackServer(proxy);
+    await closeLoopbackServer(upstream);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/integration/smoke-provider-cli-disconnect.test.ts
+++ b/test/integration/smoke-provider-cli-disconnect.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import http from 'node:http';
+import { DAEMON_RPC_PROTOCOL_VERSION } from '../../src/daemon/http-health.ts';
 import {
   closeLoopbackServer,
   listenOnLoopback,
@@ -57,7 +58,7 @@ async function createProviderDaemonFixture(t: TestContext): Promise<ProviderDaem
           ok: true,
           service: 'agent-device-daemon',
           version: '0.0.0-test',
-          rpcProtocolVersion: 1,
+          rpcProtocolVersion: DAEMON_RPC_PROTOCOL_VERSION,
         }),
       );
       return;


### PR DESCRIPTION
## Summary

- Carry the configured tenant when materializing remote daemon artifacts.
- Forward that scope through the local proxy and reconstruct it for the daemon artifact endpoint.
- Preserve auth-hook-derived tenant identities and cover both successful and cross-tenant downloads.
- Bump the daemon RPC protocol so mixed peers reject the new artifact authorization contract during health negotiation, before command RPC.

## Root cause

Screenshot RPC requests registered artifacts under `meta.tenantId`, but the later `GET /artifacts/:id` request only carried the proxy token. Local proxies use a shared proxy token, so the daemon correctly treated that download as unscoped and rejected the tenant-owned artifact.

## Validation

- `pnpm check:affected --base origin/main --run`
- `pnpm check:unit`
- `pnpm test:integration:provider` (37 files, 140 tests)
- Older/newer RPC protocol skew coverage proves rejection after `/health` and before `/rpc`
- Packaged CLI provider smoke
- Final format, typecheck, lint, and focused provider regression gate

Closes #1316
