### PR TITLE
fix(interaction): direction-named, selector-first off-screen recovery hints (#1366)

### DIFF
--- a/src/commands/interaction/interactions.test.ts
+++ b/src/commands/interaction/interactions.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest';
-import { interactionDaemonWriters } from './interactions.ts';
+import { interactionCliReaders, interactionDaemonWriters } from './interactions.ts';
+import { AppError } from '../../kernel/errors.ts';
+import type { CliFlags } from '../cli-grammar/flag-types.ts';
+
+const BASE_FLAGS: CliFlags = { json: false, help: false, version: false };
 
 test('swipe writes only typed daemon input', () => {
   const request = interactionDaemonWriters.swipe({
@@ -18,4 +22,19 @@ test('swipe writes only typed daemon input', () => {
     pauseMs: 10,
     pattern: 'ping-pong',
   });
+});
+
+test('scroll reader rejects a @ref in the direction slot with a grammar hint (#1366)', () => {
+  try {
+    interactionCliReaders.scroll(['@e29'], BASE_FLAGS);
+    expect.unreachable('scroll should reject a ref where a direction is expected');
+  } catch (error) {
+    expect(error).toBeInstanceOf(AppError);
+    const appError = error as AppError;
+    expect(appError.code).toBe('INVALID_ARGS');
+    // The hint teaches the direction-first grammar and that scroll takes no target,
+    // so the agent stops cycling `scroll @ref down` / `scroll down @ref`.
+    expect(appError.details?.hint).toMatch(/direction first/i);
+    expect(appError.details?.hint).toMatch(/no @ref or selector/i);
+  }
 });

--- a/src/commands/interaction/interactions.ts
+++ b/src/commands/interaction/interactions.ts
@@ -177,7 +177,12 @@ function readScrollDirection(value: string | undefined): ScrollInputDirection {
   ) {
     return value;
   }
-  throw new AppError('INVALID_ARGS', `Unknown direction: ${String(value)}`);
+  // #1366: agents recovering from an off-screen target often mis-shape this as
+  // `scroll @ref down` or `scroll down @ref`. scroll takes no target — name the
+  // grammar so the retry lands instead of cycling through arg orders.
+  throw new AppError('INVALID_ARGS', `Unknown direction: ${String(value)}`, {
+    hint: 'scroll takes a direction first, then an optional amount: scroll <up|down|left|right|top|bottom> [amount]. It takes no @ref or selector — scroll the whole viewport, then retry the target with a selector.',
+  });
 }
 
 function readLongPressTargetPositionals(positionals: string[]): {

--- a/src/commands/interaction/runtime/interactions.test.ts
+++ b/src/commands/interaction/runtime/interactions.test.ts
@@ -160,7 +160,10 @@ test('native ref click preflight refuses an off-screen ref without calling the b
       const details = (error as { details?: Record<string, unknown> }).details;
       assert.equal(details?.reason, 'offscreen_ref');
       assert.equal(details?.ref, 'e2');
-      assert.ok(typeof details?.hint === 'string');
+      // #1366: closed drawer sits left of the viewport -> `scroll left`, selector-first.
+      assert.equal(details?.scrollDirection, 'left');
+      assert.match(String(details?.hint), /scroll left/i);
+      assert.match(String(details?.hint), /selector/i);
       return true;
     },
   );

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -120,7 +120,11 @@ test('runtime press refuses a selector that resolves to an off-screen element', 
       assert.match(error.message, /off-screen element and is not safe to press/);
       const details = (error as { details?: Record<string, unknown> }).details;
       assert.equal(details?.reason, 'offscreen_selector');
-      assert.ok(typeof details?.hint === 'string');
+      // #1366: the closed-drawer shape sits fully left of the viewport, so the
+      // hint names `scroll left` and steers back through the same selector.
+      assert.equal(details?.scrollDirection, 'left');
+      assert.match(String(details?.hint), /scroll left/i);
+      assert.match(String(details?.hint), /selector/i);
       return true;
     },
   );

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -168,6 +168,10 @@ test('runtime press names a direction for a partial clip whose center is off-scr
       assert.equal(details?.reason, 'offscreen_selector');
       assert.equal(details?.scrollDirection, 'down');
       assert.match(String(details?.hint), /scroll down/i);
+      // #1366 recovery must be bounded: a single large (fling) scroll overshoots,
+      // so the hint steers to small steps / a bounded gesture pan.
+      assert.match(String(details?.hint), /small steps/i);
+      assert.match(String(details?.hint), /gesture pan/i);
       return true;
     },
   );

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -131,6 +131,49 @@ test('runtime press refuses a selector that resolves to an off-screen element', 
   assert.equal(taps.length, 0);
 });
 
