### PR TITLE
refactor(commands): derive pass-through command bindings with a generic BoundOf helper

### DIFF
--- a/src/commands/capture/runtime/index.ts
+++ b/src/commands/capture/runtime/index.ts
@@ -1,6 +1,5 @@
-import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
 import type {
-  BoundRuntimeCommand,
+  BoundOf,
   DiffSnapshotCommandOptions,
   RuntimeCommand,
   ScreenshotCommandOptions,
@@ -26,12 +25,7 @@ export type CaptureCommands = {
   diffSnapshot: RuntimeCommand<DiffSnapshotCommandOptions, DiffSnapshotCommandResult>;
 };
 
-export type BoundCaptureCommands = {
-  screenshot: BoundRuntimeCommand<ScreenshotCommandOptions, ScreenshotCommandResult>;
-  diffScreenshot: BoundRuntimeCommand<DiffScreenshotCommandOptions, DiffScreenshotCommandResult>;
-  snapshot: BoundRuntimeCommand<SnapshotCommandOptions, SnapshotCommandResult>;
-  diffSnapshot: BoundRuntimeCommand<DiffSnapshotCommandOptions, DiffSnapshotCommandResult>;
-};
+export type BoundCaptureCommands = BoundOf<CaptureCommands>;
 
 export const captureCommands: CaptureCommands = {
   screenshot: screenshotCommand,
@@ -39,12 +33,3 @@ export const captureCommands: CaptureCommands = {
   snapshot: snapshotCommand,
   diffSnapshot: diffSnapshotCommand,
 };
-
-export function bindCaptureCommands(runtime: AgentDeviceRuntime): BoundCaptureCommands {
-  return {
-    screenshot: (options) => captureCommands.screenshot(runtime, options),
-    diffScreenshot: (options) => captureCommands.diffScreenshot(runtime, options),
-    snapshot: (options) => captureCommands.snapshot(runtime, options),
-    diffSnapshot: (options) => captureCommands.diffSnapshot(runtime, options),
-  };
-}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,6 @@
 import type { AgentDeviceRuntime } from '../runtime-contract.ts';
+import { bindRuntimeCommands } from './runtime-types.ts';
 import {
-  bindCaptureCommands,
   captureCommands,
   type BoundCaptureCommands,
   type CaptureCommands,
@@ -18,7 +18,6 @@ import {
 import {
   adminCommands,
   appCommands,
-  bindAdminCommands,
   bindAppCommands,
   type AdminCommands,
   type AppCommands,
@@ -26,19 +25,16 @@ import {
   type BoundAppCommands,
 } from './management/runtime/index.ts';
 import {
-  bindObservabilityCommands,
   diagnosticsCommands,
   type BoundObservabilityCommands,
   type DiagnosticsCommands,
 } from './observability/runtime/index.ts';
 import {
-  bindRecordingCommands,
   recordingCommands,
   type BoundRecordingCommands,
   type RecordingCommands,
 } from './recording/runtime/index.ts';
 import {
-  bindSystemCommands,
   systemCommands,
   type BoundSystemCommands,
   type SystemCommands,
@@ -84,13 +80,13 @@ export const commands: AgentDeviceCommands = {
 
 export function bindCommands(runtime: AgentDeviceRuntime): BoundAgentDeviceCommands {
   return {
-    capture: bindCaptureCommands(runtime),
+    capture: bindRuntimeCommands(captureCommands, runtime),
     selectors: bindSelectorCommands(runtime),
     interactions: bindInteractionCommands(runtime),
-    system: bindSystemCommands(runtime),
+    system: bindRuntimeCommands(systemCommands, runtime),
     apps: bindAppCommands(runtime),
-    admin: bindAdminCommands(runtime),
-    recording: bindRecordingCommands(runtime),
-    observability: bindObservabilityCommands(runtime),
+    admin: bindRuntimeCommands(adminCommands, runtime),
+    recording: bindRuntimeCommands(recordingCommands, runtime),
+    observability: bindRuntimeCommands(diagnosticsCommands, runtime),
   };
 }

--- a/src/commands/management/runtime/index.ts
+++ b/src/commands/management/runtime/index.ts
@@ -1,5 +1,5 @@
 import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
-import type { BoundRuntimeCommand, RuntimeCommand } from '../../runtime-types.ts';
+import { bindRuntimeCommands, type BoundOf, type RuntimeCommand } from '../../runtime-types.ts';
 import { resolveAppsFilter } from '../app-inventory-contract.ts';
 import {
   bootCommand,
@@ -61,26 +61,9 @@ export type AdminCommands = {
   >;
 };
 
-export type BoundAppCommands = {
-  open: BoundRuntimeCommand<OpenAppCommandOptions, OpenAppCommandResult>;
-  close: (options?: CloseAppCommandOptions) => Promise<CloseAppCommandResult>;
-  list: (options?: ListAppsCommandOptions) => Promise<ListAppsCommandResult>;
-  state: BoundRuntimeCommand<GetAppStateCommandOptions, GetAppStateCommandResult>;
-  push: BoundRuntimeCommand<PushAppCommandOptions, PushAppCommandResult>;
-  triggerEvent: BoundRuntimeCommand<TriggerAppEventCommandOptions, TriggerAppEventCommandResult>;
-};
+export type BoundAppCommands = BoundOf<AppCommands>;
 
-export type BoundAdminCommands = {
-  devices: (options?: AdminDevicesCommandOptions) => Promise<AdminDevicesCommandResult>;
-  boot: (options?: AdminBootCommandOptions) => Promise<AdminBootCommandResult>;
-  shutdown: (options?: AdminShutdownCommandOptions) => Promise<AdminShutdownCommandResult>;
-  install: BoundRuntimeCommand<AdminInstallCommandOptions, AdminInstallCommandResult>;
-  reinstall: BoundRuntimeCommand<AdminReinstallCommandOptions, AdminInstallCommandResult>;
-  installFromSource: BoundRuntimeCommand<
-    AdminInstallFromSourceCommandOptions,
-    AdminInstallCommandResult
-  >;
-};
+export type BoundAdminCommands = BoundOf<AdminCommands>;
 
 export const appCommands: AppCommands = {
   open: openAppCommand,
@@ -102,26 +85,11 @@ export const adminCommands: AdminCommands = {
 
 export function bindAppCommands(runtime: AgentDeviceRuntime): BoundAppCommands {
   return {
-    open: (options) => appCommands.open(runtime, options),
-    close: (options) => appCommands.close(runtime, options),
+    ...bindRuntimeCommands(appCommands, runtime),
     list: (options = {}) =>
       appCommands.list(runtime, {
         ...options,
         filter: resolveAppsFilter(options.filter),
       }),
-    state: (options) => appCommands.state(runtime, options),
-    push: (options) => appCommands.push(runtime, options),
-    triggerEvent: (options) => appCommands.triggerEvent(runtime, options),
-  };
-}
-
-export function bindAdminCommands(runtime: AgentDeviceRuntime): BoundAdminCommands {
-  return {
-    devices: (options) => adminCommands.devices(runtime, options),
-    boot: (options) => adminCommands.boot(runtime, options),
-    shutdown: (options) => adminCommands.shutdown(runtime, options),
-    install: (options) => adminCommands.install(runtime, options),
-    reinstall: (options) => adminCommands.reinstall(runtime, options),
-    installFromSource: (options) => adminCommands.installFromSource(runtime, options),
   };
 }

--- a/src/commands/observability/runtime/index.ts
+++ b/src/commands/observability/runtime/index.ts
@@ -1,5 +1,4 @@
-import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
-import type { RuntimeCommand } from '../../runtime-types.ts';
+import type { BoundOf, RuntimeCommand } from '../../runtime-types.ts';
 import {
   logsCommand,
   networkCommand,
@@ -21,22 +20,10 @@ export type DiagnosticsCommands = {
   perf: RuntimeCommand<DiagnosticsPerfCommandOptions | undefined, DiagnosticsPerfCommandResult>;
 };
 
-export type BoundObservabilityCommands = {
-  logs: (options?: DiagnosticsLogsCommandOptions) => Promise<DiagnosticsLogsCommandResult>;
-  network: (options?: DiagnosticsNetworkCommandOptions) => Promise<DiagnosticsNetworkCommandResult>;
-  perf: (options?: DiagnosticsPerfCommandOptions) => Promise<DiagnosticsPerfCommandResult>;
-};
+export type BoundObservabilityCommands = BoundOf<DiagnosticsCommands>;
 
 export const diagnosticsCommands: DiagnosticsCommands = {
   logs: logsCommand,
   network: networkCommand,
   perf: perfCommand,
 };
-
-export function bindObservabilityCommands(runtime: AgentDeviceRuntime): BoundObservabilityCommands {
-  return {
-    logs: (options) => diagnosticsCommands.logs(runtime, options),
-    network: (options) => diagnosticsCommands.network(runtime, options),
-    perf: (options) => diagnosticsCommands.perf(runtime, options),
-  };
-}

--- a/src/commands/recording/runtime/index.ts
+++ b/src/commands/recording/runtime/index.ts
@@ -1,5 +1,4 @@
-import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
-import type { BoundRuntimeCommand, RuntimeCommand } from '../../runtime-types.ts';
+import type { BoundOf, RuntimeCommand } from '../../runtime-types.ts';
 import {
   recordCommand,
   traceCommand,
@@ -14,19 +13,9 @@ export type RecordingCommands = {
   trace: RuntimeCommand<RecordingTraceCommandOptions, RecordingTraceCommandResult>;
 };
 
-export type BoundRecordingCommands = {
-  record: BoundRuntimeCommand<RecordingRecordCommandOptions, RecordingRecordCommandResult>;
-  trace: BoundRuntimeCommand<RecordingTraceCommandOptions, RecordingTraceCommandResult>;
-};
+export type BoundRecordingCommands = BoundOf<RecordingCommands>;
 
 export const recordingCommands: RecordingCommands = {
   record: recordCommand,
   trace: traceCommand,
 };
-
-export function bindRecordingCommands(runtime: AgentDeviceRuntime): BoundRecordingCommands {
-  return {
-    record: (options) => recordingCommands.record(runtime, options),
-    trace: (options) => recordingCommands.trace(runtime, options),
-  };
-}

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -13,6 +13,26 @@ export type BoundRuntimeCommand<TOptions = Record<string, unknown>, TResult = Co
   options: TOptions,
 ) => Promise<TResult>;
 
+export type BoundOf<T> = {
+  [K in keyof T]: T[K] extends RuntimeCommand<infer TOptions, infer TResult>
+    ? undefined extends TOptions
+      ? (options?: TOptions) => Promise<TResult>
+      : BoundRuntimeCommand<TOptions, TResult>
+    : never;
+};
+
+export function bindRuntimeCommands<T extends Record<string, RuntimeCommand<any, any>>>(
+  commands: T,
+  runtime: AgentDeviceRuntime,
+): BoundOf<T> {
+  return Object.fromEntries(
+    Object.entries(commands).map(([name, command]) => [
+      name,
+      (options: unknown) => command(runtime, options),
+    ]),
+  ) as BoundOf<T>;
+}
+
 export function toBackendResult(result: unknown): Record<string, unknown> | undefined {
   return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
 }

--- a/src/commands/system/runtime/index.ts
+++ b/src/commands/system/runtime/index.ts
@@ -1,5 +1,4 @@
-import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
-import type { BoundRuntimeCommand, RuntimeCommand } from '../../runtime-types.ts';
+import type { BoundOf, RuntimeCommand } from '../../runtime-types.ts';
 import {
   alertCommand,
   appSwitcherCommand,
@@ -45,19 +44,7 @@ export type SystemCommands = {
   tvRemote: RuntimeCommand<SystemTvRemoteCommandOptions, SystemTvRemoteCommandResult>;
 };
 
-export type BoundSystemCommands = {
-  back: (options?: SystemBackCommandOptions) => Promise<SystemBackCommandResult>;
-  home: (options?: SystemHomeCommandOptions) => Promise<SystemHomeCommandResult>;
-  orientation: BoundRuntimeCommand<SystemOrientationCommandOptions, SystemOrientationCommandResult>;
-  keyboard: (options?: SystemKeyboardCommandOptions) => Promise<SystemKeyboardCommandResult>;
-  clipboard: BoundRuntimeCommand<SystemClipboardCommandOptions, SystemClipboardCommandResult>;
-  settings: (options?: SystemSettingsCommandOptions) => Promise<SystemSettingsCommandResult>;
-  alert: (options?: SystemAlertCommandOptions) => Promise<SystemAlertCommandResult>;
-  appSwitcher: (
-    options?: SystemAppSwitcherCommandOptions,
-  ) => Promise<SystemAppSwitcherCommandResult>;
-  tvRemote: BoundRuntimeCommand<SystemTvRemoteCommandOptions, SystemTvRemoteCommandResult>;
-};
+export type BoundSystemCommands = BoundOf<SystemCommands>;
 
 export const systemCommands: SystemCommands = {
   back: backCommand,
@@ -70,17 +57,3 @@ export const systemCommands: SystemCommands = {
   appSwitcher: appSwitcherCommand,
   tvRemote: tvRemoteCommand,
 };
-
-export function bindSystemCommands(runtime: AgentDeviceRuntime): BoundSystemCommands {
-  return {
-    back: (options) => systemCommands.back(runtime, options),
-    home: (options) => systemCommands.home(runtime, options),
-    orientation: (options) => systemCommands.orientation(runtime, options),
-    keyboard: (options) => systemCommands.keyboard(runtime, options),
-    clipboard: (options) => systemCommands.clipboard(runtime, options),
-    settings: (options) => systemCommands.settings(runtime, options),
-    alert: (options) => systemCommands.alert(runtime, options),
-    appSwitcher: (options) => systemCommands.appSwitcher(runtime, options),
-    tvRemote: (options) => systemCommands.tvRemote(runtime, options),
-  };
-}


### PR DESCRIPTION
## What

Replaces the hand-written `bind*Commands` functions and their mirrored `Bound*Commands` type declarations with one derived form, for the families that are genuinely pass-through:

- `BoundOf<T>` mapped type + `bindRuntimeCommands(commands, runtime)` in `runtime-types.ts` (~20 lines)
- `capture`, `system`, `admin`, `recording`, `observability`: bind function and mirrored type deleted; `Bound*Commands` becomes a one-line `BoundOf<...>` alias, `bindCommands()` calls the generic directly
- `apps`: keeps `bindAppCommands` as `...bindRuntimeCommands(appCommands, runtime)` plus the manual `list` override (its `resolveAppsFilter` normalization is real logic, not boilerplate)
- `selectors` / `interactions`: **untouched by design** — 11 of their 17 entries prepend a positional `target`/`text` argument and `Omit` that field from options, which a mapped type cannot derive

Net −86 lines. From the adversarially-verified overengineering audit (follow-up to #1367; scope was verified there, including the selector/interaction exclusion).

## Behavior-preservation notes

- `BoundOf` has an `undefined extends O` branch producing `(options?: O) => Promise<R>`, matching the hand-written optional-parameter shape — zero-arg calls like `commands.system.back()` type-check exactly as before. A naive `RuntimeCommand<O,R> → BoundRuntimeCommand<O,R>` mapping would have broken them.
- The mapped type is homomorphic, so property JSDoc on the source command-map types propagates to the derived bound types.
- `Bound*` type names were never on the published surface (only `bindCommands`/`BoundAgentDeviceCommands` escape, to `runtime.ts`).

## Verification

`typecheck` · `lint` · `check:production-exports` · full unit suite (489/489 files) · `format`

## Note

Stacked on #1367 (base = its branch) with the `system/runtime/index.ts` overlap already resolved as the union of both deletions. After #1367 squash-merges and GitHub retargets this PR to `main`, rebase with `git rebase --onto origin/main <old-base-head>` to drop the inherited commits — no conflict resolution remains.
