### PR TITLE
feat: add advisory device claims

### DIFF
--- a/src/__tests__/cli-device-status.test.ts
+++ b/src/__tests__/cli-device-status.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { runCliCapture } from './cli-capture.ts';
+
+test('device status is daemonless and does not send a daemon request', async () => {
+  const result = await runCliCapture(['device', 'status', '--json']);
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload, { success: true, data: { claims: [] } });
+});

--- a/src/cli-schema/command-overrides.ts
+++ b/src/cli-schema/command-overrides.ts
@@ -39,6 +39,15 @@ const SCHEMA_ONLY_CLI_COMMAND_SCHEMAS = {
     allowedFlags: ['clean'],
     supportedFlags: ['stateDir'],
   },
+  device: {
+    usageOverride: 'device status [--platform <platform>] [--udid <udid>] [--serial <serial>]',
+    listUsageOverride: 'device status',
+    helpDescription:
+      'Inspect advisory host-local device ownership claims without starting or contacting a daemon.',
+    summary: 'Inspect local advisory device ownership without daemon side effects',
+    positionalArgs: ['status'],
+    supportedFlags: ['platform', 'device', 'udid', 'serial'],
+  },
   connect: {
     usageOverride:
       'connect [cloud|proxy|limrun|browserstack|aws-device-farm] [--remote-config <path>] [--daemon-base-url <url>] [--tenant <id>] [--run-id <id>] [--lease-id <id>] [--lease-backend <backend>] [--force] [--no-login]',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,6 +76,7 @@ const REMOTE_MATERIALIZATION_DEFERRED_COMMANDS = new Set([
   'connection',
   'close',
   'daemon',
+  'device',
   'disconnect',
   'metro',
   'proxy',
@@ -580,7 +581,11 @@ function shouldMaterializeRemoteConnection(command: string): boolean {
 
 function shouldResolveRemoteAuth(command: string): boolean {
   return (
-    command !== 'auth' && command !== 'connection' && command !== 'daemon' && command !== 'proxy'
+    command !== 'auth' &&
+    command !== 'connection' &&
+    command !== 'daemon' &&
+    command !== 'device' &&
+    command !== 'proxy'
   );
 }
 

--- a/src/cli/commands/device.ts
+++ b/src/cli/commands/device.ts
@@ -1,0 +1,72 @@
+import { AppError } from '../../kernel/errors.ts';
+import {
+  inspectDeviceClaims,
+  type InspectedDeviceClaim,
+} from '../../daemon/device-claim-inspection.ts';
+import { writeCommandOutput } from './shared.ts';
+import type { ClientCommandHandler } from './router-types.ts';
+
+export const deviceCommand: ClientCommandHandler = async ({ positionals, flags }) => {
+  if (positionals[0] !== 'status' || positionals.length !== 1) {
+    throw new AppError('INVALID_ARGS', 'device accepts only: status');
+  }
+  const claims = inspectDeviceClaims({
+    platform: flags.platform,
+    device: flags.device,
+    udid: flags.udid,
+    serial: flags.serial,
+  }).map(serializeClaim);
+  const data = { claims };
+  writeCommandOutput(flags, data, () => renderDeviceStatus(claims));
+  return true;
+};
+
+function serializeClaim(entry: InspectedDeviceClaim): Record<string, unknown> {
+  const claim = entry.claim;
+  return {
+    ...(entry.deviceKey ? { deviceKey: entry.deviceKey } : {}),
+    classification: entry.classification,
+    ...(claim
+      ? {
+          device: claim.device,
+          owner: {
+            session: claim.session,
+            workspace: claim.workspace,
+            stateDir: claim.stateDir,
+            pid: claim.ownerPid,
+            startTime: claim.ownerStartTime,
+          },
+          recovery: {
+            command: futureRecoveryCommand(claim.device.platform, claim.device.id),
+          },
+        }
+      : {}),
+    ...(entry.error ? { error: entry.error } : {}),
+  };
+}
+
+function futureRecoveryCommand(platform: string, id: string): string | undefined {
+  if (platform === 'ios' || platform === 'macos') {
+    return `agent-device device release --platform ${platform} --udid ${id} --stale`;
+  }
+  if (platform === 'android') {
+    return `agent-device device release --platform android --serial ${id} --stale`;
+  }
+  return undefined;
+}
+
+function renderDeviceStatus(claims: Record<string, unknown>[]): string {
+  if (claims.length === 0) return 'No local advisory device claims found.';
+  return claims
+    .map((claim) => {
+      const device = claim.device as { platform?: string; id?: string; name?: string } | undefined;
+      const owner = claim.owner as { session?: string; workspace?: string } | undefined;
+      return [
+        `${device?.platform ?? 'unknown'} ${device?.name ?? device?.id ?? claim.deviceKey ?? 'claim'}: ${claim.classification}`,
+        owner ? `session=${owner.session} workspace=${owner.workspace}` : null,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(' ');
+    })
+    .join('\n');
+}

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -4,6 +4,7 @@ import { isClientBackedCliCommandName, type ClientBackedCliCommandName } from '.
 import { connectCommand, connectionCommand, disconnectCommand } from './connection.ts';
 import { authCommand } from './auth.ts';
 import { daemonCommand } from './daemon.ts';
+import { deviceCommand } from './device.ts';
 import { proxyCommand } from './proxy.ts';
 import { replayCommand } from './replay.ts';
 import { screenshotCommand, diffCommand } from './screenshot.ts';
@@ -21,6 +22,7 @@ const dedicatedCliCommandHandlers = {
   connection: connectionCommand,
   auth: authCommand,
   daemon: daemonCommand,
+  device: deviceCommand,
   proxy: proxyCommand,
   replay: replayCommand,
   screenshot: screenshotCommand,

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1085,6 +1085,15 @@ export const RAW_COMMAND_DESCRIPTORS = [
     mcpExposed: false,
   },
   {
+    name: 'device',
+    ...(ownerFilesEnabled ? { ownerFiles: ['src/cli/commands/device.ts'] as const } : {}),
+    catalog: { group: 'local-cli' },
+    recordsSessionAction: false,
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
     name: 'metro',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/metro/index.ts'] as const } : {}),
     catalog: { group: 'local-cli' },

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import {
+  acquireAdvisoryDeviceClaim,
+  canonicalLocalDeviceKey,
+  clearAdvisoryDeviceClaim,
+} from '../device-claims.ts';
+import { inspectDeviceClaims } from '../device-claim-inspection.ts';
+import type { DeviceInfo } from '../../kernel/device.ts';
+
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.AGENT_DEVICE_CLAIMS_DIR;
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function useClaimsRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-claims-'));
+  roots.push(root);
+  process.env.AGENT_DEVICE_CLAIMS_DIR = root;
+  return root;
+}
+
+function claimPath(root: string): string {
+  const key = canonicalLocalDeviceKey(device);
+  const hash = crypto.createHash('sha256').update(key).digest('hex');
+  return path.join(root, `${hash}.json`);
+}
+
+test('preserves a live foreign advisory claim without blocking or overwriting it', async () => {
+  const root = useClaimsRoot();
+  const first = await acquireAdvisoryDeviceClaim({
+    device,
+    session: 'first',
+    workspace: '/worktrees/first',
+    stateDir: root,
+  });
+  assert.ok(first.ownership);
+  const second = await acquireAdvisoryDeviceClaim({
+    device,
+    session: 'second',
+    workspace: '/worktrees/second',
+    stateDir: root,
+  });
+  assert.equal(second.ownership, undefined);
+  assert.equal(second.conflict?.classification, 'live');
+  assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.session, 'first');
+});
+
+test('clears only the exact owner token and identity, never a successor claim', async () => {
+  const root = useClaimsRoot();
+  const acquired = await acquireAdvisoryDeviceClaim({
+    device,
+    session: 'first',
+    workspace: '/worktrees/first',
+    stateDir: root,
+  });
+  assert.ok(acquired.ownership);
+  const stored = JSON.parse(fs.readFileSync(claimPath(root), 'utf8')) as Record<string, unknown>;
+  fs.writeFileSync(
+    claimPath(root),
+    JSON.stringify({ ...stored, ownerToken: 'successor-token', session: 'second' }),
+  );
+  await clearAdvisoryDeviceClaim(acquired.ownership);
+  assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.session, 'second');
+});
+
+test('keeps corrupt records visible and classifies dead owners without reclaiming either', () => {
+  const root = useClaimsRoot();
+  fs.writeFileSync(path.join(root, 'corrupt.json'), '{bad json');
+  fs.writeFileSync(
+    path.join(root, 'dead.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      deviceKey: 'local:android:none:dead',
+      device: { platform: 'android', id: 'dead', name: 'Dead', kind: 'emulator' },
+      session: 'dead-owner',
+      workspace: '/worktrees/dead',
+      stateDir: root,
+      ownerPid: 999_999_999,
+      ownerStartTime: 'old-start',
+      ownerToken: 'opaque-token',
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    }),
+  );
+  const claims = inspectDeviceClaims({});
+  assert.equal(
+    claims.find((claim) => claim.fileName === 'corrupt.json')?.classification,
+    'inconsistent',
+  );
+  assert.equal(
+    claims.find((claim) => claim.fileName === 'dead.json')?.classification,
+    'owner-process-dead',
+  );
+  assert.equal(fs.existsSync(path.join(root, 'corrupt.json')), true);
+  assert.equal(fs.existsSync(path.join(root, 'dead.json')), true);
+});
+
+test('fails closed when claim inspection encounters a permission or transient I/O failure', () => {
+  useClaimsRoot();
+  vi.spyOn(fs, 'readdirSync').mockImplementation(() => {
+    const error = new Error('permission denied') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    throw error;
+  });
+  const claims = inspectDeviceClaims({});
+  assert.equal(claims[0]?.classification, 'unknown');
+});

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -61,6 +61,26 @@ test('preserves a live foreign advisory claim without blocking or overwriting it
   assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.session, 'first');
 });
 
+test('does not treat a same-named session in another worktree as its claim owner', async () => {
+  const root = useClaimsRoot();
+  const first = await acquireAdvisoryDeviceClaim({
+    device,
+    session: 'default',
+    workspace: '/worktrees/first',
+    stateDir: root,
+  });
+  assert.ok(first.ownership);
+  const second = await acquireAdvisoryDeviceClaim({
+    device,
+    session: 'default',
+    workspace: '/worktrees/second',
+    stateDir: path.join(root, 'second-state'),
+  });
+  assert.equal(second.ownership, undefined);
+  await clearAdvisoryDeviceClaim(second.ownership);
+  assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.workspace, '/worktrees/first');
+});
+
 test('clears only the exact owner token and identity, never a successor claim', async () => {
   const root = useClaimsRoot();
   const acquired = await acquireAdvisoryDeviceClaim({
@@ -120,4 +140,36 @@ test('fails closed when claim inspection encounters a permission or transient I/
   });
   const claims = inspectDeviceClaims({});
   assert.equal(claims[0]?.classification, 'unknown');
+});
+
+test('classifies transient claim-file read errors as unknown, not inconsistent', () => {
+  const root = useClaimsRoot();
+  fs.writeFileSync(path.join(root, 'transient.json'), '{}');
+  vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+    const error = new Error('I/O error') as NodeJS.ErrnoException;
+    error.code = 'EIO';
+    throw error;
+  });
+  const claims = inspectDeviceClaims({});
+  assert.equal(claims[0]?.classification, 'unknown');
+});
+
+test('matches public Apple claim records through the shared platform selector semantics', async () => {
+  const root = useClaimsRoot();
+  await acquireAdvisoryDeviceClaim({
+    device: {
+      platform: 'apple',
+      appleOs: 'ios',
+      id: 'ios-claim',
+      name: 'iPhone',
+      kind: 'simulator',
+      booted: true,
+    },
+    session: 'ios',
+    workspace: process.cwd(),
+    stateDir: root,
+  });
+  assert.equal(inspectDeviceClaims({ platform: 'apple' }).length, 1);
+  assert.equal(inspectDeviceClaims({ platform: 'ios' }).length, 1);
+  assert.equal(inspectDeviceClaims({ platform: 'macos' }).length, 0);
 });

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { PlatformSelector } from '../kernel/device.ts';
+import {
+  deviceFieldsFromPublicPlatform,
+  matchesPlatformSelector,
+  type PlatformSelector,
+} from '../kernel/device.ts';
 import { classifyOwnerLiveness, type OwnerLiveness } from '../utils/owner-identity.ts';
 import { resolveDeviceClaimRoot } from './device-claim-paths.ts';
 import type { DeviceClaim } from './device-claims.ts';
