### PR TITLE
test: smoke every package.json export subpath from the packed package

### DIFF
--- a/test/integration/installed-package-metro.test.ts
+++ b/test/integration/installed-package-metro.test.ts
@@ -271,11 +271,60 @@ test('installed package exposes Node APIs and packaged companion tunnel entrypoi
       consumerRoot,
       ['--input-type=module', '-e'],
       `
+        import { readFileSync } from 'node:fs';
+        import nodePath from 'node:path';
         import * as agentDeviceRoot from 'agent-device';
         import 'agent-device/contracts';
         import { createLocalArtifactAdapter as createIoArtifactAdapter } from 'agent-device/io';
         import { buildBundleUrl, normalizeBaseUrl } from 'agent-device/metro';
         const client = agentDeviceRoot.createAgentDeviceClient();
+        const exportSubpaths = Object.keys(
+          JSON.parse(
+            readFileSync(
+              nodePath.join(process.cwd(), 'node_modules', 'agent-device', 'package.json'),
+              'utf8',
+            ),
+          ).exports,
+        ).sort();
+        const subpathSmoke = {
+          '.': (mod) => mod.centerOfRect({ x: 0, y: 0, width: 10, height: 4 }),
+          './android-adb': (mod) => {
+            const manager = mod.createAndroidPortReverseManager(async () => ({
+              stdout: '',
+              stderr: '',
+              exitCode: 0,
+            }));
+            return typeof manager.ensure;
+          },
+          './artifacts': async (mod) => {
+            const name = await mod.resolveAndroidArchivePackageName(
+              nodePath.join(process.cwd(), 'package.json'),
+            );
+            return String(name);
+          },
+          './batch': async (mod) => {
+            const response = await mod.runBatch(
+              { command: 'batch', positionals: [], flags: { batchOnError: 'continue' } },
+              'smoke-session',
+              async () => {
+                throw new Error('batch invoke should not run');
+              },
+            );
+            return response.ok === false ? response.error.code : 'unexpected-success';
+          },
+          './contracts': (mod) => mod.centerOfRect({ x: 2, y: 2, width: 6, height: 6 }),
+          './finders': (mod) => mod.findBestMatchesByLocator([], 'text', 'anything').matches.length,
+          './install-source': (mod) => typeof mod.isTrustedInstallSourceUrl('https://example.test/app.apk'),
+          './io': (mod) => typeof mod.createLocalArtifactAdapter({ cwd: process.cwd() }).reserveOutput,
+          './metro': (mod) => mod.buildBundleUrl('https://public.example.test', 'ios'),
+          './remote-config': (mod) => typeof mod,
+          './selectors': (mod) => mod.isSelectorToken('||') && typeof mod.parseSelectorChain === 'function',
+        };
+        const subpathSmokeResults = {};
+        for (const subpath of Object.keys(subpathSmoke).sort()) {
+          const mod = await import('agent-device' + subpath.slice(1));
+          subpathSmokeResults[subpath] = await subpathSmoke[subpath](mod);
+        }
         const removedSubpaths = await Promise.all([
           'agent-device/backend',
           'agent-device/commands',
@@ -300,6 +349,9 @@ test('installed package exposes Node APIs and packaged companion tunnel entrypoi
           removedSubpathsBlocked: removedSubpaths.every(Boolean),
           normalizedBaseUrl: normalizeBaseUrl('https://public.example.test///'),
           protocolBundleUrl: buildBundleUrl('https://public.example.test', 'android'),
+          exportSubpaths,
+          smokedSubpaths: Object.keys(subpathSmoke).sort(),
+          subpathSmokeResults,
         }));
       `,
     );
@@ -324,6 +376,24 @@ test('installed package exposes Node APIs and packaged companion tunnel entrypoi
       imports.protocolBundleUrl,
       'https://public.example.test/index.bundle?platform=android&dev=true&minify=false',
     );
+    // Every subpath in the packed package's exports map must have a smoke check
+    // above; adding a subpath without one fails here.
+    assert.deepEqual(imports.smokedSubpaths, imports.exportSubpaths);
+    assert.deepEqual(imports.subpathSmokeResults, {
+      '.': { x: 5, y: 2 },
+      './android-adb': 'function',
+      './artifacts': 'undefined',
+      './batch': 'INVALID_ARGS',
+      './contracts': { x: 5, y: 5 },
+      './finders': 0,
+      './install-source': 'boolean',
+      './io': 'function',
+      // Type-only subpath: resolving the module from the packed exports map is
+      // the entire runtime check.
+      './remote-config': 'object',
+      './metro': 'https://public.example.test/index.bundle?platform=ios&dev=true&minify=false',
+      './selectors': true,
+    });
     const cliStdout = await execFileText(
       process.execPath,
       [


### PR DESCRIPTION
## What

Extends the installed-package integration test to import and minimally invoke a named export from **every** subpath in the `package.json` exports map, resolved from the packed-and-extracted tarball. Previously only 3 of 11 subpaths were exercised (`io`, `metro`, and `contracts` as a bare side-effect import).

## Why

The other 8 subpaths (`artifacts`, `batch`, `remote-config`, `install-source`, `android-adb`, `selectors`, `finders`, plus named imports from `contracts`) have real external consumers — agent-device-cloud's bridge app imports all 11 — but nothing in CI ever resolved them from the packed package, so a broken subpath export would ship silently.

## How

- The consumer script derives the subpath list from the **installed** package's `exports` map and asserts it deep-equals the smoke table's keys — adding a subpath without a smoke check (or removing one while keeping the table entry) fails loudly ("what enumerates N").
- Each check invokes a named export with cheap deterministic inputs, no device/daemon/network:
  - `./batch`: `runBatch` with unsupported `batchOnError: 'continue'` → synchronous `INVALID_ARGS` response, invoke stub never called
  - `./artifacts`: `resolveAndroidArchivePackageName` on a non-archive → `undefined` (unzip/aapt fallbacks are `allowFailure`)
  - `./android-adb`: `createAndroidPortReverseManager` with a stub executor
  - `./finders`: `findBestMatchesByLocator([], 'text', …)` → empty `matches`
  - `./contracts`/`.`: `centerOfRect` arithmetic asserted; `./selectors`: `isSelectorToken('||')`; `./install-source`: `isTrustedInstallSourceUrl`
  - `./remote-config` is type-only at runtime, so resolving the module is its entire check (commented in the test)
- Existing static-import assertions are untouched; everything stays inside the existing pack-and-install harness (still one `node -e` consumer invocation).

## Reviewer notes

Gate integrity was negative-tested: temporarily removing `./selectors` from the smoke table fails the deepEqual with a diff naming the missing subpath. Test runs in ~6s; oxfmt/oxlint/tsc clean.