### PR TITLE
fix(cli): reject excess positionals

### DIFF
--- a/scripts/help-conformance-command-validator.ts
+++ b/scripts/help-conformance-command-validator.ts
@@ -1,6 +1,5 @@
 import { pathToFileURL } from 'node:url';
 import { parseArgs } from '../src/cli/parser/args.ts';
-import { getCommandSchema } from '../src/cli-schema/command-schema.ts';
 import { readInputFromCli } from '../src/commands/cli-grammar.ts';
 import { isCommandName } from '../src/commands/command-metadata.ts';
 
@@ -34,8 +33,6 @@ export function validateAgentDeviceCommand(value: unknown): ValidationResult {
 function validateParsedCommand(parsed: ReturnType<typeof parseArgs>): ValidationResult {
   if (!parsed.command) return validateGlobalFlags(parsed.flags);
 
-  const arityError = validatePositionalArity(parsed.command, parsed.positionals);
-  if (arityError) return arityError;
   const pseudoRef = targetRefCandidate(parsed.command, parsed.positionals);
   if (pseudoRef && !CONCRETE_REF.test(pseudoRef)) {
     return invalid('pseudo-ref', `Pseudo ref "${pseudoRef}" is not an observed @eN or @cN ref.`);
@@ -51,20 +48,6 @@ function validateGlobalFlags(flags: ReturnType<typeof parseArgs>['flags']): Vali
   return flags.version || flags.help
     ? { valid: true }
     : invalid('agent-device-grammar', 'Missing command.');
-}
-
-function validatePositionalArity(
-  command: string,
-  positionals: string[],
-): ValidationResult | undefined {
-  const schema = getCommandSchema(command);
-  if (!schema || schema.allowsExtraPositionals) return undefined;
-  const maximum = schema.positionalArgs?.length ?? 0;
-  if (positionals.length <= maximum) return undefined;
-  return invalid(
-    'agent-device-grammar',
-    `${command} accepts at most ${maximum} positional argument(s), received ${positionals.length}: ${positionals.join(' ')}`,
-  );
 }
 
 function targetRefCandidate(command: string, positionals: string[]): string | undefined {

--- a/src/cli-schema/command-overrides.ts
+++ b/src/cli-schema/command-overrides.ts
@@ -58,6 +58,7 @@ const SCHEMA_ONLY_CLI_COMMAND_SCHEMAS = {
     listUsageOverride: 'connect',
     summary:
       'Attach CLI commands to a saved remote daemon/cloud lease; inspect for remote runs, tenants, or service-token CI',
+    positionalArgs: ['provider?'],
     allowedFlags: [
       'remoteConfig',
       'daemonBaseUrl',

--- a/src/cli-schema/command-schema.ts
+++ b/src/cli-schema/command-schema.ts
@@ -12,6 +12,7 @@ import {
   type FlagDefinition,
   type FlagKey,
 } from '../commands/cli-grammar/flag-types.ts';
+import { AppError } from '../kernel/errors.ts';
 
 export type { CliFlags, FlagDefinition, FlagKey };
 export type { CommandSchema };
@@ -35,6 +36,22 @@ export function getCliCommandSchema(command: CliCommandName): CommandSchema {
     throw new Error(`Missing command schema for ${command}`);
   }
   return schema;
+}
+
+export function assertCommandPositionalArity(
+  command: string | null,
+  positionals: readonly string[],
+  context?: string,
+): void {
+  const schema = getCommandSchema(command);
+  if (!command || !schema || schema.allowsExtraPositionals) return;
+  const maximum = schema.positionalArgs?.length ?? 0;
+  if (positionals.length <= maximum) return;
+  const subject = context ? `${context} ${command}` : command;
+  throw new AppError(
+    'INVALID_ARGS',
+    `${subject} accepts at most ${maximum} positional argument(s), received ${positionals.length}: ${positionals.join(' ')}`,
+  );
 }
 
 function readCommandSchema(command: string): CommandSchema | undefined {

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -6,6 +6,7 @@ import { isCommandName, type CommandName } from '../commands/command-metadata.ts
 import type { CliFlags } from '../contracts/cli-flags.ts';
 import { AppError } from '../kernel/errors.ts';
 import { isRecord } from '../utils/parsing.ts';
+import { assertCommandPositionalArity } from '../cli-schema/command-schema.ts';
 
 type LegacyCliBatchStep = {
   command: CommandName;
@@ -79,6 +80,7 @@ function readLegacyCliBatchStep(step: unknown, stepNumber: number): LegacyCliBat
   assertLegacyBatchStepKeys(step, stepNumber);
   const command = readLegacyCommand(step.command, stepNumber);
   const positionals = readLegacyPositionals(step.positionals, stepNumber);
+  assertCommandPositionalArity(command, positionals ?? [], `Batch step ${stepNumber}`);
   const flags = readLegacyFlags(step.flags, stepNumber);
   const runtime = parseBatchStepRuntime(step.runtime, stepNumber);
   return {

--- a/src/cli/parser/__tests__/args-validation.test.ts
+++ b/src/cli/parser/__tests__/args-validation.test.ts
@@ -132,6 +132,13 @@ test('negative numeric positionals are accepted without -- separator', () => {
   assert.deepEqual(pressed.positionals, ['-10', '20']);
 });
 
+test('get accepts a snapshot ref with a multiword label', () => {
+  const parsed = parseArgs(['get', 'text', '@e5~s3', 'World', 'Clock'], { strictFlags: true });
+
+  assert.equal(parsed.command, 'get');
+  assert.deepEqual(parsed.positionals, ['text', '@e5~s3', 'World', 'Clock']);
+});
+
 test('bounded commands reject excess positionals from their CLI schema', () => {
   for (const command of listCliCommandNames()) {
     const schema = getCliCommandSchema(command);

--- a/src/cli/parser/__tests__/args-validation.test.ts
+++ b/src/cli/parser/__tests__/args-validation.test.ts
@@ -2,6 +2,8 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { parseArgs } from '../args.ts';
 import { AppError } from '../../../kernel/errors.ts';
+import { listCliCommandNames } from '../../../command-catalog.ts';
+import { getCliCommandSchema } from '../../../cli-schema/command-schema.ts';
 
 test('parseArgs rejects test retries above the supported ceiling', () => {
   assert.throws(
@@ -128,6 +130,25 @@ test('negative numeric positionals are accepted without -- separator', () => {
   const pressed = parseArgs(['press', '-10', '20'], { strictFlags: true });
   assert.equal(pressed.command, 'press');
   assert.deepEqual(pressed.positionals, ['-10', '20']);
+});
+
+test('bounded commands reject excess positionals from their CLI schema', () => {
+  for (const command of listCliCommandNames()) {
+    const schema = getCliCommandSchema(command);
+    if (schema.allowsExtraPositionals) continue;
+    const maximum = schema.positionalArgs?.length ?? 0;
+    const positionals = Array.from({ length: maximum + 1 }, (_, index) => `arg-${index + 1}`);
+
+    assert.throws(
+      () => parseArgs([command, ...positionals], { strictFlags: true }),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message ===
+          `${command} accepts at most ${maximum} positional argument(s), received ${positionals.length}: ${positionals.join(' ')}`,
+      `Expected ${command} to reject excess positionals`,
+    );
+  }
 });
 
 test('command-specific flags without command fail in strict mode', () => {

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -2,6 +2,7 @@ import { AppError } from '../../kernel/errors.ts';
 import { mergeDefinedFlags } from '../../utils/merge-flags.ts';
 import {
   applyCommandDefaults,
+  assertCommandPositionalArity,
   getCommandSchema,
   getFlagDefinition,
   getFlagDefinitions,
@@ -200,7 +201,14 @@ export function finalizeParsedArgs(
   }
   assertNoConflictingBackModeFlags(parsed);
   applyCommandDefaults(parsed.command, flags);
-  if (parsed.command === 'batch') {
+  const normalized = normalizeParsedCommandAliases({
+    command: parsed.command,
+    positionals: parsed.positionals,
+    flags,
+    warnings,
+  });
+  assertCommandPositionalArity(normalized.command, normalized.positionals);
+  if (normalized.command === 'batch') {
     const stepSourceCount = (flags.steps ? 1 : 0) + (flags.stepsFile ? 1 : 0);
     if (stepSourceCount !== 1) {
       throw new AppError(
@@ -209,12 +217,7 @@ export function finalizeParsedArgs(
       );
     }
   }
-  return normalizeParsedCommandAliases({
-    command: parsed.command,
-    positionals: parsed.positionals,
-    flags,
-    warnings,
-  });
+  return normalized;
 }
 
 function assertNoConflictingBackModeFlags(parsed: RawParsedArgs): void {

--- a/src/commands/batch/cli.test.ts
+++ b/src/commands/batch/cli.test.ts
@@ -153,6 +153,21 @@ test('batch accepts legacy positionals/flags steps with deprecation warning', as
   });
 });
 
+test('batch rejects excess legacy positionals before daemon projection', async () => {
+  const result = await runCliCapture([
+    'batch',
+    '--steps',
+    '[{"command":"open","positionals":["settings","https://example.com","close"]}]',
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 0);
+  assert.match(
+    result.stderr,
+    /Batch step 1 open accepts at most 2 positional argument\(s\), received 3/,
+  );
+});
+
 test('batch rejects hybrid structured and legacy step shapes', async () => {
   const result = await runCliCapture([
     'batch',

--- a/src/commands/batch/cli.test.ts
+++ b/src/commands/batch/cli.test.ts
@@ -168,6 +168,23 @@ test('batch rejects excess legacy positionals before daemon projection', async (
   );
 });
 
+test('batch accepts a multiword ref label in a legacy get step', async () => {
+  const result = await runCliCapture([
+    'batch',
+    '--steps',
+    '[{"command":"get","positionals":["text","@e5~s3","World","Clock"]}]',
+    '--json',
+  ]);
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  assert.deepEqual((result.calls[0]?.flags?.batchSteps ?? [])[0]?.positionals, [
+    'text',
+    '@e5~s3',
+    'World Clock',
+  ]);
+});
+
 test('batch rejects hybrid structured and legacy step shapes', async () => {
   const result = await runCliCapture([
     'batch',

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -60,6 +60,7 @@ const interactionCliSchemas = {
   get: {
     usageOverride: 'get text|attrs <@ref|selector>',
     positionalArgs: ['subcommand', 'target'],
+    allowsExtraPositionals: true,
     allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS, 'record'],
   },
   find: {

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -108,7 +108,7 @@ const interactionCliSchemas = {
   },
   swipe: {
     helpDescription: 'Quick coordinate fling with optional repeat pattern.',
-    positionalArgs: ['x1', 'y1', 'x2', 'y2'],
+    positionalArgs: ['x1', 'y1', 'x2', 'y2', 'durationMs?'],
     allowedFlags: ['count', 'pauseMs', 'pattern'],
   },
   gesture: {


### PR DESCRIPTION
## Summary

Bounded CLI commands now fail closed when a plan supplies extra positionals. For example, `open app url close` previously swallowed `close`; it now returns `INVALID_ARGS` before command execution.

- derive one positional limit from `CommandSchema` and enforce it in normal parsing, deprecated legacy batch steps, and help-conformance validation
- keep explicitly variadic commands unchanged, while declaring the existing optional `connect` provider and `swipe` duration inputs accurately
- add schema-exhaustive and legacy-batch regressions for the motivating failure

This production-contract slice changes 8 files and stays within the CLI schema/parser, legacy batch, and deterministic validator family. It does not modify guidance or SkillGym while the active harness split moves command-planning coverage out of the oversized suite; that coverage remains follow-up work.

## Validation

The focused parser, interaction, session, batch, and help-conformance suites pass (133 tests). Formatting, typechecking, linting, layering, Fallow, build, and generated MCP metadata checks are green locally.

The native-Windows full unit sweep reached 4,249 passing and 8 skipped tests, with 257 existing environment-sensitive failures involving platform paths, unavailable host tools, symlinks, and fixture checksums. All changed-path suites pass in isolation; CI remains the cross-platform authority. This is parser-only behavior, so no device session was opened.

Related: #1406, #1411
