### PR TITLE
fix(ci): upload hidden diagnostics

### DIFF
--- a/.github/actions/upload-agent-device-artifacts/action.yml
+++ b/.github/actions/upload-agent-device-artifacts/action.yml
@@ -21,6 +21,7 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
         if-no-files-found: ignore
+        include-hidden-files: true
         path: |
           ${{ inputs.agent-home-dir }}/daemon.log
           ${{ inputs.agent-home-dir }}/logs/**

--- a/.github/actions/upload-agent-device-artifacts/action.yml
+++ b/.github/actions/upload-agent-device-artifacts/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "Artifact name"
     required: true
   agent-home-dir:
-    description: "Resolved agent-device home directory"
+    description: "Resolved agent-device daemon state directory"
     required: true
   runner-derived-path:
     description: "Optional Apple runner derived data path to upload cache metadata and Xcode logs"
@@ -24,7 +24,7 @@ runs:
         include-hidden-files: true
         path: |
           ${{ inputs.agent-home-dir }}/daemon.log
-          ${{ inputs.agent-home-dir }}/logs/**
+          ~/.agent-device/logs/**
           ${{ inputs.agent-home-dir }}/sessions/**
           ${{ inputs.runner-derived-path }}/.agent-device-runner-cache.json
           ${{ inputs.runner-derived-path }}/Logs/**

--- a/.github/workflows/conformance-differential.yml
+++ b/.github/workflows/conformance-differential.yml
@@ -140,6 +140,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: conformance-differential-ios
+          include-hidden-files: true
           path: |
             .tmp/conformance-differential/differential-report.json
             .agent-device/**/replay-timing.ndjson

--- a/test/ci/upload-agent-device-artifacts.test.ts
+++ b/test/ci/upload-agent-device-artifacts.test.ts
@@ -5,32 +5,71 @@ import { parse } from 'yaml';
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 const actionPath = path.join(repoRoot, '.github/actions/upload-agent-device-artifacts/action.yml');
+const conformanceWorkflowPath = path.join(
+  repoRoot,
+  '.github/workflows/conformance-differential.yml',
+);
 
