### PR TITLE
chore: gitignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
-examples/test-app/.env.local
+.env
+.env.*
+!.env.example
 scripts/perf/.results/
 .pnpm-store/
 .fallow/


### PR DESCRIPTION
The repository is public and the root `.env` was untracked but matched no ignore rule. It showed up in `git status`, so any `git add .` or `git add -A` would have staged it — publishing whatever it holds to the repo and every fork.

```
$ git status --porcelain   # ?? .env
$ git check-ignore -v .env # no match
```

**It has never been committed to any ref** (`git log --all --oneline -- .env` is empty), so this is prevention rather than a leak. Nothing needs rotating.

## What changed

`.env.*` subsumes the old `examples/test-app/.env.local` entry — the only dotenv rule in the file, covering exactly one path. Gitignore matches basenames at any depth, so every variant is now covered wherever it appears. `!.env.example` keeps templates trackable; none exist today, but that negation is what makes the broad `.env.*` safe.

## Verified

Removing the `examples/test-app/.env.local` line is only safe if `.env.*` really does cover it, so I checked rather than assumed:

| path | result |
|---|---|
| `.env`, `examples/test-app/.env` | ignored |
| `.env.local`, `.env.production.local` | ignored |
| `examples/test-app/.env.local` (the removed rule) | still ignored |
| `website/.env.local` | ignored |
| `.env.example` | trackable — negation works |
| `src/utils/env-map.ts`, `src/platforms/linux/linux-env.ts` | unaffected |

`git ls-files | git check-ignore --stdin` returns nothing, so no tracked file becomes ignored by this change.

Found while preparing #1321, and deliberately kept out of it — that PR staged explicit paths so `.env` was never at risk there.