+test('runtime press names a direction for a partial clip whose center is off-screen', async () => {
+  // #1366 regression: the row still OVERLAPS the viewport (top edge inside), so
+  // the rect-vs-viewport form yields no direction — but its tap-point center is
+  // below the bottom edge, which is what the visibility guard rejects. The hint
+  // must still name `scroll down` rather than falling back to the generic phrasing.
+  const partialClipSnapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 400, height: 800 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 2,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Cash',
+      rect: { x: 20, y: 790, width: 200, height: 44 },
+      hittable: true,
+    },
+  ]);
+  const taps: unknown[] = [];
+  const device = createInteractionDevice(partialClipSnapshot, {
+    tap: async (_context, point) => {
+      taps.push(point);
+    },
+  });
+
+  await assert.rejects(
+    () => device.interactions.press(selector('label=Cash'), { session: 'default' }),
+    (error: unknown) => {
+      const details = (error as { details?: Record<string, unknown> }).details;
+      assert.equal(details?.reason, 'offscreen_selector');
+      assert.equal(details?.scrollDirection, 'down');
+      assert.match(String(details?.hint), /scroll down/i);
+      return true;
+    },
+  );
+  assert.equal(taps.length, 0);
+});
+
 test('runtime click keeps distinct tab button centers when iOS reports the tab bar as hittable', async () => {
   const calls: Point[] = [];
   const device = createInteractionDevice(iosTabBarSnapshot(), {

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -700,11 +700,13 @@ function assertVisibleSelectorTarget(
     message: `Selector ${selector} resolved to an off-screen element and is not safe to ${action}`,
     details: { reason: 'offscreen_selector', selector },
     // A selector re-resolves against a fresh snapshot on every attempt, so the
-    // recovery is just: scroll the named direction, then retry THIS selector —
-    // no separate snapshot step, and no @ref (a scroll expires the ref frame,
-    // #1366). Naming the direction stops the wrong-way / retry-the-same-ref loop.
+    // recovery is: move the named direction, then retry THIS selector — no
+    // separate snapshot step, and no @ref (a scroll expires the ref frame,
+    // #1366). Naming the direction stops the wrong-way / retry-the-same-ref loop;
+    // bounded steps stop the overshoot loop — a single large scroll (fling
+    // momentum on iOS) can sail past the target, so a short gesture pan lands it.
     hint: (direction) =>
-      `${scrollRevealClause(direction)}, then retry ${action} with the same selector — a selector re-resolves against a fresh snapshot, so no separate snapshot is needed. If it is inside a closed drawer or another tab, open that container first.`,
+      `${scrollRevealClause(direction)} in small steps, retrying ${action} with the same selector after each (it re-resolves against a fresh snapshot). A single large scroll can overshoot the target; a short bounded gesture pan lands it more reliably. If it is inside a closed drawer or another tab, open that container first.`,
   });
 }
 
@@ -721,17 +723,17 @@ function assertVisibleRefTarget(
     // 0014), so retrying this @ref would be rejected next. Steer to a selector,
     // which re-resolves against a fresh snapshot and bypasses the ref-frame guard.
     hint: (direction) =>
-      `${scrollRevealClause(direction)}, then retry ${action} with a selector (e.g. text=/id=) rather than this @ref — the scroll expires the ref frame, so re-run snapshot -i before reusing any @ref.`,
+      `${scrollRevealClause(direction)} in small steps (a single large scroll can overshoot; a short bounded gesture pan lands it more reliably), then retry ${action} with a selector (e.g. text=/id=) rather than this @ref — the scroll expires the ref frame, so re-run snapshot -i before reusing any @ref.`,
   });
 }
 
 // Shared lead-in for both off-screen hints. Names the concrete `scroll <dir>`
