### PR TITLE
test(replay): split session-replay-vars.test.ts by actual subject (#1460)

### DIFF
--- a/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
@@ -7,6 +7,16 @@ import { test, vi } from 'vitest';
 // (slow/hanging) runner dispatch path. Reject fast so failure-path tests keep
 // exercising `divergence.screen: unavailable` deterministically, exactly like
 // a real capture failure would.
+//
+// This file carries the Maestro-heavy majority of what used to live in
+// session-replay-vars.test.ts, plus a handful of generic (non-Maestro) `.ad`
+// runReplayScriptFile tests that happen to share the same runReplayFixture
+// helper and mock configuration below. It is a sibling of
+// session-replay-runtime.test.ts rather than a merge into it because that
+// file mocks '../../../core/dispatch.ts' differently (dispatchCommand
+// resolves `{}`, not throws) — vitest allows only one vi.mock per module per
+// file, so reconciling the two configurations was out of scope for a pure
+// test-file split (see #1460).
 vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
   return {
@@ -40,24 +50,13 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { AppError } from '../../../kernel/errors.ts';
 import { PNG } from '../../../utils/png.ts';
 import { runCmdBackground, type ExecBackgroundResult } from '../../../utils/exec.ts';
-import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../../types.ts';
 import type { CommandFlags } from '../../../core/dispatch.ts';
 import { SessionStore } from '../../session-store.ts';
 import { makeAndroidSession, makeIosSession } from '../../../__tests__/test-utils/index.ts';
-import {
-  buildReplayVarScope,
-  collectReplayShellEnv,
-  parseReplayCliEnvEntries,
-  resolveReplayAction,
-  resolveReplayString,
-} from '../../../replay/vars.ts';
-import { parseReplayScriptDetailed, readReplayScriptMetadata } from '../../../replay/script.ts';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';
-
-const LOC = { file: 'test.ad', line: 1 };
 
 type CapturedInvocation = {
   command: string;
@@ -178,206 +177,6 @@ async function readFirstStdoutLine(process: ExecBackgroundResult): Promise<strin
   });
 }
 
