### PR TITLE
fix(bench): waive help-conformance coverage for ios-system-ui topic

### DIFF
--- a/scripts/__tests__/help-conformance-topic-coverage.test.ts
+++ b/scripts/__tests__/help-conformance-topic-coverage.test.ts
@@ -12,6 +12,8 @@ const WAIVED_TOPICS: Record<string, string> = {
   cdp: 'JS-heap forensics niche; add cases when heap-guidance regressions show up in practice.',
   macos: 'macOS surface guidance is thin and stable; no observed planning regressions yet.',
   maestro: 'Compatibility reference, not a planning loop; conformance is oracle-tested instead.',
+  'ios-system-ui':
+    'Simulator-only workflow with known coordinate-fallback and sparse-a11y gaps; add cases once the gallery capture gap closes and physical-device support is verified.',
   'physical-device': 'Needs device-specific setup guidance; no portable planning task defined yet.',
   'react-devtools':
     'Profiling-window guidance; add cases when render-diagnosis planning regresses.',


### PR DESCRIPTION
## Summary
- The `ios-system-ui` help topic (added in #1395) had neither a benchmark case in `scripts/help-conformance-cases.mjs` nor an entry in `WAIVED_TOPICS`, which fails the `every help topic has a benchmark case or an explicit waiver` test — breaking Coverage CI on unrelated PRs rebased onto `main` (observed on #1392).
- Added a waiver for `ios-system-ui`, following the style of the existing `physical-device`/`remote` waivers: the topic itself documents that it's simulator-only, with known coordinate-fallback steps and a sparse-a11y gallery-search gap, so a stable renderer-pinned benchmark case isn't practical yet.

## Test plan
- [x] `npx vitest run scripts/__tests__/help-conformance-topic-coverage.test.ts` — 4/4 passing (was 1 failing)
- [x] `npx vitest run scripts/__tests__/help-conformance*` — 33/33 passing across all three help-conformance suites