### PR TITLE
test: pin daemon modularity migration contracts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -306,11 +306,21 @@ The perfect-shape refactor is complete and merged. Its end-state:
 - Type-cycle growth (R9). R4 keeps the VALUE import graph acyclic, so every remaining cycle is
   created by type-only imports — free at runtime, invisible to R5/R6, and the largest single
   obstacle to reading a subsystem in isolation: inside a strongly-connected component of 102 files,
-  no file has a self-contained slice. `TYPE_CYCLE_BASELINE` in `check.ts` ratchets it for **growth
-  only**, deliberately unlike R6: reducing it is a real refactor rather than a file move, so a hard
-  equality would turn every unrelated improvement into a baseline edit. A shrunk tree is reported in
-  the success line instead of failing. Hubs by in-component dependents: `runtime-contract.ts` (25),
+  no file has a self-contained slice. `TYPE_CYCLE_BASELINE`, exported from
+  `scripts/layering/check.ts`, ratchets it for **growth only**, deliberately unlike R6: reducing it
+  is a real refactor rather than a file move, so a hard equality would turn every unrelated
+  improvement into a baseline edit. A shrunk tree is reported in the success line instead of
+  failing. Hubs by in-component dependents: `runtime-contract.ts` (25),
   `commands/runtime-types.ts` (21), `backend.ts` (15), `commands/runtime-common.ts` (12).
+- Daemon modularity migration (R10). The same tooling-only declaration records R7 at 30
+  writer-owned fields / 42 owner-file claims, R9's 102 members by zone (`commands` 33,
+  `daemon-server` 30, `platforms` 19, `core` 12, root 5, `contracts` 2, `client` 1), and the four
+  production importers of `daemon/types.ts` from outside daemon. R7 counts and external importers may
+  only shrink; no zone may grow inside R9, and replay/Maestro/replay-test engine files remain outside
+  it. Zero-count policies begin enforcing when `src/ad-replay/` or `src/maestro/` first exists and
+  already protect `src/replay/test/`: engines cannot import daemon/platform/provider implementations,
+  and no logical module may deep-import another module's `internal/` tree. These are migration
+  ratchets, not permission to scaffold façades before a real seam has two adapters.
 - Zero-dep CI jobs (R8). Some jobs run scripts straight from a checkout with `install-deps: false`,
   so they have no `node_modules`. Nothing local can feel that constraint — every dev machine has
   `node_modules` sitting right there — so a script grows a package import, passes locally, and fails

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -306,8 +306,8 @@ The perfect-shape refactor is complete and merged. Its end-state:
 - Type-cycle growth (R9). R4 keeps the VALUE import graph acyclic, so every remaining cycle is
   created by type-only imports — free at runtime, invisible to R5/R6, and the largest single
   obstacle to reading a subsystem in isolation: inside a strongly-connected component of 102 files,
-  no file has a self-contained slice. `TYPE_CYCLE_BASELINE`, exported from
-  `scripts/layering/check.ts`, ratchets it for **growth only**, deliberately unlike R6: reducing it
+  no file has a self-contained slice. `TYPE_CYCLE_BASELINE`, derived from the zone ceilings in
+  `scripts/layering/daemon-modularity.ts`, ratchets it for **growth only**, deliberately unlike R6: reducing it
   is a real refactor rather than a file move, so a hard equality would turn every unrelated
   improvement into a baseline edit. A shrunk tree is reported in the success line instead of
   failing. Hubs by in-component dependents: `runtime-contract.ts` (25),
@@ -317,7 +317,10 @@ The perfect-shape refactor is complete and merged. Its end-state:
   `daemon-server` 30, `platforms` 19, `core` 12, root 5, `contracts` 2, `client` 1), and the four
   production importers of `daemon/types.ts` from outside daemon. R7 counts and external importers may
   only shrink; no zone may grow inside R9, and replay/Maestro/replay-test engine files remain outside
-  it. Zero-count policies begin enforcing when `src/ad-replay/` or `src/maestro/` first exists and
+  it. This per-zone migration ratchet is intentionally stricter than R9's ordinary total-growth
+  rule: during the extraction, even moving cycle membership into a zone at its ceiling must be
+  justified by lowering another ceiling or changing the migration baseline explicitly. Zero-count
+  policies begin enforcing when `src/ad-replay/` or `src/maestro/` first exists and
   already protect `src/replay/test/`: engines cannot import daemon/platform/provider implementations,
   and no logical module may deep-import another module's `internal/` tree. These are migration
   ratchets, not permission to scaffold façades before a real seam has two adapters.

--- a/docs/dependency-graph-findings.md
+++ b/docs/dependency-graph-findings.md
@@ -161,7 +161,8 @@ but it is a comprehension one, and it is the single largest obstacle to reading 
 isolation. At the current measured commit it spans `commands` (33), `daemon-server` (30),
 `platforms` (19), `core` (12), root composition (5), `contracts` (2), and `client` (1).
 
-Now ratcheted for growth by **R9** (`TYPE_CYCLE_BASELINE` in `check.ts`), so it cannot get worse
+Now ratcheted for growth by **R9** (`TYPE_CYCLE_BASELINE`, derived from the zone ceilings in
+`scripts/layering/daemon-modularity.ts`), so it cannot get worse
 while nobody is looking — a type-only import that closes a new loop fails the gate, verified by
 adding one type-only import that closes a loop and watching the gate reject it. Growth-only on
 purpose: reducing it is a real refactor, so a

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "check:affected:test": "node --experimental-strip-types --test scripts/check-affected/model.test.ts scripts/check-affected/run.test.ts",
     "check:coverage-changed": "node --experimental-strip-types scripts/coverage-changed/run.ts",
     "check:coverage-changed:test": "node --experimental-strip-types --test scripts/coverage-changed/model.test.ts scripts/coverage-changed/run.test.ts",
-    "check:layering": "node --experimental-strip-types --test scripts/layering/model.test.ts scripts/layering/zone-policy.test.ts && node --experimental-strip-types scripts/layering/check.ts",
+    "check:layering": "node --experimental-strip-types --test scripts/layering/model.test.ts scripts/layering/zone-policy.test.ts scripts/layering/daemon-modularity.test.ts && node --experimental-strip-types scripts/layering/check.ts",
     "depgraph": "node --experimental-strip-types scripts/depgraph/build.ts",
     "depgraph:test": "node --experimental-strip-types --test scripts/depgraph/model.test.ts scripts/depgraph/affected.test.ts",
     "check:production-exports": "fallow dead-code --config fallow-production-exports.json --production --unused-exports --fail-on-issues",

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -21,6 +21,9 @@
 //   - Over the TYPE GRAPH: the largest type-level import cycle may not grow (R9). R4
 //     keeps the value graph acyclic, so these cycles are free at runtime but bound
 //     what can be read in isolation. Growth-only, deliberately loose.