-// when the geometry gives one, and falls back to the container-aware phrasing
-// when the target is off more than one edge in a way that has no single reveal.
+// when the geometry gives one, and falls back to the generic phrasing when the
+// target is off more than one edge in a way that has no single reveal. Callers
+// append the bounded-steps guidance: a single large scroll (fling momentum on
+// iOS) can sail past the target, so small bounded moves are what actually land.
 function scrollRevealClause(direction: OffscreenScrollDirection | null): string {
-  return direction
-    ? `Scroll ${direction} to bring it on-screen`
-    : 'Scroll toward it (open its container if it is in a closed drawer or another tab)';
+  return direction ? `Scroll ${direction} toward it` : 'Scroll toward it';
 }
 
 /**

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -796,8 +796,10 @@ function throwIfOffscreenInteractionTarget(
   if (!node.rect || !viewport || isNodeVisibleOnScreen(node, nodes)) return;
   // The direction that scrolls this off-screen target into view. Named in the
   // hint (and surfaced as a machine-readable detail) so the recovery is a single
-  // deterministic move instead of a guess (#1366).
-  const scrollDirection = classifyOffscreenScrollDirection(node.rect, viewport);
+  // deterministic move instead of a guess (#1366). Derived from the same
+  // boundary the rejection above used, so partial clips and off-screen
+  // containers get a direction too, not just fully-scrolled-out items.
+  const scrollDirection = classifyOffscreenScrollDirection(node, nodes);
   throw new AppError('COMMAND_FAILED', failure.message, {
     ...failure.details,
     rect: node.rect,

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -24,8 +24,10 @@ import {
   resolveRefLabel,
 } from '../../../snapshot/snapshot-processing.ts';
 import {
+  classifyOffscreenScrollDirection,
   isNodeVisibleOnScreen,
   resolveEffectiveViewportRect,
+  type OffscreenScrollDirection,
 } from '../../../snapshot/mobile-snapshot-semantics.ts';
 import { containsPoint, resolveViewportRect } from '../../../utils/rect-visibility.ts';
 import { isSnapshotNodeInteractionBlocked } from '../../../snapshot/snapshot-occlusion.ts';
@@ -697,7 +699,12 @@ function assertVisibleSelectorTarget(
   throwIfOffscreenInteractionTarget(node, nodes, {
     message: `Selector ${selector} resolved to an off-screen element and is not safe to ${action}`,
     details: { reason: 'offscreen_selector', selector },
-    hint: `The element is outside the visible viewport — likely inside a closed drawer, another tab, or scrolled content. Scroll toward it or open its container, take a fresh snapshot, then retry ${action}.`,
+    // A selector re-resolves against a fresh snapshot on every attempt, so the
+    // recovery is just: scroll the named direction, then retry THIS selector —
+    // no separate snapshot step, and no @ref (a scroll expires the ref frame,
+    // #1366). Naming the direction stops the wrong-way / retry-the-same-ref loop.
+    hint: (direction) =>
+      `${scrollRevealClause(direction)}, then retry ${action} with the same selector — a selector re-resolves against a fresh snapshot, so no separate snapshot is needed. If it is inside a closed drawer or another tab, open that container first.`,
   });
 }
 
@@ -710,8 +717,21 @@ function assertVisibleRefTarget(
   throwIfOffscreenInteractionTarget(node, nodes, {
     message: `Ref ${refInput} is off-screen and not safe to ${action}`,
     details: { reason: 'offscreen_ref', ref: normalizeRef(refInput) },
-    hint: `Use scroll with the direction from the off-screen summary, take a fresh snapshot, then retry ${action} with the new ref or a selector.`,
+    // The scroll that reveals the target expires the ref frame (#1366, ADR
+    // 0014), so retrying this @ref would be rejected next. Steer to a selector,
+    // which re-resolves against a fresh snapshot and bypasses the ref-frame guard.
+    hint: (direction) =>
+      `${scrollRevealClause(direction)}, then retry ${action} with a selector (e.g. text=/id=) rather than this @ref — the scroll expires the ref frame, so re-run snapshot -i before reusing any @ref.`,
   });
+}
+
+// Shared lead-in for both off-screen hints. Names the concrete `scroll <dir>`
+// when the geometry gives one, and falls back to the container-aware phrasing
+// when the target is off more than one edge in a way that has no single reveal.
+function scrollRevealClause(direction: OffscreenScrollDirection | null): string {
+  return direction
+    ? `Scroll ${direction} to bring it on-screen`
+    : 'Scroll toward it (open its container if it is in a closed drawer or another tab)';
 }
 
 /**
@@ -766,14 +786,23 @@ export async function preflightNativeRefInteraction(
 function throwIfOffscreenInteractionTarget(
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
-  failure: { message: string; details: Record<string, unknown>; hint: string },
+  failure: {
+    message: string;
+    details: Record<string, unknown>;
+    hint: (direction: OffscreenScrollDirection | null) => string;
+  },
 ): void {
   const viewport = node.rect ? resolveEffectiveViewportRect(node, nodes) : null;
   if (!node.rect || !viewport || isNodeVisibleOnScreen(node, nodes)) return;
+  // The direction that scrolls this off-screen target into view. Named in the
+  // hint (and surfaced as a machine-readable detail) so the recovery is a single
+  // deterministic move instead of a guess (#1366).
+  const scrollDirection = classifyOffscreenScrollDirection(node.rect, viewport);
   throw new AppError('COMMAND_FAILED', failure.message, {
     ...failure.details,
     rect: node.rect,
     viewport,
-    hint: failure.hint,
+    ...(scrollDirection ? { scrollDirection } : {}),
+    hint: failure.hint(scrollDirection),
   });
 }

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -2593,8 +2593,12 @@ test('press @ref fails fast when the target is off-screen', async () => {
   if (response && !response.ok) {
     expect(response.error.code).toBe('COMMAND_FAILED');
     expect(response.error.message).toMatch(/off-screen/i);
-    expect(response.error.hint).toMatch(/scroll.*fresh snapshot/i);
+    // #1366: the hint names the concrete scroll direction and steers to a
+    // selector-based retry (a @ref would be rejected as expired after the scroll).
+    expect(response.error.hint).toMatch(/scroll down/i);
+    expect(response.error.hint).toMatch(/selector/i);
     expect(response.error.details?.reason).toBe('offscreen_ref');
+    expect(response.error.details?.scrollDirection).toBe('down');
   }
 });
 
@@ -2715,8 +2719,11 @@ test('fill @ref fails fast when the target is off-screen', async () => {
   if (response && !response.ok) {
     expect(response.error.code).toBe('COMMAND_FAILED');
     expect(response.error.message).toMatch(/off-screen/i);
-    expect(response.error.hint).toMatch(/scroll.*fresh snapshot/i);
+    // #1366: direction-named, selector-first recovery hint (see press test above).
+    expect(response.error.hint).toMatch(/scroll down/i);
+    expect(response.error.hint).toMatch(/selector/i);
     expect(response.error.details?.reason).toBe('offscreen_ref');
+    expect(response.error.details?.scrollDirection).toBe('down');
   }
 });
 

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -2593,10 +2593,13 @@ test('press @ref fails fast when the target is off-screen', async () => {
   if (response && !response.ok) {
     expect(response.error.code).toBe('COMMAND_FAILED');
     expect(response.error.message).toMatch(/off-screen/i);
-    // #1366: the hint names the concrete scroll direction and steers to a
-    // selector-based retry (a @ref would be rejected as expired after the scroll).
+    // #1366: the hint names the concrete scroll direction, steers to a
+    // selector-based retry (a @ref would be rejected as expired after the scroll),
+    // and prescribes bounded movement (a large fling scroll overshoots).
     expect(response.error.hint).toMatch(/scroll down/i);
     expect(response.error.hint).toMatch(/selector/i);
+    expect(response.error.hint).toMatch(/small steps/i);
+    expect(response.error.hint).toMatch(/gesture pan/i);
     expect(response.error.details?.reason).toBe('offscreen_ref');
     expect(response.error.details?.scrollDirection).toBe('down');
   }

--- a/src/snapshot/mobile-snapshot-semantics.ts
+++ b/src/snapshot/mobile-snapshot-semantics.ts
@@ -150,6 +150,38 @@ export function resolveEffectiveViewportRect(
   return resolveViewportRect(nodes, node.rect ?? { x: 0, y: 0, width: 0, height: 0 });
 }
 
+/** The concrete `scroll <direction>` that brings an off-screen target into view. */
+export type OffscreenScrollDirection = 'up' | 'down' | 'left' | 'right';
+
+/**
+ * The direction to `scroll` so an off-screen target comes into view, from its
+ * rect and effective viewport. Follows the reveal convention the CLI hints
+ * already use (`cli-help.ts`): off-screen below -> scroll down, above -> up, and
+ * the horizontal mirror. When a target sits off more than one edge (a diagonal
+ * closed drawer), the axis with the largest overshoot wins so the agent's first
+ * move is the dominant one. Returns `null` when the rect is not fully past any
+ * edge — i.e. it is not off-screen on a single axis — leaving the caller's
+ * generic "scroll toward it" phrasing in place.
+ */
+export function classifyOffscreenScrollDirection(
+  targetRect: Rect,
+  viewportRect: Rect,
+): OffscreenScrollDirection | null {
+  const overshoots: Array<{ direction: OffscreenScrollDirection; amount: number }> = [
+    { direction: 'down', amount: targetRect.y - (viewportRect.y + viewportRect.height) },
+    { direction: 'up', amount: viewportRect.y - (targetRect.y + targetRect.height) },
+    { direction: 'right', amount: targetRect.x - (viewportRect.x + viewportRect.width) },
+    { direction: 'left', amount: viewportRect.x - (targetRect.x + targetRect.width) },
+  ];
+  let best: { direction: OffscreenScrollDirection; amount: number } | null = null;
+  for (const candidate of overshoots) {
+    if (candidate.amount > 0 && (!best || candidate.amount > best.amount)) {
+      best = candidate;
+    }
+  }
+  return best?.direction ?? null;
+}
+
 function deriveContainerHints(
   allNodes: SnapshotNode[],
   offscreenNodes: SnapshotNode[],

--- a/src/snapshot/mobile-snapshot-semantics.ts
+++ b/src/snapshot/mobile-snapshot-semantics.ts
@@ -154,24 +154,68 @@ export function resolveEffectiveViewportRect(
 export type OffscreenScrollDirection = 'up' | 'down' | 'left' | 'right';
 
 /**
- * The direction to `scroll` so an off-screen target comes into view, from its
- * rect and effective viewport. Follows the reveal convention the CLI hints
- * already use (`cli-help.ts`): off-screen below -> scroll down, above -> up, and
- * the horizontal mirror. When a target sits off more than one edge (a diagonal
- * closed drawer), the axis with the largest overshoot wins so the agent's first
- * move is the dominant one. Returns `null` when the rect is not fully past any
- * edge — i.e. it is not off-screen on a single axis — leaving the caller's
- * generic "scroll toward it" phrasing in place.
+ * The direction to `scroll` so an off-screen interaction target comes into view.
+ * Derived from the SAME two boundaries `isNodeVisibleOnScreen` rejects against,
+ * so every rejected target yields a direction (#1366) — not just the subset a
+ * rect-vs-one-viewport check catches:
+ *
+ *  1. The rect has no overlap with its effective (scroll-container) viewport —
+ *     an item scrolled out of an on-screen list. Direction from the container.
+ *  2. The rect still overlaps its container, but the tap-point CENTER is pushed
+ *     outside the ROOT viewport — a child inside an off-screen drawer, or a row
+ *     straddling the viewport edge whose center is past it. The rect-vs-effective
+ *     -viewport form misses both; this reads the boundary that actually failed.
+ *
+ * Direction follows the reveal convention the CLI hints already use
+ * (`cli-help.ts`): off-screen below -> scroll down, above -> up, horizontal
+ * mirror; the axis with the largest center overshoot wins so a corner-off target
+ * gets its dominant move. Returns null only when the node is on-screen.
  */
 export function classifyOffscreenScrollDirection(
-  targetRect: Rect,
-  viewportRect: Rect,
+  node: Pick<SnapshotNode, 'rect' | 'index' | 'parentIndex' | 'type' | 'role' | 'subrole'>,
+  nodes: SnapshotNode[],
+  byIndex: Map<number, SnapshotNode> = buildSnapshotNodeMap(nodes),
 ): OffscreenScrollDirection | null {
+  if (!node.rect) {
+    return null;
+  }
+  // Boundary 1: fully separated from the effective (scroll-container) viewport.
+  const effectiveViewport = resolveEffectiveViewportRect(node, nodes, byIndex);
+  if (effectiveViewport && !isRectVisibleInViewport(node.rect, effectiveViewport)) {
+    const direction = directionOfCenterOutsideViewport(node.rect, effectiveViewport);
+    if (direction) {
+      return direction;
+    }
+  }
+  // Boundary 2: tap-point center outside the root viewport (off-screen container
+  // or an edge-straddling rect whose center is past the frame).
+  const rootViewport = resolveViewportRect(nodes, node.rect);
+  if (rootViewport && !isTapPointInsideViewport(node.rect, rootViewport)) {
+    const direction = directionOfCenterOutsideViewport(node.rect, rootViewport);
+    if (direction) {
+      return direction;
+    }
+  }
+  return null;
+}
+
+/**
+ * The dominant edge the rect's tap-point center sits beyond, or null when the
+ * center is within the viewport on both axes. Uses the same unrounded center as
+ * `isTapPointInsideViewport` so the direction agrees with the rejection at the
+ * pixel boundary.
+ */
+function directionOfCenterOutsideViewport(
+  rect: Rect,
+  viewport: Rect,
+): OffscreenScrollDirection | null {
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
   const overshoots: Array<{ direction: OffscreenScrollDirection; amount: number }> = [
-    { direction: 'down', amount: targetRect.y - (viewportRect.y + viewportRect.height) },
-    { direction: 'up', amount: viewportRect.y - (targetRect.y + targetRect.height) },
-    { direction: 'right', amount: targetRect.x - (viewportRect.x + viewportRect.width) },
-    { direction: 'left', amount: viewportRect.x - (targetRect.x + targetRect.width) },
+    { direction: 'down', amount: centerY - (viewport.y + viewport.height) },
+    { direction: 'up', amount: viewport.y - centerY },
+    { direction: 'right', amount: centerX - (viewport.x + viewport.width) },
+    { direction: 'left', amount: viewport.x - centerX },
   ];
   let best: { direction: OffscreenScrollDirection; amount: number } | null = null;
   for (const candidate of overshoots) {

--- a/src/utils/__tests__/mobile-snapshot-semantics.test.ts
+++ b/src/utils/__tests__/mobile-snapshot-semantics.test.ts
@@ -325,40 +325,110 @@ test('visibility is false for node just outside viewport boundary', () => {
   assert.equal(isNodeVisibleInEffectiveViewport(nodes[1]!, nodes), false);
 });
 
-test('classifyOffscreenScrollDirection names the reveal direction per edge', () => {
-  const viewport = { x: 0, y: 0, width: 400, height: 800 };
-  // Below the viewport bottom -> scroll down; above the top -> scroll up.
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: 20, y: 1200, width: 120, height: 44 }, viewport),
-    'down',
-  );
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: 20, y: -100, width: 120, height: 44 }, viewport),
-    'up',
-  );
-  // Horizontal mirror: fully left of the viewport -> scroll left; right -> right.
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: -320, y: 240, width: 300, height: 50 }, viewport),
-    'left',
-  );
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: 500, y: 240, width: 120, height: 44 }, viewport),
-    'right',
-  );
+function windowRoot(): SnapshotNode {
+  return { ref: 'e1', index: 0, depth: 0, type: 'Window', rect: { x: 0, y: 0, width: 400, height: 800 } };
+}
+
+test('classifyOffscreenScrollDirection names the reveal direction for a fully scrolled-out item', () => {
+  const below: SnapshotNode[] = [
+    windowRoot(),
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Far below',
+      rect: { x: 20, y: 1200, width: 120, height: 44 },
+      hittable: true,
+    },
+  ];
+  assert.equal(classifyOffscreenScrollDirection(below[1]!, below), 'down');
+
+  const above: SnapshotNode[] = [
+    windowRoot(),
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Far above',
+      rect: { x: 20, y: -100, width: 120, height: 44 },
+      hittable: true,
+    },
+  ];
+  assert.equal(classifyOffscreenScrollDirection(above[1]!, above), 'up');
 });
 
