### PR TITLE
fix(tvos): skip SpringBoard system-modal probe on tvOS (#1351)

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+BlockingSystemModalResolution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+BlockingSystemModalResolution.swift
@@ -16,6 +16,10 @@ extension RunnerTests {
   func resolveBlockingSystemModal(
     deadline: Date
   ) -> BlockingSystemModalResolution {
+    guard Self.hasSpringBoardSystemModalHost else {
+      return .absent
+    }
+
     guard let springboardModal = firstBlockingSystemModal(
       in: springboard,
       deadline: deadline
@@ -90,5 +94,20 @@ extension RunnerTests {
     XCTAssertFalse(RemoteHostedSystemModalPolicy.isEligibleHostState(.notRunning))
     XCTAssertFalse(RemoteHostedSystemModalPolicy.isEligibleHostState(.unknown))
   }
+
+  // tvOS has no SpringBoard host, so both the snapshot and alert-resolution paths
+  // must resolve without probing com.apple.springboard (#1351).
+  #if os(tvOS)
+  func testResolveBlockingSystemModalIsAbsentWithoutSpringBoardOnTvOS() {
+    guard case .absent = resolveBlockingSystemModal(deadline: .distantFuture) else {
+      XCTFail("tvOS blocking system-modal resolution must be .absent")
+      return
+    }
+  }
+
+  func testBlockingSystemAlertSnapshotIsNilOnTvOS() {
+    XCTAssertNil(blockingSystemAlertSnapshot(deadline: .distantFuture))
+  }
+  #endif
 }
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -29,6 +29,15 @@ final class RunnerTests: XCTestCase {
   }
 
   static let springboardBundleId = "com.apple.springboard"
+  // SpringBoard hosts blocking system modals on iOS/visionOS; tvOS (PineBoard/HeadBoard)
+  // and macOS have no such host, so there is nothing to probe there.
+  static let hasSpringBoardSystemModalHost: Bool = {
+    #if os(tvOS) || os(macOS)
+      return false
+    #else
+      return true
+    #endif
+  }()
   static let defaultRecordingFps: Int32 = 15
   var listener: NWListener?
   var doneExpectation: XCTestExpectation?


### PR DESCRIPTION
Fixes #1351

## Problem

On tvOS, **every** snapshot and alert resolution failed. The runner probes `com.apple.springboard` for blocking system modals on each snapshot/alert resolution, but tvOS has no SpringBoard (it uses PineBoard/HeadBoard). The query raises an XCTest failure — `Failed to resolve query: Application com.apple.springboard is not running` — that `safely()` cannot trap (it only catches Obj-C exceptions), so the whole runner test dies. The CLI then misreported this as the screen "overwhelming the iOS accessibility capture".

## Fix

The root problem is that `resolveBlockingSystemModal` — the single chokepoint every snapshot/alert path funnels through — implicitly assumed a SpringBoard host always exists. Rather than special-casing tvOS at each call site (the issue suggested flipping `#if os(macOS)` in two files), I made that assumption explicit and let the resolution fall out of it:

```swift
// SpringBoard hosts blocking system modals on iOS/visionOS; tvOS (PineBoard/HeadBoard)
// and macOS have no such host, so there is nothing to probe there.
static let hasSpringBoardSystemModalHost: Bool = { … }()

func resolveBlockingSystemModal(deadline: Date) -> BlockingSystemModalResolution {
  guard Self.hasSpringBoardSystemModalHost else { return .absent }
  … existing SpringBoard probe …
}
```

Guarding the one chokepoint covers all three modal-resolution sites and is future-proof against a new caller re-introducing the probe. Returning `.absent` (rather than short-circuiting the callers) is what preserves **app-owned** alert queries: `resolveAlert(app:)` sees `.absent`, falls through, and still queries the foreground app's own `alerts`.

The fourth SpringBoard probe site, `shouldRouteToSpringboardBlockingSystemModal`, is already `#if os(iOS)` and needs no change.

### Out of scope (per triage)
- **PineBoard/HeadBoard system-modal support** on tvOS — a separate enhancement; today the probe is skipped, not re-hosted.
- **Error-classification follow-up** — the misleading "overwhelming accessibility capture" message. It no longer appears here because the runner no longer terminates; if it surfaces for other reasons it should be a focused follow-up.

## Regression tests

Added two tvOS-gated unit tests (`RunnerTests+BlockingSystemModalResolution.swift`) covering the snapshot and alert-resolution paths. They are revert-sensitive: with the guard removed, both reproduce the exact issue signature on a tvOS build.

```
Test Case '…testBlockingSystemAlertSnapshotIsNilOnTvOS' passed (0.019 seconds).
Test Case '…testResolveBlockingSystemModalIsAbsentWithoutSpringBoardOnTvOS' passed (0.008 seconds).
```

Revert-sensitivity check (guard temporarily disabled → SpringBoard probed on tvOS):
```
…testResolveBlockingSystemModalIsAbsentWithoutSpringBoardOnTvOS :
    Failed to resolve query: Application com.apple.springboard is not running   ← reproduces #1351
** TEST EXECUTE FAILED **
```

## Verification

Environment: tvOS Simulator — Apple TV 4K (3rd gen), tvOS 26.2 (matches the report). Runner built from this branch's source via the real CLI.

- ✅ `pnpm build:xcuitest` (iOS + macOS) — both `** TEST BUILD SUCCEEDED **` (no regression on the shared runner).
- ✅ tvOS runner builds (`build:xcuitest:tvos`, with unit tests) — no warnings.
- ✅ Live `snapshot -i` on `com.apple.TVSettings` now returns a real tree instead of the "overwhelming capture" error:
  ```
  Snapshot: 47 nodes
  @e1 [application] "Settings"
  @e6 [table] "General"
  @e7 [cell] "General"
  …
  ```
- ✅ Live `alert get` completes cleanly (`alert not found` — no alert present) instead of crashing the runner; `runner.log` shows **0** `com.apple.springboard is not running` failures.
- ✅ Live `press @e7 --settle` navigates (General → About/Appearance/…) with a proper settled diff — repeated probes stay clean.
- ✅ npm-package source stripper ships the production predicate/guard and strips the nested unit-test block (`apple-runner-package-source.test.ts` passes).

Note: there is no tvOS CI lane, so the tvOS regression tests run on `build:xcuitest:tvos` (exercised locally here), not in the default iOS/macOS CI.
