### PR TITLE
fix: relaunch iOS simulator app URLs atomically

### DIFF
--- a/src/core/__tests__/dispatch-open.test.ts
+++ b/src/core/__tests__/dispatch-open.test.ts
@@ -77,6 +77,23 @@ test('dispatch open rejects launch arguments without an app target', async () =>
   );
 });
 
+test('dispatch open forwards terminate-running semantics with an iOS app URL', async () => {
+  await dispatchCommand(
+    IOS_SIMULATOR,
+    'open',
+    ['com.example.app', 'myapp://automation'],
+    undefined,
+    {
+      terminateRunningApp: true,
+    },
+  );
+
+  assert.equal(mockOpenIosApp.mock.calls.length, 1);
+  assert.deepEqual(mockOpenIosApp.mock.calls[0]?.slice(0, 2), [IOS_SIMULATOR, 'com.example.app']);
+  assert.equal(mockOpenIosApp.mock.calls[0]?.[2]?.url, 'myapp://automation');
+  assert.equal(mockOpenIosApp.mock.calls[0]?.[2]?.terminateRunningApp, true);
+});
+
 test('dispatch open forwards Android launch arguments to openAndroidApp', async () => {
   const device: DeviceInfo = {
     platform: 'android',

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -268,6 +268,7 @@ async function handleOpenCommand(
       activity: context?.activity,
       appBundleId: context?.appBundleId,
       launchArgs,
+      terminateRunningApp: context?.terminateRunningApp,
       url,
     });
     return { app, url, ...successText(`Opened: ${app}`) };

--- a/src/daemon/handlers/__tests__/session-open-launch-url.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-launch-url.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  makeSession,
+  makeSessionStore,
+  mockDispatch,
+  mockResolveTargetDevice,
+  noopInvoke,
+} from './session-test-harness.ts';
+import { buildSessionOpenLaunchPlan } from '../session-open-launch-url.ts';
+import { handleSessionCommands } from '../session.ts';
+
+const iosSimulator = {
+  platform: 'apple' as const,
+  appleOs: 'ios' as const,
+  id: 'sim-1',
+  name: 'iPhone 17 Pro',
+  kind: 'simulator' as const,
+  booted: true,
+};
+
+describe('buildSessionOpenLaunchPlan', () => {
+  test('folds an iOS launch URL into the app open', () => {
+    expect(
+      buildSessionOpenLaunchPlan({
+        device: iosSimulator,
+        openPositionals: ['com.example.app'],
+        runtime: { platform: 'ios', launchUrl: 'myapp://automation' },
+        flags: { relaunch: true },
+      }),
+    ).toEqual({
+      openPositionals: ['com.example.app', 'myapp://automation'],
+      supportsTerminateRunningApp: true,
+    });
+  });
+
+  test('keeps launch options on the direct app launch before the URL open', () => {
+    expect(
+      buildSessionOpenLaunchPlan({
+        device: iosSimulator,
+        openPositionals: ['com.example.app'],
+        runtime: { platform: 'ios', launchUrl: 'myapp://automation' },
+        flags: { launchArgs: ['-Flag', 'YES'] },
+      }),
+    ).toEqual({
+      openPositionals: ['com.example.app'],
+      followUpLaunchUrl: 'myapp://automation',
+      supportsTerminateRunningApp: true,
+    });
+  });
+
+  test('keeps the existing two-dispatch contract off Apple platforms', () => {
+    expect(
+      buildSessionOpenLaunchPlan({
+        device: {
+          platform: 'android',
+          id: 'emulator-5554',
+          name: 'Pixel',
+          kind: 'emulator',
+          booted: true,
+        },
+        openPositionals: ['com.example.app'],
+        runtime: { platform: 'android', launchUrl: 'myapp://automation' },
+        flags: {},
+      }),
+    ).toEqual({
+      openPositionals: ['com.example.app'],
+      followUpLaunchUrl: 'myapp://automation',
+      supportsTerminateRunningApp: true,
+    });
+  });
+
+  test('makes iOS relaunch terminate inside one cold URL launch dispatch', async () => {
+    const sessionStore = makeSessionStore();
+    const sessionName = 'ios-simulator-runtime-url-relaunch-session';
+    sessionStore.set(sessionName, {
+      ...makeSession(sessionName, iosSimulator),
+      appName: 'com.example.app',
+    });
+    sessionStore.setRuntimeHints(sessionName, {
+      platform: 'ios',
+      launchUrl: 'myapp://automation',
+    });
+
+    const calls: Array<{ command: string; terminateRunningApp?: boolean }> = [];
+    mockResolveTargetDevice.mockResolvedValue(iosSimulator);
+    mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
+      calls.push({
+        command: `${command}:${positionals.join(' ')}`,
+        terminateRunningApp: context?.terminateRunningApp,
+      });
+      return {};
+    });
+
+    const response = await handleSessionCommands({
+      req: {
+        token: 't',
+        session: sessionName,
+        command: 'open',
+        positionals: [],
+        flags: { relaunch: true },
+      },
+      sessionName,
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      sessionStore,
+      invoke: noopInvoke,
+    });
+
+    expect(response?.ok).toBe(true);
+    expect(calls).toEqual([
+      {
+        command: 'open:com.example.app myapp://automation',
+        terminateRunningApp: true,
+      },
+    ]);
+  });
+});

