### PR TITLE
docs: retire Maestro compatibility tracker

### DIFF
--- a/scripts/maestro-conformance/README.md
+++ b/scripts/maestro-conformance/README.md
@@ -118,7 +118,8 @@ The verifier fails on any **undeclared** divergence: a flow our engine parses
 that upstream rejects (a conformance regression), an undeclared parse mismatch,
 or an undeclared `we-reject`. Every `we-reject` must list the unsupported
 command/option in [`expected-divergence.ts`](./expected-divergence.ts) — that
-list is the mechanical parity backlog.
+list is the mechanical parity record. A focused issue is attached only when
+implementation work is planned.
 
 ## Regenerate (only on an upstream-pin bump)
 

--- a/scripts/maestro-conformance/expected-divergence.ts
+++ b/scripts/maestro-conformance/expected-divergence.ts
@@ -15,10 +15,8 @@ export type FlowDivergence = {
 
 // Keyed by corpus flow id. Every flow the verifier classifies as `we-reject`,
 // `mismatch`, or `we-are-lenient` must appear here; anything undeclared fails the
-// suite. This is the mechanical parity backlog — the list the old hand-typed
-// fixture could not produce. `tracking` points at the Maestro compat tracker for
-// option-level gaps.
-const COMPAT_TRACKER = 'https://github.com/callstack/agent-device/issues/558';
+// mechanical parity record — the list the old hand-typed fixture could not
+// produce. `tracking` points at a focused issue only when implementation work is planned.
 
 export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
   // --- Unsupported commands (support-matrix decisions) ---
@@ -39,9 +37,9 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
   },
   'upstream/067_assertTrue_pass': {
     classification: 'we-reject',
-    reason: 'assertTrue is outside the supported subset.',
+    reason: 'assertTrue is outside the current subset; this flow requires a JavaScript expression.',
     unsupported: ['assertTrue'],
-    tracking: COMPAT_TRACKER,
+    tracking: 'https://github.com/callstack/agent-device/issues/1292',
   },
   'upstream/090_travel': {
     classification: 'we-reject',
@@ -55,14 +53,13 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
   },
   'upstream/131_setPermissions': {
     classification: 'we-reject',
-    reason: 'Standalone setPermissions is outside the supported subset (launchApp permissions are supported).',
+    reason: 'Standalone setPermissions is outside the supported subset.',
     unsupported: ['setPermissions'],
   },
   'upstream/053_repeat_times': {
     classification: 'we-reject',
     reason: 'repeat is supported, but the flow also uses evalScript and a ${output.list.length} times expression.',
     unsupported: ['evalScript'],
-    tracking: COMPAT_TRACKER,
   },
   // --- Deliberately stricter than upstream ---
   'invalid/duplicate-keys': {
@@ -83,7 +80,6 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
     classification: 'we-reject',
     reason: 'pressKey supports back/enter/home/return; the flow exercises ~30 Android/TV keycodes.',
     unsupported: ['pressKey (extended keycodes)'],
-    tracking: COMPAT_TRACKER,
   },
   'upstream/076_optional_assertion': {
     classification: 'we-reject',
@@ -95,44 +91,37 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
     classification: 'we-reject',
     reason: 'scrollUntilVisible is supported; the flow sets the unsupported speed and visibilityPercentage options.',
     unsupported: ['scrollUntilVisible.speed', 'scrollUntilVisible.visibilityPercentage'],
-    tracking: COMPAT_TRACKER,
   },
   'upstream/101_doubleTapOn': {
     classification: 'we-reject',
     reason: 'doubleTapOn is supported; the flow sets the unsupported retryTapIfNoChange option on it.',
     unsupported: ['doubleTapOn.retryTapIfNoChange'],
-    tracking: COMPAT_TRACKER,
   },
   'upstream/119_retry_commands': {
     classification: 'we-reject',
     reason: 'retry is supported; the flow uses the unsupported per-command waitToSettleTimeoutMs option on a nested tapOn.',
     unsupported: ['tapOn.waitToSettleTimeoutMs'],
-    tracking: COMPAT_TRACKER,
   },
   // --- agent-device supports ${VAR} in integer-typed numeric option fields that the pinned upstream parser rejects ---
   'authored/numeric-variable-tap': {
     classification: 'we-are-lenient',
     reason:
       'agent-device supports ${VAR} lookup in tapOn.index/repeat/delay; the pinned upstream Maestro 2.5.1 parser only accepts ${VAR} in tapOn.index (string-typed) and rejects repeat/delay as integer-typed.',
-    tracking: 'https://github.com/callstack/agent-device/issues/1293',
   },
   'authored/numeric-variable-doubletap': {
     classification: 'we-are-lenient',
     reason:
       'agent-device supports ${VAR} lookup in doubleTapOn.delay; the pinned upstream Maestro 2.5.1 parser rejects it as integer-typed.',
-    tracking: 'https://github.com/callstack/agent-device/issues/1293',
   },
   'authored/numeric-variable-swipe': {
     classification: 'we-are-lenient',
     reason:
       'agent-device supports ${VAR} lookup in swipe.duration; the pinned upstream Maestro 2.5.1 parser rejects it as integer-typed.',
-    tracking: 'https://github.com/callstack/agent-device/issues/1293',
   },
   'authored/numeric-variable-erase': {
     classification: 'we-are-lenient',
     reason:
       'agent-device supports ${VAR} lookup in eraseText.charactersToErase; the pinned upstream Maestro 2.5.1 parser rejects it as integer-typed.',
-    tracking: 'https://github.com/callstack/agent-device/issues/1293',
   },
 };
 

