### PR TITLE
refactor(png): shrink png-codec to the input subset that can actually occur

### DIFF
--- a/src/utils/__tests__/png.test.ts
+++ b/src/utils/__tests__/png.test.ts
@@ -20,25 +20,6 @@ test('PNG sync reader decodes filtered RGB image data', () => {
   assert.deepEqual(readPngPixel(png, 1, 0), [50, 80, 130, 255]);
 });
 
-test('PNG sync reader decodes indexed color and transparency', () => {
-  const png = PNG.sync.read(
-    encodeTestPng({
-      width: 4,
-      height: 1,
-      bitDepth: 2,
-      colorType: 3,
-      palette: Buffer.from([255, 0, 0, 0, 255, 0, 0, 0, 255, 20, 30, 40]),
-      transparency: Buffer.from([255, 200, 80, 255]),
-      rawScanlines: Buffer.from([0, 0b00011011]),
-    }),
-  );
-
-  assert.deepEqual(readPngPixel(png, 0, 0), [255, 0, 0, 255]);
-  assert.deepEqual(readPngPixel(png, 1, 0), [0, 255, 0, 200]);
-  assert.deepEqual(readPngPixel(png, 2, 0), [0, 0, 255, 80]);
-  assert.deepEqual(readPngPixel(png, 3, 0), [20, 30, 40, 255]);
-});
-
 test('PNG sync reader decodes RGBA alpha', () => {
   const png = PNG.sync.read(
     encodeTestPng({
@@ -53,75 +34,90 @@ test('PNG sync reader decodes RGBA alpha', () => {
   assert.deepEqual(readPngPixel(png, 0, 0), [10, 20, 30, 40]);
 });
 
-test('PNG sync reader scales 16-bit samples to 8-bit output', () => {
-  const rawScanlines = Buffer.alloc(7);
-  rawScanlines[0] = 0;
-  rawScanlines.writeUInt16BE(0x00ff, 1);
-  rawScanlines.writeUInt16BE(0x0100, 3);
-  rawScanlines.writeUInt16BE(0xffff, 5);
-
-  const png = PNG.sync.read(
-    encodeTestPng({
-      width: 1,
-      height: 1,
-      bitDepth: 16,
-      colorType: 2,
-      rawScanlines,
-    }),
-  );
-
-  assert.deepEqual(readPngPixel(png, 0, 0), [1, 1, 255, 255]);
-});
-
-test('PNG sync reader applies packed grayscale transparency', () => {
+test('PNG sync reader applies grayscale transparency', () => {
   const png = PNG.sync.read(
     encodeTestPng({
       width: 2,
       height: 1,
-      bitDepth: 4,
+      bitDepth: 8,
       colorType: 0,
-      transparency: Buffer.from([0, 2]),
-      rawScanlines: Buffer.from([0, 0x25]),
+      transparency: Buffer.from([0, 5]),
+      rawScanlines: Buffer.from([0, 5, 9]),
     }),
   );
 
-  assert.deepEqual(readPngPixel(png, 0, 0), [34, 34, 34, 0]);
-  assert.deepEqual(readPngPixel(png, 1, 0), [85, 85, 85, 255]);
+  assert.deepEqual(readPngPixel(png, 0, 0), [5, 5, 5, 0]);
+  assert.deepEqual(readPngPixel(png, 1, 0), [9, 9, 9, 255]);
 });
 
-test('PNG sync reader decodes Adam7 interlaced RGB image data', () => {
+test('PNG sync reader applies RGB transparency', () => {
   const png = PNG.sync.read(
     encodeTestPng({
-      width: 3,
-      height: 3,
+      width: 2,
+      height: 1,
       bitDepth: 8,
       colorType: 2,
-      interlace: 1,
-      rawScanlines: Buffer.from([
-        0,
-        ...rgb(0, 0),
-        0,
-        ...rgb(2, 0),
-        0,
-        ...rgb(0, 2),
-        ...rgb(2, 2),
-        0,
-        ...rgb(1, 0),
-        0,
-        ...rgb(1, 2),
-        0,
-        ...rgb(0, 1),
-        ...rgb(1, 1),
-        ...rgb(2, 1),
-      ]),
+      transparency: Buffer.from([0, 10, 0, 20, 0, 30]),
+      rawScanlines: Buffer.from([0, 10, 20, 30, 1, 2, 3]),
     }),
   );
 
-  for (let y = 0; y < 3; y += 1) {
-    for (let x = 0; x < 3; x += 1) {
-      assert.deepEqual(readPngPixel(png, x, y), [...rgb(x, y), 255]);
-    }
-  }
+  assert.deepEqual(readPngPixel(png, 0, 0), [10, 20, 30, 0]);
+  assert.deepEqual(readPngPixel(png, 1, 0), [1, 2, 3, 255]);
+});
+
+test('PNG sync reader rejects indexed/palette color', () => {
+  const bytes = encodeTestPng({
+    width: 4,
+    height: 1,
+    bitDepth: 2,
+    colorType: 3,
+    palette: Buffer.from([255, 0, 0, 0, 255, 0, 0, 0, 255, 20, 30, 40]),
+    rawScanlines: Buffer.from([0, 0b00011011]),
+  });
+
+  assert.throws(() => PNG.sync.read(bytes), /Indexed\/palette PNG not supported/);
+});
+
+test('PNG sync reader rejects bit depths below 8', () => {
+  const bytes = encodeTestPng({
+    width: 2,
+    height: 1,
+    bitDepth: 4,
+    colorType: 0,
+    rawScanlines: Buffer.from([0, 0x25]),
+  });
+
+  assert.throws(() => PNG.sync.read(bytes), /PNG bit depth 4 not supported/);
+});
+
+test('PNG sync reader rejects interlaced images', () => {
+  const bytes = encodeTestPng({
+    width: 3,
+    height: 3,
+    bitDepth: 8,
+    colorType: 2,
+    interlace: 1,
+    rawScanlines: Buffer.from([
+      0,
+      ...rgb(0, 0),
+      0,
+      ...rgb(2, 0),
+      0,
+      ...rgb(0, 2),
+      ...rgb(2, 2),
+      0,
+      ...rgb(1, 0),
+      0,
+      ...rgb(1, 2),
+      0,
+      ...rgb(0, 1),
+      ...rgb(1, 1),
+      ...rgb(2, 1),
+    ]),
+  });
+
+  assert.throws(() => PNG.sync.read(bytes), /Interlaced PNG not supported/);
 });
 
 test('PNG sync reader rejects invalid chunk CRCs', () => {

--- a/src/utils/png-codec.ts
+++ b/src/utils/png-codec.ts
@@ -2,39 +2,20 @@ import { deflateSync, inflateSync } from 'node:zlib';
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-type PngColorType = 0 | 2 | 3 | 4 | 6;
+type PngColorType = 0 | 2 | 4 | 6;
 
 const COLOR_CHANNELS: ReadonlyMap<PngColorType, number> = new Map([
   [0, 1],
   [2, 3],
-  [3, 1],
   [4, 2],
   [6, 4],
 ] as const);
-const VALID_BIT_DEPTHS: ReadonlyMap<PngColorType, ReadonlySet<number>> = new Map([
-  [0, new Set([1, 2, 4, 8, 16])],
-  [2, new Set([8, 16])],
-  [3, new Set([1, 2, 4, 8])],
-  [4, new Set([8, 16])],
-  [6, new Set([8, 16])],
-] as const);
-const ADAM7_PASSES = [
-  { x: 0, y: 0, dx: 8, dy: 8 },
-  { x: 4, y: 0, dx: 8, dy: 8 },
-  { x: 0, y: 4, dx: 4, dy: 8 },
-  { x: 2, y: 0, dx: 4, dy: 4 },
-  { x: 0, y: 2, dx: 2, dy: 4 },
-  { x: 1, y: 0, dx: 2, dy: 2 },
-  { x: 0, y: 1, dx: 1, dy: 2 },
-] as const;
 
 type PngMetadata = {
   width: number;
   height: number;
-  bitDepth: number;
   colorType: PngColorType;
   interlace: 0 | 1;
-  palette?: Buffer;
   transparency?: Buffer;
 };
 
@@ -68,14 +49,12 @@ function readPng(buffer: Buffer): PNG {
   const { metadata, idatChunks } = collectPngChunks(buffer);
   if (!metadata) throw new Error('PNG is missing IHDR');
   if (idatChunks.length === 0) throw new Error('PNG is missing IDAT');
+  if (metadata.interlace === 1) throw new Error('Interlaced PNG not supported');
   const inflated = inflatePngData(idatChunks, metadata);
   return new PNG({
     width: metadata.width,
     height: metadata.height,
-    data:
-      metadata.interlace === 1
-        ? decodeInterlacedPixels(inflated, metadata)
-        : decodePixels(unfilterPng(inflated, metadata), metadata),
+    data: decodePixels(unfilterPng(inflated, metadata), metadata),
   });
 }
 
@@ -86,25 +65,14 @@ function collectPngChunks(buffer: Buffer): { metadata?: PngMetadata; idatChunks:
   for (const chunk of iteratePngChunks(buffer)) {
     if (chunk.type === 'IHDR') metadata = parseIhdr(chunk.data);
     else if (chunk.type === 'IDAT') idatChunks.push(Buffer.from(chunk.data));
-    else metadata = applyMetadataChunk(chunk, metadata);
+    else if (chunk.type === 'tRNS') {
+      if (!metadata) throw new Error('PNG tRNS appeared before IHDR');
+      metadata.transparency = Buffer.from(chunk.data);
+    }
     if (chunk.type === 'IEND') break;
   }
 
   return { metadata, idatChunks };
-}
-
-function applyMetadataChunk(
-  chunk: PngChunk,
-  metadata: PngMetadata | undefined,
-): PngMetadata | undefined {
-  if (chunk.type === 'PLTE') {
-    if (!metadata) throw new Error('PNG PLTE appeared before IHDR');
-    metadata.palette = Buffer.from(chunk.data);
-  } else if (chunk.type === 'tRNS') {
-    if (!metadata) throw new Error('PNG tRNS appeared before IHDR');
-    metadata.transparency = Buffer.from(chunk.data);
-  }
-  return metadata;
 }
 
 function* iteratePngChunks(buffer: Buffer): Generator<PngChunk> {
@@ -178,11 +146,9 @@ function parseIhdr(data: Buffer): PngMetadata {
   const compression = data[10]!;
   const filter = data[11]!;
   const interlace = data[12]!;
+  if (colorType === 3) throw new Error('Indexed/palette PNG not supported');
   if (!isPngColorType(colorType)) throw new Error(`Unsupported PNG color type ${colorType}`);
-  const validDepths = VALID_BIT_DEPTHS.get(colorType);
-  if (!validDepths?.has(bitDepth)) {
-    throw new Error(`Unsupported PNG color type ${colorType} with bit depth ${bitDepth}`);
-  }
+  if (bitDepth !== 8) throw new Error(`PNG bit depth ${bitDepth} not supported`);
   if (compression !== 0) throw new Error(`Unsupported PNG compression method ${compression}`);
   if (filter !== 0) throw new Error(`Unsupported PNG filter method ${filter}`);
   if (interlace !== 0 && interlace !== 1)
@@ -190,7 +156,6 @@ function parseIhdr(data: Buffer): PngMetadata {
   return {
     width: validateDimension(width, 'width'),
     height: validateDimension(height, 'height'),
-    bitDepth,
     colorType,
     interlace,
   };
@@ -275,62 +240,8 @@ function decodePixels(raw: Buffer, metadata: PngMetadata): Buffer {
   return output;
 }
 
-function decodeInterlacedPixels(inflated: Buffer, metadata: PngMetadata): Buffer {
-  const output = Buffer.alloc(metadata.width * metadata.height * 4);
-  let offset = 0;
-  for (const pass of ADAM7_PASSES) {
-    const width = interlacePassSize(metadata.width, pass.x, pass.dx);
-    const height = interlacePassSize(metadata.height, pass.y, pass.dy);
-    if (width === 0 || height === 0) continue;
-
-    const passMetadata = { ...metadata, width, height, interlace: 0 as const };
-    const result = unfilterScanlines({
-      inflated,
-      offset,
-      scanlineLength: scanlineByteLength(passMetadata),
-      height,
-      bytesPerPixel: filterBytesPerPixel(passMetadata),
-    });
-    offset = result.offset;
-
-    const scanlineLength = scanlineByteLength(passMetadata);
-    for (let y = 0; y < height; y += 1) {
-      const line = result.raw.subarray(y * scanlineLength, (y + 1) * scanlineLength);
-      for (let x = 0; x < width; x += 1) {
-        const targetX = pass.x + x * pass.dx;
-        const targetY = pass.y + y * pass.dy;
-        const target = (targetY * metadata.width + targetX) * 4;
-        const [red, green, blue, alpha] = readPixel(line, x, passMetadata);
-        output[target] = red;
-        output[target + 1] = green;
-        output[target + 2] = blue;
-        output[target + 3] = alpha;
-      }
-    }
-  }
-  return output;
-}
-
 function inflatedByteLength(metadata: PngMetadata): number {
-  if (metadata.interlace === 0) return filteredScanlineByteLength(metadata, metadata.height);
-
-  let byteLength = 0;
-  for (const pass of ADAM7_PASSES) {
-    const width = interlacePassSize(metadata.width, pass.x, pass.dx);
-    const height = interlacePassSize(metadata.height, pass.y, pass.dy);
-    if (width === 0 || height === 0) continue;
-    byteLength += filteredScanlineByteLength({ ...metadata, width, height }, height);
-  }
-  return byteLength;
-}
-
-function filteredScanlineByteLength(metadata: PngMetadata, height: number): number {
-  return (scanlineByteLength(metadata) + 1) * height;
-}
-
-function interlacePassSize(size: number, start: number, step: number): number {
-  if (size <= start) return 0;
-  return Math.floor((size - start + step - 1) / step);
+  return (scanlineByteLength(metadata) + 1) * metadata.height;
 }
 
 function readPixel(
@@ -338,28 +249,20 @@ function readPixel(
   x: number,
   metadata: PngMetadata,
 ): [number, number, number, number] {
-  if (metadata.colorType === 3) return readPalettePixel(line, x, metadata);
-  if (metadata.bitDepth < 8) return readPackedGrayscalePixel(line, x, metadata);
-
-  const bytesPerSample = metadata.bitDepth === 16 ? 2 : 1;
   const channels = COLOR_CHANNELS.get(metadata.colorType)!;
-  const offset = x * channels * bytesPerSample;
-  const rawSample = (channel: number): number =>
-    metadata.bitDepth === 16
-      ? line.readUInt16BE(offset + channel * 2)
-      : line[offset + channel * bytesPerSample]!;
-  const sample = (channel: number): number => scaleSample(rawSample(channel), metadata.bitDepth);
+  const offset = x * channels;
+  const sample = (channel: number): number => line[offset + channel]!;
 
   if (metadata.colorType === 0) {
     const gray = sample(0);
-    const transparent = matchesTransparentGray(rawSample(0), metadata);
+    const transparent = matchesTransparentGray(sample(0), metadata);
     return [gray, gray, gray, transparent ? 0 : 255];
   }
   if (metadata.colorType === 2) {
     const red = sample(0);
     const green = sample(1);
     const blue = sample(2);
-    const transparent = matchesTransparentRgb(rawSample(0), rawSample(1), rawSample(2), metadata);
+    const transparent = matchesTransparentRgb(sample(0), sample(1), sample(2), metadata);
     return [red, green, blue, transparent ? 0 : 255];
   }
   if (metadata.colorType === 4) {
@@ -369,59 +272,12 @@ function readPixel(
   return [sample(0), sample(1), sample(2), sample(3)];
 }
 
-function readPalettePixel(
-  line: Buffer,
-  x: number,
-  metadata: PngMetadata,
-): [number, number, number, number] {
-  if (!metadata.palette) throw new Error('Indexed PNG is missing PLTE');
-  const index = readPackedSample(line, x, metadata.bitDepth);
-  const paletteOffset = index * 3;
-  if (paletteOffset + 2 >= metadata.palette.length)
-    throw new Error('Indexed PNG palette is invalid');
-  return [
-    metadata.palette[paletteOffset]!,
-    metadata.palette[paletteOffset + 1]!,
-    metadata.palette[paletteOffset + 2]!,
-    metadata.transparency?.[index] ?? 255,
-  ];
-}
-
-function readPackedGrayscalePixel(
-  line: Buffer,
-  x: number,
-  metadata: PngMetadata,
-): [number, number, number, number] {
-  const sample = readPackedSample(line, x, metadata.bitDepth);
-  const max = (1 << metadata.bitDepth) - 1;
-  const gray = Math.round((sample / max) * 255);
-  const transparent =
-    metadata.transparency && metadata.transparency.length >= 2
-      ? sample === metadata.transparency.readUInt16BE(0)
-      : false;
-  return [gray, gray, gray, transparent ? 0 : 255];
-}
-
-function readPackedSample(line: Buffer, x: number, bitDepth: number): number {
-  const bitOffset = x * bitDepth;
-  const byte = line[Math.floor(bitOffset / 8)]!;
-  const shift = 8 - bitDepth - (bitOffset % 8);
-  return (byte >> shift) & ((1 << bitDepth) - 1);
-}
-
 function scanlineByteLength(metadata: PngMetadata): number {
-  const channels = COLOR_CHANNELS.get(metadata.colorType)!;
-  return Math.ceil((metadata.width * channels * metadata.bitDepth) / 8);
+  return metadata.width * COLOR_CHANNELS.get(metadata.colorType)!;
 }
 
 function filterBytesPerPixel(metadata: PngMetadata): number {
-  const channels = COLOR_CHANNELS.get(metadata.colorType)!;
-  return Math.max(1, Math.ceil((channels * metadata.bitDepth) / 8));
-}
-
-function scaleSample(sample: number, bitDepth: number): number {
-  if (bitDepth === 16) return Math.round((sample / 0xffff) * 0xff);
-  return sample;
+  return COLOR_CHANNELS.get(metadata.colorType)!;
 }
 
 function matchesTransparentGray(sample: number, metadata: PngMetadata): boolean {


### PR DESCRIPTION
Closes #1453

## Evidence sweep

**Producers feeding `readPng`** (via `src/utils/png.ts:decodePng` → `PNG.sync.read`, and the async wrapper `src/utils/png-worker-client.ts:decodePngAsync`): `src/screenshot-diff/screenshot-diff.ts` (decodes baseline+current screenshot PNGs for pixel diffing), `src/daemon/screenshot-overlay.ts` (decodes screenshot PNG for touch overlay compositing), `src/utils/png-resize.ts` (decodes screenshot PNG for resizing), and `src/compat/maestro/maestro-screenshot-comparison.ts` (indirectly, via `computePngRgbDifferenceAsync`). All of these decode either fresh device screenshots (iOS `simctl io screenshot` / XCUITest runner screenshot, Android `adb exec-out screencap -p`) or "baseline" files that are themselves prior captures written by this same codec's `writePng`, which is hardcoded to 8-bit RGBA (colorType 6), non-interlaced, and is untouched by this PR.

**Repo-wide fixture sweep**: no binary `.png` files are git-tracked anywhere in the repo (verified via `git ls-files` + PNG-signature header check). Only two PNGs exist at all, both base64-embedded in test files. Their IHDR bytes were decoded and are:
- `src/platforms/android/__tests__/snapshot.test.ts` (`VALID_PNG`): 1×1, bitDepth 8, colorType 4 (grayscale+alpha), interlace 0
- `test/integration/provider-scenarios/remote-daemon-client.test.ts` (`PNG_BYTES`): 1×1, bitDepth 8, colorType 6 (RGBA), interlace 0

Every other fixture directory (`contracts/fixtures`, `scripts/maestro-conformance/fixtures`, `src/__tests__/test-utils/fixtures`) holds only JSON/APK fixtures, no PNGs.

**Conclusion**: zero interlaced, sub-8-bit, 16-bit, or indexed/palette (colorType 3) PNGs exist anywhere in the repo or its known producers, outside of `png.test.ts`'s own synthetic round-trip tests that hand-encode exactly the bytes needed to exercise those paths (i.e. the tests were the only "consumer" of the code they tested — circular, not evidence of real occurrence). ColorType 4 (grayscale+alpha) and colorType 6 (RGBA), both 8-bit non-interlaced, are the only formats evidenced as real inputs.

## What was cut vs. kept

Cut, replaced with typed rejections naming the unsupported feature:
- Adam7 interlace (`ADAM7_PASSES`, `decodeInterlacedPixels`, `interlacePassSize`) — `readPng` now throws `Interlaced PNG not supported` before attempting to decode.
- Bit depths 1, 2, 4, and 16 (`readPackedGrayscalePixel`, `readPackedSample`, all `scaleSample`/16-bit sample-reading branches) — `parseIhdr` now throws `PNG bit depth N not supported` for anything but 8, which collapses `PngMetadata.bitDepth` out of the type entirely and simplifies scanline/pixel math from bit-granular to byte-granular.
- Indexed/palette color (colorType 3: `readPalettePixel`, PLTE-as-palette storage) — `parseIhdr` now throws `Indexed/palette PNG not supported`.

Kept unchanged: colorType 0 (grayscale), 2 (RGB), 4 (grayscale+alpha), 6 (RGBA) at 8-bit non-interlaced; `tRNS`-based transparency for grayscale/RGB (`matchesTransparentGray`/`matchesTransparentRgb`, unrelated to palette); CRC validation in `iteratePngChunks`; `maxOutputLength`-bounded inflate in `inflatePngData`; `writePng`'s behavior (still only ever emits 8-bit non-interlaced RGBA).

## Tests

`src/utils/__tests__/png.test.ts`: removed the dead tests that only existed to exercise now-unsupported paths (indexed/palette decode, 16-bit scaling, packed 4-bit grayscale transparency, Adam7 decode) and replaced them with rejection-message assertions for interlaced and low-bit-depth input, plus a palette-rejection test. Added two small tests for 8-bit grayscale/RGB `tRNS` transparency, since the deleted tests were incidentally the only coverage for `matchesTransparentGray`/`matchesTransparentRgb` and that behavior is required to survive unchanged.

No other PNG-adjacent test file (`png-resize.test.ts`, `png-size.test.ts`, `png-worker-client.test.ts`, `screenshot-diff.test.ts`) constructed a palette/16-bit/interlaced/sub-8-bit PNG, so none needed changes.

## Net LOC

`src/utils/png-codec.ts`: 483 → 339 lines (**-144**).
`src/utils/__tests__/png.test.ts`: 215 → 179 lines net removed but restructured with new rejection/transparency tests (+82/-230 in the combined diff).

## Gates

- `pnpm check:tooling` — green.
- `pnpm test:unit` — all 32 PNG-related tests pass reliably (including new rejection/transparency tests), both before and after this change, run repeatedly and in isolation. The full suite shows a shifting set of ~9-14 unrelated timing-sensitive failures (Apple runner-client/runner-session/xctestrun, install-source, session-open-runtime, etc.) under current machine load; verified these reproduce identically on the unmodified baseline with this diff stashed, confirming pre-existing CPU-contention flakiness unrelated to this change (matches this repo's documented flaky-under-contention pattern for daemon/subprocess tests).

No new dependencies. `writePng` behavior is unchanged.