@@ -70,16 +74,30 @@ function matchesClaimDevice(claim: DeviceClaim, device: string | undefined): boo
 }
 
 function matchesClaimPlatform(claim: DeviceClaim, platform: PlatformSelector | undefined): boolean {
-  if (!platform) return true;
-  if (platform === 'ios') return claim.device.platform === 'ios';
-  if (platform === 'macos') return claim.device.platform === 'macos';
-  return claim.device.platform === platform;
+  return matchesPlatformSelector(
+    { ...deviceFieldsFromPublicPlatform(claim.device.platform), appleOs: claim.device.appleOs },
+    platform,
+  );
 }
 
 export function inspectDeviceClaimFile(filePath: string): InspectedDeviceClaim | null {
   const fileName = path.basename(filePath);
   try {
-    const claim = normalizeClaim(JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown);
+    return inspectClaimContents(fileName, fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    return {
+      fileName,
+      classification: 'unknown',
+      error: String(error),
+    };
+  }
+}
+
+function inspectClaimContents(fileName: string, contents: string): InspectedDeviceClaim {
+  try {
+    const claim = normalizeClaim(JSON.parse(contents) as unknown);
     if (!claim) return { fileName, classification: 'inconsistent' };
     return {
       fileName,
@@ -91,13 +109,7 @@ export function inspectDeviceClaimFile(filePath: string): InspectedDeviceClaim |
       }),
     };
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
-    return {
-      fileName,
-      classification: code === 'EACCES' || code === 'EPERM' ? 'unknown' : 'inconsistent',
-      error: String(error),
-    };
+    return { fileName, classification: 'inconsistent', error: String(error) };
   }
 }
 

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { PlatformSelector } from '../kernel/device.ts';
+import { classifyOwnerLiveness, type OwnerLiveness } from '../utils/owner-identity.ts';
+import { resolveDeviceClaimRoot } from './device-claim-paths.ts';
+import type { DeviceClaim } from './device-claims.ts';
+
+const DEVICE_CLAIM_SCHEMA_VERSION = 1;
+
+export type DeviceClaimClassification = OwnerLiveness | 'inconsistent';
+
+export type InspectedDeviceClaim = {
+  fileName: string;
+  deviceKey?: string;
+  claim?: DeviceClaim;
+  classification: DeviceClaimClassification;
+  error?: string;
+};
+
+export type DeviceClaimSelectors = {
+  platform?: PlatformSelector;
+  device?: string;
+  udid?: string;
+  serial?: string;
+};
+
+export function inspectDeviceClaims(selectors: DeviceClaimSelectors): InspectedDeviceClaim[] {
+  const root = resolveDeviceClaimRoot();
+  const listed = readClaimEntries(root);
+  if ('claims' in listed) return listed.claims;
+  return listed.entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => inspectDeviceClaimFile(path.join(root, entry.name)))
+    .filter((entry): entry is InspectedDeviceClaim => entry !== null)
+    .filter((entry) => matchesClaimSelectors(entry.claim, selectors));
+}
+
+function readClaimEntries(
+  root: string,
+): { entries: fs.Dirent[] } | { claims: InspectedDeviceClaim[] } {
+  try {
+    return { entries: fs.readdirSync(root, { withFileTypes: true }) };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { claims: [] };
+    return {
+      claims: [{ fileName: path.basename(root), classification: 'unknown', error: String(error) }],
+    };
+  }
+}
+
+function matchesClaimSelectors(
+  claim: DeviceClaim | undefined,
+  selectors: DeviceClaimSelectors,
+): boolean {
+  if (!claim) return true;
+  return [
+    matchesClaimId(claim, selectors.udid ?? selectors.serial),
+    matchesClaimDevice(claim, selectors.device),
+    matchesClaimPlatform(claim, selectors.platform),
+  ].every(Boolean);
+}
+
+function matchesClaimId(claim: DeviceClaim, expectedId: string | undefined): boolean {
+  return !expectedId || claim.device.id === expectedId;
+}
+
+function matchesClaimDevice(claim: DeviceClaim, device: string | undefined): boolean {
+  return !device || claim.device.name === device || claim.device.id === device;
+}
+
+function matchesClaimPlatform(claim: DeviceClaim, platform: PlatformSelector | undefined): boolean {
+  if (!platform) return true;
+  if (platform === 'ios') return claim.device.platform === 'ios';
+  if (platform === 'macos') return claim.device.platform === 'macos';
+  return claim.device.platform === platform;
+}
+
+export function inspectDeviceClaimFile(filePath: string): InspectedDeviceClaim | null {
+  const fileName = path.basename(filePath);
+  try {
+    const claim = normalizeClaim(JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown);
+    if (!claim) return { fileName, classification: 'inconsistent' };
+    return {
+      fileName,
+      deviceKey: claim.deviceKey,
+      claim,
+      classification: classifyOwnerLiveness({
+        owner: { pid: claim.ownerPid, startTime: claim.ownerStartTime },
+        stateDir: claim.stateDir,
+      }),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    return {
+      fileName,
+      classification: code === 'EACCES' || code === 'EPERM' ? 'unknown' : 'inconsistent',
+      error: String(error),
+    };
+  }
+}
+
+function normalizeClaim(value: unknown): DeviceClaim | null {
+  if (!isClaimObject(value)) return null;
+  const raw = value as Partial<DeviceClaim>;
+  return isValidClaimRecord(raw) ? (raw as DeviceClaim) : null;
+}
+
+function isClaimObject(value: unknown): value is object {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidClaimRecord(raw: Partial<DeviceClaim>): boolean {
+  return (
+    raw.schemaVersion === DEVICE_CLAIM_SCHEMA_VERSION &&
+    isClaimDevice(raw.device) &&
+    [raw.deviceKey, raw.session, raw.workspace, raw.stateDir, raw.ownerToken].every(
+      isNonEmptyString,
+    ) &&
+    isPositiveInteger(raw.ownerPid) &&
+    isFiniteNumber(raw.createdAtMs) &&
+    isFiniteNumber(raw.updatedAtMs)
+  );
+}
+
+function isClaimDevice(value: unknown): value is DeviceClaim['device'] {
+  if (!isClaimObject(value)) return false;
+  const device = value as Partial<DeviceClaim['device']>;
+  return [device.id, device.name, device.platform, device.kind].every(isNonEmptyString);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/src/daemon/device-claim-paths.ts
+++ b/src/daemon/device-claim-paths.ts
@@ -1,0 +1,15 @@
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+export function resolveDeviceClaimRoot(): string {
+  const override = process.env.AGENT_DEVICE_CLAIMS_DIR?.trim();
+  return override
+    ? path.resolve(override)
+    : path.join(os.homedir(), '.agent-device', 'device-claims');
+}
+
+export function resolveDeviceClaimPath(deviceKey: string): string {
+  const hash = crypto.createHash('sha256').update(deviceKey).digest('hex');
+  return path.join(resolveDeviceClaimRoot(), `${hash}.json`);
+}

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -64,13 +64,10 @@ export async function acquireAdvisoryDeviceClaim(params: {
 }): Promise<{ ownership?: DeviceClaimSessionOwnership; conflict?: InspectedDeviceClaim }> {
   const deviceKey = canonicalLocalDeviceKey(params.device);
   return await withDeviceClaimLock(deviceKey, async () => {
+    const owner = readCurrentOwnerIdentity();
     const existing = inspectDeviceClaimFile(resolveDeviceClaimPath(deviceKey));
     if (existing) {
-      if (
-        existing.claim &&
-        existing.claim.session === params.session &&
-        existing.classification === 'live'
-      ) {
+      if (existing.claim && isCurrentClaimOwner(existing.claim, params, owner)) {
         return { ownership: ownershipFromClaim(existing.claim) };
       }
       emitDiagnostic({
@@ -85,7 +82,6 @@ export async function acquireAdvisoryDeviceClaim(params: {
       });
       return { conflict: existing };
     }
-    const owner = readCurrentOwnerIdentity();
     const now = Date.now();
     const claim: DeviceClaim = {
       schemaVersion: DEVICE_CLAIM_SCHEMA_VERSION,
@@ -110,6 +106,22 @@ export async function acquireAdvisoryDeviceClaim(params: {
     writeClaim(claim);
     return { ownership: ownershipFromClaim(claim) };
   });
+}
+
+function isCurrentClaimOwner(
+  claim: DeviceClaim,
+  params: Pick<
+    Parameters<typeof acquireAdvisoryDeviceClaim>[0],
+    'session' | 'workspace' | 'stateDir'
+  >,
+  owner: ReturnType<typeof readCurrentOwnerIdentity>,
+): boolean {
+  return (
+    claim.session === params.session &&
+    claim.workspace === params.workspace &&
+    claim.stateDir === params.stateDir &&
+    ownerIdentityMatches({ pid: claim.ownerPid, startTime: claim.ownerStartTime }, owner)
+  );
 }
 
 export async function clearAdvisoryDeviceClaim(

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -1,0 +1,170 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { publicPlatformString, type DeviceInfo } from '../kernel/device.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { acquireProcessLock } from '../utils/process-lock.ts';
+import { ownerIdentityMatches, readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
+import { inspectDeviceClaimFile, type InspectedDeviceClaim } from './device-claim-inspection.ts';
+import { resolveDeviceClaimPath } from './device-claim-paths.ts';
+
+const DEVICE_CLAIM_SCHEMA_VERSION = 1;
+const DEVICE_CLAIM_LOCK_TIMEOUT_MS = 30_000;
+
+export type DeviceClaim = {
+  schemaVersion: 1;
+  deviceKey: string;
+  device: {
+    platform: ReturnType<typeof publicPlatformString>;
+    id: string;
+    name: string;
+    kind: DeviceInfo['kind'];
+    target?: DeviceInfo['target'];
+    appleOs?: DeviceInfo['appleOs'];
+  };
+  session: string;
+  workspace: string;
+  stateDir: string;
+  ownerPid: number;
+  ownerStartTime: string | null;
+  ownerToken: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+export type DeviceClaimSessionOwnership = {
+  deviceKey: string;
+  ownerToken: string;
+  ownerPid: number;
+  ownerStartTime: string | null;
+};
+
+export function isLocalDeviceClaimTarget(
+  meta:
+    | {
+        leaseProvider?: string;
+        deviceKey?: string;
+      }
+    | undefined,
+  providerOwned: boolean,
+): boolean {
+  return !providerOwned && !meta?.leaseProvider && !meta?.deviceKey;
+}
+
+export function canonicalLocalDeviceKey(device: DeviceInfo): string {
+  const appleOs = device.appleOs ?? 'none';
+  return `local:${device.platform}:${appleOs}:${device.id}`;
+}
+
+export async function acquireAdvisoryDeviceClaim(params: {
+  device: DeviceInfo;
+  session: string;
+  workspace: string;
+  stateDir: string;
+}): Promise<{ ownership?: DeviceClaimSessionOwnership; conflict?: InspectedDeviceClaim }> {
+  const deviceKey = canonicalLocalDeviceKey(params.device);
+  return await withDeviceClaimLock(deviceKey, async () => {
+    const existing = inspectDeviceClaimFile(resolveDeviceClaimPath(deviceKey));
+    if (existing) {
+      if (
+        existing.claim &&
+        existing.claim.session === params.session &&
+        existing.classification === 'live'
+      ) {
+        return { ownership: ownershipFromClaim(existing.claim) };
+      }
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'device_claim_advisory_conflict',
+        data: {
+          deviceKey,
+          classification: existing.classification,
+          ownerSession: existing.claim?.session,
+          ownerStateDir: existing.claim?.stateDir,
+        },
+      });
+      return { conflict: existing };
+    }
+    const owner = readCurrentOwnerIdentity();
+    const now = Date.now();
+    const claim: DeviceClaim = {
+      schemaVersion: DEVICE_CLAIM_SCHEMA_VERSION,
+      deviceKey,
+      device: {
+        platform: publicPlatformString(params.device),
+        id: params.device.id,
+        name: params.device.name,
+        kind: params.device.kind,
+        ...(params.device.target ? { target: params.device.target } : {}),
+        ...(params.device.appleOs ? { appleOs: params.device.appleOs } : {}),
+      },
+      session: params.session,
+      workspace: params.workspace,
+      stateDir: params.stateDir,
+      ownerPid: owner.pid,
+      ownerStartTime: owner.startTime,
+      ownerToken: crypto.randomUUID(),
+      createdAtMs: now,
+      updatedAtMs: now,
+    };
+    writeClaim(claim);
+    return { ownership: ownershipFromClaim(claim) };
+  });
+}
+
+export async function clearAdvisoryDeviceClaim(
+  ownership: DeviceClaimSessionOwnership | undefined,
+): Promise<void> {
+  if (!ownership) return;
+  await withDeviceClaimLock(ownership.deviceKey, async () => {
+    const inspected = inspectDeviceClaimFile(resolveDeviceClaimPath(ownership.deviceKey));
+    if (!inspected?.claim) return;
+    const claim = inspected.claim;
+    if (
+      claim.ownerToken !== ownership.ownerToken ||
+      !ownerIdentityMatches(
+        { pid: claim.ownerPid, startTime: claim.ownerStartTime },
+        { pid: ownership.ownerPid, startTime: ownership.ownerStartTime },
+      )
+    ) {
+      return;
+    }
+    try {
+      fs.unlinkSync(resolveDeviceClaimPath(ownership.deviceKey));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  });
+}
+
+function writeClaim(claim: DeviceClaim): void {
+  const claimPath = resolveDeviceClaimPath(claim.deviceKey);
+  fs.mkdirSync(path.dirname(claimPath), { recursive: true, mode: 0o700 });
+  const tmpPath = `${claimPath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(claim)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(tmpPath, claimPath);
+}
+
+async function withDeviceClaimLock<T>(deviceKey: string, task: () => Promise<T>): Promise<T> {
+  const owner = readCurrentOwnerIdentity();
+  const release = await acquireProcessLock({
+    lockDirPath: `${resolveDeviceClaimPath(deviceKey)}.lock`,
+    owner: { pid: owner.pid, startTime: owner.startTime, acquiredAtMs: Date.now() },
+    timeoutMs: DEVICE_CLAIM_LOCK_TIMEOUT_MS,
+    description: `device claim for ${deviceKey}`,
+  });
+  try {
+    return await task();
+  } finally {
+    await release();
+  }
+}
+
+function ownershipFromClaim(claim: DeviceClaim): DeviceClaimSessionOwnership {
+  return {
+    deviceKey: claim.deviceKey,
+    ownerToken: claim.ownerToken,
+    ownerPid: claim.ownerPid,
+    ownerStartTime: claim.ownerStartTime,
+  };
+}

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -67,6 +67,28 @@ test('failed local open rolls its advisory claim back', async () => {
   assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
 });
 
+test('failed local open response rolls its advisory claim back', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+
+  const response = await handleOpenCommand({
+    req: {
+      command: 'open',
+      token: 'test',
+      session: 'claim-response-rollback',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+      runtime: { metroHost: '10.0.0.10', metroPort: 70_000 },
+    },
+    sessionName: 'claim-response-rollback',
+    logPath: path.join(stateDir, 'daemon.log'),
+    sessionStore: store,
+  });
+
+  assert.equal(response.ok, false);
+  assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+});
+
 test('remote open creates no host-local advisory claim', async () => {
   const { store, stateDir } = setup();
   mockResolveTargetDevice.mockResolvedValue(android);

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(), resolveTargetDevice: vi.fn() };
+});
+vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+
+import { dispatchCommand, resolveTargetDevice } from '../../../core/dispatch.ts';
+import { acquireAdvisoryDeviceClaim } from '../../device-claims.ts';
+import { inspectDeviceClaims } from '../../device-claim-inspection.ts';
+import { LeaseRegistry } from '../../lease-registry.ts';
+import { SessionStore } from '../../session-store.ts';
+import { handleCloseCommand } from '../session-close.ts';
+import { handleOpenCommand } from '../session-open.ts';
+import type { DeviceInfo } from '../../../kernel/device.ts';
+
+const mockDispatch = vi.mocked(dispatchCommand);
+const mockResolveTargetDevice = vi.mocked(resolveTargetDevice);
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.AGENT_DEVICE_CLAIMS_DIR;
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function setup(): { store: SessionStore; stateDir: string } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-device-claim-'));
+  const claimsDir = path.join(stateDir, 'claims');
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  roots.push(stateDir);
+  return { store: new SessionStore(path.join(stateDir, 'sessions')), stateDir };
+}
+
+const android: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+test('failed local open rolls its advisory claim back', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockRejectedValue(new Error('open failed'));
+
+  await assert.rejects(async () =>
+    handleOpenCommand({
+      req: {
+        command: 'open',
+        token: 'test',
+        session: 'claim-rollback',
+        positionals: ['Demo'],
+        flags: { platform: 'android' },
+      },
+      sessionName: 'claim-rollback',
+      logPath: path.join(stateDir, 'daemon.log'),
+      sessionStore: store,
+    }),
+  );
+  assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+});
+
+test('remote open creates no host-local advisory claim', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockResolvedValue({});
+
+  const response = await handleOpenCommand({
+    req: {
+      command: 'open',
+      token: 'test',
+      session: 'remote-open',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+      meta: { leaseProvider: 'proxy', deviceKey: 'android:emulator-5554' },
+    },
+    sessionName: 'remote-open',
+    logPath: path.join(stateDir, 'daemon.log'),
+    sessionStore: store,
+  });
+  assert.equal(response.ok, true);
+  assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+  assert.equal(store.get('remote-open')?.deviceClaim, undefined);
+});
+
+test('local close clears its matching advisory claim after teardown', async () => {
+  const { store, stateDir } = setup();
+  const acquired = await acquireAdvisoryDeviceClaim({
+    device: android,
+    session: 'close-claim',
+    workspace: process.cwd(),
+    stateDir,
+  });
+  assert.ok(acquired.ownership);
+  store.set('close-claim', {
+    name: 'close-claim',
+    device: android,
+    deviceClaim: acquired.ownership,
+    createdAt: Date.now(),
+    actions: [],
+  });
+  mockDispatch.mockResolvedValue({});
+
+  const response = await handleCloseCommand({
+    req: { command: 'close', token: 'test', session: 'close-claim', positionals: [], flags: {} },
+    sessionName: 'close-claim',
+    logPath: path.join(stateDir, 'daemon.log'),
+    sessionStore: store,
+    leaseRegistry: new LeaseRegistry(),
+  });
+  assert.equal(response.ok, true);
+  assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+});

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -9,6 +9,14 @@ vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
   return { ...actual, dispatchCommand: vi.fn(), resolveTargetDevice: vi.fn() };
 });
 vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('../../runtime-hints.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../runtime-hints.ts')>();
+  return { ...actual, applyRuntimeHintsToApp: vi.fn(async () => {}) };
+});
+vi.mock('../session-open-target.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../session-open-target.ts')>();
+  return { ...actual, resolveAndroidPackageForOpen: vi.fn() };
+});
 vi.mock('../../../platforms/android/ime-lifecycle.ts', () => ({
   activateAndroidTestIme: vi.fn(async () => {}),
   restoreAndroidTestIme: vi.fn(async () => ({ restored: false, reason: 'no-record' })),
@@ -16,6 +24,8 @@ vi.mock('../../../platforms/android/ime-lifecycle.ts', () => ({
 
 import { dispatchCommand, resolveTargetDevice } from '../../../core/dispatch.ts';
 import { ensureDeviceReady } from '../../device-ready.ts';
+import { applyRuntimeHintsToApp } from '../../runtime-hints.ts';
+import { resolveAndroidPackageForOpen } from '../session-open-target.ts';
 import { activateAndroidTestIme } from '../../../platforms/android/ime-lifecycle.ts';
 import { clearRequestCanceled, markRequestCanceled } from '../../../request/cancel.ts';
 import { acquireAdvisoryDeviceClaim } from '../../device-claims.ts';
@@ -29,11 +39,15 @@ import type { DeviceInfo } from '../../../kernel/device.ts';
 const mockDispatch = vi.mocked(dispatchCommand);
 const mockResolveTargetDevice = vi.mocked(resolveTargetDevice);
 const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
+const mockApplyRuntimeHints = vi.mocked(applyRuntimeHintsToApp);
+const mockResolveAndroidPackage = vi.mocked(resolveAndroidPackageForOpen);
 const roots: string[] = [];
 
 afterEach(() => {
   vi.clearAllMocks();
   mockEnsureDeviceReady.mockResolvedValue(undefined);
+  mockApplyRuntimeHints.mockResolvedValue(undefined);
+  mockResolveAndroidPackage.mockResolvedValue(undefined);
   delete process.env.AGENT_DEVICE_CLAIMS_DIR;
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
@@ -96,6 +110,34 @@ test('failed local open after dispatch retains its advisory claim for recovery',
     }),
   );
   assert.equal(inspectDeviceClaims({ serial: android.id })[0]?.classification, 'live');
+});
+
+test('failed local runtime-hint setup retains its advisory claim before open dispatch', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockResolveAndroidPackage.mockResolvedValue('com.example.demo');
+  mockApplyRuntimeHints.mockRejectedValue(new Error('runtime hints changed before failure'));
+
+  await assert.rejects(async () =>
+    handleOpenCommand({
+      req: {
+        command: 'open',
+        token: 'test',
+        session: 'claim-runtime-hint-failure',
+        positionals: ['Demo'],
+        flags: { platform: 'android' },
+        runtime: { metroHost: '10.0.0.10', metroPort: 8081 },
+      },
+      sessionName: 'claim-runtime-hint-failure',
+      logPath: path.join(stateDir, 'daemon.log'),
+      sessionStore: store,
+    }),
+  );
+
+  assert.equal(mockApplyRuntimeHints.mock.calls.length, 1);
+  assert.equal(mockDispatch.mock.calls.length, 0);
+  assert.equal(inspectDeviceClaims({ serial: android.id })[0]?.classification, 'live');
+  assert.equal(store.get('claim-runtime-hint-failure'), undefined);
 });
 
 test('failed local open response rolls its advisory claim back', async () => {

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -9,8 +9,15 @@ vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
   return { ...actual, dispatchCommand: vi.fn(), resolveTargetDevice: vi.fn() };
 });
 vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('../../../platforms/android/ime-lifecycle.ts', () => ({
+  activateAndroidTestIme: vi.fn(async () => {}),
+  restoreAndroidTestIme: vi.fn(async () => ({ restored: false, reason: 'no-record' })),
+}));
 
 import { dispatchCommand, resolveTargetDevice } from '../../../core/dispatch.ts';
+import { ensureDeviceReady } from '../../device-ready.ts';
+import { activateAndroidTestIme } from '../../../platforms/android/ime-lifecycle.ts';
+import { clearRequestCanceled, markRequestCanceled } from '../../../request/cancel.ts';
 import { acquireAdvisoryDeviceClaim } from '../../device-claims.ts';
 import { inspectDeviceClaims } from '../../device-claim-inspection.ts';
 import { LeaseRegistry } from '../../lease-registry.ts';
@@ -21,10 +28,12 @@ import type { DeviceInfo } from '../../../kernel/device.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
 const mockResolveTargetDevice = vi.mocked(resolveTargetDevice);
+const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
 const roots: string[] = [];
 
 afterEach(() => {
   vi.clearAllMocks();
+  mockEnsureDeviceReady.mockResolvedValue(undefined);
   delete process.env.AGENT_DEVICE_CLAIMS_DIR;
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
@@ -45,10 +54,10 @@ const android: DeviceInfo = {
   booted: true,
 };
 
-test('failed local open rolls its advisory claim back', async () => {
+test('failed local open before device setup rolls its advisory claim back', async () => {
   const { store, stateDir } = setup();
   mockResolveTargetDevice.mockResolvedValue(android);
-  mockDispatch.mockRejectedValue(new Error('open failed'));
+  mockEnsureDeviceReady.mockRejectedValue(new Error('device not ready'));
 
   await assert.rejects(async () =>
     handleOpenCommand({
@@ -65,6 +74,28 @@ test('failed local open rolls its advisory claim back', async () => {
     }),
   );
   assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+});
+
+test('failed local open after dispatch retains its advisory claim for recovery', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockRejectedValue(new Error('open failed'));
+
+  await assert.rejects(async () =>
+    handleOpenCommand({
+      req: {
+        command: 'open',
+        token: 'test',
+        session: 'claim-dispatch-failure',
+        positionals: ['Demo'],
+        flags: { platform: 'android' },
+      },
+      sessionName: 'claim-dispatch-failure',
+      logPath: path.join(stateDir, 'daemon.log'),
+      sessionStore: store,
+    }),
+  );
+  assert.equal(inspectDeviceClaims({ serial: android.id })[0]?.classification, 'live');
 });
 
 test('failed local open response rolls its advisory claim back', async () => {
@@ -87,6 +118,38 @@ test('failed local open response rolls its advisory claim back', async () => {
 
   assert.equal(response.ok, false);
   assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
+});
+
+test('cancellation after local device setup retains the advisory claim for recovery', async () => {
+  const { store, stateDir } = setup();
+  const requestId = 'claim-canceled-after-dispatch';
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockResolvedValue({});
+  markRequestCanceled(requestId);
+
+  try {
+    const response = await handleOpenCommand({
+      req: {
+        command: 'open',
+        token: 'test',
+        session: 'claim-canceled-after-dispatch',
+        positionals: ['Demo'],
+        flags: { platform: 'android' },
+        meta: { requestId },
+      },
+      sessionName: 'claim-canceled-after-dispatch',
+      logPath: path.join(stateDir, 'daemon.log'),
+      sessionStore: store,
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(mockDispatch.mock.calls.length, 1);
+    assert.equal(vi.mocked(activateAndroidTestIme).mock.calls.length, 1);
+    assert.equal(inspectDeviceClaims({ serial: android.id })[0]?.classification, 'live');
+    assert.equal(store.get('claim-canceled-after-dispatch'), undefined);
+  } finally {
+    clearRequestCanceled(requestId);
+  }
 });
 
 test('remote open creates no host-local advisory claim', async () => {

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -39,6 +39,7 @@ import {
   stopSessionAudioProbe,
   type SessionCleanupFailure,
 } from '../session-teardown.ts';
+import { clearAdvisoryDeviceClaim } from '../device-claims.ts';
 
 async function maybeShutdownSessionTarget(params: {
   device: DeviceInfo;
@@ -473,12 +474,15 @@ export async function handleCloseCommand(params: {
     leaseLifecycleProvider,
   });
   if (leaseRelease.response) return leaseRelease.response;
-  sessionStore.delete(sessionName);
   const cleanupAggregate = reportSessionCleanupFailures({
     sessionName,
     phase: 'session_close_cleanup_failed',
     failures: cleanupFailures,
   });
+  if (!platformCloseError && !cleanupAggregate) {
+    await clearAdvisoryDeviceClaim(session.deviceClaim);
+  }
+  sessionStore.delete(sessionName);
   // The platform-close failure is the primary error: rethrow it with its original
   // code/details/hint intact. The cleanup aggregate has already been emitted as a
   // diagnostic above so per-resource failures stay visible.

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -76,7 +76,7 @@ type OpenTiming = {
   postOpenSettleDurationMs?: number;
 };
 
-type NewSessionOpenEffects = { started: boolean };
+type NewSessionOpenEffects = { mayHaveStarted: boolean };
 
 async function relaunchCloseApp(params: {
   device: DeviceInfo;
@@ -207,7 +207,6 @@ async function completeOpenCommand(params: {
   runtime: SessionRuntimeHints | undefined;
   existingSession?: SessionState;
   deviceClaim?: DeviceClaimSessionOwnership;
-  newSessionEffects?: NewSessionOpenEffects;
 }): Promise<DaemonResponse> {
   const {
     req,
@@ -223,7 +222,6 @@ async function completeOpenCommand(params: {
     runtime,
     existingSession,
     deviceClaim,
-    newSessionEffects,
   } = params;
   const shouldRelaunch = req.flags?.relaunch === true;
   const traceLogPath = existingSession?.trace?.outPath;
@@ -352,7 +350,6 @@ async function completeOpenCommand(params: {
   // its visible surface. Expire that session's frame before the first
   // close/launch dispatch; a fresh first open has no prior frame to expire.
   if (openDispatchSession) expireRefFrame(openDispatchSession);
-  if (newSessionEffects) newSessionEffects.started = true;
   await dispatchCommand(device, 'open', openPositionals, req.flags?.out, {
     ...contextFromFlags(logPath, req.flags, sessionAppBundleId),
     ...(collapseSimulatorRelaunch ? { terminateRunningApp: true } : {}),
@@ -565,7 +562,7 @@ async function openNewSessionWithAdvisoryClaim(params: {
   if (conflict) return conflict;
 
   const localClaim = await acquireLocalDeviceClaim({ req, device, sessionName, logPath });
-  const effects: NewSessionOpenEffects = { started: false };
+  const effects: NewSessionOpenEffects = { mayHaveStarted: false };
   try {
     const details = await prepareOpenCommandDetails({
       req,
@@ -586,6 +583,10 @@ async function openNewSessionWithAdvisoryClaim(params: {
       await rollbackNewSessionClaim(localClaim.ownership, effects);
       return details.response;
     }
+    // Preparation above is validation-only. `completeOpenCommand` can prewarm a runner,
+    // relaunch-close an app, or write runtime hints before its main open dispatch, so a
+    // failure from that point cannot prove the device is unchanged.
+    effects.mayHaveStarted = true;
     const response = await completeOpenCommand({
       req,
       sessionName,
@@ -599,7 +600,6 @@ async function openNewSessionWithAdvisoryClaim(params: {
       runtime: details.details.runtime,
       surface,
       deviceClaim: localClaim.ownership,
-      newSessionEffects: effects,
     });
     if (!response.ok) await rollbackNewSessionClaim(localClaim.ownership, effects);
     return response;
@@ -614,7 +614,7 @@ async function rollbackNewSessionClaim(
   effects: NewSessionOpenEffects,
 ): Promise<void> {
   if (!ownership) return;
-  if (effects.started) {
+  if (effects.mayHaveStarted) {
     emitDiagnostic({
       level: 'warn',
       phase: 'device_claim_open_effects_unconfirmed',

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { dispatchCommand, resolveTargetDevice } from '../../core/dispatch.ts';
 import { isDeepLinkTarget } from '../../contracts/open-target.ts';
 import type { SessionSurface } from '../../contracts/session-surface.ts';
@@ -53,6 +54,12 @@ import {
   resolvePublicSessionName,
 } from '../session-routing.ts';
 import { resolveSessionLeaseForRequest } from '../lease-lifecycle.ts';
+import {
+  acquireAdvisoryDeviceClaim,
+  clearAdvisoryDeviceClaim,
+  isLocalDeviceClaimTarget,
+  type DeviceClaimSessionOwnership,
+} from '../device-claims.ts';
 
 const firstSessionOpenLocks = new Map<string, Promise<unknown>>();
 
@@ -197,6 +204,7 @@ async function completeOpenCommand(params: {
   appBundleId?: string;
   runtime: SessionRuntimeHints | undefined;
   existingSession?: SessionState;
+  deviceClaim?: DeviceClaimSessionOwnership;
 }): Promise<DaemonResponse> {
   const {
     req,
@@ -211,6 +219,7 @@ async function completeOpenCommand(params: {
     appBundleId,
     runtime,
     existingSession,
+    deviceClaim,
   } = params;
   const shouldRelaunch = req.flags?.relaunch === true;
   const traceLogPath = existingSession?.trace?.outPath;
@@ -405,6 +414,7 @@ async function completeOpenCommand(params: {
     req,
     existingLease: existingSession?.lease,
   });
+  if (deviceClaim) nextSession.deviceClaim = deviceClaim;
   if (req.runtime !== undefined) {
     setSessionRuntimeHintsForOpen(sessionStore, sessionName, runtime);
   }
@@ -491,6 +501,102 @@ async function prepareOpenDispatchSession(params: {
     return { type: 'response', response: lifecycleResponse };
   }
   return { type: 'session', session: sessionStore.get(sessionName) ?? provisionalSession };
+}
+
+function findNewSessionDeviceConflict(params: {
+  req: DaemonRequest;
+  device: DeviceInfo;
+  sessionStore: SessionStore;
+}): DaemonResponse | undefined {
+  const { req, device, sessionStore } = params;
+  const inUse = sessionStore.toArray().find((session) => session.device.id === device.id);
+  if (!inUse) return undefined;
+  if (isImplicitSessionScopeConflict(req, inUse)) {
+    return errorResponse(
+      'DEVICE_IN_USE',
+      'Device is already in use by another workspace session.',
+      {
+        deviceId: device.id,
+        deviceName: device.name,
+        hint: 'Use a different device selector, wait for the other workspace to close its session, or run agent-device devices to choose another target.',
+      },
+    );
+  }
+  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUse.name}".`, {
+    session: inUse.name,
+    deviceId: device.id,
+    deviceName: device.name,
+    hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
+  });
+}
+
+async function acquireLocalDeviceClaim(params: {
+  req: DaemonRequest;
+  device: DeviceInfo;
+  sessionName: string;
+  logPath: string;
+}): Promise<{ ownership?: DeviceClaimSessionOwnership }> {
+  const { req, device, sessionName, logPath } = params;
+  if (!isLocalDeviceClaimTarget(req.meta, isActiveProviderDevice(device))) return {};
+  return await acquireAdvisoryDeviceClaim({
+    device,
+    session: sessionName,
+    workspace: req.meta?.cwd ?? process.cwd(),
+    stateDir: path.dirname(logPath),
+  });
+}
+
+async function openNewSessionWithAdvisoryClaim(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  device: DeviceInfo;
+  surface: SessionSurface;
+  openTarget: string | undefined;
+}): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore, device, surface, openTarget } = params;
+  const conflict = findNewSessionDeviceConflict({ req, device, sessionStore });
+  if (conflict) return conflict;
+
+  const localClaim = await acquireLocalDeviceClaim({ req, device, sessionName, logPath });
+  try {
+    const details = await prepareOpenCommandDetails({
+      req,
+      sessionName,
+      sessionStore,
+      device,
+      surface,
+      openTarget,
+      onIosSimulatorColdBootStart: createAppleRunnerCacheColdBootPrewarmForOpen({
+        req,
+        logPath,
+        device,
+        surface,
+        openTarget,
+      }),
+    });
+    if (details.type === 'response') return details.response;
+    const response = await completeOpenCommand({
+      req,
+      sessionName,
+      sessionStore,
+      logPath,
+      device,
+      openTarget,
+      openPositionals: req.positionals ?? [],
+      appBundleId: details.details.appBundleId,
+      appName: details.details.appName,
+      runtime: details.details.runtime,
+      surface,
+      deviceClaim: localClaim.ownership,
+    });
+    if (!response.ok) await clearAdvisoryDeviceClaim(localClaim.ownership);
+    return response;
+  } catch (error) {
+    await clearAdvisoryDeviceClaim(localClaim.ownership);
+    throw error;
+  }
 }
 
 // fallow-ignore-next-line complexity
@@ -605,65 +711,18 @@ export async function handleOpenCommand(params: {
     return validation;
   }
 
-  return await withKeyedLock(firstSessionOpenLocks, device.id, async () => {
-    const inUse = sessionStore
-      .toArray()
-      .find((activeSession) => activeSession.device.id === device.id);
-    if (inUse) {
-      if (isImplicitSessionScopeConflict(req, inUse)) {
-        return errorResponse(
-          'DEVICE_IN_USE',
-          'Device is already in use by another workspace session.',
-          {
-            deviceId: device.id,
-            deviceName: device.name,
-            hint: 'Use a different device selector, wait for the other workspace to close its session, or run agent-device devices to choose another target.',
-          },
-        );
-      }
-      return errorResponse(
-        'DEVICE_IN_USE',
-        `Device is already in use by session "${inUse.name}".`,
-        {
-          session: inUse.name,
-          deviceId: device.id,
-          deviceName: device.name,
-          hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
-        },
-      );
-    }
-
-    const details = await prepareOpenCommandDetails({
-      req,
-      sessionName,
-      sessionStore,
-      device,
-      surface: surfaceResult,
-      openTarget,
-      onIosSimulatorColdBootStart: createAppleRunnerCacheColdBootPrewarmForOpen({
+  return await withKeyedLock(
+    firstSessionOpenLocks,
+    device.id,
+    async () =>
+      await openNewSessionWithAdvisoryClaim({
         req,
+        sessionName,
         logPath,
+        sessionStore,
         device,
         surface: surfaceResult,
         openTarget,
       }),
-    });
-    if (details.type === 'response') {
-      return details.response;
-    }
-
-    return await completeOpenCommand({
-      req,
-      sessionName,
-      sessionStore,
-      logPath,
-      device,
-      openTarget,
-      openPositionals: req.positionals ?? [],
-      appBundleId: details.details.appBundleId,
-      appName: details.details.appName,
-      runtime: details.details.runtime,
-      surface: surfaceResult,
-    });
-  });
+  );
 }

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -76,6 +76,8 @@ type OpenTiming = {
   postOpenSettleDurationMs?: number;
 };
 
+type NewSessionOpenEffects = { started: boolean };
+
 async function relaunchCloseApp(params: {
   device: DeviceInfo;
   closeTarget: string;
@@ -205,6 +207,7 @@ async function completeOpenCommand(params: {
   runtime: SessionRuntimeHints | undefined;
   existingSession?: SessionState;
   deviceClaim?: DeviceClaimSessionOwnership;
+  newSessionEffects?: NewSessionOpenEffects;
 }): Promise<DaemonResponse> {
   const {
     req,
@@ -220,6 +223,7 @@ async function completeOpenCommand(params: {
     runtime,
     existingSession,
     deviceClaim,
+    newSessionEffects,
   } = params;
   const shouldRelaunch = req.flags?.relaunch === true;
   const traceLogPath = existingSession?.trace?.outPath;
@@ -348,6 +352,7 @@ async function completeOpenCommand(params: {
   // its visible surface. Expire that session's frame before the first
   // close/launch dispatch; a fresh first open has no prior frame to expire.
   if (openDispatchSession) expireRefFrame(openDispatchSession);
+  if (newSessionEffects) newSessionEffects.started = true;
   await dispatchCommand(device, 'open', openPositionals, req.flags?.out, {
     ...contextFromFlags(logPath, req.flags, sessionAppBundleId),
     ...(collapseSimulatorRelaunch ? { terminateRunningApp: true } : {}),
@@ -560,6 +565,7 @@ async function openNewSessionWithAdvisoryClaim(params: {
   if (conflict) return conflict;
 
   const localClaim = await acquireLocalDeviceClaim({ req, device, sessionName, logPath });
+  const effects: NewSessionOpenEffects = { started: false };
   try {
     const details = await prepareOpenCommandDetails({
       req,
@@ -577,7 +583,7 @@ async function openNewSessionWithAdvisoryClaim(params: {
       }),
     });
     if (details.type === 'response') {
-      await clearAdvisoryDeviceClaim(localClaim.ownership);
+      await rollbackNewSessionClaim(localClaim.ownership, effects);
       return details.response;
     }
     const response = await completeOpenCommand({
@@ -593,13 +599,30 @@ async function openNewSessionWithAdvisoryClaim(params: {
       runtime: details.details.runtime,
       surface,
       deviceClaim: localClaim.ownership,
+      newSessionEffects: effects,
     });
-    if (!response.ok) await clearAdvisoryDeviceClaim(localClaim.ownership);
+    if (!response.ok) await rollbackNewSessionClaim(localClaim.ownership, effects);
     return response;
   } catch (error) {
-    await clearAdvisoryDeviceClaim(localClaim.ownership);
+    await rollbackNewSessionClaim(localClaim.ownership, effects);
     throw error;
   }
+}
+
+async function rollbackNewSessionClaim(
+  ownership: DeviceClaimSessionOwnership | undefined,
+  effects: NewSessionOpenEffects,
+): Promise<void> {
+  if (!ownership) return;
+  if (effects.started) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'device_claim_open_effects_unconfirmed',
+      data: { deviceKey: ownership.deviceKey },
+    });
+    return;
+  }
+  await clearAdvisoryDeviceClaim(ownership);
 }
 
 // fallow-ignore-next-line complexity

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -576,7 +576,10 @@ async function openNewSessionWithAdvisoryClaim(params: {
         openTarget,
       }),
     });
-    if (details.type === 'response') return details.response;
+    if (details.type === 'response') {
+      await clearAdvisoryDeviceClaim(localClaim.ownership);
+      return details.response;
+    }
     const response = await completeOpenCommand({
       req,
       sessionName,

--- a/src/daemon/lease-lifecycle.ts
+++ b/src/daemon/lease-lifecycle.ts
@@ -1,5 +1,6 @@
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { leaseScopeToReleaseRequest } from '../core/lease-scope.ts';
+import { clearAdvisoryDeviceClaim } from './device-claims.ts';
 import type { DeviceLease, LeaseRegistry } from './lease-registry.ts';
 import { buildSessionLeaseFromRequest, type SessionLease } from './lease-context.ts';
 import {
@@ -78,6 +79,17 @@ export async function cleanupExpiredLeasedSession(params: {
         reason: 'LEASE_EXPIRED',
         leaseId: lease.leaseId,
         session: session.name,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+  });
+  await clearAdvisoryDeviceClaim(session.deviceClaim).catch((error) => {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'leased_session_expiry_device_claim_clear_failed',
+      data: {
+        session: session.name,
+        deviceKey: session.deviceClaim?.deviceKey,
         error: error instanceof Error ? error.message : String(error),
       },
     });

--- a/src/daemon/server/daemon-runtime-device-claims.test.ts
+++ b/src/daemon/server/daemon-runtime-device-claims.test.ts
@@ -33,10 +33,11 @@ function setup(): { session: SessionState; sessionStore: SessionStore; stateDir:
   return { session, sessionStore, stateDir };
 }
 
-test('does not run beforeDelete after shutdown teardown rejects', async () => {
+test('finalizes provider state but does not clear a claim after shutdown teardown rejects', async () => {
   const { session, sessionStore, stateDir } = setup();
   mockTeardownSessionResources.mockRejectedValueOnce(new Error('teardown failed'));
   const beforeDelete = vi.fn(async () => {});
+  const afterSuccessfulTeardown = vi.fn(async () => {});
 
   await teardownDaemonSessionForShutdown({
     session,
@@ -44,17 +45,20 @@ test('does not run beforeDelete after shutdown teardown rejects', async () => {
     stateDir,
     stderr: { write: () => {} },
     beforeDelete,
+    afterSuccessfulTeardown,
   });
 
-  expect(beforeDelete).not.toHaveBeenCalled();
+  expect(beforeDelete).toHaveBeenCalledWith(session);
+  expect(afterSuccessfulTeardown).not.toHaveBeenCalled();
   expect(sessionStore.get(session.name)).toBeUndefined();
 });
 
-test('does not run beforeDelete after shutdown teardown times out', async () => {
+test('finalizes provider state but does not clear a claim after shutdown teardown times out', async () => {
   vi.useFakeTimers();
   const { session, sessionStore, stateDir } = setup();
   mockTeardownSessionResources.mockReturnValueOnce(new Promise(() => {}));
   const beforeDelete = vi.fn(async () => {});
+  const afterSuccessfulTeardown = vi.fn(async () => {});
 
   const teardown = teardownDaemonSessionForShutdown({
     session,
@@ -62,10 +66,12 @@ test('does not run beforeDelete after shutdown teardown times out', async () => 
     stateDir,
     stderr: { write: () => {} },
     beforeDelete,
+    afterSuccessfulTeardown,
   });
   await vi.advanceTimersByTimeAsync(5_000);
   await teardown;
 
-  expect(beforeDelete).not.toHaveBeenCalled();
+  expect(beforeDelete).toHaveBeenCalledWith(session);
+  expect(afterSuccessfulTeardown).not.toHaveBeenCalled();
   expect(sessionStore.get(session.name)).toBeUndefined();
 });

--- a/src/daemon/server/daemon-runtime-device-claims.test.ts
+++ b/src/daemon/server/daemon-runtime-device-claims.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('../session-teardown.ts', () => ({ teardownSessionResources: vi.fn() }));
+
+import { SessionStore } from '../session-store.ts';
+import { teardownSessionResources } from '../session-teardown.ts';
+import type { SessionState } from '../types.ts';
+import { teardownDaemonSessionForShutdown } from './daemon-runtime.ts';
+
+const mockTeardownSessionResources = vi.mocked(teardownSessionResources);
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function setup(): { session: SessionState; sessionStore: SessionStore; stateDir: string } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-shutdown-claim-'));
+  roots.push(stateDir);
+  const session: SessionState = {
+    name: 'claim-session',
+    device: { platform: 'android', id: 'emulator-5554', name: 'Pixel', kind: 'emulator' },
+    createdAt: Date.now(),
+    actions: [],
+  };
+  const sessionStore = new SessionStore(path.join(stateDir, 'sessions'));
+  sessionStore.set(session.name, session);
+  return { session, sessionStore, stateDir };
+}
+
+test('does not run beforeDelete after shutdown teardown rejects', async () => {
+  const { session, sessionStore, stateDir } = setup();
+  mockTeardownSessionResources.mockRejectedValueOnce(new Error('teardown failed'));
+  const beforeDelete = vi.fn(async () => {});
+
+  await teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir,
+    stderr: { write: () => {} },
+    beforeDelete,
+  });
+
+  expect(beforeDelete).not.toHaveBeenCalled();
+  expect(sessionStore.get(session.name)).toBeUndefined();
+});
+
+test('does not run beforeDelete after shutdown teardown times out', async () => {
+  vi.useFakeTimers();
+  const { session, sessionStore, stateDir } = setup();
+  mockTeardownSessionResources.mockReturnValueOnce(new Promise(() => {}));
+  const beforeDelete = vi.fn(async () => {});
+
+  const teardown = teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir,
+    stderr: { write: () => {} },
+    beforeDelete,
+  });
+  await vi.advanceTimersByTimeAsync(5_000);
+  await teardown;
+
+  expect(beforeDelete).not.toHaveBeenCalled();
+  expect(sessionStore.get(session.name)).toBeUndefined();
+});

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -24,6 +24,7 @@ import { closeDaemonServers } from './server-shutdown.ts';
 import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';
 import { finalizeDaemonSessionLease } from './daemon-session-lease-finalizer.ts';
+import { clearAdvisoryDeviceClaim } from '../device-claims.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -218,13 +219,15 @@ export async function startDaemonRuntime(
       sessionStore,
       stateDir: baseDir,
       stderr,
-      beforeDelete: async (sessionToFinalize) =>
+      beforeDelete: async (sessionToFinalize) => {
         await finalizeDaemonSessionLease({
           session: sessionToFinalize,
           leaseRegistry,
           expiredProviderLeaseReleaser,
           timeoutMs: DAEMON_SESSION_LEASE_RELEASE_TIMEOUT_MS,
-        }),
+        });
+        await clearAdvisoryDeviceClaim(sessionToFinalize.deviceClaim);
+      },
     });
 
   const teardownDaemonSessions = async (): Promise<void> => {

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -96,8 +96,9 @@ export async function teardownDaemonSessionForShutdown(params: {
   stateDir?: string;
   stderr: WritableOutput;
   beforeDelete?: (session: SessionState) => Promise<void>;
+  afterSuccessfulTeardown?: (session: SessionState) => Promise<void>;
 }): Promise<void> {
-  const { session, sessionStore, stateDir, stderr, beforeDelete } = params;
+  const { session, sessionStore, stateDir, stderr, beforeDelete, afterSuccessfulTeardown } = params;
   const timeoutMs = resolveDaemonSessionTeardownTimeoutMs(session);
   const teardown = teardownSessionResources(session, session.name, stateDir).then(
     () => true,
@@ -121,7 +122,8 @@ export async function teardownDaemonSessionForShutdown(params: {
   // `.ad` iff the repair transaction completed, else leave a bounded
   // `REPAIR_SESSION_EXPIRED` tombstone for the reaped-before-finalize case.
   sessionStore.finalizeRepairTeardown(session);
-  if (teardownSucceeded) await beforeDelete?.(session);
+  await beforeDelete?.(session);
+  if (teardownSucceeded) await afterSuccessfulTeardown?.(session);
   sessionStore.delete(session.name);
 }
 
@@ -231,8 +233,9 @@ export async function startDaemonRuntime(
           expiredProviderLeaseReleaser,
           timeoutMs: DAEMON_SESSION_LEASE_RELEASE_TIMEOUT_MS,
         });
-        await clearAdvisoryDeviceClaim(sessionToFinalize.deviceClaim);
       },
+      afterSuccessfulTeardown: async (sessionToFinalize) =>
+        await clearAdvisoryDeviceClaim(sessionToFinalize.deviceClaim),
     });
 
   const teardownDaemonSessions = async (): Promise<void> => {

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -99,24 +99,29 @@ export async function teardownDaemonSessionForShutdown(params: {
 }): Promise<void> {
   const { session, sessionStore, stateDir, stderr, beforeDelete } = params;
   const timeoutMs = resolveDaemonSessionTeardownTimeoutMs(session);
-  const teardown = teardownSessionResources(session, session.name, stateDir).catch((error) => {
-    stderr.write(
-      `Daemon session teardown error (${session.name}): ${
-        error instanceof Error ? error.message : String(error)
-      }\n`,
-    );
-  });
-  await Promise.race([
+  const teardown = teardownSessionResources(session, session.name, stateDir).then(
+    () => true,
+    (error) => {
+      stderr.write(
+        `Daemon session teardown error (${session.name}): ${
+          error instanceof Error ? error.message : String(error)
+        }\n`,
+      );
+      return false;
+    },
+  );
+  const teardownSucceeded = await Promise.race([
     teardown,
     sleep(timeoutMs).then(() => {
       stderr.write(`Daemon session teardown timed out (${session.name}).\n`);
+      return false;
     }),
   ]);
   // ADR 0012 decision 6, R7 + commit semantics (C2/C5a): commit the healed
   // `.ad` iff the repair transaction completed, else leave a bounded
   // `REPAIR_SESSION_EXPIRED` tombstone for the reaped-before-finalize case.
   sessionStore.finalizeRepairTeardown(session);
-  await beforeDelete?.(session);
+  if (teardownSucceeded) await beforeDelete?.(session);
   sessionStore.delete(session.name);
 }
 

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -67,7 +67,15 @@ export async function restoreSessionAndroidIme(
   stateDir?: string,
 ): Promise<void> {
   if (session.device.platform !== 'android') return;
-  await restoreAndroidTestIme(session.device, { stateDir }).catch((error) => {
+  try {
+    const result = await restoreAndroidTestIme(session.device, { stateDir });
+    if (result.reason !== 'set-failed') return;
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Android test IME could not be restored on ${session.device.name ?? session.device.id}.`,
+      { reason: 'android_test_ime_restore_incomplete', deviceId: session.device.id },
+    );
+  } catch (error) {
     emitDiagnostic({
       level: 'warn',
       phase: 'android_test_ime_restore_failed',
@@ -76,7 +84,8 @@ export async function restoreSessionAndroidIme(
         error: error instanceof Error ? error.message : String(error),
       },
     });
-  });
+    throw error;
+  }
 }
 
 type SessionCleanupStep = { step: string; run: () => Promise<void> };

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -237,6 +237,13 @@ export type SessionState = {
     clientId?: string;
     expiresAt?: number;
   };
+  /** Advisory host-global local-device claim owned by this session, if acquired. */
+  deviceClaim?: {
+    deviceKey: string;
+    ownerToken: string;
+    ownerPid: number;
+    ownerStartTime: string | null;
+  };
   device: DeviceInfo;
   createdAt: number;
   surface?: SessionSurface;

--- a/src/platforms/android/__tests__/ime-lifecycle.test.ts
+++ b/src/platforms/android/__tests__/ime-lifecycle.test.ts
@@ -41,6 +41,8 @@ import {
   restoreOrphanedAndroidTestImeOnDaemonStartup,
   resetAndroidTestImeActivationCacheForTests,
 } from '../ime-lifecycle.ts';
+import { teardownSessionResources } from '../../../daemon/session-teardown.ts';
+import type { SessionState } from '../../../daemon/types.ts';
 
 const LATIN_IME = 'com.google.android.inputmethod.latin/.LatinIME';
 const SERIAL = ANDROID_EMULATOR.id;
@@ -245,6 +247,27 @@ test('a failed restore keeps the recovery value AND the marker for a later retry
     assert.equal(state.getCurrentIme(), LATIN_IME);
     assert.equal(state.getPreviousImeRecord(), undefined);
     assert.equal(await pendingMarkerExists(stateDir, SERIAL), false);
+  });
+});
+
+test('session teardown fails when a real IME restore reports set-failed', async () => {
+  const state = fakeDeviceState(LATIN_IME);
+  const stateDir = await makeStateDir();
+  const session: SessionState = {
+    name: 'ime-restore-failure',
+    device: ANDROID_EMULATOR,
+    createdAt: Date.now(),
+    actions: [],
+  };
+  state.markInstalled();
+
+  await withAndroidAdbProvider(state.adb, { serial: SERIAL }, async () => {
+    await activateAndroidTestIme(ANDROID_EMULATOR, { stateDir });
+    state.blockImeSetTo(LATIN_IME);
+    await assert.rejects(
+      async () => await teardownSessionResources(session, session.name, stateDir),
+      /android_ime: Android test IME could not be restored/,
+    );
   });
 });
 

--- a/src/platforms/apple/core/runner/runner-lease.ts
+++ b/src/platforms/apple/core/runner/runner-lease.ts
@@ -5,7 +5,8 @@ import path from 'node:path';
 import { emitDiagnostic } from '../../../../utils/diagnostics.ts';
 import { AppError } from '../../../../kernel/errors.ts';
 import { acquireProcessLock } from '../../../../utils/process-lock.ts';
-import { isProcessAlive, readProcessStartTime } from '../../../../utils/host-process.ts';
+import { readProcessStartTime } from '../../../../utils/host-process.ts';
+import { classifyOwnerLiveness } from '../../../../utils/owner-identity.ts';
 import type { RunnerLogicalLeaseContext } from '../../../../core/runner-lease-context.ts';
 
 const RUNNER_LEASE_SCHEMA_VERSION = 1;
@@ -416,28 +417,21 @@ function readFiniteNumber(value: unknown): number | null {
 // field existed (no ownerStateDir) skip the check and fall back to PID
 // liveness only.
 function isRunnerLeaseOwnerProcessAlive(lease: RunnerLease): boolean {
-  if (!isProcessAlive(lease.ownerPid)) return false;
-  if (lease.ownerStartTime) {
-    return readProcessStartTime(lease.ownerPid) === lease.ownerStartTime;
-  }
-  return true;
+  return (
+    classifyOwnerLiveness({
+      owner: { pid: lease.ownerPid, startTime: lease.ownerStartTime },
+    }) === 'live'
+  );
 }
 
 function isRunnerLeaseOwnerStateDirGone(lease: RunnerLease): boolean {
   if (!lease.ownerStateDir) return false;
-  // statSync, not existsSync: existsSync never throws - it swallows EACCES
-  // and transient IO errors into `false`, which would misclassify a
-  // still-present-but-unreadable state dir as gone and force an unwarranted
-  // takeover of a live owner. Only a proven-missing path (ENOENT, or ENOTDIR
-  // on a parent component) counts as gone; any other stat error fails closed
-  // and treats the owner as alive.
-  try {
-    fs.statSync(lease.ownerStateDir);
-    return false;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException | null)?.code;
-    return code === 'ENOENT' || code === 'ENOTDIR';
-  }
+  return (
+    classifyOwnerLiveness({
+      owner: { pid: lease.ownerPid, startTime: lease.ownerStartTime },
+      stateDir: lease.ownerStateDir,
+    }) === 'owner-state-dir-gone'
+  );
 }
 
 async function cleanupLeasedRunnerProcesses(

--- a/src/utils/__tests__/owner-identity.test.ts
+++ b/src/utils/__tests__/owner-identity.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import { classifyOwnerLiveness } from '../owner-identity.ts';
+import { readProcessStartTime } from '../host-process.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('classifies dead and PID-reused owners as owner-process-dead', () => {
+  assert.equal(
+    classifyOwnerLiveness({ owner: { pid: 999_999_999, startTime: 'old-start' } }),
+    'owner-process-dead',
+  );
+  assert.equal(
+    classifyOwnerLiveness({ owner: { pid: process.pid, startTime: 'not-this-process' } }),
+    'owner-process-dead',
+  );
+});
+
+test('distinguishes a gone state directory from permission and transient I/O failures', () => {
+  const startTime = readProcessStartTime(process.pid);
+  const missing = path.join(os.tmpdir(), `agent-device-missing-owner-${Date.now()}`);
+  assert.equal(
+    classifyOwnerLiveness({ owner: { pid: process.pid, startTime }, stateDir: missing }),
+    'owner-state-dir-gone',
+  );
+
+  vi.spyOn(fs, 'statSync').mockImplementation(() => {
+    const error = new Error('permission denied') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    throw error;
+  });
+  assert.equal(
+    classifyOwnerLiveness({ owner: { pid: process.pid, startTime }, stateDir: '/protected' }),
+    'unknown',
+  );
+});

--- a/src/utils/owner-identity.ts
+++ b/src/utils/owner-identity.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import { isProcessAlive, readProcessStartTime } from './host-process.ts';
+
+export type OwnerIdentity = {
+  pid: number;
+  startTime: string | null;
+};
+
+export type OwnerLiveness = 'live' | 'owner-process-dead' | 'owner-state-dir-gone' | 'unknown';
+
+export function readCurrentOwnerIdentity(): OwnerIdentity {
+  return { pid: process.pid, startTime: readProcessStartTime(process.pid) };
+}
+
+export function ownerIdentityMatches(
+  left: Pick<OwnerIdentity, 'pid' | 'startTime'>,
+  right: Pick<OwnerIdentity, 'pid' | 'startTime'>,
+): boolean {
+  return left.pid === right.pid && left.startTime === right.startTime;
+}
+
+/**
+ * This is deliberately proof-oriented. A filesystem read error is not proof
+ * that an owner state directory disappeared, so callers must surface it as an
+ * unknown owner rather than treating the resource as free.
+ */
+export function classifyOwnerLiveness(params: {
+  owner: Pick<OwnerIdentity, 'pid' | 'startTime'>;
+  stateDir?: string;
+}): OwnerLiveness {
+  const { owner, stateDir } = params;
+  if (!isProcessAlive(owner.pid)) return 'owner-process-dead';
+  if (owner.startTime && readProcessStartTime(owner.pid) !== owner.startTime) {
+    return 'owner-process-dead';
+  }
+  if (!stateDir) return 'live';
+  try {
+    fs.statSync(stateDir);
+    return 'live';
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 'owner-state-dir-gone';
+    return 'unknown';
+  }
+}

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -1104,6 +1104,18 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     allowOnlyLocalCliHelpCommands: true,
   }),
   makeCase({
+    id: 'advisory-device-status-no-daemon',
+    contract: [
+      'Another worktree may have an advisory claim on Android emulator-5554',
+      'Need to inspect local ownership without starting or contacting any daemon',
+      'Stage 1 is observational only: device release and --stale are not available yet',
+    ],
+    task: 'Plan the one command that inspects this Android device claim directly. Do not use ps, daemon commands, or an unavailable release command.',
+    outputs: [plannedCommand('device status')],
+    forbiddenOutputs: [/\bdaemon\b/i, /\bdevice\s+release\b/i, /\bps\b/i],
+    strictFinalOutput: true,
+  }),
+  makeCase({
     id: 'selector-role-filter-not-role-key',
     contract: [
       'App name: Agent Device Tester',

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -59,6 +59,7 @@ agent-device app-switcher
 - `shutdown` turns off the selected Apple simulator or Android emulator.
 - `shutdown` must not target an active session device; use `close --shutdown` to end the session and turn it off.
 - `daemon stop --state-dir <path>` verifies the daemon PID/start-time identity, requests graceful shutdown, and reports whether provider-release state is known. Use `daemon stop --clean` to also remove retained Apple runner processes and leases owned by that daemon.
+- `device status` reads host-local advisory device claims without starting or contacting a daemon. Scope it with `--platform` plus `--udid` (Apple) or `--serial` (Android) to inspect one target. Stage 1 claims are observational: a live claim is reported but does not yet block `open` or offer a release command.
 - `--platform apple` is an alias for the Apple automation backend (`ios`, `tvOS`, `macOS` selection).
 - Use `--target mobile|tv|desktop` with `--platform` (required) to select phone/tablet vs TV-class vs desktop-class targets.
 - `boot` is mainly needed when starting a new session and `open` fails because no booted simulator/emulator is available.


### PR DESCRIPTION
## Summary

Implements Stage 1 host-global advisory claims for local devices and a side-effect-free `device status` command.

- Records local ownership before open and clears only matching owner/token after safe close, shutdown, expiry, or failed-open rollback.
- Preserves live foreign, stale, corrupt, and unknown claims; remote targets never create a local claim.
- Shares fail-closed PID/start-time/state-directory liveness classification with Apple runner leases.
- Adds lifecycle, daemonless-status, and owner-classification regression coverage.

Closes #1328

## Validation

- `pnpm check:affected --base origin/main --run` (static gates/build passed; its parallel related-test phase hit host-load flakes)
- Focused advisory suites: 25 passed
- Serialized provider integration: 140 passed
- Serialized coverage: 4,495/4,496 passed; the sole existing Apple concurrent-build test passed on isolated retry
- `pnpm test:skillgym:case advisory-device-status-no-daemon` built successfully, but both external model runners exited before assertions
- Isolated cross-process evidence: create claim -> `device status --json` reports live -> matching close removes claim