+//   - Across the DAEMON MODULARITY MIGRATION: R7 ownership pressure and external
+//     daemon/types.ts importers only shrink, R9 zone membership cannot grow or absorb
+//     engine files, and planned logical modules start with zero forbidden/internal imports (R10).
 // Only `(root)` is unranked (see `UNRANKED_ZONES` in model.ts): it holds the
 // entrypoints and the composition roots that wire the command surface into the
 // daemon, which R2 forbids the daemon from importing, so they sit outside the
@@ -41,13 +44,21 @@ import { uninstallableImports, zeroDepJobs } from './zero-dep-jobs.ts';
 import {
   backEdgePair,
   findValueImportCycles,
-  largestTypeCycleSize,
+  largestTypeCycleMembers,
   resolveImportEdges,
   topFolder,
   typeInversionPair,
   type ResolvedImportEdge,
 } from './model.ts';
+import {
+  checkDaemonModularityRatchets,
+  daemonModularitySummary,
+  sessionStateFieldCount,
+  TYPE_CYCLE_BASELINE,
+} from './daemon-modularity.ts';
 import { policyLead, policyViolation, ZONE_POLICIES } from './zone-policy.ts';
+
+export { TYPE_CYCLE_BASELINE } from './daemon-modularity.ts';
 
 type Violation = {
   rule: string;
@@ -241,44 +252,6 @@ function checkTypeInversions(edges: readonly ResolvedImportEdge[]): Violation[] 
   return violations;
 }
 
