### PR TITLE
fix(mcp): restore result and config parity

### DIFF
--- a/src/commands/command-metadata.ts
+++ b/src/commands/command-metadata.ts
@@ -37,6 +37,8 @@ export function isCommandName(name: string): name is CommandName {
   return commandMetadataMap.has(name as CommandName);
 }
 
+export function findCommandMetadata(name: CommandName): AnyCommandMetadata;
+export function findCommandMetadata(name: string): AnyCommandMetadata | undefined;
 export function findCommandMetadata(name: string): AnyCommandMetadata | undefined {
   return commandMetadataMap.get(name as CommandName);
 }

--- a/src/commands/command-surface.ts
+++ b/src/commands/command-surface.ts
@@ -7,16 +7,28 @@ const commandSurface = listCommandFamilyDefinitions();
 
 export type { BatchCommandName, CommandName };
 
+type CommandDefinitionFor<Name extends CommandName> = Extract<
+  CommandFamilyDefinition,
+  { name: Name }
+>;
+
+export type CommandExecutionResult<Name extends CommandName = CommandName> = Awaited<
+  ReturnType<CommandDefinitionFor<Name>['invoke']>
+>;
+
 const commandMap: ReadonlyMap<CommandName, CommandFamilyDefinition> = new Map(
   commandSurface.map((definition) => [definition.name, definition]),
 );
 