--- a/src/cli/parser/__tests__/cli-help-command-usage.test.ts
+++ b/src/cli/parser/__tests__/cli-help-command-usage.test.ts
@@ -84,14 +84,10 @@ test('usageForCommand includes Maestro replay flag', async () => {
   assert.match(help, /--format maestro/);
   assert.match(help, /--out <path>/);
   assert.match(help, /--maestro/);
-  assert.match(help, /doubleTapOn/);
-  assert.doesNotMatch(help, /pasteText/);
-  assert.match(help, /runFlow file\/inline/);
-  assert.match(help, /ordered trusted runScript/);
-  assert.match(help, /repeat\.times/);
-  assert.match(help, /stopApp/);
-  assert.match(help, /Unsupported syntax fails loudly/);
-  assert.match(help, /issues\/558/);
+  assert.match(help, /supported Maestro YAML subset/);
+  assert.match(help, /unsupported syntax fails loudly/);
+  assert.match(help, /agent-device help maestro/);
+  assert.doesNotMatch(help, /issues\/558/);
 });
 
 test('usageForCommand includes Maestro test suite flag', async () => {

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -197,6 +197,21 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /agent-device test \.\/suite --platform android/);
 });
 
+test('usageForCommand resolves Maestro compatibility help topic', async () => {
+  const help = await usageForCommand('maestro');
+  if (help === null) throw new Error('Expected Maestro help text');
+  assert.match(help, /Supported subset:/);
+  assert.match(help, /runFlow file\/inline/);
+  assert.match(help, /tapOn, doubleTapOn, longPressOn/);
+  assert.match(help, /Boundaries:/);
+  assert.match(help, /iOS and Android only/);
+  assert.match(help, /AD_VAR_\* overrides it/);
+  assert.match(help, /may make http\.post network requests/);
+  assert.match(help, /not a security sandbox/);
+  assert.match(help, /0015-direct-maestro-engine\.md/);
+  assert.doesNotMatch(help, /issues\/558/);
+});
+
 test('usageForCommand resolves workflow help topic', async () => {
   const help = await usageForCommand('workflow');
   if (help === null) throw new Error('Expected workflow help text');

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -1,5 +1,10 @@
 import { listCliCommandNames } from '../../command-catalog.ts';
 import {
+  formatMaestroCompatibilityReference,
+  MAESTRO_COMPATIBILITY_ADR_URL,
+  MAESTRO_COMPATIBILITY_ISSUE_URL,
+} from '../../compat/maestro/support-matrix.ts';
+import {
   getCliCommandSchema,
   getCommandSchema,
   getFlagDefinitions,
@@ -172,6 +177,17 @@ Recovery:
   Keyboard visible over the next target: the on-screen keyboard usually does not block presses, so press the target directly instead of dismissing. If the press fails or reports no visible effect, scroll the target into view or use keyboard enter when submission is wanted.
   Sparse or recovered accessibility snapshot: use screenshot as visual truth, leave the bad screen if needed, then retry snapshot -i.
   Non-hittable success hint: verify with the settled diff or snapshot; retarget by a better ref/selector if the UI did not change.`,
+  },
+  maestro: {
+    summary: 'Supported Maestro YAML commands, grammar, and runtime boundaries',
+    body: `agent-device help maestro
+
+Run Maestro compatibility flows with replay <flow.yaml> --maestro or test <path> --maestro. Bind an iOS or Android target with --platform or an existing session.
+
+${formatMaestroCompatibilityReference()}
+
+Unsupported syntax fails loudly rather than being skipped. Architecture, performance tradeoffs, and declared conformance divergences: ${MAESTRO_COMPATIBILITY_ADR_URL}
+Focused compatibility request: ${MAESTRO_COMPATIBILITY_ISSUE_URL}`,
   },
   workflow: {
     summary: 'Normal agent-device bootstrap, exploration, and validation loop',

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -1,8 +1,4 @@
 import { SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS } from '../../contracts/screenshot.ts';
-import {
-  MAESTRO_COMPAT_TRACKER_URL,
-  formatMaestroSupportedSubsetForCli,
-} from '../../compat/maestro/support-matrix.ts';
 import type { FlagDefinition } from './flag-types.ts';
 
 export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
@@ -40,8 +36,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--maestro',
     usageDescription:
-      `Replay: treat input as a Maestro YAML compatibility flow. ${formatMaestroSupportedSubsetForCli()} ` +
-      `Unsupported syntax fails loudly with a link to ${MAESTRO_COMPAT_TRACKER_URL}`,
+      'Replay: treat input as a supported Maestro YAML subset; unsupported syntax fails loudly. ' +
+      'See agent-device help maestro for commands and boundaries',
   },
   {
     key: 'replayExportFormat',

--- a/src/compat/maestro/__tests__/support-matrix.test.ts
+++ b/src/compat/maestro/__tests__/support-matrix.test.ts
@@ -1,24 +1,44 @@
 import fs from 'node:fs';
 import { expect, test } from 'vitest';
+import { usageForCommand } from '../../../cli/parser/args.ts';
 import { getFlagDefinitions } from '../../../commands/cli-grammar/flag-registry.ts';
 import {
+  MAESTRO_COMPATIBILITY_ADR_URL,
+  MAESTRO_COMPATIBILITY_ISSUE_URL,
+  MAESTRO_COMPAT_LIMITATIONS,
   MAESTRO_COMPAT_SUPPORTED_CAPABILITIES,
-  MAESTRO_COMPAT_TRACKER_URL,
-  formatMaestroCapabilityList,
 } from '../support-matrix.ts';
 
-test('Maestro CLI help uses the shared compatibility support matrix', () => {
+test('Maestro flag routes to the versioned compatibility help topic', () => {
   const flag = getFlagDefinitions().find((definition) => definition.key === 'replayMaestro');
-  expect(flag?.usageDescription).toContain(
-    `Supported subset: ${formatMaestroCapabilityList(MAESTRO_COMPAT_SUPPORTED_CAPABILITIES)}.`,
-  );
-  expect(flag?.usageDescription).toContain(MAESTRO_COMPAT_TRACKER_URL);
+  expect(flag?.usageDescription).toContain('supported Maestro YAML subset');
+  expect(flag?.usageDescription).toContain('agent-device help maestro');
 });
 
-test('Maestro replay docs stay in sync with the compatibility support matrix', () => {
+test('Maestro help covers the supported subset and operational boundaries', async () => {
+  const help = await usageForCommand('maestro');
+  expect(help).not.toBeNull();
+  for (const statement of [
+    ...MAESTRO_COMPAT_SUPPORTED_CAPABILITIES,
+    ...MAESTRO_COMPAT_LIMITATIONS,
+  ]) {
+    expect(help).toContain(statement);
+  }
+  expect(help).toContain(MAESTRO_COMPATIBILITY_ADR_URL);
+  expect(help).toContain(MAESTRO_COMPATIBILITY_ISSUE_URL);
+  expect(help).not.toContain('issues/558');
+});
+
+test('Maestro replay docs stay in sync with versioned compatibility help', () => {
   const docs = fs.readFileSync('website/docs/docs/replay-e2e.md', 'utf8');
   const plainDocs = docs.replace(/`/g, '');
-  for (const capability of MAESTRO_COMPAT_SUPPORTED_CAPABILITIES) {
-    expect(plainDocs).toContain(capability);
+  for (const statement of [
+    ...MAESTRO_COMPAT_SUPPORTED_CAPABILITIES,
+    ...MAESTRO_COMPAT_LIMITATIONS,
+  ]) {
+    expect(plainDocs).toContain(statement);
   }
+  expect(docs).toContain(MAESTRO_COMPATIBILITY_ADR_URL);
+  expect(docs).toContain(MAESTRO_COMPATIBILITY_ISSUE_URL);
+  expect(docs).not.toContain('issues/558');
 });

--- a/src/compat/maestro/support-matrix.ts
+++ b/src/compat/maestro/support-matrix.ts
@@ -1,30 +1,30 @@
 export const MAESTRO_COMPAT_SUPPORTED_CAPABILITIES = [
-  'app launch with Apple-platform launch arguments and Android/iOS simulator clearState',
-  'runFlow file/inline with when.platform, when.visible, when.notVisible, and limited when.true boolean/platform expressions',
-  'onFlowStart and onFlowComplete hooks',
-  'deterministic repeat.times and retry blocks',
-  'tapOn including index, childOf, label, and absolute/percentage point taps',
-  'doubleTapOn and longPressOn',
-  'optional target, assertion, scrollUntilVisible, and extendedWaitUntil commands',
-  'inputText and focused-field eraseText',
-  'openLink',
-  'visibility assertions including childOf and extendedWaitUntil',
-  'scroll and scrollUntilVisible',
-  'absolute/percentage swipe and swipe.label',
-  'screenshots',
-  'keyboard dismiss',
-  'basic pressKey, back, animation waits, and stopApp',
-  'ordered trusted runScript file/env scripts with http.post, json, and output variables',
+  'Flows: launchApp; runFlow file/inline with platform, visibility, and limited boolean conditions; onFlowStart/onFlowComplete; repeat.times and retry.',
+  'Interactions: tapOn, doubleTapOn, longPressOn, inputText, eraseText, openLink, hideKeyboard, basic pressKey, and back; targets support index, childOf, label, points, and optional.',
+  'Assertions and navigation: assertVisible, assertNotVisible, extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
+  'Scripts: ordered runScript file/env scripts with http.post, json, and output variables.',
 ] as const;
 
-export const MAESTRO_COMPAT_TRACKER_URL = 'https://github.com/callstack/agent-device/issues/558';
+export const MAESTRO_COMPAT_LIMITATIONS = [
+  'Runtime: iOS and Android only; launchApp.clearState supports Android and iOS simulators, launch arguments are Apple-only, and standalone device utility/state commands are unsupported.',
+  'Expressions: when.true supports boolean literals and maestro.platform comparisons; repeat.while, evalScript, and broader JavaScript expressions are unsupported.',
+  'Environment: flow env is the default, AD_VAR_* overrides it, and CLI -e KEY=VALUE wins over both.',
+  'Trust: runScript executes trusted scripts, may make http.post network requests, and is not a security sandbox; output keys cannot contain a dot.',
+  'Errors and tracking: unsupported commands and fields fail with source context when available; open a focused issue only when implementation work is planned.',
+] as const;
 
-export function formatMaestroSupportedSubsetForCli(): string {
-  return `Supported subset: ${formatMaestroCapabilityList(MAESTRO_COMPAT_SUPPORTED_CAPABILITIES)}.`;
-}
+export const MAESTRO_COMPATIBILITY_ADR_URL =
+  'https://github.com/callstack/agent-device/blob/main/docs/adr/0015-direct-maestro-engine.md';
 
-export function formatMaestroCapabilityList(capabilities: readonly string[]): string {
-  return capabilities.length > 1
-    ? `${capabilities.slice(0, -1).join(', ')}, and ${capabilities.at(-1)}`
-    : (capabilities[0] ?? '');
+export const MAESTRO_COMPATIBILITY_ISSUE_URL =
+  'https://github.com/callstack/agent-device/issues/new';
+
+export function formatMaestroCompatibilityReference(): string {
+  return [
+    'Supported subset:',
+    ...MAESTRO_COMPAT_SUPPORTED_CAPABILITIES.map((capability) => `  - ${capability}`),
+    '',
+    'Boundaries:',
+    ...MAESTRO_COMPAT_LIMITATIONS.map((limitation) => `  - ${limitation}`),
+  ].join('\n');
 }

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -57,16 +57,22 @@ agent-device replay ./flow.yaml --maestro --platform ios --session e2e-run
 agent-device test ./maestro-flows --maestro --platform android --artifacts-dir ./tmp/maestro-artifacts
 ```
 
-Maestro compatibility parses supported YAML into a source-preserving typed program and executes it directly through the Agent Device runtime. It is intended for common mobile flows, not full Maestro parity; it does not lower YAML into generic replay actions. Unsupported Maestro syntax fails loudly with the command or field name and a line number when available. If a missing command matters for your flows, use the compatibility tracker to check current support and share demand:
+Supported subset:
 
-- Supported and unsupported capabilities: https://github.com/callstack/agent-device/issues/558
-- New focused compatibility request: https://github.com/callstack/agent-device/issues/new
+- Flows: `launchApp`; `runFlow` file/inline with platform, visibility, and limited boolean conditions; `onFlowStart`/`onFlowComplete`; `repeat.times` and retry.
+- Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText`, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; targets support `index`, `childOf`, `label`, points, and `optional`.
+- Assertions and navigation: `assertVisible`, `assertNotVisible`, `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
+- Scripts: ordered `runScript` file/env scripts with `http.post`, `json`, and `output` variables.
 
-Currently supported areas include app launch with Apple-platform launch arguments and Android/iOS simulator `clearState`, `runFlow` file/inline with `when.platform`, `when.visible`, `when.notVisible`, and limited `when.true` boolean/platform expressions, `onFlowStart` and `onFlowComplete` hooks, deterministic `repeat.times` and retry blocks, `tapOn` including `index`, `childOf`, `label`, and absolute/percentage point taps, `doubleTapOn` and `longPressOn`, `optional` target, assertion, `scrollUntilVisible`, and `extendedWaitUntil` commands, `inputText` and focused-field `eraseText`, `openLink`, visibility assertions including `childOf` and `extendedWaitUntil`, `scroll` and `scrollUntilVisible`, absolute/percentage `swipe` and `swipe.label`, screenshots, keyboard dismiss, basic `pressKey`, `back`, animation waits, and `stopApp`, and ordered trusted `runScript` file/env scripts with `http.post`, `json`, and `output` variables. `runScript` is supported only as an ordered Maestro compatibility step for trusted file/env scripts; it can make network requests, and is not a native `.ad` command or security sandbox. Script execution uses Node `vm` only for compatibility isolation, not for security; the script timeout bounds synchronous execution, while `http.post` requests are bounded by the helper process timeout. Output keys cannot contain `.` because exported variables are addressed as `output.<key>`.
+Boundaries:
 
-Maestro `env` values use the same replay precedence as `.ad` files: flow `env` is the default, shell `AD_VAR_*` values override it, and CLI `-e KEY=VALUE` wins over both.
+- Runtime: iOS and Android only; `launchApp.clearState` supports Android and iOS simulators, launch arguments are Apple-only, and standalone device utility/state commands are unsupported.
+- Expressions: `when.true` supports boolean literals and `maestro.platform` comparisons; `repeat.while`, `evalScript`, and broader JavaScript expressions are unsupported.
+- Environment: flow `env` is the default, `AD_VAR_*` overrides it, and CLI `-e KEY=VALUE` wins over both.
+- Trust: `runScript` executes trusted scripts, may make `http.post` network requests, and is not a security sandbox; output keys cannot contain a dot.
+- Errors and tracking: unsupported commands and fields fail with source context when available; open a focused issue only when implementation work is planned.
 
-Unsupported Maestro features such as `repeat.while`, full expression predicates beyond boolean literals and `maestro.platform` comparisons, `evalScript`, device utility commands, Android app launch arguments, and Android app state reset are tracked separately because they require neutral Agent Device runtime or device capabilities before they can be mapped safely.
+See [ADR 0015](https://github.com/callstack/agent-device/blob/main/docs/adr/0015-direct-maestro-engine.md) for architecture, performance tradeoffs, and deliberate deviations. If a missing feature matters for your suite, [open a focused issue](https://github.com/callstack/agent-device/issues/new) with a small flow snippet.
 
 ## Export `.ad` scripts to Maestro YAML
 
@@ -357,4 +363,4 @@ Passing `--plan-digest` that no longer matches the current script — because yo
 - Replay file parse error:
   - Validate quoting in `.ad` lines (unclosed quotes are rejected).
 - Maestro compatibility flow fails on unsupported syntax:
-  - Check the linked command or field in https://github.com/callstack/agent-device/issues/558. If it is important to your suite, comment there or open a focused issue with a small flow snippet.
+  - Check [ADR 0015](https://github.com/callstack/agent-device/blob/main/docs/adr/0015-direct-maestro-engine.md). If the missing feature matters to your suite, open a focused issue with a small flow snippet.


### PR DESCRIPTION
## Summary

Retire the stale #558 Maestro compatibility umbrella while keeping a concise versioned capability and limitations reference in `agent-device help maestro` and the website docs.
Treat conformance divergences as a mechanical parity record, with focused issue links only when implementation work is planned, and preserve #1342's intentional `we-are-lenient` cases.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/compat/maestro/__tests__/support-matrix.test.ts src/cli/parser/__tests__/cli-help-command-usage.test.ts src/cli/parser/__tests__/cli-help-topics.test.ts` (61 tests)
- `pnpm maestro:conformance` (46 tests)
- Broad related run: 863/868 passed in parallel; all five fixed-timeout failures passed when their four files were rerun with one worker (23 tests)
