### PR TITLE
feat: expose Limrun device session capabilities

### DIFF
--- a/src/__tests__/limrun-runtime.test.ts
+++ b/src/__tests__/limrun-runtime.test.ts
@@ -33,23 +33,8 @@ const limrunMockState = vi.hoisted(() => {
       { bundleId: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
       { bundleId: 'com.example.ios', name: 'Example', installType: 'User' },
     ]),
-    iosPressKey: vi.fn(async () => undefined),
-    iosAppLogTail: vi.fn(async () => 'line one\nline two\n'),
-    iosStartRecording: vi.fn(async () => undefined),
-    iosStopRecording: vi.fn(async () => 'https://ios.example/recording'),
-    iosSimctlWait: vi.fn(async () => ({ code: 0, stdout: 'ok', stderr: '' })),
-    iosSimctlStop: vi.fn(),
-    iosSimctl: vi.fn(() => ({
-      on: vi.fn().mockReturnThis(),
-      off: vi.fn().mockReturnThis(),
-      wait: limrunMockState.iosSimctlWait,
-      stop: limrunMockState.iosSimctlStop,
-    })),
     androidOpenUrl: vi.fn(async () => undefined),
     androidDisconnect: vi.fn(),
-    androidPressKey: vi.fn(async () => undefined),
-    androidStartRecording: vi.fn(async () => undefined),
-    androidStopRecording: vi.fn(async () => 'https://android.example/recording'),
     androidSendAsset: vi.fn(async () => undefined),
     androidTunnelClose,
     androidStartAdbTunnel: vi.fn(async () => ({
@@ -111,11 +96,6 @@ vi.mock('@limrun/api/ios-client', () => ({
     openUrl: limrunMockState.iosOpenUrl,
     setOrientation: limrunMockState.iosSetOrientation,
     listApps: limrunMockState.iosListApps,
-    pressKey: limrunMockState.iosPressKey,
-    appLogTail: limrunMockState.iosAppLogTail,
-    startRecording: limrunMockState.iosStartRecording,
-    stopRecording: limrunMockState.iosStopRecording,
-    simctl: limrunMockState.iosSimctl,
     deviceInfo: {
       udid: 'ios-device',
       screenWidth: 402,
@@ -129,9 +109,6 @@ vi.mock('@limrun/api/instance-client', () => ({
   createInstanceClient: vi.fn(async () => ({
     disconnect: limrunMockState.androidDisconnect,
     openUrl: limrunMockState.androidOpenUrl,
-    pressKey: limrunMockState.androidPressKey,
-    startRecording: limrunMockState.androidStartRecording,
-    stopRecording: limrunMockState.androidStopRecording,
     sendAsset: limrunMockState.androidSendAsset,
     startAdbTunnel: limrunMockState.androidStartAdbTunnel,
   })),
@@ -169,7 +146,12 @@ test('Limrun runtime identifies direct CLI usage to the Limrun API', async () =>
   try {
     const allocateLease = runtime.leaseLifecycle.allocate;
     if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    await allocateLease(lease);
+    const allocation = await allocateLease(lease);
+    const device = allocation?.device as DeviceInfo | undefined;
+    if (!device) throw new Error('Limrun runtime must expose its allocated device');
+    const deviceSession = runtime.getDeviceSession(device);
+    assert.equal(deviceSession?.platform, 'ios');
+    assert.equal(deviceSession ? 'client' in deviceSession : true, false);
 
     assert.deepEqual(limrunMockState.constructorOptions[0]?.defaultHeaders, {
       'x-agent-device-client': 'agent-device-cli',
@@ -185,189 +167,6 @@ test('Limrun runtime identifies direct CLI usage to the Limrun API', async () =>
       provider: 'limrun',
       source: 'agent-device-cli',
     });
-  } finally {
-    await runtime.shutdown();
-  }
-});
-
-test('Limrun runtime exposes a client-private iOS device session facade', async () => {
-  const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-ios-session',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'ios-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
-
-  try {
-    const device = await allocateLimrunDevice(runtime, lease);
-    const session = runtime.getDeviceSession(device);
-    assert.equal(session?.platform, 'ios');
-    if (!session || session.platform !== 'ios') {
-      throw new Error('Limrun runtime must expose an iOS device session');
-    }
-
-    assert.deepEqual(await session.listApps('user-installed'), [
-      {
-        id: 'com.example.ios',
-        name: 'Example',
-        installType: 'User',
-      },
-    ]);
-    assert.deepEqual(await session.listApps(), [
-      {
-        id: 'com.apple.Preferences',
-        name: 'Settings',
-        installType: 'System',
-      },
-      {
-        id: 'com.example.ios',
-        name: 'Example',
-        installType: 'User',
-      },
-    ]);
-    assert.equal(await session.getForegroundApp(), undefined);
-    assert.deepEqual(session.viewport, { width: 402, height: 874 });
-    await session.pressKey('enter', ['command']);
-    assert.equal(await session.readLogs('com.example.ios', 200), 'line one\nline two\n');
-    await assert.rejects(
-      () => session.readLogs(undefined, 200),
-      /require an app bundle identifier/,
-    );
-    await session.startRecording({ quality: 8 });
-    await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' });
-    assert.deepEqual(await session.runSimctl(['listapps', 'booted']).wait(), {
-      code: 0,
-      stdout: 'ok',
-      stderr: '',
-    });
-    assert.deepEqual(
-      await session.installRemoteApp('https://assets.example/runner.zip', {
-        md5: 'runner-md5',
-        relaunch: true,
-      }),
-      { appId: 'com.example.ios' },
-    );
-
-    assert.deepEqual(limrunMockState.iosPressKey.mock.calls[0], [['enter', ['command']]][0]);
-    assert.deepEqual(limrunMockState.iosAppLogTail.mock.calls[0], ['com.example.ios', 200]);
-    assert.deepEqual(limrunMockState.iosStartRecording.mock.calls[0], [{ quality: 8 }]);
-    assert.deepEqual(limrunMockState.iosStopRecording.mock.calls[0], [
-      { localPath: '/tmp/ios-recording.mp4' },
-    ]);
-    assert.deepEqual(limrunMockState.iosSimctl.mock.calls[0], [['listapps', 'booted']]);
-    assert.deepEqual(limrunMockState.iosInstallApp.mock.calls.at(-1), [
-      'https://assets.example/runner.zip',
-      {
-        md5: 'runner-md5',
-        launchMode: 'RelaunchIfRunning',
-      },
-    ]);
-    assert.equal('client' in session, false);
-  } finally {
-    await runtime.shutdown();
-  }
-});
-
-test('Limrun runtime exposes reusable Android capabilities without the raw client', async () => {
-  const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
-
-  try {
-    vi.mocked(runCmd).mockImplementation(async (_command, args) => {
-      if (args.includes('query-activities')) {
-        return {
-          stdout: 'com.example.android/.MainActivity\n',
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-      if (args.includes('window')) {
-        return {
-          stdout: 'mCurrentFocus=Window{42 u0 com.example.android/.MainActivity}\n',
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-      if (args.includes('input_method')) {
-        return {
-          stdout: 'mInputShown=false mCurMethodId=com.android.inputmethod.latin/.LatinIME',
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-      if (args.includes('logcat')) {
-        return {
-          stdout: 'log line\n',
-          stderr: '',
-          exitCode: 0,
-        };
-      }
-      return { stdout: '', stderr: '', exitCode: 0 };
-    });
-    const device = await allocateLimrunDevice(runtime, androidLease());
-    const session = runtime.getDeviceSession(device);
-    assert.equal(session?.platform, 'android');
-    if (!session || session.platform !== 'android') {
-      throw new Error('Limrun runtime must expose an Android device session');
-    }
-
-    assert.deepEqual(await session.listApps(), [{ id: 'com.example.android', name: 'Example' }]);
-    assert.deepEqual(await session.getForegroundApp(), {
-      appId: 'com.example.android',
-      activity: '.MainActivity',
-    });
-    assert.equal((await session.getKeyboardState()).visible, false);
-    assert.deepEqual(await session.dismissKeyboard(), {
-      attempts: 0,
-      wasVisible: false,
-      dismissed: false,
-      visible: false,
-      inputType: undefined,
-      type: undefined,
-      inputMethodPackage: 'com.android.inputmethod.latin',
-      focusedPackage: undefined,
-      focusedResourceId: undefined,
-      inputOwner: 'unknown',
-    });
-    assert.equal(await session.readLogs(undefined, 20), 'log line\n');
-    assert.deepEqual(
-      await session.installRemoteApp('https://assets.example/android.apk', {
-        appIdentifierHint: 'com.example.android',
-      }),
-      { appId: 'com.example.android' },
-    );
-    await session.pressKey('KEYCODE_ENTER', ['shift']);
-    await session.startRecording({ quality: 7 });
-    await session.stopRecording({ outPath: '/tmp/android-recording.mp4' });
-    await runtime.configurePortReverse({
-      leaseId: 'lease-android',
-      devicePort: 8081,
-      hostPort: 8081,
-      name: 'metro',
-    });
-    await session.removePortReverse(8081);
-    await assert.rejects(() => session.removePortReverse(0), /Invalid Android tcp reverse port/);
-
-    assert.deepEqual(limrunMockState.androidSendAsset.mock.calls[0], [
-      'https://assets.example/android.apk',
-    ]);
-    assert.deepEqual(limrunMockState.androidPressKey.mock.calls[0], ['KEYCODE_ENTER', ['shift']]);
-    assert.deepEqual(limrunMockState.androidStartRecording.mock.calls[0], [{ quality: 7 }]);
-    assert.deepEqual(limrunMockState.androidStopRecording.mock.calls[0], [
-      { localPath: '/tmp/android-recording.mp4' },
-    ]);
-    assert.equal(typeof session.adb.exec, 'function');
-    assert.equal('client' in session, false);
-    assert.equal(
-      vi
-        .mocked(runCmd)
-        .mock.calls.some(([, args]) => args.includes('--remove') && args.includes('tcp:8081')),
-      true,
-    );
   } finally {
     await runtime.shutdown();
   }

--- a/src/__tests__/limrun-runtime.test.ts
+++ b/src/__tests__/limrun-runtime.test.ts
@@ -218,9 +218,26 @@ test('Limrun runtime exposes a client-private iOS device session facade', async 
         installType: 'User',
       },
     ]);
+    assert.deepEqual(await session.listApps(), [
+      {
+        id: 'com.apple.Preferences',
+        name: 'Settings',
+        installType: 'System',
+      },
+      {
+        id: 'com.example.ios',
+        name: 'Example',
+        installType: 'User',
+      },
+    ]);
+    assert.equal(await session.getForegroundApp(), undefined);
     assert.deepEqual(session.viewport, { width: 402, height: 874 });
     await session.pressKey('enter', ['command']);
     assert.equal(await session.readLogs('com.example.ios', 200), 'line one\nline two\n');
+    await assert.rejects(
+      () => session.readLogs(undefined, 200),
+      /require an app bundle identifier/,
+    );
     await session.startRecording({ quality: 8 });
     await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' });
     assert.deepEqual(await session.runSimctl(['listapps', 'booted']).wait(), {
@@ -260,6 +277,37 @@ test('Limrun runtime exposes reusable Android capabilities without the raw clien
   const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
 
   try {
+    vi.mocked(runCmd).mockImplementation(async (_command, args) => {
+      if (args.includes('query-activities')) {
+        return {
+          stdout: 'com.example.android/.MainActivity\n',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (args.includes('window')) {
+        return {
+          stdout: 'mCurrentFocus=Window{42 u0 com.example.android/.MainActivity}\n',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (args.includes('input_method')) {
+        return {
+          stdout: 'mInputShown=false mCurMethodId=com.android.inputmethod.latin/.LatinIME',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (args.includes('logcat')) {
+        return {
+          stdout: 'log line\n',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
     const device = await allocateLimrunDevice(runtime, androidLease());
     const session = runtime.getDeviceSession(device);
     assert.equal(session?.platform, 'android');
@@ -267,6 +315,31 @@ test('Limrun runtime exposes reusable Android capabilities without the raw clien
       throw new Error('Limrun runtime must expose an Android device session');
     }
 
+    assert.deepEqual(await session.listApps(), [{ id: 'com.example.android', name: 'Example' }]);
+    assert.deepEqual(await session.getForegroundApp(), {
+      appId: 'com.example.android',
+      activity: '.MainActivity',
+    });
+    assert.equal((await session.getKeyboardState()).visible, false);
+    assert.deepEqual(await session.dismissKeyboard(), {
+      attempts: 0,
+      wasVisible: false,
+      dismissed: false,
+      visible: false,
+      inputType: undefined,
+      type: undefined,
+      inputMethodPackage: 'com.android.inputmethod.latin',
+      focusedPackage: undefined,
+      focusedResourceId: undefined,
+      inputOwner: 'unknown',
+    });
+    assert.equal(await session.readLogs(undefined, 20), 'log line\n');
+    assert.deepEqual(
+      await session.installRemoteApp('https://assets.example/android.apk', {
+        appIdentifierHint: 'com.example.android',
+      }),
+      { appId: 'com.example.android' },
+    );
     await session.pressKey('KEYCODE_ENTER', ['shift']);
     await session.startRecording({ quality: 7 });
     await session.stopRecording({ outPath: '/tmp/android-recording.mp4' });
@@ -277,7 +350,11 @@ test('Limrun runtime exposes reusable Android capabilities without the raw clien
       name: 'metro',
     });
     await session.removePortReverse(8081);
+    await assert.rejects(() => session.removePortReverse(0), /Invalid Android tcp reverse port/);
 
+    assert.deepEqual(limrunMockState.androidSendAsset.mock.calls[0], [
+      'https://assets.example/android.apk',
+    ]);
     assert.deepEqual(limrunMockState.androidPressKey.mock.calls[0], ['KEYCODE_ENTER', ['shift']]);
     assert.deepEqual(limrunMockState.androidStartRecording.mock.calls[0], [{ quality: 7 }]);
     assert.deepEqual(limrunMockState.androidStopRecording.mock.calls[0], [

--- a/src/__tests__/limrun-runtime.test.ts
+++ b/src/__tests__/limrun-runtime.test.ts
@@ -29,8 +29,27 @@ const limrunMockState = vi.hoisted(() => {
     iosLaunchApp: vi.fn(async () => undefined),
     iosOpenUrl: vi.fn(async () => undefined),
     iosSetOrientation: vi.fn(async () => undefined),
+    iosListApps: vi.fn(async () => [
+      { bundleId: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
+      { bundleId: 'com.example.ios', name: 'Example', installType: 'User' },
+    ]),
+    iosPressKey: vi.fn(async () => undefined),
+    iosAppLogTail: vi.fn(async () => 'line one\nline two\n'),
+    iosStartRecording: vi.fn(async () => undefined),
+    iosStopRecording: vi.fn(async () => 'https://ios.example/recording'),
+    iosSimctlWait: vi.fn(async () => ({ code: 0, stdout: 'ok', stderr: '' })),
+    iosSimctlStop: vi.fn(),
+    iosSimctl: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      off: vi.fn().mockReturnThis(),
+      wait: limrunMockState.iosSimctlWait,
+      stop: limrunMockState.iosSimctlStop,
+    })),
     androidOpenUrl: vi.fn(async () => undefined),
     androidDisconnect: vi.fn(),
+    androidPressKey: vi.fn(async () => undefined),
+    androidStartRecording: vi.fn(async () => undefined),
+    androidStopRecording: vi.fn(async () => 'https://android.example/recording'),
     androidSendAsset: vi.fn(async () => undefined),
     androidTunnelClose,
     androidStartAdbTunnel: vi.fn(async () => ({
@@ -91,6 +110,18 @@ vi.mock('@limrun/api/ios-client', () => ({
     launchApp: limrunMockState.iosLaunchApp,
     openUrl: limrunMockState.iosOpenUrl,
     setOrientation: limrunMockState.iosSetOrientation,
+    listApps: limrunMockState.iosListApps,
+    pressKey: limrunMockState.iosPressKey,
+    appLogTail: limrunMockState.iosAppLogTail,
+    startRecording: limrunMockState.iosStartRecording,
+    stopRecording: limrunMockState.iosStopRecording,
+    simctl: limrunMockState.iosSimctl,
+    deviceInfo: {
+      udid: 'ios-device',
+      screenWidth: 402,
+      screenHeight: 874,
+      model: 'iPhone',
+    },
   })),
 }));
 
@@ -98,6 +129,9 @@ vi.mock('@limrun/api/instance-client', () => ({
   createInstanceClient: vi.fn(async () => ({
     disconnect: limrunMockState.androidDisconnect,
     openUrl: limrunMockState.androidOpenUrl,
+    pressKey: limrunMockState.androidPressKey,
+    startRecording: limrunMockState.androidStartRecording,
+    stopRecording: limrunMockState.androidStopRecording,
     sendAsset: limrunMockState.androidSendAsset,
     startAdbTunnel: limrunMockState.androidStartAdbTunnel,
   })),
@@ -151,6 +185,112 @@ test('Limrun runtime identifies direct CLI usage to the Limrun API', async () =>
       provider: 'limrun',
       source: 'agent-device-cli',
     });
+  } finally {
+    await runtime.shutdown();
+  }
+});
+
+test('Limrun runtime exposes a client-private iOS device session facade', async () => {
+  const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
+  const lease: SimulatorLease = {
+    leaseId: 'lease-ios-session',
+    tenantId: 'team-a',
+    runId: 'run-a',
+    backend: 'ios-instance',
+    leaseProvider: 'limrun',
+    createdAt: 1,
+    heartbeatAt: 1,
+    expiresAt: 60_001,
+  };
+
+  try {
+    const device = await allocateLimrunDevice(runtime, lease);
+    const session = runtime.getDeviceSession(device);
+    assert.equal(session?.platform, 'ios');
+    if (!session || session.platform !== 'ios') {
+      throw new Error('Limrun runtime must expose an iOS device session');
+    }
+
+    assert.deepEqual(await session.listApps('user-installed'), [
+      {
+        id: 'com.example.ios',
+        name: 'Example',
+        installType: 'User',
+      },
+    ]);
+    assert.deepEqual(session.viewport, { width: 402, height: 874 });
+    await session.pressKey('enter', ['command']);
+    assert.equal(await session.readLogs('com.example.ios', 200), 'line one\nline two\n');
+    await session.startRecording({ quality: 8 });
+    await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' });
+    assert.deepEqual(await session.runSimctl(['listapps', 'booted']).wait(), {
+      code: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    assert.deepEqual(
+      await session.installRemoteApp('https://assets.example/runner.zip', {
+        md5: 'runner-md5',
+        relaunch: true,
+      }),
+      { appId: 'com.example.ios' },
+    );
+
+    assert.deepEqual(limrunMockState.iosPressKey.mock.calls[0], [['enter', ['command']]][0]);
+    assert.deepEqual(limrunMockState.iosAppLogTail.mock.calls[0], ['com.example.ios', 200]);
+    assert.deepEqual(limrunMockState.iosStartRecording.mock.calls[0], [{ quality: 8 }]);
+    assert.deepEqual(limrunMockState.iosStopRecording.mock.calls[0], [
+      { localPath: '/tmp/ios-recording.mp4' },
+    ]);
+    assert.deepEqual(limrunMockState.iosSimctl.mock.calls[0], [['listapps', 'booted']]);
+    assert.deepEqual(limrunMockState.iosInstallApp.mock.calls.at(-1), [
+      'https://assets.example/runner.zip',
+      {
+        md5: 'runner-md5',
+        launchMode: 'RelaunchIfRunning',
+      },
+    ]);
+    assert.equal('client' in session, false);
+  } finally {
+    await runtime.shutdown();
+  }
+});
+
+test('Limrun runtime exposes reusable Android capabilities without the raw client', async () => {
+  const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
+
+  try {
+    const device = await allocateLimrunDevice(runtime, androidLease());
+    const session = runtime.getDeviceSession(device);
+    assert.equal(session?.platform, 'android');
+    if (!session || session.platform !== 'android') {
+      throw new Error('Limrun runtime must expose an Android device session');
+    }
+
+    await session.pressKey('KEYCODE_ENTER', ['shift']);
+    await session.startRecording({ quality: 7 });
+    await session.stopRecording({ outPath: '/tmp/android-recording.mp4' });
+    await runtime.configurePortReverse({
+      leaseId: 'lease-android',
+      devicePort: 8081,
+      hostPort: 8081,
+      name: 'metro',
+    });
+    await session.removePortReverse(8081);
+
+    assert.deepEqual(limrunMockState.androidPressKey.mock.calls[0], ['KEYCODE_ENTER', ['shift']]);
+    assert.deepEqual(limrunMockState.androidStartRecording.mock.calls[0], [{ quality: 7 }]);
+    assert.deepEqual(limrunMockState.androidStopRecording.mock.calls[0], [
+      { localPath: '/tmp/android-recording.mp4' },
+    ]);
+    assert.equal(typeof session.adb.exec, 'function');
+    assert.equal('client' in session, false);
+    assert.equal(
+      vi
+        .mocked(runCmd)
+        .mock.calls.some(([, args]) => args.includes('--remove') && args.includes('tcp:8081')),
+      true,
+    );
   } finally {
     await runtime.shutdown();
   }

--- a/src/providers/limrun/device-session.test.ts
+++ b/src/providers/limrun/device-session.test.ts
@@ -37,20 +37,22 @@ test('iOS device session exposes reusable capabilities without its raw client', 
   assert.equal(session.platform, 'ios');
   if (session.platform !== 'ios') throw new Error('Expected an iOS device session');
 
-  assert.deepEqual(await session.listApps('user-installed'), [
+  assert.deepEqual(await session.listApps(), [
     { id: 'com.example.ios', name: 'Example', installType: 'User' },
   ]);
-  assert.deepEqual(await session.listApps(), [
+  assert.deepEqual(await session.listApps('all'), [
     { id: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
     { id: 'com.example.ios', name: 'Example', installType: 'User' },
   ]);
-  assert.equal(await session.getForegroundApp(), undefined);
+  assert.equal('getForegroundApp' in session, false);
   assert.deepEqual(session.viewport, { width: 402, height: 874 });
   await session.pressKey('enter', ['command']);
   assert.equal(await session.readLogs('com.example.ios', 200), 'line one\nline two\n');
-  await assert.rejects(() => session.readLogs(undefined, 200), /bundle identifier/);
   await session.startRecording({ quality: 8 });
-  await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' });
+  assert.equal(
+    await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' }),
+    'https://ios.example/recording',
+  );
   assert.deepEqual(await session.runSimctl(['listapps', 'booted']).wait(), {
     code: 0,
     stdout: 'ok',
@@ -100,6 +102,7 @@ test('iOS remote install waits for eventually consistent app inventory', async (
 test('Android device session exposes semantic ADB capabilities without its raw client', async () => {
   const adb = vi.fn(async (args: string[]) => {
     if (args.includes('query-activities')) return adbResult('com.example.android/.MainActivity\n');
+    if (args.includes('packages')) return adbResult('package:com.example.android\n');
     if (args.includes('window')) {
       return adbResult('mCurrentFocus=Window{42 u0 com.example.android/.MainActivity}\n');
     }
@@ -136,18 +139,15 @@ test('Android device session exposes semantic ADB capabilities without its raw c
   });
   assert.equal((await session.getKeyboardState()).visible, false);
   assert.equal((await session.dismissKeyboard()).dismissed, false);
-  assert.equal(await session.readLogs(undefined, 20), 'log line\n');
-  assert.deepEqual(
-    await session.installRemoteApp('https://assets.example/android.apk', {
-      appIdentifierHint: 'com.example.android',
-    }),
-    { appId: 'com.example.android' },
-  );
+  assert.equal(await session.readLogs(20), 'log line\n');
+  assert.equal(await session.installRemoteApp('https://assets.example/android.apk'), undefined);
   await session.pressKey('KEYCODE_ENTER', ['shift']);
   await session.startRecording({ quality: 7 });
-  await session.stopRecording({ outPath: '/tmp/android-recording.mp4' });
-  await session.removePortReverse(8081);
-  await assert.rejects(() => session.removePortReverse(0), /Invalid Android tcp reverse port/);
+  assert.equal(
+    await session.stopRecording({ outPath: '/tmp/android-recording.mp4' }),
+    'https://android.example/recording',
+  );
+  await session.adb.reverse?.remove('tcp:8081');
 
   assert.deepEqual(sendAsset.mock.calls[0], ['https://assets.example/android.apk']);
   assert.deepEqual(pressKey.mock.calls[0], ['KEYCODE_ENTER', ['shift']]);

--- a/src/providers/limrun/device-session.test.ts
+++ b/src/providers/limrun/device-session.test.ts
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+import type { DeviceLease } from '../../contracts/device-provider.ts';
+import type { DeviceInfo } from '../../kernel/device.ts';
+import type {
+  AndroidAdbExecutor,
+  AndroidAdbProvider,
+} from '../../platforms/android/adb-executor.ts';
+import type { LimrunAndroidSession } from './android.ts';
+import { createLimrunDeviceSession, type LimrunIosCommandExecution } from './device-session.ts';
+import type { LimrunIosSession } from './ios.ts';
+
+const IOS_APPS = [
+  { bundleId: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
+  { bundleId: 'com.example.ios', name: 'Example', installType: 'User' },
+];
+
+test('iOS device session exposes reusable capabilities without its raw client', async () => {
+  const pressKey = vi.fn(async () => undefined);
+  const readLogs = vi.fn(async () => 'line one\nline two\n');
+  const startRecording = vi.fn(async () => undefined);
+  const stopRecording = vi.fn(async () => 'https://ios.example/recording');
+  const simctlWait = vi.fn(async () => ({ code: 0, stdout: 'ok', stderr: '' }));
+  const simctl = vi.fn(() => commandExecution(simctlWait));
+  const session = createLimrunDeviceSession(
+    iosSession({
+      deviceInfo: { screenWidth: 402, screenHeight: 874 },
+      listApps: vi.fn(async () => IOS_APPS),
+      pressKey,
+      appLogTail: readLogs,
+      startRecording,
+      stopRecording,
+      simctl,
+    }),
+  );
+
+  assert.equal(session.platform, 'ios');
+  if (session.platform !== 'ios') throw new Error('Expected an iOS device session');
+
+  assert.deepEqual(await session.listApps('user-installed'), [
+    { id: 'com.example.ios', name: 'Example', installType: 'User' },
+  ]);
+  assert.deepEqual(await session.listApps(), [
+    { id: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
+    { id: 'com.example.ios', name: 'Example', installType: 'User' },
+  ]);
+  assert.equal(await session.getForegroundApp(), undefined);
+  assert.deepEqual(session.viewport, { width: 402, height: 874 });
+  await session.pressKey('enter', ['command']);
+  assert.equal(await session.readLogs('com.example.ios', 200), 'line one\nline two\n');
+  await assert.rejects(() => session.readLogs(undefined, 200), /bundle identifier/);
+  await session.startRecording({ quality: 8 });
+  await session.stopRecording({ outPath: '/tmp/ios-recording.mp4' });
+  assert.deepEqual(await session.runSimctl(['listapps', 'booted']).wait(), {
+    code: 0,
+    stdout: 'ok',
+    stderr: '',
+  });
+
+  assert.deepEqual(pressKey.mock.calls[0], ['enter', ['command']]);
+  assert.deepEqual(readLogs.mock.calls[0], ['com.example.ios', 200]);
+  assert.deepEqual(startRecording.mock.calls[0], [{ quality: 8 }]);
+  assert.deepEqual(stopRecording.mock.calls[0], [{ localPath: '/tmp/ios-recording.mp4' }]);
+  assert.deepEqual(simctl.mock.calls[0], [['listapps', 'booted']]);
+  assert.equal('client' in session, false);
+});
+
+test('iOS remote install waits for eventually consistent app inventory', async () => {
+  const staleApps = IOS_APPS.slice(0, 1);
+  const installedApps = [...staleApps, IOS_APPS[1]];
+  const listApps = vi
+    .fn(async () => installedApps)
+    .mockResolvedValueOnce(staleApps)
+    .mockResolvedValueOnce(staleApps);
+  const installApp = vi.fn(async () => ({ bundleId: 'com.example.ios' }));
+  const session = createLimrunDeviceSession(
+    iosSession({
+      deviceInfo: { screenWidth: 402, screenHeight: 874 },
+      listApps,
+      installApp,
+    }),
+  );
+
+  assert.equal(session.platform, 'ios');
+  assert.deepEqual(
+    await session.installRemoteApp('https://assets.example/example.zip', {
+      md5: 'example-md5',
+      relaunch: true,
+      appIdentifierHint: 'com.example.ios',
+    }),
+    { appId: 'com.example.ios' },
+  );
+  assert.equal(listApps.mock.calls.length, 3);
+  assert.deepEqual(installApp.mock.calls[0], [
+    'https://assets.example/example.zip',
+    { md5: 'example-md5', launchMode: 'RelaunchIfRunning' },
+  ]);
+});
+
+test('Android device session exposes semantic ADB capabilities without its raw client', async () => {
+  const adb = vi.fn(async (args: string[]) => {
+    if (args.includes('query-activities')) return adbResult('com.example.android/.MainActivity\n');
+    if (args.includes('window')) {
+      return adbResult('mCurrentFocus=Window{42 u0 com.example.android/.MainActivity}\n');
+    }
+    if (args.includes('input_method')) {
+      return adbResult('mInputShown=false mCurMethodId=com.android.inputmethod.latin/.LatinIME');
+    }
+    if (args.includes('logcat')) return adbResult('log line\n');
+    return adbResult('');
+  }) as AndroidAdbExecutor;
+  const removeReverse = vi.fn(async () => undefined);
+  const provider: AndroidAdbProvider = {
+    exec: adb,
+    reverse: {
+      ensure: vi.fn(async () => undefined),
+      remove: removeReverse,
+      removeAllOwned: vi.fn(async () => undefined),
+    },
+  };
+  const pressKey = vi.fn(async () => undefined);
+  const startRecording = vi.fn(async () => undefined);
+  const stopRecording = vi.fn(async () => 'https://android.example/recording');
+  const sendAsset = vi.fn(async () => undefined);
+  const session = createLimrunDeviceSession(
+    androidSession(provider, { pressKey, startRecording, stopRecording, sendAsset }),
+  );
+
+  assert.equal(session.platform, 'android');
+  if (session.platform !== 'android') throw new Error('Expected an Android device session');
+
+  assert.deepEqual(await session.listApps(), [{ id: 'com.example.android', name: 'Example' }]);
+  assert.deepEqual(await session.getForegroundApp(), {
+    appId: 'com.example.android',
+    activity: '.MainActivity',
+  });
+  assert.equal((await session.getKeyboardState()).visible, false);
+  assert.equal((await session.dismissKeyboard()).dismissed, false);
+  assert.equal(await session.readLogs(undefined, 20), 'log line\n');
+  assert.deepEqual(
+    await session.installRemoteApp('https://assets.example/android.apk', {
+      appIdentifierHint: 'com.example.android',
+    }),
+    { appId: 'com.example.android' },
+  );
+  await session.pressKey('KEYCODE_ENTER', ['shift']);
+  await session.startRecording({ quality: 7 });
+  await session.stopRecording({ outPath: '/tmp/android-recording.mp4' });
+  await session.removePortReverse(8081);
+  await assert.rejects(() => session.removePortReverse(0), /Invalid Android tcp reverse port/);
+
+  assert.deepEqual(sendAsset.mock.calls[0], ['https://assets.example/android.apk']);
+  assert.deepEqual(pressKey.mock.calls[0], ['KEYCODE_ENTER', ['shift']]);
+  assert.deepEqual(startRecording.mock.calls[0], [{ quality: 7 }]);
+  assert.deepEqual(stopRecording.mock.calls[0], [{ localPath: '/tmp/android-recording.mp4' }]);
+  assert.deepEqual(removeReverse.mock.calls[0], ['tcp:8081']);
+  assert.equal(session.adb, provider);
+  assert.equal('client' in session, false);
+});
+
+function iosSession(client: Record<string, unknown>): LimrunIosSession {
+  return {
+    platform: 'ios',
+    lease: lease('ios-instance'),
+    instanceId: 'ios-instance',
+    device: device('ios'),
+    client,
+  } as unknown as LimrunIosSession;
+}
+
+function androidSession(
+  adbProvider: AndroidAdbProvider,
+  client: Record<string, unknown>,
+): LimrunAndroidSession {
+  return {
+    platform: 'android',
+    lease: lease('android-instance'),
+    instanceId: 'android-instance',
+    device: device('android'),
+    client,
+    adbProvider,
+  } as unknown as LimrunAndroidSession;
+}
+
+function lease(backend: 'ios-instance' | 'android-instance'): DeviceLease {
+  return {
+    leaseId: `lease-${backend}`,
+    tenantId: 'team-a',
+    runId: 'run-a',
+    backend,
+    leaseProvider: 'limrun',
+    createdAt: 1,
+    heartbeatAt: 1,
+    expiresAt: 60_001,
+  };
+}
+
+function device(platform: 'ios' | 'android'): DeviceInfo {
+  return {
+    platform: platform === 'ios' ? 'apple' : 'android',
+    ...(platform === 'ios' ? { appleOs: 'ios' as const } : {}),
+    id: `limrun:${platform}:lease`,
+    name: `Limrun ${platform}`,
+    kind: platform === 'ios' ? 'simulator' : 'emulator',
+    target: 'mobile',
+    booted: true,
+  };
+}
+
+function commandExecution(
+  wait: () => Promise<{ code: number; stdout: string; stderr: string }>,
+): LimrunIosCommandExecution {
+  const execution = {
+    on: () => execution,
+    off: () => execution,
+    wait,
+    stop: vi.fn(),
+  };
+  return execution;
+}
+
+function adbResult(stdout: string) {
+  return { stdout, stderr: '', exitCode: 0, stdoutBuffer: undefined };
+}

--- a/src/providers/limrun/device-session.ts
+++ b/src/providers/limrun/device-session.ts
@@ -3,17 +3,10 @@ import type { AppsFilter } from '../../contracts/app-inventory.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
 import { AppError } from '../../kernel/errors.ts';
 import type { AndroidAdbProvider } from '../../platforms/android/adb-executor.ts';
-import {
-  getAndroidAppStateWithAdb,
-  listAndroidAppsWithAdb,
-} from '../../platforms/android/app-helpers.ts';
-import {
-  dismissAndroidKeyboardWithAdb,
-  getAndroidKeyboardStatusWithAdb,
-  type AndroidKeyboardDismissResult,
-  type AndroidKeyboardState,
+import type {
+  AndroidKeyboardDismissResult,
+  AndroidKeyboardState,
 } from '../../platforms/android/device-input-state.ts';
-import { captureAndroidLogcatWithAdb } from '../../platforms/android/logcat.ts';
 import { createLimrunAndroidInteractor, type LimrunAndroidSession } from './android.ts';
 import {
   createLimrunIosInteractor,
@@ -119,25 +112,38 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
     device: session.device,
     interactor: createLimrunAndroidInteractor(session),
     adb: session.adbProvider,
-    listApps: async (filter = 'all') =>
-      (await listAndroidAppsWithAdb(adb, { filter, target: 'mobile' })).map((app) => ({
+    listApps: async (filter = 'all') => {
+      const { listAndroidAppsWithAdb } = await import('../../platforms/android/app-helpers.ts');
+      return (await listAndroidAppsWithAdb(adb, { filter, target: 'mobile' })).map((app) => ({
         id: app.package,
         name: app.name,
-      })),
+      }));
+    },
     getForegroundApp: async () => {
+      const { getAndroidAppStateWithAdb } = await import('../../platforms/android/app-helpers.ts');
       const app = await getAndroidAppStateWithAdb(adb);
       return app.package ? { appId: app.package, activity: app.activity } : undefined;
     },
     pressKey: async (key, modifiers) => {
       await session.client.pressKey(key, modifiers);
     },
-    getKeyboardState: async () => await getAndroidKeyboardStatusWithAdb(adb),
-    dismissKeyboard: async () => await dismissAndroidKeyboardWithAdb(adb),
-    readLogs: async (_appId, lineLimit) =>
-      await captureAndroidLogcatWithAdb(adb, {
+    getKeyboardState: async () => {
+      const { getAndroidKeyboardStatusWithAdb } =
+        await import('../../platforms/android/device-input-state.ts');
+      return await getAndroidKeyboardStatusWithAdb(adb);
+    },
+    dismissKeyboard: async () => {
+      const { dismissAndroidKeyboardWithAdb } =
+        await import('../../platforms/android/device-input-state.ts');
+      return await dismissAndroidKeyboardWithAdb(adb);
+    },
+    readLogs: async (_appId, lineLimit) => {
+      const { captureAndroidLogcatWithAdb } = await import('../../platforms/android/logcat.ts');
+      return await captureAndroidLogcatWithAdb(adb, {
         lines: lineLimit,
         timeoutMs: 5_000,
-      }),
+      });
+    },
     ...createRecordingOperations(session.client),
     installRemoteApp: async (url, options) => {
       await session.client.sendAsset(url);

--- a/src/providers/limrun/device-session.ts
+++ b/src/providers/limrun/device-session.ts
@@ -1,0 +1,213 @@
+import type { Interactor } from '../../contracts/interactor-types.ts';
+import type { AppsFilter } from '../../contracts/app-inventory.ts';
+import type { DeviceInfo } from '../../kernel/device.ts';
+import { AppError } from '../../kernel/errors.ts';
+import type { AndroidAdbProvider } from '../../platforms/android/adb-executor.ts';
+import {
+  getAndroidAppStateWithAdb,
+  listAndroidAppsWithAdb,
+} from '../../platforms/android/app-helpers.ts';
+import {
+  dismissAndroidKeyboardWithAdb,
+  getAndroidKeyboardStatusWithAdb,
+  type AndroidKeyboardDismissResult,
+  type AndroidKeyboardState,
+} from '../../platforms/android/device-input-state.ts';
+import { captureAndroidLogcatWithAdb } from '../../platforms/android/logcat.ts';
+import { createLimrunAndroidInteractor, type LimrunAndroidSession } from './android.ts';
+import {
+  createLimrunIosInteractor,
+  installLimrunIosRemoteApp,
+  type LimrunIosSession,
+} from './ios.ts';
+
+export type LimrunRecordingQuality = 5 | 6 | 7 | 8 | 9 | 10;
+
+export type LimrunInstalledApp = {
+  id: string;
+  name?: string;
+  installType?: string;
+};
+
+export type LimrunForegroundApp = {
+  appId?: string;
+  activity?: string;
+};
+
+export type LimrunRemoteInstallOptions = {
+  md5?: string;
+  relaunch?: boolean;
+  appIdentifierHint?: string;
+};
+
+export type LimrunRemoteInstallResult = {
+  appId?: string;
+};
+
+export type LimrunIosCommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type LimrunIosCommandExecution = {
+  on(
+    event: 'line-stdout' | 'line-stderr',
+    listener: (line: string) => void,
+  ): LimrunIosCommandExecution;
+  on(event: 'exit', listener: (code: number) => void): LimrunIosCommandExecution;
+  on(event: 'error', listener: (error: Error) => void): LimrunIosCommandExecution;
+  off(
+    event: 'line-stdout' | 'line-stderr',
+    listener: (line: string) => void,
+  ): LimrunIosCommandExecution;
+  off(event: 'exit', listener: (code: number) => void): LimrunIosCommandExecution;
+  off(event: 'error', listener: (error: Error) => void): LimrunIosCommandExecution;
+  wait(): Promise<LimrunIosCommandResult>;
+  stop(): void;
+};
+
+type LimrunDeviceSessionBase = {
+  readonly platform: 'android' | 'ios';
+  readonly device: DeviceInfo;
+  readonly interactor: Interactor;
+  readonly viewport?: { width: number; height: number };
+  listApps(filter?: AppsFilter): Promise<LimrunInstalledApp[]>;
+  getForegroundApp(): Promise<LimrunForegroundApp | undefined>;
+  pressKey(key: string, modifiers?: string[]): Promise<void>;
+  readLogs(appId: string | undefined, lineLimit: number): Promise<string>;
+  startRecording(options?: { quality?: LimrunRecordingQuality }): Promise<void>;
+  stopRecording(options: { outPath: string }): Promise<void>;
+  installRemoteApp(
+    url: string,
+    options?: LimrunRemoteInstallOptions,
+  ): Promise<LimrunRemoteInstallResult>;
+};
+
+type LimrunRecordingClient = {
+  startRecording(options?: { quality?: LimrunRecordingQuality }): Promise<void>;
+  stopRecording(options: { localPath: string }): Promise<string>;
+};
+
+export type LimrunAndroidDeviceSession = LimrunDeviceSessionBase & {
+  readonly platform: 'android';
+  readonly adb: AndroidAdbProvider;
+  getKeyboardState(): Promise<AndroidKeyboardState>;
+  dismissKeyboard(): Promise<AndroidKeyboardDismissResult>;
+  removePortReverse(devicePort: number): Promise<void>;
+};
+
+export type LimrunIosDeviceSession = LimrunDeviceSessionBase & {
+  readonly platform: 'ios';
+  runSimctl(args: string[]): LimrunIosCommandExecution;
+};
+
+export type LimrunDeviceSession = LimrunAndroidDeviceSession | LimrunIosDeviceSession;
+
+export function createLimrunDeviceSession(
+  session: LimrunAndroidSession | LimrunIosSession,
+): LimrunDeviceSession {
+  return session.platform === 'android'
+    ? createAndroidDeviceSession(session)
+    : createIosDeviceSession(session);
+}
+
+function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroidDeviceSession {
+  const adb = session.adbProvider.exec;
+  return {
+    platform: 'android',
+    device: session.device,
+    interactor: createLimrunAndroidInteractor(session),
+    adb: session.adbProvider,
+    listApps: async (filter = 'all') =>
+      (await listAndroidAppsWithAdb(adb, { filter, target: 'mobile' })).map((app) => ({
+        id: app.package,
+        name: app.name,
+      })),
+    getForegroundApp: async () => {
+      const app = await getAndroidAppStateWithAdb(adb);
+      return app.package ? { appId: app.package, activity: app.activity } : undefined;
+    },
+    pressKey: async (key, modifiers) => {
+      await session.client.pressKey(key, modifiers);
+    },
+    getKeyboardState: async () => await getAndroidKeyboardStatusWithAdb(adb),
+    dismissKeyboard: async () => await dismissAndroidKeyboardWithAdb(adb),
+    readLogs: async (_appId, lineLimit) =>
+      await captureAndroidLogcatWithAdb(adb, {
+        lines: lineLimit,
+        timeoutMs: 5_000,
+      }),
+    ...createRecordingOperations(session.client),
+    installRemoteApp: async (url, options) => {
+      await session.client.sendAsset(url);
+      return { appId: options?.appIdentifierHint };
+    },
+    removePortReverse: async (devicePort) => {
+      await session.adbProvider.reverse?.remove(tcpEndpoint(devicePort));
+    },
+  };
+}
+
+function createIosDeviceSession(session: LimrunIosSession): LimrunIosDeviceSession {
+  return {
+    platform: 'ios',
+    device: session.device,
+    interactor: createLimrunIosInteractor(session),
+    viewport: {
+      width: session.client.deviceInfo.screenWidth,
+      height: session.client.deviceInfo.screenHeight,
+    },
+    listApps: async (filter = 'all') =>
+      (await session.client.listApps())
+        .filter((app) => filter === 'all' || isUserInstalledIosApp(app))
+        .map((app) => ({
+          id: app.bundleId,
+          name: app.name,
+          installType: app.installType,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+    getForegroundApp: async () => undefined,
+    pressKey: async (key, modifiers) => {
+      await session.client.pressKey(key, modifiers);
+    },
+    readLogs: async (appId, lineLimit) => {
+      if (!appId) {
+        throw unsupported('logs', 'Limrun iOS app logs require an app bundle identifier.');
+      }
+      return await session.client.appLogTail(appId, lineLimit);
+    },
+    ...createRecordingOperations(session.client),
+    installRemoteApp: async (url, options) =>
+      await installLimrunIosRemoteApp(session, url, options),
+    runSimctl: (args) => session.client.simctl(args) as LimrunIosCommandExecution,
+  };
+}
+
+function createRecordingOperations(client: LimrunRecordingClient) {
+  return {
+    startRecording: async (options?: { quality?: LimrunRecordingQuality }) => {
+      await client.startRecording(options);
+    },
+    stopRecording: async ({ outPath }: { outPath: string }) => {
+      await client.stopRecording({ localPath: outPath });
+    },
+  };
+}
+
+function isUserInstalledIosApp(app: { bundleId: string; installType: string }): boolean {
+  return (
+    !app.bundleId.startsWith('com.apple.') && !app.installType.toLowerCase().includes('system')
+  );
+}
+
+function tcpEndpoint(port: number): `tcp:${number}` {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new AppError('INVALID_ARGS', `Invalid Android tcp reverse port: ${port}`);
+  }
+  return `tcp:${port}`;
+}
+
+function unsupported(command: string, message: string): AppError {
+  return new AppError('UNSUPPORTED_OPERATION', message, { command });
+}

--- a/src/providers/limrun/device-session.ts
+++ b/src/providers/limrun/device-session.ts
@@ -1,7 +1,6 @@
 import type { Interactor } from '../../contracts/interactor-types.ts';
-import type { AppsFilter } from '../../contracts/app-inventory.ts';
+import { resolveAppsFilter, type AppsFilter } from '../../contracts/app-inventory.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
-import { AppError } from '../../kernel/errors.ts';
 import type { AndroidAdbProvider } from '../../platforms/android/adb-executor.ts';
 import type {
   AndroidKeyboardDismissResult,
@@ -11,6 +10,9 @@ import { createLimrunAndroidInteractor, type LimrunAndroidSession } from './andr
 import {
   createLimrunIosInteractor,
   installLimrunIosRemoteApp,
+  isUserInstalledIosApp,
+  type LimrunIosRemoteInstallOptions,
+  type LimrunIosRemoteInstallResult,
   type LimrunIosSession,
 } from './ios.ts';
 
@@ -25,16 +27,6 @@ export type LimrunInstalledApp = {
 export type LimrunForegroundApp = {
   appId?: string;
   activity?: string;
-};
-
-export type LimrunRemoteInstallOptions = {
-  md5?: string;
-  relaunch?: boolean;
-  appIdentifierHint?: string;
-};
-
-export type LimrunRemoteInstallResult = {
-  appId?: string;
 };
 
 export type LimrunIosCommandResult = {
@@ -64,17 +56,10 @@ type LimrunDeviceSessionBase = {
   readonly platform: 'android' | 'ios';
   readonly device: DeviceInfo;
   readonly interactor: Interactor;
-  readonly viewport?: { width: number; height: number };
   listApps(filter?: AppsFilter): Promise<LimrunInstalledApp[]>;
-  getForegroundApp(): Promise<LimrunForegroundApp | undefined>;
   pressKey(key: string, modifiers?: string[]): Promise<void>;
-  readLogs(appId: string | undefined, lineLimit: number): Promise<string>;
   startRecording(options?: { quality?: LimrunRecordingQuality }): Promise<void>;
-  stopRecording(options: { outPath: string }): Promise<void>;
-  installRemoteApp(
-    url: string,
-    options?: LimrunRemoteInstallOptions,
-  ): Promise<LimrunRemoteInstallResult>;
+  stopRecording(options: { outPath: string }): Promise<string>;
 };
 
 type LimrunRecordingClient = {
@@ -85,13 +70,21 @@ type LimrunRecordingClient = {
 export type LimrunAndroidDeviceSession = LimrunDeviceSessionBase & {
   readonly platform: 'android';
   readonly adb: AndroidAdbProvider;
+  getForegroundApp(): Promise<LimrunForegroundApp | undefined>;
   getKeyboardState(): Promise<AndroidKeyboardState>;
   dismissKeyboard(): Promise<AndroidKeyboardDismissResult>;
-  removePortReverse(devicePort: number): Promise<void>;
+  readLogs(lineLimit: number): Promise<string>;
+  installRemoteApp(url: string): Promise<void>;
 };
 
 export type LimrunIosDeviceSession = LimrunDeviceSessionBase & {
   readonly platform: 'ios';
+  readonly viewport: { width: number; height: number };
+  readLogs(appId: string, lineLimit: number): Promise<string>;
+  installRemoteApp(
+    url: string,
+    options?: LimrunIosRemoteInstallOptions,
+  ): Promise<LimrunIosRemoteInstallResult>;
   runSimctl(args: string[]): LimrunIosCommandExecution;
 };
 
@@ -112,9 +105,14 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
     device: session.device,
     interactor: createLimrunAndroidInteractor(session),
     adb: session.adbProvider,
-    listApps: async (filter = 'all') => {
+    listApps: async (filter) => {
       const { listAndroidAppsWithAdb } = await import('../../platforms/android/app-helpers.ts');
-      return (await listAndroidAppsWithAdb(adb, { filter, target: 'mobile' })).map((app) => ({
+      return (
+        await listAndroidAppsWithAdb(adb, {
+          filter: resolveAppsFilter(filter),
+          target: 'mobile',
+        })
+      ).map((app) => ({
         id: app.package,
         name: app.name,
       }));
@@ -137,7 +135,7 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
         await import('../../platforms/android/device-input-state.ts');
       return await dismissAndroidKeyboardWithAdb(adb);
     },
-    readLogs: async (_appId, lineLimit) => {
+    readLogs: async (lineLimit) => {
       const { captureAndroidLogcatWithAdb } = await import('../../platforms/android/logcat.ts');
       return await captureAndroidLogcatWithAdb(adb, {
         lines: lineLimit,
@@ -145,12 +143,8 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
       });
     },
     ...createRecordingOperations(session.client),
-    installRemoteApp: async (url, options) => {
+    installRemoteApp: async (url) => {
       await session.client.sendAsset(url);
-      return { appId: options?.appIdentifierHint };
-    },
-    removePortReverse: async (devicePort) => {
-      await session.adbProvider.reverse?.remove(tcpEndpoint(devicePort));
     },
   };
 }
@@ -164,29 +158,23 @@ function createIosDeviceSession(session: LimrunIosSession): LimrunIosDeviceSessi
       width: session.client.deviceInfo.screenWidth,
       height: session.client.deviceInfo.screenHeight,
     },
-    listApps: async (filter = 'all') =>
+    listApps: async (filter) =>
       (await session.client.listApps())
-        .filter((app) => filter === 'all' || isUserInstalledIosApp(app))
+        .filter((app) => resolveAppsFilter(filter) === 'all' || isUserInstalledIosApp(app))
         .map((app) => ({
           id: app.bundleId,
           name: app.name,
           installType: app.installType,
         }))
         .sort((left, right) => left.id.localeCompare(right.id)),
-    getForegroundApp: async () => undefined,
     pressKey: async (key, modifiers) => {
       await session.client.pressKey(key, modifiers);
     },
-    readLogs: async (appId, lineLimit) => {
-      if (!appId) {
-        throw unsupported('logs', 'Limrun iOS app logs require an app bundle identifier.');
-      }
-      return await session.client.appLogTail(appId, lineLimit);
-    },
+    readLogs: async (appId, lineLimit) => await session.client.appLogTail(appId, lineLimit),
     ...createRecordingOperations(session.client),
     installRemoteApp: async (url, options) =>
       await installLimrunIosRemoteApp(session, url, options),
-    runSimctl: (args) => session.client.simctl(args) as LimrunIosCommandExecution,
+    runSimctl: (args): LimrunIosCommandExecution => session.client.simctl(args),
   };
 }
 
@@ -195,25 +183,7 @@ function createRecordingOperations(client: LimrunRecordingClient) {
     startRecording: async (options?: { quality?: LimrunRecordingQuality }) => {
       await client.startRecording(options);
     },
-    stopRecording: async ({ outPath }: { outPath: string }) => {
-      await client.stopRecording({ localPath: outPath });
-    },
+    stopRecording: async ({ outPath }: { outPath: string }) =>
+      await client.stopRecording({ localPath: outPath }),
   };
-}
-
-function isUserInstalledIosApp(app: { bundleId: string; installType: string }): boolean {
-  return (
-    !app.bundleId.startsWith('com.apple.') && !app.installType.toLowerCase().includes('system')
-  );
-}
-
-function tcpEndpoint(port: number): `tcp:${number}` {
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new AppError('INVALID_ARGS', `Invalid Android tcp reverse port: ${port}`);
-  }
-  return `tcp:${port}`;
-}
-
-function unsupported(command: string, message: string): AppError {
-  return new AppError('UNSUPPORTED_OPERATION', message, { command });
 }

--- a/src/providers/limrun/ios.ts
+++ b/src/providers/limrun/ios.ts
@@ -66,11 +66,12 @@ export async function installLimrunIosApp(
       path: prepared.uploadPath,
       name: prepared.assetName,
     });
-    const result = await session.client.installApp(asset.signedDownloadUrl, {
+    const result = await installLimrunIosRemoteApp(session, asset.signedDownloadUrl, {
       md5: asset.md5,
-      launchMode: options?.relaunch ? 'RelaunchIfRunning' : 'ForegroundIfRunning',
+      relaunch: options?.relaunch,
+      appIdentifierHint: options?.appIdentifierHint,
     });
-    const bundleId = normalizeOptionalString(result.bundleId) ?? options?.appIdentifierHint;
+    const bundleId = result.appId;
     return {
       ...(bundleId ? { bundleId, launchTarget: bundleId } : {}),
       ...(prepared.appName ? { appName: prepared.appName } : {}),
@@ -78,6 +79,44 @@ export async function installLimrunIosApp(
   } finally {
     await prepared.cleanup();
   }
+}
+
+export async function installLimrunIosRemoteApp(
+  session: LimrunIosSession,
+  url: string,
+  options?: {
+    md5?: string;
+    relaunch?: boolean;
+    appIdentifierHint?: string;
+  },
+): Promise<{ appId?: string }> {
+  const beforeInstallApps = await session.client.listApps().catch(() => undefined);
+  const result = await session.client.installApp(url, {
+    md5: options?.md5,
+    launchMode: options?.relaunch ? 'RelaunchIfRunning' : 'ForegroundIfRunning',
+  });
+  const resultBundleId = normalizeOptionalString(result.bundleId);
+  const requestedBundleId = normalizeOptionalString(options?.appIdentifierHint);
+  let afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> = [];
+  for (const delayMs of IOS_APP_INVENTORY_RETRY_DELAYS_MS) {
+    if (delayMs > 0) await sleep(delayMs);
+    afterInstallApps = await session.client.listApps();
+    const verifiedBundleId = resolveInstalledIosAppId({
+      resultBundleId,
+      requestedBundleId,
+      beforeInstallApps,
+      afterInstallApps,
+    });
+    if (verifiedBundleId) return { appId: verifiedBundleId };
+  }
+  throw new AppError('COMMAND_FAILED', 'Limrun iOS app installation could not be verified.', {
+    resultBundleId,
+    requestedBundleId,
+    installedUserApps: afterInstallApps
+      .filter(isUserInstalledIosApp)
+      .map((app) => app.bundleId)
+      .sort(),
+  });
 }
 
 export function createLimrunIosInteractor(session: LimrunIosSession): Interactor {
@@ -265,6 +304,44 @@ async function resolveIosTarget(app: string): Promise<string> {
 function inferAppNameFromPath(appPath: string): string | undefined {
   const base = path.basename(appPath).replace(/\.(?:app|ipa|apk|aab|zip)$/i, '');
   return base || undefined;
+}
+
+const IOS_APP_INVENTORY_RETRY_DELAYS_MS = [0, 250] as const;
+
+function resolveInstalledIosAppId(params: {
+  resultBundleId?: string;
+  requestedBundleId?: string;
+  beforeInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> | undefined;
+  afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>>;
+}): string | undefined {
+  const installedBundleIds = new Set(params.afterInstallApps.map((app) => app.bundleId));
+  return (
+    (params.resultBundleId && installedBundleIds.has(params.resultBundleId)
+      ? params.resultBundleId
+      : undefined) ??
+    (params.requestedBundleId && installedBundleIds.has(params.requestedBundleId)
+      ? params.requestedBundleId
+      : undefined) ??
+    inferNewUserInstalledApp(params.beforeInstallApps, params.afterInstallApps)
+  );
+}
+
+function inferNewUserInstalledApp(
+  beforeInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> | undefined,
+  afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>>,
+): string | undefined {
+  if (!beforeInstallApps) return undefined;
+  const beforeBundleIds = new Set(beforeInstallApps.map((app) => app.bundleId));
+  const candidates = afterInstallApps.filter(
+    (app) => isUserInstalledIosApp(app) && !beforeBundleIds.has(app.bundleId),
+  );
+  return candidates.length === 1 ? candidates[0]?.bundleId : undefined;
+}
+
+function isUserInstalledIosApp(app: { bundleId: string; installType: string }): boolean {
+  return (
+    !app.bundleId.startsWith('com.apple.') && !app.installType.toLowerCase().includes('system')
+  );
 }
 
 async function readIosBundleAppName(appPath: string): Promise<string | undefined> {

--- a/src/providers/limrun/ios.ts
+++ b/src/providers/limrun/ios.ts
@@ -33,6 +33,18 @@ export type LimrunIosSession = {
   client: LimrunIosClient;
 };
 
+export type LimrunIosRemoteInstallOptions = {
+  md5?: string;
+  relaunch?: boolean;
+  appIdentifierHint?: string;
+};
+
+export type LimrunIosRemoteInstallResult = {
+  appId?: string;
+};
+
+type LimrunIosApp = Awaited<ReturnType<LimrunIosClient['listApps']>>[number];
+
 export async function createLimrunIosSession(options: {
   lease: DeviceLease;
   instanceId: string;
@@ -84,12 +96,8 @@ export async function installLimrunIosApp(
 export async function installLimrunIosRemoteApp(
   session: LimrunIosSession,
   url: string,
-  options?: {
-    md5?: string;
-    relaunch?: boolean;
-    appIdentifierHint?: string;
-  },
-): Promise<{ appId?: string }> {
+  options?: LimrunIosRemoteInstallOptions,
+): Promise<LimrunIosRemoteInstallResult> {
   const beforeInstallApps = await session.client.listApps().catch(() => undefined);
   const result = await session.client.installApp(url, {
     md5: options?.md5,
@@ -97,7 +105,7 @@ export async function installLimrunIosRemoteApp(
   });
   const resultBundleId = normalizeOptionalString(result.bundleId);
   const requestedBundleId = normalizeOptionalString(options?.appIdentifierHint);
-  let afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> = [];
+  let afterInstallApps: LimrunIosApp[] = [];
   for (const delayMs of IOS_APP_INVENTORY_RETRY_DELAYS_MS) {
     if (delayMs > 0) await sleep(delayMs);
     afterInstallApps = await session.client.listApps();
@@ -311,8 +319,8 @@ const IOS_APP_INVENTORY_RETRY_DELAYS_MS = [0, 250] as const;
 function resolveInstalledIosAppId(params: {
   resultBundleId?: string;
   requestedBundleId?: string;
-  beforeInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> | undefined;
-  afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>>;
+  beforeInstallApps: LimrunIosApp[] | undefined;
+  afterInstallApps: LimrunIosApp[];
 }): string | undefined {
   const installedBundleIds = new Set(params.afterInstallApps.map((app) => app.bundleId));
   return (
@@ -327,8 +335,8 @@ function resolveInstalledIosAppId(params: {
 }
 
 function inferNewUserInstalledApp(
-  beforeInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>> | undefined,
-  afterInstallApps: Awaited<ReturnType<LimrunIosSession['client']['listApps']>>,
+  beforeInstallApps: LimrunIosApp[] | undefined,
+  afterInstallApps: LimrunIosApp[],
 ): string | undefined {
   if (!beforeInstallApps) return undefined;
   const beforeBundleIds = new Set(beforeInstallApps.map((app) => app.bundleId));
@@ -338,7 +346,7 @@ function inferNewUserInstalledApp(
   return candidates.length === 1 ? candidates[0]?.bundleId : undefined;
 }
 
-function isUserInstalledIosApp(app: { bundleId: string; installType: string }): boolean {
+export function isUserInstalledIosApp(app: LimrunIosApp): boolean {
   return (
     !app.bundleId.startsWith('com.apple.') && !app.installType.toLowerCase().includes('system')
   );

--- a/src/providers/limrun/runtime.ts
+++ b/src/providers/limrun/runtime.ts
@@ -35,6 +35,7 @@ import {
   installLimrunIosApp,
   type LimrunIosSession,
 } from './ios.ts';
+import { createLimrunDeviceSession, type LimrunDeviceSession } from './device-session.ts';
 
 type LimrunInstance = {
   metadata: { id: string };
@@ -105,6 +106,11 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
     return session.platform === 'ios'
       ? createLimrunIosInteractor(session)
       : createLimrunAndroidInteractor(session);
+  }
+
+  getDeviceSession(device: DeviceInfo): LimrunDeviceSession | undefined {
+    const session = this.getSessionForDevice(device);
+    return session ? createLimrunDeviceSession(session) : undefined;
   }
 
   async installApp(

--- a/src/sdk/android-adb.ts
+++ b/src/sdk/android-adb.ts
@@ -2,6 +2,7 @@ export {
   createAndroidPortReverseManager,
   type AndroidAdbExecutor,
   type AndroidAdbExecutorOptions,
+  type AndroidAdbProvider,
   type AndroidPortReverseEndpoint,
 } from '../platforms/android/adb-executor.ts';
 export {
@@ -17,5 +18,7 @@ export {
   dismissAndroidKeyboardWithAdb,
   getAndroidKeyboardStatusWithAdb,
   readAndroidClipboardWithAdb,
+  type AndroidKeyboardDismissResult,
+  type AndroidKeyboardState,
   writeAndroidClipboardWithAdb,
 } from '../platforms/android/device-input-state.ts';

--- a/src/sdk/limrun.ts
+++ b/src/sdk/limrun.ts
@@ -1,1 +1,18 @@
 export { LimrunRuntime, type LimrunRuntimeOptions } from '../providers/limrun/runtime.ts';
+export type { AndroidAdbProvider } from '../platforms/android/adb-executor.ts';
+export type {
+  AndroidKeyboardDismissResult,
+  AndroidKeyboardState,
+} from '../platforms/android/device-input-state.ts';
+export type {
+  LimrunAndroidDeviceSession,
+  LimrunDeviceSession,
+  LimrunForegroundApp,
+  LimrunInstalledApp,
+  LimrunIosCommandExecution,
+  LimrunIosCommandResult,
+  LimrunIosDeviceSession,
+  LimrunRecordingQuality,
+  LimrunRemoteInstallOptions,
+  LimrunRemoteInstallResult,
+} from '../providers/limrun/device-session.ts';

--- a/src/sdk/limrun.ts
+++ b/src/sdk/limrun.ts
@@ -13,6 +13,8 @@ export type {
   LimrunIosCommandResult,
   LimrunIosDeviceSession,
   LimrunRecordingQuality,
-  LimrunRemoteInstallOptions,
-  LimrunRemoteInstallResult,
 } from '../providers/limrun/device-session.ts';
+export type {
+  LimrunIosRemoteInstallOptions,
+  LimrunIosRemoteInstallResult,
+} from '../providers/limrun/ios.ts';

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -62,10 +62,14 @@ Public subpath API exposed for Node consumers:
   - `forceStopAndroidAppWithAdb(executor, packageName)`
   - `listAndroidAppsWithAdb(executor)`
   - `getAndroidAppStateWithAdb(executor)`
-  - types: `AndroidAdbExecutor`, `AndroidAdbExecutorOptions`, `AndroidPortReverseEndpoint`
+  - types: `AndroidAdbExecutor`, `AndroidAdbExecutorOptions`, `AndroidAdbProvider`,
+    `AndroidKeyboardState`, `AndroidKeyboardDismissResult`, `AndroidPortReverseEndpoint`
 - `agent-device/limrun`
   - `new LimrunRuntime(options)`
-  - types: `LimrunRuntimeOptions`
+  - `runtime.getDeviceSession(device)`
+  - types: `LimrunRuntimeOptions`, `LimrunDeviceSession`, `LimrunAndroidDeviceSession`,
+    `LimrunIosDeviceSession`, `AndroidAdbProvider`, `AndroidKeyboardState`,
+    `AndroidKeyboardDismissResult`
 
 The `contracts`, `selectors`, `finders`, `install-source`, `android-adb`, `limrun`, `artifacts`, `batch`, `metro`, `remote-config`, and `io` subpaths are the supported Node entry points. The former compatibility subpaths `agent-device/android-apps` and `agent-device/daemon`, plus hosted-runtime subpaths `agent-device/cloud-webdriver`, `agent-device/commands`, `agent-device/backend`, `agent-device/testing/conformance`, and `agent-device/observability`, are not published.
 

--- a/website/docs/docs/device-clouds.md
+++ b/website/docs/docs/device-clouds.md
@@ -270,6 +270,14 @@ const runtime = new LimrunRuntime({
 });
 ```
 
+After allocating a lease, embedding bridges can call `runtime.getDeviceSession(device)` to access
+the allocated device's reusable semantic capabilities. The facade includes app inventory,
+foreground state where the provider exposes it, key input, bounded log reads, recording, remote
+asset installation, and the existing interactor. Android additionally exposes agent-device's
+`AndroidAdbProvider` abstraction for helpers and reversible port forwarding. iOS exposes a typed
+`simctl` execution handle for bridge-owned runner lifecycle and launch policy. Raw Limrun clients
+remain private to the provider runtime.
+
 ## MCP Experience
 
 The MCP server exposes operational command tools such as `open`, `snapshot`, `click`, `close`, and `artifacts`. It does not expose provider `connect` commands.


### PR DESCRIPTION
## Summary

- expose a client-private Limrun device-session facade for reusable app, input, log, recording, install, and interactor capabilities
- expose the existing Android ADB provider and reversible port forwarding plus a typed iOS simctl seam
- preserve verified iOS remote-install behavior with bounded inventory retries, while keeping raw Limrun clients private
- keep focused mirrored facade tests, including delayed iOS inventory consistency

## Validation

- `pnpm check:affected --base origin/main --run`
- `pnpm exec vitest run src/providers/limrun/device-session.test.ts src/__tests__/limrun-runtime.test.ts`
- `pnpm exec vitest run --project unit-core --maxWorkers 1 scripts/__tests__/help-conformance-bench.test.ts src/screenshot-diff/__tests__/screenshot-diff.test.ts src/platforms/apple/core/__tests__/runner-client.test.ts`
- local agent-device-cloud package: `pnpm --filter @agent-device-cloud/bridge check`
- local agent-device-cloud package: `pnpm --filter @agent-device-cloud/bridge test -- test/limrun-session.test.ts`
- live Limrun Android E2E through agent-device-cloud: app inventory, Settings launch, snapshot, screenshot, app/keyboard state, key input, bounded logs, recording, port reverse, and individual reverse removal; session terminated after the run
- live Limrun iOS E2E through the public facade: fresh lease, inventory changed from 1 to 2 after remotely installing `dev.agentdevice.LimrunParityE2E`, both facade inventory and `runSimctl(["listapps", "booted"])` verified the install, recording produced 27,380 bytes, and no raw client was exposed; lease and temporary uploaded asset were cleaned up
