### PR TITLE
refactor(cli): decompose runCli into explicit phase functions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,379 +100,460 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
       debug: debugEnabled,
     },
     async () => {
-      let parsed: ReturnType<typeof resolveCliOptions>;
-      try {
-        parsed = resolveCliOptions(argv, { cwd: process.cwd(), env: process.env });
-      } catch (error) {
-        emitDiagnostic({
-          level: 'error',
-          phase: 'cli_parse_failed',
-          data: {
-            error: error instanceof Error ? error.message : String(error),
-          },
-        });
-        const normalized = normalizeError(error, {
-          diagnosticId: getDiagnosticsMeta().diagnosticId,
-          logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
-        });
-        if (jsonRequested) {
-          printJson({ success: false, error: normalized });
-        } else {
-          printHumanError(normalized, { showDetails: debugEnabled });
-        }
-        process.exit(1);
-        return;
-      }
-
-      for (const warning of parsed.warnings) {
-        process.stderr.write(`Warning: ${warning}\n`);
-      }
-
-      if (parsed.flags.version) {
-        process.stdout.write(`${version}\n`);
-        process.exit(0);
-      }
-
-      const isHelpAlias = parsed.command === 'help';
-      const isHelpFlag = parsed.flags.help;
-      if (isHelpAlias || isHelpFlag) {
-        if (isHelpAlias && parsed.positionals.length > 1) {
-          printHumanError(new AppError('INVALID_ARGS', 'help accepts at most one command.'));
-          process.exit(1);
-        }
-        const helpTarget = isHelpAlias ? parsed.positionals[0] : parsed.command;
-        if (!helpTarget) {
-          process.stdout.write(`${await usage()}\n`);
-          process.exit(0);
-        }
-        const commandHelp = await usageForCommand(helpTarget);
-        if (commandHelp) {
-          process.stdout.write(commandHelp);
-          process.exit(0);
-        }
-        printHumanError(new AppError('INVALID_ARGS', formatUnknownHelpTargetMessage(helpTarget)));
-        process.stdout.write(`${await usage()}\n`);
-        process.exit(1);
-      }
-
-      if (!parsed.command) {
-        process.stdout.write(`${await usage()}\n`);
-        process.exit(1);
-      }
-
-      const { command, positionals } = parsed;
+      const { parsed, command, positionals } = await parseCliInputOrExit(argv, {
+        version,
+        jsonRequested,
+        debugEnabled,
+      });
       const debugOutputEnabled = isParsedDebugRequested(command, parsed.providedFlags);
-      let binding: ReturnType<typeof resolveBindingSettings>;
-      let flags: typeof parsed.flags;
-      let daemonPaths: ReturnType<typeof resolveDaemonPaths>;
-      let sessionName: string;
-      let connectionDefaults: ReturnType<typeof resolveActiveConnectionDefaults>;
-      let effectiveFlags: typeof parsed.flags;
-      const explicitFlagKeys = new Set(parsed.providedFlags.map((entry) => entry.key));
-      try {
-        binding = resolveBindingSettings({
-          policyOverrides: parsed.flags,
-          configuredPlatform: parsed.flags.platform,
-          configuredSession: parsed.flags.session,
-        });
-        flags = binding.lockPolicy
-          ? { ...parsed.flags }
-          : applyDefaultPlatformBinding(parsed.flags, {
-              policyOverrides: parsed.flags,
-              configuredPlatform: parsed.flags.platform,
-              configuredSession: parsed.flags.session,
-            });
-        daemonPaths = resolveDaemonPaths(flags.stateDir);
-        sessionName = flags.session ?? 'default';
-        connectionDefaults = resolveActiveConnectionDefaults({
-          command,
-          explicitFlagKeys,
-          stateDir: daemonPaths.baseDir,
-          session: sessionName,
-          remoteConfig: flags.remoteConfig,
-          hasResolvedSession: flags.session !== undefined,
-        });
-        effectiveFlags = connectionDefaults
-          ? mergeConnectionFlags(flags, connectionDefaults.flags, explicitFlagKeys)
-          : flags;
-      } catch (err) {
-        const appErr = asAppError(err);
-        const normalized = normalizeError(appErr, {
-          diagnosticId: getDiagnosticsMeta().diagnosticId,
-          logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
-        });
-        if (parsed.flags.json) {
-          printJson({ success: false, error: normalized });
-        } else {
-          printHumanError(normalized, { showDetails: debugOutputEnabled });
-        }
-        process.exit(1);
-        return;
-      }
+      const ctx = resolveRunContextOrExit(parsed, {
+        command,
+        positionals,
+        requestId,
+        debugOutputEnabled,
+      });
       let logTailStopper: (() => void) | null = null;
       try {
         if (command === 'react-devtools') {
-          const exitCode = await runReactDevtoolsCommand(positionals, {
-            flags: {
-              ...effectiveFlags,
-              leaseProvider: connectionDefaults?.connection?.leaseProvider,
-            },
-            stateDir: daemonPaths.baseDir,
-            session: effectiveFlags.session ?? sessionName,
-            cwd: process.cwd(),
-            env: process.env,
-            configureDirectPortReverse: async () => {
-              const response = await deps.sendToDaemon({
-                command: INTERNAL_COMMANDS.runtime,
-                positionals: ['port-reverse'],
-                flags: {
-                  ...effectiveFlags,
-                  leaseProvider: connectionDefaults?.connection?.leaseProvider,
-                  devicePort: 8097,
-                  hostPort: 8097,
-                  portReverseName: 'react-devtools',
-                },
-                session: effectiveFlags.session ?? sessionName,
-              });
-              if (!response.ok) throwDaemonError(response.error);
-            },
-          });
-          process.exit(exitCode);
+          process.exit(await runReactDevtoolsCli(ctx, deps));
           return;
         }
         if (command === 'web') {
-          const exitCode = await runWebCommand(positionals, {
-            flags: effectiveFlags,
-            stateDir: daemonPaths.baseDir,
-          });
-          process.exit(exitCode);
+          process.exit(
+            await runWebCommand(positionals, {
+              flags: ctx.effectiveFlags,
+              stateDir: ctx.daemonPaths.baseDir,
+            }),
+          );
           return;
         }
         maybeRunUpgradeNotifier({
           command,
           currentVersion: version,
-          stateDir: daemonPaths.baseDir,
-          flags: effectiveFlags,
+          stateDir: ctx.daemonPaths.baseDir,
+          flags: ctx.effectiveFlags,
         });
-        let resolvedRuntime = connectionDefaults?.runtime;
-        let connectionMetadata = connectionDefaults?.connection;
-        const buildClientConfig = (
-          currentFlags: CliFlags,
-          runtime: SessionRuntimeHints | undefined,
-          connection: RemoteConnectionRequestMetadata | undefined,
-        ): AgentDeviceClientConfig => ({
-          session: currentFlags.session,
-          requestId,
-          stateDir: currentFlags.stateDir,
-          daemonBaseUrl: currentFlags.daemonBaseUrl,
-          daemonAuthToken: currentFlags.daemonAuthToken,
-          daemonTransport: currentFlags.daemonTransport,
-          daemonServerMode: currentFlags.daemonServerMode,
-          tenant: currentFlags.tenant,
-          sessionIsolation: currentFlags.sessionIsolation,
-          runId: currentFlags.runId,
-          leaseId: currentFlags.leaseId,
-          leaseBackend: currentFlags.leaseBackend,
-          leaseProvider: connection?.leaseProvider,
-          clientId: connection?.clientId,
-          deviceKey: connection?.deviceKey,
-          providerApp: currentFlags.providerApp,
-          providerOsVersion: currentFlags.providerOsVersion,
-          providerProject: currentFlags.providerProject,
-          providerBuild: currentFlags.providerBuild,
-          providerSessionName: currentFlags.providerSessionName,
-          awsProjectArn: currentFlags.awsProjectArn,
-          awsDeviceArn: currentFlags.awsDeviceArn,
-          awsAppArn: currentFlags.awsAppArn,
-          awsRegion: currentFlags.awsRegion,
-          awsInteractionMode: currentFlags.awsInteractionMode,
-          runtime,
-          lockPolicy: binding.lockPolicy,
-          lockPlatform: binding.defaultPlatform,
-          cwd: process.cwd(),
-          debug: debugOutputEnabled,
-          cost: currentFlags.cost,
-          responseLevel: currentFlags.responseLevel,
-        });
-        let parsedBatchSteps: BatchStep[] | undefined;
-        if (command === 'batch') {
-          if (positionals.length > 0) {
-            throw new AppError('INVALID_ARGS', 'batch does not accept positional arguments.');
-          }
-          parsedBatchSteps = readBatchSteps(flags);
-        }
-
-        if (shouldResolveRemoteAuth(command)) {
-          const authResolution = await resolveRemoteAuthForCli({
-            command,
-            flags: effectiveFlags,
-            stateDir: daemonPaths.baseDir,
-            env: process.env,
-          });
-          effectiveFlags = authResolution.flags;
-        }
-
-        if (effectiveFlags.remoteConfig && shouldMaterializeRemoteConnection(command)) {
-          const materializationClient = createAgentDeviceClient(
-            buildClientConfig(effectiveFlags, resolvedRuntime, connectionMetadata),
-            {
-              transport: createClientDaemonTransport(deps.sendToDaemon),
-            },
-          );
-          const materialized = await materializeRemoteConnectionForCommand({
-            command,
-            flags: effectiveFlags,
-            client: materializationClient,
-            runtime: resolvedRuntime,
-            positionals,
-            batchSteps: parsedBatchSteps,
-            forceRuntimePrepare: hasExplicitMetroRuntimeOverrides(explicitFlagKeys),
-          });
-          effectiveFlags = materialized.flags;
-          resolvedRuntime = materialized.runtime;
-          connectionMetadata = materialized.connection;
-        }
-        if (
-          shouldWarnOpenMayMissRemoteRuntime({
-            command,
-            flags: effectiveFlags,
-            runtime: resolvedRuntime,
-            explicitFlagKeys,
-            hadConnectionDefaults: Boolean(connectionDefaults),
-          })
-        ) {
-          process.stderr.write(
-            'Warning: open is using explicit remote daemon or tenant flags without saved Metro runtime hints. React Native apps may launch without bundle/runtime hints; prefer connect --remote-config <path> first or pass --remote-config <path> on this command.\n',
-          );
-        }
+        await resolveRemoteContext(ctx, deps);
         if (command === 'cdp') {
-          const exitCode = await runAgentCdpCommand(positionals, {
-            flags: effectiveFlags,
-            runtime: resolvedRuntime,
-            cwd: process.cwd(),
-            env: process.env,
-          });
-          process.exit(exitCode);
-          return;
-        }
-        const remoteDaemonBaseUrl = effectiveFlags.daemonBaseUrl;
-        logTailStopper =
-          debugOutputEnabled && !effectiveFlags.json && !remoteDaemonBaseUrl
-            ? startDaemonLogTail(daemonPaths.logPath)
-            : null;
-        const replayTestReporterRuntime =
-          command === 'test'
-            ? // Lazy: the replay test reporter is only needed by `test`, and its
-              // static import would put the reporting runtime on every command's path.
-              await import('./replay/test/reporting.ts').then(
-                ({ createReplayTestReporterRuntime }) =>
-                  createReplayTestReporterRuntime({
-                    debug: debugOutputEnabled,
-                    verbose: effectiveFlags.verbose,
-                    json: effectiveFlags.json,
-                    reporter: effectiveFlags.reporter,
-                    reportJunit: effectiveFlags.reportJunit,
-                  }),
-              )
-            : undefined;
-        const client = createAgentDeviceClient(
-          buildClientConfig(effectiveFlags, resolvedRuntime, connectionMetadata),
-          {
-            transport: createCliDaemonTransport({
-              command,
-              flags: effectiveFlags,
-              replayTestReporterRuntime,
-              transport: deps.sendToDaemon,
+          process.exit(
+            await runAgentCdpCommand(positionals, {
+              flags: ctx.effectiveFlags,
+              runtime: ctx.resolvedRuntime,
+              cwd: process.cwd(),
+              env: process.env,
             }),
-          },
-        );
-        if (command === 'batch') {
-          if (!parsedBatchSteps) {
-            throw new AppError('INVALID_ARGS', 'batch requires --steps or --steps-file.');
-          }
-          const batchSteps = parsedBatchSteps.map((step, _index) => ({
-            ...step,
-            input:
-              binding.lockPolicy && flags.platform === undefined
-                ? { ...step.input }
-                : applyDefaultPlatformBinding(step.input, {
-                    policyOverrides: effectiveFlags,
-                    configuredPlatform: effectiveFlags.platform,
-                    configuredSession: effectiveFlags.session,
-                    inheritedPlatform: effectiveFlags.platform,
-                  }),
-          }));
-          if (
-            await tryRunClientBackedCommand({
-              command,
-              positionals,
-              flags: { ...effectiveFlags, batchSteps },
-              client,
-              debug: debugOutputEnabled,
-              replayTestReporterRuntime,
-            })
-          ) {
-            return;
-          }
-        } else if (command === 'runtime') {
-          throw new AppError(
-            'INVALID_ARGS',
-            'runtime command was removed. Use connect --remote-config <path> for remote runs, or metro prepare --remote-config <path> for inspection.',
           );
-        } else if (
-          await tryRunClientBackedCommand({
+          return;
+        }
+        logTailStopper = maybeStartDaemonLogTail(ctx);
+        const replayTestReporterRuntime = await createReplayReporterForTest(ctx);
+        const client = createAgentDeviceClient(buildClientConfig(ctx), {
+          transport: createCliDaemonTransport({
             command,
-            positionals,
-            flags: effectiveFlags,
-            client,
-            debug: debugOutputEnabled,
+            flags: ctx.effectiveFlags,
             replayTestReporterRuntime,
-          })
-        ) {
-          return;
-        }
-
-        throw new AppError('INVALID_ARGS', formatUnhandledCommandMessage(command));
-      } catch (err) {
-        const appErr = asAppError(err);
-        const normalized = normalizeError(appErr, {
-          diagnosticId: getDiagnosticsMeta().diagnosticId,
-          logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
+            transport: deps.sendToDaemon,
+          }),
         });
-        if (command === 'close' && isDaemonStartupFailure(appErr)) {
-          if (effectiveFlags.json) {
-            printJson({ success: true, data: { closed: 'session', source: 'no-daemon' } });
-          }
-          return;
-        }
-        if (effectiveFlags.json) {
-          printJson({
-            success: false,
-            error: normalized,
-          });
-        } else {
-          printHumanError(normalized, { showDetails: debugOutputEnabled });
-          if (debugOutputEnabled) {
-            try {
-              const logPath = daemonPaths.logPath;
-              if (fs.existsSync(logPath)) {
-                const content = fs.readFileSync(logPath, 'utf8');
-                const lines = content.split('\n');
-                const tail = lines.slice(Math.max(0, lines.length - 200)).join('\n');
-                if (tail.trim().length > 0) {
-                  process.stderr.write(`\n[daemon log]\n${tail}\n`);
-                }
-              }
-            } catch {}
-          }
-        }
-        if (logTailStopper) logTailStopper();
-        process.exit(1);
+        await dispatchCliCommand(ctx, client, replayTestReporterRuntime);
+      } catch (err) {
+        handleRunCliFailure(err, ctx, logTailStopper);
       } finally {
         if (logTailStopper) logTailStopper();
       }
     },
   );
+}
+
+type ParsedCliInput = {
+  parsed: ReturnType<typeof resolveCliOptions>;
+  command: string;
+  positionals: string[];
+};
+
+async function parseCliInputOrExit(
+  argv: string[],
+  options: { version: string; jsonRequested: boolean; debugEnabled: boolean },
+): Promise<ParsedCliInput> {
+  let parsed: ReturnType<typeof resolveCliOptions>;
+  try {
+    parsed = resolveCliOptions(argv, { cwd: process.cwd(), env: process.env });
+  } catch (error) {
+    emitDiagnostic({
+      level: 'error',
+      phase: 'cli_parse_failed',
+      data: {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    const normalized = normalizeError(error, {
+      diagnosticId: getDiagnosticsMeta().diagnosticId,
+      logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
+    });
+    if (options.jsonRequested) {
+      printJson({ success: false, error: normalized });
+    } else {
+      printHumanError(normalized, { showDetails: options.debugEnabled });
+    }
+    process.exit(1);
+  }
+
+  for (const warning of parsed.warnings) {
+    process.stderr.write(`Warning: ${warning}\n`);
+  }
+
+  if (parsed.flags.version) {
+    process.stdout.write(`${options.version}\n`);
+    process.exit(0);
+  }
+
+  const isHelpAlias = parsed.command === 'help';
+  const isHelpFlag = parsed.flags.help;
+  if (isHelpAlias || isHelpFlag) {
+    if (isHelpAlias && parsed.positionals.length > 1) {
+      printHumanError(new AppError('INVALID_ARGS', 'help accepts at most one command.'));
+      process.exit(1);
+    }
+    const helpTarget = isHelpAlias ? parsed.positionals[0] : parsed.command;
+    if (!helpTarget) {
+      process.stdout.write(`${await usage()}\n`);
+      process.exit(0);
+    }
+    const commandHelp = await usageForCommand(helpTarget);
+    if (commandHelp) {
+      process.stdout.write(commandHelp);
+      process.exit(0);
+    }
+    printHumanError(new AppError('INVALID_ARGS', formatUnknownHelpTargetMessage(helpTarget)));
+    process.stdout.write(`${await usage()}\n`);
+    process.exit(1);
+  }
+
+  if (!parsed.command) {
+    process.stdout.write(`${await usage()}\n`);
+    process.exit(1);
+  }
+
+  return { parsed, command: parsed.command, positionals: parsed.positionals };
+}
+
+type CliRunContext = {
+  command: string;
+  positionals: string[];
+  requestId: string;
+  debugOutputEnabled: boolean;
+  binding: ReturnType<typeof resolveBindingSettings>;
+  // Flags after platform binding but before connection-default merge; batch
+  // step inheritance keys off this pre-merge view.
+  flags: CliFlags;
+  daemonPaths: ReturnType<typeof resolveDaemonPaths>;
+  sessionName: string;
+  connectionDefaults: ReturnType<typeof resolveActiveConnectionDefaults>;
+  explicitFlagKeys: Set<FlagKey>;
+  // Mutated in place by resolveRemoteContext (auth, materialization) so the
+  // failure handler always sees the same state the throwing phase saw.
+  effectiveFlags: CliFlags;
+  resolvedRuntime: SessionRuntimeHints | undefined;
+  connectionMetadata: RemoteConnectionRequestMetadata | undefined;
+  parsedBatchSteps: BatchStep[] | undefined;
+};
+
+function resolveRunContextOrExit(
+  parsed: ReturnType<typeof resolveCliOptions>,
+  base: { command: string; positionals: string[]; requestId: string; debugOutputEnabled: boolean },
+): CliRunContext {
+  const explicitFlagKeys = new Set(parsed.providedFlags.map((entry) => entry.key));
+  try {
+    const binding = resolveBindingSettings({
+      policyOverrides: parsed.flags,
+      configuredPlatform: parsed.flags.platform,
+      configuredSession: parsed.flags.session,
+    });
+    const flags = binding.lockPolicy
+      ? { ...parsed.flags }
+      : applyDefaultPlatformBinding(parsed.flags, {
+          policyOverrides: parsed.flags,
+          configuredPlatform: parsed.flags.platform,
+          configuredSession: parsed.flags.session,
+        });
+    const daemonPaths = resolveDaemonPaths(flags.stateDir);
+    const sessionName = flags.session ?? 'default';
+    const connectionDefaults = resolveActiveConnectionDefaults({
+      command: base.command,
+      explicitFlagKeys,
+      stateDir: daemonPaths.baseDir,
+      session: sessionName,
+      remoteConfig: flags.remoteConfig,
+      hasResolvedSession: flags.session !== undefined,
+    });
+    const effectiveFlags = connectionDefaults
+      ? mergeConnectionFlags(flags, connectionDefaults.flags, explicitFlagKeys)
+      : flags;
+    return {
+      ...base,
+      binding,
+      flags,
+      daemonPaths,
+      sessionName,
+      connectionDefaults,
+      explicitFlagKeys,
+      effectiveFlags,
+      resolvedRuntime: connectionDefaults?.runtime,
+      connectionMetadata: connectionDefaults?.connection,
+      parsedBatchSteps: undefined,
+    };
+  } catch (err) {
+    const appErr = asAppError(err);
+    const normalized = normalizeError(appErr, {
+      diagnosticId: getDiagnosticsMeta().diagnosticId,
+      logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
+    });
+    if (parsed.flags.json) {
+      printJson({ success: false, error: normalized });
+    } else {
+      printHumanError(normalized, { showDetails: base.debugOutputEnabled });
+    }
+    process.exit(1);
+  }
+}
+
+async function runReactDevtoolsCli(ctx: CliRunContext, deps: CliDeps): Promise<number> {
+  return await runReactDevtoolsCommand(ctx.positionals, {
+    flags: {
+      ...ctx.effectiveFlags,
+      leaseProvider: ctx.connectionDefaults?.connection?.leaseProvider,
+    },
+    stateDir: ctx.daemonPaths.baseDir,
+    session: ctx.effectiveFlags.session ?? ctx.sessionName,
+    cwd: process.cwd(),
+    env: process.env,
+    configureDirectPortReverse: async () => {
+      const response = await deps.sendToDaemon({
+        command: INTERNAL_COMMANDS.runtime,
+        positionals: ['port-reverse'],
+        flags: {
+          ...ctx.effectiveFlags,
+          leaseProvider: ctx.connectionDefaults?.connection?.leaseProvider,
+          devicePort: 8097,
+          hostPort: 8097,
+          portReverseName: 'react-devtools',
+        },
+        session: ctx.effectiveFlags.session ?? ctx.sessionName,
+      });
+      if (!response.ok) throwDaemonError(response.error);
+    },
+  });
+}
+
+async function resolveRemoteContext(ctx: CliRunContext, deps: CliDeps): Promise<void> {
+  if (ctx.command === 'batch') {
+    if (ctx.positionals.length > 0) {
+      throw new AppError('INVALID_ARGS', 'batch does not accept positional arguments.');
+    }
+    ctx.parsedBatchSteps = readBatchSteps(ctx.flags);
+  }
+
+  if (shouldResolveRemoteAuth(ctx.command)) {
+    const authResolution = await resolveRemoteAuthForCli({
+      command: ctx.command,
+      flags: ctx.effectiveFlags,
+      stateDir: ctx.daemonPaths.baseDir,
+      env: process.env,
+    });
+    ctx.effectiveFlags = authResolution.flags;
+  }
+
+  if (ctx.effectiveFlags.remoteConfig && shouldMaterializeRemoteConnection(ctx.command)) {
+    const materializationClient = createAgentDeviceClient(buildClientConfig(ctx), {
+      transport: createClientDaemonTransport(deps.sendToDaemon),
+    });
+    const materialized = await materializeRemoteConnectionForCommand({
+      command: ctx.command,
+      flags: ctx.effectiveFlags,
+      client: materializationClient,
+      runtime: ctx.resolvedRuntime,
+      positionals: ctx.positionals,
+      batchSteps: ctx.parsedBatchSteps,
+      forceRuntimePrepare: hasExplicitMetroRuntimeOverrides(ctx.explicitFlagKeys),
+    });
+    ctx.effectiveFlags = materialized.flags;
+    ctx.resolvedRuntime = materialized.runtime;
+    ctx.connectionMetadata = materialized.connection;
+  }
+  if (
+    shouldWarnOpenMayMissRemoteRuntime({
+      command: ctx.command,
+      flags: ctx.effectiveFlags,
+      runtime: ctx.resolvedRuntime,
+      explicitFlagKeys: ctx.explicitFlagKeys,
+      hadConnectionDefaults: Boolean(ctx.connectionDefaults),
+    })
+  ) {
+    process.stderr.write(
+      'Warning: open is using explicit remote daemon or tenant flags without saved Metro runtime hints. React Native apps may launch without bundle/runtime hints; prefer connect --remote-config <path> first or pass --remote-config <path> on this command.\n',
+    );
+  }
+}
+
+function buildClientConfig(ctx: CliRunContext): AgentDeviceClientConfig {
+  const currentFlags = ctx.effectiveFlags;
+  const connection = ctx.connectionMetadata;
+  return {
+    session: currentFlags.session,
+    requestId: ctx.requestId,
+    stateDir: currentFlags.stateDir,
+    daemonBaseUrl: currentFlags.daemonBaseUrl,
+    daemonAuthToken: currentFlags.daemonAuthToken,
+    daemonTransport: currentFlags.daemonTransport,
+    daemonServerMode: currentFlags.daemonServerMode,
+    tenant: currentFlags.tenant,
+    sessionIsolation: currentFlags.sessionIsolation,
+    runId: currentFlags.runId,
+    leaseId: currentFlags.leaseId,
+    leaseBackend: currentFlags.leaseBackend,
+    leaseProvider: connection?.leaseProvider,
+    clientId: connection?.clientId,
+    deviceKey: connection?.deviceKey,
+    providerApp: currentFlags.providerApp,
+    providerOsVersion: currentFlags.providerOsVersion,
+    providerProject: currentFlags.providerProject,
+    providerBuild: currentFlags.providerBuild,
+    providerSessionName: currentFlags.providerSessionName,
+    awsProjectArn: currentFlags.awsProjectArn,
+    awsDeviceArn: currentFlags.awsDeviceArn,
+    awsAppArn: currentFlags.awsAppArn,
+    awsRegion: currentFlags.awsRegion,
+    awsInteractionMode: currentFlags.awsInteractionMode,
+    runtime: ctx.resolvedRuntime,
+    lockPolicy: ctx.binding.lockPolicy,
+    lockPlatform: ctx.binding.defaultPlatform,
+    cwd: process.cwd(),
+    debug: ctx.debugOutputEnabled,
+    cost: currentFlags.cost,
+    responseLevel: currentFlags.responseLevel,
+  };
+}
+
+function maybeStartDaemonLogTail(ctx: CliRunContext): (() => void) | null {
+  const remoteDaemonBaseUrl = ctx.effectiveFlags.daemonBaseUrl;
+  return ctx.debugOutputEnabled && !ctx.effectiveFlags.json && !remoteDaemonBaseUrl
+    ? startDaemonLogTail(ctx.daemonPaths.logPath)
+    : null;
+}
+
+async function createReplayReporterForTest(
+  ctx: CliRunContext,
+): Promise<ReplayTestReporterRuntime | undefined> {
+  if (ctx.command !== 'test') return undefined;
+  // Lazy: the replay test reporter is only needed by `test`, and its
+  // static import would put the reporting runtime on every command's path.
+  const { createReplayTestReporterRuntime } = await import('./replay/test/reporting.ts');
+  return createReplayTestReporterRuntime({
+    debug: ctx.debugOutputEnabled,
+    verbose: ctx.effectiveFlags.verbose,
+    json: ctx.effectiveFlags.json,
+    reporter: ctx.effectiveFlags.reporter,
+    reportJunit: ctx.effectiveFlags.reportJunit,
+  });
+}
+
+async function dispatchCliCommand(
+  ctx: CliRunContext,
+  client: ReturnType<typeof createAgentDeviceClient>,
+  replayTestReporterRuntime: ReplayTestReporterRuntime | undefined,
+): Promise<void> {
+  const { command, positionals, effectiveFlags } = ctx;
+  if (command === 'batch') {
+    if (!ctx.parsedBatchSteps) {
+      throw new AppError('INVALID_ARGS', 'batch requires --steps or --steps-file.');
+    }
+    const batchSteps = ctx.parsedBatchSteps.map((step, _index) => ({
+      ...step,
+      input:
+        ctx.binding.lockPolicy && ctx.flags.platform === undefined
+          ? { ...step.input }
+          : applyDefaultPlatformBinding(step.input, {
+              policyOverrides: effectiveFlags,
+              configuredPlatform: effectiveFlags.platform,
+              configuredSession: effectiveFlags.session,
+              inheritedPlatform: effectiveFlags.platform,
+            }),
+    }));
+    if (
+      await tryRunClientBackedCommand({
+        command,
+        positionals,
+        flags: { ...effectiveFlags, batchSteps },
+        client,
+        debug: ctx.debugOutputEnabled,
+        replayTestReporterRuntime,
+      })
+    ) {
+      return;
+    }
+  } else if (command === 'runtime') {
+    throw new AppError(
+      'INVALID_ARGS',
+      'runtime command was removed. Use connect --remote-config <path> for remote runs, or metro prepare --remote-config <path> for inspection.',
+    );
+  } else if (
+    await tryRunClientBackedCommand({
+      command,
+      positionals,
+      flags: effectiveFlags,
+      client,
+      debug: ctx.debugOutputEnabled,
+      replayTestReporterRuntime,
+    })
+  ) {
+    return;
+  }
+
+  throw new AppError('INVALID_ARGS', formatUnhandledCommandMessage(command));
+}
+
+function handleRunCliFailure(
+  err: unknown,
+  ctx: CliRunContext,
+  logTailStopper: (() => void) | null,
+): void {
+  const appErr = asAppError(err);
+  const normalized = normalizeError(appErr, {
+    diagnosticId: getDiagnosticsMeta().diagnosticId,
+    logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
+  });
+  if (ctx.command === 'close' && isDaemonStartupFailure(appErr)) {
+    if (ctx.effectiveFlags.json) {
+      printJson({ success: true, data: { closed: 'session', source: 'no-daemon' } });
+    }
+    return;
+  }
+  if (ctx.effectiveFlags.json) {
+    printJson({
+      success: false,
+      error: normalized,
+    });
+  } else {
+    printHumanError(normalized, { showDetails: ctx.debugOutputEnabled });
+    if (ctx.debugOutputEnabled) {
+      printDaemonLogTailOnError(ctx.daemonPaths.logPath);
+    }
+  }
+  if (logTailStopper) logTailStopper();
+  process.exit(1);
+}
+
+function printDaemonLogTailOnError(logPath: string): void {
+  try {
+    if (fs.existsSync(logPath)) {
+      const content = fs.readFileSync(logPath, 'utf8');
+      const lines = content.split('\n');
+      const tail = lines.slice(Math.max(0, lines.length - 200)).join('\n');
+      if (tail.trim().length > 0) {
+        process.stderr.write(`\n[daemon log]\n${tail}\n`);
+      }
+    }
+  } catch {}
 }
 
 function isDebugRequested(argv: string[]): boolean {


### PR DESCRIPTION
## What

Item 1 of the code-quality follow-ups: `runCli()` was one ~390-line function inlining every phase of a CLI invocation, sharing ~10 mutable `let` bindings by closure, with a catch block coupled to nearly all of them. It is now ~75 lines of orchestration over named phase functions, each with explicit inputs:

- `parseCliInputOrExit` — parse + parse-error formatting, warnings, `--version`/help short-circuits, no-command usage exit
- `resolveRunContextOrExit` — binding/platform defaulting, daemon paths, session, connection-defaults merge; produces the `CliRunContext`
- `runReactDevtoolsCli` — the react-devtools special case (config + port-reverse callback)
- `resolveRemoteContext` — batch-step parsing, remote-auth resolution, remote-connection materialization, the open-without-runtime-hints warning
- `buildClientConfig` — the client config projection (was a closure)
- `maybeStartDaemonLogTail` / `createReplayReporterForTest` — the two conditional setups
- `dispatchCliCommand` — batch mapping + removed-`runtime` error + generic dispatch + unhandled-command throw
- `handleRunCliFailure` + `printDaemonLogTailOnError` — the catch block, including the `close`-with-no-daemon success path

## Behavior preservation

The one structural subtlety: the old catch block read `effectiveFlags`/`resolvedRuntime` mid-mutation through the closure — auth and materialization reassign them, and an error thrown between phases must be formatted with the partially-updated state. `CliRunContext` is therefore mutated in place by `resolveRemoteContext` (called out in the type's doc), so `handleRunCliFailure` sees exactly what the throwing phase saw. Exit codes, error formatting, phase order (warnings → version → help → binding → react-devtools/web → upgrade notifier → batch parse → auth → materialization → warning → cdp → log tail → dispatch), and the `finally` log-tail stop are unchanged; special-case bodies were moved verbatim.

Net +81 lines — this is a navigability refactor, not a deletion; the win is that each phase now has a name, an explicit signature, and a visible mutation contract.

## Verification

`typecheck` · `lint` · `check:fallow` · `format` · full unit suite 487/487 (one earlier run hit the documented contention-timeout flake while three sibling worktrees ran concurrent suites; clean rerun on identical code).