### PR TITLE
refactor(daemon): table-ify handleSessionCommands

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -87,6 +87,11 @@
       "comment": "Help-benchmark conformance seams: helpTopicIds feeds the topic-coverage gate and PRIVATE_AX_RECOVERY_SAMPLE feeds the skillgym suite; both consumers are test-tree files outside --production analysis.",
       "file": "{src/cli/parser/cli-help.ts,scripts/help-conformance-sample-outputs.mjs}",
       "exports": ["helpTopicIds", "PRIVATE_AX_RECOVERY_SAMPLE"]
+    },
+    {
+      "comment": "#1458: getSessionCommandKind's former production consumer (the session.ts if-chain) was replaced by SESSION_COMMAND_HANDLER_IMPLS, which encodes command-kind groupings directly via shared handler references instead of a kind lookup. The accessor and its SessionCommandKind classification remain covered by daemon-command-registry.test.ts, a test-tree file outside --production analysis.",
+      "file": "src/daemon/daemon-command-registry.ts",
+      "exports": ["getSessionCommandKind"]
     }
   ],
   "usedClassMembers": ["name", "listActiveLeases", "delete", "values", "elapsedMs", "isExpired"],

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -66,6 +66,23 @@ export type DescriptorDispatchCommandName =
       : never
     : never;
 
