### PR TITLE
fix(android): preserve fixed siblings after snapshot filtering

### DIFF
--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -1,5 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import { buildSnapshotState } from '../../../daemon/handlers/snapshot-capture.ts';
+import { isNodeVisibleOnScreen } from '../../../snapshot/mobile-snapshot-semantics.ts';
 import { androidUiNodes, parseUiHierarchy } from '../ui-hierarchy.ts';
 
 test('parseUiHierarchy does not truncate when no max node count is requested', () => {
@@ -83,6 +85,31 @@ test('parseUiHierarchy keeps visible Android nodes with meaningful test identifi
     result.nodes.some((node) => node.identifier === 'album-0'),
     true,
   );
+});
+
+test('interactive Android snapshots keep a fixed sibling outside filtered scroll content (#1377)', () => {
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][400,800]" visible-to-user="true">
+    <node class="android.view.View" bounds="[0,0][400,800]" visible-to-user="true">
+      <node class="android.widget.ScrollView" bounds="[0,100][400,800]" scrollable="true" visible-to-user="true">
+        <node class="android.widget.TextView" text="Row 1" bounds="[0,100][400,160]" clickable="true" visible-to-user="true"/>
+      </node>
+      <node class="android.view.View" bounds="[0,0][400,100]" visible-to-user="true">
+        <node class="android.view.View" resource-id="header-action" bounds="[340,20][400,80]" clickable="true" visible-to-user="true"/>
+      </node>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const parsed = parseUiHierarchy(xml, 800, { interactiveOnly: true });
+  const snapshot = buildSnapshotState(
+    { nodes: parsed.nodes, backend: 'android' },
+    { snapshotInteractiveOnly: true },
+  );
+  const header = snapshot.nodes.find((node) => node.identifier === 'header-action');
+
+  assert.equal(header?.parentIndex, undefined);
+  assert.equal(header && isNodeVisibleOnScreen(header, snapshot.nodes), true);
 });
 
 test('parseUiHierarchy reads Android bounds with negative coordinates', () => {

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -190,7 +190,7 @@ function walkUiHierarchyNode(
   const systemChrome =
     ancestorSystemChrome || isAndroidSystemChromeWindowResourceId(node.identifier);
   const currentIndex = include
-    ? appendAndroidSnapshotNode(state, node, depth, parentIndex, systemChrome)
+    ? appendAndroidSnapshotNode(state, node, parentIndex, systemChrome)
     : parentIndex;
   const nextAncestorHittable = ancestorHittable || Boolean(node.hittable);
   const nextAncestorCollection = ancestorCollection || isCollectionContainerType(node.type);
@@ -211,11 +211,14 @@ function walkUiHierarchyNode(
 function appendAndroidSnapshotNode(
   state: AndroidSnapshotBuildState,
   node: AndroidNode,
-  depth: number,
   parentIndex: number | undefined,
   systemChrome: boolean,
 ): number {
   const currentIndex = state.nodes.length;
+  // Snapshot filtering removes Compose layout wrappers. Keep depth aligned with
+  // the retained parent edge, rather than the source tree's depth: otherwise a
+  // fixed sibling that follows scroll content can be re-parented under the last
+  // retained row by normalizeSnapshotTree's depth fallback (#1377).
   state.sourceNodes.push(node);
   state.nodes.push({
     index: currentIndex,
@@ -229,13 +232,20 @@ function appendAndroidSnapshotNode(
     focused: node.focused,
     visibleToUser: node.visibleToUser,
     hittable: node.hittable,
-    depth,
+    depth: compactedAndroidNodeDepth(state.nodes, parentIndex),
     parentIndex,
     ...(node.hiddenContentAbove ? { hiddenContentAbove: true } : {}),
     ...(node.hiddenContentBelow ? { hiddenContentBelow: true } : {}),
     ...(systemChrome ? { systemChrome: true } : {}),
   });
   return currentIndex;
+}
+
+function compactedAndroidNodeDepth(
+  nodes: AndroidRawSnapshotNode[],
+  parentIndex: number | undefined,
+): number {
+  return parentIndex === undefined ? 0 : (nodes[parentIndex]?.depth ?? -1) + 1;
 }
 
 function hasInteractiveDescendant(state: AndroidSnapshotBuildState, node: AndroidNode): boolean {


### PR DESCRIPTION
## Summary

Fixes #1377.

- Preserve compact Android snapshot depths after filtered Compose wrappers so fixed siblings do not inherit the preceding scroll-content row.
- Keep on-screen Material3 TopAppBar actions selectable instead of treating them as off-screen scroll content.

## Validation

- `pnpm check:affected --base origin/main --run`
- `pnpm test:coverage`
- `pnpm test:integration:provider`
- End-to-end on Pixel 9 Pro XL API 37 (`emulator-5554`) using the issue repro: `click id=header-action` succeeded and `text="last tap: header-action"` was visible.
