### PR TITLE
fix: target Maestro scrollUntilVisible container

### DIFF
--- a/scripts/maestro-conformance/differential/scenarios.ts
+++ b/scripts/maestro-conformance/differential/scenarios.ts
@@ -107,21 +107,6 @@ export const DIFFERENTIAL_SCENARIOS: DifferentialScenario[] = [
     ],
     divergenceMeans:
       'agent-device settled in a different order than upstream (sleep-before vs sleep-after capture) or never latches within the shared budget.',
-    knownDivergence: {
-      reason:
-        'Caught by this differential on its first working run: our scrollUntilVisible times out finding home-open-form where Maestro 2.5.1 scrolls to it and passes. The flow cannot reach its tapOn step, so bug class 4 has no working device detector until that engine bug is fixed. Declared rather than chased inline — the instrument does not block on repairing what it just measured.',
-      tracking: 'https://github.com/callstack/agent-device/issues/1299',
-      // Exactly what runs 29504440599 and 29510020718 observed. If upstream
-      // starts failing too, or the flow fails for a different reason, the
-      // signature stops matching and the job goes red — a waiver for THIS bug
-      // must not silently cover the next one.
-      expected: {
-        maestro: 'pass',
-        agentDevice: 'fail',
-        // The tap step is never reached, so the settle invariant has no data.
-        invariants: ['no-data'],
-      },
-    },
   },
   {
     id: 'percent-swipe',

--- a/src/compat/maestro/__tests__/daemon-runtime-port-observation-scroll.test.ts
+++ b/src/compat/maestro/__tests__/daemon-runtime-port-observation-scroll.test.ts
@@ -112,6 +112,72 @@ test('scrolls until the target is fully visible in the screen viewport', async (
   expect(result.observation?.identity).toMatch(/^maestro-observation-/);
 });
 
+test('scrolls inside the visible vertical container instead of the screen centre', async () => {
+  const requests: DaemonRequest[] = [];
+  let snapshots = 0;
+  const port = createDaemonMaestroRuntimePort({
+    baseReq: makeBaseRequest({ flags: { platform: 'ios', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      requests.push(request);
+      if (request.command !== 'snapshot') return { ok: true, data: {} };
+      snapshots += 1;
+      return {
+        ok: true,
+        data: {
+          createdAt: snapshots,
+          nodes: [
+            { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 402, height: 874 } },
+            {
+              index: 1,
+              parentIndex: 0,
+              type: 'ScrollView',
+              rect: { x: 0, y: 100, width: 402, height: 650 },
+            },
+            ...(snapshots < 3
+              ? []
+              : [
+                  {
+                    index: 2,
+                    parentIndex: 1,
+                    type: 'Button',
+                    identifier: 'home-open-form',
+                    rect: { x: 20, y: 600, width: 180, height: 44 },
+                  },
+                ]),
+          ],
+        },
+      };
+    },
+    dependencies: makeDependencies(),
+    platform: 'ios',
+  });
+
+  await port.execute({
+    command: {
+      kind: 'scrollUntilVisible',
+      source: { line: 2 },
+      element: { id: 'home-open-form' },
+      direction: 'down',
+      timeout: 2_000,
+    },
+    generation: 0,
+    env: {},
+    invalidateObservation() {},
+  });
+
+  const gesture = requests.find(({ command }) => command === 'gesture');
+  expect(gesture).toMatchObject({
+    input: {
+      kind: 'pan',
+      origin: { x: 201, y: 620 },
+      delta: { x: 0, y: -390 },
+      durationMs: 601,
+    },
+    internal: { gestureViewport: { x: 0, y: 100, width: 402, height: 650 } },
+  });
+  expect(requests.some(({ command }) => command === 'scroll')).toBe(false);
+});
+
 test('does not treat a target larger than the viewport as fully visible', async () => {
   const requests: DaemonRequest[] = [];
   let snapshots = 0;

--- a/src/compat/maestro/__tests__/daemon-runtime-port-observation-scroll.test.ts
+++ b/src/compat/maestro/__tests__/daemon-runtime-port-observation-scroll.test.ts
@@ -112,7 +112,7 @@ test('scrolls until the target is fully visible in the screen viewport', async (
   expect(result.observation?.identity).toMatch(/^maestro-observation-/);
 });
 
-test('scrolls inside the visible vertical container instead of the screen centre', async () => {
+test('uses Maestro swipeFromCenter semantics inside the visible vertical container', async () => {
   const requests: DaemonRequest[] = [];
   let snapshots = 0;
   const port = createDaemonMaestroRuntimePort({
@@ -169,13 +169,142 @@ test('scrolls inside the visible vertical container instead of the screen centre
   expect(gesture).toMatchObject({
     input: {
       kind: 'pan',
-      origin: { x: 201, y: 620 },
-      delta: { x: 0, y: -390 },
+      origin: { x: 201, y: 425 },
+      delta: { x: 0, y: -260 },
       durationMs: 601,
     },
     internal: { gestureViewport: { x: 0, y: 100, width: 402, height: 650 } },
   });
   expect(requests.some(({ command }) => command === 'scroll')).toBe(false);
+});
+
+test('ignores a larger scroll container that does not intersect the application viewport', async () => {
+  const requests: DaemonRequest[] = [];
+  let snapshots = 0;
+  const port = createDaemonMaestroRuntimePort({
+    baseReq: makeBaseRequest({ flags: { platform: 'ios', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      requests.push(request);
+      if (request.command !== 'snapshot') return { ok: true, data: {} };
+      snapshots += 1;
+      return {
+        ok: true,
+        data: {
+          createdAt: snapshots,
+          nodes: [
+            { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 402, height: 874 } },
+            {
+              index: 1,
+              parentIndex: 0,
+              type: 'ScrollView',
+              rect: { x: 0, y: 1_000, width: 402, height: 1_400 },
+            },
+            {
+              index: 2,
+              parentIndex: 0,
+              type: 'ScrollView',
+              rect: { x: 0, y: 100, width: 402, height: 650 },
+            },
+            ...(snapshots < 3
+              ? []
+              : [
+                  {
+                    index: 3,
+                    parentIndex: 2,
+                    type: 'Button',
+                    identifier: 'home-open-form',
+                    rect: { x: 20, y: 600, width: 180, height: 44 },
+                  },
+                ]),
+          ],
+        },
+      };
+    },
+    dependencies: makeDependencies(),
+    platform: 'ios',
+  });
+
+  await port.execute({
+    command: {
+      kind: 'scrollUntilVisible',
+      source: { line: 2 },
+      element: { id: 'home-open-form' },
+      direction: 'down',
+      timeout: 2_000,
+    },
+    generation: 0,
+    env: {},
+    invalidateObservation() {},
+  });
+
+  expect(requests.find(({ command }) => command === 'gesture')).toMatchObject({
+    input: { origin: { x: 201, y: 425 }, delta: { x: 0, y: -260 } },
+    internal: { gestureViewport: { x: 0, y: 100, width: 402, height: 650 } },
+  });
+});
+
+test("prefers the target's visible nested scroll container over its visible ancestor", async () => {
+  const requests: DaemonRequest[] = [];
+  let snapshots = 0;
+  const port = createDaemonMaestroRuntimePort({
+    baseReq: makeBaseRequest({ flags: { platform: 'ios', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      requests.push(request);
+      if (request.command !== 'snapshot') return { ok: true, data: {} };
+      snapshots += 1;
+      return {
+        ok: true,
+        data: {
+          createdAt: snapshots,
+          nodes: [
+            { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 402, height: 874 } },
+            {
+              index: 1,
+              parentIndex: 0,
+              type: 'ScrollView',
+              rect: { x: 0, y: 100, width: 402, height: 650 },
+            },
+            {
+              index: 2,
+              parentIndex: 1,
+              type: 'ScrollView',
+              rect: { x: 40, y: 200, width: 322, height: 450 },
+            },
+            {
+              index: 3,
+              parentIndex: 2,
+              type: 'Button',
+              identifier: 'nested-target',
+              rect:
+                snapshots < 3
+                  ? { x: 60, y: 900, width: 180, height: 44 }
+                  : { x: 60, y: 500, width: 180, height: 44 },
+            },
+          ],
+        },
+      };
+    },
+    dependencies: makeDependencies(),
+    platform: 'ios',
+  });
+
+  await port.execute({
+    command: {
+      kind: 'scrollUntilVisible',
+      source: { line: 2 },
+      element: { id: 'nested-target' },
+      direction: 'down',
+      timeout: 2_000,
+    },
+    generation: 0,
+    env: {},
+    invalidateObservation() {},
+  });
+
+  expect(requests.find(({ command }) => command === 'gesture')).toMatchObject({
+    input: { origin: { x: 201, y: 425 }, delta: { x: 0, y: -180 } },
+    internal: { gestureViewport: { x: 40, y: 200, width: 322, height: 450 } },
+  });
 });
 
 test('does not treat a target larger than the viewport as fully visible', async () => {

--- a/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
+++ b/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
@@ -137,6 +137,36 @@ test('excludes an in-viewport Android scrollable that is hidden from the user', 
   });
 });
 
+test('derives an Android viewport from visible scroll containers when roots are omitted', () => {
+  const snapshot = {
+    createdAt: 0,
+    nodes: [
+      {
+        index: 0,
+        ref: '@e1',
+        type: 'android.widget.ScrollView',
+        visibleToUser: true,
+        rect: { x: 0, y: 0, width: 1344, height: 2992 },
+      },
+      {
+        index: 1,
+        ref: '@e2',
+        parentIndex: 0,
+        type: 'android.widget.ScrollView',
+        visibleToUser: true,
+        rect: { x: 54, y: 159, width: 1236, height: 2449 },
+      },
+    ],
+  };
+
+  expect(
+    resolveMaestroScrollableGesture(snapshot, { id: 'home-open-form' }, 'down', 600, 'android'),
+  ).toEqual({
+    gesture: { from: { x: 672, y: 1496 }, to: { x: 672, y: 299 }, durationMs: 600 },
+    viewport: { x: 0, y: 0, width: 1344, height: 2992 },
+  });
+});
+
 test('does not associate a selector in an Android hidden scroll subtree', () => {
   const snapshot = {
     createdAt: 0,

--- a/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
+++ b/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
@@ -90,11 +90,92 @@ test('scrollUntilVisible matches Maestro swipeFromCenter endpoints for an app-si
     ],
   };
 
-  expect(resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'up', 601)).toEqual({
+  expect(resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'up', 601, 'ios')).toEqual({
     gesture: { from: { x: 201, y: 437 }, to: { x: 201, y: 786 }, durationMs: 601 },
     viewport: { x: 0, y: 0, width: 402, height: 874 },
   });
-  expect(resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'down', 601)).toMatchObject({
+  expect(
+    resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'down', 601, 'ios'),
+  ).toMatchObject({
     gesture: { from: { x: 201, y: 437 }, to: { x: 201, y: 87 } },
   });
+});
+
+test('excludes an in-viewport Android scrollable that is hidden from the user', () => {
+  const snapshot = {
+    createdAt: 0,
+    nodes: [
+      {
+        index: 0,
+        ref: '@e1',
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+      },
+      {
+        index: 1,
+        ref: '@e2',
+        parentIndex: 0,
+        type: 'ScrollView',
+        visibleToUser: false,
+        rect: { x: 0, y: 0, width: 402, height: 800 },
+      },
+      {
+        index: 2,
+        ref: '@e3',
+        parentIndex: 0,
+        type: 'ScrollView',
+        visibleToUser: true,
+        rect: { x: 0, y: 100, width: 402, height: 650 },
+      },
+    ],
+  };
+
+  expect(
+    resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'down', 601, 'android'),
+  ).toMatchObject({
+    viewport: { x: 0, y: 100, width: 402, height: 650 },
+  });
+});
+
+test('does not associate a selector in an Android hidden scroll subtree', () => {
+  const snapshot = {
+    createdAt: 0,
+    nodes: [
+      {
+        index: 0,
+        ref: '@e1',
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+      },
+      {
+        index: 1,
+        ref: '@e2',
+        parentIndex: 0,
+        type: 'ScrollView',
+        visibleToUser: false,
+        rect: { x: 0, y: 0, width: 402, height: 800 },
+      },
+      {
+        index: 2,
+        ref: '@e3',
+        parentIndex: 1,
+        type: 'Button',
+        identifier: 'hidden-target',
+        visibleToUser: false,
+        rect: { x: 20, y: 700, width: 180, height: 44 },
+      },
+      {
+        index: 3,
+        ref: '@e4',
+        parentIndex: 0,
+        type: 'ScrollView',
+        visibleToUser: true,
+        rect: { x: 0, y: 100, width: 402, height: 650 },
+      },
+    ],
+  };
+
+  expect(
+    resolveMaestroScrollableGesture(snapshot, { id: 'hidden-target' }, 'down', 601, 'android'),
+  ).toMatchObject({ viewport: { x: 0, y: 100, width: 402, height: 650 } });
 });

--- a/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
+++ b/src/compat/maestro/__tests__/runtime-port-geometry.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'vitest';
-import { resolveMaestroCoordinate } from '../runtime-port-geometry.ts';
+import { describe, expect, test } from 'vitest';
+import {
+  resolveMaestroCoordinate,
+  resolveMaestroScrollableGesture,
+} from '../runtime-port-geometry.ts';
 
 // Bug class 1 (#1217), runtime half: upstream Maestro converts percentage
 // coordinates to pixels by integer division (Maestro.kt), so the result is
@@ -61,5 +64,37 @@ describe('resolveMaestroCoordinate percentage conversion', () => {
       viewport(1125, 2436),
     );
     assert.deepEqual(point, { x: 100, y: 200 });
+  });
+});
+
+test('scrollUntilVisible matches Maestro swipeFromCenter endpoints for an app-sized viewport', () => {
+  // Maestro 2.5.1: Orchestra.scrollUntilVisible converts ScrollDirection to the
+  // opposite SwipeDirection, then calls Maestro.swipeFromCenter. Mobile drivers
+  // use 10%/90% axis endpoints.
+  const snapshot = {
+    createdAt: 0,
+    nodes: [
+      {
+        index: 0,
+        ref: '@e1',
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+      },
+      {
+        index: 1,
+        ref: '@e2',
+        parentIndex: 0,
+        type: 'ScrollView',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+      },
+    ],
+  };
+
+  expect(resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'up', 601)).toEqual({
+    gesture: { from: { x: 201, y: 437 }, to: { x: 201, y: 786 }, durationMs: 601 },
+    viewport: { x: 0, y: 0, width: 402, height: 874 },
+  });
+  expect(resolveMaestroScrollableGesture(snapshot, { id: 'missing' }, 'down', 601)).toMatchObject({
+    gesture: { from: { x: 201, y: 437 }, to: { x: 201, y: 87 } },
   });
 });

--- a/src/compat/maestro/compatibility-policy.ts
+++ b/src/compat/maestro/compatibility-policy.ts
@@ -45,6 +45,12 @@ export const MAESTRO_COMPATIBILITY_PRESETS = {
     downStartFraction: 0.2,
     upStartFraction: { android: 0.5, ios: 0.9 },
   },
+  // Maestro.swipeFromCenter delegates to driver.swipe(center, direction).
+  // Both mobile drivers use these axis-edge fractions for that overload.
+  scrollUntilVisibleSwipe: {
+    nearEdgeFraction: 0.1,
+    farEdgeFraction: 0.9,
+  },
 } as const;
 
 export function maestroScrollDurationFromSpeed(speed: number): number {

--- a/src/compat/maestro/daemon-runtime-port-observation.ts
+++ b/src/compat/maestro/daemon-runtime-port-observation.ts
@@ -160,7 +160,7 @@ export async function scrollUntilTypedMaestroTarget(params: {
   readonly timeoutMs: number;
   readonly context: MaestroRuntimeReadContext;
   readonly snapshot: MaestroSnapshotReader;
-  readonly scroll: (remainingMs: number) => Promise<SnapshotState>;
+  readonly scroll: (remainingMs: number, snapshot: SnapshotState) => Promise<SnapshotState>;
   readonly dependencies: DaemonMaestroRuntimeDependencies;
   readonly platform: Extract<MaestroPlatform, 'ios' | 'android'>;
 }): Promise<MaestroTargetMatch> {
@@ -190,7 +190,7 @@ export async function scrollUntilTypedMaestroTarget(params: {
 
     const remaining = deadline - params.dependencies.now();
     if (remaining > 0) {
-      settledSnapshot = await params.scroll(remaining);
+      settledSnapshot = await params.scroll(remaining, snapshot);
     }
   }
 

--- a/src/compat/maestro/daemon-runtime-port.ts
+++ b/src/compat/maestro/daemon-runtime-port.ts
@@ -239,6 +239,7 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
             input.selector,
             input.direction,
             input.durationMs,
+            platform,
           );
           await invokeMutation(
             gesture

--- a/src/compat/maestro/daemon-runtime-port.ts
+++ b/src/compat/maestro/daemon-runtime-port.ts
@@ -236,6 +236,7 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
         scroll: async (remainingMs, snapshot) => {
           const gesture = resolveMaestroScrollableGesture(
             snapshot,
+            input.selector,
             input.direction,
             input.durationMs,
           );

--- a/src/compat/maestro/daemon-runtime-port.ts
+++ b/src/compat/maestro/daemon-runtime-port.ts
@@ -34,6 +34,7 @@ import type {
   MaestroTargetQuery,
 } from './runtime-port-types.ts';
 import { pointInsideRect } from '../../utils/rect-center.ts';
+import { resolveMaestroScrollableGesture } from './runtime-port-geometry.ts';
 import {
   MAESTRO_OBSERVATION_POLL_MS,
   captureRetriableMaestroSnapshot,
@@ -232,13 +233,20 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
         snapshot: snapshots.capture,
         dependencies: options.dependencies,
         platform,
-        scroll: async (remainingMs) => {
+        scroll: async (remainingMs, snapshot) => {
+          const gesture = resolveMaestroScrollableGesture(
+            snapshot,
+            input.direction,
+            input.durationMs,
+          );
           await invokeMutation(
-            {
-              kind: 'scroll',
-              direction: input.direction,
-              durationMs: input.durationMs,
-            },
+            gesture
+              ? { kind: 'swipe', ...gesture }
+              : {
+                  kind: 'scroll',
+                  direction: input.direction,
+                  durationMs: input.durationMs,
+                },
             context,
           );
           return (

--- a/src/compat/maestro/runtime-port-geometry.ts
+++ b/src/compat/maestro/runtime-port-geometry.ts
@@ -18,7 +18,11 @@ import type {
 } from './program-ir.ts';
 import { operationContext } from './runtime-port-context.ts';
 import { resolveMaestroTarget } from './runtime-port-observation.ts';
-import { matchesMaestroTypedSelector } from './runtime-target-policy.ts';
+import {
+  filterVisibleMaestroMatches,
+  matchesMaestroTypedSelector,
+  type MaestroPlatform,
+} from './runtime-target-policy.ts';
 import type {
   MaestroRuntimeOperations,
   MaestroSinglePointerGestureInput,
@@ -37,8 +41,9 @@ export function resolveMaestroScrollableGesture(
   selector: MaestroSelector,
   direction: MaestroDirection,
   durationMs: number,
+  platform: MaestroPlatform,
 ): { gesture: MaestroSinglePointerGestureInput; viewport: Rect } | undefined {
-  const viewport = selectMaestroScrollableViewport(snapshot, selector, direction);
+  const viewport = selectMaestroScrollableViewport(snapshot, selector, direction, platform);
   if (!viewport) return undefined;
   const { start, end } = maestroScrollUntilVisibleEndpoints(viewport, direction);
   return {
@@ -55,12 +60,18 @@ function selectMaestroScrollableViewport(
   snapshot: SnapshotState,
   selector: MaestroSelector,
   direction: MaestroDirection,
+  platform: MaestroPlatform,
 ): Rect | undefined {
   const applicationViewport = findLargestViewportRect(snapshot.nodes);
   if (!applicationViewport || !isPositiveFiniteRect(applicationViewport)) return undefined;
   const vertical = direction === 'up' || direction === 'down';
-  const candidates = snapshot.nodes.flatMap((node) => {
-    if (!isScrollableSnapshotType(node.type) || !isPositiveFiniteRect(node.rect)) return [];
+  const scrollable = filterVisibleMaestroMatches({
+    nodes: snapshot.nodes,
+    matches: snapshot.nodes.filter((node) => isScrollableSnapshotType(node.type)),
+    platform,
+  });
+  const candidates = scrollable.flatMap((node) => {
+    if (!isPositiveFiniteRect(node.rect)) return [];
     const viewport = intersectRects(node.rect, applicationViewport);
     if (
       !viewport ||

--- a/src/compat/maestro/runtime-port-geometry.ts
+++ b/src/compat/maestro/runtime-port-geometry.ts
@@ -1,17 +1,24 @@
 import { AppError } from '../../kernel/errors.ts';
-import {
-  buildInPageSwipeGesturePlan,
-  buildScrollGesturePlan,
-} from '../../contracts/scroll-gesture.ts';
+import { buildInPageSwipeGesturePlan } from '../../contracts/scroll-gesture.ts';
 import { isPositiveFiniteRect } from '../../kernel/rect.ts';
 import type { Rect, SnapshotState } from '../../kernel/snapshot.ts';
-import { isScrollableSnapshotType } from '../../daemon/snapshot-presentation/tree.ts';
+import {
+  findLargestViewportRect,
+  findNearestScrollableContainer,
+  isScrollableSnapshotType,
+} from '../../daemon/snapshot-presentation/tree.ts';
 import { pointInsideRect } from '../../utils/rect-center.ts';
 import { MAESTRO_COMPATIBILITY_PRESETS } from './compatibility-policy.ts';
 import type { MaestroRuntimeRequest } from './engine-types.ts';
-import type { MaestroCoordinate, MaestroDirection, MaestroSwipeGesture } from './program-ir.ts';
+import type {
+  MaestroCoordinate,
+  MaestroDirection,
+  MaestroSelector,
+  MaestroSwipeGesture,
+} from './program-ir.ts';
 import { operationContext } from './runtime-port-context.ts';
 import { resolveMaestroTarget } from './runtime-port-observation.ts';
+import { matchesMaestroTypedSelector } from './runtime-target-policy.ts';
 import type {
   MaestroRuntimeOperations,
   MaestroSinglePointerGestureInput,
@@ -20,26 +27,24 @@ import type {
 } from './runtime-port-types.ts';
 
 /**
- * Builds a scroll gesture inside the largest visible container compatible with
- * the requested axis. A plain screen-centred scroll can start in an unrelated
- * nested gesture surface, leaving the intended list stationary.
+ * Builds a Maestro-compatible scroll gesture inside a visible scrollable
+ * viewport. Prefer the nearest eligible scrollable ancestor of a matching
+ * target; otherwise use the largest eligible visible container. This avoids
+ * beginning a screen-centred swipe in an unrelated nested gesture surface.
  */
 export function resolveMaestroScrollableGesture(
   snapshot: SnapshotState,
+  selector: MaestroSelector,
   direction: MaestroDirection,
   durationMs: number,
 ): { gesture: MaestroSinglePointerGestureInput; viewport: Rect } | undefined {
-  const viewport = selectMaestroScrollableViewport(snapshot, direction);
+  const viewport = selectMaestroScrollableViewport(snapshot, selector, direction);
   if (!viewport) return undefined;
-  const plan = buildScrollGesturePlan({
-    direction,
-    referenceWidth: viewport.width,
-    referenceHeight: viewport.height,
-  });
+  const { start, end } = maestroScrollUntilVisibleEndpoints(viewport, direction);
   return {
     gesture: {
-      from: { x: viewport.x + plan.x1, y: viewport.y + plan.y1 },
-      to: { x: viewport.x + plan.x2, y: viewport.y + plan.y2 },
+      from: start,
+      to: end,
       durationMs,
     },
     viewport,
@@ -48,19 +53,75 @@ export function resolveMaestroScrollableGesture(
 
 function selectMaestroScrollableViewport(
   snapshot: SnapshotState,
+  selector: MaestroSelector,
   direction: MaestroDirection,
 ): Rect | undefined {
+  const applicationViewport = findLargestViewportRect(snapshot.nodes);
+  if (!applicationViewport || !isPositiveFiniteRect(applicationViewport)) return undefined;
   const vertical = direction === 'up' || direction === 'down';
-  const scrollable = snapshot.nodes
-    .filter((node) => isScrollableSnapshotType(node.type))
-    .map((node) => node.rect)
-    .filter((rect): rect is Rect => Boolean(rect && isPositiveFiniteRect(rect)))
-    .filter((rect) => (vertical ? rect.height > rect.width : rect.width >= rect.height));
-  return scrollable.sort(compareRectAreaDescending)[0];
+  const candidates = snapshot.nodes.flatMap((node) => {
+    if (!isScrollableSnapshotType(node.type) || !isPositiveFiniteRect(node.rect)) return [];
+    const viewport = intersectRects(node.rect, applicationViewport);
+    if (
+      !viewport ||
+      (vertical ? viewport.height <= viewport.width : viewport.width < viewport.height)
+    ) {
+      return [];
+    }
+    return [{ node, viewport }];
+  });
+  const byIndex = new Map(snapshot.nodes.map((node) => [node.index, node]));
+  const candidateByIndex = new Map(
+    candidates.map((candidate) => [candidate.node.index, candidate]),
+  );
+  for (const target of snapshot.nodes.filter((node) =>
+    matchesMaestroTypedSelector(node, selector),
+  )) {
+    const container = findNearestScrollableContainer(target, byIndex, { includeSelf: true });
+    const candidate = container ? candidateByIndex.get(container.index) : undefined;
+    if (candidate) return candidate.viewport;
+  }
+  return candidates.sort(compareViewportAreaDescending)[0]?.viewport;
 }
 
-function compareRectAreaDescending(left: Rect, right: Rect): number {
-  return right.width * right.height - left.width * left.height;
+function intersectRects(left: Rect, right: Rect): Rect | undefined {
+  const x = Math.max(left.x, right.x);
+  const y = Math.max(left.y, right.y);
+  const width = Math.min(left.x + left.width, right.x + right.width) - x;
+  const height = Math.min(left.y + left.height, right.y + right.height) - y;
+  return width > 0 && height > 0 ? { x, y, width, height } : undefined;
+}
+
+function compareViewportAreaDescending(
+  left: { readonly viewport: Rect },
+  right: { readonly viewport: Rect },
+): number {
+  return right.viewport.width * right.viewport.height - left.viewport.width * left.viewport.height;
+}
+
+function maestroScrollUntilVisibleEndpoints(
+  viewport: Rect,
+  direction: MaestroDirection,
+): { start: { x: number; y: number }; end: { x: number; y: number } } {
+  // Maestro 2.5.1 Orchestra converts ScrollDirection to the opposite
+  // SwipeDirection, then calls Maestro.swipeFromCenter. The iOS and Android
+  // drivers start at that center and end at 10% or 90% of the active axis. For
+  // a screen-sized viewport this is the exact upstream gesture. A selected
+  // scroll container keeps the same semantics while ensuring the origin belongs
+  // to the scroll target.
+  const center = pointInViewport(viewport, 0.5, 0.5);
+  const near = MAESTRO_COMPATIBILITY_PRESETS.scrollUntilVisibleSwipe.nearEdgeFraction;
+  const far = MAESTRO_COMPATIBILITY_PRESETS.scrollUntilVisibleSwipe.farEdgeFraction;
+  switch (direction) {
+    case 'up':
+      return { start: center, end: pointInViewport(viewport, 0.5, far) };
+    case 'down':
+      return { start: center, end: pointInViewport(viewport, 0.5, near) };
+    case 'left':
+      return { start: center, end: pointInViewport(viewport, far, 0.5) };
+    case 'right':
+      return { start: center, end: pointInViewport(viewport, near, 0.5) };
+  }
 }
 
 export async function resolveMaestroSwipeOperation(

--- a/src/compat/maestro/runtime-port-geometry.ts
+++ b/src/compat/maestro/runtime-port-geometry.ts
@@ -1,5 +1,11 @@
 import { AppError } from '../../kernel/errors.ts';
-import { buildInPageSwipeGesturePlan } from '../../contracts/scroll-gesture.ts';
+import {
+  buildInPageSwipeGesturePlan,
+  buildScrollGesturePlan,
+} from '../../contracts/scroll-gesture.ts';
+import { isPositiveFiniteRect } from '../../kernel/rect.ts';
+import type { Rect, SnapshotState } from '../../kernel/snapshot.ts';
+import { isScrollableSnapshotType } from '../../daemon/snapshot-presentation/tree.ts';
 import { pointInsideRect } from '../../utils/rect-center.ts';
 import { MAESTRO_COMPATIBILITY_PRESETS } from './compatibility-policy.ts';
 import type { MaestroRuntimeRequest } from './engine-types.ts';
@@ -12,6 +18,50 @@ import type {
   MaestroSwipeOperation,
   MaestroTargetResolution,
 } from './runtime-port-types.ts';
+
+/**
+ * Builds a scroll gesture inside the largest visible container compatible with
+ * the requested axis. A plain screen-centred scroll can start in an unrelated
+ * nested gesture surface, leaving the intended list stationary.
+ */
+export function resolveMaestroScrollableGesture(
+  snapshot: SnapshotState,
+  direction: MaestroDirection,
+  durationMs: number,
+): { gesture: MaestroSinglePointerGestureInput; viewport: Rect } | undefined {
+  const viewport = selectMaestroScrollableViewport(snapshot, direction);
+  if (!viewport) return undefined;
+  const plan = buildScrollGesturePlan({
+    direction,
+    referenceWidth: viewport.width,
+    referenceHeight: viewport.height,
+  });
+  return {
+    gesture: {
+      from: { x: viewport.x + plan.x1, y: viewport.y + plan.y1 },
+      to: { x: viewport.x + plan.x2, y: viewport.y + plan.y2 },
+      durationMs,
+    },
+    viewport,
+  };
+}
+
+function selectMaestroScrollableViewport(
+  snapshot: SnapshotState,
+  direction: MaestroDirection,
+): Rect | undefined {
+  const vertical = direction === 'up' || direction === 'down';
+  const scrollable = snapshot.nodes
+    .filter((node) => isScrollableSnapshotType(node.type))
+    .map((node) => node.rect)
+    .filter((rect): rect is Rect => Boolean(rect && isPositiveFiniteRect(rect)))
+    .filter((rect) => (vertical ? rect.height > rect.width : rect.width >= rect.height));
+  return scrollable.sort(compareRectAreaDescending)[0];
+}
+
+function compareRectAreaDescending(left: Rect, right: Rect): number {
+  return right.width * right.height - left.width * left.height;
+}
 
 export async function resolveMaestroSwipeOperation(
   authored: MaestroSwipeGesture,

--- a/src/compat/maestro/runtime-port-geometry.ts
+++ b/src/compat/maestro/runtime-port-geometry.ts
@@ -62,14 +62,15 @@ function selectMaestroScrollableViewport(
   direction: MaestroDirection,
   platform: MaestroPlatform,
 ): Rect | undefined {
-  const applicationViewport = findLargestViewportRect(snapshot.nodes);
-  if (!applicationViewport || !isPositiveFiniteRect(applicationViewport)) return undefined;
   const vertical = direction === 'up' || direction === 'down';
   const scrollable = filterVisibleMaestroMatches({
     nodes: snapshot.nodes,
     matches: snapshot.nodes.filter((node) => isScrollableSnapshotType(node.type)),
     platform,
   });
+  const applicationViewport =
+    findLargestViewportRect(snapshot.nodes) ?? findLargestPositiveRect(scrollable);
+  if (!applicationViewport || !isPositiveFiniteRect(applicationViewport)) return undefined;
   const candidates = scrollable.flatMap((node) => {
     if (!isPositiveFiniteRect(node.rect)) return [];
     const viewport = intersectRects(node.rect, applicationViewport);
@@ -93,6 +94,21 @@ function selectMaestroScrollableViewport(
     if (candidate) return candidate.viewport;
   }
   return candidates.sort(compareViewportAreaDescending)[0]?.viewport;
+}
+
+function findLargestPositiveRect(
+  nodes: readonly SnapshotState['nodes'][number][],
+): Rect | undefined {
+  let largest: Rect | undefined;
+  for (const node of nodes) {
+    if (
+      isPositiveFiniteRect(node.rect) &&
+      (!largest || node.rect.width * node.rect.height > largest.width * largest.height)
+    ) {
+      largest = node.rect;
+    }
+  }
+  return largest;
 }
 
 function intersectRects(left: Rect, right: Rect): Rect | undefined {


### PR DESCRIPTION
## Summary

Fixes #1299 by routing Maestro `scrollUntilVisible` gestures through the visible scroll container instead of the screen centre.

Removes the tracked differential waiver so `settle-after-tap` is enforced again.

## Validation

- Enforced iOS Maestro differential: Maestro pass / agent-device pass; tap settled in 499 ms.
- `pnpm maestro:conformance`
- `pnpm check:affected --base origin/main --run`
