### PR TITLE
fix: resolve qs Dependabot alert #55

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2535,8 +2535,8 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -5634,7 +5634,7 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
 
@@ -6023,7 +6023,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.2
       tunnel: 0.0.6
       underscore: 1.13.8
 


### PR DESCRIPTION
## Summary

Update the transitive `qs` dependency from 6.15.1 to 6.15.2 to resolve Dependabot alert #55 (GHSA-q8mj-m7cp-5q26 / CVE-2026-8723).

The dependency is reached through `@stryker-mutator/core` and `typed-rest-client`. This removes the vulnerable version from the repository lockfile without changing runtime source code.

## Validation

- Frozen pnpm install passed and resolved `qs@6.15.2`.
- Supply-chain policy, formatting, lint, typecheck, layering, Fallow, build, and unit validation passed.

Docs and skills were not changed because this is a lockfile-only dependency security fix.
