### PR TITLE
fix: secure Limrun dependency packaging

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Block vulnerable dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: development, runtime, unknown

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "check:affected:test": "node --experimental-strip-types --test scripts/check-affected/model.test.ts scripts/check-affected/run.test.ts",
     "check:coverage-changed": "node --experimental-strip-types scripts/coverage-changed/run.ts",
     "check:coverage-changed:test": "node --experimental-strip-types --test scripts/coverage-changed/model.test.ts scripts/coverage-changed/run.test.ts",
+    "check:dependency-security": "node --experimental-strip-types scripts/security/check-production-dependencies.ts",
+    "check:dependency-security:test": "node --experimental-strip-types --test scripts/security/production-dependency-policy.test.ts",
     "check:layering": "node --experimental-strip-types --test scripts/layering/model.test.ts && node --experimental-strip-types scripts/layering/check.ts",
     "depgraph": "node --experimental-strip-types scripts/depgraph/build.ts",
     "depgraph:test": "node --experimental-strip-types --test scripts/depgraph/model.test.ts",
@@ -137,10 +139,10 @@
     "sync:mcp-metadata": "node scripts/sync-mcp-metadata.mjs",
     "check:mcp-metadata": "node scripts/sync-mcp-metadata.mjs --check",
     "version": "node scripts/sync-mcp-metadata.mjs && git add server.json",
-    "check:tooling": "pnpm lint && pnpm typecheck && pnpm check:layering && pnpm depgraph:test && pnpm check:production-exports && pnpm check:mcp-metadata && pnpm build && pnpm check:bundle-owner-files",
+    "check:tooling": "pnpm lint && pnpm typecheck && pnpm check:dependency-security:test && pnpm check:dependency-security && pnpm check:layering && pnpm depgraph:test && pnpm check:production-exports && pnpm check:mcp-metadata && pnpm build && pnpm check:bundle-owner-files",
     "check:unit": "pnpm test:unit && pnpm test:smoke",
     "check": "pnpm check:tooling && pnpm check:fallow && pnpm check:unit",
-    "prepack": "pnpm check:mcp-metadata && pnpm build:all && pnpm package:apple-runner:npm && pnpm package:android-snapshot-helper:npm && pnpm package:android-ime-helper:npm",
+    "prepack": "pnpm check:dependency-security && pnpm check:mcp-metadata && pnpm build:all && pnpm package:apple-runner:npm && pnpm package:android-snapshot-helper:npm && pnpm package:android-ime-helper:npm",
     "typecheck": "tsc -p tsconfig.json",
     "test-app:install": "pnpm install --dir examples/test-app",
     "test-app:start": "pnpm --dir examples/test-app start",
@@ -234,9 +236,12 @@
     "detox"
   ],
   "dependencies": {
-    "@limrun/api": "^0.24.5",
+    "@limrun/api": "0.24.5",
     "yaml": "^2.9.0"
   },