-export async function runCommand(
+export async function runCommand<Name extends CommandName>(
   client: AgentDeviceClient,
-  name: CommandName,
+  name: Name,
   input: unknown,
-): Promise<unknown> {
-  return await getCommandDefinition(name).invoke(client, input);
+): Promise<CommandExecutionResult<Name>> {
+  // The map is total over CommandName, but Map#get cannot retain the correlation
+  // between a runtime key and that definition's return type. Re-establish it at
+  // this single lookup seam; callers keep the per-command result type.
+  return (await getCommandDefinition(name).invoke(client, input)) as CommandExecutionResult<Name>;
 }
 
 /**

--- a/src/mcp/__tests__/command-tools-parity.test.ts
+++ b/src/mcp/__tests__/command-tools-parity.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import type { AgentDeviceClient } from '../../client/client-types.ts';
+import { createCommandToolExecutor, listCommandTools } from '../command-tools.ts';
+import { validateAgainstSchema } from './output-schema-validator.ts';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+const temporaryDirectories: string[] = [];
+
+test('MCP collection results use object envelopes without changing object results or text', async () => {
+  const results = {
+    devices: [
+      { id: 'device-1', name: 'iPhone', platform: 'ios', target: 'mobile', kind: 'device' },
+    ],
+    apps: ['com.example.app'],
+    wait: { message: 'Wait complete' },
+  } as const;
+  const executor = createCommandToolExecutor({
+    createClient: () => ({}) as AgentDeviceClient,
+    runCommand: async (_client, name) => results[name as keyof typeof results],
+  });
+
+  const devices = await executor.execute('devices', {});
+  const apps = await executor.execute('apps', {});
+  const wait = await executor.execute('wait', {});
+
+  assert.deepEqual(devices.structuredContent, { devices: results.devices });
+  assert.deepEqual(apps.structuredContent, { apps: results.apps });
+  assert.deepEqual(wait.structuredContent, results.wait);
+  assert.equal(devices.content[0]?.text, 'iPhone (ios device target=mobile)');
+  assert.equal(apps.content[0]?.text, 'com.example.app');
+
+  for (const [name, result] of [
+    ['devices', devices],
+    ['apps', apps],
+  ] as const) {
+    const schema = listCommandTools().find((tool) => tool.name === name)?.outputSchema;
+    assert.ok(schema, `${name} advertises an output schema`);
+    assert.deepEqual(validateAgainstSchema(result.structuredContent, schema), []);
+  }
+});
+
+test('MCP applies config-backed command defaults with explicit-input precedence and applicability', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-mcp-config-'));
+  temporaryDirectories.push(home);
+  const configuredXctestrun = path.join(home, 'configured.xctestrun');
+  fs.mkdirSync(path.join(home, '.agent-device'));
+  fs.writeFileSync(
+    path.join(home, '.agent-device', 'config.json'),
+    JSON.stringify({ iosXctestrunFile: configuredXctestrun, appsFilter: 'all' }),
+  );
+  vi.stubEnv('HOME', home);
+
+  const calls: unknown[] = [];
+  const client = {
+    capture: {
+      snapshot: async (input: unknown) => {
+        calls.push(input);
+        return { nodes: [], truncated: false };
+      },
+    },
+  } as unknown as AgentDeviceClient;
+  const executor = createCommandToolExecutor({
+    createClient: () => client,
+  });
+
+  await executor.execute('snapshot', {});
+  await executor.execute('snapshot', { iosXctestrunFile: '/explicit/runner.xctestrun' });
+
+  assert.deepEqual(calls, [
+    { iosXctestrunFile: configuredXctestrun },
+    { iosXctestrunFile: '/explicit/runner.xctestrun' },
+  ]);
+});

--- a/src/mcp/__tests__/command-tools-parity.test.ts
+++ b/src/mcp/__tests__/command-tools-parity.test.ts
@@ -10,12 +10,13 @@ import { validateAgainstSchema } from './output-schema-validator.ts';
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  for (const directory of temporaryDirectories.splice(0)) {
-    fs.rmSync(directory, { recursive: true, force: true });
+  if (temporaryDirectory) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
   }
 });
 
-const temporaryDirectories: string[] = [];
+let temporaryDirectory: string | undefined;
 
 test('MCP collection results use object envelopes without changing object results or text', async () => {
   const results = {
@@ -52,7 +53,7 @@ test('MCP collection results use object envelopes without changing object result
 
 test('MCP applies config-backed command defaults with explicit-input precedence and applicability', async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-mcp-config-'));
-  temporaryDirectories.push(home);
+  temporaryDirectory = home;
   const configuredXctestrun = path.join(home, 'configured.xctestrun');
   fs.mkdirSync(path.join(home, '.agent-device'));
   fs.writeFileSync(

--- a/src/mcp/__tests__/command-tools-parity.test.ts
+++ b/src/mcp/__tests__/command-tools-parity.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import { createAgentDeviceClient } from '../../agent-device-client.ts';
 import type { AgentDeviceClient, AgentDeviceDaemonTransport } from '../../client/client-types.ts';
+import type { CommandExecutionResult } from '../../commands/command-surface.ts';
 import { createCommandToolExecutor, listCommandTools } from '../command-tools.ts';
 import { validateAgainstSchema } from './output-schema-validator.ts';
 
@@ -21,11 +22,18 @@ let temporaryDirectory: string | undefined;
 test('MCP collection results use object envelopes without changing object results or text', async () => {
   const results = {
     devices: [
-      { id: 'device-1', name: 'iPhone', platform: 'ios', target: 'mobile', kind: 'device' },
+      {
+        id: 'device-1',
+        name: 'iPhone',
+        platform: 'ios',
+        target: 'mobile',
+        kind: 'device',
+        identifiers: {},
+      },
     ],
     apps: ['com.example.app'],
-    wait: { message: 'Wait complete' },
-  } as const;
+    wait: { waitedMs: 10 },
+  } satisfies Record<'devices' | 'apps' | 'wait', CommandExecutionResult>;
   const executor = createCommandToolExecutor({
     createClient: () => ({}) as AgentDeviceClient,
     runCommand: async (_client, name) => results[name as keyof typeof results],
@@ -35,7 +43,11 @@ test('MCP collection results use object envelopes without changing object result
   const apps = await executor.execute('apps', {});
   const wait = await executor.execute('wait', {});
 
-  assert.deepEqual(devices.structuredContent, { devices: results.devices });
+  assert.deepEqual(devices.structuredContent, {
+    devices: [
+      { id: 'device-1', name: 'iPhone', platform: 'ios', target: 'mobile', kind: 'device' },
+    ],
+  });
   assert.deepEqual(apps.structuredContent, { apps: results.apps });
   assert.deepEqual(wait.structuredContent, results.wait);
   assert.equal(devices.content[0]?.text, 'iPhone (ios device target=mobile)');

--- a/src/mcp/__tests__/command-tools-parity.test.ts
+++ b/src/mcp/__tests__/command-tools-parity.test.ts
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
-import type { AgentDeviceClient } from '../../client/client-types.ts';
+import { createAgentDeviceClient } from '../../agent-device-client.ts';
+import type { AgentDeviceClient, AgentDeviceDaemonTransport } from '../../client/client-types.ts';
 import { createCommandToolExecutor, listCommandTools } from '../command-tools.ts';
 import { validateAgainstSchema } from './output-schema-validator.ts';
 
@@ -60,24 +61,22 @@ test('MCP applies config-backed command defaults with explicit-input precedence 
   );
   vi.stubEnv('HOME', home);
 
-  const calls: unknown[] = [];
-  const client = {
-    capture: {
-      snapshot: async (input: unknown) => {
-        calls.push(input);
-        return { nodes: [], truncated: false };
-      },
-    },
-  } as unknown as AgentDeviceClient;
+  const calls: Array<Parameters<AgentDeviceDaemonTransport>[0]> = [];
+  const transport: AgentDeviceDaemonTransport = async (request) => {
+    calls.push(request);
+    return { ok: true, data: { nodes: [], truncated: false } };
+  };
   const executor = createCommandToolExecutor({
-    createClient: () => client,
+    createClient: (config) => createAgentDeviceClient(config, { transport }),
   });
 
   await executor.execute('snapshot', {});
   await executor.execute('snapshot', { iosXctestrunFile: '/explicit/runner.xctestrun' });
 
-  assert.deepEqual(calls, [
-    { iosXctestrunFile: configuredXctestrun },
-    { iosXctestrunFile: '/explicit/runner.xctestrun' },
-  ]);
+  assert.deepEqual(
+    calls.map((request) => request.flags?.iosXctestrunFile),
+    [configuredXctestrun, '/explicit/runner.xctestrun'],
+  );
+  assert.ok(calls.every((request) => request.command === 'snapshot'));
+  assert.ok(calls.every((request) => request.flags?.appsFilter === undefined));
 });

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -409,18 +409,13 @@ test('MCP prepare outputSchema stays complete for the typed non-exposed command'
   assert.ok(prepareSchema.required?.includes('timing'));
 });
 
-test('MCP untyped tools stay byte-identical: no outputSchema key', () => {
+test('MCP untyped object tools stay byte-identical: no outputSchema key', () => {
   const tools = listCommandTools();
 
   // snapshot is intentionally absent from the typed registry (dynamic shape).
   const snapshot = tools.find((tool) => tool.name === 'snapshot');
   assert.ok(snapshot);
   assert.equal('outputSchema' in snapshot, false);
-
-  // devices is likewise untyped.
-  const devices = tools.find((tool) => tool.name === 'devices');
-  assert.ok(devices);
-  assert.equal('outputSchema' in devices, false);
 });
 
 test('MCP boot structuredContent is consistent with its advertised outputSchema', async () => {

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -209,7 +209,7 @@ test('MCP includeCost:true opts into agent-cost: sets client.cost, strips the ar
     },
     runCommand: async (_client, name, input) => {
       calls.push({ name, input });
-      return { message: `Ran ${name}`, cost: { wallClockMs: 42 } };
+      return { waitedMs: 42, cost: { wallClockMs: 42, runnerRoundTrips: 0 } };
     },
   });
 
@@ -220,7 +220,10 @@ test('MCP includeCost:true opts into agent-cost: sets client.cost, strips the ar
   // includeCost is an MCP-boundary field and must not leak into the command input.
   assert.deepEqual(calls, [{ name: 'wait', input: {} }]);
   // The daemon-provided cost rides through structuredContent unchanged.
-  assert.deepEqual(result.structuredContent, { message: 'Ran wait', cost: { wallClockMs: 42 } });
+  assert.deepEqual(result.structuredContent, {
+    waitedMs: 42,
+    cost: { wallClockMs: 42, runnerRoundTrips: 0 },
+  });
 });
 
 test('MCP includeCost absent/false leaves the request shape untouched (no cost config)', async () => {

--- a/src/mcp/__tests__/router.test.ts
+++ b/src/mcp/__tests__/router.test.ts
@@ -45,6 +45,16 @@ test('MCP exposes every automatable CLI command as a structured direct tool', as
   assert.ok(invalidFillResponse && 'result' in invalidFillResponse);
   assert.equal((invalidFillResponse.result as { isError: boolean }).isError, true);
   assert.match(JSON.stringify(invalidFillResponse.result), /Expected target to be set/);
+
+  const malformedArgumentsResponse = await handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: { name: 'devices', arguments: [] },
+  });
+  assert.ok(malformedArgumentsResponse && 'result' in malformedArgumentsResponse);
+  assert.equal((malformedArgumentsResponse.result as { isError: boolean }).isError, true);
+  assert.match(JSON.stringify(malformedArgumentsResponse.result), /Expected object parameters/);
 });
 
 test('MCP JSON-RPC batches return responses in request order and skip notifications', async () => {

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -27,7 +27,7 @@ import { DEVICE_TARGETS, PUBLIC_PLATFORMS } from '../kernel/device.ts';
  *    and discriminated-union branches mirror the source contract types.
  */
 
-const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
+export const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
 
 function numberSchema(description?: string): JsonSchema {
   return { type: 'number', ...(description ? { description } : {}) };
@@ -649,35 +649,3 @@ export const COMMAND_OUTPUT_SCHEMAS = {
     ],
   },
 } satisfies Record<keyof CommandResultMap, JsonSchema>;