-// R9: the largest type-level import cycle, ratcheted for GROWTH ONLY.
-//
-// R4 keeps the value graph acyclic, so every cycle counted here is created by type-only imports.
-// That is free at runtime and invisible to R5/R6, but it bounds what can be read in isolation:
-// inside a strongly-connected component of 102 files, no file has a self-contained slice — reading
-// any one of them means reaching every other one's declarations. It is the largest single obstacle
-// to understanding a subsystem on its own, and nothing else in this gate measures it.
-//
-// Deliberately loose. Unlike R6 this does NOT fail when the number drops, because the number is
-// large and reducing it is a real refactor rather than a file move — a hard equality would turn
-// every unrelated improvement into a baseline edit. It fails only on growth, and reports the slack
-// when the tree has improved so the baseline can be lowered when someone is in here anyway.
-//
-// Hubs at the time of writing, by in-component dependents: runtime-contract.ts (25),
-// commands/runtime-types.ts (21), backend.ts (15), commands/runtime-common.ts (12). A pass at this
-// starts there. See docs/dependency-graph-findings.md.
-// Set to what THIS branch achieves, not to what main carries: main is at 107, and the boundary
-// moves here bring it to 102. Measured on the rebased tree — an earlier 87 was taken against an
-// older main and was stale rather than violated, which is exactly the kind of drift a ratchet
-// measured at merge time prevents.
-export const TYPE_CYCLE_BASELINE = 102;
-
-function checkTypeCycleGrowth(actual: number): Violation[] {
-  if (actual <= TYPE_CYCLE_BASELINE) return [];
-  return [
-    {
-      rule: 'R9 type-cycle-growth',
-      file: 'scripts/layering/check.ts',
-      line: 1,
-      message:
-        `the largest type-level import cycle grew to ${actual} files (baseline ` +
-        `${TYPE_CYCLE_BASELINE}). A type-only import that closes a loop makes every file in the ` +
-        `loop unreadable in isolation. Declare the shared type below both modules, or if the growth ` +
-        `is genuinely warranted, raise TYPE_CYCLE_BASELINE in the same commit and say why.`,
-    },
-  ];
-}
-
 function checkSessionStateOwnership(sources: ReadonlyMap<string, string>): Violation[] {
   const types = sources.get('src/daemon/types.ts');
   if (!types) {
@@ -434,16 +407,13 @@ function checkZeroDepJobs(): Violation[] {
   return violations;
 }
 
-function sessionStateFieldCount(): number {
-  return Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size;
-}
-
 /** R9 is growth-only, so a shrunk tree is reported rather than failed — see checkTypeCycleGrowth. */
 function typeCycleNote(actual: number): string {
-  if (actual >= TYPE_CYCLE_BASELINE) return `the largest type-level cycle is ${actual} files (R9)`;
+  const baseline = TYPE_CYCLE_BASELINE;
+  if (actual >= baseline) return `the largest type-level cycle is ${actual} files (R9)`;
   return (
     `the largest type-level cycle is down to ${actual} files, under the R9 baseline of ` +
-    `${TYPE_CYCLE_BASELINE} — lower TYPE_CYCLE_BASELINE when convenient`
+    `${baseline} — lower the daemon modularity baseline when convenient`
   );
 }
 
@@ -460,7 +430,7 @@ function report(
         `inversions match the R6 ratchet (${Object.values(TYPE_INVERSION_BASELINE).reduce((sum, count) => sum + count, 0)} remaining); ` +
         `all ${sessionStateFieldCount()} SessionState fields are classified and every write is ` +
         `inside its declared owner (R7); every zero-dep CI job resolves without ` +
-        `node_modules (R8); and ${typeCycleNote(typeCycle)}.\n`,
+        `node_modules (R8); ${typeCycleNote(typeCycle)}; and ${daemonModularitySummary()}.\n`,
     );
     return 0;
   }
@@ -491,14 +461,15 @@ export function main(): number {
   const sources = readSources(sourceFiles);
   const edges = resolveImportEdges(sources);
   // Computed once and threaded: the rule and the success line must report the same number.
-  const typeCycle = largestTypeCycleSize(edges);
+  const typeCycleMembers = largestTypeCycleMembers(edges);
+  const typeCycle = typeCycleMembers.length;
   const violations = [
     ...checkLayeringRules(edges),
     ...checkCycles(edges),
     ...checkBackEdges(edges),
     ...checkTypeInversions(edges),
     ...checkSessionStateOwnership(sources),
-    ...checkTypeCycleGrowth(typeCycle),
+    ...checkDaemonModularityRatchets(edges, typeCycleMembers),
     ...checkZeroDepJobs(),
   ];
   return report(sourceFiles, violations, typeCycle);

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -37,6 +37,7 @@ import {
   fieldClassificationDrift,
   findSessionStateWrites,
   sessionStateFields,
+  sessionStateFieldCount,
   SESSION_STATE_FIELD_OWNERS,
   STORE_OWNED_SESSION_STATE_FIELDS,
 } from './session-state.ts';
@@ -48,24 +49,15 @@ import {
   resolveImportEdges,
   topFolder,
   typeInversionPair,
+  type LayeringViolation,
   type ResolvedImportEdge,
 } from './model.ts';
 import {
   checkDaemonModularityRatchets,
   daemonModularitySummary,
-  sessionStateFieldCount,
   TYPE_CYCLE_BASELINE,
 } from './daemon-modularity.ts';
 import { policyLead, policyViolation, ZONE_POLICIES } from './zone-policy.ts';
-
-export { TYPE_CYCLE_BASELINE } from './daemon-modularity.ts';
-
-type Violation = {
-  rule: string;
-  file: string;
-  line: number;
-  message: string;
-};
 
 const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
   encoding: 'utf8',
@@ -102,8 +94,8 @@ function isProductionSourceFile(file: string): boolean {
 
 // R1-R3 are declared as a policy table in zone-policy.ts. This walks it; the boundaries
 // themselves are data, so adding one is a table entry rather than a fourth predicate.
-function checkLayeringRules(edges: readonly ResolvedImportEdge[]): Violation[] {
-  const violations: Violation[] = [];
+function checkLayeringRules(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
+  const violations: LayeringViolation[] = [];
   for (const edge of edges) {
     const fromZone = topFolder(edge.file);
     const toZone = topFolder(edge.target);
@@ -123,7 +115,7 @@ function checkLayeringRules(edges: readonly ResolvedImportEdge[]): Violation[] {
   return violations;
 }
 
-function checkCycles(edges: readonly ResolvedImportEdge[]): Violation[] {
+function checkCycles(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   return findValueImportCycles(edges).map((cycle) => ({
     rule: 'R4 value-import-cycle',
     file: cycle[0]!,
@@ -132,7 +124,7 @@ function checkCycles(edges: readonly ResolvedImportEdge[]): Violation[] {
   }));
 }
 
-function checkBackEdges(edges: readonly ResolvedImportEdge[]): Violation[] {
+function checkBackEdges(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   const seen = new Set<string>();
   return edges.flatMap((edge) => {
     const pair = backEdgePair(edge);
@@ -192,7 +184,7 @@ export const TYPE_INVERSION_BASELINE: Readonly<Record<string, number>> = {
   'mcp -> client': 1,
 };
 
-function checkTypeInversions(edges: readonly ResolvedImportEdge[]): Violation[] {
+function checkTypeInversions(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   const seen = new Set<string>();
   const countsByPair = new Map<string, number>();
   const firstEdgeByPair = new Map<string, ResolvedImportEdge>();
@@ -206,7 +198,7 @@ function checkTypeInversions(edges: readonly ResolvedImportEdge[]): Violation[] 
     if (!firstEdgeByPair.has(pair)) firstEdgeByPair.set(pair, edge);
   }
 
-  const violations: Violation[] = [];
+  const violations: LayeringViolation[] = [];
   for (const [pair, count] of [...countsByPair].sort(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -252,7 +244,7 @@ function checkTypeInversions(edges: readonly ResolvedImportEdge[]): Violation[] 
   return violations;
 }
 
-function checkSessionStateOwnership(sources: ReadonlyMap<string, string>): Violation[] {
+function checkSessionStateOwnership(sources: ReadonlyMap<string, string>): LayeringViolation[] {
   const types = sources.get('src/daemon/types.ts');
   if (!types) {
     return [
@@ -267,7 +259,7 @@ function checkSessionStateOwnership(sources: ReadonlyMap<string, string>): Viola
 
   const fields = sessionStateFields(types);
   const writes = findSessionStateWrites(sources, fields);
-  const violations: Violation[] = [];
+  const violations: LayeringViolation[] = [];
   const seenOwners = new Map<string, Set<string>>();
 
   // Parity first: the rule is only exhaustive if every declared field is classified. A field
@@ -362,7 +354,7 @@ function checkSessionStateOwnership(sources: ReadonlyMap<string, string>): Viola
 // R8: a CI job that runs with `install-deps: false` has no `node_modules`, so every script it
 // reaches must import only Node builtins and other repo files. Locally the opposite is true —
 // `node_modules` is always present — which is why this needs a gate rather than a convention.
-function checkZeroDepJobs(): Violation[] {
+function checkZeroDepJobs(): LayeringViolation[] {
   const workflows = readSources(
     execFileSync('git', ['ls-files', '.github/workflows/*.yml'], {
       cwd: repoRoot,
@@ -376,7 +368,7 @@ function checkZeroDepJobs(): Violation[] {
   };
   const packageScripts = new Map(Object.entries(packageJson.scripts ?? {}));
 
-  const violations: Violation[] = [];
+  const violations: LayeringViolation[] = [];
   for (const job of zeroDepJobs(workflows, fileExists, packageScripts)) {
     // Fail closed: a zero-dep job whose commands the entry scan cannot recognize would
     // otherwise be silently exempt from the rule it is the whole reason for.
@@ -407,19 +399,20 @@ function checkZeroDepJobs(): Violation[] {
   return violations;
 }
 
-/** R9 is growth-only, so a shrunk tree is reported rather than failed — see checkTypeCycleGrowth. */
+/** R9 is growth-only, so a shrunk tree is reported rather than failed by the ratchet. */
 function typeCycleNote(actual: number): string {
-  const baseline = TYPE_CYCLE_BASELINE;
-  if (actual >= baseline) return `the largest type-level cycle is ${actual} files (R9)`;
+  if (actual >= TYPE_CYCLE_BASELINE) {
+    return `the largest type-level cycle is ${actual} files (R9)`;
+  }
   return (
     `the largest type-level cycle is down to ${actual} files, under the R9 baseline of ` +
-    `${baseline} — lower the daemon modularity baseline when convenient`
+    `${TYPE_CYCLE_BASELINE} — lower the daemon modularity zone ceilings when convenient`
   );
 }
 
 function report(
   files: readonly string[],
-  violations: readonly Violation[],
+  violations: readonly LayeringViolation[],
   typeCycle: number,
 ): number {
   if (violations.length === 0) {
@@ -435,7 +428,7 @@ function report(
     return 0;
   }
 
-  const byRule = new Map<string, Violation[]>();
+  const byRule = new Map<string, LayeringViolation[]>();
   for (const violation of violations) {
     const group = byRule.get(violation.rule) ?? [];
     group.push(violation);

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { checkDaemonModularityRatchets, DAEMON_MODULARITY_BASELINE } from './daemon-modularity.ts';
+import { SESSION_STATE_FIELD_OWNERS, STORE_OWNED_SESSION_STATE_FIELDS } from './session-state.ts';
+import { resolveImportEdges, targetDagZone, type ResolvedImportEdge } from './model.ts';
+
+function importEdge(file: string, target: string): ResolvedImportEdge {
+  return {
+    file,
+    target,
+    spec: target,
+    line: 1,
+    dynamic: false,
+    typeOnly: true,
+    fromZone: targetDagZone(file),
+    toZone: targetDagZone(target),
+  };
+}
+
+function baselineDaemonTypesEdges(): ResolvedImportEdge[] {
+  return DAEMON_MODULARITY_BASELINE.externalDaemonTypesImporters.map((file) =>
+    importEdge(file, 'src/daemon/types.ts'),
+  );
+}
+
+test('daemon modularity baseline records the measured R7 ownership pressure', () => {
+  assert.equal(
+    Object.keys(SESSION_STATE_FIELD_OWNERS).length,
+    DAEMON_MODULARITY_BASELINE.sessionState.writerOwnedFields,
+  );
+  assert.equal(
+    Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
+    DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
+  );
+  assert.equal(
+    Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size,
+    41,
+  );
+  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 30);
+  assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);
+});
+
+test('external daemon/types.ts importer membership changes require the baseline to change', () => {
+  const edges = resolveImportEdges(
+    new Map([
+      ['src/client/new-importer.ts', "import type { DaemonRequest } from '../daemon/types.ts';"],
+      ['src/daemon/types.ts', 'export type DaemonRequest = { command: string };'],
+    ]),
+  );
+
+  const violations = checkDaemonModularityRatchets([...baselineDaemonTypesEdges(), ...edges], []);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0]!.message, /may only shrink from the recorded four/);
+
+  const removed = checkDaemonModularityRatchets(baselineDaemonTypesEdges().slice(1), []);
+  assert.equal(removed.length, 1);
+  assert.match(removed[0]!.message, /delete it from externalDaemonTypesImporters/);
+});
+
+test('planned logical modules start with zero forbidden imports', () => {
+  const edges = resolveImportEdges(
+    new Map([
+      ['src/replay/test/scheduler.ts', "import type { Device } from '../../platforms/device.ts';"],
+      ['src/platforms/device.ts', 'export type Device = { id: string };'],
+    ]),
+  );
+
+  const violations = checkDaemonModularityRatchets([...baselineDaemonTypesEdges(), ...edges], []);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0]!.message, /replay-test must not import/);
+});
+
+test('internal trees reject deep imports globally, including from daemon', () => {
+  const edges = resolveImportEdges(
+    new Map([
+      ['src/daemon/adapter.ts', "import type { Plan } from '../maestro/internal/plan.ts';"],
+      ['src/maestro/internal/plan.ts', 'export type Plan = { steps: number };'],
+    ]),
+  );
+
+  const violations = checkDaemonModularityRatchets([...baselineDaemonTypesEdges(), ...edges], []);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0]!.message, /must not import maestro's internal tree/);
+});
+
+test('R9 records zone ceilings and keeps engine files outside the largest component', () => {
+  const commandMembers = Array.from(
+    { length: DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers.commands + 1 },
+    (_, index) => `src/commands/probe-${index}.ts`,
+  );
+  const violations = checkDaemonModularityRatchets(baselineDaemonTypesEdges(), [
+    ...commandMembers,
+    'src/ad-replay/internal/engine.ts',
+  ]);
+
+  assert.equal(violations.length, 3);
+  assert.ok(violations.some(({ message }) => /contains 34 commands file/.test(message)));
+  assert.ok(violations.some(({ message }) => /contains 1 ad-replay file/.test(message)));
+  assert.ok(violations.some(({ message }) => /engine file entered/.test(message)));
+});

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -5,7 +5,7 @@ import {
   DAEMON_MODULARITY_BASELINE,
   TYPE_CYCLE_BASELINE,
 } from './daemon-modularity.ts';
-import { sessionStateFieldCount, SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
+import { SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
 import { resolveImportEdges, targetDagZone, type ResolvedImportEdge } from './model.ts';
 
 function importEdge(file: string, target: string): ResolvedImportEdge {
@@ -36,7 +36,6 @@ test('daemon modularity baseline records the measured R7 ownership pressure', ()
     Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
     DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
   );
-  assert.equal(sessionStateFieldCount(), 41);
   assert.equal(TYPE_CYCLE_BASELINE, 102);
   assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 30);
   assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { checkDaemonModularityRatchets, DAEMON_MODULARITY_BASELINE } from './daemon-modularity.ts';
-import { SESSION_STATE_FIELD_OWNERS, STORE_OWNED_SESSION_STATE_FIELDS } from './session-state.ts';
+import {
+  checkDaemonModularityRatchets,
+  DAEMON_MODULARITY_BASELINE,
+  TYPE_CYCLE_BASELINE,
+} from './daemon-modularity.ts';
+import { sessionStateFieldCount, SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
 import { resolveImportEdges, targetDagZone, type ResolvedImportEdge } from './model.ts';
 
 function importEdge(file: string, target: string): ResolvedImportEdge {
@@ -32,10 +36,8 @@ test('daemon modularity baseline records the measured R7 ownership pressure', ()
     Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
     DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
   );
-  assert.equal(
-    Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size,
-    41,
-  );
+  assert.equal(sessionStateFieldCount(), 41);
+  assert.equal(TYPE_CYCLE_BASELINE, 102);
   assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 30);
   assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);
 });
@@ -50,7 +52,7 @@ test('external daemon/types.ts importer membership changes require the baseline 
 
   const violations = checkDaemonModularityRatchets([...baselineDaemonTypesEdges(), ...edges], []);
   assert.equal(violations.length, 1);
-  assert.match(violations[0]!.message, /may only shrink from the recorded four/);
+  assert.match(violations[0]!.message, /may only shrink from the recorded 4/);
 
   const removed = checkDaemonModularityRatchets(baselineDaemonTypesEdges().slice(1), []);
   assert.equal(removed.length, 1);

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -1,12 +1,15 @@
 import path from 'node:path';
-import { SESSION_STATE_FIELD_OWNERS, STORE_OWNED_SESSION_STATE_FIELDS } from './session-state.ts';
-import { targetDagZone, type ResolvedImportEdge } from './model.ts';
+import { targetDagZone, type LayeringViolation, type ResolvedImportEdge } from './model.ts';
+import { SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
 
-export type LayeringViolation = {
-  rule: string;
-  file: string;
-  line: number;
-  message: string;
+const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
+  '(root)': 5,
+  client: 1,
+  commands: 33,
+  contracts: 2,
+  core: 12,
+  'daemon-server': 30,
+  platforms: 19,
 };
 
 export const DAEMON_MODULARITY_BASELINE = {
@@ -15,16 +18,7 @@ export const DAEMON_MODULARITY_BASELINE = {
     ownerFileClaims: 42,
   },
   largestTypeCycle: {
-    size: 102,
-    zoneMembers: {
-      '(root)': 5,
-      client: 1,
-      commands: 33,
-      contracts: 2,
-      core: 12,
-      'daemon-server': 30,
-      platforms: 19,
-    },
+    zoneMembers: LARGEST_TYPE_CYCLE_ZONE_CEILINGS,
   },
   externalDaemonTypesImporters: [
     'src/client/client-normalizers.ts',
@@ -34,7 +28,10 @@ export const DAEMON_MODULARITY_BASELINE = {
   ],
 } as const;
 
-export const TYPE_CYCLE_BASELINE = DAEMON_MODULARITY_BASELINE.largestTypeCycle.size;
+export const TYPE_CYCLE_BASELINE = Object.values(LARGEST_TYPE_CYCLE_ZONE_CEILINGS).reduce(
+  (sum, count) => sum + count,
+  0,
+);
 
 type LogicalModulePolicy = {
   name: string;
@@ -67,13 +64,7 @@ export const LOGICAL_MODULE_POLICIES: readonly LogicalModulePolicy[] = [
   {
     name: 'replay-test',
     roots: ['src/replay/test/'],
-    forbiddenTargetRoots: [
-      'src/daemon/',
-      'src/platforms/',
-      'src/providers/',
-      'src/ad-replay/internal/',
-      'src/maestro/internal/',
-    ],
+    forbiddenTargetRoots: ['src/daemon/', 'src/platforms/', 'src/providers/'],
   },
 ];
 
@@ -126,18 +117,22 @@ function checkSessionStateBaseline(): LayeringViolation[] {
 function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[] {
   const violations: LayeringViolation[] = [];
   const baseline = DAEMON_MODULARITY_BASELINE.largestTypeCycle;
-  if (members.length > baseline.size) {
+  if (members.length > TYPE_CYCLE_BASELINE) {
     violations.push({
       rule: 'R9 type-cycle-growth',
       file: 'scripts/layering/daemon-modularity.ts',
       line: 1,
-      message: `the largest type-level import cycle grew to ${members.length} files (baseline ${baseline.size}). Declare the shared type below both modules.`,
+      message:
+        `the largest type-level import cycle grew to ${members.length} files (baseline ` +
+        `${TYPE_CYCLE_BASELINE}). A type-only import that closes a loop makes every file in the ` +
+        `loop unreadable in isolation. Declare the shared type below both modules, or if the growth ` +
+        `is genuinely warranted, raise the zone ceilings in the same commit and say why.`,
     });
   }
 
   const zoneCounts = countBy(members, targetDagZone);
   for (const [zone, count] of zoneCounts) {
-    const allowed = baseline.zoneMembers[zone as keyof typeof baseline.zoneMembers] ?? 0;
+    const allowed = baseline.zoneMembers[zone] ?? 0;
     if (count <= allowed) continue;
     violations.push({
       rule: 'R10 daemon-modularity',
@@ -174,7 +169,8 @@ function checkDaemonTypesImporters(edges: readonly ResolvedImportEdge[]): Layeri
       file,
       line: edge.line,
       message:
-        'external production imports of daemon/types.ts may only shrink from the recorded four. Use an existing neutral contract; do not move DaemonRequest into contracts to satisfy this gate.',
+        `external production imports of daemon/types.ts may only shrink from the recorded ${allowed.size}. ` +
+        'Use an existing neutral contract; do not move DaemonRequest into contracts to satisfy this gate.',
     }));
   for (const file of allowed) {
     if (importers.has(file)) continue;
@@ -242,15 +238,10 @@ function countBy(values: readonly string[], keyOf: (value: string) => string): M
 
 export function daemonModularitySummary(): string {
   const session = DAEMON_MODULARITY_BASELINE.sessionState;
-  const cycle = DAEMON_MODULARITY_BASELINE.largestTypeCycle;
   return (
     `R10 pins R7 at ${session.writerOwnedFields} writer-owned fields / ` +
-    `${session.ownerFileClaims} owner claims, R9 at ${cycle.size} files with zone ceilings, ` +
+    `${session.ownerFileClaims} owner claims, R9 at ${TYPE_CYCLE_BASELINE} files with zone ceilings, ` +
     `${DAEMON_MODULARITY_BASELINE.externalDaemonTypesImporters.length} external daemon/types.ts importers, ` +
     'and zero forbidden logical-module imports'
   );
-}
-
-export function sessionStateFieldCount(): number {
-  return Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size;
 }

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -1,0 +1,256 @@
+import path from 'node:path';
+import { SESSION_STATE_FIELD_OWNERS, STORE_OWNED_SESSION_STATE_FIELDS } from './session-state.ts';
+import { targetDagZone, type ResolvedImportEdge } from './model.ts';
+
+export type LayeringViolation = {
+  rule: string;
+  file: string;
+  line: number;
+  message: string;
+};
+
+export const DAEMON_MODULARITY_BASELINE = {
+  sessionState: {
+    writerOwnedFields: 30,
+    ownerFileClaims: 42,
+  },
+  largestTypeCycle: {
+    size: 102,
+    zoneMembers: {
+      '(root)': 5,
+      client: 1,
+      commands: 33,
+      contracts: 2,
+      core: 12,
+      'daemon-server': 30,
+      platforms: 19,
+    },
+  },
+  externalDaemonTypesImporters: [
+    'src/client/client-normalizers.ts',
+    'src/compat/maestro/daemon-runtime-port-support.ts',
+    'src/compat/maestro/daemon-runtime-public-operation.ts',
+    'src/remote/daemon-artifacts.ts',
+  ],
+} as const;
+
+export const TYPE_CYCLE_BASELINE = DAEMON_MODULARITY_BASELINE.largestTypeCycle.size;
+
+type LogicalModulePolicy = {
+  name: string;
+  roots: readonly string[];
+  forbiddenTargetRoots: readonly string[];
+};
+
+/**
+ * Zero-count targets for the accepted daemon modularity design. A root may be absent today:
+ * the policy starts enforcing as soon as the first file is added, without scaffolding an empty
+ * façade or package merely to make the gate concrete.
+ */
+export const LOGICAL_MODULE_POLICIES: readonly LogicalModulePolicy[] = [
+  {
+    name: 'ad-replay',
+    roots: ['src/ad-replay/'],
+    forbiddenTargetRoots: [
+      'src/daemon/',
+      'src/platforms/',
+      'src/providers/',
+      'src/compat/',
+      'src/maestro/',
+    ],
+  },
+  {
+    name: 'maestro',
+    roots: ['src/maestro/'],
+    forbiddenTargetRoots: ['src/daemon/', 'src/platforms/', 'src/providers/', 'src/ad-replay/'],
+  },
+  {
+    name: 'replay-test',
+    roots: ['src/replay/test/'],
+    forbiddenTargetRoots: [
+      'src/daemon/',
+      'src/platforms/',
+      'src/providers/',
+      'src/ad-replay/internal/',
+      'src/maestro/internal/',
+    ],
+  },
+];
+
+const ENGINE_FILE_PREFIXES = [
+  'src/ad-replay/',
+  'src/maestro/',
+  'src/replay/',
+  'src/compat/maestro/',
+  'src/daemon/handlers/session-replay',
+  'src/daemon/handlers/session-test',
+] as const;
+
+export function checkDaemonModularityRatchets(
+  edges: readonly ResolvedImportEdge[],
+  largestTypeCycleMembers: readonly string[],
+): LayeringViolation[] {
+  return [
+    ...checkSessionStateBaseline(),
+    ...checkTypeCycleBaseline(largestTypeCycleMembers),
+    ...checkDaemonTypesImporters(edges),
+    ...checkLogicalModuleImports(edges),
+  ];
+}
+
+function checkSessionStateBaseline(): LayeringViolation[] {
+  const actual = {
+    writerOwnedFields: Object.keys(SESSION_STATE_FIELD_OWNERS).length,
+    ownerFileClaims: Object.values(SESSION_STATE_FIELD_OWNERS).reduce(
+      (sum, owners) => sum + owners.length,
+      0,
+    ),
+  };
+  const violations: LayeringViolation[] = [];
+  for (const metric of ['writerOwnedFields', 'ownerFileClaims'] as const) {
+    const baseline = DAEMON_MODULARITY_BASELINE.sessionState[metric];
+    if (actual[metric] === baseline) continue;
+    violations.push({
+      rule: 'R10 daemon-modularity',
+      file: 'scripts/layering/daemon-modularity.ts',
+      line: 1,
+      message:
+        actual[metric] > baseline
+          ? `R7 ${metric} grew to ${actual[metric]} (baseline ${baseline}). Route the new write through an existing owner instead.`
+          : `R7 ${metric} dropped to ${actual[metric]} — lower the daemon modularity baseline in the same capability move so it cannot regrow.`,
+    });
+  }
+  return violations;
+}
+
+function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[] {
+  const violations: LayeringViolation[] = [];
+  const baseline = DAEMON_MODULARITY_BASELINE.largestTypeCycle;
+  if (members.length > baseline.size) {
+    violations.push({
+      rule: 'R9 type-cycle-growth',
+      file: 'scripts/layering/daemon-modularity.ts',
+      line: 1,
+      message: `the largest type-level import cycle grew to ${members.length} files (baseline ${baseline.size}). Declare the shared type below both modules.`,
+    });
+  }
+
+  const zoneCounts = countBy(members, targetDagZone);
+  for (const [zone, count] of zoneCounts) {
+    const allowed = baseline.zoneMembers[zone as keyof typeof baseline.zoneMembers] ?? 0;
+    if (count <= allowed) continue;
+    violations.push({
+      rule: 'R10 daemon-modularity',
+      file: members.find((member) => targetDagZone(member) === zone) ?? 'scripts/layering/check.ts',
+      line: 1,
+      message: `the largest type cycle now contains ${count} ${zone} file(s) (baseline ${allowed}); extraction must not trade one zone's locality for another's.`,
+    });
+  }
+
+  for (const member of members) {
+    if (!ENGINE_FILE_PREFIXES.some((prefix) => member.startsWith(prefix))) continue;
+    violations.push({
+      rule: 'R10 daemon-modularity',
+      file: member,
+      line: 1,
+      message:
+        'an engine file entered the largest type cycle. Keep engine contracts neutral and adapters outside the engine so extraction does not worsen R9.',
+    });
+  }
+  return violations;
+}
+
+function checkDaemonTypesImporters(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
+  const allowed = new Set<string>(DAEMON_MODULARITY_BASELINE.externalDaemonTypesImporters);
+  const importers = new Map<string, ResolvedImportEdge>();
+  for (const edge of edges) {
+    if (edge.target !== 'src/daemon/types.ts' || edge.file.startsWith('src/daemon/')) continue;
+    importers.set(edge.file, edge);
+  }
+  const violations = [...importers]
+    .filter(([file]) => !allowed.has(file))
+    .map(([file, edge]) => ({
+      rule: 'R10 daemon-modularity',
+      file,
+      line: edge.line,
+      message:
+        'external production imports of daemon/types.ts may only shrink from the recorded four. Use an existing neutral contract; do not move DaemonRequest into contracts to satisfy this gate.',
+    }));
+  for (const file of allowed) {
+    if (importers.has(file)) continue;
+    violations.push({
+      rule: 'R10 daemon-modularity',
+      file: 'scripts/layering/daemon-modularity.ts',
+      line: 1,
+      message: `${file} no longer imports daemon/types.ts — delete it from externalDaemonTypesImporters in the same change so the dependency cannot return.`,
+    });
+  }
+  return violations;
+}
+
+function checkLogicalModuleImports(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
+  const violations: LayeringViolation[] = [];
+  for (const edge of edges) {
+    const sourceModule = moduleForFile(edge.file);
+    const targetModule = moduleForFile(edge.target);
+    if (
+      targetModule &&
+      sourceModule !== targetModule &&
+      isInsideInternalTree(edge.target, targetModule.roots)
+    ) {
+      violations.push({
+        rule: 'R10 daemon-modularity',
+        file: edge.file,
+        line: edge.line,
+        message: `${edge.file} must not import ${targetModule.name}'s internal tree (${edge.target}); use that module's façade.`,
+      });
+      continue;
+    }
+
+    if (!sourceModule) continue;
+    if (sourceModule.forbiddenTargetRoots.some((root) => edge.target.startsWith(root))) {
+      violations.push({
+        rule: 'R10 daemon-modularity',
+        file: edge.file,
+        line: edge.line,
+        message: `${sourceModule.name} must not import ${edge.target}; communicate through its façade and a narrow port with two real adapters.`,
+      });
+      continue;
+    }
+  }
+  return violations;
+}
+
+function moduleForFile(file: string): LogicalModulePolicy | undefined {
+  return LOGICAL_MODULE_POLICIES.find((module) =>
+    module.roots.some((root) => file.startsWith(root)),
+  );
+}
+
+function isInsideInternalTree(file: string, roots: readonly string[]): boolean {
+  return roots.some((root) => file.startsWith(path.posix.join(root, 'internal/')));
+}
+
+function countBy(values: readonly string[], keyOf: (value: string) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    const key = keyOf(value);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function daemonModularitySummary(): string {
+  const session = DAEMON_MODULARITY_BASELINE.sessionState;
+  const cycle = DAEMON_MODULARITY_BASELINE.largestTypeCycle;
+  return (
+    `R10 pins R7 at ${session.writerOwnedFields} writer-owned fields / ` +
+    `${session.ownerFileClaims} owner claims, R9 at ${cycle.size} files with zone ceilings, ` +
+    `${DAEMON_MODULARITY_BASELINE.externalDaemonTypesImporters.length} external daemon/types.ts importers, ` +
+    'and zero forbidden logical-module imports'
+  );
+}
+
+export function sessionStateFieldCount(): number {
+  return Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size;
+}

--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -12,6 +12,7 @@ import {
 } from './session-state.ts';
 import { uninstallableImports, zeroDepJobs } from './zero-dep-jobs.ts';
 import {
+  largestTypeCycleMembers,
   largestTypeCycleSize,
   RANKED_ZONES,
   typeInversionPair,
@@ -631,6 +632,11 @@ test('largestTypeCycleSize counts type-only cycles and ignores dynamic ones', ()
     ),
   );
   assert.equal(largestTypeCycleSize(typeCycle), 3);
+  assert.deepEqual(largestTypeCycleMembers(typeCycle), [
+    'src/core/a.ts',
+    'src/core/b.ts',
+    'src/core/c.ts',
+  ]);
 
   // A loop closed through a DYNAMIC import is excluded on purpose: a lazy seam is not a
   // comprehension barrier, and R3 relies on dynamic imports existing. With no non-dynamic edge at
@@ -644,6 +650,7 @@ test('largestTypeCycleSize counts type-only cycles and ignores dynamic ones', ()
     ),
   );
   assert.equal(largestTypeCycleSize(dynamicCycle), 0);
+  assert.deepEqual(largestTypeCycleMembers(dynamicCycle), []);
 
   // A value cycle counts too — R4 rejects it separately, so R9 must not be the thing that
   // notices, but it must not under-report either.

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -14,6 +14,13 @@ export type ResolvedImportEdge = ImportEdge & {
   toZone: string;
 };
 
+export type LayeringViolation = {
+  rule: string;
+  file: string;
+  line: number;
+  message: string;
+};
+
 export type BackEdgeMap = Record<string, string[]>;
 
 // The ranked target spine. Back-edge detection is defined ONLY between two ranked

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -344,8 +344,6 @@ export function collectBackEdges(edges: readonly ResolvedImportEdge[]): BackEdge
  * self-contained slice. Dynamic edges are excluded deliberately: a dynamic import is a lazy seam,
  * and a loop through one is not a comprehension barrier in the same way.
  *
- * Returned as a single number because that is all R9 ratchets.
- *
  * Floor semantics, which are specified rather than incidental: only files that participate in at
  * least one non-dynamic edge are considered, so an acyclic graph reports 1 (every such file is its
  * own trivial component) and a graph whose only edges are dynamic reports 0 (no file enters the
@@ -357,7 +355,7 @@ export function largestTypeCycleSize(edges: readonly ResolvedImportEdge[]): numb
 }
 
 /** Members of the largest value+type strongly-connected component, sorted. */
-function largestTypeCycleMembers(edges: readonly ResolvedImportEdge[]): string[] {
+export function largestTypeCycleMembers(edges: readonly ResolvedImportEdge[]): string[] {
   const successors = new Map<string, string[]>();
   for (const edge of edges) {
     if (edge.dynamic) continue;

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -125,6 +125,10 @@ export const STORE_OWNED_SESSION_STATE_FIELDS: ReadonlySet<string> = new Set([
   'surface',
 ]);
 
+export function sessionStateFieldCount(): number {
+  return Object.keys(SESSION_STATE_FIELD_OWNERS).length + STORE_OWNED_SESSION_STATE_FIELDS.size;
+}
+
 export type FieldClassificationDrift = {
   field: string;
   problem: 'unclassified' | 'both' | 'not-a-field';

--- a/src/daemon/handlers/__tests__/session-test-discovery.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-discovery.test.ts
@@ -219,3 +219,54 @@ test('discoverReplayTestEntries orders Maestro file inputs before expanded flows
     ['99-explicit.yaml', '01-directory.yaml', '02-glob.yaml'],
   );
 });
+
+test('discoverReplayTestEntries de-duplicates overlapping Maestro file and glob inputs', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-discovery-overlap-'));
+  const explicit = path.join(root, '02-explicit.yaml');
+  fs.writeFileSync(explicit, 'appId: demo\n---\n- launchApp\n');
+  fs.writeFileSync(path.join(root, '01-expanded.yaml'), 'appId: demo\n---\n- launchApp\n');
+
+  const entries = discoverReplayTestEntries({
+    inputs: [explicit, path.join(root, '*.yaml')],
+    cwd: root,
+    replayBackend: 'maestro',
+  });
+
+  assert.deepEqual(
+    entries.map((entry) => path.basename(entry.path)),
+    ['02-explicit.yaml', '01-expanded.yaml'],
+  );
+});
+
+test('discoverReplayTestEntries sorts mixed Maestro glob matches by YAML-first compatibility order', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-discovery-mixed-glob-'));
+  fs.writeFileSync(path.join(root, '20-zeta.yaml'), 'appId: demo\n---\n- launchApp\n');
+  fs.writeFileSync(path.join(root, '10-alpha.yml'), 'appId: demo\n---\n- launchApp\n');
+  fs.writeFileSync(path.join(root, '00-native.ad'), 'open "Demo"\n');
+  fs.writeFileSync(path.join(root, '30-native.ad'), 'open "Demo"\n');
+
+  const entries = discoverReplayTestEntries({
+    inputs: [path.join(root, '*.{yaml,yml,ad}')],
+    cwd: root,
+    replayBackend: 'maestro',
+  });
+
+  assert.deepEqual(
+    entries.map((entry) => path.basename(entry.path)),
+    ['10-alpha.yml', '20-zeta.yaml', '00-native.ad', '30-native.ad'],
+  );
+});
+
+test('discoverReplayTestEntries rejects YAML without explicit Maestro routing', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-discovery-yaml-route-'));
+  const flowPath = path.join(root, 'flow.yaml');
+  fs.writeFileSync(flowPath, 'appId: demo\n---\n- launchApp\n');
+
+  assert.throws(
+    () => discoverReplayTestEntries({ inputs: [flowPath], cwd: root }),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === `test does not support this file type: ${flowPath}`,
+  );
+});

--- a/src/replay/test/reporters/__tests__/custom.test.ts
+++ b/src/replay/test/reporters/__tests__/custom.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { AppError } from '../../../../kernel/errors.ts';
+import { createCustomReplayTestReporter } from '../custom.ts';
+
+test.each([
+  {
+    label: 'default reporter object',
+    source: "export default { name: 'default-object' };",
+    expectedName: 'default-object',
+  },
+  {
+    label: 'named reporter object',
+    source: "export const reporter = { name: 'named-object' };",
+    expectedName: 'named-object',
+  },
+  {
+    label: 'async createReporter factory',
+    source: [
+      'export async function createReporter(context) {',
+      "  return { name: context.spec === context.modulePath ? 'async-factory' : 'wrong-context' };",
+      '}',
+    ].join('\n'),
+    expectedName: 'async-factory',
+  },
+])('loads the shipped $label form', async ({ source, expectedName }) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-reporter-contract-'));
+  const modulePath = path.join(root, 'reporter.mjs');
+  try {
+    await fs.writeFile(modulePath, source, 'utf8');
+    const reporter = await createCustomReplayTestReporter({
+      kind: 'custom',
+      modulePath,
+      raw: modulePath,
+    });
+    assert.equal(reporter.name, expectedName);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects malformed reporter hooks when the module is loaded', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-reporter-invalid-'));
+  const modulePath = path.join(root, 'reporter.mjs');
+  try {
+    await fs.writeFile(
+      modulePath,
+      "export default { name: 'invalid', onSuiteEnd: 'not-a-function' };",
+      'utf8',
+    );
+    await assert.rejects(
+      createCustomReplayTestReporter({
+        kind: 'custom',
+        modulePath,
+        raw: modulePath,
+      }),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        /onSuiteEnd must be a function/.test(error.message),
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/replay/test/reporters/__tests__/registry.test.ts
+++ b/src/replay/test/reporters/__tests__/registry.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { ReplaySuiteResult } from '../../../../contracts/replay.ts';
+import {
+  getReplayTestReporterExitCode,
+  runReplayTestReporterProgress,
+  runReplayTestReporters,
+} from '../registry.ts';
+import type { ReplayTestReporter, ReplayTestReporterContext } from '../types.ts';
+
+const context: ReplayTestReporterContext = {
+  stdout: { isTTY: false, write() {} },
+  stderr: { isTTY: false, write() {} },
+};
+
+function suite(failed = 0): ReplaySuiteResult {
+  return {
+    total: 1,
+    executed: 1,
+    passed: failed === 0 ? 1 : 0,
+    failed,
+    skipped: 0,
+    notRun: 0,
+    durationMs: 1,
+    failures: [],
+    tests: [],
+  };
+}
+
+test('runs live hooks in reporter order and awaits final hooks sequentially', async () => {
+  const calls: string[] = [];
+  const reporters: ReplayTestReporter[] = [
+    {
+      name: 'first',
+      onTestResult() {
+        calls.push('first:live');
+      },
+      async onSuiteEnd() {
+        calls.push('first:end:start');
+        await Promise.resolve();
+        calls.push('first:end:done');
+      },
+    },
+    {
+      name: 'second',
+      onTestResult() {
+        calls.push('second:live');
+      },
+      onSuiteEnd() {
+        calls.push('second:end');
+      },
+    },
+  ];
+
+  runReplayTestReporterProgress(
+    reporters,
+    {
+      type: 'replay-test',
+      file: '/tmp/flow.ad',
+      status: 'pass',
+      index: 1,
+      total: 1,
+      durationMs: 1,
+    },
+    context,
+  );
+  await runReplayTestReporters(reporters, suite(), context);
+
+  assert.deepEqual(calls, [
+    'first:live',
+    'second:live',
+    'first:end:start',
+    'first:end:done',
+    'second:end',
+  ]);
+});
+
+test('reporter exit codes can raise but never lower the suite exit code', () => {
+  const reporters: ReplayTestReporter[] = [
+    { name: 'lower', getExitCode: () => 0 },
+    { name: 'higher', getExitCode: () => 3 },
+    { name: 'absent', getExitCode: () => undefined },
+  ];
+
+  assert.equal(getReplayTestReporterExitCode(reporters, suite(1)), 3);
+  assert.equal(
+    getReplayTestReporterExitCode([{ name: 'lower', getExitCode: () => 0 }], suite(1)),
+    1,
+  );
+});

--- a/src/replay/test/reporters/__tests__/registry.test.ts
+++ b/src/replay/test/reporters/__tests__/registry.test.ts
@@ -13,6 +13,23 @@ const context: ReplayTestReporterContext = {
   stderr: { isTTY: false, write() {} },
 };
 
+function createRecordingContext(): {
+  context: ReplayTestReporterContext;
+  stdout: string[];
+  stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    context: {
+      stdout: { isTTY: false, write: (text) => stdout.push(text) },
+      stderr: { isTTY: false, write: (text) => stderr.push(text) },
+    },
+    stdout,
+    stderr,
+  };
+}
+
 function suite(failed = 0): ReplaySuiteResult {
   return {
     total: 1,
@@ -73,6 +90,104 @@ test('runs live hooks in reporter order and awaits final hooks sequentially', as
     'first:end:done',
     'second:end',
   ]);
+});
+
+test('isolates thrown live-hook failures so later reporters and final rendering continue', async () => {
+  const output = createRecordingContext();
+  const calls: string[] = [];
+  const reporters: ReplayTestReporter[] = [
+    {
+      name: 'throwing',
+      onTestResult() {
+        calls.push('throwing:live');
+        throw new Error('sync boom');
+      },
+    },
+    {
+      name: 'renderer',
+      onTestResult(_test, reporterContext) {
+        calls.push('renderer:live');
+        reporterContext.stdout.write('live rendered\n');
+      },
+      onSuiteEnd(_suite, reporterContext) {
+        calls.push('renderer:end');
+        reporterContext.stdout.write('final rendered\n');
+      },
+    },
+  ];
+
+  runReplayTestReporterProgress(
+    reporters,
+    {
+      type: 'replay-test',
+      file: '/tmp/flow.ad',
+      status: 'pass',
+      index: 1,
+      total: 1,
+      durationMs: 1,
+    },
+    output.context,
+  );
+  await runReplayTestReporters(reporters, suite(), output.context);
+
+  assert.deepEqual(calls, ['throwing:live', 'renderer:live', 'renderer:end']);
+  assert.deepEqual(output.stdout, ['live rendered\n', 'final rendered\n']);
+  assert.deepEqual(output.stderr, ['Reporter throwing onTestResult failed: sync boom\n']);
+});
+
+test('reports rejected live hooks and never awaits pending live promises', async () => {
+  const output = createRecordingContext();
+  const calls: string[] = [];
+  let resolvePending!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    resolvePending = resolve;
+  });
+  const reporters: ReplayTestReporter[] = [
+    {
+      name: 'rejecting',
+      onTestResult() {
+        calls.push('rejecting:live');
+        return Promise.reject(new Error('async boom'));
+      },
+    },
+    {
+      name: 'pending',
+      onTestResult() {
+        calls.push('pending:live');
+        return pending;
+      },
+    },
+    {
+      name: 'later',
+      onTestResult() {
+        calls.push('later:live');
+      },
+      onSuiteEnd() {
+        calls.push('later:end');
+      },
+    },
+  ];
+
+  runReplayTestReporterProgress(
+    reporters,
+    {
+      type: 'replay-test',
+      file: '/tmp/flow.ad',
+      status: 'pass',
+      index: 1,
+      total: 1,
+      durationMs: 1,
+    },
+    output.context,
+  );
+
+  assert.deepEqual(calls, ['rejecting:live', 'pending:live', 'later:live']);
+  await Promise.resolve();
+  await Promise.resolve();
+  await runReplayTestReporters(reporters, suite(), output.context);
+  assert.deepEqual(calls, ['rejecting:live', 'pending:live', 'later:live', 'later:end']);
+  assert.deepEqual(output.stderr, ['Reporter rejecting onTestResult failed: async boom\n']);
+  resolvePending();
 });
 
 test('reporter exit codes can raise but never lower the suite exit code', () => {


### PR DESCRIPTION
## Summary

Pin the released behavior and architecture baselines needed to safely execute the daemon modularity work in #1478.

This adds characterization coverage for replay-test reporters and Maestro-compatible discovery, plus executable ratchets for SessionState ownership, dependency-cycle size and zone membership, external `daemon/types.ts` importers, logical-module direction, and private `internal/` trees. Production behavior is unchanged.

The ratchet implementation keeps one source of truth for each concept: the cycle total is derived from its zone ceilings, layering violations share one model type, and SessionState field counts live with the ownership model.

Scope is limited to P0: 12 touched files. P1 and the in-progress P2 cutover are intentionally excluded.

Part of #1478.

## Validation

`check:affected` passed formatting, lint, typecheck, layering, Fallow, metadata sync, build, and all 19 directly affected tests. The layering gate reports R6 at 7, all SessionState fields classified, R7 at 30 writer-owned fields / 42 owner claims, and R9 at 102 files.

The full unit lane saturated the host and produced unrelated five-second timeouts across eight files. All eight failure files were rerun serially; 173 tests passed, including an exact comparison run of the remaining Apple runner cancellation case on both `origin/main` and the PR head. CI remains authoritative for the full aggregate and platform jobs.

No device verification was required because this PR changes tests, documentation, and enforcement tooling only.
