### PR TITLE
refactor: isolate Limrun construction dependencies

### DIFF
--- a/src/limrun-runtime-types.ts
+++ b/src/limrun-runtime-types.ts
@@ -1,0 +1,20 @@
+import type { AndroidAdbProvider } from './platforms/android/adb-executor.ts';
+import type {
+  AndroidKeyboardDismissResult,
+  AndroidKeyboardState,
+} from './platforms/android/device-input-state.ts';
+import type {
+  LimrunAndroidDeviceSession as InternalLimrunAndroidDeviceSession,
+  LimrunIosDeviceSession,
+} from './providers/limrun/device-session.ts';
+
+export type LimrunAndroidDeviceSession = Omit<
+  InternalLimrunAndroidDeviceSession,
+  'adb' | 'getKeyboardState' | 'dismissKeyboard'
+> & {
+  readonly adb: AndroidAdbProvider;
+  getKeyboardState(): Promise<AndroidKeyboardState>;
+  dismissKeyboard(): Promise<AndroidKeyboardDismissResult>;
+};
+
+export type LimrunDeviceSession = LimrunAndroidDeviceSession | LimrunIosDeviceSession;

--- a/src/provider-device-runtimes.ts
+++ b/src/provider-device-runtimes.ts
@@ -19,7 +19,7 @@ export async function createDefaultProviderDeviceRuntimes(
   const apiKey = env.LIMRUN_API_KEY?.trim();
   if (!apiKey) return runtimes;
 
-  const { LimrunRuntime } = await import('./providers/limrun/runtime.ts');
+  const { LimrunRuntime } = await import('./provider-limrun-runtime.ts');
   return [
     ...runtimes,
     new LimrunRuntime({

--- a/src/provider-limrun-runtime.ts
+++ b/src/provider-limrun-runtime.ts
@@ -23,15 +23,23 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
   // Called through ProviderDeviceRuntime composition and the public Limrun SDK.
   // fallow-ignore-next-line unused-class-member
   readonly provider = LIMRUN_PROVIDER;
-  readonly leaseLifecycle: LeaseLifecycleProvider;
-  readonly recoverExpiredLease: ProviderExpiredLeaseRecovery;
-  readonly deviceInventoryProvider: DeviceInventoryProvider;
 
   constructor(options: LimrunRuntimeOptions) {
     this.implementation = createLimrunRuntime(options, createLimrunRuntimeDependencies());
-    this.leaseLifecycle = this.implementation.leaseLifecycle;
-    this.recoverExpiredLease = this.implementation.recoverExpiredLease;
-    this.deviceInventoryProvider = this.implementation.deviceInventoryProvider;
+  }
+
+  get leaseLifecycle(): LeaseLifecycleProvider {
+    return this.implementation.leaseLifecycle;
+  }
+
+  get recoverExpiredLease(): ProviderExpiredLeaseRecovery {
+    return this.implementation.recoverExpiredLease;
+  }
+
+  // Called through ProviderDeviceRuntime composition.
+  // fallow-ignore-next-line unused-class-member
+  get deviceInventoryProvider(): DeviceInventoryProvider {
+    return this.implementation.deviceInventoryProvider;
   }
 
   // Called through ProviderDeviceRuntime composition and the public Limrun SDK.

--- a/src/provider-limrun-runtime.ts
+++ b/src/provider-limrun-runtime.ts
@@ -1,0 +1,81 @@
+import type {
+  DeviceInventoryProvider,
+  LeaseLifecycleProvider,
+  ProviderDeviceInstallOptions,
+  ProviderDeviceInstallResult,
+  ProviderDeviceRuntime,
+  ProviderExpiredLeaseRecovery,
+  ProviderPortReverseOptions,
+} from '@agent-device/contracts/device';
+import type { Interactor } from '@agent-device/contracts/interaction';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { LimrunDeviceSession } from './limrun-runtime-types.ts';
+import {
+  createLimrunRuntime,
+  type LimrunRuntime as LimrunRuntimeImplementation,
+  type LimrunRuntimeOptions,
+} from './providers/limrun/runtime.ts';
+import { LIMRUN_PROVIDER } from './providers/limrun/device.ts';
+import { createLimrunRuntimeDependencies } from './sdk/limrun-runtime-dependencies.ts';
+
+export class LimrunRuntime implements ProviderDeviceRuntime {
+  private readonly implementation: LimrunRuntimeImplementation;
+  // Called through ProviderDeviceRuntime composition and the public Limrun SDK.
+  // fallow-ignore-next-line unused-class-member
+  readonly provider = LIMRUN_PROVIDER;
+  readonly leaseLifecycle: LeaseLifecycleProvider;
+  readonly recoverExpiredLease: ProviderExpiredLeaseRecovery;
+  readonly deviceInventoryProvider: DeviceInventoryProvider;
+
+  constructor(options: LimrunRuntimeOptions) {
+    this.implementation = createLimrunRuntime(options, createLimrunRuntimeDependencies());
+    this.leaseLifecycle = this.implementation.leaseLifecycle;
+    this.recoverExpiredLease = this.implementation.recoverExpiredLease;
+    this.deviceInventoryProvider = this.implementation.deviceInventoryProvider;
+  }
+
+  // Called through ProviderDeviceRuntime composition and the public Limrun SDK.
+  // fallow-ignore-next-line unused-class-member
+  ownsDevice(device: DeviceInfo): boolean {
+    return this.implementation.ownsDevice(device);
+  }
+
+  getInteractor(device: DeviceInfo): Interactor | undefined {
+    return this.implementation.getInteractor(device);
+  }
+
+  getDeviceSession(device: DeviceInfo): LimrunDeviceSession | undefined {
+    return this.implementation.getDeviceSession(device) as LimrunDeviceSession | undefined;
+  }
+
+  async installApp(
+    device: DeviceInfo,
+    app: string,
+    appPath: string,
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined> {
+    return await this.implementation.installApp?.(device, app, appPath, options);
+  }
+
+  // Called through ProviderDeviceRuntime composition and the public Limrun SDK.
+  // fallow-ignore-next-line unused-class-member
+  async installInstallablePath(
+    device: DeviceInfo,
+    installablePath: string,
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined> {
+    return await this.implementation.installInstallablePath?.(device, installablePath, options);
+  }
+
+  async configurePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
+    return await this.implementation.configurePortReverse?.(options);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.implementation.shutdown();
+  }
+}
+
+export type { LimrunRuntimeOptions };

--- a/src/providers/limrun/android.ts
+++ b/src/providers/limrun/android.ts
@@ -33,7 +33,7 @@ type LimrunAndroidAdbSession = {
   adbTunnel?: LimrunAdbTunnel;
   adbSerial?: string;
   adbTunnelPromise?: Promise<string>;
-  dependencies: Pick<LimrunRuntimeDependencies, 'android' | 'host'>;
+  readonly dependencies: Pick<LimrunRuntimeDependencies, 'android' | 'host'>;
 };
 
 export type LimrunAndroidSession = LimrunAndroidAdbSession & {
@@ -71,7 +71,7 @@ export async function createLimrunAndroidSession(
       await client.setText(request.target, request.text);
     },
   };
-  adbProvider.reverse = await dependencies.android.createPortReverse(adbProvider);
+  adbProvider.reverse = await dependencies.android.createPortReverse(adbProvider.exec);
   return Object.assign(session, { adbProvider });
 }
 

--- a/src/providers/limrun/android.ts
+++ b/src/providers/limrun/android.ts
@@ -71,7 +71,7 @@ export async function createLimrunAndroidSession(
       await client.setText(request.target, request.text);
     },
   };
-  adbProvider.reverse = dependencies.android.createPortReverse(adbProvider);
+  adbProvider.reverse = await dependencies.android.createPortReverse(adbProvider);
   return Object.assign(session, { adbProvider });
 }
 
@@ -96,7 +96,9 @@ export async function installLimrunAndroidApp(
     name: buildAndroidAssetName(packageName, installablePath),
   });
   await session.client.sendAsset(asset.signedDownloadUrl);
-  const appName = packageName ? session.dependencies.android.inferAppName(packageName) : undefined;
+  const appName = packageName
+    ? await session.dependencies.android.inferAppName(packageName)
+    : undefined;
   return {
     ...(packageName ? { packageName, launchTarget: packageName } : {}),
     ...(appName ? { appName } : {}),
@@ -186,7 +188,7 @@ async function requireSuccessfulLimrunAndroidAdb(
   dependencies: Pick<LimrunRuntimeDependencies, 'android'>,
 ): Promise<LimrunAdbCommandResult> {
   if (result.exitCode !== 0 && allowFailure !== true) {
-    throw dependencies.android.adbError('Limrun Android ADB command failed', result, {
+    throw await dependencies.android.adbError('Limrun Android ADB command failed', result, {
       command: ['adb', ...adbArgs].join(' '),
     });
   }

--- a/src/providers/limrun/android.ts
+++ b/src/providers/limrun/android.ts
@@ -4,7 +4,6 @@ import {
   createInstanceClient as createAndroidInstanceClient,
   type InstanceClient as LimrunAndroidClient,
 } from '@limrun/api/instance-client';
-import { createAndroidInteractor } from '../../core/interactors/android.ts';
 import type { Interactor } from '@agent-device/contracts/interaction';
 import type {
   DeviceLease,
@@ -14,13 +13,13 @@ import type {
 } from '@agent-device/contracts/device';
 import { AppError } from '@agent-device/kernel/errors';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import {
-  type AndroidAdbExecutorOptions,
-  type AndroidAdbExecutorResult,
-  type AndroidAdbProvider,
-  type AndroidPortReverseEndpoint,
-} from '../../platforms/android/adb-executor.ts';
-import { runCmd } from '../../utils/exec.ts';
+import type {
+  LimrunAdbCommandOptions,
+  LimrunAdbCommandResult,
+  LimrunAdbProvider,
+  LimrunPortReverseEndpoint,
+  LimrunRuntimeDependencies,
+} from './runtime-dependencies.ts';
 import { normalizeOptionalString } from './strings.ts';
 
 type LimrunAdbTunnel = Awaited<ReturnType<LimrunAndroidClient['startAdbTunnel']>>;
@@ -34,20 +33,24 @@ type LimrunAndroidAdbSession = {
   adbTunnel?: LimrunAdbTunnel;
   adbSerial?: string;
   adbTunnelPromise?: Promise<string>;
+  dependencies: Pick<LimrunRuntimeDependencies, 'android' | 'host'>;
 };
 
 export type LimrunAndroidSession = LimrunAndroidAdbSession & {
-  adbProvider: AndroidAdbProvider;
+  adbProvider: LimrunAdbProvider;
 };
 
-export async function createLimrunAndroidSession(options: {
-  lease: DeviceLease;
-  instanceId: string;
-  device: DeviceInfo;
-  apiUrl: string;
-  adbUrl: string;
-  token: string;
-}): Promise<LimrunAndroidSession> {
+export async function createLimrunAndroidSession(
+  options: {
+    lease: DeviceLease;
+    instanceId: string;
+    device: DeviceInfo;
+    apiUrl: string;
+    adbUrl: string;
+    token: string;
+  },
+  dependencies: Pick<LimrunRuntimeDependencies, 'android' | 'host'>,
+): Promise<LimrunAndroidSession> {
   const client = await createAndroidInstanceClient({
     apiUrl: options.apiUrl,
     adbUrl: options.adbUrl,
@@ -60,21 +63,20 @@ export async function createLimrunAndroidSession(options: {
     instanceId: options.instanceId,
     device: options.device,
     client,
+    dependencies,
   };
-  const adbProvider: AndroidAdbProvider = {
+  const adbProvider: LimrunAdbProvider = {
     exec: async (args, execOptions) => await runLimrunAndroidAdb(session, args, execOptions),
     text: async (request) => {
       await client.setText(request.target, request.text);
     },
   };
-  const { createAndroidPortReverseManager } =
-    await import('../../platforms/android/adb-executor.ts');
-  adbProvider.reverse = createAndroidPortReverseManager(adbProvider);
+  adbProvider.reverse = dependencies.android.createPortReverse(adbProvider);
   return Object.assign(session, { adbProvider });
 }
 
 export function createLimrunAndroidInteractor(session: LimrunAndroidSession): Interactor {
-  return createAndroidInteractor(session.device, session.adbProvider);
+  return session.dependencies.android.createInteractor(session.device, session.adbProvider);
 }
 
 export async function installLimrunAndroidApp(
@@ -94,9 +96,7 @@ export async function installLimrunAndroidApp(
     name: buildAndroidAssetName(packageName, installablePath),
   });
   await session.client.sendAsset(asset.signedDownloadUrl);
-  const appName = packageName
-    ? (await import('../../platforms/android/app-lifecycle.ts')).inferAndroidAppName(packageName)
-    : undefined;
+  const appName = packageName ? session.dependencies.android.inferAppName(packageName) : undefined;
   return {
     ...(packageName ? { packageName, launchTarget: packageName } : {}),
     ...(appName ? { appName } : {}),
@@ -119,10 +119,12 @@ export async function cleanupLimrunAndroidAdbTunnel(session: LimrunAndroidSessio
   const serial = session.adbSerial;
   if (serial) {
     await cleanupAndroidPortReverse(session);
-    await runCmd('adb', ['disconnect', serial], {
-      allowFailure: true,
-      timeoutMs: 10_000,
-    }).catch(() => {});
+    await session.dependencies.host
+      .runAdb(['disconnect', serial], {
+        allowFailure: true,
+        timeoutMs: 10_000,
+      })
+      .catch(() => {});
   }
   session.adbTunnel?.close();
   session.adbTunnel = undefined;
@@ -135,7 +137,7 @@ async function cleanupAndroidPortReverse(session: LimrunAndroidSession): Promise
   if (!reverse?.list) return;
   const mappings = await reverse.list().catch(() => []);
   const owners = new Set<string>();
-  const unownedLocals: AndroidPortReverseEndpoint[] = [];
+  const unownedLocals: LimrunPortReverseEndpoint[] = [];
   for (const mapping of mappings) {
     if (mapping.ownerId) owners.add(mapping.ownerId);
     else unownedLocals.push(mapping.local);
@@ -149,20 +151,25 @@ async function cleanupAndroidPortReverse(session: LimrunAndroidSession): Promise
 async function runLimrunAndroidAdb(
   session: LimrunAndroidAdbSession,
   args: string[],
-  options?: AndroidAdbExecutorOptions,
-): Promise<AndroidAdbExecutorResult> {
+  options?: LimrunAdbCommandOptions,
+): Promise<LimrunAdbCommandResult> {
   const { adbArgs, result } = await executeLimrunAndroidAdb(session, args, options);
-  return await requireSuccessfulLimrunAndroidAdb(adbArgs, result, options?.allowFailure);
+  return await requireSuccessfulLimrunAndroidAdb(
+    adbArgs,
+    result,
+    options?.allowFailure,
+    session.dependencies,
+  );
 }
 
 async function executeLimrunAndroidAdb(
   session: LimrunAndroidAdbSession,
   args: string[],
-  options?: AndroidAdbExecutorOptions,
-): Promise<{ adbArgs: string[]; result: AndroidAdbExecutorResult }> {
+  options?: LimrunAdbCommandOptions,
+): Promise<{ adbArgs: string[]; result: LimrunAdbCommandResult }> {
   const serial = await ensurePersistentAndroidAdbSerial(session);
   const adbArgs = ['-s', serial, ...args];
-  const result = await runCmd('adb', adbArgs, {
+  const result = await session.dependencies.host.runAdb(adbArgs, {
     allowFailure: options?.allowFailure,
     binaryStdout: options?.binaryStdout,
     stdin: options?.stdin,
@@ -174,12 +181,12 @@ async function executeLimrunAndroidAdb(
 
 async function requireSuccessfulLimrunAndroidAdb(
   adbArgs: string[],
-  result: AndroidAdbExecutorResult,
+  result: LimrunAdbCommandResult,
   allowFailure: boolean | undefined,
-): Promise<AndroidAdbExecutorResult> {
+  dependencies: Pick<LimrunRuntimeDependencies, 'android'>,
+): Promise<LimrunAdbCommandResult> {
   if (result.exitCode !== 0 && allowFailure !== true) {
-    const { androidAdbResultError } = await import('../../platforms/android/adb-executor.ts');
-    throw androidAdbResultError('Limrun Android ADB command failed', result, {
+    throw dependencies.android.adbError('Limrun Android ADB command failed', result, {
       command: ['adb', ...adbArgs].join(' '),
     });
   }
@@ -206,7 +213,7 @@ async function startAndroidAdbTunnel(session: LimrunAndroidAdbSession): Promise<
   return serial;
 }
 
-function tcpEndpoint(port: number): AndroidPortReverseEndpoint {
+function tcpEndpoint(port: number): LimrunPortReverseEndpoint {
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new AppError('INVALID_ARGS', `Invalid Android tcp reverse port: ${port}`);
   }

--- a/src/providers/limrun/device-session.test.ts
+++ b/src/providers/limrun/device-session.test.ts
@@ -2,18 +2,68 @@ import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 import type { DeviceLease } from '@agent-device/contracts/device';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type {
-  AndroidAdbExecutor,
-  AndroidAdbProvider,
+import { createAndroidInteractor } from '../../core/interactors/android.ts';
+import {
+  androidAdbResultError,
+  createAndroidPortReverseManager,
+  type AndroidAdbExecutor,
+  type AndroidAdbProvider,
 } from '../../platforms/android/adb-executor.ts';
+import {
+  getAndroidAppStateWithAdb,
+  listAndroidAppsWithAdb,
+} from '../../platforms/android/app-helpers.ts';
+import { inferAndroidAppName } from '../../platforms/android/app-lifecycle.ts';
+import {
+  dismissAndroidKeyboardWithAdb,
+  getAndroidKeyboardStatusWithAdb,
+} from '../../platforms/android/device-input-state.ts';
+import { captureAndroidLogcatWithAdb } from '../../platforms/android/logcat.ts';
 import type { LimrunAndroidSession } from './android.ts';
 import { createLimrunDeviceSession, type LimrunIosCommandExecution } from './device-session.ts';
 import type { LimrunIosSession } from './ios.ts';
+import type { LimrunRuntimeDependencies } from './runtime-dependencies.ts';
 
 const IOS_APPS = [
   { bundleId: 'com.apple.Preferences', name: 'Settings', installType: 'System' },
   { bundleId: 'com.example.ios', name: 'Example', installType: 'User' },
 ];
+
+const TEST_IOS_ADAPTER = {
+  resolveAppAlias: (app: string) => app,
+  readBundleAppName: async () => undefined,
+};
+
+const TEST_ANDROID_DEPENDENCIES = {
+  android: {
+    createInteractor: createAndroidInteractor,
+    createPortReverse: createAndroidPortReverseManager,
+    inferAppName: inferAndroidAppName,
+    listApps: async (adb, filter) =>
+      (
+        await listAndroidAppsWithAdb(adb, {
+          filter,
+          target: 'mobile',
+        })
+      ).map((app) => ({ id: app.package, name: app.name })),
+    getForegroundApp: async (adb) => {
+      const app = await getAndroidAppStateWithAdb(adb);
+      return app.package ? { appId: app.package, activity: app.activity } : undefined;
+    },
+    getKeyboardState: getAndroidKeyboardStatusWithAdb,
+    dismissKeyboard: dismissAndroidKeyboardWithAdb,
+    readLogs: async (adb, lineLimit) =>
+      await captureAndroidLogcatWithAdb(adb, {
+        lines: lineLimit,
+        timeoutMs: 5_000,
+      }),
+    adbError: androidAdbResultError,
+  },
+  host: {
+    runAdb: async () => adbResult(''),
+    archiveDirectory: async () => undefined,
+  },
+} satisfies Pick<LimrunRuntimeDependencies, 'android' | 'host'>;
 
 test('iOS device session exposes reusable capabilities without its raw client', async () => {
   const pressKey = vi.fn(async () => undefined);
@@ -32,6 +82,7 @@ test('iOS device session exposes reusable capabilities without its raw client', 
       stopRecording,
       simctl,
     }),
+    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'ios');
@@ -81,6 +132,7 @@ test('iOS remote install waits for eventually consistent app inventory', async (
       listApps,
       installApp,
     }),
+    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'ios');
@@ -127,6 +179,7 @@ test('Android device session exposes semantic ADB capabilities without its raw c
   const sendAsset = vi.fn(async () => undefined);
   const session = createLimrunDeviceSession(
     androidSession(provider, { pressKey, startRecording, stopRecording, sendAsset }),
+    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'android');
@@ -179,6 +232,7 @@ function androidSession(
     device: device('android'),
     client,
     adbProvider,
+    dependencies: TEST_ANDROID_DEPENDENCIES,
   } as unknown as LimrunAndroidSession;
 }
 

--- a/src/providers/limrun/device-session.test.ts
+++ b/src/providers/limrun/device-session.test.ts
@@ -29,12 +29,8 @@ const IOS_APPS = [
   { bundleId: 'com.example.ios', name: 'Example', installType: 'User' },
 ];
 
-const TEST_IOS_ADAPTER = {
-  resolveAppAlias: async (app: string) => app,
-  readBundleAppName: async () => undefined,
-};
-
-const TEST_ANDROID_DEPENDENCIES = {
+const TEST_DEPENDENCIES = {
+  clientVersion: 'test-version',
   android: {
     createInteractor: createAndroidInteractor,
     createPortReverse: async (adb) => createAndroidPortReverseManager(adb),
@@ -63,7 +59,11 @@ const TEST_ANDROID_DEPENDENCIES = {
     runAdb: async () => adbResult(''),
     archiveDirectory: async () => undefined,
   },
-} satisfies Pick<LimrunRuntimeDependencies, 'android' | 'host'>;
+  ios: {
+    resolveAppAlias: async (app: string) => app,
+    readBundleAppName: async () => undefined,
+  },
+} satisfies LimrunRuntimeDependencies;
 
 test('iOS device session exposes reusable capabilities without its raw client', async () => {
   const pressKey = vi.fn(async () => undefined);
@@ -82,7 +82,6 @@ test('iOS device session exposes reusable capabilities without its raw client', 
       stopRecording,
       simctl,
     }),
-    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'ios');
@@ -132,7 +131,6 @@ test('iOS remote install waits for eventually consistent app inventory', async (
       listApps,
       installApp,
     }),
-    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'ios');
@@ -179,7 +177,6 @@ test('Android device session exposes semantic ADB capabilities without its raw c
   const sendAsset = vi.fn(async () => undefined);
   const session = createLimrunDeviceSession(
     androidSession(provider, { pressKey, startRecording, stopRecording, sendAsset }),
-    TEST_IOS_ADAPTER,
   );
 
   assert.equal(session.platform, 'android');
@@ -218,6 +215,7 @@ function iosSession(client: Record<string, unknown>): LimrunIosSession {
     instanceId: 'ios-instance',
     device: device('ios'),
     client,
+    dependencies: TEST_DEPENDENCIES,
   } as unknown as LimrunIosSession;
 }
 
@@ -232,7 +230,7 @@ function androidSession(
     device: device('android'),
     client,
     adbProvider,
-    dependencies: TEST_ANDROID_DEPENDENCIES,
+    dependencies: TEST_DEPENDENCIES,
   } as unknown as LimrunAndroidSession;
 }
 

--- a/src/providers/limrun/device-session.test.ts
+++ b/src/providers/limrun/device-session.test.ts
@@ -30,15 +30,15 @@ const IOS_APPS = [
 ];
 
 const TEST_IOS_ADAPTER = {
-  resolveAppAlias: (app: string) => app,
+  resolveAppAlias: async (app: string) => app,
   readBundleAppName: async () => undefined,
 };
 
 const TEST_ANDROID_DEPENDENCIES = {
   android: {
     createInteractor: createAndroidInteractor,
-    createPortReverse: createAndroidPortReverseManager,
-    inferAppName: inferAndroidAppName,
+    createPortReverse: async (adb) => createAndroidPortReverseManager(adb),
+    inferAppName: async (packageName) => inferAndroidAppName(packageName),
     listApps: async (adb, filter) =>
       (
         await listAndroidAppsWithAdb(adb, {
@@ -57,7 +57,7 @@ const TEST_ANDROID_DEPENDENCIES = {
         lines: lineLimit,
         timeoutMs: 5_000,
       }),
-    adbError: androidAdbResultError,
+    adbError: async (message, result, details) => androidAdbResultError(message, result, details),
   },
   host: {
     runAdb: async () => adbResult(''),

--- a/src/providers/limrun/device-session.ts
+++ b/src/providers/limrun/device-session.ts
@@ -1,11 +1,12 @@
 import type { Interactor } from '@agent-device/contracts/interaction';
 import { resolveAppsFilter, type AppsFilter } from '@agent-device/contracts/device';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { AndroidAdbProvider } from '../../platforms/android/adb-executor.ts';
 import type {
-  AndroidKeyboardDismissResult,
-  AndroidKeyboardState,
-} from '../../platforms/android/device-input-state.ts';
+  LimrunAdbProvider,
+  LimrunAndroidKeyboardDismissResult,
+  LimrunAndroidKeyboardState,
+  LimrunIosRuntimeAdapter,
+} from './runtime-dependencies.ts';
 import { createLimrunAndroidInteractor, type LimrunAndroidSession } from './android.ts';
 import {
   createLimrunIosInteractor,
@@ -69,10 +70,10 @@ type LimrunRecordingClient = {
 
 export type LimrunAndroidDeviceSession = LimrunDeviceSessionBase & {
   readonly platform: 'android';
-  readonly adb: AndroidAdbProvider;
+  readonly adb: LimrunAdbProvider;
   getForegroundApp(): Promise<LimrunForegroundApp | undefined>;
-  getKeyboardState(): Promise<AndroidKeyboardState>;
-  dismissKeyboard(): Promise<AndroidKeyboardDismissResult>;
+  getKeyboardState(): Promise<LimrunAndroidKeyboardState>;
+  dismissKeyboard(): Promise<LimrunAndroidKeyboardDismissResult>;
   readLogs(lineLimit: number): Promise<string>;
   installRemoteApp(url: string): Promise<void>;
 };
@@ -92,10 +93,11 @@ export type LimrunDeviceSession = LimrunAndroidDeviceSession | LimrunIosDeviceSe
 
 export function createLimrunDeviceSession(
   session: LimrunAndroidSession | LimrunIosSession,
+  ios: LimrunIosRuntimeAdapter,
 ): LimrunDeviceSession {
   return session.platform === 'android'
     ? createAndroidDeviceSession(session)
-    : createIosDeviceSession(session);
+    : createIosDeviceSession(session, ios);
 }
 
 function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroidDeviceSession {
@@ -105,43 +107,15 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
     device: session.device,
     interactor: createLimrunAndroidInteractor(session),
     adb: session.adbProvider,
-    listApps: async (filter) => {
-      const { listAndroidAppsWithAdb } = await import('../../platforms/android/app-helpers.ts');
-      return (
-        await listAndroidAppsWithAdb(adb, {
-          filter: resolveAppsFilter(filter),
-          target: 'mobile',
-        })
-      ).map((app) => ({
-        id: app.package,
-        name: app.name,
-      }));
-    },
-    getForegroundApp: async () => {
-      const { getAndroidAppStateWithAdb } = await import('../../platforms/android/app-helpers.ts');
-      const app = await getAndroidAppStateWithAdb(adb);
-      return app.package ? { appId: app.package, activity: app.activity } : undefined;
-    },
+    listApps: async (filter) =>
+      await session.dependencies.android.listApps(adb, resolveAppsFilter(filter)),
+    getForegroundApp: async () => await session.dependencies.android.getForegroundApp(adb),
     pressKey: async (key, modifiers) => {
       await session.client.pressKey(key, modifiers);
     },
-    getKeyboardState: async () => {
-      const { getAndroidKeyboardStatusWithAdb } =
-        await import('../../platforms/android/device-input-state.ts');
-      return await getAndroidKeyboardStatusWithAdb(adb);
-    },
-    dismissKeyboard: async () => {
-      const { dismissAndroidKeyboardWithAdb } =
-        await import('../../platforms/android/device-input-state.ts');
-      return await dismissAndroidKeyboardWithAdb(adb);
-    },
-    readLogs: async (lineLimit) => {
-      const { captureAndroidLogcatWithAdb } = await import('../../platforms/android/logcat.ts');
-      return await captureAndroidLogcatWithAdb(adb, {
-        lines: lineLimit,
-        timeoutMs: 5_000,
-      });
-    },
+    getKeyboardState: async () => await session.dependencies.android.getKeyboardState(adb),
+    dismissKeyboard: async () => await session.dependencies.android.dismissKeyboard(adb),
+    readLogs: async (lineLimit) => await session.dependencies.android.readLogs(adb, lineLimit),
     ...createRecordingOperations(session.client),
     installRemoteApp: async (url) => {
       await session.client.sendAsset(url);
@@ -149,11 +123,14 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
   };
 }
 
-function createIosDeviceSession(session: LimrunIosSession): LimrunIosDeviceSession {
+function createIosDeviceSession(
+  session: LimrunIosSession,
+  ios: LimrunIosRuntimeAdapter,
+): LimrunIosDeviceSession {
   return {
     platform: 'ios',
     device: session.device,
-    interactor: createLimrunIosInteractor(session),
+    interactor: createLimrunIosInteractor(session, ios),
     viewport: {
       width: session.client.deviceInfo.screenWidth,
       height: session.client.deviceInfo.screenHeight,

--- a/src/providers/limrun/device-session.ts
+++ b/src/providers/limrun/device-session.ts
@@ -5,7 +5,6 @@ import type {
   LimrunAdbProvider,
   LimrunAndroidKeyboardDismissResult,
   LimrunAndroidKeyboardState,
-  LimrunIosRuntimeAdapter,
 } from './runtime-dependencies.ts';
 import { createLimrunAndroidInteractor, type LimrunAndroidSession } from './android.ts';
 import {
@@ -93,11 +92,10 @@ export type LimrunDeviceSession = LimrunAndroidDeviceSession | LimrunIosDeviceSe
 
 export function createLimrunDeviceSession(
   session: LimrunAndroidSession | LimrunIosSession,
-  ios: LimrunIosRuntimeAdapter,
 ): LimrunDeviceSession {
   return session.platform === 'android'
     ? createAndroidDeviceSession(session)
-    : createIosDeviceSession(session, ios);
+    : createIosDeviceSession(session);
 }
 
 function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroidDeviceSession {
@@ -123,14 +121,11 @@ function createAndroidDeviceSession(session: LimrunAndroidSession): LimrunAndroi
   };
 }
 
-function createIosDeviceSession(
-  session: LimrunIosSession,
-  ios: LimrunIosRuntimeAdapter,
-): LimrunIosDeviceSession {
+function createIosDeviceSession(session: LimrunIosSession): LimrunIosDeviceSession {
   return {
     platform: 'ios',
     device: session.device,
-    interactor: createLimrunIosInteractor(session, ios),
+    interactor: createLimrunIosInteractor(session),
     viewport: {
       width: session.client.deviceInfo.screenWidth,
       height: session.client.deviceInfo.screenHeight,

--- a/src/providers/limrun/ios.ts
+++ b/src/providers/limrun/ios.ts
@@ -146,7 +146,7 @@ class LimrunIosInteractor implements Interactor {
 
   async open(app: string, options?: { url?: string }): Promise<void> {
     if (options?.url) {
-      await this.session.client.launchApp(this.ios.resolveAppAlias(app));
+      await this.session.client.launchApp(await this.ios.resolveAppAlias(app));
       await this.session.client.openUrl(options.url);
       return;
     }
@@ -154,13 +154,15 @@ class LimrunIosInteractor implements Interactor {
       await this.session.client.openUrl(app);
       return;
     }
-    await this.session.client.launchApp(this.ios.resolveAppAlias(app));
+    await this.session.client.launchApp(await this.ios.resolveAppAlias(app));
   }
 
   async openDevice(): Promise<void> {}
 
   async close(app: string): Promise<void> {
-    if (app) await this.session.client.terminateApp(this.ios.resolveAppAlias(app)).catch(() => {});
+    if (app) {
+      await this.session.client.terminateApp(await this.ios.resolveAppAlias(app)).catch(() => {});
+    }
   }
 
   async tap(x: number, y: number): Promise<void> {

--- a/src/providers/limrun/ios.ts
+++ b/src/providers/limrun/ios.ts
@@ -20,10 +20,10 @@ import {
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFailureDetails, runCmd } from '../../utils/exec.ts';
-import { sleep } from '../../utils/timeouts.ts';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { flattenIosTree, toIosSelector, writeBase64File, type IosTreeNode } from './snapshot.ts';
 import { normalizeOptionalString } from './strings.ts';
+import type { LimrunIosRuntimeAdapter, LimrunRuntimeDependencies } from './runtime-dependencies.ts';
 
 export type LimrunIosSession = {
   platform: 'ios';
@@ -70,9 +70,10 @@ export async function installLimrunIosApp(
   limrun: Limrun,
   session: LimrunIosSession,
   installablePath: string,
+  dependencies: Pick<LimrunRuntimeDependencies, 'host' | 'ios'>,
   options?: ProviderDeviceInstallOptions,
 ): Promise<ProviderDeviceInstallResult> {
-  const prepared = await prepareLimrunIosAsset(installablePath);
+  const prepared = await prepareLimrunIosAsset(installablePath, dependencies);
   try {
     const asset = await limrun.assets.getOrUpload({
       path: prepared.uploadPath,
@@ -127,20 +128,25 @@ export async function installLimrunIosRemoteApp(
   });
 }
 
-export function createLimrunIosInteractor(session: LimrunIosSession): Interactor {
-  return new LimrunIosInteractor(session);
+export function createLimrunIosInteractor(
+  session: LimrunIosSession,
+  ios: LimrunIosRuntimeAdapter,
+): Interactor {
+  return new LimrunIosInteractor(session, ios);
 }
 
 class LimrunIosInteractor implements Interactor {
   private readonly session: LimrunIosSession;
+  private readonly ios: LimrunIosRuntimeAdapter;
 
-  constructor(session: LimrunIosSession) {
+  constructor(session: LimrunIosSession, ios: LimrunIosRuntimeAdapter) {
     this.session = session;
+    this.ios = ios;
   }
 
   async open(app: string, options?: { url?: string }): Promise<void> {
     if (options?.url) {
-      await this.session.client.launchApp(await resolveIosTarget(app));
+      await this.session.client.launchApp(this.ios.resolveAppAlias(app));
       await this.session.client.openUrl(options.url);
       return;
     }
@@ -148,13 +154,13 @@ class LimrunIosInteractor implements Interactor {
       await this.session.client.openUrl(app);
       return;
     }
-    await this.session.client.launchApp(await resolveIosTarget(app));
+    await this.session.client.launchApp(this.ios.resolveAppAlias(app));
   }
 
   async openDevice(): Promise<void> {}
 
   async close(app: string): Promise<void> {
-    if (app) await this.session.client.terminateApp(await resolveIosTarget(app)).catch(() => {});
+    if (app) await this.session.client.terminateApp(this.ios.resolveAppAlias(app)).catch(() => {});
   }
 
   async tap(x: number, y: number): Promise<void> {
@@ -265,7 +271,10 @@ class LimrunIosInteractor implements Interactor {
   }
 }
 
-async function prepareLimrunIosAsset(artifactPath: string): Promise<{
+async function prepareLimrunIosAsset(
+  artifactPath: string,
+  dependencies: Pick<LimrunRuntimeDependencies, 'host' | 'ios'>,
+): Promise<{
   uploadPath: string;
   assetName: string;
   appName?: string;
@@ -283,30 +292,26 @@ async function prepareLimrunIosAsset(artifactPath: string): Promise<{
 
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-limrun-ios-app-'));
   const zipPath = path.join(tempDir, `${path.basename(artifactPath)}.zip`);
-  const result = await runCmd('zip', ['-qr', zipPath, path.basename(artifactPath)], {
-    cwd: path.dirname(artifactPath),
-    timeoutMs: 120_000,
-  });
-  if (result.exitCode !== 0) {
-    await fs.promises.rm(tempDir, { recursive: true, force: true });
-    throw new AppError('COMMAND_FAILED', 'Failed to package iOS .app for Limrun install', {
-      command: ['zip', '-qr', zipPath, path.basename(artifactPath)].join(' '),
-      ...execFailureDetails(result),
+  try {
+    await dependencies.host.archiveDirectory({
+      sourceDirectory: path.dirname(artifactPath),
+      entryName: path.basename(artifactPath),
+      archivePath: zipPath,
     });
+  } catch (error) {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+    throw error;
   }
   return {
     uploadPath: zipPath,
     assetName: path.basename(zipPath),
-    appName: await readIosBundleAppName(artifactPath),
+    appName:
+      (await dependencies.ios.readBundleAppName(artifactPath)) ??
+      inferAppNameFromPath(artifactPath),
     cleanup: async () => {
       await fs.promises.rm(tempDir, { recursive: true, force: true });
     },
   };
-}
-
-async function resolveIosTarget(app: string): Promise<string> {
-  const { resolveIosAppAlias } = await import('../../platforms/apple/core/app-resolution.ts');
-  return resolveIosAppAlias(app);
 }
 
 function inferAppNameFromPath(appPath: string): string | undefined {
@@ -350,11 +355,6 @@ export function isUserInstalledIosApp(app: LimrunIosApp): boolean {
   return (
     !app.bundleId.startsWith('com.apple.') && !app.installType.toLowerCase().includes('system')
   );
-}
-
-async function readIosBundleAppName(appPath: string): Promise<string | undefined> {
-  const { readIosBundleInfo } = await import('../../platforms/apple/core/install-artifact.ts');
-  return (await readIosBundleInfo(appPath)).appName ?? inferAppNameFromPath(appPath);
 }
 
 function unsupported(command: string, message: string): never {

--- a/src/providers/limrun/ios.ts
+++ b/src/providers/limrun/ios.ts
@@ -23,7 +23,7 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { flattenIosTree, toIosSelector, writeBase64File, type IosTreeNode } from './snapshot.ts';
 import { normalizeOptionalString } from './strings.ts';
-import type { LimrunIosRuntimeAdapter, LimrunRuntimeDependencies } from './runtime-dependencies.ts';
+import type { LimrunRuntimeDependencies } from './runtime-dependencies.ts';
 
 export type LimrunIosSession = {
   platform: 'ios';
@@ -31,6 +31,7 @@ export type LimrunIosSession = {
   instanceId: string;
   device: DeviceInfo;
   client: LimrunIosClient;
+  readonly dependencies: Pick<LimrunRuntimeDependencies, 'host' | 'ios'>;
 };
 
 export type LimrunIosRemoteInstallOptions = {
@@ -45,13 +46,16 @@ export type LimrunIosRemoteInstallResult = {
 
 type LimrunIosApp = Awaited<ReturnType<LimrunIosClient['listApps']>>[number];
 
-export async function createLimrunIosSession(options: {
-  lease: DeviceLease;
-  instanceId: string;
-  device: DeviceInfo;
-  apiUrl: string;
-  token: string;
-}): Promise<LimrunIosSession> {
+export async function createLimrunIosSession(
+  options: {
+    lease: DeviceLease;
+    instanceId: string;
+    device: DeviceInfo;
+    apiUrl: string;
+    token: string;
+  },
+  dependencies: Pick<LimrunRuntimeDependencies, 'host' | 'ios'>,
+): Promise<LimrunIosSession> {
   const client = await createIosInstanceClient({
     apiUrl: options.apiUrl,
     token: options.token,
@@ -63,6 +67,7 @@ export async function createLimrunIosSession(options: {
     instanceId: options.instanceId,
     device: options.device,
     client,
+    dependencies,
   };
 }
 
@@ -70,10 +75,9 @@ export async function installLimrunIosApp(
   limrun: Limrun,
   session: LimrunIosSession,
   installablePath: string,
-  dependencies: Pick<LimrunRuntimeDependencies, 'host' | 'ios'>,
   options?: ProviderDeviceInstallOptions,
 ): Promise<ProviderDeviceInstallResult> {
-  const prepared = await prepareLimrunIosAsset(installablePath, dependencies);
+  const prepared = await prepareLimrunIosAsset(installablePath, session.dependencies);
   try {
     const asset = await limrun.assets.getOrUpload({
       path: prepared.uploadPath,
@@ -128,25 +132,20 @@ export async function installLimrunIosRemoteApp(
   });
 }
 
-export function createLimrunIosInteractor(
-  session: LimrunIosSession,
-  ios: LimrunIosRuntimeAdapter,
-): Interactor {
-  return new LimrunIosInteractor(session, ios);
+export function createLimrunIosInteractor(session: LimrunIosSession): Interactor {
+  return new LimrunIosInteractor(session);
 }
 
 class LimrunIosInteractor implements Interactor {
   private readonly session: LimrunIosSession;
-  private readonly ios: LimrunIosRuntimeAdapter;
 
-  constructor(session: LimrunIosSession, ios: LimrunIosRuntimeAdapter) {
+  constructor(session: LimrunIosSession) {
     this.session = session;
-    this.ios = ios;
   }
 
   async open(app: string, options?: { url?: string }): Promise<void> {
     if (options?.url) {
-      await this.session.client.launchApp(await this.ios.resolveAppAlias(app));
+      await this.session.client.launchApp(await this.session.dependencies.ios.resolveAppAlias(app));
       await this.session.client.openUrl(options.url);
       return;
     }
@@ -154,14 +153,16 @@ class LimrunIosInteractor implements Interactor {
       await this.session.client.openUrl(app);
       return;
     }
-    await this.session.client.launchApp(await this.ios.resolveAppAlias(app));
+    await this.session.client.launchApp(await this.session.dependencies.ios.resolveAppAlias(app));
   }
 
   async openDevice(): Promise<void> {}
 
   async close(app: string): Promise<void> {
     if (app) {
-      await this.session.client.terminateApp(await this.ios.resolveAppAlias(app)).catch(() => {});
+      await this.session.client
+        .terminateApp(await this.session.dependencies.ios.resolveAppAlias(app))
+        .catch(() => {});
     }
   }
 

--- a/src/providers/limrun/runtime-dependencies.test.ts
+++ b/src/providers/limrun/runtime-dependencies.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+import type { AppsFilter, DeviceLease } from '@agent-device/contracts/device';
+import type { Interactor } from '@agent-device/contracts/interaction';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { createLimrunRuntime } from './runtime.ts';
+import type {
+  LimrunAdbProvider,
+  LimrunAdbExecutor,
+  LimrunPortReverseMapping,
+  LimrunRuntimeDependencies,
+} from './runtime-dependencies.ts';
+
+const state = vi.hoisted(() => ({
+  constructorOptions: [] as Array<{ defaultHeaders?: Record<string, string> }>,
+  tunnelClose: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock('@limrun/api', () => ({
+  default: class MockLimrun {
+    readonly iosInstances = {
+      create: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    readonly androidInstances = {
+      create: vi.fn(async () => ({
+        metadata: { id: 'android-instance-1' },
+        status: {
+          token: 'instance-token',
+          apiUrl: 'https://android.example',
+          adbWebSocketUrl: 'wss://adb.example',
+        },
+      })),
+      list: vi.fn(),
+      delete: vi.fn(async () => undefined),
+    };
+
+    readonly assets = {
+      getOrUpload: vi.fn(),
+    };
+
+    constructor(options: { defaultHeaders?: Record<string, string> }) {
+      state.constructorOptions.push(options);
+    }
+  },
+}));
+
+vi.mock('@limrun/api/instance-client', () => ({
+  createInstanceClient: vi.fn(async () => ({
+    disconnect: state.disconnect,
+    setText: vi.fn(async () => undefined),
+    startAdbTunnel: vi.fn(async () => ({
+      address: { address: '127.0.0.1', port: 62_001 },
+      close: state.tunnelClose,
+    })),
+  })),
+}));
+
+test('factory uses the injected Android and host adapters as its construction seam', async () => {
+  const fixture = createContractFixture();
+  const runtime = createLimrunRuntime({ apiKey: 'lim_test_key' }, fixture.dependencies);
+
+  try {
+    const device = await allocateAndroidDevice(runtime);
+
+    assert.equal(runtime.getInteractor(device), fixture.interactor);
+    const deviceSession = runtime.getDeviceSession(device);
+    assert.equal(deviceSession?.platform, 'android');
+    if (deviceSession?.platform !== 'android') throw new Error('Expected Android device session');
+
+    assert.deepEqual(await deviceSession.listApps('all'), [
+      { id: 'com.example.app', name: 'Example' },
+    ]);
+    assert.equal((await deviceSession.getKeyboardState()).visible, false);
+    await runtime.configurePortReverse?.({
+      leaseId: 'lease-android',
+      devicePort: 8081,
+      hostPort: 8081,
+      name: 'metro',
+    });
+
+    assert.deepEqual(state.constructorOptions[0]?.defaultHeaders, {
+      'x-agent-device-client': 'agent-device-cli',
+      'x-agent-device-version': 'test-version',
+    });
+    assert.equal(fixture.createInteractor.mock.calls[0]?.[0], device);
+    assert.equal(fixture.listApps.mock.calls[0]?.[1], 'all');
+    assert.equal(fixture.getKeyboardState.mock.calls.length, 1);
+    assert.deepEqual(fixture.adbCalls[0], [
+      '-s',
+      '127.0.0.1:62001',
+      'reverse',
+      'tcp:8081',
+      'tcp:8081',
+    ]);
+  } finally {
+    await runtime.shutdown();
+  }
+
+  assert.deepEqual(fixture.adbCalls.slice(-2), [
+    ['-s', '127.0.0.1:62001', 'reverse', '--remove', 'tcp:8081'],
+    ['disconnect', '127.0.0.1:62001'],
+  ]);
+  assert.equal(state.tunnelClose.mock.calls.length, 1);
+});
+
+function createContractFixture() {
+  const adbCalls: string[][] = [];
+  const activeReverseMappings: LimrunPortReverseMapping[] = [];
+  const interactor = { open: vi.fn() } as unknown as Interactor;
+  const createInteractor = vi.fn((_device: DeviceInfo, _adb: LimrunAdbProvider) => interactor);
+  const listApps = vi.fn(async (_adb: LimrunAdbExecutor, _filter: AppsFilter) => [
+    { id: 'com.example.app', name: 'Example' },
+  ]);
+  const getKeyboardState = vi.fn(async () => ({
+    visible: false,
+    inputOwner: 'unknown' as const,
+  }));
+  const dependencies = {
+    clientVersion: 'test-version',
+    android: {
+      createInteractor,
+      createPortReverse: (adb: LimrunAdbProvider) =>
+        createInMemoryPortReverse(adb, activeReverseMappings),
+      inferAppName: () => 'Example',
+      listApps,
+      getForegroundApp: async () => ({
+        appId: 'com.example.app',
+        activity: '.MainActivity',
+      }),
+      getKeyboardState,
+      dismissKeyboard: async () => ({
+        visible: false,
+        inputOwner: 'unknown' as const,
+        attempts: 0,
+        wasVisible: false,
+        dismissed: false,
+      }),
+      readLogs: async () => 'log line\n',
+      adbError: (message: string) => new Error(message),
+    },
+    host: {
+      runAdb: async (args: string[]) => {
+        adbCalls.push(args);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      archiveDirectory: async () => undefined,
+    },
+    ios: {
+      resolveAppAlias: (app: string) => app,
+      readBundleAppName: async () => undefined,
+    },
+  } satisfies LimrunRuntimeDependencies;
+  return { adbCalls, createInteractor, dependencies, getKeyboardState, interactor, listApps };
+}
+
+function createInMemoryPortReverse(adb: LimrunAdbProvider, mappings: LimrunPortReverseMapping[]) {
+  return {
+    ensure: async (mapping: LimrunPortReverseMapping) => {
+      mappings.push(mapping);
+      await adb.exec(['reverse', mapping.local, mapping.remote]);
+    },
+    remove: async (local: LimrunPortReverseMapping['local']) => {
+      const index = mappings.findIndex((mapping) => mapping.local === local);
+      if (index >= 0) mappings.splice(index, 1);
+      await adb.exec(['reverse', '--remove', local]);
+    },
+    removeAllOwned: async (ownerId: string) => {
+      const owned = mappings.filter((mapping) => mapping.ownerId === ownerId);
+      for (const mapping of owned) {
+        mappings.splice(mappings.indexOf(mapping), 1);
+        await adb.exec(['reverse', '--remove', mapping.local]);
+      }
+    },
+    list: async () => [...mappings],
+  };
+}
+
+async function allocateAndroidDevice(
+  runtime: ReturnType<typeof createLimrunRuntime>,
+): Promise<DeviceInfo> {
+  const allocation = await runtime.leaseLifecycle.allocate?.(androidLease());
+  const allocatedDevice = allocation?.device;
+  if (!allocatedDevice || typeof allocatedDevice !== 'object') {
+    throw new Error('Expected allocated device');
+  }
+  return allocatedDevice as DeviceInfo;
+}
+
+function androidLease(): DeviceLease {
+  return {
+    leaseId: 'lease-android',
+    tenantId: 'team-a',
+    runId: 'run-a',
+    backend: 'android-instance',
+    leaseProvider: 'limrun',
+    createdAt: 1,
+    heartbeatAt: 1,
+    expiresAt: 60_001,
+  };
+}

--- a/src/providers/limrun/runtime-dependencies.test.ts
+++ b/src/providers/limrun/runtime-dependencies.test.ts
@@ -123,9 +123,9 @@ function createContractFixture() {
     clientVersion: 'test-version',
     android: {
       createInteractor,
-      createPortReverse: (adb: LimrunAdbProvider) =>
+      createPortReverse: async (adb: LimrunAdbProvider) =>
         createInMemoryPortReverse(adb, activeReverseMappings),
-      inferAppName: () => 'Example',
+      inferAppName: async () => 'Example',
       listApps,
       getForegroundApp: async () => ({
         appId: 'com.example.app',
@@ -140,7 +140,7 @@ function createContractFixture() {
         dismissed: false,
       }),
       readLogs: async () => 'log line\n',
-      adbError: (message: string) => new Error(message),
+      adbError: async (message: string) => new Error(message),
     },
     host: {
       runAdb: async (args: string[]) => {
@@ -150,7 +150,7 @@ function createContractFixture() {
       archiveDirectory: async () => undefined,
     },
     ios: {
-      resolveAppAlias: (app: string) => app,
+      resolveAppAlias: async (app: string) => app,
       readBundleAppName: async () => undefined,
     },
   } satisfies LimrunRuntimeDependencies;

--- a/src/providers/limrun/runtime-dependencies.test.ts
+++ b/src/providers/limrun/runtime-dependencies.test.ts
@@ -3,6 +3,7 @@ import { test, vi } from 'vitest';
 import type { AppsFilter, DeviceLease } from '@agent-device/contracts/device';
 import type { Interactor } from '@agent-device/contracts/interaction';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
 import { createLimrunRuntime } from './runtime.ts';
 import type {
   LimrunAdbProvider,
@@ -123,7 +124,7 @@ function createContractFixture() {
     clientVersion: 'test-version',
     android: {
       createInteractor,
-      createPortReverse: async (adb: LimrunAdbProvider) =>
+      createPortReverse: async (adb: LimrunAdbExecutor) =>
         createInMemoryPortReverse(adb, activeReverseMappings),
       inferAppName: async () => 'Example',
       listApps,
@@ -140,7 +141,7 @@ function createContractFixture() {
         dismissed: false,
       }),
       readLogs: async () => 'log line\n',
-      adbError: async (message: string) => new Error(message),
+      adbError: async (message: string) => new AppError('COMMAND_FAILED', message),
     },
     host: {
       runAdb: async (args: string[]) => {
@@ -157,22 +158,22 @@ function createContractFixture() {
   return { adbCalls, createInteractor, dependencies, getKeyboardState, interactor, listApps };
 }
 
-function createInMemoryPortReverse(adb: LimrunAdbProvider, mappings: LimrunPortReverseMapping[]) {
+function createInMemoryPortReverse(adb: LimrunAdbExecutor, mappings: LimrunPortReverseMapping[]) {
   return {
     ensure: async (mapping: LimrunPortReverseMapping) => {
       mappings.push(mapping);
-      await adb.exec(['reverse', mapping.local, mapping.remote]);
+      await adb(['reverse', mapping.local, mapping.remote]);
     },
     remove: async (local: LimrunPortReverseMapping['local']) => {
       const index = mappings.findIndex((mapping) => mapping.local === local);
       if (index >= 0) mappings.splice(index, 1);
-      await adb.exec(['reverse', '--remove', local]);
+      await adb(['reverse', '--remove', local]);
     },
     removeAllOwned: async (ownerId: string) => {
       const owned = mappings.filter((mapping) => mapping.ownerId === ownerId);
       for (const mapping of owned) {
         mappings.splice(mappings.indexOf(mapping), 1);
-        await adb.exec(['reverse', '--remove', mapping.local]);
+        await adb(['reverse', '--remove', mapping.local]);
       }
     },
     list: async () => [...mappings],

--- a/src/providers/limrun/runtime-dependencies.ts
+++ b/src/providers/limrun/runtime-dependencies.ts
@@ -1,0 +1,113 @@
+import type { AppsFilter } from '@agent-device/contracts/device';
+import type { Interactor } from '@agent-device/contracts/interaction';
+import type { AndroidInputOwner } from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+export type LimrunAdbCommandOptions = {
+  allowFailure?: boolean;
+  binaryStdout?: boolean;
+  stdin?: string | Buffer;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export type LimrunAdbCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  stdoutBuffer?: Buffer;
+};
+
+export type LimrunAdbExecutor = (
+  args: string[],
+  options?: LimrunAdbCommandOptions,
+) => Promise<LimrunAdbCommandResult>;
+
+export type LimrunPortReverseEndpoint = `tcp:${number}` | `localabstract:${string}`;
+
+export type LimrunPortReverseMapping = {
+  local: LimrunPortReverseEndpoint;
+  remote: LimrunPortReverseEndpoint;
+  ownerId?: string;
+};
+
+export type LimrunPortReverseOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type LimrunPortReverse = {
+  ensure(mapping: LimrunPortReverseMapping, options?: LimrunPortReverseOptions): Promise<void>;
+  remove(local: LimrunPortReverseEndpoint, options?: LimrunPortReverseOptions): Promise<void>;
+  removeAllOwned(ownerId: string, options?: LimrunPortReverseOptions): Promise<void>;
+  list?(options?: LimrunPortReverseOptions): Promise<LimrunPortReverseMapping[]>;
+};
+
+export type LimrunAdbProvider = {
+  exec: LimrunAdbExecutor;
+  reverse?: LimrunPortReverse;
+  text?: (request: {
+    action: 'type' | 'fill';
+    text: string;
+    delayMs?: number;
+    target?: { x: number; y: number };
+  }) => Promise<void>;
+};
+
+export type LimrunAndroidKeyboardState = {
+  visible: boolean;
+  inputType?: string;
+  type?: 'text' | 'number' | 'email' | 'phone' | 'password' | 'datetime' | 'unknown';
+  inputMethodPackage?: string;
+  focusedPackage?: string;
+  focusedResourceId?: string;
+  inputOwner: AndroidInputOwner;
+};
+
+export type LimrunAndroidKeyboardDismissResult = LimrunAndroidKeyboardState & {
+  attempts: number;
+  wasVisible: boolean;
+  dismissed: boolean;
+};
+
+export type LimrunAndroidRuntimeAdapter = {
+  createInteractor(device: DeviceInfo, adb: LimrunAdbProvider): Interactor;
+  createPortReverse(adb: LimrunAdbProvider): LimrunPortReverse;
+  inferAppName(packageName: string): string;
+  listApps(
+    adb: LimrunAdbExecutor,
+    filter: AppsFilter,
+  ): Promise<Array<{ id: string; name?: string }>>;
+  getForegroundApp(
+    adb: LimrunAdbExecutor,
+  ): Promise<{ appId?: string; activity?: string } | undefined>;
+  getKeyboardState(adb: LimrunAdbExecutor): Promise<LimrunAndroidKeyboardState>;
+  dismissKeyboard(adb: LimrunAdbExecutor): Promise<LimrunAndroidKeyboardDismissResult>;
+  readLogs(adb: LimrunAdbExecutor, lineLimit: number): Promise<string>;
+  adbError(
+    message: string,
+    result: LimrunAdbCommandResult,
+    details?: Record<string, unknown>,
+  ): Error;
+};
+
+export type LimrunHostAdapter = {
+  runAdb(args: string[], options?: LimrunAdbCommandOptions): Promise<LimrunAdbCommandResult>;
+  archiveDirectory(options: {
+    sourceDirectory: string;
+    entryName: string;
+    archivePath: string;
+  }): Promise<void>;
+};
+
+export type LimrunIosRuntimeAdapter = {
+  resolveAppAlias(app: string): string;
+  readBundleAppName(appPath: string): Promise<string | undefined>;
+};
+
+export type LimrunRuntimeDependencies = {
+  clientVersion: string;
+  android: LimrunAndroidRuntimeAdapter;
+  host: LimrunHostAdapter;
+  ios: LimrunIosRuntimeAdapter;
+};

--- a/src/providers/limrun/runtime-dependencies.ts
+++ b/src/providers/limrun/runtime-dependencies.ts
@@ -72,8 +72,8 @@ export type LimrunAndroidKeyboardDismissResult = LimrunAndroidKeyboardState & {
 
 export type LimrunAndroidRuntimeAdapter = {
   createInteractor(device: DeviceInfo, adb: LimrunAdbProvider): Interactor;
-  createPortReverse(adb: LimrunAdbProvider): LimrunPortReverse;
-  inferAppName(packageName: string): string;
+  createPortReverse(adb: LimrunAdbProvider): Promise<LimrunPortReverse>;
+  inferAppName(packageName: string): Promise<string>;
   listApps(
     adb: LimrunAdbExecutor,
     filter: AppsFilter,
@@ -88,7 +88,7 @@ export type LimrunAndroidRuntimeAdapter = {
     message: string,
     result: LimrunAdbCommandResult,
     details?: Record<string, unknown>,
-  ): Error;
+  ): Promise<Error>;
 };
 
 export type LimrunHostAdapter = {
@@ -101,7 +101,7 @@ export type LimrunHostAdapter = {
 };
 
 export type LimrunIosRuntimeAdapter = {
-  resolveAppAlias(app: string): string;
+  resolveAppAlias(app: string): Promise<string>;
   readBundleAppName(appPath: string): Promise<string | undefined>;
 };
 

--- a/src/providers/limrun/runtime-dependencies.ts
+++ b/src/providers/limrun/runtime-dependencies.ts
@@ -2,6 +2,7 @@ import type { AppsFilter } from '@agent-device/contracts/device';
 import type { Interactor } from '@agent-device/contracts/interaction';
 import type { AndroidInputOwner } from '@agent-device/contracts/platform';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { AppError } from '@agent-device/kernel/errors';
 
 export type LimrunAdbCommandOptions = {
   allowFailure?: boolean;
@@ -71,8 +72,9 @@ export type LimrunAndroidKeyboardDismissResult = LimrunAndroidKeyboardState & {
 };
 
 export type LimrunAndroidRuntimeAdapter = {
+  // Interactors need provider-scoped capabilities; command helpers below need only ADB execution.
   createInteractor(device: DeviceInfo, adb: LimrunAdbProvider): Interactor;
-  createPortReverse(adb: LimrunAdbProvider): Promise<LimrunPortReverse>;
+  createPortReverse(adb: LimrunAdbExecutor): Promise<LimrunPortReverse>;
   inferAppName(packageName: string): Promise<string>;
   listApps(
     adb: LimrunAdbExecutor,
@@ -88,7 +90,7 @@ export type LimrunAndroidRuntimeAdapter = {
     message: string,
     result: LimrunAdbCommandResult,
     details?: Record<string, unknown>,
-  ): Promise<Error>;
+  ): Promise<AppError>;
 };
 
 export type LimrunHostAdapter = {

--- a/src/providers/limrun/runtime.ts
+++ b/src/providers/limrun/runtime.ts
@@ -12,7 +12,6 @@ import type {
 } from '@agent-device/contracts/device';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import { readVersion } from '../../utils/version.ts';
 import {
   cleanupLimrunAndroidAdbTunnel,
   configureLimrunAndroidPortReverse,
@@ -34,6 +33,7 @@ import {
   type LimrunIosSession,
 } from './ios.ts';
 import { createLimrunDeviceSession, type LimrunDeviceSession } from './device-session.ts';
+import type { LimrunRuntimeDependencies } from './runtime-dependencies.ts';
 
 type LimrunInstance = {
   metadata: { id: string };
@@ -53,10 +53,23 @@ export type LimrunRuntimeOptions = {
 
 const LIMRUN_CLIENT_HEADER = 'agent-device-cli';
 
-export class LimrunRuntime implements ProviderDeviceRuntime {
+export type LimrunRuntime = ProviderDeviceRuntime & {
+  recoverExpiredLease: ProviderExpiredLeaseRecovery;
+  getDeviceSession(device: DeviceInfo): LimrunDeviceSession | undefined;
+};
+
+export function createLimrunRuntime(
+  options: LimrunRuntimeOptions,
+  dependencies: LimrunRuntimeDependencies,
+): LimrunRuntime {
+  return new LimrunRuntimeImplementation(options, dependencies);
+}
+
+class LimrunRuntimeImplementation implements ProviderDeviceRuntime {
   private readonly limrun: Limrun;
   private readonly sessions = new Map<string, LimrunRuntimeSession>();
   private readonly options: LimrunRuntimeOptions;
+  private readonly dependencies: LimrunRuntimeDependencies;
   readonly provider = LIMRUN_PROVIDER;
 
   readonly leaseLifecycle: LeaseLifecycleProvider = {
@@ -75,8 +88,6 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
     await this.release(lease);
   };
 
-  // Called through ProviderDeviceRuntime composition, not by this concrete class.
-  // fallow-ignore-next-line unused-class-member
   readonly deviceInventoryProvider: DeviceInventoryProvider = async (request) => {
     if (request.leaseProvider !== this.provider || !request.leaseId) return null;
     const session = this.sessions.get(request.leaseId);
@@ -85,19 +96,18 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
     return [session.device];
   };
 
-  constructor(options: LimrunRuntimeOptions) {
+  constructor(options: LimrunRuntimeOptions, dependencies: LimrunRuntimeDependencies) {
     this.options = options;
+    this.dependencies = dependencies;
     this.limrun = new Limrun({
       apiKey: options.apiKey,
       defaultHeaders: {
         'x-agent-device-client': LIMRUN_CLIENT_HEADER,
-        'x-agent-device-version': readVersion(),
+        'x-agent-device-version': dependencies.clientVersion,
       },
     });
   }
 
-  // Called through ProviderDeviceRuntime composition, not by this concrete class.
-  // fallow-ignore-next-line unused-class-member
   ownsDevice(device: DeviceInfo): boolean {
     return parseLimrunDeviceId(device.id) !== undefined;
   }
@@ -106,13 +116,13 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
     const session = this.getSessionForDevice(device);
     if (!session) return undefined;
     return session.platform === 'ios'
-      ? createLimrunIosInteractor(session)
+      ? createLimrunIosInteractor(session, this.dependencies.ios)
       : createLimrunAndroidInteractor(session);
   }
 
   getDeviceSession(device: DeviceInfo): LimrunDeviceSession | undefined {
     const session = this.getSessionForDevice(device);
-    return session ? createLimrunDeviceSession(session) : undefined;
+    return session ? createLimrunDeviceSession(session, this.dependencies.ios) : undefined;
   }
 
   async installApp(
@@ -136,7 +146,7 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
     const session = this.getSessionForDevice(device);
     if (!session) return undefined;
     return session.platform === 'ios'
-      ? await installLimrunIosApp(this.limrun, session, installablePath, options)
+      ? await installLimrunIosApp(this.limrun, session, installablePath, this.dependencies, options)
       : await installLimrunAndroidApp(this.limrun, session, installablePath, options);
   }
 
@@ -206,14 +216,17 @@ export class LimrunRuntime implements ProviderDeviceRuntime {
           'Limrun Android instance did not expose API and ADB websocket endpoints',
         );
       }
-      return await createLimrunAndroidSession({
-        lease,
-        instanceId: instance.metadata.id,
-        device: buildLimrunDevice('android', lease, instance.metadata.id),
-        apiUrl: instance.status.apiUrl,
-        adbUrl: instance.status.adbWebSocketUrl,
-        token: instance.status.token,
-      });
+      return await createLimrunAndroidSession(
+        {
+          lease,
+          instanceId: instance.metadata.id,
+          device: buildLimrunDevice('android', lease, instance.metadata.id),
+          apiUrl: instance.status.apiUrl,
+          adbUrl: instance.status.adbWebSocketUrl,
+          token: instance.status.token,
+        },
+        this.dependencies,
+      );
     } catch (error) {
       await this.limrun.androidInstances.delete(instance.metadata.id).catch(() => {});
       throw error;

--- a/src/providers/limrun/runtime.ts
+++ b/src/providers/limrun/runtime.ts
@@ -116,13 +116,13 @@ class LimrunRuntimeImplementation implements ProviderDeviceRuntime {
     const session = this.getSessionForDevice(device);
     if (!session) return undefined;
     return session.platform === 'ios'
-      ? createLimrunIosInteractor(session, this.dependencies.ios)
+      ? createLimrunIosInteractor(session)
       : createLimrunAndroidInteractor(session);
   }
 
   getDeviceSession(device: DeviceInfo): LimrunDeviceSession | undefined {
     const session = this.getSessionForDevice(device);
-    return session ? createLimrunDeviceSession(session, this.dependencies.ios) : undefined;
+    return session ? createLimrunDeviceSession(session) : undefined;
   }
 
   async installApp(
@@ -146,7 +146,7 @@ class LimrunRuntimeImplementation implements ProviderDeviceRuntime {
     const session = this.getSessionForDevice(device);
     if (!session) return undefined;
     return session.platform === 'ios'
-      ? await installLimrunIosApp(this.limrun, session, installablePath, this.dependencies, options)
+      ? await installLimrunIosApp(this.limrun, session, installablePath, options)
       : await installLimrunAndroidApp(this.limrun, session, installablePath, options);
   }
 
@@ -190,13 +190,16 @@ class LimrunRuntimeImplementation implements ProviderDeviceRuntime {
       if (!instance.status.apiUrl) {
         throw new AppError('COMMAND_FAILED', 'Limrun iOS instance did not expose apiUrl');
       }
-      return await createLimrunIosSession({
-        lease,
-        instanceId: instance.metadata.id,
-        device: buildLimrunDevice('ios', lease, instance.metadata.id),
-        apiUrl: instance.status.apiUrl,
-        token: instance.status.token,
-      });
+      return await createLimrunIosSession(
+        {
+          lease,
+          instanceId: instance.metadata.id,
+          device: buildLimrunDevice('ios', lease, instance.metadata.id),
+          apiUrl: instance.status.apiUrl,
+          token: instance.status.token,
+        },
+        this.dependencies,
+      );
     } catch (error) {
       await this.limrun.iosInstances.delete(instance.metadata.id).catch(() => {});
       throw error;

--- a/src/sdk/limrun-runtime-dependencies.test.ts
+++ b/src/sdk/limrun-runtime-dependencies.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+
+const moduleLoads = vi.hoisted(() => ({
+  androidAppHelpers: 0,
+  androidLogcat: 0,
+  appleAppResolution: 0,
+  appleInstallArtifact: 0,
+}));
+
+vi.mock('@limrun/api', () => ({
+  default: class MockLimrun {},
+}));
+
+vi.mock('../platforms/android/app-helpers.ts', () => {
+  moduleLoads.androidAppHelpers += 1;
+  return {
+    getAndroidAppStateWithAdb: vi.fn(async () => ({
+      package: 'com.example.app',
+      activity: '.MainActivity',
+    })),
+    listAndroidAppsWithAdb: vi.fn(async () => [{ package: 'com.example.app', name: 'Example' }]),
+  };
+});
+
+vi.mock('../platforms/android/logcat.ts', () => {
+  moduleLoads.androidLogcat += 1;
+  return {
+    captureAndroidLogcatWithAdb: vi.fn(async () => 'log line\n'),
+  };
+});
+
+vi.mock('../platforms/apple/core/app-resolution.ts', () => {
+  moduleLoads.appleAppResolution += 1;
+  return {
+    resolveIosAppAlias: vi.fn((app: string) => `resolved:${app}`),
+  };
+});
+
+vi.mock('../platforms/apple/core/install-artifact.ts', () => {
+  moduleLoads.appleInstallArtifact += 1;
+  return {
+    readIosBundleInfo: vi.fn(async () => ({ appName: 'Example' })),
+  };
+});
+
+test('Limrun construction defers operation and opposite-platform helper modules', async () => {
+  const { LimrunRuntime } = await import('../provider-limrun-runtime.ts');
+  const runtime = new LimrunRuntime({ apiKey: 'lim_test_key' });
+
+  assert.deepEqual(moduleLoads, {
+    androidAppHelpers: 0,
+    androidLogcat: 0,
+    appleAppResolution: 0,
+    appleInstallArtifact: 0,
+  });
+  await runtime.shutdown();
+
+  const { createLimrunRuntimeDependencies } = await import('./limrun-runtime-dependencies.ts');
+  const dependencies = createLimrunRuntimeDependencies();
+  const adb = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+  assert.deepEqual(await dependencies.android.listApps(adb, 'all'), [
+    { id: 'com.example.app', name: 'Example' },
+  ]);
+  assert.equal(moduleLoads.androidAppHelpers, 1);
+  assert.equal(moduleLoads.androidLogcat, 0);
+  assert.equal(moduleLoads.appleAppResolution, 0);
+  assert.equal(moduleLoads.appleInstallArtifact, 0);
+
+  assert.equal(await dependencies.android.readLogs(adb, 10), 'log line\n');
+  assert.equal(moduleLoads.androidLogcat, 1);
+  assert.equal(moduleLoads.appleAppResolution, 0);
+  assert.equal(moduleLoads.appleInstallArtifact, 0);
+
+  assert.equal(await dependencies.ios.resolveAppAlias('settings'), 'resolved:settings');
+  assert.equal(moduleLoads.appleAppResolution, 1);
+  assert.equal(moduleLoads.appleInstallArtifact, 0);
+
+  assert.equal(await dependencies.ios.readBundleAppName('/tmp/Example.app'), 'Example');
+  assert.equal(moduleLoads.appleInstallArtifact, 1);
+});

--- a/src/sdk/limrun-runtime-dependencies.ts
+++ b/src/sdk/limrun-runtime-dependencies.ts
@@ -1,0 +1,71 @@
+import { AppError } from '@agent-device/kernel/errors';
+import { createAndroidInteractor } from '../core/interactors/android.ts';
+import {
+  androidAdbResultError,
+  createAndroidPortReverseManager,
+} from '../platforms/android/adb-executor.ts';
+import {
+  getAndroidAppStateWithAdb,
+  listAndroidAppsWithAdb,
+} from '../platforms/android/app-helpers.ts';
+import { inferAndroidAppName } from '../platforms/android/app-lifecycle.ts';
+import {
+  dismissAndroidKeyboardWithAdb,
+  getAndroidKeyboardStatusWithAdb,
+} from '../platforms/android/device-input-state.ts';
+import { captureAndroidLogcatWithAdb } from '../platforms/android/logcat.ts';
+import { resolveIosAppAlias } from '../platforms/apple/core/app-resolution.ts';
+import { readIosBundleInfo } from '../platforms/apple/core/install-artifact.ts';
+import type { LimrunRuntimeDependencies } from '../providers/limrun/runtime-dependencies.ts';
+import { execFailureDetails, runCmd } from '../utils/exec.ts';
+import { readVersion } from '../utils/version.ts';
+
+export function createLimrunRuntimeDependencies(): LimrunRuntimeDependencies {
+  return {
+    clientVersion: readVersion(),
+    android: {
+      createInteractor: (device, adb) => createAndroidInteractor(device, adb),
+      createPortReverse: (adb) => createAndroidPortReverseManager(adb),
+      inferAppName: inferAndroidAppName,
+      listApps: async (adb, filter) =>
+        (
+          await listAndroidAppsWithAdb(adb, {
+            filter,
+            target: 'mobile',
+          })
+        ).map((app) => ({ id: app.package, name: app.name })),
+      getForegroundApp: async (adb) => {
+        const app = await getAndroidAppStateWithAdb(adb);
+        return app.package ? { appId: app.package, activity: app.activity } : undefined;
+      },
+      getKeyboardState: getAndroidKeyboardStatusWithAdb,
+      dismissKeyboard: dismissAndroidKeyboardWithAdb,
+      readLogs: async (adb, lineLimit) =>
+        await captureAndroidLogcatWithAdb(adb, {
+          lines: lineLimit,
+          timeoutMs: 5_000,
+        }),
+      adbError: androidAdbResultError,
+    },
+    host: {
+      runAdb: async (args, options) => await runCmd('adb', args, options),
+      archiveDirectory: async ({ sourceDirectory, entryName, archivePath }) => {
+        const args = ['-qr', archivePath, entryName];
+        const result = await runCmd('zip', args, {
+          cwd: sourceDirectory,
+          timeoutMs: 120_000,
+        });
+        if (result.exitCode !== 0) {
+          throw new AppError('COMMAND_FAILED', 'Failed to package iOS .app for Limrun install', {
+            command: ['zip', ...args].join(' '),
+            ...execFailureDetails(result),
+          });
+        }
+      },
+    },
+    ios: {
+      resolveAppAlias: resolveIosAppAlias,
+      readBundleAppName: async (appPath) => (await readIosBundleInfo(appPath)).appName,
+    },
+  };
+}

--- a/src/sdk/limrun-runtime-dependencies.ts
+++ b/src/sdk/limrun-runtime-dependencies.ts
@@ -1,21 +1,5 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { createAndroidInteractor } from '../core/interactors/android.ts';
-import {
-  androidAdbResultError,
-  createAndroidPortReverseManager,
-} from '../platforms/android/adb-executor.ts';
-import {
-  getAndroidAppStateWithAdb,
-  listAndroidAppsWithAdb,
-} from '../platforms/android/app-helpers.ts';
-import { inferAndroidAppName } from '../platforms/android/app-lifecycle.ts';
-import {
-  dismissAndroidKeyboardWithAdb,
-  getAndroidKeyboardStatusWithAdb,
-} from '../platforms/android/device-input-state.ts';
-import { captureAndroidLogcatWithAdb } from '../platforms/android/logcat.ts';
-import { resolveIosAppAlias } from '../platforms/apple/core/app-resolution.ts';
-import { readIosBundleInfo } from '../platforms/apple/core/install-artifact.ts';
 import type { LimrunRuntimeDependencies } from '../providers/limrun/runtime-dependencies.ts';
 import { execFailureDetails, runCmd } from '../utils/exec.ts';
 import { readVersion } from '../utils/version.ts';
@@ -25,27 +9,50 @@ export function createLimrunRuntimeDependencies(): LimrunRuntimeDependencies {
     clientVersion: readVersion(),
     android: {
       createInteractor: (device, adb) => createAndroidInteractor(device, adb),
-      createPortReverse: (adb) => createAndroidPortReverseManager(adb),
-      inferAppName: inferAndroidAppName,
-      listApps: async (adb, filter) =>
-        (
+      createPortReverse: async (adb) => {
+        const { createAndroidPortReverseManager } =
+          await import('../platforms/android/adb-executor.ts');
+        return createAndroidPortReverseManager(adb);
+      },
+      inferAppName: async (packageName) => {
+        const { inferAndroidAppName } = await import('../platforms/android/app-lifecycle.ts');
+        return inferAndroidAppName(packageName);
+      },
+      listApps: async (adb, filter) => {
+        const { listAndroidAppsWithAdb } = await import('../platforms/android/app-helpers.ts');
+        return (
           await listAndroidAppsWithAdb(adb, {
             filter,
             target: 'mobile',
           })
-        ).map((app) => ({ id: app.package, name: app.name })),
+        ).map((app) => ({ id: app.package, name: app.name }));
+      },
       getForegroundApp: async (adb) => {
+        const { getAndroidAppStateWithAdb } = await import('../platforms/android/app-helpers.ts');
         const app = await getAndroidAppStateWithAdb(adb);
         return app.package ? { appId: app.package, activity: app.activity } : undefined;
       },
-      getKeyboardState: getAndroidKeyboardStatusWithAdb,
-      dismissKeyboard: dismissAndroidKeyboardWithAdb,
-      readLogs: async (adb, lineLimit) =>
-        await captureAndroidLogcatWithAdb(adb, {
+      getKeyboardState: async (adb) => {
+        const { getAndroidKeyboardStatusWithAdb } =
+          await import('../platforms/android/device-input-state.ts');
+        return await getAndroidKeyboardStatusWithAdb(adb);
+      },
+      dismissKeyboard: async (adb) => {
+        const { dismissAndroidKeyboardWithAdb } =
+          await import('../platforms/android/device-input-state.ts');
+        return await dismissAndroidKeyboardWithAdb(adb);
+      },
+      readLogs: async (adb, lineLimit) => {
+        const { captureAndroidLogcatWithAdb } = await import('../platforms/android/logcat.ts');
+        return await captureAndroidLogcatWithAdb(adb, {
           lines: lineLimit,
           timeoutMs: 5_000,
-        }),
-      adbError: androidAdbResultError,
+        });
+      },
+      adbError: async (message, result, details) => {
+        const { androidAdbResultError } = await import('../platforms/android/adb-executor.ts');
+        return androidAdbResultError(message, result, details);
+      },
     },
     host: {
       runAdb: async (args, options) => await runCmd('adb', args, options),
@@ -64,8 +71,14 @@ export function createLimrunRuntimeDependencies(): LimrunRuntimeDependencies {
       },
     },
     ios: {
-      resolveAppAlias: resolveIosAppAlias,
-      readBundleAppName: async (appPath) => (await readIosBundleInfo(appPath)).appName,
+      resolveAppAlias: async (app) => {
+        const { resolveIosAppAlias } = await import('../platforms/apple/core/app-resolution.ts');
+        return resolveIosAppAlias(app);
+      },
+      readBundleAppName: async (appPath) => {
+        const { readIosBundleInfo } = await import('../platforms/apple/core/install-artifact.ts');
+        return (await readIosBundleInfo(appPath)).appName;
+      },
     },
   };
 }

--- a/src/sdk/limrun-runtime-dependencies.ts
+++ b/src/sdk/limrun-runtime-dependencies.ts
@@ -1,4 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
+// ProviderDeviceRuntime.getInteractor is synchronous, so this previously eager factory remains the
+// deliberate static edge; making it lazy would require a proxy interactor rather than this seam.
 import { createAndroidInteractor } from '../core/interactors/android.ts';
 import type { LimrunRuntimeDependencies } from '../providers/limrun/runtime-dependencies.ts';
 import { execFailureDetails, runCmd } from '../utils/exec.ts';
@@ -50,6 +52,7 @@ export function createLimrunRuntimeDependencies(): LimrunRuntimeDependencies {
         });
       },
       adbError: async (message, result, details) => {
+        // Error construction is async so the platform helper remains lazy until an ADB failure.
         const { androidAdbResultError } = await import('../platforms/android/adb-executor.ts');
         return androidAdbResultError(message, result, details);
       },

--- a/src/sdk/limrun.ts
+++ b/src/sdk/limrun.ts
@@ -1,12 +1,11 @@
-export { LimrunRuntime, type LimrunRuntimeOptions } from '../providers/limrun/runtime.ts';
+export { LimrunRuntime, type LimrunRuntimeOptions } from '../provider-limrun-runtime.ts';
+export type { LimrunAndroidDeviceSession, LimrunDeviceSession } from '../limrun-runtime-types.ts';
 export type { AndroidAdbProvider } from '../platforms/android/adb-executor.ts';
 export type {
   AndroidKeyboardDismissResult,
   AndroidKeyboardState,
 } from '../platforms/android/device-input-state.ts';
 export type {
-  LimrunAndroidDeviceSession,
-  LimrunDeviceSession,
   LimrunForegroundApp,
   LimrunInstalledApp,
   LimrunIosCommandExecution,


### PR DESCRIPTION
## Summary

Prepare the Limrun runtime seam for later package extraction without packaging it yet.

This is an extraction-enabling construction seam, not a claimed domain port. It currently has one
production adapter (`createLimrunRuntimeDependencies`) plus deterministic test doubles, not two real
adapters, and must not be cited as precedent for satisfying the two-real-adapter rule. Its purpose in
W1c is to remove package-blocking imports while preserving behavior and the released interface.

- inject a narrow construction dependency object for Android interactor, ADB/reverse, host-command,
  and iOS host-adapter operations
- keep concrete construction in root/SDK composition, backed by the existing platform modules and
  `src/utils/exec.ts`
- store each platform's dependencies on its allocated session, so Android and iOS use one coherent
  ownership/threading style without widening `ProviderDeviceRuntime`
- acquire operation-specific Android helpers and Apple capabilities lazily through async dependency
  methods
- type ADB error construction as `Promise<AppError>`; it remains async specifically so the platform
  error helper is imported only on failure
- use `LimrunAdbProvider` only for interactor creation and `LimrunAdbExecutor` for command-only and
  port-reverse construction dependencies
- delegate wrapper lifecycle/inventory properties through getters instead of copying references
- exercise the same construction contract through deterministic in-memory test doubles
- retain conditional Limrun loading, `ProviderDeviceRuntime`, and the released
  `new LimrunRuntime(options)` SDK shape
- reduce production imports from `src/providers/limrun/**` into root core/platform/utils from 18 to
  0

`createAndroidInteractor` deliberately remains the one static construction edge. The released
`ProviderDeviceRuntime.getInteractor` contract is synchronous; hiding that factory behind a dynamic
import would require a lazy proxy interactor and broaden this extraction-only change. All
operation-specific helper imports remain lazy.

Related: #1490

## Validation

- `pnpm exec vitest run src/sdk/limrun-runtime-dependencies.test.ts src/providers/limrun/runtime-dependencies.test.ts src/providers/limrun/device-session.test.ts src/__tests__/limrun-runtime.test.ts src/__tests__/provider-device-runtimes.test.ts` (22 passed)
- `pnpm test:integration:provider` (150 passed before the review follow-up; rerun outside the sandbox
  after the sandbox denied localhost binding)
- `pnpm check:affected --run`
- `pnpm check:layering`
- `pnpm check:quick`

The module-load regression test proves runtime import/construction loads none of the Android
app-inventory/log or Apple app-resolution/install helpers, then verifies each module loads only when
its capability is called. The emitted `dist/src/provider-limrun-runtime.js` has dynamic imports for
`app-helpers`, `logcat`, `app-resolution`, and Apple `install-artifact`; none is in its static import
header.

Live credentialed Limrun evidence was not run because this environment has no `LIMRUN_API_KEY`,
`LIMRUN_REGION`, or `.env.local`. Residual risk remains real Android and iOS allocation/lifecycle
behavior, especially Android tunnel establishment, reverse setup, disconnect, and teardown. The PR
stays draft until that evidence is available.