-test('resolveReplayString substitutes variables', () => {
-  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
-  assert.equal(resolveReplayString('open ${APP}', scope, LOC), 'open settings');
-});
-
-test('resolveReplayString supports fallback with :-default', () => {
-  const scope = buildReplayVarScope({});
-  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 500');
-});
-
-test('resolveReplayString prefers scope value over fallback', () => {
-  const scope = buildReplayVarScope({ fileEnv: { WAIT_SHORT: '1000' } });
-  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 1000');
-});
-
-test('resolveReplayString fallback preserves embedded braces via escapes', () => {
-  const scope = buildReplayVarScope({});
-  assert.equal(resolveReplayString('x ${A:-one\\}two}', scope, LOC), 'x one}two');
-});
-
-test('resolveReplayString throws on unresolved variable with file:line', () => {
-  const scope = buildReplayVarScope({ fileEnv: { OTHER: 'x' } });
-  assert.throws(
-    () => resolveReplayString('open ${MISSING}', scope, { file: 'a.ad', line: 7 }),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /Unresolved variable \$\{MISSING\} at a\.ad:7/.test(error.message),
-  );
-});
-
-test('resolveReplayString is case-sensitive', () => {
-  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
-  assert.throws(() => resolveReplayString('${app}', scope, LOC), AppError);
-});
-
-test('resolveReplayString substitutes multiple vars on one line', () => {
-  const scope = buildReplayVarScope({ fileEnv: { A: '1', B: '2' } });
-  assert.equal(resolveReplayString('${A}-${B}-${A}', scope, LOC), '1-2-1');
-});
-
-test('buildReplayVarScope precedence: cli > shell > file > builtin', () => {
-  const scope = buildReplayVarScope({
-    builtins: { K: 'builtin' },
-    fileEnv: { K: 'file' },
-    shellEnv: { K: 'shell' },
-    cliEnv: { K: 'cli' },
-  });
-  assert.equal(scope.values.K, 'cli');
-
-  const shellWinsOverFile = buildReplayVarScope({
-    fileEnv: { K: 'file' },
-    shellEnv: { K: 'shell' },
-  });
-  assert.equal(shellWinsOverFile.values.K, 'shell');
-});
-
-test('collectReplayShellEnv strips AD_VAR_ prefix and ignores other vars', () => {
-  const result = collectReplayShellEnv({
-    AD_VAR_APP_ID: 'settings',
-    PATH: '/bin',
-    AD_VAR_123: 'x',
-    AD_VAR_: 'empty',
-    OTHER_VAR: 'y',
-    AD_APP_ID: 'no-legacy-prefix',
-  });
-  assert.equal(result.APP_ID, 'settings');
-  assert.equal(result.PATH, undefined);
-  assert.equal(result['123'], undefined);
-  assert.equal(result[''], undefined);
-  // legacy AD_* (non AD_VAR_*) is no longer auto-imported.
-  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_APP_ID'), false);
-});
-
-test('collectReplayShellEnv skips keys that land in reserved AD_* namespace after strip', () => {
-  const result = collectReplayShellEnv({
-    AD_VAR_AD_SESSION: 'evil',
-    AD_VAR_AD_FOO: 'evil',
-  });
-  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_SESSION'), false);
-  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_FOO'), false);
-});
-
-test('parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys', () => {
-  assert.deepEqual(parseReplayCliEnvEntries(['APP=settings', 'FOO=bar=baz']), {
-    APP: 'settings',
-    FOO: 'bar=baz',
-  });
-  assert.throws(() => parseReplayCliEnvEntries(['NOEQUAL']), AppError);
-  assert.throws(() => parseReplayCliEnvEntries(['lower=x']), AppError);
-  assert.throws(() => parseReplayCliEnvEntries(['=value']), AppError);
-});
-
-test('resolveReplayAction walks positionals and string flags', () => {
-  const action: SessionAction = {
-    ts: 0,
-    command: 'snapshot',
-    positionals: ['${FOO}'],
-    flags: {
-      snapshotScope: '${SCOPE}',
-      snapshotInteractiveOnly: true,
-      snapshotDepth: 3,
-    },
-  };
-  const scope = buildReplayVarScope({ fileEnv: { FOO: 'bar', SCOPE: 'app' } });
-  const resolved = resolveReplayAction(action, scope, LOC);
-  assert.deepEqual(resolved.positionals, ['bar']);
-  assert.equal(resolved.flags?.snapshotScope, 'app');
-  assert.equal(resolved.flags?.snapshotInteractiveOnly, true);
-  assert.equal(resolved.flags?.snapshotDepth, 3);
-});
-
-test('resolveReplayAction walks runtime hints', () => {
-  const action: SessionAction = {
-    ts: 0,
-    command: 'open',
-    positionals: [],
-    runtime: { platform: 'android', metroHost: '${HOST}' },
-    flags: {},
-  };
-  const scope = buildReplayVarScope({ fileEnv: { HOST: '10.0.0.1' } });
-  const resolved = resolveReplayAction(action, scope, LOC);
-  assert.equal(resolved.runtime?.metroHost, '10.0.0.1');
-});
-
-test('parseReplayScriptDetailed tracks line numbers', () => {
-  const script = [
-    '# comment',
-    'context platform=android',
-    'env APP=settings',
-    '',
-    'open ${APP}',
-    'wait 500',
-  ].join('\n');
-  const parsed = parseReplayScriptDetailed(script);
-  assert.equal(parsed.actions.length, 2);
-  assert.deepEqual(parsed.actionLines, [5, 6]);
-});
-
-test('readReplayScriptMetadata parses env KEY=VALUE directives', () => {
-  const metadata = readReplayScriptMetadata(
-    'context platform=android\nenv APP=settings\nenv WAIT=500\nopen ${APP}\n',
-  );
-  assert.equal(metadata.env?.APP, 'settings');
-  assert.equal(metadata.env?.WAIT, '500');
-});
-
-test('readReplayScriptMetadata accepts env before context', () => {
-  const metadata = readReplayScriptMetadata(
-    'env APP=settings\ncontext platform=ios target=mobile\n',
-  );
-  assert.equal(metadata.platform, 'ios');
-  assert.equal(metadata.target, 'mobile');
-  assert.equal(metadata.env?.APP, 'settings');
-});
-
-test('readReplayScriptMetadata parses quoted env values with spaces', () => {
-  const metadata = readReplayScriptMetadata(
-    'context platform=android\nenv SEL="label=Wait || label=Apps"\n',
-  );
-  assert.equal(metadata.env?.SEL, 'label=Wait || label=Apps');
-});
-
-test('readReplayScriptMetadata rejects invalid env key', () => {
-  assert.throws(
-    () => readReplayScriptMetadata('context platform=android\nenv lower=settings\n'),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /Invalid env key "lower"/.test(error.message),
-  );
-});
-
-test('readReplayScriptMetadata rejects duplicate env key', () => {
-  assert.throws(
-    () => readReplayScriptMetadata('context platform=android\nenv APP=a\nenv APP=b\n'),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /Duplicate env directive "APP"/.test(error.message),
-  );
-});
-
-// ADR 0012 decision 1 / migration step 6: `--update` retirement removed the
-// env/interpolation/compat-flow refusal guards below — they existed only to
-// protect the now-deleted heal-and-rewrite path, which could not safely
-// round-trip `env`/`${VAR}` or serialize Maestro's in-memory flow controls
-// back to `.ad`. With no rewrite, `--update` no longer needs to refuse
-// anything; it runs exactly like a plain replay.
-
-test('--update no longer rejects scripts with env directives (the guard existed only for rewrite safety)', async () => {
-  const { response, calls } = await runReplayFixture({
-    label: 'env-heal',
-    script: 'context platform=android\nenv APP=settings\nopen ${APP}\n',
-    flags: { replayUpdate: true },
-  });
-  assert.equal(response.ok, true);
-  assert.deepEqual(calls[0]?.positionals, ['settings']);
-});
-
 test('--update no longer rejects Maestro compat flow controls (the guard existed only for rewrite safety)', async () => {
   const { response } = await runReplayFixture({
     label: 'maestro-replay-update-flow-control',
@@ -396,84 +195,6 @@ test('--update no longer rejects Maestro compat flow controls (the guard existed
   assert.equal(response.ok, true);
 });
 
-test('resolveReplayAction produces dispatch-ready literals for a realistic fixture', () => {
-  const script = [
-    'context platform=android',
-    'env APP_ID=settings',
-    'env WAIT_SHORT=500',
-    'env SETTINGS_ITEMS="label=Wait || label=Apps"',
-    '',
-    'open ${APP_ID} --relaunch',
-    'wait ${WAIT_SHORT}',
-    'click "${SETTINGS_ITEMS}"',
-    'is exists "${SETTINGS_ITEMS}"',
-    'snapshot -s "${SNAPSHOT_SCOPE:-app}"',
-  ].join('\n');
-  const metadata = readReplayScriptMetadata(script);
-  const parsed = parseReplayScriptDetailed(script);
-  const scope = buildReplayVarScope({
-    builtins: { AD_PLATFORM: 'android' },
-    fileEnv: metadata.env,
-    shellEnv: { APP_ID: 'shell-wins' },
-    cliEnv: { APP_ID: 'cli-wins' },
-  });
-  const resolved = parsed.actions.map((action, index) =>
-    resolveReplayAction(action, scope, {
-      file: 'fixture.ad',
-      line: parsed.actionLines[index] ?? 0,
-    }),
-  );
-  assert.deepEqual(resolved[0]?.positionals, ['cli-wins']);
-  assert.equal(resolved[0]?.flags.relaunch, true);
-  assert.deepEqual(resolved[1]?.positionals, ['500']);
-  assert.deepEqual(resolved[2]?.positionals, ['label=Wait || label=Apps']);
-  assert.deepEqual(resolved[3]?.positionals, ['exists', 'label=Wait || label=Apps']);
-  assert.equal(resolved[4]?.flags.snapshotScope, 'app');
-});
-
-test.each([
-  {
-    name: 'file env via parseReplayEnvLine',
-    run: () => readReplayScriptMetadata('context platform=android\nenv AD_FOO=bar\n'),
-    keyMatch: /AD_FOO/,
-  },
-  {
-    name: 'CLI -e via parseReplayCliEnvEntries',
-    run: () => parseReplayCliEnvEntries(['AD_FOO=x']),
-    keyMatch: /AD_FOO/,
-  },
-  {
-    name: 'buildReplayVarScope.fileEnv',
-    run: () => buildReplayVarScope({ fileEnv: { AD_FOO: 'x' } }),
-    keyMatch: /AD_FOO/,
-  },
-  {
-    name: 'buildReplayVarScope.cliEnv',
-    run: () => buildReplayVarScope({ cliEnv: { AD_SESSION: 'x' } }),
-    keyMatch: /AD_SESSION/,
-  },
-])('rejects AD_* as reserved namespace in $name', ({ run, keyMatch }) => {
-  assert.throws(
-    run,
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /AD_\* namespace is reserved/.test(error.message) &&
-      keyMatch.test(error.message),
-  );
-});
-
-test('parseReplayCliEnvEntries error wording is user-friendly for invalid keys', () => {
-  assert.throws(
-    () => parseReplayCliEnvEntries(['lower=x']),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /uppercase letters, digits, and underscores/.test(error.message),
-  );
-});
-
-// fallow-ignore-next-line complexity
 test('runReplayScriptFile dispatches resolved literals with file env overridden by CLI', async () => {
   const { response, calls } = await runReplayFixture({
     label: 'green',

--- a/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
@@ -195,6 +195,14 @@ test('--update no longer rejects Maestro compat flow controls (the guard existed
   assert.equal(response.ok, true);
 });
 
+function assertNoUnresolvedInterpolation(calls: CapturedInvocation[]): void {
+  for (const call of calls) {
+    for (const pos of call.positionals ?? []) {
+      assert.equal(pos.includes('${'), false, `unresolved interpolation leaked: ${pos}`);
+    }
+  }
+}
+
 test('runReplayScriptFile dispatches resolved literals with file env overridden by CLI', async () => {
   const { response, calls } = await runReplayFixture({
     label: 'green',
@@ -211,21 +219,19 @@ test('runReplayScriptFile dispatches resolved literals with file env overridden 
     flags: { replayEnv: ['APP=cli-app'] },
   });
   assert.equal(response.ok, true);
+  const [open, snapshot, click] = calls;
+  assert.ok(open && snapshot && click);
   // open ${APP} -> CLI override wins.
-  assert.equal(calls[0]?.command, 'open');
-  assert.deepEqual(calls[0]?.positionals, ['cli-app']);
+  assert.equal(open.command, 'open');
+  assert.deepEqual(open.positionals, ['cli-app']);
   // snapshot -s ${SCOPE} -> file env fills in.
-  assert.equal(calls[1]?.command, 'snapshot');
-  assert.equal(calls[1]?.flags?.snapshotScope, 'file-scope');
+  assert.equal(snapshot.command, 'snapshot');
+  assert.equal(snapshot.flags?.snapshotScope, 'file-scope');
   // click with ${AD_FILENAME} resolves to the relative script path.
-  assert.equal(calls[2]?.command, 'click');
-  assert.deepEqual(calls[2]?.positionals, ['at flow.ad']);
+  assert.equal(click.command, 'click');
+  assert.deepEqual(click.positionals, ['at flow.ad']);
   // And nothing dispatched still contains a literal ${...} token.
-  for (const call of calls) {
-    for (const pos of call.positionals ?? []) {
-      assert.equal(pos.includes('${'), false, `unresolved interpolation leaked: ${pos}`);
-    }
-  }
+  assertNoUnresolvedInterpolation(calls);
 });
 
 test('.ad replay normalizes resolved gesture and swipe syntax into structured daemon input', async () => {

--- a/src/replay/__tests__/script.test.ts
+++ b/src/replay/__tests__/script.test.ts
@@ -387,6 +387,64 @@ test('readReplayScriptMetadata rejects conflicting metadata keys in context head
   );
 });
 
+test('parseReplayScriptDetailed tracks line numbers', () => {
+  const script = [
+    '# comment',
+    'context platform=android',
+    'env APP=settings',
+    '',
+    'open ${APP}',
+    'wait 500',
+  ].join('\n');
+  const parsed = parseReplayScriptDetailed(script);
+  assert.equal(parsed.actions.length, 2);
+  assert.deepEqual(parsed.actionLines, [5, 6]);
+});
+
+test('readReplayScriptMetadata parses env KEY=VALUE directives', () => {
+  const metadata = readReplayScriptMetadata(
+    'context platform=android\nenv APP=settings\nenv WAIT=500\nopen ${APP}\n',
+  );
+  assert.equal(metadata.env?.APP, 'settings');
+  assert.equal(metadata.env?.WAIT, '500');
+});
+
+test('readReplayScriptMetadata accepts env before context', () => {
+  const metadata = readReplayScriptMetadata(
+    'env APP=settings\ncontext platform=ios target=mobile\n',
+  );
+  assert.equal(metadata.platform, 'ios');
+  assert.equal(metadata.target, 'mobile');
+  assert.equal(metadata.env?.APP, 'settings');
+});
+
+test('readReplayScriptMetadata parses quoted env values with spaces', () => {
+  const metadata = readReplayScriptMetadata(
+    'context platform=android\nenv SEL="label=Wait || label=Apps"\n',
+  );
+  assert.equal(metadata.env?.SEL, 'label=Wait || label=Apps');
+});
+
+test('readReplayScriptMetadata rejects invalid env key', () => {
+  assert.throws(
+    () => readReplayScriptMetadata('context platform=android\nenv lower=settings\n'),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Invalid env key "lower"/.test(error.message),
+  );
+});
+
+test('readReplayScriptMetadata rejects duplicate env key', () => {
+  assert.throws(
+    () => readReplayScriptMetadata('context platform=android\nenv APP=a\nenv APP=b\n'),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Duplicate env directive "APP"/.test(error.message),
+  );
+});
+
 test('replay parsing strips versioned-ref pins from recorded refs (#1076)', () => {
   // Generations are session-scoped; a replayed script runs against a NEW
   // session, so pins are stripped and IGNORED rather than re-validated.

--- a/src/replay/__tests__/vars.test.ts
+++ b/src/replay/__tests__/vars.test.ts
@@ -1,0 +1,216 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AppError } from '../../kernel/errors.ts';
+import {
+  buildReplayVarScope,
+  collectReplayShellEnv,
+  parseReplayCliEnvEntries,
+  resolveReplayAction,
+  resolveReplayString,
+} from '../vars.ts';
+import { parseReplayScriptDetailed, readReplayScriptMetadata } from '../script.ts';
+import type { SessionAction } from '../../contracts/session-action.ts';
+
+const LOC = { file: 'test.ad', line: 1 };
+
+test('resolveReplayString substitutes variables', () => {
+  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
+  assert.equal(resolveReplayString('open ${APP}', scope, LOC), 'open settings');
+});
+
+test('resolveReplayString supports fallback with :-default', () => {
+  const scope = buildReplayVarScope({});
+  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 500');
+});
+
+test('resolveReplayString prefers scope value over fallback', () => {
+  const scope = buildReplayVarScope({ fileEnv: { WAIT_SHORT: '1000' } });
+  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 1000');
+});
+
+test('resolveReplayString fallback preserves embedded braces via escapes', () => {
+  const scope = buildReplayVarScope({});
+  assert.equal(resolveReplayString('x ${A:-one\\}two}', scope, LOC), 'x one}two');
+});
+
+test('resolveReplayString throws on unresolved variable with file:line', () => {
+  const scope = buildReplayVarScope({ fileEnv: { OTHER: 'x' } });
+  assert.throws(
+    () => resolveReplayString('open ${MISSING}', scope, { file: 'a.ad', line: 7 }),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Unresolved variable \$\{MISSING\} at a\.ad:7/.test(error.message),
+  );
+});
+
+test('resolveReplayString is case-sensitive', () => {
+  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
+  assert.throws(() => resolveReplayString('${app}', scope, LOC), AppError);
+});
+
+test('resolveReplayString substitutes multiple vars on one line', () => {
+  const scope = buildReplayVarScope({ fileEnv: { A: '1', B: '2' } });
+  assert.equal(resolveReplayString('${A}-${B}-${A}', scope, LOC), '1-2-1');
+});
+
+test('buildReplayVarScope precedence: cli > shell > file > builtin', () => {
+  const scope = buildReplayVarScope({
+    builtins: { K: 'builtin' },
+    fileEnv: { K: 'file' },
+    shellEnv: { K: 'shell' },
+    cliEnv: { K: 'cli' },
+  });
+  assert.equal(scope.values.K, 'cli');
+
+  const shellWinsOverFile = buildReplayVarScope({
+    fileEnv: { K: 'file' },
+    shellEnv: { K: 'shell' },
+  });
+  assert.equal(shellWinsOverFile.values.K, 'shell');
+});
+
+test('collectReplayShellEnv strips AD_VAR_ prefix and ignores other vars', () => {
+  const result = collectReplayShellEnv({
+    AD_VAR_APP_ID: 'settings',
+    PATH: '/bin',
+    AD_VAR_123: 'x',
+    AD_VAR_: 'empty',
+    OTHER_VAR: 'y',
+    AD_APP_ID: 'no-legacy-prefix',
+  });
+  assert.equal(result.APP_ID, 'settings');
+  assert.equal(result.PATH, undefined);
+  assert.equal(result['123'], undefined);
+  assert.equal(result[''], undefined);
+  // legacy AD_* (non AD_VAR_*) is no longer auto-imported.
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_APP_ID'), false);
+});
+
+test('collectReplayShellEnv skips keys that land in reserved AD_* namespace after strip', () => {
+  const result = collectReplayShellEnv({
+    AD_VAR_AD_SESSION: 'evil',
+    AD_VAR_AD_FOO: 'evil',
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_SESSION'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_FOO'), false);
+});
+
+test('parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys', () => {
+  assert.deepEqual(parseReplayCliEnvEntries(['APP=settings', 'FOO=bar=baz']), {
+    APP: 'settings',
+    FOO: 'bar=baz',
+  });
+  assert.throws(() => parseReplayCliEnvEntries(['NOEQUAL']), AppError);
+  assert.throws(() => parseReplayCliEnvEntries(['lower=x']), AppError);
+  assert.throws(() => parseReplayCliEnvEntries(['=value']), AppError);
+});
+
+test('resolveReplayAction walks positionals and string flags', () => {
+  const action: SessionAction = {
+    ts: 0,
+    command: 'snapshot',
+    positionals: ['${FOO}'],
+    flags: {
+      snapshotScope: '${SCOPE}',
+      snapshotInteractiveOnly: true,
+      snapshotDepth: 3,
+    },
+  };
+  const scope = buildReplayVarScope({ fileEnv: { FOO: 'bar', SCOPE: 'app' } });
+  const resolved = resolveReplayAction(action, scope, LOC);
+  assert.deepEqual(resolved.positionals, ['bar']);
+  assert.equal(resolved.flags?.snapshotScope, 'app');
+  assert.equal(resolved.flags?.snapshotInteractiveOnly, true);
+  assert.equal(resolved.flags?.snapshotDepth, 3);
+});
+
+test('resolveReplayAction walks runtime hints', () => {
+  const action: SessionAction = {
+    ts: 0,
+    command: 'open',
+    positionals: [],
+    runtime: { platform: 'android', metroHost: '${HOST}' },
+    flags: {},
+  };
+  const scope = buildReplayVarScope({ fileEnv: { HOST: '10.0.0.1' } });
+  const resolved = resolveReplayAction(action, scope, LOC);
+  assert.equal(resolved.runtime?.metroHost, '10.0.0.1');
+});
+
+test('resolveReplayAction produces dispatch-ready literals for a realistic fixture', () => {
+  const script = [
+    'context platform=android',
+    'env APP_ID=settings',
+    'env WAIT_SHORT=500',
+    'env SETTINGS_ITEMS="label=Wait || label=Apps"',
+    '',
+    'open ${APP_ID} --relaunch',
+    'wait ${WAIT_SHORT}',
+    'click "${SETTINGS_ITEMS}"',
+    'is exists "${SETTINGS_ITEMS}"',
+    'snapshot -s "${SNAPSHOT_SCOPE:-app}"',
+  ].join('\n');
+  const metadata = readReplayScriptMetadata(script);
+  const parsed = parseReplayScriptDetailed(script);
+  const scope = buildReplayVarScope({
+    builtins: { AD_PLATFORM: 'android' },
+    fileEnv: metadata.env,
+    shellEnv: { APP_ID: 'shell-wins' },
+    cliEnv: { APP_ID: 'cli-wins' },
+  });
+  const resolved = parsed.actions.map((action, index) =>
+    resolveReplayAction(action, scope, {
+      file: 'fixture.ad',
+      line: parsed.actionLines[index] ?? 0,
+    }),
+  );
+  assert.deepEqual(resolved[0]?.positionals, ['cli-wins']);
+  assert.equal(resolved[0]?.flags.relaunch, true);
+  assert.deepEqual(resolved[1]?.positionals, ['500']);
+  assert.deepEqual(resolved[2]?.positionals, ['label=Wait || label=Apps']);
+  assert.deepEqual(resolved[3]?.positionals, ['exists', 'label=Wait || label=Apps']);
+  assert.equal(resolved[4]?.flags.snapshotScope, 'app');
+});
+
+test.each([
+  {
+    name: 'file env via parseReplayEnvLine',
+    run: () => readReplayScriptMetadata('context platform=android\nenv AD_FOO=bar\n'),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'CLI -e via parseReplayCliEnvEntries',
+    run: () => parseReplayCliEnvEntries(['AD_FOO=x']),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'buildReplayVarScope.fileEnv',
+    run: () => buildReplayVarScope({ fileEnv: { AD_FOO: 'x' } }),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'buildReplayVarScope.cliEnv',
+    run: () => buildReplayVarScope({ cliEnv: { AD_SESSION: 'x' } }),
+    keyMatch: /AD_SESSION/,
+  },
+])('rejects AD_* as reserved namespace in $name', ({ run, keyMatch }) => {
+  assert.throws(
+    run,
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /AD_\* namespace is reserved/.test(error.message) &&
+      keyMatch.test(error.message),
+  );
+});
+
+test('parseReplayCliEnvEntries error wording is user-friendly for invalid keys', () => {
+  assert.throws(
+    () => parseReplayCliEnvEntries(['lower=x']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /uppercase letters, digits, and underscores/.test(error.message),
+  );
+});


### PR DESCRIPTION
Closes #1460.

`session-replay-vars.test.ts` contained zero references to `buildReplayBuiltinVars` (the module it was named after — that module's real test is `session-replay-builtin-vars.test.ts`, untouched by this PR). It actually held tests of `src/replay/vars.ts`, `src/replay/script.ts`, and `runReplayScriptFile` (`src/daemon/handlers/session-replay-runtime.ts`). This PR redistributes each of the file's 66 test blocks to where its subject actually lives, and deletes the original file. **No production code was changed.**

## Discrepancy vs. the issue's estimate

The issue guessed "~15 tests...are pure duplication" against `script.test.ts`. That guess was checked per-test and found incorrect: `script.test.ts` had **zero** coverage of the `env` directive feature or of `parseReplayScriptDetailed`'s `actionLines`, so all 6 script.ts-subject tests moved as genuinely new coverage, none deleted.

Across the whole file, only **1 test total** was deleted, as a genuine duplicate of existing `session-replay-runtime.test.ts` coverage.

## Disposition tally

- 16 test blocks (19 individual test cases, one is a 4-case `test.each`) → moved to new `src/replay/__tests__/vars.test.ts`
- 6 test blocks → moved to `src/replay/__tests__/script.test.ts`
- 43 test blocks → moved to new `src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts`
- 1 test block → deleted as a duplicate
- **16 + 6 + 43 + 1 = 66**, matching the original file's test count exactly. No test was silently dropped.

## Why a new sibling file instead of merging into `session-replay-runtime.test.ts`

The 43 `runReplayScriptFile` tests all depend on a `runReplayFixture` helper that requires `vi.mock('../../../core/dispatch.ts', ...)` mocking `resolveTargetDevice` (realistic android/ios device objects) and `dispatchCommand` (rejecting, to keep post-failure screen-digest-capture paths deterministic). `session-replay-runtime.test.ts` already has its own, differently-shaped `vi.mock` of the same module (`dispatchCommand` resolves `{}`, `resolveTargetDevice` is a bare `vi.fn()`). Vitest allows only one `vi.mock` per module per file, so merging would require reconciling two incompatible mock configurations — out of scope for a pure test-file split per the issue's "keep the move minimal and mechanical" instruction. The new sibling file carries the `runReplayFixture` helper and its `vi.mock` over verbatim.

That sibling file also carries a handful of generic (non-Maestro) `.ad` `runReplayScriptFile` tests alongside the Maestro-heavy majority, since they share the same fixture helper; this is called out in a comment at the top of the file.

## Per-test itemized disposition

### Moved to `src/replay/__tests__/vars.test.ts` (16 blocks / 19 cases)

1. `resolveReplayString substitutes variables`
2. `resolveReplayString supports fallback with :-default`
3. `resolveReplayString prefers scope value over fallback`
4. `resolveReplayString fallback preserves embedded braces via escapes`
5. `resolveReplayString throws on unresolved variable with file:line`
6. `resolveReplayString is case-sensitive`
7. `resolveReplayString substitutes multiple vars on one line`
8. `buildReplayVarScope precedence: cli > shell > file > builtin`
9. `collectReplayShellEnv strips AD_VAR_ prefix and ignores other vars`
10. `collectReplayShellEnv skips keys that land in reserved AD_* namespace after strip`
11. `parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys`
12. `resolveReplayAction walks positionals and string flags`
13. `resolveReplayAction walks runtime hints`
14. `resolveReplayAction produces dispatch-ready literals for a realistic fixture`
15. `test.each` block `rejects AD_* as reserved namespace in $name` (4 cases: file env via `readReplayScriptMetadata`, CLI via `parseReplayCliEnvEntries`, `buildReplayVarScope.fileEnv`, `buildReplayVarScope.cliEnv`) — kept together as one cross-cutting invariant rather than split across files
16. `parseReplayCliEnvEntries error wording is user-friendly for invalid keys`

### Moved to `src/replay/__tests__/script.test.ts` (6 blocks — verified NOT duplicates; `script.test.ts` had no prior `env`/`actionLines` coverage)

1. `parseReplayScriptDetailed tracks line numbers` (the `actionLines` array)
2. `readReplayScriptMetadata parses env KEY=VALUE directives`
3. `readReplayScriptMetadata accepts env before context`
4. `readReplayScriptMetadata parses quoted env values with spaces`
5. `readReplayScriptMetadata rejects invalid env key`
6. `readReplayScriptMetadata rejects duplicate env key`

### Deleted as duplicate (1 block)

- `--update no longer rejects scripts with env directives (the guard existed only for rewrite safety)` — deleted as duplicate of `session-replay-runtime.test.ts`'s `--update no longer refuses env directives (the guard existed only for rewrite safety)` (same guard-removal regression, same ADR 0012 migration-step-6 context). The one extra assertion in the deleted test (that variable substitution completed, `calls[0].positionals === ['settings']`) is not distinct coverage — substitution itself is thoroughly covered by the vars.ts unit tests moved to `vars.test.ts`.

### Moved to new `src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts` (43 blocks — all new coverage, zero duplicates of the existing 17-test/18-call-site `session-replay-runtime.test.ts`)

1. `--update no longer rejects Maestro compat flow controls (the guard existed only for rewrite safety)`
2. `runReplayScriptFile dispatches resolved literals with file env overridden by CLI`
3. `.ad replay normalizes resolved gesture and swipe syntax into structured daemon input`
4. `runReplayScriptFile reports snapshot diagnostics from per-action session samples`
5. `runReplayScriptFile reports snapshot diagnostics on replay failure`
6. `runReplayScriptFile applies CLI env overrides before Maestro compat mapping`
7. `runReplayScriptFile runs Maestro runScript in replay order and exposes output variables`
8. `runReplayScriptFile supports successful Maestro runScript http.post calls`
9. `runReplayScriptFile strips prototype pollution keys from runScript json()`
10. `runReplayScriptFile reports Maestro runScript failures at the runScript step`
11. `runReplayScriptFile reports iOS Maestro openLink setup failures before assertions`
12. `runReplayScriptFile explains empty Maestro runScript JSON bodies`
13. `runReplayScriptFile rejects Maestro runScript output keys containing dots`
14. `runReplayScriptFile retries Maestro scrollUntilVisible with scroll probes`
15. `runReplayScriptFile uses semantic iOS dispatch for an exact text tapOn`
16. `runReplayScriptFile uses matched Android id geometry for tapOn`
17. `runReplayScriptFile captures fresh geometry for tapOn after assertVisible`
18. `runReplayScriptFile scopes duplicate tap targets after native Maestro assertVisible`
19. `runReplayScriptFile treats absent Maestro assertNotVisible targets as passing`
20. `runReplayScriptFile propagates Maestro assertNotVisible infrastructure failures`
21. `runReplayScriptFile waits briefly for Maestro assertNotVisible to stabilize`
22. `runReplayScriptFile treats absent Maestro extendedWaitUntil.notVisible targets as passing`
23. `runReplayScriptFile resolves Maestro percentage point taps from the direct viewport`
24. `runReplayScriptFile retries Maestro id tapOn through snapshot coordinates`
25. `runReplayScriptFile resolves Maestro tapOn index and childOf from snapshots`
26. `runReplayScriptFile lets snapshot id tap handle Maestro one-point edge controls`
27. `runReplayScriptFile resolves a text-entry target once before typing`
28. `runReplayScriptFile resolves Maestro swipe.label from a labeled element rect`
29. `runReplayScriptFile keeps Maestro swipe.label anchored to the matched label rect`
30. `runReplayScriptFile resolves Maestro screen swipes from the direct viewport`
31. `runReplayScriptFile delegates Android directional swipes and preserves percentage points`
32. `runReplayScriptFile maps Maestro enter to keyboard enter`
33. `runReplayScriptFile waits for Maestro animation screenshots to stabilize`
34. `runReplayScriptFile propagates unsupported keyboard enter dispatch`
35. `runReplayScriptFile retries Maestro retry commands until they pass`
36. `runReplayScriptFile propagates Maestro runFlow.when runtime errors`
37. `runReplayScriptFile runs Maestro runFlow.when.visible commands when present`
38. `runReplayScriptFile runs nested Maestro runtime commands inside runFlow.when`
39. `runReplayScriptFile resolves nested Maestro runFlow.when command variables once at execution`
40. `runReplayScriptFile reads shell env from request (client-collected), not daemon process.env`
41. `runReplayScriptFile falls back to process.env when request omits replayShellEnv`
42. `runReplayScriptFile writes per-action timing events to active trace`
43. `AD_ARTIFACTS resolves to per-attempt dir when artifactsDir flag is set by the test runner`

## Verification

- `pnpm test:unit` — 524 test files, 4659 tests passed, 4 skipped, no failures.
- `pnpm check:tooling` — lint, typecheck, layering, depgraph, production-exports, mcp-metadata, build, bundle-owner-files all pass.
- `session-replay-builtin-vars.test.ts` (the correctly-named `buildReplayBuiltinVars` test) is untouched.

Per the issue: this is a mechanical move only. A later PR (#1451) will restructure this area further.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdZN42axqHTJ7jdwKZQPq3)_