### PR TITLE
fix: report bundle sizes with two decimal MB precision

### DIFF
--- a/scripts/size-report.mjs
+++ b/scripts/size-report.mjs
@@ -347,7 +347,7 @@ function formatBytes(value) {
   const absoluteValue = Math.abs(value);
   if (absoluteValue < 1000) return `${value} B`;
   if (absoluteValue < 1000 * 1000) return `${(value / 1000).toFixed(1)} kB`;
-  return `${(value / (1000 * 1000)).toFixed(1)} MB`;
+  return `${(value / (1000 * 1000)).toFixed(2)} MB`;
 }
 
 function formatSignedBytes(value) {


### PR DESCRIPTION
## Summary

Update the size report’s megabyte formatter to always show two decimal places, so values render as `2.41 MB` instead of `2.4 MB`.

## Validation

- `node --check scripts/size-report.mjs`
- `pnpm exec oxfmt --check scripts/size-report.mjs`
- Affected checks passed through formatting, lint, typecheck, and layering.
- The broader affected check stopped at Fallow because its temporary baseline worktree could not be created in the local environment.