+  "bundleDependencies": [
+    "@limrun/api"
+  ],
   "devDependencies": {
     "@chenglou/freerange": "^0.0.1",
     "@stryker-mutator/core": "9.6.1",

--- a/patches/@limrun__api@0.24.5.patch
+++ b/patches/@limrun__api@0.24.5.patch
@@ -1,0 +1,53 @@
+diff --git a/instance-client.js b/instance-client.js
+index 9b5f73b1e60b72a95d562a17ec9d2165c01f923c..701dbb9c9450764df33b825aef4371609d440998 100644
+--- a/instance-client.js
++++ b/instance-client.js
+@@ -523,7 +523,7 @@ async function createInstanceClient(options) {
+             });
+             try {
+                 await new Promise((resolve, reject) => {
+-                    (0, node_child_process_1.exec)(`${options.adbPath ?? 'adb'} connect ${tunnel.address.address}:${tunnel.address.port}`, (err) => {
++                    (0, node_child_process_1.execFile)(options.adbPath ?? 'adb', ['connect', `${tunnel.address.address}:${tunnel.address.port}`], (err) => {
+                         if (err)
+                             return reject(err);
+                         resolve();
+diff --git a/instance-client.mjs b/instance-client.mjs
+index 14da077ecc1bb8232dfee06d1616962e5c225971..a73778d6193b34cb15319912675ad7a2a7b0fc29 100644
+--- a/instance-client.mjs
++++ b/instance-client.mjs
+@@ -1,5 +1,5 @@
+ import { WebSocket } from 'ws';
+-import { exec } from 'node:child_process';
++import { execFile } from 'node:child_process';
+ import { downloadFileToLocalPath } from "./internal/download-file.mjs";
+ import { nodeProxyTransport } from "./internal/proxy-transport.mjs";
+ import { startTcpTunnel, isNonRetryableError } from "./tunnel.mjs";
+@@ -519,7 +519,7 @@ export async function createInstanceClient(options) {
+             });
+             try {
+                 await new Promise((resolve, reject) => {
+-                    exec(`${options.adbPath ?? 'adb'} connect ${tunnel.address.address}:${tunnel.address.port}`, (err) => {
++                    execFile(options.adbPath ?? 'adb', ['connect', `${tunnel.address.address}:${tunnel.address.port}`], (err) => {
+                         if (err)
+                             return reject(err);
+                         resolve();
+diff --git a/src/instance-client.ts b/src/instance-client.ts
+index 666f631530b18267f1eda032e206cca4901fd2b8..e40d8b641416bec96c22a183a93c84c98b434d11 100644
+--- a/src/instance-client.ts
++++ b/src/instance-client.ts
+@@ -1,2 +1,2 @@
+ import { WebSocket, Data } from 'ws';
+-import { exec } from 'node:child_process';
++import { execFile } from 'node:child_process';
+@@ -994,8 +994,9 @@ export async function createInstanceClient(options: InstanceClientOptions): Prom
+       });
+       try {
+         await new Promise<void>((resolve, reject) => {
+-          exec(
+-            `${options.adbPath ?? 'adb'} connect ${tunnel.address.address}:${tunnel.address.port}`,
++          execFile(
++            options.adbPath ?? 'adb',
++            ['connect', `${tunnel.address.address}:${tunnel.address.port}`],
+             (err) => {
+               if (err) return reject(err);
+               resolve();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,16 @@ overrides:
   react-router: 7.18.1
   react-router-dom: 7.18.1
 
+patchedDependencies:
+  '@limrun/api@0.24.5': e79aa299f9e7bfd51c93d462a4f5be21b042ad1968bceec9e6360dffbb9547b7
+
 importers:
 
   .:
     dependencies:
       '@limrun/api':
-        specifier: ^0.24.5
-        version: 0.24.5
+        specifier: 0.24.5
+        version: 0.24.5(patch_hash=e79aa299f9e7bfd51c93d462a4f5be21b042ad1968bceec9e6360dffbb9547b7)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -3587,7 +3590,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@limrun/api@0.24.5':
+  '@limrun/api@0.24.5(patch_hash=e79aa299f9e7bfd51c93d462a4f5be21b042ad1968bceec9e6360dffbb9547b7)':
     dependencies:
       eventsource-client: 1.2.0
       https-proxy-agent: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'website'
+nodeLinker: hoisted
 # Keep non-interactive checks from downloading tooling or reinstalling dependencies implicitly.
 pmOnFail: warn
 verifyDepsBeforeRun: warn
@@ -8,11 +9,13 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - '@chenglou/freerange@0.0.1'
 # @limrun/api pins undici to an exact vulnerable version (7.24.7) even in its
-# latest release, so a direct bump can't clear the Dependabot alerts. Override
-# the transitive resolution instead; scoped to major 7 so any future undici 8
-# elsewhere in the tree is untouched.
+# latest release. agent-device bundles the resolved Limrun tree so this override
+# reaches npm consumers; an override alone would apply only in this workspace.
+# Keep the override scoped to major 7 so future undici 8 users stay untouched.
 overrides:
   undici@7: '^7.28.0'
   postcss: 8.5.18
   react-router: 7.18.1
   react-router-dom: 7.18.1
+patchedDependencies:
+  '@limrun/api@0.24.5': patches/@limrun__api@0.24.5.patch

--- a/scripts/security/check-production-dependencies.ts
+++ b/scripts/security/check-production-dependencies.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+import { productionDependencyPolicyIssues } from './production-dependency-policy.ts';
+
+type PackageManifest = {
+  version?: string;
+  dependencies?: Record<string, string>;
+  bundleDependencies?: string[];
+};
+
+type WorkspaceManifest = {
+  nodeLinker?: string;
+  overrides?: Record<string, string>;
+  patchedDependencies?: Record<string, string>;
+};
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const packageManifest = readJson<PackageManifest>('package.json');
+const workspaceManifest = parse(
+  fs.readFileSync(path.join(root, 'pnpm-workspace.yaml'), 'utf8'),
+) as WorkspaceManifest;
+const limrunManifest = readJson<PackageManifest>('node_modules/@limrun/api/package.json');
+const undiciManifest = readJson<PackageManifest>('node_modules/undici/package.json');
+const limrunAndroidClientPath = path.join(root, 'node_modules/@limrun/api/instance-client.mjs');
+const providerSourcePath = path.join(root, 'src/providers/limrun/android.ts');
+
+const issues = productionDependencyPolicyIssues({
+  limrunSpecifier: packageManifest.dependencies?.['@limrun/api'],
+  bundledDependencies: packageManifest.bundleDependencies ?? [],
+  nodeLinker: workspaceManifest.nodeLinker,
+  undiciOverride: workspaceManifest.overrides?.['undici@7'],
+  patchedDependencies: workspaceManifest.patchedDependencies ?? {},
+  installedLimrunVersion: limrunManifest.version,
+  installedUndiciVersion: undiciManifest.version,
+  limrunAndroidClientSource: fs.existsSync(limrunAndroidClientPath)
+    ? fs.readFileSync(limrunAndroidClientPath, 'utf8')
+    : undefined,
+  agentDeviceLimrunAndroidSource: fs.readFileSync(providerSourcePath, 'utf8'),
+});
+
+if (issues.length > 0) {
+  for (const issue of issues) process.stderr.write(`- ${issue}\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(
+    `Production dependency policy passed: @limrun/api ${limrunManifest.version}, bundled undici ${undiciManifest.version}.\n`,
+  );
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8')) as T;
+}

--- a/scripts/security/production-dependency-policy.test.ts
+++ b/scripts/security/production-dependency-policy.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  productionDependencyPolicyIssues,
+  type ProductionDependencyPolicyInput,
+} from './production-dependency-policy.ts';
+
+const validInput: ProductionDependencyPolicyInput = {
+  limrunSpecifier: '0.24.5',
+  bundledDependencies: ['@limrun/api'],
+  nodeLinker: 'hoisted',
+  undiciOverride: '^7.28.0',
+  patchedDependencies: {
+    '@limrun/api@0.24.5': 'patches/@limrun__api@0.24.5.patch',
+  },
+  installedLimrunVersion: '0.24.5',
+  installedUndiciVersion: '7.28.0',
+  limrunAndroidClientSource: [
+    "import { execFile } from 'node:child_process';",
+    "execFile(options.adbPath ?? 'adb', ['connect', serial], callback);",
+  ].join('\n'),
+  agentDeviceLimrunAndroidSource: [
+    "const tunnel = await startTcpTunnel(session.adbUrl, session.token, '127.0.0.1', 0);",
+    "await runCmd('adb', ['connect', serial]);",
+  ].join('\n'),
+};
+
+describe('production dependency policy', () => {
+  test('accepts the reviewed bundled Limrun tree', () => {
+    assert.deepEqual(productionDependencyPolicyIssues(validInput), []);
+  });
+
+  test('rejects a vulnerable bundled undici version', () => {
+    const issues = productionDependencyPolicyIssues({
+      ...validInput,
+      installedUndiciVersion: '7.24.7',
+    });
+    assert.ok(issues.some((issue) => issue.includes('Bundled undici')));
+  });
+
+  test('rejects a drifting Limrun range or missing matching patch', () => {
+    const issues = productionDependencyPolicyIssues({
+      ...validInput,
+      limrunSpecifier: '^0.24.5',
+      patchedDependencies: {},
+    });
+    assert.ok(issues.some((issue) => issue.includes('exact version')));
+    assert.ok(issues.some((issue) => issue.includes('reviewed pnpm patch')));
+  });
+
+  test('rejects the shell-interpolated adb call', () => {
+    const issues = productionDependencyPolicyIssues({
+      ...validInput,
+      limrunAndroidClientSource:
+        "import { exec } from 'node:child_process';\nexec(`${options.adbPath} connect ${serial}`);",
+    });
+    assert.ok(issues.some((issue) => issue.includes('without shell interpolation')));
+  });
+
+  test('rejects delegation to Limrun’s shell-owning adb helper', () => {
+    const issues = productionDependencyPolicyIssues({
+      ...validInput,
+      agentDeviceLimrunAndroidSource: 'await session.client.startAdbTunnel();',
+    });
+    assert.ok(issues.some((issue) => issue.includes('argument-safe adb connect')));
+  });
+});

--- a/scripts/security/production-dependency-policy.ts
+++ b/scripts/security/production-dependency-policy.ts
@@ -1,0 +1,128 @@
+export type ProductionDependencyPolicyInput = {
+  limrunSpecifier: string | undefined;
+  bundledDependencies: string[];
+  nodeLinker: string | undefined;
+  undiciOverride: string | undefined;
+  patchedDependencies: Record<string, string>;
+  installedLimrunVersion: string | undefined;
+  installedUndiciVersion: string | undefined;
+  limrunAndroidClientSource: string | undefined;
+  agentDeviceLimrunAndroidSource: string | undefined;
+};
+
+const LIMRUN_PACKAGE = '@limrun/api';
+const UNDICI_SAFE_FLOOR = '7.28.0';
+const UNDICI_OVERRIDE = '^7.28.0';
+const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+export function productionDependencyPolicyIssues(input: ProductionDependencyPolicyInput): string[] {
+  return POLICY_CHECKS.flatMap((check) => check(input));
+}
+
+type PolicyCheck = (input: ProductionDependencyPolicyInput) => string[];
+
+const POLICY_CHECKS: PolicyCheck[] = [
+  checkPinnedLimrun,
+  checkBundledLimrun,
+  checkHoistedLinker,
+  checkUndiciOverride,
+  checkInstalledLimrun,
+  checkLimrunPatch,
+  checkInstalledUndici,
+  checkLimrunAndroidClient,
+  checkAgentDeviceLimrunProvider,
+];
+
+function checkPinnedLimrun(input: ProductionDependencyPolicyInput): string[] {
+  return input.limrunSpecifier && EXACT_VERSION_PATTERN.test(input.limrunSpecifier)
+    ? []
+    : ['@limrun/api must use an exact version so security patches cannot drift at pack time.'];
+}
+
+function checkBundledLimrun(input: ProductionDependencyPolicyInput): string[] {
+  return input.bundledDependencies.includes(LIMRUN_PACKAGE)
+    ? []
+    : ['@limrun/api must be bundled so the patched transitive tree reaches npm consumers.'];
+}
+
+function checkHoistedLinker(input: ProductionDependencyPolicyInput): string[] {
+  return input.nodeLinker === 'hoisted'
+    ? []
+    : ['pnpm nodeLinker must be hoisted for bundleDependencies to include the Limrun tree.'];
+}
+
+function checkUndiciOverride(input: ProductionDependencyPolicyInput): string[] {
+  return input.undiciOverride === UNDICI_OVERRIDE
+    ? []
+    : [`undici@7 must be overridden to ${UNDICI_OVERRIDE}.`];
+}
+
+function checkInstalledLimrun(input: ProductionDependencyPolicyInput): string[] {
+  return !input.limrunSpecifier || input.installedLimrunVersion === input.limrunSpecifier
+    ? []
+    : [
+        `Installed @limrun/api ${input.installedLimrunVersion ?? 'is missing'}; expected ${input.limrunSpecifier}.`,
+      ];
+}
+
+function checkLimrunPatch(input: ProductionDependencyPolicyInput): string[] {
+  const limrunVersion = input.limrunSpecifier;
+  const patchKey = limrunVersion ? `${LIMRUN_PACKAGE}@${limrunVersion}` : undefined;
+  const expectedPatchPath = limrunVersion
+    ? `patches/@limrun__api@${limrunVersion}.patch`
+    : undefined;
+  return patchKey && input.patchedDependencies[patchKey] === expectedPatchPath
+    ? []
+    : ['The pinned @limrun/api version must retain its reviewed pnpm patch.'];
+}
+
+function checkInstalledUndici(input: ProductionDependencyPolicyInput): string[] {
+  const installedVersion = input.installedUndiciVersion;
+  return installedVersion && isSameMajorAndAtLeast(installedVersion, UNDICI_SAFE_FLOOR)
+    ? []
+    : [
+        `Bundled undici must be on patched major 7 at or above ${UNDICI_SAFE_FLOOR}; found ${
+          installedVersion ?? 'nothing'
+        }.`,
+      ];
+}
+
+function checkLimrunAndroidClient(input: ProductionDependencyPolicyInput): string[] {
+  const androidClient = input.limrunAndroidClientSource;
+  const usesArgumentSafeExec =
+    androidClient?.includes("import { execFile } from 'node:child_process';") &&
+    androidClient.includes('execFile(options.adbPath') &&
+    !androidClient.includes('exec(`${options.adbPath');
+  return usesArgumentSafeExec
+    ? []
+    : ['The Limrun Android client must execute adb without shell interpolation.'];
+}
+
+function checkAgentDeviceLimrunProvider(input: ProductionDependencyPolicyInput): string[] {
+  const providerSource = input.agentDeviceLimrunAndroidSource;
+  const ownsArgumentSafeConnect =
+    providerSource?.includes('startTcpTunnel(') &&
+    providerSource.includes("runCmd('adb', ['connect', serial]") &&
+    !providerSource.includes('client.startAdbTunnel(');
+  return ownsArgumentSafeConnect
+    ? []
+    : ['The agent-device Limrun provider must own the argument-safe adb connect call.'];
+}
+
+function isSameMajorAndAtLeast(actual: string, floor: string): boolean {
+  const actualParts = parseVersion(actual);
+  const floorParts = parseVersion(floor);
+  if (!actualParts || !floorParts || actualParts[0] !== floorParts[0]) return false;
+  for (let index = 1; index < actualParts.length; index += 1) {
+    if (actualParts[index] !== floorParts[index]) {
+      return actualParts[index] > floorParts[index];
+    }
+  }
+  return true;
+}
+
+function parseVersion(version: string): [number, number, number] | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}

--- a/src/__tests__/limrun-runtime.test.ts
+++ b/src/__tests__/limrun-runtime.test.ts
@@ -32,7 +32,7 @@ const limrunMockState = vi.hoisted(() => {
     androidDisconnect: vi.fn(),
     androidSendAsset: vi.fn(async () => undefined),
     androidTunnelClose,
-    androidStartAdbTunnel: vi.fn(async () => ({
+    androidStartTcpTunnel: vi.fn(async () => ({
       address: { address: '127.0.0.1', port: 62_001 },
       close: androidTunnelClose,
     })),
@@ -98,8 +98,11 @@ vi.mock('@limrun/api/instance-client', () => ({
     disconnect: limrunMockState.androidDisconnect,
     openUrl: limrunMockState.androidOpenUrl,
     sendAsset: limrunMockState.androidSendAsset,
-    startAdbTunnel: limrunMockState.androidStartAdbTunnel,
   })),
+}));
+
+vi.mock('@limrun/api/tunnel', () => ({
+  startTcpTunnel: limrunMockState.androidStartTcpTunnel,
 }));
 
 vi.mock('../utils/exec.ts', async (importOriginal) => {
@@ -317,16 +320,19 @@ async function allocateLimrunDevice(
 }
 
 function assertAndroidTunnelLifecycle(openUrl: string): void {
-  assert.equal(limrunMockState.androidStartAdbTunnel.mock.calls.length, 1);
+  assert.deepEqual(limrunMockState.androidStartTcpTunnel.mock.calls, [
+    ['wss://adb.example', 'instance-token', '127.0.0.1', 0, { logLevel: 'warn' }],
+  ]);
   assert.equal(limrunMockState.androidOpenUrl.mock.calls.length, 0);
-  assert.deepEqual(vi.mocked(runCmd).mock.calls[0]?.[1], [
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[0]?.[1], ['connect', '127.0.0.1:62001']);
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[1]?.[1], [
     '-s',
     '127.0.0.1:62001',
     'reverse',
     'tcp:8081',
     'tcp:8081',
   ]);
-  assert.deepEqual(vi.mocked(runCmd).mock.calls[1]?.[1], [
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[2]?.[1], [
     '-s',
     '127.0.0.1:62001',
     'shell',
@@ -338,20 +344,20 @@ function assertAndroidTunnelLifecycle(openUrl: string): void {
     '-d',
     openUrl,
   ]);
-  assert.deepEqual(vi.mocked(runCmd).mock.calls[2]?.[1], [
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[3]?.[1], [
     '-s',
     '127.0.0.1:62001',
     'reverse',
     '--list',
   ]);
-  assert.deepEqual(vi.mocked(runCmd).mock.calls[3]?.[1], [
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[4]?.[1], [
     '-s',
     '127.0.0.1:62001',
     'reverse',
     '--remove',
     'tcp:8081',
   ]);
-  assert.deepEqual(vi.mocked(runCmd).mock.calls[4]?.[1], ['disconnect', '127.0.0.1:62001']);
+  assert.deepEqual(vi.mocked(runCmd).mock.calls[5]?.[1], ['disconnect', '127.0.0.1:62001']);
   assert.equal(limrunMockState.androidTunnelClose.mock.calls.length, 1);
 }
 
@@ -429,7 +435,7 @@ test('Limrun Android shares an in-flight ADB tunnel across concurrent port rever
       }),
     ]);
 
-    assert.equal(limrunMockState.androidStartAdbTunnel.mock.calls.length, 1);
+    assert.equal(limrunMockState.androidStartTcpTunnel.mock.calls.length, 1);
   } finally {
     await runtime.shutdown();
   }
@@ -588,7 +594,8 @@ test('Limrun Android configures an explicit port reverse', async () => {
         name: 'react-devtools',
       },
     );
-    assert.deepEqual(vi.mocked(runCmd).mock.calls[0]?.[1], [
+    assert.deepEqual(vi.mocked(runCmd).mock.calls[0]?.[1], ['connect', '127.0.0.1:62001']);
+    assert.deepEqual(vi.mocked(runCmd).mock.calls[1]?.[1], [
       '-s',
       '127.0.0.1:62001',
       'reverse',
@@ -605,6 +612,12 @@ test('Limrun Android preserves canonical ADB failure classification', async () =
 
   try {
     await allocateLimrunDevice(runtime, androidLease());
+    await runtime.configurePortReverse({
+      leaseId: 'lease-android',
+      devicePort: 8081,
+      hostPort: 8081,
+      name: 'metro',
+    });
     vi.mocked(runCmd).mockResolvedValueOnce({
       stdout: '',
       stderr: 'error: device offline',

--- a/src/providers/limrun/android.ts
+++ b/src/providers/limrun/android.ts
@@ -4,6 +4,7 @@ import {
   createInstanceClient as createAndroidInstanceClient,
   type InstanceClient as LimrunAndroidClient,
 } from '@limrun/api/instance-client';
+import { startTcpTunnel, type Tunnel as LimrunAdbTunnel } from '@limrun/api/tunnel';
 import { createAndroidInteractor } from '../../core/interactors/android.ts';
 import type { Interactor } from '../../contracts/interactor-types.ts';
 import type { DeviceLease } from '../../contracts/device-provider.ts';
@@ -23,14 +24,14 @@ import type {
 import { runCmd } from '../../utils/exec.ts';
 import { normalizeOptionalString } from './strings.ts';
 
-type LimrunAdbTunnel = Awaited<ReturnType<LimrunAndroidClient['startAdbTunnel']>>;
-
 type LimrunAndroidAdbSession = {
   platform: 'android';
   lease: DeviceLease;
   instanceId: string;
   device: DeviceInfo;
   client: LimrunAndroidClient;
+  adbUrl: string;
+  token: string;
   adbTunnel?: LimrunAdbTunnel;
   adbSerial?: string;
   adbTunnelPromise?: Promise<string>;
@@ -60,6 +61,8 @@ export async function createLimrunAndroidSession(options: {
     instanceId: options.instanceId,
     device: options.device,
     client,
+    adbUrl: options.adbUrl,
+    token: options.token,
   };
   const adbProvider: AndroidAdbProvider = {
     exec: async (args, execOptions) => await runLimrunAndroidAdb(session, args, execOptions),
@@ -199,8 +202,16 @@ async function ensurePersistentAndroidAdbSerial(session: LimrunAndroidAdbSession
 }
 
 async function startAndroidAdbTunnel(session: LimrunAndroidAdbSession): Promise<string> {
-  const tunnel = await session.client.startAdbTunnel();
+  const tunnel = await startTcpTunnel(session.adbUrl, session.token, '127.0.0.1', 0, {
+    logLevel: 'warn',
+  });
   const serial = `${tunnel.address.address}:${tunnel.address.port}`;
+  try {
+    await runCmd('adb', ['connect', serial], { timeoutMs: 30_000 });
+  } catch (error) {
+    tunnel.close();
+    throw error;
+  }
   session.adbTunnel = tunnel;
   session.adbSerial = serial;
   return serial;


### PR DESCRIPTION
## Summary

- ship the patched Limrun dependency tree with Undici 7.28.0 so npm consumers no longer resolve the vulnerable 7.24.7 pin
- replace Limrun's shell-interpolated `adb connect` path with argument-separated execution and keep agent-device on its shared execution helper
- add prepack/tooling dependency policy enforcement and GitHub dependency review for new vulnerable dependency changes

The latest Limrun release still pins Undici 7.24.7, and dependency overrides are root-only. Bundling the reviewed, patched Limrun tree ensures the safe resolution reaches downstream installs.

This touches 10 files and expands from the Limrun Android provider into package security and CI enforcement. No CLI or wire contract changes.

## Validation

- packaged tarball contains `@limrun/api` 0.24.5, Undici 7.28.0, and the patched `execFile` call
- security policy tests pass, including vulnerable Undici and shell-interpolation regression cases
- full unit + subprocess-stub suite passes with `--maxWorkers=4`; smoke suite passes
- formatting, typecheck, lint, build, layering, Fallow, dependency policy, Node integration, provider scenarios, and replay provenance passed
- full default-concurrency runs hit existing host-contention timeouts; every timed-out scenario passed in isolation
- SkillGym external runners were DNS-blocked before assertions

Residual risk: no live Limrun Android device was available to validate tunnel allocation and `adb connect`, so this PR is draft.