-
-/**
- * MCP-only envelopes for commands whose public Node results are arrays. MCP
- * requires structuredContent to be an object, while the Node and CLI contracts
- * intentionally keep their existing list shapes.
- */
-const MCP_COLLECTION_OUTPUT_SCHEMAS = {
-  devices: objectSchema(
-    {
-      devices: {
-        type: 'array',
-        items: objectSchema(
-          {
-            platform: enumSchema(PUBLIC_PLATFORMS),
-            target: enumSchema(DEVICE_TARGETS),
-            kind: enumSchema(DEVICE_KINDS),
-            id: stringSchema(),
-            name: stringSchema(),
-          },
-          ['platform', 'target', 'kind', 'id', 'name'],
-        ),
-      },
-    },
-    ['devices'],
-  ),
-  apps: objectSchema({ apps: stringArraySchema }, ['apps']),
-} as const satisfies Record<'devices' | 'apps', JsonSchema>;
-
-export const MCP_COMMAND_OUTPUT_SCHEMAS = {
-  ...COMMAND_OUTPUT_SCHEMAS,
-  ...MCP_COLLECTION_OUTPUT_SCHEMAS,
-} as const;

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -649,3 +649,35 @@ export const COMMAND_OUTPUT_SCHEMAS = {
     ],
   },
 } satisfies Record<keyof CommandResultMap, JsonSchema>;
+
+/**
+ * MCP-only envelopes for commands whose public Node results are arrays. MCP
+ * requires structuredContent to be an object, while the Node and CLI contracts
+ * intentionally keep their existing list shapes.
+ */
+const MCP_COLLECTION_OUTPUT_SCHEMAS = {
+  devices: objectSchema(
+    {
+      devices: {
+        type: 'array',
+        items: objectSchema(
+          {
+            platform: enumSchema(PUBLIC_PLATFORMS),
+            target: enumSchema(DEVICE_TARGETS),
+            kind: enumSchema(DEVICE_KINDS),
+            id: stringSchema(),
+            name: stringSchema(),
+          },
+          ['platform', 'target', 'kind', 'id', 'name'],
+        ),
+      },
+    },
+    ['devices'],
+  ),
+  apps: objectSchema({ apps: stringArraySchema }, ['apps']),
+} as const satisfies Record<'devices' | 'apps', JsonSchema>;
+
+export const MCP_COMMAND_OUTPUT_SCHEMAS = {
+  ...COMMAND_OUTPUT_SCHEMAS,
+  ...MCP_COLLECTION_OUTPUT_SCHEMAS,
+} as const;

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -1,5 +1,6 @@
 import type { AgentDeviceClient, AgentDeviceClientConfig } from '../client/client-types.ts';
 import type { JsonSchema } from '../commands/command-contract.ts';