+/**
+ * The literal union of every command whose `daemon.route` is `'session'`.
+ * Drives `SESSION_COMMAND_HANDLER_IMPLS` in `src/daemon/handlers/session.ts`
+ * (mirrors `DescriptorDispatchCommandName` above): adding a session-routed
+ * descriptor without a matching handler table entry is a compile error rather
+ * than a runtime routing gap caught only by `expectHandlerResponse`.
+ */
+export type DescriptorSessionRouteCommandName =
+  Extract<
+    (typeof commandDescriptors)[number],
+    { daemon: { route: 'session' } }
+  > extends infer Descriptor
+    ? Descriptor extends { name: infer Name extends string }
+      ? Name
+      : never
+    : never;
+
 // ---------------------------------------------------------------------------
 // Daemon request-policy trait bundles — copied VERBATIM from
 // src/daemon/daemon-command-registry.ts (DAEMON_COMMAND_DESCRIPTORS).

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -1,5 +1,5 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
-import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
+import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { resolvePayloadInput } from '../../utils/payload-input.ts';
 import type { AndroidAdbExecutor } from '../../platforms/android/adb-executor.ts';
 import {
@@ -38,7 +38,8 @@ import { handleSessionObservabilityCommands } from './session-observability.ts';
 import { handleSessionReplayCommands } from './session-replay.ts';
 import { handleSessionScriptPublication } from './session-script-publication.ts';
 import { handleDoctorCommand } from './session-doctor.ts';
-import { getSessionCommandKind, resolveRefFrameEffect } from '../daemon-command-registry.ts';
+import { resolveRefFrameEffect } from '../daemon-command-registry.ts';
+import type { DescriptorSessionRouteCommandName } from '../../core/command-descriptor/registry.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { PREPARE_REQUEST_TIMEOUT_MS } from '../../core/command-descriptor/timeout-policy.ts';
@@ -268,7 +269,213 @@ async function handleClipboardCommand(params: {
   return { ok: true, data: { platform: publicPlatformString(device), ...(result ?? {}) } };
 }
 
-// fallow-ignore-next-line complexity
+type SessionCommandParams = {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  leaseRegistry: LeaseRegistry;
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
+  invoke: DaemonInvokeFn;
+  invokeReplayAction?: DaemonInvokeFn;
+  androidAdbExecutor?: AndroidAdbExecutor;
+};
+
+type SessionCommandHandler = (params: SessionCommandParams) => Promise<DaemonResponse | null>;
+
+const handleSessionInventoryCommandGroup: SessionCommandHandler = async ({
+  req,
+  sessionName,
+  sessionStore,
+}) => await handleSessionInventoryCommands({ req, sessionName, sessionStore });
+
+const handleSessionStateCommandGroup: SessionCommandHandler = async ({
+  req,
+  sessionName,
+  logPath,
+  sessionStore,
+}) => await handleSessionStateCommands({ req, sessionName, logPath, sessionStore });
+
+const handleSessionObservabilityCommandGroup: SessionCommandHandler = async ({
+  req,
+  sessionName,
+  sessionStore,
+  androidAdbExecutor,
+}) =>
+  await handleSessionObservabilityCommands({ req, sessionName, sessionStore, androidAdbExecutor });
+
+const handleSessionReplayCommandGroup: SessionCommandHandler = async ({
+  req,
+  sessionName,
+  logPath,
+  sessionStore,
+  leaseRegistry,
+  invoke,
+  invokeReplayAction,
+}) =>
+  await handleSessionReplayCommands({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+    invoke: invokeReplayAction ?? invoke,
+  });
+
+async function handleKeyboardCommand(params: SessionCommandParams): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore } = params;
+  const session = sessionStore.get(sessionName);
+  const keyboardAction = req.positionals?.[0]?.trim().toLowerCase();
+  const needsForegroundIosApp =
+    keyboardAction === 'dismiss' || keyboardAction === 'enter' || keyboardAction === 'return';
+  if (!session && needsForegroundIosApp) {
+    const flags = req.flags ?? {};
+    const normalizedPlatform = flags.platform;
+    if (normalizedPlatform === 'ios') {
+      return errorResponse(
+        'SESSION_NOT_FOUND',
+        'iOS keyboard action requires an active session so the target app stays foregrounded. Run open first.',
+      );
+    }
+  }
+  return await runSessionOrSelectorDispatch({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    command: PUBLIC_COMMANDS.keyboard,
+    positionals: req.positionals ?? [],
+  });
+}
+
+async function handlePushCommand(params: SessionCommandParams): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore } = params;
+  const appId = req.positionals?.[0]?.trim();
+  const payloadArg = req.positionals?.[1]?.trim();
+  if (!appId || !payloadArg) {
+    return errorResponse(
+      'INVALID_ARGS',
+      'push requires <bundle|package> <payload.json|inline-json>',
+    );
+  }
+
+  return await runSessionOrSelectorDispatch({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    command: PUBLIC_COMMANDS.push,
+    positionals: [appId, maybeResolvePushPayloadPath(payloadArg, req.meta?.cwd)],
+    recordPositionals: [appId, payloadArg],
+  });
+}
+
+async function handleTriggerAppEventCommand(params: SessionCommandParams): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore } = params;
+  return await runSessionOrSelectorDispatch({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    command: PUBLIC_COMMANDS.triggerAppEvent,
+    positionals: req.positionals ?? [],
+    deriveNextSession: async (session, result) => {
+      const eventUrl = typeof result?.eventUrl === 'string' ? result.eventUrl : undefined;
+      const nextAppBundleId = eventUrl
+        ? ((await resolveSessionAppBundleIdForTarget(
+            session.device,
+            eventUrl,
+            session.appBundleId,
+            resolveAndroidPackageForOpen,
+          )) ?? session.appBundleId)
+        : session.appBundleId;
+      return {
+        ...session,
+        appBundleId: nextAppBundleId,
+      };
+    },
+  });
+}
+
+/**
+ * Descriptor-driven exhaustive dispatch table for the daemon's `session`
+ * route (mirrors `DISPATCH_HANDLERS` in src/core/dispatch.ts and
+ * `SNAPSHOT_COMMAND_HANDLER_IMPLS` in src/daemon/handlers/snapshot.ts). The
+ * `satisfies Record<DescriptorSessionRouteCommandName, …>` check means a
+ * session-routed descriptor added to the registry without a matching entry
+ * here is a COMPILE error, not a runtime routing gap. Command-kind groupings
+ * (`getSessionCommandKind`'s former inventory/state/observability/replay
+ * clusters) map several keys to the SAME handler reference below.
+ */
+const SESSION_COMMAND_HANDLER_IMPLS = {
+  session_list: handleSessionInventoryCommandGroup,
+  devices: handleSessionInventoryCommandGroup,
+  capabilities: handleSessionInventoryCommandGroup,
+  apps: handleSessionInventoryCommandGroup,
+  doctor: async ({ req, sessionName, sessionStore, androidAdbExecutor }) =>
+    await handleDoctorCommand({ req, sessionName, sessionStore, androidAdbExecutor }),
+  boot: handleSessionStateCommandGroup,
+  shutdown: handleSessionStateCommandGroup,
+  appstate: handleSessionStateCommandGroup,
+  session_save_script: async ({ req, sessionName, sessionStore }) =>
+    handleSessionScriptPublication({ req, sessionName, sessionStore }),
+  runtime: async ({ req, sessionName, sessionStore }) =>
+    await handleRuntimeCommand({ req, sessionName, sessionStore }),
+  clipboard: async ({ req, sessionName, logPath, sessionStore }) =>
+    await handleClipboardCommand({ req, sessionName, logPath, sessionStore }),
+  keyboard: handleKeyboardCommand,
+  perf: handleSessionObservabilityCommandGroup,
+  logs: handleSessionObservabilityCommandGroup,
+  events: handleSessionObservabilityCommandGroup,
+  network: handleSessionObservabilityCommandGroup,
+  audio: handleSessionObservabilityCommandGroup,
+  prepare: async ({ req, sessionName, logPath, sessionStore }) =>
+    await handlePrepareCommand({ req, sessionName, logPath, sessionStore }),
+  install: async ({ req, sessionName, sessionStore }) =>
+    await handleAppDeployCommand({
+      req,
+      command: 'install',
+      sessionName,
+      sessionStore,
+      deployOps: defaultInstallOps,
+    }),
+  reinstall: async ({ req, sessionName, sessionStore }) =>
+    await handleAppDeployCommand({
+      req,
+      command: 'reinstall',
+      sessionName,
+      sessionStore,
+      deployOps: defaultReinstallOps,
+    }),
+  install_source: async ({ req, sessionName, sessionStore }) =>
+    await handleInstallFromSourceCommand({ req, sessionName, sessionStore }),
+  release_materialized_paths: async ({ req }) =>
+    await handleReleaseMaterializedPathsCommand({ req }),
+  push: handlePushCommand,
+  'trigger-app-event': handleTriggerAppEventCommand,
+  open: async ({ req, sessionName, logPath, sessionStore }) =>
+    await handleOpenCommand({ req, sessionName, logPath, sessionStore }),
+  replay: handleSessionReplayCommandGroup,
+  test: handleSessionReplayCommandGroup,
+  batch: async ({ req, sessionName, invoke }) => await runBatchCommands(req, sessionName, invoke),
+  close: async ({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+    leaseLifecycleProvider,
+  }) =>
+    await handleCloseCommand({
+      req,
+      sessionName,
+      logPath,
+      sessionStore,
+      leaseRegistry,
+      leaseLifecycleProvider,
+    }),
+} satisfies Record<DescriptorSessionRouteCommandName, SessionCommandHandler>;
+
 export async function handleSessionCommands(params: {
   req: DaemonRequest;
   sessionName: string;
@@ -292,201 +499,21 @@ export async function handleSessionCommands(params: {
     androidAdbExecutor,
   } = params;
 
-  if (req.command === PUBLIC_COMMANDS.doctor) {
-    return await handleDoctorCommand({
-      req,
-      sessionName,
-      sessionStore,
-      androidAdbExecutor,
-    });
-  }
+  const handler =
+    SESSION_COMMAND_HANDLER_IMPLS[req.command as keyof typeof SESSION_COMMAND_HANDLER_IMPLS];
+  if (!handler) return null;
 
-  if (getSessionCommandKind(req.command) === 'inventory') {
-    return await handleSessionInventoryCommands({
-      req,
-      sessionName,
-      sessionStore,
-    });
-  }
-
-  if (req.command === 'runtime') {
-    return await handleRuntimeCommand({
-      req,
-      sessionName,
-      sessionStore,
-    });
-  }
-
-  if (getSessionCommandKind(req.command) === 'state') {
-    return await handleSessionStateCommands({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-    });
-  }
-
-  if (getSessionCommandKind(req.command) === 'publication') {
-    return handleSessionScriptPublication({ req, sessionName, sessionStore });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.clipboard) {
-    return await handleClipboardCommand({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.keyboard) {
-    const session = sessionStore.get(sessionName);
-    const keyboardAction = req.positionals?.[0]?.trim().toLowerCase();
-    const needsForegroundIosApp =
-      keyboardAction === 'dismiss' || keyboardAction === 'enter' || keyboardAction === 'return';
-    if (!session && needsForegroundIosApp) {
-      const flags = req.flags ?? {};
-      const normalizedPlatform = flags.platform;
-      if (normalizedPlatform === 'ios') {
-        return errorResponse(
-          'SESSION_NOT_FOUND',
-          'iOS keyboard action requires an active session so the target app stays foregrounded. Run open first.',
-        );
-      }
-    }
-    return await runSessionOrSelectorDispatch({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      command: PUBLIC_COMMANDS.keyboard,
-      positionals: req.positionals ?? [],
-    });
-  }
-
-  if (getSessionCommandKind(req.command) === 'observability') {
-    return await handleSessionObservabilityCommands({
-      req,
-      sessionName,
-      sessionStore,
-      androidAdbExecutor,
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.prepare) {
-    return await handlePrepareCommand({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.install || req.command === PUBLIC_COMMANDS.reinstall) {
-    return await handleAppDeployCommand({
-      req,
-      command: req.command,
-      sessionName,
-      sessionStore,
-      deployOps: req.command === PUBLIC_COMMANDS.install ? defaultInstallOps : defaultReinstallOps,
-    });
-  }
-
-  if (req.command === INTERNAL_COMMANDS.installSource) {
-    return await handleInstallFromSourceCommand({
-      req,
-      sessionName,
-      sessionStore,
-    });
-  }
-
-  if (req.command === INTERNAL_COMMANDS.releaseMaterializedPaths) {
-    return await handleReleaseMaterializedPathsCommand({ req });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.push) {
-    const appId = req.positionals?.[0]?.trim();
-    const payloadArg = req.positionals?.[1]?.trim();
-    if (!appId || !payloadArg) {
-      return errorResponse(
-        'INVALID_ARGS',
-        'push requires <bundle|package> <payload.json|inline-json>',
-      );
-    }
-
-    return await runSessionOrSelectorDispatch({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      command: PUBLIC_COMMANDS.push,
-      positionals: [appId, maybeResolvePushPayloadPath(payloadArg, req.meta?.cwd)],
-      recordPositionals: [appId, payloadArg],
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.triggerAppEvent) {
-    return await runSessionOrSelectorDispatch({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      command: PUBLIC_COMMANDS.triggerAppEvent,
-      positionals: req.positionals ?? [],
-      deriveNextSession: async (session, result) => {
-        const eventUrl = typeof result?.eventUrl === 'string' ? result.eventUrl : undefined;
-        const nextAppBundleId = eventUrl
-          ? ((await resolveSessionAppBundleIdForTarget(
-              session.device,
-              eventUrl,
-              session.appBundleId,
-              resolveAndroidPackageForOpen,
-            )) ?? session.appBundleId)
-          : session.appBundleId;
-        return {
-          ...session,
-          appBundleId: nextAppBundleId,
-        };
-      },
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.open) {
-    return await handleOpenCommand({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-    });
-  }
-
-  if (getSessionCommandKind(req.command) === 'replay') {
-    return await handleSessionReplayCommands({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      leaseRegistry,
-      invoke: invokeReplayAction ?? invoke,
-    });
-  }
-
-  if (req.command === PUBLIC_COMMANDS.batch) {
-    return await runBatchCommands(req, sessionName, invoke);
-  }
-
-  if (req.command === PUBLIC_COMMANDS.close) {
-    return await handleCloseCommand({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      leaseRegistry,
-      leaseLifecycleProvider,
-    });
-  }
-
-  return null;
+  return await handler({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+    leaseLifecycleProvider,
+    invoke,
+    invokeReplayAction,
+    androidAdbExecutor,
+  });
 }
 
 function maybeResolvePushPayloadPath(payloadArg: string, cwd?: string): string {


### PR DESCRIPTION
Fixes #1458.

## Summary

- Replaces the 18-branch if-chain in `handleSessionCommands` (`src/daemon/handlers/session.ts`) with `SESSION_COMMAND_HANDLER_IMPLS`, a handler table keyed by session-routed command name, following the existing `snapshot.ts` / `dispatch.ts` pattern.
- Adds `DescriptorSessionRouteCommandName` to `src/core/command-descriptor/registry.ts` — the literal union of every command whose `daemon.route` is `'session'`, derived from the descriptor registry (mirrors the existing `DescriptorDispatchCommandName`).
- The table is `satisfies Record<DescriptorSessionRouteCommandName, SessionCommandHandler>`, so a session-routed descriptor with no matching table entry is a **compile error**.
- Command-kind groupings are preserved by mapping several command names to the *same* handler reference (e.g. `session_list`/`devices`/`capabilities`/`apps` all point at `handleSessionInventoryCommandGroup`; `boot`/`shutdown`/`appstate` at `handleSessionStateCommandGroup`; `perf`/`logs`/`events`/`network`/`audio` at `handleSessionObservabilityCommandGroup`; `replay`/`test` at `handleSessionReplayCommandGroup`) — no working handler was split.
- Deletes the `fallow-ignore-next-line complexity` waiver that gated the old if-chain.
- `expectHandlerResponse` in `request-handler-chain.ts` is untouched — it stays as defense-in-depth for raw-wire requests.
- Zero behavior change: every branch's request/response shape, error messages, and ordering are identical; only the dispatch mechanism changed.

## Compile-time exhaustiveness demonstration

Per the acceptance criteria, I verified the guard actually fires by temporarily adding a fake session-routed descriptor with no handler entry:

```ts
{
  name: 'fake_session_probe',
  catalog: { group: 'internal', key: 'fakeSessionProbe' },
  recordsSessionAction: false,
  daemon: { route: 'session', refFrameEffect: 'preserve' },
  timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
  batchable: false,
},
```

`pnpm typecheck` failed as expected:

```
src/daemon/handlers/session.ts(465,3): error TS2741: Property 'fake_session_probe' is missing in type '{ session_list: SessionCommandHandler; ... }' but required in type 'Record<"apps" | "appstate" | ... | "fake_session_probe" | ... , SessionCommandHandler>'.
```

The fake descriptor was then reverted before this commit — it isn't part of the diff.

## Incidental fix

`getSessionCommandKind` (`src/daemon/daemon-command-registry.ts`) had no production consumer left after this refactor (the new table encodes command-kind clustering directly via shared handler references instead of a runtime kind lookup), which tripped the `fallow dead-code --production` gate. The function and its `SessionCommandKind` classification are still exercised by `daemon-command-registry.test.ts`, so I added it to `.fallowrc.json`'s `ignoreExports` allowlist, following the same pattern already used there for other test-only-consumed exports (e.g. `listRegisteredDispatchCommandNames`'s sibling in `dispatch.ts`).

## Test plan

- [x] `pnpm check:tooling` (lint, typecheck, layering, depgraph, production-exports, mcp-metadata, build, bundle-owner-files) — green
- [x] `pnpm test:unit` — 523/523 test files, 4660 tests passing
- [x] `pnpm test:smoke` — 13/15 passing; the 2 failures (`smoke-daemon-clean`, `smoke-daemon-http`) reproduce identically on the unmodified `main` baseline in this sandbox (real daemon-process spawn is restricted here), unrelated to this change
- [x] Existing handler tests pass unmodified (no test file edits were needed at all — imports of `handleSessionCommands` are unchanged since its exported signature is identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7JRr87E2QguHF36XrVbph)_