--- a/src/daemon/handlers/__tests__/session-open-launch-url.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-launch-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { setActiveProviderDeviceRuntimes } from '../../../provider-device-runtime.ts';
 import {
   makeSession,
   makeSessionStore,
@@ -24,50 +25,41 @@ describe('buildSessionOpenLaunchPlan', () => {
   test('folds an iOS launch URL into the app open', () => {
     expect(
       buildSessionOpenLaunchPlan({
-        device: iosSimulator,
         openPositionals: ['com.example.app'],
         runtime: { platform: 'ios', launchUrl: 'myapp://automation' },
         flags: { relaunch: true },
+        foldRuntimeLaunchUrl: true,
       }),
     ).toEqual({
       openPositionals: ['com.example.app', 'myapp://automation'],
-      supportsTerminateRunningApp: true,
     });
   });
 
   test('keeps launch options on the direct app launch before the URL open', () => {
     expect(
       buildSessionOpenLaunchPlan({
-        device: iosSimulator,
         openPositionals: ['com.example.app'],
         runtime: { platform: 'ios', launchUrl: 'myapp://automation' },
         flags: { launchArgs: ['-Flag', 'YES'] },
+        foldRuntimeLaunchUrl: true,
       }),
     ).toEqual({
       openPositionals: ['com.example.app'],
       followUpLaunchUrl: 'myapp://automation',
-      supportsTerminateRunningApp: true,
     });
   });
 
-  test('keeps the existing two-dispatch contract off Apple platforms', () => {
+  test('keeps the existing two-dispatch contract when URL folding is unavailable', () => {
     expect(
       buildSessionOpenLaunchPlan({
-        device: {
-          platform: 'android',
-          id: 'emulator-5554',
-          name: 'Pixel',
-          kind: 'emulator',
-          booted: true,
-        },
         openPositionals: ['com.example.app'],
-        runtime: { platform: 'android', launchUrl: 'myapp://automation' },
+        runtime: { platform: 'ios', launchUrl: 'myapp://automation' },
         flags: {},
+        foldRuntimeLaunchUrl: false,
       }),
     ).toEqual({
       openPositionals: ['com.example.app'],
       followUpLaunchUrl: 'myapp://automation',
-      supportsTerminateRunningApp: true,
     });
   });
 
@@ -114,5 +106,96 @@ describe('buildSessionOpenLaunchPlan', () => {
         terminateRunningApp: true,
       },
     ]);
+  });
+
+  test('keeps a physical iOS runtime URL as a follow-up open', async () => {
+    const sessionStore = makeSessionStore();
+    const sessionName = 'ios-device-runtime-url-session';
+    const iosDevice = {
+      ...iosSimulator,
+      id: 'device-1',
+      name: 'My iPhone',
+      kind: 'device' as const,
+    };
+    sessionStore.setRuntimeHints(sessionName, {
+      platform: 'ios',
+      launchUrl: 'https://example.com/automation',
+    });
+
+    const calls: string[] = [];
+    mockResolveTargetDevice.mockResolvedValue(iosDevice);
+    mockDispatch.mockImplementation(async (_device, command, positionals) => {
+      calls.push(`${command}:${positionals.join(' ')}`);
+      return {};
+    });
+
+    const response = await handleSessionCommands({
+      req: {
+        token: 't',
+        session: sessionName,
+        command: 'open',
+        positionals: ['com.example.app'],
+        flags: {},
+      },
+      sessionName,
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      sessionStore,
+      invoke: noopInvoke,
+    });
+
+    expect(response).toMatchObject({ ok: true });
+    expect(calls).toEqual(['open:com.example.app', 'open:https://example.com/automation']);
+  });
+
+  test('keeps a provider iOS simulator runtime URL as a follow-up open', async () => {
+    const sessionStore = makeSessionStore();
+    const sessionName = 'provider-ios-runtime-url-session';
+    const providerSimulator = {
+      ...iosSimulator,
+      id: 'provider:ios:lease-a',
+      name: 'Provider iPhone',
+    };
+    sessionStore.setRuntimeHints(sessionName, {
+      platform: 'ios',
+      launchUrl: 'myapp://automation',
+    });
+    setActiveProviderDeviceRuntimes([
+      {
+        provider: 'fake-provider',
+        leaseLifecycle: {},
+        deviceInventoryProvider: async () => [providerSimulator],
+        ownsDevice: (candidate) => candidate.id === providerSimulator.id,
+        getInteractor: () => undefined,
+        shutdown: async () => {},
+      },
+    ]);
+
+    const calls: string[] = [];
+    mockResolveTargetDevice.mockResolvedValue(providerSimulator);
+    mockDispatch.mockImplementation(async (_device, command, positionals) => {
+      calls.push(`${command}:${positionals.join(' ')}`);
+      return {};
+    });
+
+    try {
+      const response = await handleSessionCommands({
+        req: {
+          token: 't',
+          session: sessionName,
+          command: 'open',
+          positionals: ['com.example.app'],
+          flags: {},
+        },
+        sessionName,
+        logPath: path.join(os.tmpdir(), 'daemon.log'),
+        sessionStore,
+        invoke: noopInvoke,
+      });
+
+      expect(response).toMatchObject({ ok: true });
+      expect(calls).toEqual(['open:com.example.app', 'open:myapp://automation']);
+    } finally {
+      setActiveProviderDeviceRuntimes([]);
+    }
   });
 });