+import type { CommandExecutionResult } from '../commands/command-surface.ts';
 import { RESPONSE_LEVELS, type ResponseLevel } from '../kernel/contracts.ts';
 import { formatCliOutput } from '../commands/cli-output.ts';
 import {
@@ -29,7 +30,7 @@ type CommandToolExecutorDeps = {
     client: AgentDeviceClient,
     name: CommandName,
     input: Record<string, unknown>,
-  ) => Promise<unknown>;
+  ) => Promise<CommandExecutionResult>;
 };
 
 type CommandToolExecutor = {
@@ -220,7 +221,7 @@ function mergeIssuedRefPins(
   refPinsByScope: Map<string, Map<string, number>>,
   scopeKey: string,
   name: CommandName,
-  result: unknown,
+  result: CommandExecutionResult,
 ): void {
   if (SETTLE_REF_ISSUING_TOOLS.has(name)) {
     mergeSettleIssuedRefPins(refPinsByScope, scopeKey, result);
@@ -253,7 +254,7 @@ function mergeIssuedRefPins(
 function mergeSettleIssuedRefPins(
   refPinsByScope: Map<string, Map<string, number>>,
   scopeKey: string,
-  result: unknown,
+  result: CommandExecutionResult,
 ): void {
   const settle = asOptionalRecord(asOptionalRecord(result)?.settle);
   if (!settle) return;
@@ -380,7 +381,7 @@ async function runCommand(
   client: AgentDeviceClient,
   name: CommandName,
   input: Record<string, unknown>,
-): Promise<unknown> {
+): Promise<CommandExecutionResult> {
   const commandSurface = await import('../commands/command-surface.ts');
   return await commandSurface.runCommand(client, name, input);
 }
@@ -483,7 +484,7 @@ function withMcpConfigSchema(name: CommandName, schema: JsonSchema): JsonSchema 
 function renderToolText(params: {
   name: CommandName;
   input: Record<string, unknown>;
-  result: unknown;
+  result: CommandExecutionResult;
   outputFormat: McpOutputFormat;
   responseLevel?: ResponseLevel;
 }): string {

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -9,7 +9,7 @@ import {
   type CommandName,
 } from '../commands/command-metadata.ts';
 import { resolveCommandRecordsSessionAction } from '../core/command-descriptor/registry.ts';
-import { MCP_COMMAND_OUTPUT_SCHEMAS } from './command-output-schemas.ts';
+import { MCP_COMMAND_OUTPUT_SCHEMAS } from './mcp-output-schemas.ts';
 import { AppError } from '../kernel/errors.ts';
 import { formatToolErrorText, normalizeToolError } from './tool-error.ts';
 import { resolveMcpConfigDefaults } from './tool-input-config.ts';
@@ -73,10 +73,9 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
         throw new AppError('INVALID_ARGS', `Unknown command tool: ${name}`);
       }
       const metadata = findCommandMetadata(name);
-      const supportedKeys = metadata
-        ? Object.keys(withMcpConfigSchema(name, metadata.inputSchema).properties ?? {})
-        : [];
-      const resolvedInput = resolveMcpConfigDefaults(name, input, supportedKeys);
+      if (!metadata) throw new Error(`Missing command metadata: ${name}`);
+      const supportedProperties = withMcpConfigSchema(name, metadata.inputSchema).properties ?? {};
+      const resolvedInput = resolveMcpConfigDefaults(name, input, supportedProperties);
       const config = readMcpToolConfig(resolvedInput);
       const commandInput = stripMcpConfigFields(resolvedInput);
       const scopeKey = readPinScopeKey(config, commandInput);

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -25,11 +25,15 @@ type CommandToolExecutorDeps = {
   createClient?: (
     config: AgentDeviceClientConfig,
   ) => AgentDeviceClient | Promise<AgentDeviceClient>;
-  runCommand?: (client: AgentDeviceClient, name: CommandName, input: unknown) => Promise<unknown>;
+  runCommand?: (
+    client: AgentDeviceClient,
+    name: CommandName,
+    input: Record<string, unknown>,
+  ) => Promise<unknown>;
 };
 
 type CommandToolExecutor = {
-  execute: (name: string, input: unknown) => Promise<ToolResult>;
+  execute: (name: string, input: Record<string, unknown>) => Promise<ToolResult>;
 };
 
 type McpOutputFormat = 'optimized' | 'json';
@@ -375,17 +379,13 @@ async function createClient(
 async function runCommand(
   client: AgentDeviceClient,
   name: CommandName,
-  input: unknown,
+  input: Record<string, unknown>,
 ): Promise<unknown> {
   const commandSurface = await import('../commands/command-surface.ts');
   return await commandSurface.runCommand(client, name, input);
 }
 
-function readMcpToolConfig(input: unknown): McpToolConfig {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    return { client: {}, outputFormat: 'optimized' };
-  }
-  const record = input as Record<string, unknown>;
+function readMcpToolConfig(record: Record<string, unknown>): McpToolConfig {
   return {
     client: readClientConfig(record),
     outputFormat: readMcpOutputFormat(record.mcpOutputFormat),

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -78,8 +78,7 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
         throw new AppError('INVALID_ARGS', `Unknown command tool: ${name}`);
       }
       const metadata = findCommandMetadata(name);
-      if (!metadata) throw new Error(`Missing command metadata: ${name}`);
-      const supportedProperties = withMcpConfigSchema(name, metadata.inputSchema).properties ?? {};
+      const supportedProperties = withMcpConfigSchema(name, metadata.inputSchema).properties;
       const resolvedInput = resolveMcpConfigDefaults(name, input, supportedProperties);
       const config = readMcpToolConfig(resolvedInput);
       const commandInput = stripMcpConfigFields(resolvedInput);
@@ -91,7 +90,7 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
         mergeIssuedRefPins(refPinsByScope, scopeKey, name, result);
         return {
           isError: false,
-          structuredContent: projectStructuredContent(name, commandInput, result),
+          structuredContent: projectStructuredContent(name, result),
           content: [
             {
               type: 'text',
@@ -228,9 +227,9 @@ function mergeIssuedRefPins(
     return;
   }
   if (!REF_ISSUING_TOOLS.has(name)) return;
-  const record = asOptionalRecord(result);
-  const refsGeneration = record?.refsGeneration;
-  if (record === undefined || typeof refsGeneration !== 'number') {
+  const record = result as CommandExecutionResult<'snapshot' | 'find'>;
+  const refsGeneration = record.refsGeneration;
+  if (typeof refsGeneration !== 'number') {
     // ADR 0014: a MUTATING find returns its acted ref as diagnostic pre-action
     // identity WITHOUT `refsGeneration` — it is explicitly non-issuing and must
     // leave remembered pins untouched (forwarding the old pin on a later ref is
@@ -256,11 +255,14 @@ function mergeSettleIssuedRefPins(
   scopeKey: string,
   result: CommandExecutionResult,
 ): void {
-  const settle = asOptionalRecord(asOptionalRecord(result)?.settle);
+  const interactionResult = result as CommandExecutionResult<
+    'press' | 'click' | 'fill' | 'longpress'
+  >;
+  const settle = asOptionalRecord(interactionResult.settle);
   if (!settle) return;
-  const refsGeneration = settle?.refsGeneration;
+  const refsGeneration = settle.refsGeneration;
   if (typeof refsGeneration !== 'number') return;
-  const lines = asOptionalRecord(settle?.diff)?.lines;
+  const lines = asOptionalRecord(settle.diff)?.lines;
   const issuedRefs: string[] = [];
   collectRefBodies(lines, issuedRefs);
   collectRefBodies(settle.refs, issuedRefs);
@@ -292,9 +294,7 @@ function recordIssuedPins(
     pins.set(ref, refsGeneration);
   }
   while (pins.size > MAX_REF_PINS_PER_SCOPE) {
-    const oldest = pins.keys().next().value;
-    if (oldest === undefined) break;
-    pins.delete(oldest);
+    pins.delete(pins.keys().next().value!);
   }
 }
 
@@ -398,16 +398,20 @@ function readClientConfig(record: Record<string, unknown>): AgentDeviceClientCon
   const includeCost = record.includeCost;
   const responseLevel = record.responseLevel;
   const client: AgentDeviceClientConfig = {};
-  if (stateDir !== undefined && (typeof stateDir !== 'string' || stateDir.length === 0)) {
-    throw new AppError('INVALID_ARGS', 'Expected stateDir to be a non-empty string.');
+  if (stateDir !== undefined) {
+    if (typeof stateDir !== 'string' || stateDir.length === 0) {
+      throw new AppError('INVALID_ARGS', 'Expected stateDir to be a non-empty string.');
+    }
+    client.stateDir = stateDir;
   }
-  if (typeof stateDir === 'string') client.stateDir = stateDir;
-  if (includeCost !== undefined && typeof includeCost !== 'boolean') {
-    throw new AppError('INVALID_ARGS', 'Expected includeCost to be a boolean.');
+  if (includeCost !== undefined) {
+    if (typeof includeCost !== 'boolean') {
+      throw new AppError('INVALID_ARGS', 'Expected includeCost to be a boolean.');
+    }
+    // Only set when explicitly true so the default request shape is untouched
+    // (cost rides on response.data → structuredContent only when opted in).
+    if (includeCost) client.cost = true;
   }
-  // Only set when explicitly true so the default request shape is untouched
-  // (cost rides on response.data → structuredContent only when opted in).
-  if (includeCost === true) client.cost = true;
   // Only set when it names a known level so the default request shape is
   // untouched (responseLevel rides on meta.responseLevel only when opted in).
   const level = readResponseLevel(responseLevel);
@@ -445,7 +449,10 @@ function stripMcpConfigFields(input: Record<string, unknown>): Record<string, un
   return commandInput;
 }
 
-function withMcpConfigSchema(name: CommandName, schema: JsonSchema): JsonSchema {
+function withMcpConfigSchema(
+  name: CommandName,
+  schema: JsonSchema,
+): JsonSchema & { properties: Record<string, JsonSchema> } {
   const noRecord = resolveCommandRecordsSessionAction(name);
   return {
     ...schema,

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -73,10 +73,10 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
         throw new AppError('INVALID_ARGS', `Unknown command tool: ${name}`);
       }
       const metadata = findCommandMetadata(name);
-      const supportedProperties = metadata
-        ? (withMcpConfigSchema(name, metadata.inputSchema).properties ?? {})
-        : {};
-      const resolvedInput = resolveMcpConfigDefaults(name, input, supportedProperties);
+      const supportedKeys = metadata
+        ? Object.keys(withMcpConfigSchema(name, metadata.inputSchema).properties ?? {})
+        : [];
+      const resolvedInput = resolveMcpConfigDefaults(name, input, supportedKeys);
       const config = readMcpToolConfig(resolvedInput);
       const commandInput = stripMcpConfigFields(resolvedInput);
       const scopeKey = readPinScopeKey(config, commandInput);
@@ -199,9 +199,8 @@ const MAX_REF_PINS_PER_SCOPE = 1000;
  * state dirs — two same-named sessions there are different sessions and must
  * not cross-pollinate generations.
  */
-function readPinScopeKey(config: McpToolConfig, input: unknown): string {
-  const record = asOptionalRecord(input);
-  const session = record?.session;
+function readPinScopeKey(config: McpToolConfig, input: Record<string, unknown>): string {
+  const session = input.session;
   const sessionName = typeof session === 'string' && session.length > 0 ? session : 'default';
   // NUL separator: neither state-dir paths nor session names contain it.
   return `${config.client.stateDir ?? ''}\u0000${sessionName}`;
@@ -319,15 +318,13 @@ function collectRefBodies(entries: unknown, into: string[]): void {
 
 function pinPlainRefArguments(
   name: CommandName,
-  input: unknown,
+  input: Record<string, unknown>,
   pins: Map<string, number> | undefined,
-): unknown {
+): Record<string, unknown> {
   // No remembered pins for this scope → pass refs through unpinned.
   if (pins === undefined || pins.size === 0) return input;
-  const record = asOptionalRecord(input);
-  if (!record) return input;
-  if (name === 'wait') return pinWaitRef(record, pins) ?? input;
-  if (TARGET_REF_TOOLS.has(name)) return pinTargetRef(record, pins) ?? input;
+  if (name === 'wait') return pinWaitRef(input, pins) ?? input;
+  if (TARGET_REF_TOOLS.has(name)) return pinTargetRef(input, pins) ?? input;
   return input;
 }
 
@@ -437,15 +434,14 @@ function readMcpOutputFormat(outputFormat: unknown): McpOutputFormat {
   return outputFormat;
 }
 
-function stripMcpConfigFields(input: unknown): unknown {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+function stripMcpConfigFields(input: Record<string, unknown>): Record<string, unknown> {
   const {
     stateDir: _stateDir,
     mcpOutputFormat: _mcpOutputFormat,
     includeCost: _includeCost,
     responseLevel: _responseLevel,
     ...commandInput
-  } = input as Record<string, unknown>;
+  } = input;
   return commandInput;
 }
 
@@ -487,7 +483,7 @@ function withMcpConfigSchema(name: CommandName, schema: JsonSchema): JsonSchema 
 
 function renderToolText(params: {
   name: CommandName;
-  input: unknown;
+  input: Record<string, unknown>;
   result: unknown;
   outputFormat: McpOutputFormat;
   responseLevel?: ResponseLevel;

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -3,18 +3,21 @@ import type { JsonSchema } from '../commands/command-contract.ts';
 import { RESPONSE_LEVELS, type ResponseLevel } from '../kernel/contracts.ts';
 import { formatCliOutput } from '../commands/cli-output.ts';
 import {
+  findCommandMetadata,
   isCommandName,
   listMcpCommandMetadata,
   type CommandName,
 } from '../commands/command-metadata.ts';
 import { resolveCommandRecordsSessionAction } from '../core/command-descriptor/registry.ts';
-import { COMMAND_OUTPUT_SCHEMAS } from './command-output-schemas.ts';
+import { MCP_COMMAND_OUTPUT_SCHEMAS } from './command-output-schemas.ts';
 import { AppError } from '../kernel/errors.ts';
 import { formatToolErrorText, normalizeToolError } from './tool-error.ts';
+import { resolveMcpConfigDefaults } from './tool-input-config.ts';
+import { projectStructuredContent } from './tool-result.ts';
 
 export type ToolResult = {
   isError: boolean;
-  structuredContent?: unknown;
+  structuredContent?: Record<string, unknown>;
   content: Array<{ type: 'text'; text: string }>;
 };
 
@@ -46,8 +49,8 @@ export function listCommandTools(): Array<{
     // The registry is keyed by the typed-result commands only (CommandResultMap),
     // so guard the lookup; untyped tools resolve to no outputSchema.
     const outputSchema =
-      definition.name in COMMAND_OUTPUT_SCHEMAS
-        ? COMMAND_OUTPUT_SCHEMAS[definition.name as keyof typeof COMMAND_OUTPUT_SCHEMAS]
+      definition.name in MCP_COMMAND_OUTPUT_SCHEMAS
+        ? MCP_COMMAND_OUTPUT_SCHEMAS[definition.name as keyof typeof MCP_COMMAND_OUTPUT_SCHEMAS]
         : undefined;
     return {
       name: definition.name,
@@ -69,8 +72,13 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
       if (!isCommandName(name)) {
         throw new AppError('INVALID_ARGS', `Unknown command tool: ${name}`);
       }
-      const config = readMcpToolConfig(input);
-      const commandInput = stripMcpConfigFields(input);
+      const metadata = findCommandMetadata(name);
+      const supportedProperties = metadata
+        ? (withMcpConfigSchema(name, metadata.inputSchema).properties ?? {})
+        : {};
+      const resolvedInput = resolveMcpConfigDefaults(name, input, supportedProperties);
+      const config = readMcpToolConfig(resolvedInput);
+      const commandInput = stripMcpConfigFields(resolvedInput);
       const scopeKey = readPinScopeKey(config, commandInput);
       const pinnedInput = pinPlainRefArguments(name, commandInput, refPinsByScope.get(scopeKey));
       const client = await createClient(deps, config.client);
@@ -79,7 +87,7 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
         mergeIssuedRefPins(refPinsByScope, scopeKey, name, result);
         return {
           isError: false,
-          structuredContent: result,
+          structuredContent: projectStructuredContent(name, commandInput, result),
           content: [
             {
               type: 'text',

--- a/src/mcp/mcp-output-schemas.ts
+++ b/src/mcp/mcp-output-schemas.ts
@@ -1,0 +1,38 @@
+import type { JsonSchema } from '../commands/command-contract.ts';
+import { DEVICE_TARGETS, PUBLIC_PLATFORMS } from '../kernel/device.ts';
+import { COMMAND_OUTPUT_SCHEMAS, DEVICE_KINDS } from './command-output-schemas.ts';
+
+const MCP_COLLECTION_OUTPUT_SCHEMAS = {
+  devices: {
+    type: 'object',
+    properties: {
+      devices: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            platform: { type: 'string', enum: PUBLIC_PLATFORMS },
+            target: { type: 'string', enum: DEVICE_TARGETS },
+            kind: { type: 'string', enum: DEVICE_KINDS },
+            id: { type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['platform', 'target', 'kind', 'id', 'name'],
+        },
+      },
+    },
+    required: ['devices'],
+  },
+  apps: {
+    type: 'object',
+    properties: {
+      apps: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['apps'],
+  },
+} as const satisfies Record<'devices' | 'apps', JsonSchema>;
+
+export const MCP_COMMAND_OUTPUT_SCHEMAS = {
+  ...COMMAND_OUTPUT_SCHEMAS,
+  ...MCP_COLLECTION_OUTPUT_SCHEMAS,
+} as const;

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -65,7 +65,7 @@ async function callTool(params: unknown): Promise<ToolResult> {
     // Command-level failures are handled (and ref-pinned) by the executor's
     // own catch; this one covers failures outside a resolved command call
     // (unknown tool name, malformed params).
-    return await commandToolExecutor.execute(name, record.arguments);
+    return await commandToolExecutor.execute(name, optionalArguments(record.arguments));
   } catch (error) {
     return textToolResult(formatToolErrorText(normalizeToolError(error)), true);
   }
@@ -95,6 +95,10 @@ function asRecord(value: unknown): Record<string, unknown> {
     throw new AppError('INVALID_ARGS', 'Expected object parameters.');
   }
   return value as Record<string, unknown>;
+}
+
+function optionalArguments(value: unknown): Record<string, unknown> {
+  return value === undefined ? {} : asRecord(value);
 }
 
 function stringField(record: Record<string, unknown>, key: string): string {

--- a/src/mcp/tool-input-config.ts
+++ b/src/mcp/tool-input-config.ts
@@ -1,0 +1,30 @@
+import { isFlagSupportedForCommand } from '../cli-schema/option-schema.ts';
+import type { CliFlags, FlagKey } from '../commands/cli-grammar/flag-types.ts';
+import type { CommandName } from '../commands/command-metadata.ts';
+import { resolveConfigBackedFlagDefaults } from '../utils/cli-config.ts';
+import { mergeDefinedFlags } from '../utils/merge-flags.ts';
+
+export function resolveMcpConfigDefaults(
+  name: CommandName,
+  input: unknown,
+  supportedProperties: Record<string, unknown>,
+): Record<string, unknown> {
+  const explicitInput = asInputRecord(input);
+  const defaults = resolveConfigBackedFlagDefaults({
+    command: name,
+    cwd: process.cwd(),
+    cliFlags: explicitInput as CliFlags,
+  });
+  const applicableDefaults = Object.fromEntries(
+    Object.entries(defaults).filter(
+      ([key]) =>
+        Object.hasOwn(supportedProperties, key) && isFlagSupportedForCommand(key as FlagKey, name),
+    ),
+  );
+  return mergeDefinedFlags(applicableDefaults as Record<string, unknown>, explicitInput);
+}
+
+function asInputRecord(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  return input as Record<string, unknown>;
+}

--- a/src/mcp/tool-input-config.ts
+++ b/src/mcp/tool-input-config.ts
@@ -1,5 +1,6 @@
 import { isFlagSupportedForCommand } from '../cli-schema/option-schema.ts';
 import type { CliFlags, FlagKey } from '../commands/cli-grammar/flag-types.ts';
+import type { JsonSchema } from '../commands/command-contract.ts';
 import type { CommandName } from '../commands/command-metadata.ts';
 import { resolveConfigBackedFlagDefaults } from '../utils/cli-config.ts';
 import { mergeDefinedFlags } from '../utils/merge-flags.ts';
@@ -7,7 +8,7 @@ import { mergeDefinedFlags } from '../utils/merge-flags.ts';
 export function resolveMcpConfigDefaults(
   name: CommandName,
   input: unknown,
-  supportedKeys: readonly string[],
+  supportedProperties: Readonly<Record<string, JsonSchema>>,
 ): Record<string, unknown> {
   const explicitInput = asInputRecord(input);
   const defaults = resolveConfigBackedFlagDefaults({
@@ -15,12 +16,16 @@ export function resolveMcpConfigDefaults(
     cwd: process.cwd(),
     cliFlags: explicitInput as CliFlags,
   });
-  const applicableDefaults = Object.fromEntries(
-    Object.entries(defaults).filter(
-      ([key]) => supportedKeys.includes(key) && isFlagSupportedForCommand(key as FlagKey, name),
-    ),
-  );
-  return mergeDefinedFlags(applicableDefaults as Record<string, unknown>, explicitInput);
+  const applicableDefaults: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    if (
+      Object.hasOwn(supportedProperties, key) &&
+      isFlagSupportedForCommand(key as FlagKey, name)
+    ) {
+      applicableDefaults[key] = value;
+    }
+  }
+  return mergeDefinedFlags(applicableDefaults, explicitInput);
 }
 
 function asInputRecord(input: unknown): Record<string, unknown> {

--- a/src/mcp/tool-input-config.ts
+++ b/src/mcp/tool-input-config.ts
@@ -7,7 +7,7 @@ import { mergeDefinedFlags } from '../utils/merge-flags.ts';
 export function resolveMcpConfigDefaults(
   name: CommandName,
   input: unknown,
-  supportedProperties: Record<string, unknown>,
+  supportedKeys: readonly string[],
 ): Record<string, unknown> {
   const explicitInput = asInputRecord(input);
   const defaults = resolveConfigBackedFlagDefaults({
@@ -17,8 +17,7 @@ export function resolveMcpConfigDefaults(
   });
   const applicableDefaults = Object.fromEntries(
     Object.entries(defaults).filter(
-      ([key]) =>
-        Object.hasOwn(supportedProperties, key) && isFlagSupportedForCommand(key as FlagKey, name),
+      ([key]) => supportedKeys.includes(key) && isFlagSupportedForCommand(key as FlagKey, name),
     ),
   );
   return mergeDefinedFlags(applicableDefaults as Record<string, unknown>, explicitInput);

--- a/src/mcp/tool-input-config.ts
+++ b/src/mcp/tool-input-config.ts
@@ -7,10 +7,9 @@ import { mergeDefinedFlags } from '../utils/merge-flags.ts';
 
 export function resolveMcpConfigDefaults(
   name: CommandName,
-  input: unknown,
+  explicitInput: Record<string, unknown>,
   supportedProperties: Readonly<Record<string, JsonSchema>>,
 ): Record<string, unknown> {
-  const explicitInput = asInputRecord(input);
   const defaults = resolveConfigBackedFlagDefaults({
     command: name,
     cwd: process.cwd(),
@@ -26,9 +25,4 @@ export function resolveMcpConfigDefaults(
     }
   }
   return mergeDefinedFlags(applicableDefaults, explicitInput);
-}
-
-function asInputRecord(input: unknown): Record<string, unknown> {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
-  return input as Record<string, unknown>;
 }

--- a/src/mcp/tool-result.ts
+++ b/src/mcp/tool-result.ts
@@ -3,7 +3,7 @@ import type { CommandName } from '../commands/command-metadata.ts';
 
 export function projectStructuredContent(
   name: CommandName,
-  input: unknown,
+  input: Record<string, unknown>,
   result: unknown,
 ): Record<string, unknown> {
   if (result && typeof result === 'object' && !Array.isArray(result)) {

--- a/src/mcp/tool-result.ts
+++ b/src/mcp/tool-result.ts
@@ -1,0 +1,17 @@
+import { formatCliOutput } from '../commands/cli-output.ts';
+import type { CommandName } from '../commands/command-metadata.ts';
+
+export function projectStructuredContent(
+  name: CommandName,
+  input: unknown,
+  result: unknown,
+): Record<string, unknown> {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return result as Record<string, unknown>;
+  }
+  const projected = formatCliOutput({ name, input, result })?.data;
+  if (projected && typeof projected === 'object' && !Array.isArray(projected)) {
+    return projected as Record<string, unknown>;
+  }
+  return { result };
+}

--- a/src/mcp/tool-result.ts
+++ b/src/mcp/tool-result.ts
@@ -1,10 +1,11 @@
 import { formatCliOutput } from '../commands/cli-output.ts';
 import type { CommandName } from '../commands/command-metadata.ts';
+import type { CommandExecutionResult } from '../commands/command-surface.ts';
 
 export function projectStructuredContent(
   name: CommandName,
   input: Record<string, unknown>,
-  result: unknown,
+  result: CommandExecutionResult,
 ): Record<string, unknown> {
   if (result && typeof result === 'object' && !Array.isArray(result)) {
     return result as Record<string, unknown>;

--- a/src/mcp/tool-result.ts
+++ b/src/mcp/tool-result.ts
@@ -1,18 +1,38 @@
-import { formatCliOutput } from '../commands/cli-output.ts';
 import type { CommandName } from '../commands/command-metadata.ts';
 import type { CommandExecutionResult } from '../commands/command-surface.ts';
+import { serializeDevice } from '../contracts/result-serialization.ts';
+
+type CollectionCommandName = {
+  [Name in CommandName]: CommandExecutionResult<Name> extends readonly unknown[] ? Name : never;
+}[CommandName];
+
+type CollectionResultProjectors = {
+  [Name in CollectionCommandName]: (
+    result: CommandExecutionResult<Name>,
+  ) => Record<string, unknown>;
+};
+
+type NonCollectionCommandName = Exclude<CommandName, CollectionCommandName>;
+type NonObjectCommandName = {
+  [Name in NonCollectionCommandName]: CommandExecutionResult<Name> extends object ? never : Name;
+}[NonCollectionCommandName];
+
+const COLLECTION_RESULT_PROJECTORS = {
+  devices: (devices: CommandExecutionResult<'devices'>) => ({
+    devices: devices.map(serializeDevice),
+  }),
+  apps: (apps: CommandExecutionResult<'apps'>) => ({ apps }),
+} satisfies CollectionResultProjectors & Record<NonObjectCommandName, never>;
 
 export function projectStructuredContent(
   name: CommandName,
-  input: Record<string, unknown>,
   result: CommandExecutionResult,
 ): Record<string, unknown> {
-  if (result && typeof result === 'object' && !Array.isArray(result)) {
-    return result as Record<string, unknown>;
-  }
-  const projected = formatCliOutput({ name, input, result })?.data;
-  if (projected && typeof projected === 'object' && !Array.isArray(projected)) {
-    return projected as Record<string, unknown>;
-  }
-  return { result };
+  // Command execution preserves name/result correlation, but a dynamic lookup
+  // cannot express it to TypeScript. This is the single re-correlation seam.
+  const projector = COLLECTION_RESULT_PROJECTORS[name as CollectionCommandName] as
+    | ((value: CommandExecutionResult) => Record<string, unknown>)
+    | undefined;
+  if (projector) return projector(result);
+  return result as Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

- wrap array-returning MCP `devices` and `apps` results in spec-valid object envelopes and advertise matching output schemas
- apply shared config-backed defaults at the MCP command boundary with explicit-input precedence and command applicability filtering
- preserve existing object results, optimized text output, and CLI/Node return contracts

The MCP executor previously assigned raw command results directly to `structuredContent` and never resolved config-backed defaults. Spec-validating clients therefore rejected list results, while omitted external XCTest runner settings fell through to the built-in build path.

Closes #1340.
Closes #1341.

## Validation

- `pnpm check:affected --base origin/main --run`
  - format, lint, typecheck, layering, Fallow, build/declarations, and related Vitest tests passed
  - 86 related tests passed
- regression coverage validates object-shaped collection results against advertised schemas, preserves existing object/text projections, and exercises config fallback plus explicit override through the real MCP command surface