-test('classifyOffscreenScrollDirection picks the dominant axis and ignores on-screen rects', () => {
-  const viewport = { x: 0, y: 0, width: 400, height: 800 };
-  // Off both the bottom (overshoot 400) and the right (overshoot 100): down wins.
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: 500, y: 1200, width: 120, height: 44 }, viewport),
-    'down',
-  );
-  // Overlapping the viewport on every edge is not off-screen on a single axis.
-  assert.equal(
-    classifyOffscreenScrollDirection({ x: 20, y: 40, width: 120, height: 44 }, viewport),
-    null,
-  );
+test('classifyOffscreenScrollDirection returns null for an on-screen node', () => {
+  const nodes: SnapshotNode[] = [
+    windowRoot(),
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Visible',
+      rect: { x: 20, y: 40, width: 120, height: 44 },
+      hittable: true,
+    },
+  ];
+  assert.equal(classifyOffscreenScrollDirection(nodes[1]!, nodes), null);
+});
+
+test('classifyOffscreenScrollDirection resolves a partial clip whose center is past the viewport (#1366)', () => {
+  // The rect still OVERLAPS the root viewport (top edge inside), so the rect-vs-
+  // viewport form returns null — but the tap-point center sits below the bottom
+  // edge, which is exactly what isNodeVisibleOnScreen rejects. Direction must be down.
+  const nodes: SnapshotNode[] = [
+    windowRoot(),
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Straddling the bottom edge',
+      rect: { x: 20, y: 790, width: 120, height: 44 },
+      hittable: true,
+    },
+  ];
+  // Sanity: this node is genuinely rejected by the interaction visibility guard.
+  assert.equal(isNodeVisibleInEffectiveViewport(nodes[1]!, nodes), true);
+  assert.equal(classifyOffscreenScrollDirection(nodes[1]!, nodes), 'down');
+});
+
+test('classifyOffscreenScrollDirection resolves a child inside an off-screen scrollable ancestor (#1366)', () => {
+  // Closed drawer: the child overlaps its own ScrollView (so boundary 1 passes),
+  // but the container is off the root viewport to the left, so the child's center
+  // is outside the root frame. Direction must come from the root boundary: left.
+  const nodes: SnapshotNode[] = [
+    windowRoot(),
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'ScrollView',
+      label: 'Drawer',
+      rect: { x: -400, y: 0, width: 400, height: 800 },
+    },
+    {
+      ref: 'e3',
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Drawer action',
+      rect: { x: -380, y: 300, width: 200, height: 44 },
+      hittable: true,
+    },
+  ];
+  // Boundary 1 passes (child overlaps its container); the root boundary fails.
+  assert.equal(isNodeVisibleInEffectiveViewport(nodes[2]!, nodes), true);
+  assert.equal(classifyOffscreenScrollDirection(nodes[2]!, nodes), 'left');
 });
 
 test('mobile presentation infers hidden content from vertical scroll indicator value at top', () => {

--- a/src/utils/__tests__/mobile-snapshot-semantics.test.ts
+++ b/src/utils/__tests__/mobile-snapshot-semantics.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   buildMobileSnapshotPresentation,
+  classifyOffscreenScrollDirection,
   isNodeVisibleInEffectiveViewport,
 } from '../../snapshot/mobile-snapshot-semantics.ts';
 import type { SnapshotNode } from '../../kernel/snapshot.ts';
@@ -322,6 +323,42 @@ test('visibility is false for node just outside viewport boundary', () => {
   ];
 
   assert.equal(isNodeVisibleInEffectiveViewport(nodes[1]!, nodes), false);
+});
+
+test('classifyOffscreenScrollDirection names the reveal direction per edge', () => {
+  const viewport = { x: 0, y: 0, width: 400, height: 800 };
+  // Below the viewport bottom -> scroll down; above the top -> scroll up.
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: 20, y: 1200, width: 120, height: 44 }, viewport),
+    'down',
+  );
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: 20, y: -100, width: 120, height: 44 }, viewport),
+    'up',
+  );
+  // Horizontal mirror: fully left of the viewport -> scroll left; right -> right.
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: -320, y: 240, width: 300, height: 50 }, viewport),
+    'left',
+  );
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: 500, y: 240, width: 120, height: 44 }, viewport),
+    'right',
+  );
+});
+
+test('classifyOffscreenScrollDirection picks the dominant axis and ignores on-screen rects', () => {
+  const viewport = { x: 0, y: 0, width: 400, height: 800 };
+  // Off both the bottom (overshoot 400) and the right (overshoot 100): down wins.
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: 500, y: 1200, width: 120, height: 44 }, viewport),
+    'down',
+  );
+  // Overlapping the viewport on every edge is not off-screen on a single axis.
+  assert.equal(
+    classifyOffscreenScrollDirection({ x: 20, y: 40, width: 120, height: 44 }, viewport),
+    null,
+  );
 });
 
 test('mobile presentation infers hidden content from vertical scroll indicator value at top', () => {

--- a/src/utils/__tests__/mobile-snapshot-semantics.test.ts
+++ b/src/utils/__tests__/mobile-snapshot-semantics.test.ts
@@ -326,7 +326,13 @@ test('visibility is false for node just outside viewport boundary', () => {
 });
 
 function windowRoot(): SnapshotNode {
-  return { ref: 'e1', index: 0, depth: 0, type: 'Window', rect: { x: 0, y: 0, width: 400, height: 800 } };
+  return {
+    ref: 'e1',
+    index: 0,
+    depth: 0,
+    type: 'Window',
+    rect: { x: 0, y: 0, width: 400, height: 800 },
+  };
 }
 
 test('classifyOffscreenScrollDirection names the reveal direction for a fully scrolled-out item', () => {


### PR DESCRIPTION
Fixes #1366.

## Problem

An agent driving a scrollable form hits an off-screen target, gets **correctly** rejected, and then can't recover within the turn budget. In `bootstrap-bench`, 2/10 runs (one per arm, so not an arm regression) burned all 60 turns on a single checkout-form screen — combined lost cost $3.83.

The two guards involved are both working as designed and are **kept intact**:

1. **Off-screen press/click rejection** (`resolution.ts`) — refuses a tap outside the visible viewport.
2. **Ref-frame expiry after a device side effect** (ADR 0014) — a scroll invalidates the refs it just resolved.

The friction is the *recovery loop*: the agent's obvious next move after scrolling — retry the same `@ref` — is exactly what both guards reject (still off-screen, or now an expired frame). The old hints didn't name a concrete escape:

- selector: *"Scroll toward it or open its container, take a fresh snapshot, then retry press."* (no direction)
- ref: *"Use scroll with the direction from the off-screen summary…"* (indirection to a summary the agent may not have, and offers "the new ref" — which needs a full re-snapshot to re-authorize)

## Fix

Make the rejection self-sufficient for recovery, without relaxing either guard:

- **Name the exact scroll direction** in the off-screen hint, computed from the target rect vs its effective viewport (new `classifyOffscreenScrollDirection`, largest-overshoot axis, following the same reveal convention `cli-help.ts` already uses). Also surfaced as a machine-readable `scrollDirection` error detail.
- **Steer the retry to a selector**, not a `@ref`. A selector re-resolves against a fresh snapshot on every attempt and bypasses the ref-frame admission guard entirely (verified: `refMutationAdmissionResponse` runs only for `kind === 'ref'` targets) — so it's the one move that isn't rejected after the scroll.
- **`scroll` unknown-direction error** now carries a grammar hint. The transcripts show agents mis-shaping it as `scroll @ref down` / `scroll down @ref`; `scroll` takes a direction and no target.

The rejection **messages and semantics are unchanged** — only the hints and one added detail field differ.

### Example (before → after)

```
Error: Ref @e35 is off-screen and not safe to press
Hint (before): Use scroll with the direction from the off-screen summary, take a fresh snapshot, then retry press with the new ref or a selector.
Hint (after):  Scroll down to bring it on-screen, then retry press with a selector (e.g. text=/id=) rather than this @ref — the scroll expires the ref frame, so re-run snapshot -i before reusing any @ref.
```

## Tests

- New unit tests for `classifyOffscreenScrollDirection` (per-edge, dominant-axis, on-screen → null).
- New test: `scroll` reader rejects a `@ref` in the direction slot with the grammar hint.
- Updated off-screen selector/ref tests (runtime + daemon fast-path) to assert the named direction, `scrollDirection` detail, and selector-first steering.
- Full `unit-core` suite green (4146 tests); typecheck, oxlint, and `fallow audit` clean.