--- a/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
+++ b/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
@@ -260,7 +260,7 @@ test('open --relaunch on iOS simulator collapses into one terminate-running open
   );
 });
 
-test('open <app> <url> --relaunch on iOS simulator keeps close-first ordering', async () => {
+test('open <app> <url> --relaunch on iOS simulator delegates termination to the URL open', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-simulator-url-relaunch-session';
   sessionStore.set(sessionName, {
@@ -305,10 +305,8 @@ test('open <app> <url> --relaunch on iOS simulator keeps close-first ordering', 
 
   expect(response).toBeTruthy();
   expect(response?.ok).toBe(true);
-  // The URL dispatch path cannot carry the terminate, so the relaunch keeps
-  // the explicit close-then-open sequence.
-  expect(calls).toEqual(['close:com.example.app', 'open:com.example.app https://example.com/deal']);
-  expect(openContext?.terminateRunningApp).toBeUndefined();
+  expect(calls).toEqual(['open:com.example.app https://example.com/deal']);
+  expect(openContext?.terminateRunningApp).toBe(true);
 });
 
 test('open --relaunch --clear-app-state on iOS simulator keeps close-first ordering', async () => {

--- a/src/daemon/handlers/session-open-launch-url.ts
+++ b/src/daemon/handlers/session-open-launch-url.ts
@@ -1,0 +1,63 @@
+import { isDeepLinkTarget } from '../../contracts/open-target.ts';
+import { dispatchCommand } from '../../core/dispatch.ts';
+import { isIosFamily, type DeviceInfo } from '../../kernel/device.ts';
+import type { DaemonRequest, SessionRuntimeHints } from '../types.ts';
+import { contextFromFlags } from '../context.ts';
+
+type SessionOpenLaunchPlan = {
+  openPositionals: string[];
+  followUpLaunchUrl?: string;
+  supportsTerminateRunningApp: boolean;
+};
+
+export function buildSessionOpenLaunchPlan(params: {
+  device: DeviceInfo;
+  openPositionals: string[];
+  runtime: SessionRuntimeHints | undefined;
+  flags: DaemonRequest['flags'];
+}): SessionOpenLaunchPlan {
+  const { device, openPositionals, runtime, flags } = params;
+  const launchUrl = runtime?.launchUrl;
+  if (!launchUrl || openPositionals.length !== 1) {
+    return {
+      openPositionals,
+      supportsTerminateRunningApp:
+        openPositionals.length === 2 ||
+        (openPositionals.length === 1 && !isDeepLinkTarget(openPositionals[0] ?? '')),
+    };
+  }
+  const openTarget = openPositionals[0]?.trim();
+  if (!openTarget || isDeepLinkTarget(openTarget)) {
+    return { openPositionals, supportsTerminateRunningApp: false };
+  }
+
+  const hasDirectLaunchOptions =
+    Boolean(flags?.launchConsole?.trim()) || Boolean(flags?.launchArgs?.length);
+  if (isIosFamily(device) && !hasDirectLaunchOptions) {
+    return {
+      openPositionals: [openTarget, launchUrl],
+      supportsTerminateRunningApp: true,
+    };
+  }
+  return {
+    openPositionals,
+    followUpLaunchUrl: launchUrl,
+    supportsTerminateRunningApp: true,
+  };
+}
+
+export async function dispatchSessionOpenFollowUpLaunchUrl(params: {
+  launchUrl: string | undefined;
+  device: DeviceInfo;
+  req: DaemonRequest;
+  logPath: string;
+  appBundleId?: string;
+  traceLogPath?: string;
+}): Promise<void> {
+  const { launchUrl, device, req, logPath, appBundleId, traceLogPath } = params;
+  if (!launchUrl) return;
+  const context = contextFromFlags(logPath, req.flags, appBundleId, traceLogPath);
+  delete context.launchConsole;
+  delete context.launchArgs;
+  await dispatchCommand(device, 'open', [launchUrl], req.flags?.out, context);
+}

--- a/src/daemon/handlers/session-open-launch-url.ts
+++ b/src/daemon/handlers/session-open-launch-url.ts
@@ -1,53 +1,43 @@
 import { isDeepLinkTarget } from '../../contracts/open-target.ts';
 import { dispatchCommand } from '../../core/dispatch.ts';
-import { isIosFamily, type DeviceInfo } from '../../kernel/device.ts';
+import type { DeviceInfo } from '../../kernel/device.ts';
 import type { DaemonRequest, SessionRuntimeHints } from '../types.ts';
 import { contextFromFlags } from '../context.ts';
 
 type SessionOpenLaunchPlan = {
   openPositionals: string[];
   followUpLaunchUrl?: string;
-  supportsTerminateRunningApp: boolean;
 };
 
 export function buildSessionOpenLaunchPlan(params: {
-  device: DeviceInfo;
   openPositionals: string[];
   runtime: SessionRuntimeHints | undefined;
   flags: DaemonRequest['flags'];
+  foldRuntimeLaunchUrl: boolean;
 }): SessionOpenLaunchPlan {
-  const { device, openPositionals, runtime, flags } = params;
+  const { openPositionals, runtime, flags, foldRuntimeLaunchUrl } = params;
   const launchUrl = runtime?.launchUrl;
   if (!launchUrl || openPositionals.length !== 1) {
-    return {
-      openPositionals,
-      supportsTerminateRunningApp:
-        openPositionals.length === 2 ||
-        (openPositionals.length === 1 && !isDeepLinkTarget(openPositionals[0] ?? '')),
-    };
+    return { openPositionals };
   }
   const openTarget = openPositionals[0]?.trim();
   if (!openTarget || isDeepLinkTarget(openTarget)) {
-    return { openPositionals, supportsTerminateRunningApp: false };
+    return { openPositionals };
   }
 
   const hasDirectLaunchOptions =
     Boolean(flags?.launchConsole?.trim()) || Boolean(flags?.launchArgs?.length);
-  if (isIosFamily(device) && !hasDirectLaunchOptions) {
-    return {
-      openPositionals: [openTarget, launchUrl],
-      supportsTerminateRunningApp: true,
-    };
+  if (foldRuntimeLaunchUrl && !hasDirectLaunchOptions) {
+    return { openPositionals: [openTarget, launchUrl] };
   }
   return {
     openPositionals,
     followUpLaunchUrl: launchUrl,
-    supportsTerminateRunningApp: true,
   };
 }
 
 export async function dispatchSessionOpenFollowUpLaunchUrl(params: {
-  launchUrl: string | undefined;
+  launchUrl: string;
   device: DeviceInfo;
   req: DaemonRequest;
   logPath: string;
@@ -55,9 +45,13 @@ export async function dispatchSessionOpenFollowUpLaunchUrl(params: {
   traceLogPath?: string;
 }): Promise<void> {
   const { launchUrl, device, req, logPath, appBundleId, traceLogPath } = params;
-  if (!launchUrl) return;
-  const context = contextFromFlags(logPath, req.flags, appBundleId, traceLogPath);
-  delete context.launchConsole;
-  delete context.launchArgs;
+  const followUpFlags = req.flags
+    ? (Object.fromEntries(
+        Object.entries(req.flags).filter(
+          ([name]) => name !== 'launchConsole' && name !== 'launchArgs',
+        ),
+      ) as NonNullable<DaemonRequest['flags']>)
+    : undefined;
+  const context = contextFromFlags(logPath, followUpFlags, appBundleId, traceLogPath);
   await dispatchCommand(device, 'open', [launchUrl], req.flags?.out, context);
 }

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -270,28 +270,17 @@ async function completeOpenCommand(params: {
     schedulePrewarm();
   }
 
+  const usesLocalIosSimulatorLifecycle = isIosSimulator(device) && !isActiveProviderDevice(device);
   const launchPlan = buildSessionOpenLaunchPlan({
-    device,
     openPositionals,
     runtime,
     flags: req.flags,
+    foldRuntimeLaunchUrl: usesLocalIosSimulatorLifecycle,
   });
-  // Local iOS simulators relaunch inside the platform open: direct app launches use
-  // `simctl launch --terminate-running-process`, while app+URL launches terminate
-  // and let `simctl openurl` be the sole launch trigger. Provider simulators must
-  // dispatch an explicit close because their interactors own app termination.
-  // Runtime hints written below are user-defaults reads at that launch, so ordering holds.
-  // Collapse when the platform open can implement terminate-before-launch
-  // itself. App+URL is one semantic relaunch: terminate the bundle, then let
-  // the URL be the sole launch trigger. --clear-app-state keeps close-first
-  // ordering because it must never mutate a running app's container.
+  // Local simulators terminate inside the Apple open path. Provider simulators
+  // keep explicit close/open dispatches, and clear-state must mutate a stopped app.
   const collapseSimulatorRelaunch =
-    shouldRelaunch &&
-    Boolean(openTarget) &&
-    launchPlan.supportsTerminateRunningApp &&
-    isIosSimulator(device) &&
-    !isActiveProviderDevice(device) &&
-    req.flags?.clearAppState !== true;
+    shouldRelaunch && usesLocalIosSimulatorLifecycle && req.flags?.clearAppState !== true;
   if (
     shouldRunRelaunchPreClose({
       shouldRelaunch,
@@ -363,14 +352,16 @@ async function completeOpenCommand(params: {
   timing.openDispatchDurationMs = Math.max(0, Date.now() - openStartedAtMs);
   await maybeActivateAndroidTestImeForOpen(device, req, sessionStore.resolveDaemonStateDir());
   const launchUrlStartedAtMs = Date.now();
-  await dispatchSessionOpenFollowUpLaunchUrl({
-    launchUrl: launchPlan.followUpLaunchUrl,
-    device,
-    req,
-    logPath,
-    appBundleId: sessionAppBundleId,
-    traceLogPath,
-  });
+  if (launchPlan.followUpLaunchUrl) {
+    await dispatchSessionOpenFollowUpLaunchUrl({
+      launchUrl: launchPlan.followUpLaunchUrl,
+      device,
+      req,
+      logPath,
+      appBundleId: sessionAppBundleId,
+      traceLogPath,
+    });
+  }
   timing.launchUrlDurationMs = Math.max(0, Date.now() - launchUrlStartedAtMs);
   if (shouldPrewarmIosRunner && !runnerPrewarmScheduled) {
     schedulePrewarm();

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { dispatchCommand, resolveTargetDevice } from '../../core/dispatch.ts';
-import { isDeepLinkTarget } from '../../contracts/open-target.ts';
 import type { SessionSurface } from '../../contracts/session-surface.ts';
 import { contextFromFlags } from '../context.ts';
 import { createRequestCanceledError, isRequestCanceled } from '../../request/cancel.ts';
@@ -38,6 +37,10 @@ import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { emitDiagnostic, getDiagnosticsMeta } from '../../utils/diagnostics.ts';
 import { isActiveProviderDevice } from '../../provider-device-runtime.ts';
 import { inferAndroidPackageAfterOpen } from './session-open-target.ts';
+import {
+  buildSessionOpenLaunchPlan,
+  dispatchSessionOpenFollowUpLaunchUrl,
+} from './session-open-launch-url.ts';
 import { buildOpenTargetDeviceResolutionOptions } from '../open-device-selection.ts';
 import {
   invalidOpenArgs,
@@ -125,39 +128,6 @@ async function relaunchCloseApp(params: {
   }
   await dispatchCommand(device, 'close', [closeTarget], outFlag, context);
   await settleIosSimulator(device, IOS_SIMULATOR_POST_CLOSE_SETTLE_MS);
-}
-
-async function maybeApplySessionLaunchUrl(params: {
-  runtime: SessionRuntimeHints | undefined;
-  device: DeviceInfo;
-  req: DaemonRequest;
-  logPath: string;
-  appBundleId?: string;
-  traceLogPath?: string;
-  openPositionals: string[];
-}): Promise<void> {
-  const { runtime, device, req, logPath, appBundleId, traceLogPath, openPositionals } = params;
-  const launchUrl = runtime?.launchUrl;
-  if (!launchUrl) return;
-  if (openPositionals.length === 0) return;
-  if (openPositionals.length > 1) return;
-  const openTarget = openPositionals[0]?.trim();
-  if (!openTarget || isDeepLinkTarget(openTarget)) return;
-  await dispatchCommand(device, 'open', [launchUrl], req.flags?.out, {
-    ...contextForRuntimeLaunchUrl(logPath, req.flags, appBundleId, traceLogPath),
-  });
-}
-
-function contextForRuntimeLaunchUrl(
-  logPath: string,
-  flags: DaemonRequest['flags'],
-  appBundleId?: string,
-  traceLogPath?: string,
-): ReturnType<typeof contextFromFlags> {
-  const context = contextFromFlags(logPath, flags, appBundleId, traceLogPath);
-  delete context.launchConsole;
-  delete context.launchArgs;
-  return context;
 }
 
 // Default-on for emulators, opt-in via --test-ime on real devices; --no-test-ime forces off.
@@ -300,18 +270,25 @@ async function completeOpenCommand(params: {
     schedulePrewarm();
   }
 
-  // Local iOS simulators relaunch with one `simctl launch --terminate-running-process`
-  // instead of terminate + settle + launch (~1s per relaunch). Provider simulators
-  // must dispatch an explicit close because their interactors own app termination.
+  const launchPlan = buildSessionOpenLaunchPlan({
+    device,
+    openPositionals,
+    runtime,
+    flags: req.flags,
+  });
+  // Local iOS simulators relaunch inside the platform open: direct app launches use
+  // `simctl launch --terminate-running-process`, while app+URL launches terminate
+  // and let `simctl openurl` be the sole launch trigger. Provider simulators must
+  // dispatch an explicit close because their interactors own app termination.
   // Runtime hints written below are user-defaults reads at that launch, so ordering holds.
-  // Only the single app-launch form collapses: `open <app> <url>` dispatches
-  // through the URL path, where a deep-link open never launches the app and
-  // so cannot carry the terminate; those keep the close-first ordering, as
-  // does --clear-app-state, which must never mutate a running app's container.
+  // Collapse when the platform open can implement terminate-before-launch
+  // itself. App+URL is one semantic relaunch: terminate the bundle, then let
+  // the URL be the sole launch trigger. --clear-app-state keeps close-first
+  // ordering because it must never mutate a running app's container.
   const collapseSimulatorRelaunch =
     shouldRelaunch &&
     Boolean(openTarget) &&
-    openPositionals.length === 1 &&
+    launchPlan.supportsTerminateRunningApp &&
     isIosSimulator(device) &&
     !isActiveProviderDevice(device) &&
     req.flags?.clearAppState !== true;
@@ -379,21 +356,20 @@ async function completeOpenCommand(params: {
   // its visible surface. Expire that session's frame before the first
   // close/launch dispatch; a fresh first open has no prior frame to expire.
   if (openDispatchSession) expireRefFrame(openDispatchSession);
-  await dispatchCommand(device, 'open', openPositionals, req.flags?.out, {
+  await dispatchCommand(device, 'open', launchPlan.openPositionals, req.flags?.out, {
     ...contextFromFlags(logPath, req.flags, sessionAppBundleId),
     ...(collapseSimulatorRelaunch ? { terminateRunningApp: true } : {}),
   });
   timing.openDispatchDurationMs = Math.max(0, Date.now() - openStartedAtMs);
   await maybeActivateAndroidTestImeForOpen(device, req, sessionStore.resolveDaemonStateDir());
   const launchUrlStartedAtMs = Date.now();
-  await maybeApplySessionLaunchUrl({
-    runtime,
+  await dispatchSessionOpenFollowUpLaunchUrl({
+    launchUrl: launchPlan.followUpLaunchUrl,
     device,
     req,
     logPath,
     appBundleId: sessionAppBundleId,
     traceLogPath,
-    openPositionals,
   });
   timing.launchUrlDurationMs = Math.max(0, Date.now() - launchUrlStartedAtMs);
   if (shouldPrewarmIosRunner && !runnerPrewarmScheduled) {

--- a/src/platforms/apple/core/__tests__/app-launch-url.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-url.test.ts
@@ -44,3 +44,22 @@ test('iOS simulator URL relaunch terminates the app before opening the URL', asy
     ['xcrun', ['simctl', 'openurl', 'sim-1', 'myapp://automation'], undefined],
   ]);
 });
+
+test('iOS simulator deep-link relaunch terminates the active app before opening the URL', async () => {
+  await openIosApp(IOS_TEST_SIMULATOR, 'myapp://automation', {
+    appBundleId: 'com.example.app',
+    terminateRunningApp: true,
+  });
+
+  assert.deepEqual(mockRunCmd.mock.calls, [
+    [
+      'xcrun',
+      ['simctl', 'terminate', 'sim-1', 'com.example.app'],
+      {
+        allowFailure: true,
+        timeoutMs: IOS_SIMULATOR_TERMINATE_TIMEOUT_MS,
+      },
+    ],
+    ['xcrun', ['simctl', 'openurl', 'sim-1', 'myapp://automation'], undefined],
+  ]);
+});

--- a/src/platforms/apple/core/__tests__/app-launch-url.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-url.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { IOS_TEST_SIMULATOR } from './apple-core-stub-helpers.ts';
+import { IOS_SIMULATOR_TERMINATE_TIMEOUT_MS } from '../config.ts';
+
+vi.mock('../../../../utils/exec.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../utils/exec.ts')>();
+  return { ...actual, runCmd: vi.fn(actual.runCmd) };
+});
+vi.mock('../simulator.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../simulator.ts')>();
+  return { ...actual, ensureBootedSimulator: vi.fn(actual.ensureBootedSimulator) };
+});
+
+import { runCmd } from '../../../../utils/exec.ts';
+import { ensureBootedSimulator } from '../simulator.ts';
+import { openIosApp } from '../app-launch.ts';
+
+const mockRunCmd = vi.mocked(runCmd);
+const mockEnsureBootedSimulator = vi.mocked(ensureBootedSimulator);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockEnsureBootedSimulator.mockResolvedValue();
+  mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+});
+
+test('iOS simulator URL relaunch terminates the app before opening the URL', async () => {
+  await openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
+    appBundleId: 'com.example.app',
+    url: 'myapp://automation',
+    terminateRunningApp: true,
+  });
+
+  assert.deepEqual(mockRunCmd.mock.calls, [
+    [
+      'xcrun',
+      ['simctl', 'terminate', 'sim-1', 'com.example.app'],
+      {
+        allowFailure: true,
+        timeoutMs: IOS_SIMULATOR_TERMINATE_TIMEOUT_MS,
+      },
+    ],
+    ['xcrun', ['simctl', 'openurl', 'sim-1', 'myapp://automation'], undefined],
+  ]);
+});

--- a/src/platforms/apple/core/app-launch.ts
+++ b/src/platforms/apple/core/app-launch.ts
@@ -108,6 +108,9 @@ export async function openIosApp(
       throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
     }
     if (device.kind === 'simulator') {
+      if (options?.terminateRunningApp && options.appBundleId) {
+        await terminateIosSimulatorApp(device, options.appBundleId);
+      }
       await openIosSimulatorUrl(device, deepLinkTarget, launchArgs);
       return;
     }

--- a/src/platforms/apple/core/app-launch.ts
+++ b/src/platforms/apple/core/app-launch.ts
@@ -71,11 +71,17 @@ export async function openIosApp(
       throw new AppError('INVALID_ARGS', 'open <app> <url> requires a valid URL target');
     }
     if (device.kind === 'simulator') {
-      if (launchArgs || isWebUrl(explicitUrl)) {
+      const shouldLaunchAppBeforeUrl = Boolean(launchArgs) || isWebUrl(explicitUrl);
+      if (options?.terminateRunningApp || shouldLaunchAppBeforeUrl) {
         const bundleId = options?.appBundleId ?? (await resolveIosApp(device, app));
-        await launchIosSimulatorApp(device, bundleId, {
-          ...(launchArgs ? { launchArgs } : {}),
-        });
+        if (shouldLaunchAppBeforeUrl) {
+          await launchIosSimulatorApp(device, bundleId, {
+            ...(launchArgs ? { launchArgs } : {}),
+            ...(options?.terminateRunningApp ? { terminateRunningApp: true } : {}),
+          });
+        } else {
+          await terminateIosSimulatorApp(device, bundleId);
+        }
       }
       await openIosSimulatorUrl(device, explicitUrl, undefined);
       return;
@@ -170,21 +176,7 @@ export async function closeIosApp(
   }
   const bundleId = await resolveIosApp(device, app);
   if (device.kind === 'simulator') {
-    await ensureBootedSimulator(device);
-    const terminateArgs = simctlArgs(device, ['terminate', device.id, bundleId]);
-    const result = await runXcrun(terminateArgs, {
-      allowFailure: true,
-      timeoutMs: IOS_SIMULATOR_TERMINATE_TIMEOUT_MS,
-    });
-    if (result.exitCode !== 0) {
-      const stderr = result.stderr.toLowerCase();
-      if (stderr.includes('found nothing to terminate')) return;
-      throw new AppError(
-        'COMMAND_FAILED',
-        `xcrun exited with code ${result.exitCode}`,
-        execFailureDetails(result, { cmd: 'xcrun', args: terminateArgs }),
-      );
-    }
+    await terminateIosSimulatorApp(device, bundleId);
     return;
   }
 
@@ -192,6 +184,23 @@ export async function closeIosApp(
     runnerOptions,
     runRunnerCommand: runAppleRunnerCommand,
   });
+}
+
+async function terminateIosSimulatorApp(device: DeviceInfo, bundleId: string): Promise<void> {
+  await ensureBootedSimulator(device);
+  const terminateArgs = simctlArgs(device, ['terminate', device.id, bundleId]);
+  const result = await runXcrun(terminateArgs, {
+    allowFailure: true,
+    timeoutMs: IOS_SIMULATOR_TERMINATE_TIMEOUT_MS,
+  });
+  if (result.exitCode === 0) return;
+  const stderr = result.stderr.toLowerCase();
+  if (stderr.includes('found nothing to terminate')) return;
+  throw new AppError(
+    'COMMAND_FAILED',
+    `xcrun exited with code ${result.exitCode}`,
+    execFailureDetails(result, { cmd: 'xcrun', args: terminateArgs }),
+  );
 }
 
 async function launchIosSimulatorApp(


### PR DESCRIPTION
## Summary

Fix local iOS simulator `open --relaunch --launch-url` so the deep link is the cold-launch trigger.

The daemon now classifies the lifecycle once: only local iOS simulators fold the runtime URL into the app open, while physical devices and provider-owned simulators preserve their existing two-dispatch behavior. The Apple backend owns terminate-before-open semantics for direct app, app+URL, and deep-link shapes, so the daemon no longer mirrors the platform branch tree.

Follow-up URL dispatches now receive a context built without direct-launch options, with no mutate-and-delete cleanup. Direct URL targets with `--relaunch` remain intentionally rejected by the existing CLI contract and regression coverage.

No CLI, docs, or skill surface changed.

## Validation

- Exact fixture-backed live iOS simulator smoke passed, including the previously failing Automation lab assertion (126 seconds).
- Focused open/relaunch regressions passed 55/55.
- Formatting, typecheck, lint, layering, production exports, build, and Fallow passed.
- The full local unit aggregate was terminated under host contention after unrelated subprocess and simulator suites failed together; changed-path suites passed repeatedly in isolation. The PR remains draft for fresh-runner CI confirmation.