### PR TITLE
fix: select app-bearing simulator for replay

### DIFF
--- a/src/core/__tests__/dispatch-resolve.test.ts
+++ b/src/core/__tests__/dispatch-resolve.test.ts
@@ -185,33 +185,28 @@ test('resolveTargetDevice selects the unique booted simulator with the requested
   );
 });
 
-test('resolveTargetDevice uses app-aware iOS selection when platform is omitted', async () => {
-  mockListAppleDevices.mockResolvedValue([bootedSimulator, secondBootedSimulator]);
-  mockFindIosSimulatorInstalledApp.mockImplementation(async (device) =>
-    device.id === secondBootedSimulator.id ? 'com.example.demo' : undefined,
+test('resolveTargetDevice leaves platform-less static app selection to normal cross-platform resolution', async () => {
+  const result = await withDeviceInventoryProvider(
+    async (request) => {
+      assert.equal(request.platform, undefined);
+      return [androidEmulator, bootedSimulator, secondBootedSimulator];
+    },
+    async () => await resolveTargetDevice({}, { appleSimulatorAppTarget: 'com.example.demo' }),
   );
 
-  const result = await resolveTargetDevice({}, { appleSimulatorAppTarget: 'com.example.demo' });
-
-  assert.equal(result.id, secondBootedSimulator.id);
-  assert.deepEqual(
-    mockFindIosSimulatorInstalledApp.mock.calls.map(([device, app]) => [device.id, app]),
-    [
-      [bootedSimulator.id, 'com.example.demo'],
-      [secondBootedSimulator.id, 'com.example.demo'],
-    ],
-  );
+  assert.equal(result.id, androidEmulator.id);
+  assert.equal(mockFindIosSimulatorInstalledApp.mock.calls.length, 0);
 });
 
-test('resolveTargetDevice reuses an app-aware selection for later platform-inferred resolution', async () => {
+test('resolveTargetDevice reuses an app-aware iOS selection for later iOS resolution', async () => {
   mockListAppleDevices.mockResolvedValue([bootedSimulator, secondBootedSimulator]);
   mockFindIosSimulatorInstalledApp.mockImplementation(async (device) =>
     device.id === secondBootedSimulator.id ? 'com.example.demo' : undefined,
   );
 
   const [appAware, laterResolution] = await withResolveTargetDeviceCacheScope(async () => [
-    await resolveTargetDevice({}, { appleSimulatorAppTarget: 'com.example.demo' }),
-    await resolveTargetDevice({}),
+    await resolveTargetDevice({ platform: 'ios' }, { appleSimulatorAppTarget: 'com.example.demo' }),
+    await resolveTargetDevice({ platform: 'ios' }),
   ]);
 
   assert.equal(appAware.id, secondBootedSimulator.id);

--- a/src/core/__tests__/dispatch-resolve.test.ts
+++ b/src/core/__tests__/dispatch-resolve.test.ts
@@ -185,15 +185,33 @@ test('resolveTargetDevice selects the unique booted simulator with the requested
   );
 });
 
-test('resolveTargetDevice reuses an app-aware selection for later request resolution', async () => {
+test('resolveTargetDevice uses app-aware iOS selection when platform is omitted', async () => {
+  mockListAppleDevices.mockResolvedValue([bootedSimulator, secondBootedSimulator]);
+  mockFindIosSimulatorInstalledApp.mockImplementation(async (device) =>
+    device.id === secondBootedSimulator.id ? 'com.example.demo' : undefined,
+  );
+
+  const result = await resolveTargetDevice({}, { appleSimulatorAppTarget: 'com.example.demo' });
+
+  assert.equal(result.id, secondBootedSimulator.id);
+  assert.deepEqual(
+    mockFindIosSimulatorInstalledApp.mock.calls.map(([device, app]) => [device.id, app]),
+    [
+      [bootedSimulator.id, 'com.example.demo'],
+      [secondBootedSimulator.id, 'com.example.demo'],
+    ],
+  );
+});
+
+test('resolveTargetDevice reuses an app-aware selection for later platform-inferred resolution', async () => {
   mockListAppleDevices.mockResolvedValue([bootedSimulator, secondBootedSimulator]);
   mockFindIosSimulatorInstalledApp.mockImplementation(async (device) =>
     device.id === secondBootedSimulator.id ? 'com.example.demo' : undefined,
   );
 
   const [appAware, laterResolution] = await withResolveTargetDeviceCacheScope(async () => [
-    await resolveTargetDevice({ platform: 'ios' }, { appleSimulatorAppTarget: 'com.example.demo' }),
-    await resolveTargetDevice({ platform: 'ios' }),
+    await resolveTargetDevice({}, { appleSimulatorAppTarget: 'com.example.demo' }),
+    await resolveTargetDevice({}),
   ]);
 
   assert.equal(appAware.id, secondBootedSimulator.id);
@@ -233,11 +251,11 @@ test('resolveTargetDevice refuses ambiguous booted simulator app matches', async
   assert.equal(error.details?.hint, 'Pass --udid to select the intended simulator explicitly.');
 });
 
-test('resolveTargetDevice does not probe when an Apple device is explicitly selected', async () => {
+test('resolveTargetDevice preserves an explicit device selector when platform is omitted', async () => {
   mockListAppleDevices.mockResolvedValue([bootedSimulator, secondBootedSimulator]);
 
   const result = await resolveTargetDevice(
-    { platform: 'ios', udid: bootedSimulator.id },
+    { udid: bootedSimulator.id },
     { appleSimulatorAppTarget: 'com.example.demo' },
   );
 

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -214,7 +214,7 @@ export async function resolveTargetDevice(
       }
       const injectedDevices = await readInjectedDeviceInventory(inventoryRequest);
       if (injectedDevices) {
-        if (isAppleResolutionSelector(selector)) {
+        if (shouldUseAppleResolution(selector, options)) {
           return cacheResolvedTargetDevice(
             cacheKey,
             await resolveAppleDevice(injectedDevices, selector as AppleDeviceSelector, {
@@ -232,7 +232,7 @@ export async function resolveTargetDevice(
 
       const devices = await listLocalDeviceInventory(inventoryRequest);
 
-      if (isAppleResolutionSelector(selector)) {
+      if (shouldUseAppleResolution(selector, options)) {
         return cacheResolvedTargetDevice(
           cacheKey,
           await resolveAppleDevice(devices, selector as AppleDeviceSelector, {
@@ -326,6 +326,14 @@ function isAppleResolutionSelector(selector: {
   target?: DeviceTarget;
 }): boolean {
   return isApplePlatform(selector.platform);
+}
+
+function shouldUseAppleResolution(
+  selector: { platform?: PlatformSelector; target?: DeviceTarget },
+  options: ResolveTargetDeviceOptions,
+): boolean {
+  if (isAppleResolutionSelector(selector)) return true;
+  return selector.platform === undefined && options.appleSimulatorAppTarget !== undefined;
 }
 
 function readResolveTargetDeviceCache(cacheKey: string): DeviceInfo | undefined {

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -214,7 +214,7 @@ export async function resolveTargetDevice(
       }
       const injectedDevices = await readInjectedDeviceInventory(inventoryRequest);
       if (injectedDevices) {
-        if (shouldUseAppleResolution(selector, options)) {
+        if (shouldUseAppleResolution(selector)) {
           return cacheResolvedTargetDevice(
             cacheKey,
             await resolveAppleDevice(injectedDevices, selector as AppleDeviceSelector, {
@@ -232,7 +232,7 @@ export async function resolveTargetDevice(
 
       const devices = await listLocalDeviceInventory(inventoryRequest);
 
-      if (shouldUseAppleResolution(selector, options)) {
+      if (shouldUseAppleResolution(selector)) {
         return cacheResolvedTargetDevice(
           cacheKey,
           await resolveAppleDevice(devices, selector as AppleDeviceSelector, {
@@ -328,12 +328,11 @@ function isAppleResolutionSelector(selector: {
   return isApplePlatform(selector.platform);
 }
 
-function shouldUseAppleResolution(
-  selector: { platform?: PlatformSelector; target?: DeviceTarget },
-  options: ResolveTargetDeviceOptions,
-): boolean {
-  if (isAppleResolutionSelector(selector)) return true;
-  return selector.platform === undefined && options.appleSimulatorAppTarget !== undefined;
+function shouldUseAppleResolution(selector: {
+  platform?: PlatformSelector;
+  target?: DeviceTarget;
+}): boolean {
+  return isAppleResolutionSelector(selector);
 }
 
 function readResolveTargetDeviceCache(cacheKey: string): DeviceInfo | undefined {

--- a/src/daemon/__tests__/replay-device-selection.test.ts
+++ b/src/daemon/__tests__/replay-device-selection.test.ts
@@ -2,7 +2,11 @@ import { test, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { buildReplayTargetDeviceResolution } from '../replay-device-selection.ts';
+import { parseReplayInput } from '../../compat/replay-input.ts';
+import {
+  buildReplayScriptPlatformFlags,
+  buildReplayTargetDeviceResolution,
+} from '../replay-device-selection.ts';
 
 test('replay leaves deep-link opens to normal device resolution', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-device-selection-'));
@@ -18,6 +22,18 @@ test('replay leaves deep-link opens to normal device resolution', () => {
       meta: { cwd: root },
     }),
   ).toBeUndefined();
+});
+
+test('native replay applies its authored platform before a first deep link', () => {
+  expect(
+    buildReplayScriptPlatformFlags(
+      undefined,
+      parseReplayInput(
+        'runtime set --platform ios --metro-port 8081\nopen demo://checkout\nopen com.example.demo\n',
+        undefined,
+      ).actions,
+    ),
+  ).toEqual({ platform: 'ios' });
 });
 
 test('native replay uses its authored Android runtime setting without an iOS app probe', () => {

--- a/src/daemon/__tests__/replay-device-selection.test.ts
+++ b/src/daemon/__tests__/replay-device-selection.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildReplayTargetDeviceResolutionOptions } from '../replay-device-selection.ts';
+
+test('replay leaves deep-link opens to normal device resolution', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-device-selection-'));
+  const replayPath = path.join(root, 'deep-link.ad');
+  fs.writeFileSync(replayPath, 'open demo://checkout\n');
+
+  expect(
+    buildReplayTargetDeviceResolutionOptions({
+      token: 'test-token',
+      session: 'default',
+      command: 'replay',
+      positionals: [replayPath],
+      meta: { cwd: root },
+    }),
+  ).toBeUndefined();
+});

--- a/src/daemon/__tests__/replay-device-selection.test.ts
+++ b/src/daemon/__tests__/replay-device-selection.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { buildReplayTargetDeviceResolutionOptions } from '../replay-device-selection.ts';
+import { buildReplayTargetDeviceResolution } from '../replay-device-selection.ts';
 
 test('replay leaves deep-link opens to normal device resolution', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-device-selection-'));
@@ -10,7 +10,7 @@ test('replay leaves deep-link opens to normal device resolution', () => {
   fs.writeFileSync(replayPath, 'open demo://checkout\n');
 
   expect(
-    buildReplayTargetDeviceResolutionOptions({
+    buildReplayTargetDeviceResolution({
       token: 'test-token',
       session: 'default',
       command: 'replay',
@@ -18,4 +18,23 @@ test('replay leaves deep-link opens to normal device resolution', () => {
       meta: { cwd: root },
     }),
   ).toBeUndefined();
+});
+
+test('native replay uses its authored Android runtime setting without an iOS app probe', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-device-selection-'));
+  const replayPath = path.join(root, 'android.ad');
+  fs.writeFileSync(
+    replayPath,
+    'runtime set --platform android --metro-port 8081\nopen com.example.demo\n',
+  );
+
+  expect(
+    buildReplayTargetDeviceResolution({
+      token: 'test-token',
+      session: 'default',
+      command: 'replay',
+      positionals: [replayPath],
+      meta: { cwd: root },
+    }),
+  ).toEqual({ flags: { platform: 'android' }, options: undefined });
 });

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -143,7 +143,7 @@ test('fresh replay reserves its authored app simulator before any replay step', 
       session: 'fresh-replay',
       command: 'replay',
       positionals: [replayPath],
-      flags: { platform: 'ios' },
+      flags: {},
       meta: { cwd: root },
     },
     sessionName: 'fresh-replay',
@@ -152,7 +152,7 @@ test('fresh replay reserves its authored app simulator before any replay step', 
 
   expect(keys).toEqual(['session:fresh-replay', 'device:SIM-WITH-APP']);
   expect(mockResolveTargetDevice).toHaveBeenCalledWith(
-    { platform: 'ios' },
+    {},
     { appleSimulatorAppTarget: 'com.example.demo' },
   );
 });

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -168,6 +168,32 @@ test('fresh replay reserves its authored app simulator before any replay step', 
   );
 });
 
+test('fresh replay leaves a first deep-link open unbound when a later app target exists', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-deep-link-lock-'));
+  const replayPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    replayPath,
+    'runtime set --platform ios --metro-port 8081\nopen demo://checkout\nopen com.example.demo\n',
+  );
+  const sessionStore = makeSessionStore('agent-device-router-replay-deep-link-lock-');
+
+  const keys = await resolveRequestExecutionLockKeys({
+    req: {
+      token: 'test-token',
+      session: 'fresh-replay-deep-link',
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {},
+      meta: { cwd: root },
+    },
+    sessionName: 'fresh-replay-deep-link',
+    sessionStore,
+  });
+
+  expect(keys).toEqual(['session:fresh-replay-deep-link']);
+  expect(mockResolveTargetDevice).not.toHaveBeenCalled();
+});
+
 test('fresh replay preserves an authored Android platform before advisory locking', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-android-lock-'));
   const replayPath = path.join(root, 'flow.ad');

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -30,6 +30,17 @@ function makeIosDevice(id: string): DeviceInfo {
   };
 }
 
+function makeAndroidDevice(id: string): DeviceInfo {
+  return {
+    platform: 'android',
+    id,
+    name: `Android ${id}`,
+    kind: 'emulator',
+    target: 'mobile',
+    booted: true,
+  };
+}
+
 function createOpenHandler(
   sessionStore: ReturnType<typeof makeSessionStore>,
   leaseRegistry = new LeaseRegistry(),
@@ -152,9 +163,37 @@ test('fresh replay reserves its authored app simulator before any replay step', 
 
   expect(keys).toEqual(['session:fresh-replay', 'device:SIM-WITH-APP']);
   expect(mockResolveTargetDevice).toHaveBeenCalledWith(
-    {},
+    { platform: 'ios' },
     { appleSimulatorAppTarget: 'com.example.demo' },
   );
+});
+
+test('fresh replay preserves an authored Android platform before advisory locking', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-android-lock-'));
+  const replayPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    replayPath,
+    'runtime set --platform android --metro-port 8081\nopen com.example.demo\n',
+  );
+  const sessionStore = makeSessionStore('agent-device-router-replay-android-lock-');
+  const androidDevice = makeAndroidDevice('ANDROID-EMULATOR');
+  mockResolveTargetDevice.mockResolvedValue(androidDevice);
+
+  const keys = await resolveRequestExecutionLockKeys({
+    req: {
+      token: 'test-token',
+      session: 'fresh-replay-android',
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {},
+      meta: { cwd: root },
+    },
+    sessionName: 'fresh-replay-android',
+    sessionStore,
+  });
+
+  expect(keys).toEqual(['session:fresh-replay-android', 'device:ANDROID-EMULATOR']);
+  expect(mockResolveTargetDevice).toHaveBeenCalledWith({ platform: 'android' }, undefined);
 });
 
 test('open --debug writes bounded open timing diagnostics to requestLogPath', async () => {

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -8,6 +8,7 @@ vi.mock('../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) 
 
 import { dispatchCommand } from '../../core/dispatch.ts';
 import { createRequestHandler } from '../request-router.ts';
+import { resolveRequestExecutionLockKeys } from '../request-binding.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
@@ -120,6 +121,40 @@ test('fresh open uses app-aware device selection for advisory locking and dispat
     [{ platform: 'ios' }, { appleSimulatorAppTarget: 'com.example.demo' }],
   ]);
   expect(sessionStore.get('session-app-aware')?.device.id).toBe(appDevice.id);
+});
+
+test('fresh replay reserves its authored app simulator before any replay step', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-app-lock-'));
+  const replayPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    replayPath,
+    'runtime set --platform ios --metro-port 8081\nopen com.example.demo\n',
+  );
+  const sessionStore = makeSessionStore('agent-device-router-replay-lock-');
+  const genericDevice = makeIosDevice('SIM-GENERIC');
+  const appDevice = makeIosDevice('SIM-WITH-APP');
+  mockResolveTargetDevice.mockImplementation(async (_flags, options) =>
+    options?.appleSimulatorAppTarget === 'com.example.demo' ? appDevice : genericDevice,
+  );
+
+  const keys = await resolveRequestExecutionLockKeys({
+    req: {
+      token: 'test-token',
+      session: 'fresh-replay',
+      command: 'replay',
+      positionals: [replayPath],
+      flags: { platform: 'ios' },
+      meta: { cwd: root },
+    },
+    sessionName: 'fresh-replay',
+    sessionStore,
+  });
+
+  expect(keys).toEqual(['session:fresh-replay', 'device:SIM-WITH-APP']);
+  expect(mockResolveTargetDevice).toHaveBeenCalledWith(
+    { platform: 'ios' },
+    { appleSimulatorAppTarget: 'com.example.demo' },
+  );
 });
 
 test('open --debug writes bounded open timing diagnostics to requestLogPath', async () => {

--- a/src/daemon/handlers/__tests__/session-command-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-command-replay.test.ts
@@ -111,7 +111,7 @@ test('replay parses inline open runtime flags and replays open with runtime payl
   expect(response?.ok).toBe(true);
   expect(invoked[0]?.command).toBe('open');
   expect(invoked[0]?.positionals).toEqual(['Demo']);
-  expect(invoked[0]?.flags).toEqual({ relaunch: true });
+  expect(invoked[0]?.flags).toEqual({ relaunch: true, platform: 'android' });
   expect(invoked[0]?.runtime).toEqual({
     platform: 'android',
     metroHost: '10.0.0.10',

--- a/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
@@ -11,7 +11,10 @@ import path from 'node:path';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';
 import { SessionStore } from '../../session-store.ts';
 import { dispatchCommand, resolveTargetDevice } from '../../../core/dispatch.ts';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeAndroidSession,
+  makeIosSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import {
   baseReplayRequest as baseReq,
   writeReplayFile,
@@ -410,7 +413,7 @@ test('fresh typed Maestro replay resolves its configured app before runtime defa
   const response = await runReplayScriptFile({
     req: baseReq({
       positionals: [flowPath],
-      flags: { replayBackend: 'maestro' },
+      flags: { replayBackend: 'maestro', platform: 'ios' },
       runtime: { metroPort: 8081 },
     }),
     sessionName: 'default',
@@ -421,13 +424,72 @@ test('fresh typed Maestro replay resolves its configured app before runtime defa
 
   expect(response.ok).toBe(true);
   expect(mockResolveTargetDevice).toHaveBeenCalledWith(
-    { replayBackend: 'maestro' },
+    { replayBackend: 'maestro', platform: 'ios' },
     { appleSimulatorAppTarget: 'com.example.demo' },
   );
   expect(invoke).toHaveBeenCalledWith(
     expect.objectContaining({
       command: 'open',
       flags: expect.objectContaining({ udid: 'SIM-WITH-APP' }),
+    }),
+  );
+});
+
+test('native replay applies an authored Android platform to its static app open', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-native-android-selection-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const replayPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    replayPath,
+    'runtime set --platform android --metro-port 8081\nopen com.example.demo\n',
+  );
+  const invoke = vi.fn(async () => ({ ok: true as const, data: {} }));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [replayPath] }),
+    sessionName: 'default',
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  expect(invoke).toHaveBeenCalledWith(
+    expect.objectContaining({
+      command: 'open',
+      positionals: ['com.example.demo'],
+      flags: expect.objectContaining({ platform: 'android' }),
+    }),
+  );
+});
+
+test('platform-less typed Maestro replay preserves a resolved Android device', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-android-selection-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const flowPath = path.join(root, 'flow.yaml');
+  fs.writeFileSync(flowPath, 'appId: com.example.demo\n---\n- launchApp\n');
+  const androidDevice = { ...makeAndroidSession('android').device, id: 'ANDROID-EMULATOR' };
+  mockResolveTargetDevice.mockResolvedValue(androidDevice);
+  const invoke = vi.fn(async () => ({ ok: true as const, data: {} }));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [flowPath],
+      flags: { replayBackend: 'maestro' },
+      runtime: { metroPort: 8081 },
+    }),
+    sessionName: 'default',
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  expect(mockResolveTargetDevice).toHaveBeenCalledWith({ replayBackend: 'maestro' }, {});
+  expect(invoke).toHaveBeenCalledWith(
+    expect.objectContaining({
+      command: 'open',
+      flags: expect.objectContaining({ platform: 'android', serial: 'ANDROID-EMULATOR' }),
     }),
   );
 });

--- a/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
@@ -395,6 +395,43 @@ test('typed Maestro rejects selectors that conflict with an active session', asy
   expect(invoke).not.toHaveBeenCalled();
 });
 
+test('fresh typed Maestro replay resolves its configured app before runtime defaults', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-app-selection-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const flowPath = path.join(root, 'flow.yaml');
+  fs.writeFileSync(flowPath, 'appId: com.example.demo\n---\n- launchApp\n');
+  const genericDevice = { ...makeIosSession('generic').device, id: 'SIM-GENERIC' };
+  const appDevice = { ...makeIosSession('app').device, id: 'SIM-WITH-APP' };
+  mockResolveTargetDevice.mockImplementation(async (_flags, options) =>
+    options?.appleSimulatorAppTarget === 'com.example.demo' ? appDevice : genericDevice,
+  );
+  const invoke = vi.fn(async () => ({ ok: true as const, data: {} }));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({
+      positionals: [flowPath],
+      flags: { replayBackend: 'maestro', platform: 'ios' },
+      runtime: { metroPort: 8081 },
+    }),
+    sessionName: 'default',
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke,
+  });
+
+  expect(response.ok).toBe(true);
+  expect(mockResolveTargetDevice).toHaveBeenCalledWith(
+    { replayBackend: 'maestro', platform: 'ios' },
+    { appleSimulatorAppTarget: 'com.example.demo' },
+  );
+  expect(invoke).toHaveBeenCalledWith(
+    expect.objectContaining({
+      command: 'open',
+      flags: expect.objectContaining({ udid: 'SIM-WITH-APP' }),
+    }),
+  );
+});
+
 test('typed Maestro resume digest binds effective stored runtime hints', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-session-runtime-'));
   const sessionStore = new SessionStore(path.join(root, 'sessions'));

--- a/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-plan.test.ts
@@ -410,7 +410,7 @@ test('fresh typed Maestro replay resolves its configured app before runtime defa
   const response = await runReplayScriptFile({
     req: baseReq({
       positionals: [flowPath],
-      flags: { replayBackend: 'maestro', platform: 'ios' },
+      flags: { replayBackend: 'maestro' },
       runtime: { metroPort: 8081 },
     }),
     sessionName: 'default',
@@ -421,7 +421,7 @@ test('fresh typed Maestro replay resolves its configured app before runtime defa
 
   expect(response.ok).toBe(true);
   expect(mockResolveTargetDevice).toHaveBeenCalledWith(
-    { replayBackend: 'maestro', platform: 'ios' },
+    { replayBackend: 'maestro' },
     { appleSimulatorAppTarget: 'com.example.demo' },
   );
   expect(invoke).toHaveBeenCalledWith(

--- a/src/daemon/handlers/session-replay-maestro-runtime.ts
+++ b/src/daemon/handlers/session-replay-maestro-runtime.ts
@@ -39,6 +39,7 @@ import {
 } from './session-replay-maestro-response.ts';
 import { resolveEffectiveOpenRuntimeHints } from './session-runtime.ts';
 import { contextFromFlags } from '../context.ts';
+import { buildMaestroReplayTargetDeviceResolutionOptions } from '../replay-device-selection.ts';
 
 type TypedMaestroReplayParams = {
   req: DaemonRequest;
@@ -176,7 +177,13 @@ async function prepareTypedMaestroReplay(
   });
   const session = sessionStore.get(sessionName);
   if (session) assertSessionSelectorMatches(session, req.flags);
-  const binding = await resolveMaestroReplayBinding({ req, sessionStore, sessionName, session });
+  const binding = await resolveMaestroReplayBinding({
+    req,
+    sessionStore,
+    sessionName,
+    session,
+    program,
+  });
   return {
     filePath,
     program,
@@ -199,8 +206,9 @@ async function resolveMaestroReplayBinding(params: {
   sessionStore: SessionStore;
   sessionName: string;
   session: ReturnType<SessionStore['get']>;
+  program: MaestroProgram;
 }): Promise<MaestroReplayBinding> {
-  const { req, sessionStore, sessionName, session } = params;
+  const { req, sessionStore, sessionName, session, program } = params;
   const requestedPlatform = req.flags?.platform;
   const device =
     session?.device ??
@@ -223,6 +231,7 @@ async function resolveMaestroReplayBinding(params: {
     platform,
     target: resolveMaestroTarget(req, device),
     runtimeHints,
+    program,
   });
 }
 
@@ -231,10 +240,14 @@ async function completeMaestroRuntimeBinding(
     req: DaemonRequest;
     sessionStore: SessionStore;
     sessionName: string;
+    program: MaestroProgram;
   } & MaestroReplayBinding,
 ): Promise<MaestroReplayBinding> {
   if (params.device || !requiresDeviceRuntimeDefaults(params.runtimeHints)) return params;
-  const device = await resolveTargetDevice(params.req.flags ?? {});
+  const device = await resolveTargetDevice(
+    params.req.flags ?? {},
+    buildMaestroReplayTargetDeviceResolutionOptions(params.program),
+  );
   return {
     device,
     platform: params.platform,

--- a/src/daemon/handlers/session-replay-maestro-runtime.ts
+++ b/src/daemon/handlers/session-replay-maestro-runtime.ts
@@ -216,7 +216,7 @@ async function resolveMaestroReplayBinding(params: {
       ? undefined
       : await resolveTargetDevice(
           req.flags ?? {},
-          buildMaestroReplayTargetDeviceResolutionOptions(program),
+          buildMaestroReplayTargetDeviceResolutionOptions(program, requestedPlatform),
         ));
   const platform = resolveMaestroPlatform(req, device);
   const runtimeHints = resolveEffectiveOpenRuntimeHints({
@@ -249,7 +249,7 @@ async function completeMaestroRuntimeBinding(
   if (params.device || !requiresDeviceRuntimeDefaults(params.runtimeHints)) return params;
   const device = await resolveTargetDevice(
     params.req.flags ?? {},
-    buildMaestroReplayTargetDeviceResolutionOptions(params.program),
+    buildMaestroReplayTargetDeviceResolutionOptions(params.program, params.platform),
   );
   return {
     device,

--- a/src/daemon/handlers/session-replay-maestro-runtime.ts
+++ b/src/daemon/handlers/session-replay-maestro-runtime.ts
@@ -214,7 +214,10 @@ async function resolveMaestroReplayBinding(params: {
     session?.device ??
     (requestedPlatform === 'android' || requestedPlatform === 'ios'
       ? undefined
-      : await resolveTargetDevice(req.flags ?? {}));
+      : await resolveTargetDevice(
+          req.flags ?? {},
+          buildMaestroReplayTargetDeviceResolutionOptions(program),
+        ));
   const platform = resolveMaestroPlatform(req, device);
   const runtimeHints = resolveEffectiveOpenRuntimeHints({
     req,

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -16,6 +16,7 @@ import {
 } from '../../request/progress.ts';
 import { SessionStore } from '../session-store.ts';
 import { expandSessionPath } from '../session-paths.ts';
+import { buildReplayScriptPlatformFlags } from '../replay-device-selection.ts';
 import { applySaveScriptRetarget } from '../session-action-recorder.ts';
 import { computeReplayPlanDigest } from '../../replay/plan-digest.ts';
 import type { TargetAnnotationV1 } from '../../replay/target-identity.ts';
@@ -534,7 +535,10 @@ function prepareReplayPlan(params: {
   if (!parsedResult.ok) return parsedResult;
   const parsed = parsedResult.value;
   const { metadata, actions, actionLines, actionSourcePaths } = parsed;
-  const replayReq = applyReplayMetadata(req, metadata);
+  const replayReq = applyReplayMetadata(
+    { ...req, flags: buildReplayScriptPlatformFlags(req.flags, actions) },
+    metadata,
+  );
   const planDigest = computeReplayPlanDigest({
     actions,
     actionLines,

--- a/src/daemon/open-device-selection.ts
+++ b/src/daemon/open-device-selection.ts
@@ -5,6 +5,12 @@ export function buildOpenTargetDeviceResolutionOptions(
   openTarget: string | undefined,
 ): ResolveTargetDeviceOptions {
   return {
-    appleSimulatorAppTarget: openTarget && !isDeepLinkTarget(openTarget) ? openTarget : undefined,
+    appleSimulatorAppTarget: appleSimulatorAppTargetForOpenTarget(openTarget),
   };
+}
+
+export function appleSimulatorAppTargetForOpenTarget(
+  openTarget: string | undefined,
+): string | undefined {
+  return openTarget && !isDeepLinkTarget(openTarget) ? openTarget : undefined;
 }

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -3,6 +3,7 @@ import { parseReplayInput } from '../compat/replay-input.ts';
 import { parseMaestroProgram } from '../compat/maestro/program-ir-parser.ts';
 import type { ResolveTargetDeviceOptions } from '../core/dispatch-resolve.ts';
 import type { MaestroProgram } from '../compat/maestro/program-ir.ts';
+import { isDeepLinkTarget } from '../contracts/open-target.ts';
 import { appleSimulatorAppTargetForOpenTarget } from './open-device-selection.ts';
 import { SessionStore } from './session-store.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
@@ -109,7 +110,7 @@ function readMaestroReplayAppTarget(program: MaestroProgram): string | undefined
 }
 
 function isStaticAppTarget(value: string | undefined): value is string {
-  return Boolean(value && value.trim() && !value.includes('$'));
+  return Boolean(value && value.trim() && !value.includes('$') && !isDeepLinkTarget(value));
 }
 
 function appTargetResolutionOptions(

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -15,8 +15,8 @@ export type ReplayTargetDeviceResolution = {
 };
 
 /**
- * Finds the first static app target a fresh replay will open.  Request binding
- * uses this before any replay action can cache an unqualified device choice.
+ * Finds a static first app target for fresh replay binding. Request binding
+ * must leave a first deep-link or dynamic open to normal device resolution.
  */
 export function buildReplayTargetDeviceResolution(
   req: DaemonRequest,
@@ -84,6 +84,7 @@ function readScriptReplaySelection(actions: SessionAction[]): {
     platform = action.runtime?.platform ?? platform;
     const target = action.positionals?.[0];
     if (isStaticAppTarget(target)) return { appTarget: target, platform };
+    return { appTarget: undefined, platform };
   }
   return { appTarget: undefined, platform };
 }

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import { parseReplayInput } from '../compat/replay-input.ts';
+import { parseMaestroProgram } from '../compat/maestro/program-ir-parser.ts';
+import type { ResolveTargetDeviceOptions } from '../core/dispatch-resolve.ts';
+import type { MaestroProgram } from '../compat/maestro/program-ir.ts';
+import { SessionStore } from './session-store.ts';
+import type { DaemonRequest, SessionAction } from './types.ts';
+
+/**
+ * Finds the first static app target a fresh replay will open.  Request binding
+ * uses this before any replay action can cache an unqualified device choice.
+ */
+export function buildReplayTargetDeviceResolutionOptions(
+  req: DaemonRequest,
+): ResolveTargetDeviceOptions | undefined {
+  if (req.command !== 'replay' || req.flags?.replayFrom !== undefined) return undefined;
+  const filePath = req.positionals?.[0];
+  if (!filePath) return undefined;
+
+  try {
+    const resolved = SessionStore.expandHome(filePath, req.meta?.cwd);
+    const source = fs.readFileSync(resolved, 'utf8');
+    const appTarget = isMaestroReplay(req, resolved)
+      ? readMaestroReplayAppTarget(parseMaestroProgram(source, { sourcePath: resolved }))
+      : readScriptReplayAppTarget(parseReplayInput(source, req.flags).actions);
+    return appTarget ? { appleSimulatorAppTarget: appTarget } : undefined;
+  } catch {
+    // Parsing and validation stay in the replay handler. Lock binding is only
+    // advisory, so an unreadable/invalid plan must not mask its real error.
+    return undefined;
+  }
+}
+
+export function buildMaestroReplayTargetDeviceResolutionOptions(
+  program: MaestroProgram,
+): ResolveTargetDeviceOptions {
+  const appTarget = readMaestroReplayAppTarget(program);
+  return appTarget ? { appleSimulatorAppTarget: appTarget } : {};
+}
+
+function isMaestroReplay(req: DaemonRequest, filePath: string): boolean {
+  return (
+    req.flags?.replayBackend === 'maestro' &&
+    (filePath.endsWith('.yaml') || filePath.endsWith('.yml'))
+  );
+}
+
+function readScriptReplayAppTarget(actions: SessionAction[]): string | undefined {
+  const target = actions.find((action) => action.command === 'open')?.positionals?.[0];
+  return isStaticAppTarget(target) ? target : undefined;
+}
+
+function readMaestroReplayAppTarget(program: MaestroProgram): string | undefined {
+  const configured = program.config.appId;
+  if (isStaticAppTarget(configured)) return configured;
+  const launch = [...(program.config.onFlowStart ?? []), ...program.commands].find(
+    (command) => command.kind === 'launchApp' && isStaticAppTarget(command.appId),
+  );
+  return launch?.kind === 'launchApp' ? launch.appId : undefined;
+}
+
+function isStaticAppTarget(value: string | undefined): value is string {
+  return Boolean(value && value.trim() && !value.includes('$'));
+}

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -89,13 +89,13 @@ function readScriptReplaySelection(actions: SessionAction[]): {
   return { appTarget: undefined, platform };
 }
 
-/** Applies a platform configured before the first static app open to replay dispatch. */
+/** Applies a platform configured before the first open to replay dispatch. */
 export function buildReplayScriptPlatformFlags(
   flags: CommandFlags | undefined,
   actions: SessionAction[],
 ): CommandFlags {
   const selection = readScriptReplaySelection(actions);
-  if (flags?.platform !== undefined || !selection.appTarget || !selection.platform) {
+  if (flags?.platform !== undefined || !selection.platform) {
     return flags ?? {};
   }
   return { ...flags, platform: selection.platform };

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -5,15 +5,21 @@ import type { ResolveTargetDeviceOptions } from '../core/dispatch-resolve.ts';
 import type { MaestroProgram } from '../compat/maestro/program-ir.ts';
 import { appleSimulatorAppTargetForOpenTarget } from './open-device-selection.ts';
 import { SessionStore } from './session-store.ts';
+import type { CommandFlags } from '../core/dispatch.ts';
 import type { DaemonRequest, SessionAction } from './types.ts';
+
+export type ReplayTargetDeviceResolution = {
+  flags: CommandFlags;
+  options: ResolveTargetDeviceOptions | undefined;
+};
 
 /**
  * Finds the first static app target a fresh replay will open.  Request binding
  * uses this before any replay action can cache an unqualified device choice.
  */
-export function buildReplayTargetDeviceResolutionOptions(
+export function buildReplayTargetDeviceResolution(
   req: DaemonRequest,
-): ResolveTargetDeviceOptions | undefined {
+): ReplayTargetDeviceResolution | undefined {
   if (req.command !== 'replay' || req.flags?.replayFrom !== undefined) return undefined;
   const filePath = req.positionals?.[0];
   if (!filePath) return undefined;
@@ -21,10 +27,25 @@ export function buildReplayTargetDeviceResolutionOptions(
   try {
     const resolved = SessionStore.expandHome(filePath, req.meta?.cwd);
     const source = fs.readFileSync(resolved, 'utf8');
-    const appTarget = isMaestroReplay(req, resolved)
-      ? readMaestroReplayAppTarget(parseMaestroProgram(source, { sourcePath: resolved }))
-      : readScriptReplayAppTarget(parseReplayInput(source, req.flags).actions);
-    return appTargetResolutionOptions(appTarget);
+    if (isMaestroReplay(req, resolved)) {
+      return {
+        flags: req.flags ?? {},
+        options: buildMaestroReplayTargetDeviceResolutionOptions(
+          parseMaestroProgram(source, { sourcePath: resolved }),
+          req.flags?.platform,
+        ),
+      };
+    }
+    const parsed = parseReplayInput(source, req.flags);
+    const selection = readScriptReplaySelection(parsed.actions);
+    if (!selection.appTarget) return undefined;
+    const scriptFlags = buildReplayScriptPlatformFlags(req.flags, parsed.actions);
+    const platform = scriptFlags.platform ?? parsed.metadata.platform;
+    return {
+      flags:
+        platform && scriptFlags.platform === undefined ? { ...scriptFlags, platform } : scriptFlags,
+      options: platform === 'ios' ? appTargetResolutionOptions(selection.appTarget) : undefined,
+    };
   } catch {
     // Parsing and validation stay in the replay handler. Lock binding is only
     // advisory, so an unreadable/invalid plan must not mask its real error.
@@ -34,7 +55,9 @@ export function buildReplayTargetDeviceResolutionOptions(
 
 export function buildMaestroReplayTargetDeviceResolutionOptions(
   program: MaestroProgram,
+  platform: CommandFlags['platform'] | undefined,
 ): ResolveTargetDeviceOptions {
+  if (platform !== 'ios') return {};
   const appTarget = readMaestroReplayAppTarget(program);
   return appTargetResolutionOptions(appTarget) ?? {};
 }
@@ -46,9 +69,34 @@ function isMaestroReplay(req: DaemonRequest, filePath: string): boolean {
   );
 }
 
-function readScriptReplayAppTarget(actions: SessionAction[]): string | undefined {
-  const target = actions.find((action) => action.command === 'open')?.positionals?.[0];
-  return isStaticAppTarget(target) ? target : undefined;
+function readScriptReplaySelection(actions: SessionAction[]): {
+  appTarget: string | undefined;
+  platform: CommandFlags['platform'] | undefined;
+} {
+  let platform: CommandFlags['platform'] | undefined;
+  for (const action of actions) {
+    if (action.command === 'runtime' && action.flags.platform) {
+      platform = action.flags.platform;
+      continue;
+    }
+    if (action.command !== 'open') continue;
+    platform = action.runtime?.platform ?? platform;
+    const target = action.positionals?.[0];
+    if (isStaticAppTarget(target)) return { appTarget: target, platform };
+  }
+  return { appTarget: undefined, platform };
+}
+
+/** Applies a platform configured before the first static app open to replay dispatch. */
+export function buildReplayScriptPlatformFlags(
+  flags: CommandFlags | undefined,
+  actions: SessionAction[],
+): CommandFlags {
+  const selection = readScriptReplaySelection(actions);
+  if (flags?.platform !== undefined || !selection.appTarget || !selection.platform) {
+    return flags ?? {};
+  }
+  return { ...flags, platform: selection.platform };
 }
 
 function readMaestroReplayAppTarget(program: MaestroProgram): string | undefined {

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -3,6 +3,7 @@ import { parseReplayInput } from '../compat/replay-input.ts';
 import { parseMaestroProgram } from '../compat/maestro/program-ir-parser.ts';
 import type { ResolveTargetDeviceOptions } from '../core/dispatch-resolve.ts';
 import type { MaestroProgram } from '../compat/maestro/program-ir.ts';
+import { appleSimulatorAppTargetForOpenTarget } from './open-device-selection.ts';
 import { SessionStore } from './session-store.ts';
 import type { DaemonRequest, SessionAction } from './types.ts';
 
@@ -23,7 +24,7 @@ export function buildReplayTargetDeviceResolutionOptions(
     const appTarget = isMaestroReplay(req, resolved)
       ? readMaestroReplayAppTarget(parseMaestroProgram(source, { sourcePath: resolved }))
       : readScriptReplayAppTarget(parseReplayInput(source, req.flags).actions);
-    return appTarget ? { appleSimulatorAppTarget: appTarget } : undefined;
+    return appTargetResolutionOptions(appTarget);
   } catch {
     // Parsing and validation stay in the replay handler. Lock binding is only
     // advisory, so an unreadable/invalid plan must not mask its real error.
@@ -35,7 +36,7 @@ export function buildMaestroReplayTargetDeviceResolutionOptions(
   program: MaestroProgram,
 ): ResolveTargetDeviceOptions {
   const appTarget = readMaestroReplayAppTarget(program);
-  return appTarget ? { appleSimulatorAppTarget: appTarget } : {};
+  return appTargetResolutionOptions(appTarget) ?? {};
 }
 
 function isMaestroReplay(req: DaemonRequest, filePath: string): boolean {
@@ -61,4 +62,11 @@ function readMaestroReplayAppTarget(program: MaestroProgram): string | undefined
 
 function isStaticAppTarget(value: string | undefined): value is string {
   return Boolean(value && value.trim() && !value.includes('$'));
+}
+
+function appTargetResolutionOptions(
+  openTarget: string | undefined,
+): ResolveTargetDeviceOptions | undefined {
+  const appTarget = appleSimulatorAppTargetForOpenTarget(openTarget);
+  return appTarget ? { appleSimulatorAppTarget: appTarget } : undefined;
 }

--- a/src/daemon/request-binding.ts
+++ b/src/daemon/request-binding.ts
@@ -2,6 +2,7 @@ import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
 import { applyRequestLockPolicy } from './request-lock-policy.ts';
 import { buildOpenTargetDeviceResolutionOptions } from './open-device-selection.ts';
+import { buildReplayTargetDeviceResolutionOptions } from './replay-device-selection.ts';
 import type { SessionStore } from './session-store.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
 
@@ -25,14 +26,12 @@ export async function resolveRequestExecutionLockKeys(params: {
 
   const keys = new Set<RequestExecutionLockKey>([sessionExecutionLockKey(sessionName)]);
   const bindingReq = resolveFreshSessionBindingRequest(req);
-  if (shouldResolveFreshSessionDeviceLock(bindingReq)) {
+  const resolutionOptions = resolveFreshSessionDeviceLockOptions(bindingReq);
+  if (resolutionOptions) {
     try {
       // This is advisory lock selection before the request enters the lock; the
       // locked request still resolves and binds the target device authoritatively.
-      const device = await resolveTargetDevice(
-        bindingReq.flags ?? {},
-        buildOpenTargetDeviceResolutionOptions(bindingReq.positionals?.[0]),
-      );
+      const device = await resolveTargetDevice(bindingReq.flags ?? {}, resolutionOptions);
       keys.add(deviceExecutionLockKey(device.id));
     } catch {
       // Fall back to session scoping when device resolution is not yet available.
@@ -64,8 +63,19 @@ function resolveFreshSessionBindingRequest(req: DaemonRequest): DaemonRequest {
   }
 }
 
-function shouldResolveFreshSessionDeviceLock(req: DaemonRequest): boolean {
-  return req.command === 'open' || hasExplicitDeviceSelector(req.flags);
+function resolveFreshSessionDeviceLockOptions(
+  req: DaemonRequest,
+): ReturnType<typeof buildOpenTargetDeviceResolutionOptions> | undefined {
+  if (req.command === 'open') {
+    return buildOpenTargetDeviceResolutionOptions(req.positionals?.[0]);
+  }
+  if (req.command === 'replay') {
+    return (
+      buildReplayTargetDeviceResolutionOptions(req) ??
+      (hasExplicitDeviceSelector(req.flags) ? {} : undefined)
+    );
+  }
+  return hasExplicitDeviceSelector(req.flags) ? {} : undefined;
 }
 
 function sessionExecutionLockKey(sessionName: string): RequestExecutionLockKey {

--- a/src/daemon/request-binding.ts
+++ b/src/daemon/request-binding.ts
@@ -2,7 +2,7 @@ import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
 import { applyRequestLockPolicy } from './request-lock-policy.ts';
 import { buildOpenTargetDeviceResolutionOptions } from './open-device-selection.ts';
-import { buildReplayTargetDeviceResolutionOptions } from './replay-device-selection.ts';
+import { buildReplayTargetDeviceResolution } from './replay-device-selection.ts';
 import type { SessionStore } from './session-store.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
 
@@ -26,12 +26,12 @@ export async function resolveRequestExecutionLockKeys(params: {
 
   const keys = new Set<RequestExecutionLockKey>([sessionExecutionLockKey(sessionName)]);
   const bindingReq = resolveFreshSessionBindingRequest(req);
-  const resolutionOptions = resolveFreshSessionDeviceLockOptions(bindingReq);
-  if (resolutionOptions) {
+  const resolution = resolveFreshSessionDeviceLock(bindingReq);
+  if (resolution) {
     try {
       // This is advisory lock selection before the request enters the lock; the
       // locked request still resolves and binds the target device authoritatively.
-      const device = await resolveTargetDevice(bindingReq.flags ?? {}, resolutionOptions);
+      const device = await resolveTargetDevice(resolution.flags, resolution.options);
       keys.add(deviceExecutionLockKey(device.id));
     } catch {
       // Fall back to session scoping when device resolution is not yet available.
@@ -63,19 +63,28 @@ function resolveFreshSessionBindingRequest(req: DaemonRequest): DaemonRequest {
   }
 }
 
-function resolveFreshSessionDeviceLockOptions(
-  req: DaemonRequest,
-): ReturnType<typeof buildOpenTargetDeviceResolutionOptions> | undefined {
-  if (req.command === 'open') {
-    return buildOpenTargetDeviceResolutionOptions(req.positionals?.[0]);
-  }
-  if (req.command === 'replay') {
-    return (
-      buildReplayTargetDeviceResolutionOptions(req) ??
-      (hasExplicitDeviceSelector(req.flags) ? {} : undefined)
-    );
-  }
-  return hasExplicitDeviceSelector(req.flags) ? {} : undefined;
+function resolveFreshSessionDeviceLock(req: DaemonRequest):
+  | {
+      flags: NonNullable<DaemonRequest['flags']>;
+      options: ReturnType<typeof buildOpenTargetDeviceResolutionOptions> | undefined;
+    }
+  | undefined {
+  if (req.command === 'open') return resolveOpenDeviceLock(req);
+  if (req.command === 'replay') return resolveReplayDeviceLock(req);
+  return resolveExplicitDeviceLock(req);
+}
+
+function resolveOpenDeviceLock(req: DaemonRequest) {
+  const options = buildOpenTargetDeviceResolutionOptions(req.positionals?.[0]);
+  return options ? { flags: req.flags ?? {}, options } : undefined;
+}
+
+function resolveReplayDeviceLock(req: DaemonRequest) {
+  return buildReplayTargetDeviceResolution(req) ?? resolveExplicitDeviceLock(req);
+}
+
+function resolveExplicitDeviceLock(req: DaemonRequest) {
+  return hasExplicitDeviceSelector(req.flags) ? { flags: req.flags ?? {}, options: {} } : undefined;
 }
 
 function sessionExecutionLockKey(sessionName: string): RequestExecutionLockKey {


### PR DESCRIPTION
## Summary

Bind fresh replay device selection to its first static app target before request locking can cache a generic simulator.
Cover Maestro runtime-default resolution with the same app-aware selector.

Fixes #1335

## Validation

- `pnpm check:affected --base origin/main --run` (format, lint, typecheck, layering passed; Fallow rerun passed; broad related tests had unrelated timeout failures)
- `pnpm check:unit` and `pnpm test:integration:provider` attempted; broad concurrent suites had unrelated environment failures, while affected unit and provider scenarios passed in isolation
- Live: booted iPhone 17 Pro and iPhone 16, with SampleApp installed only on the 17 Pro; source CLI native and Maestro replays without `--udid` both succeeded