-test('the diagnostics artifact includes hidden files only from its declared inputs', () => {
-  const action = parse(fs.readFileSync(actionPath, 'utf8')) as {
-    runs: { steps: Array<{ uses?: string; with?: Record<string, unknown> }> };
-  };
-  const upload = action.runs.steps.find((step) =>
-    step.uses?.startsWith('actions/upload-artifact@'),
-  );
+type UploadStep = { uses?: unknown; with?: Record<string, unknown> };
 
-  expect(upload, 'the artifact action must include an upload-artifact step').toBeDefined();
+function uploadArtifactSteps(source: unknown): UploadStep[] {
+  if (Array.isArray(source)) return source.flatMap(uploadArtifactSteps);
+  if (source === null || typeof source !== 'object') return [];
+  const record = source as Record<string, unknown>;
+  const matches =
+    typeof record.uses === 'string' && record.uses.startsWith('actions/upload-artifact@')
+      ? [record as UploadStep]
+      : [];
+  return [...matches, ...Object.values(record).flatMap(uploadArtifactSteps)];
+}
+
+function paths(step: UploadStep): string[] {
+  return String(step.with?.path)
+    .trim()
+    .split('\n')
+    .map((entry) => entry.trim());
+}
+
+test('the shared diagnostics artifact includes hidden files only from its declared paths', () => {
+  const action = parse(fs.readFileSync(actionPath, 'utf8'));
+  const uploads = uploadArtifactSteps(action);
+
+  expect(uploads, 'the action must have exactly one artifact upload step').toHaveLength(1);
+  const [upload] = uploads;
   expect(
     upload?.with?.['include-hidden-files'],
     'hidden daemon, session, and runner diagnostics must be included',
   ).toBe(true);
-  expect(
-    String(upload?.with?.path)
-      .trim()
-      .split('\n')
-      .map((entry) => entry.trim()),
-  ).toEqual([
+  expect(paths(upload!)).toEqual([
     '${{ inputs.agent-home-dir }}/daemon.log',
-    '${{ inputs.agent-home-dir }}/logs/**',
+    '~/.agent-device/logs/**',
     '${{ inputs.agent-home-dir }}/sessions/**',
     '${{ inputs.runner-derived-path }}/.agent-device-runner-cache.json',
     '${{ inputs.runner-derived-path }}/Logs/**',
     'test/artifacts/**',
     'test/screenshots/**',
+  ]);
+  expect(
+    paths(upload!).every((entry) =>
+      [
+        '${{ inputs.agent-home-dir }}/',
+        '${{ inputs.runner-derived-path }}/',
+        '~/.agent-device/logs/',
+        'test/',
+      ].some((prefix) => entry.startsWith(prefix)),
+    ),
+  ).toBe(true);
+});
+
+test('the conformance trace artifact includes the hidden replay root', () => {
+  const workflow = parse(fs.readFileSync(conformanceWorkflowPath, 'utf8'));
+  const uploads = uploadArtifactSteps(workflow);
+
+  expect(uploads, 'the workflow must have exactly one artifact upload step').toHaveLength(1);
+  const [upload] = uploads;
+  expect(upload?.with?.['include-hidden-files']).toBe(true);
+  expect(paths(upload!)).toEqual([
+    '.tmp/conformance-differential/differential-report.json',
+    '.agent-device/**/replay-timing.ndjson',
   ]);
 });

--- a/test/ci/upload-agent-device-artifacts.test.ts
+++ b/test/ci/upload-agent-device-artifacts.test.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const actionPath = path.join(repoRoot, '.github/actions/upload-agent-device-artifacts/action.yml');
+
+test('the diagnostics artifact includes hidden files only from its declared inputs', () => {
+  const action = parse(fs.readFileSync(actionPath, 'utf8')) as {
+    runs: { steps: Array<{ uses?: string; with?: Record<string, unknown> }> };
+  };
+  const upload = action.runs.steps.find((step) =>
+    step.uses?.startsWith('actions/upload-artifact@'),
+  );
+
+  expect(upload, 'the artifact action must include an upload-artifact step').toBeDefined();
+  expect(
+    upload?.with?.['include-hidden-files'],
+    'hidden daemon, session, and runner diagnostics must be included',
+  ).toBe(true);
+  expect(
+    String(upload?.with?.path)
+      .trim()
+      .split('\n')
+      .map((entry) => entry.trim()),
+  ).toEqual([
+    '${{ inputs.agent-home-dir }}/daemon.log',
+    '${{ inputs.agent-home-dir }}/logs/**',
+    '${{ inputs.agent-home-dir }}/sessions/**',
+    '${{ inputs.runner-derived-path }}/.agent-device-runner-cache.json',
+    '${{ inputs.runner-derived-path }}/Logs/**',
+    'test/artifacts/**',
+    'test/screenshots/**',
+  ]);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
             'scripts/__tests__/help-conformance-bench.test.ts',
             'scripts/__tests__/help-conformance-sample-outputs.test.ts',
             'scripts/__tests__/help-conformance-topic-coverage.test.ts',
+            'test/ci/**/*.test.ts',
             'test/skillgym/suites/local-cli-help-policy.test.ts',
             // The frozen replay-compat corpus (#1417): parse-only, no device or
             // subprocess work, so it belongs in the fast lane next to the

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,7 +40,8 @@ export default defineConfig({
             'scripts/__tests__/help-conformance-bench.test.ts',
             'scripts/__tests__/help-conformance-sample-outputs.test.ts',
             'scripts/__tests__/help-conformance-topic-coverage.test.ts',
-            'test/ci/**/*.test.ts',
+            // Parses CI configuration only, so this action guard needs no device or subprocess lane.
+            'test/ci/upload-agent-device-artifacts.test.ts',
             'test/skillgym/suites/local-cli-help-policy.test.ts',
             // The frozen replay-compat corpus (#1417): parse-only, no device or
             // subprocess work, so it belongs in the fast lane next to the


### PR DESCRIPTION
## Summary

Failed CI jobs now upload hidden Apple-runner metadata and nested diagnostics from the composite artifact action. The action separately collects daemon state from its supplied state directory and diagnostics from `~/.agent-device/logs/**`, where the diagnostics writer actually persists them. The opt-in remains constrained to those explicit diagnostic and test-artifact paths; it does not upload the agent-device home directory wholesale.

The conformance differential workflow now also includes its hidden replay-trace root. Deterministic CI-action tests pin both hidden-file opt-ins, one upload step per checked surface, the exact path lists, and approved path prefixes.

Touched files: 4. Scope stayed within CI artifact diagnostics and conformance trace collection.

## Validation

Ran `pnpm check:affected --base origin/main --run`, the focused artifact-action regression suite, and `actionlint` against every workflow using the composite action plus the conformance workflow. Device-build and live-web lanes are GitHub-authoritative.
