### PR TITLE
refactor(daemon): consolidate session-script test factories and drop saveScriptDefaultedHealedPath

### DIFF
--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -13,8 +13,8 @@ const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
 
 export const DAEMON_MODULARITY_BASELINE = {
   sessionState: {
-    writerOwnedFields: 30,
-    ownerFileClaims: 42,
+    writerOwnedFields: 29,
+    ownerFileClaims: 40,
   },
   largestTypeCycle: {
     zoneMembers: LARGEST_TYPE_CYCLE_ZONE_CEILINGS,

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -73,10 +73,6 @@ export const SESSION_STATE_FIELD_OWNERS: Readonly<Record<string, readonly string
     'src/daemon/handlers/session-script-publication.ts',
     'src/daemon/session-action-recorder.ts',
   ],
-  saveScriptDefaultedHealedPath: [
-    'src/daemon/handlers/session-replay-runtime.ts',
-    'src/daemon/session-action-recorder.ts',
-  ],
   saveScriptBoundary: ['src/daemon/handlers/session-replay-runtime.ts'],
   saveScriptCommitted: ['src/daemon/session-script-writer.ts'],
   repairSourcePath: ['src/daemon/handlers/session-replay-runtime.ts'],

--- a/src/__tests__/test-utils/index.ts
+++ b/src/__tests__/test-utils/index.ts
@@ -15,6 +15,7 @@ export {
   makeAndroidSession,
   makeIosSession,
   makeMacOsSession,
+  makeAuthoringSession,
   makeSession,
 } from './session-factories.ts';
 

--- a/src/__tests__/test-utils/session-factories.ts
+++ b/src/__tests__/test-utils/session-factories.ts
@@ -22,3 +22,63 @@ export function makeAndroidSession(name: string, overrides?: Partial<SessionStat
 export function makeMacOsSession(name: string, overrides?: Partial<SessionState>): SessionState {
   return makeSession(name, { device: MACOS_DEVICE, ...overrides });
 }
+
+// --- Script-authoring session states ---
+//
+// The three factories below name the states a session-script session can be in,
+// instead of leaving each test to re-derive them from a pile of `saveScript*`
+// booleans. They exist because the fields are NOT independent: `recordSession`
+// without a boundary is an ordinary recording, a boundary without
+// `saveScriptComplete` is an ARMED-but-uncommittable repair, and only the
+// COMPLETE combination publishes. Spelling that out per test made the
+// distinction the tests are actually about (ordinary vs repair, armed vs
+// complete) the hardest thing to see in them.
+//
+// A test that deliberately exercises an odd combination (a boundary with no
+// recording, say) should still build it inline — these are for the states
+// production actually produces.
+
+/**
+ * ADR 0016 ordinary authoring recording: `recordSession` armed, NO repair
+ * boundary. This is a plain `open --save-script` / `close --save-script`
+ * session, and the baseline for every authoring-side handler test (target-v1
+ * evidence, parameterized fills, landmark waits) that only needs the session to
+ * be recording its actions.
+ *
+ * "Authoring", not "recording": `session.recording` is the unrelated
+ * screen-capture state.
+ */
+export function makeAuthoringSession(
+  name: string,
+  overrides?: Partial<SessionState>,
+): SessionState {
+  return makeIosSession(name, { recordSession: true, ...overrides });
+}
+
+/**
+ * ADR 0012 decision 6: a session ARMED for repair by `replay --save-script` —
+ * recording plus the repair-run boundary watermark, which is what the writer's
+ * `repairArmed` actually keys off (`saveScriptBoundary !== undefined`).
+ *
+ * ARMED, not COMPLETE: a writer handed this session ABORTS (publishes no
+ * prefix) rather than committing. Use `makeRepairCompleteSession` for a
+ * committable one.
+ */
+export function makeRepairArmedSession(
+  name: string,
+  overrides?: Partial<SessionState>,
+): SessionState {
+  return makeAuthoringSession(name, { saveScriptBoundary: 0, ...overrides });
+}
+
+/**
+ * The same repair transaction advanced to COMPLETE — the plan reached its last
+ * executable step with no outstanding divergence — so a writer commits it
+ * (ARMED -> COMPLETE -> COMMITTED).
+ */
+export function makeRepairCompleteSession(
+  name: string,
+  overrides?: Partial<SessionState>,
+): SessionState {
+  return makeRepairArmedSession(name, { saveScriptComplete: true, ...overrides });
+}

--- a/src/daemon/__tests__/request-router-typed-error.test.ts
+++ b/src/daemon/__tests__/request-router-typed-error.test.ts
@@ -21,26 +21,36 @@ import { createRequestHandler } from '../request-router.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import {
+  makeAuthoringSession,
+  makeRepairCompleteSession,
+  makeSession,
+} from '../../__tests__/test-utils/session-factories.ts';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError, retriableForErrorCode } from '@agent-device/kernel/errors';
 import { supportedPlatformsForCommand } from '../../core/capabilities.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
 
+/**
+ * This file pins its own simulator rather than reusing the shared iOS fixture:
+ * the tenant-scoped `simulatorSetPath` is part of what the router under test
+ * carries through. Everything else comes from the shared session factories.
+ */
+const TENANT_SIMULATOR: DeviceInfo = {
+  platform: 'apple',
+  target: 'mobile',
+  id: 'SIM-001',
+  name: 'iPhone 16',
+  kind: 'simulator',
+  booted: true,
+  simulatorSetPath: '/tmp/tenant-a/set',
+};
+
+const TENANT_SESSION_DEFAULTS = { device: TENANT_SIMULATOR, createdAt: 1_700_000_000_000 } as const;
+
 function makeIosSession(name: string): SessionState {
-  return {
-    name,
-    createdAt: 1_700_000_000_000,
-    actions: [],
-    device: {
-      platform: 'apple',
-      target: 'mobile',
-      id: 'SIM-001',
-      name: 'iPhone 16',
-      kind: 'simulator',
-      booted: true,
-      simulatorSetPath: '/tmp/tenant-a/set',
-    },
-  };
+  return makeSession(name, TENANT_SESSION_DEFAULTS);
 }
 
 function makeHandler(sessionStore = makeSessionStore('agent-device-router-typed-error-')) {
@@ -135,11 +145,10 @@ test('deterministic errors (INVALID_ARGS) are returned with the default shape â€
 // `error.retriable ?? retriableForErrorCode(error.code)` fallback is caught.
 test('BLOCKER 2 (second follow-up): a repair-close platform-close failure surfaces retriable:true and diagnosticId/logPath/details at the TOP level through the router', async () => {
   const { sessionStore, handler } = makeHandler();
-  const session = makeIosSession('typed-error');
-  session.recordSession = true;
-  session.saveScriptBoundary = 0;
-  session.saveScriptComplete = true;
-  session.actions = [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }];
+  const session = makeRepairCompleteSession('typed-error', {
+    ...TENANT_SESSION_DEFAULTS,
+    actions: [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }],
+  });
   sessionStore.set('typed-error', session);
 
   // DEVICE_NOT_FOUND is not in `retriableForErrorCode`'s conservative allow
@@ -174,8 +183,7 @@ test('BLOCKER 2 (second follow-up): a repair-close platform-close failure surfac
 // details.retriable hoisting.
 test('#1391: an ordinary close-time script-save failure surfaces details.reason/path and retriable:false through the router, and the session is torn down', async () => {
   const { sessionStore, handler } = makeHandler();
-  const session = makeIosSession('typed-error');
-  session.recordSession = true;
+  const session = makeAuthoringSession('typed-error', TENANT_SESSION_DEFAULTS);
   const targetPath = path.join(
     os.tmpdir(),
     `agent-device-router-typed-error-${Date.now()}-${Math.random().toString(36).slice(2)}.ad`,

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -4,7 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { HEAL_COMPLETE_SENTINEL, SessionScriptWriter } from '../session-script-writer.ts';
 import { recordActionEntry } from '../session-action-recorder.ts';
-import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import {
+  makeAuthoringSession,
+  makeRepairArmedSession,
+  makeRepairCompleteSession,
+} from '../../__tests__/test-utils/session-factories.ts';
 import { parseReplayScriptDetailed } from '../../replay/script.ts';
 import type { SessionAction } from '../types.ts';
 
@@ -27,13 +31,11 @@ function writeAndParse(
 test('write() slices session.actions from saveScriptBoundary onward, excluding pre-watermark actions', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-boundary-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
+  // Fix 2: a repair-armed write only publishes once explicitly finalized
+  // (`close --save-script`) — COMPLETE here to isolate THIS test's own concern
+  // (boundary slicing), covered separately below.
+  const session = makeRepairCompleteSession('default', {
     saveScriptBoundary: 2,
-    // Fix 2: a repair-armed write only publishes once explicitly finalized
-    // (`close --save-script`) — set here to isolate THIS test's own concern
-    // (boundary slicing), covered separately below.
-    saveScriptComplete: true,
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({ command: 'click', positionals: ['label="Old"'] }),
@@ -50,8 +52,7 @@ test('write() slices session.actions from saveScriptBoundary onward, excluding p
 test('write() with no boundary set (ordinary open/close --save-script) serializes the full history, unchanged', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-no-boundary-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
+  const session = makeAuthoringSession('default', {
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({ command: 'click', positionals: ['label="Save"'] }),
@@ -67,10 +68,8 @@ test('write() with no boundary set (ordinary open/close --save-script) serialize
 test('a boundary-sliced script still strips diagnostic snapshot actions', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-snapshot-strip-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptBoundary: 1,
-    saveScriptComplete: true,
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({ command: 'snapshot', positionals: [] }),
@@ -92,10 +91,7 @@ test('a boundary-sliced script still strips diagnostic snapshot actions', () => 
 test('a recorded ref that resolved to a selectorChain writes a clean selector line, never the bare ref', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-resolved-ref-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     actions: [
       action({
         command: 'press',
@@ -114,10 +110,7 @@ test('a recorded ref that resolved to a selectorChain writes a clean selector li
 test('a recorded ref that never resolved to a selectorChain throws instead of emitting a bare @ref', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-bare-ref-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     actions: [action({ command: 'press', positionals: ['@e7'] })],
   });
 
@@ -135,10 +128,7 @@ test('a recorded ref that never resolved to a selectorChain throws instead of em
 test('a bare-@ref fill action also fails loud, not just click-like commands', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-bare-ref-fill-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     actions: [action({ command: 'fill', positionals: ['@e9', 'hello'] })],
   });
 
@@ -150,10 +140,7 @@ test('a bare-@ref fill action also fails loud, not just click-like commands', ()
 test('a bare @ref later in the same session (after a resolved earlier action) still fails loud, writing nothing', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-partial-write-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     actions: [
       action({ command: 'open', positionals: ['Demo'] }),
       action({
@@ -176,10 +163,10 @@ test('an ordinary (non-repair-armed) recording keeps the existing bare-ref fallb
     path.join(os.tmpdir(), 'agent-device-script-writer-ordinary-bare-ref-'),
   );
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    // No saveScriptBoundary: this session was armed by plain `open`/`close
-    // --save-script`, never by `replay --save-script` — R4 does not apply.
+  // Ordinary recording (no repair boundary): this session was armed by plain
+  // `open`/`close --save-script`, never by `replay --save-script` — R4 does
+  // not apply.
+  const session = makeAuthoringSession('default', {
     actions: [action({ command: 'click', positionals: ['@e12'], result: { refLabel: 'Save' } })],
   });
 
@@ -201,12 +188,8 @@ test('write() publishes cleanly when the target does not exist yet', () => {
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -235,12 +218,8 @@ test('write() refuses to clobber an existing COMPLETE DEFAULT .healed.ad', () =>
   );
   const before = fs.readFileSync(healedPath, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -268,12 +247,8 @@ test('write() now refuses to clobber a stale PARTIAL (non-sentinel) .healed.ad a
   fs.writeFileSync(healedPath, 'context platform=ios device="x"\nclick id="stale-partial"\n');
   const before = fs.readFileSync(healedPath, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -296,12 +271,8 @@ test('write(session, { force: true }) overwrites an existing COMPLETE target ato
     `context platform=ios device="x"\nclick id="old"\n${HEAL_COMPLETE_SENTINEL}\n`,
   );
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -322,9 +293,8 @@ test('write(session, { force: true }) overwrites an existing target for ORDINARY
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    // No saveScriptBoundary: ordinary open/close --save-script, not a repair.
+  // Ordinary open/close --save-script recording, not a repair.
+  const session = makeAuthoringSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
@@ -343,8 +313,7 @@ test('write(session) without { force: true } still refuses, even when a prior wr
   fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
   const before = fs.readFileSync(outPath, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
+  const session = makeAuthoringSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
@@ -365,20 +334,12 @@ test('two writers racing on the SAME ABSENT target: exactly one linkSync wins, t
   const healedPath = path.join(root, 'flows', 'login.healed.ad');
   fs.mkdirSync(path.dirname(healedPath), { recursive: true });
 
-  const sessionA = makeIosSession('writer-a', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const sessionA = makeRepairCompleteSession('writer-a', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="from-a"'] })],
   });
-  const sessionB = makeIosSession('writer-b', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const sessionB = makeRepairCompleteSession('writer-b', {
     saveScriptPath: healedPath,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="from-b"'] })],
   });
 
@@ -438,13 +399,10 @@ test('write() refuses to clobber an existing COMPLETE artifact at an EXPLICIT --
   );
   const before = fs.readFileSync(explicitOut, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  // An explicit, caller-DIRECTED target — the protection must apply here too,
+  // not just the default healed sibling.
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: explicitOut,
-    // No saveScriptDefaultedHealedPath: this is an explicit, caller-directed
-    // target — the protection must apply here too, not just the default path.
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -466,12 +424,10 @@ test('write() now refuses an explicit --save-script=<path> pointing at an existi
   fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
   const before = fs.readFileSync(outPath, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  // The caller directed this path explicitly rather than defaulting to the
+  // healed sibling.
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: outPath,
-    // No saveScriptDefaultedHealedPath: the caller directed this path explicitly.
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
@@ -500,10 +456,9 @@ test('an ordinary (non-repair) recording now refuses an existing target too (beh
   fs.writeFileSync(outPath, 'context platform=ios device="x"\nclick id="old"\n');
   const before = fs.readFileSync(outPath, 'utf8');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    // No saveScriptBoundary: an ordinary open/close --save-script recording,
-    // never armed via `replay --save-script` — this is NOT a repair.
+  // An ordinary open/close --save-script recording, never armed via `replay
+  // --save-script` — this is NOT a repair.
+  const session = makeAuthoringSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
@@ -528,9 +483,8 @@ test('an ordinary (non-repair) recording still publishes cleanly when its target
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const outPath = path.join(root, 'flows', 'fresh.ad');
 
-  const session = makeIosSession('default', {
-    recordSession: true,
-    // No saveScriptBoundary: ordinary recording, not a repair.
+  // Ordinary recording, not a repair.
+  const session = makeAuthoringSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
@@ -544,36 +498,31 @@ test('an ordinary (non-repair) recording still publishes cleanly when its target
   expect(fs.readFileSync(outPath, 'utf8')).not.toContain(HEAL_COMPLETE_SENTINEL);
 });
 
-test('close --save-script=<explicit path> clears the defaulted marker, and a write to that (absent) explicit path succeeds', () => {
+test('close --save-script=<explicit path> re-points a defaulted-healed repair, and a write to that (absent) explicit path succeeds', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-close-explicit-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const defaultedHealed = path.join(root, 'flows', 'login.healed.ad');
   const explicitOut = path.join(root, 'flows', 'promoted.ad');
 
-  // The repair defaulted to `.healed.ad` (marker set).
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
+  // The repair defaulted its target to the `.healed.ad` sibling.
+  const session = makeRepairArmedSession('default', {
     saveScriptPath: defaultedHealed,
-    saveScriptDefaultedHealedPath: true,
     actions: [action({ command: 'click', positionals: ['id="new"'] })],
   });
 
-  // `close --save-script=<explicit path>` re-points the path AND clears the
-  // marker (regression: it used to retain the marker and wrongly refuse the
-  // explicit target). The marker no longer affects the publish decision at
-  // all (refusal is now uniform), but a redirected session must still
-  // publish cleanly to its own (absent) explicit target.
+  // `close --save-script=<explicit path>` re-points the path (regression: it
+  // used to wrongly refuse the explicit target). Refusal is now uniform
+  // regardless of how the path was chosen, but a redirected session must
+  // still publish cleanly to its own (absent) explicit target.
   recordActionEntry(session, {
     command: 'close',
     positionals: [],
     flags: { saveScript: explicitOut },
   });
-  expect(session.saveScriptDefaultedHealedPath).toBe(false);
   expect(session.saveScriptPath).toBe(explicitOut);
   // `recordActionEntry` is the low-level action recorder `close`'s handler
   // calls on its way to setting the finalize signal (Fix 2) — set here to
-  // isolate this test's own concern (defaulted-marker clearing).
+  // isolate this test's own concern (the retarget).
   session.saveScriptComplete = true;
 
   const result = writer.write(session);
@@ -591,12 +540,10 @@ test('close --save-script=<explicit path> clears the defaulted marker, and a wri
 test('C2 abort-before-complete: a repair-armed but NOT-complete write discards — no file, no prefix', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-incomplete-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    // No saveScriptComplete: the plan never ran to its last executable step
-    // (a `close`/`close --save-script` reached after a divergence, a daemon
-    // teardown, or an idle-reap of an in-flight repair).
+  // ARMED but never COMPLETE: the plan never ran to its last executable step
+  // (a `close`/`close --save-script` reached after a divergence, a daemon
+  // teardown, or an idle-reap of an in-flight repair).
+  const session = makeRepairArmedSession('default', {
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });
 
@@ -612,10 +559,7 @@ test('C2 commit-when-complete: a repair-armed COMPLETE write publishes and marks
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const outPath = path.join(root, 'flows', 'flow.healed.ad');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });
@@ -631,10 +575,7 @@ test('C2 idempotent post-commit: a second write on a COMMITTED session no-ops (n
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const outPath = path.join(root, 'flows', 'flow.healed.ad');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });
@@ -658,10 +599,9 @@ test('write() still emits an ordinary (non-repair) recording on close without --
     path.join(os.tmpdir(), 'agent-device-script-writer-ordinary-unfinalized-'),
   );
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
-    // No saveScriptBoundary: an ordinary `open --save-script` recording, not
-    // a repair — the Fix 2 gate only applies to repair-armed sessions.
+  // An ordinary `open --save-script` recording, not a repair — the Fix 2 gate
+  // only applies to repair-armed sessions.
+  const session = makeAuthoringSession('default', {
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });
 
@@ -672,8 +612,7 @@ test('write() still emits an ordinary (non-repair) recording on close without --
 test('write() never appends the completeness sentinel to an ordinary (non-repair) recording', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-script-writer-no-sentinel-'));
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
-  const session = makeIosSession('default', {
-    recordSession: true,
+  const session = makeAuthoringSession('default', {
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });
 
@@ -686,10 +625,7 @@ test('write() publishes atomically: no stray temp file survives a successful rep
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const outPath = path.join(root, 'flows', 'atomic.healed.ad');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  const session = makeIosSession('default', {
-    recordSession: true,
-    saveScriptBoundary: 0,
-    saveScriptComplete: true,
+  const session = makeRepairCompleteSession('default', {
     saveScriptPath: outPath,
     actions: [action({ command: 'click', positionals: ['id="save"'] })],
   });

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -777,7 +777,6 @@ test('BLOCKER 2: finalizeRepairTeardown of a COMPLETE transaction whose commit F
   session.saveScriptBoundary = 0;
   session.saveScriptComplete = true;
   session.saveScriptPath = healedPath;
-  session.saveScriptDefaultedHealedPath = true;
   session.repairSourcePath = '/flows/login.ad';
   session.actions = [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }];
 
@@ -815,7 +814,6 @@ test('BLOCKER 3: finalizeRepairTeardown auto-commit records a terminal close, pr
   session.saveScriptBoundary = 0;
   session.saveScriptComplete = true;
   session.saveScriptPath = healedPath;
-  session.saveScriptDefaultedHealedPath = true;
   session.actions = [
     { ts: 1, command: 'open', positionals: ['Demo'], flags: {} },
     { ts: 2, command: 'click', positionals: ['id="save-v2"'], flags: {} },

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -3,7 +3,10 @@ import { handleFindCommands } from '../find.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
 import { buildSnapshotSignatures } from '../../android-snapshot-freshness.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import { makeIosSession as makeSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession as makeSession,
+  makeAuthoringSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 
 vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
@@ -805,8 +808,7 @@ test('find rejects --record on a mutating action before any device work', async 
 test('read-only find while recording is intentionally deferred from target-v1 evidence (#1349)', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'default';
-  const session = makeSession(sessionName);
-  session.recordSession = true;
+  const session = makeAuthoringSession(sessionName);
   sessionStore.set(sessionName, session);
   mockDispatch.mockImplementation(async (_device, command) => {
     if (command === 'snapshot') {

--- a/src/daemon/handlers/__tests__/interaction-common.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-common.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession,
+  makeAuthoringSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import { attachRefs, type RawSnapshotNode } from '@agent-device/kernel/snapshot';
 import type { CommandFlags } from '../../../core/dispatch.ts';
@@ -27,8 +30,7 @@ test('parameterized fill scrubs backend and nested settle echoes at the response
   const secret = 'OpaqueValue1348';
   const placeholder = '${PASSWORD}';
   const sessionStore = makeSessionStore();
-  const session = makeIosSession('parameterized-fill');
-  session.recordSession = true;
+  const session = makeAuthoringSession('parameterized-fill');
   sessionStore.set(session.name, session);
   const payload = {
     text: secret,
@@ -185,8 +187,7 @@ test('parameterized fill collapses whitespace-only backend echoes through the ha
   const placeholder = '${SPACES}';
   const sessionStore = makeSessionStore();
   const sessionName = 'parameterized-whitespace-fill-handler-route';
-  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
-  session.recordSession = true;
+  const session = makeAuthoringSession(sessionName, { appBundleId: 'com.example.app' });
   session.snapshot = {
     nodes: attachRefs([
       {
@@ -254,8 +255,7 @@ test.each([
   ({ literal, recordAs }) => {
     const placeholder = `\${${recordAs}}`;
     const sessionStore = makeSessionStore();
-    const session = makeIosSession(`parameterized-overlap-${recordAs}`);
-    session.recordSession = true;
+    const session = makeAuthoringSession(`parameterized-overlap-${recordAs}`);
     sessionStore.set(session.name, session);
     const payload = {
       text: literal,

--- a/src/daemon/handlers/__tests__/interaction-target-evidence.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-target-evidence.test.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 import { handleInteractionCommands } from '../interaction.ts';
 import { attachRefs, type RawSnapshotNode } from '@agent-device/kernel/snapshot';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession,
+  makeAuthoringSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import { SessionScriptWriter } from '../../session-script-writer.ts';
 import type { CommandFlags } from '../../../core/dispatch.ts';
 import type { SessionState } from '../../types.ts';
@@ -66,8 +69,10 @@ function makeSessionWithSnapshot(
   sessionName: string,
   options: { recordSession: boolean },
 ): SessionState {
-  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
-  session.recordSession = options.recordSession;
+  const session = makeIosSession(sessionName, {
+    appBundleId: 'com.example.app',
+    recordSession: options.recordSession,
+  });
   session.snapshot = {
     nodes: attachRefs(SAVE_BUTTON_NODES),
     createdAt: Date.now(),
@@ -178,8 +183,7 @@ test('get text @ref without recording never computes target-v1 evidence', async 
 test('get text simple iOS id selector while recording skips the direct runner query and records evidence from the snapshot path', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'recording-get-direct-gate';
-  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
-  session.recordSession = true;
+  const session = makeAuthoringSession(sessionName, { appBundleId: 'com.example.app' });
   sessionStore.set(sessionName, session);
   mockDispatch.mockImplementation(async (_device, command) => {
     if (command === 'snapshot') {
@@ -318,8 +322,7 @@ test('press on an identity-empty container: container-based daemon response, des
   // on the runtime resolution path (the direct-iOS fast path is gated during
   // recording) without Android's real-adb dialog-readiness probes, which
   // would burn wall-clock time this unit lane must not spend.
-  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
-  session.recordSession = true;
+  const session = makeAuthoringSession(sessionName, { appBundleId: 'com.example.app' });
   sessionStore.set(sessionName, session);
   mockDispatch.mockImplementation(async (_device, command) => {
     if (command === 'snapshot') {

--- a/src/daemon/handlers/__tests__/session-close-script.test.ts
+++ b/src/daemon/handlers/__tests__/session-close-script.test.ts
@@ -3,7 +3,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession,
+  makeRepairCompleteSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest } from '../../types.ts';
 import {
@@ -19,11 +22,10 @@ afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
-function setup(name: string) {
+function setup(name: string, session = makeIosSession(name, { appBundleId: 'com.example.app' })) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-close-script-'));
   roots.push(root);
   const sessionStore = new SessionStore(path.join(root, 'sessions'));
-  const session = makeIosSession(name, { appBundleId: 'com.example.app' });
   sessionStore.set(name, session);
   const req: DaemonRequest = {
     token: 'token',
@@ -36,10 +38,10 @@ function setup(name: string) {
 }
 
 test('failed repair publication removes only its synthetic close before retry', () => {
-  const { req, session, sessionStore } = setup('repair');
-  session.saveScriptBoundary = 0;
-  session.saveScriptComplete = true;
-  session.recordSession = true;
+  const { req, session, sessionStore } = setup(
+    'repair',
+    makeRepairCompleteSession('repair', { appBundleId: 'com.example.app' }),
+  );
   const failure = new AppError('COMMAND_FAILED', 'publish failed');
   vi.spyOn(sessionStore, 'writeSessionLog').mockReturnValue({ written: false, error: failure });
 

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -39,7 +39,7 @@ import { SessionStore } from '../../session-store.ts';
 import { handleCloseCommand } from '../session-close.ts';
 import { handleOpenCommand } from '../session-open.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { SessionState } from '../../types.ts';
+import { makeAuthoringSession } from '../../../__tests__/test-utils/session-factories.ts';
 import { AppError } from '@agent-device/kernel/errors';
 
 const mockDispatch = vi.mocked(dispatchCommand);
@@ -267,15 +267,11 @@ test('#1391: a close-time script save failure still clears the advisory claim an
   // after `handleCloseCommand` deletes it from the store — `store.delete` only
   // drops the map entry, it doesn't touch the object this variable still
   // points at.
-  const session: SessionState = {
-    name: 'close-save-script-failure',
+  const session = makeAuthoringSession('close-save-script-failure', {
     device: android,
     deviceClaim: acquired.ownership,
-    createdAt: Date.now(),
-    actions: [],
-    recordSession: true,
     saveScriptPath: targetPath,
-  };
+  });
   store.set('close-save-script-failure', session);
   mockDispatch.mockResolvedValue({});
 

--- a/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-transaction.test.ts
@@ -62,7 +62,10 @@ import { SessionStore } from '../../session-store.ts';
 import { LeaseRegistry } from '../../lease-registry.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
 import { AppError } from '@agent-device/kernel/errors';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession,
+  makeRepairCompleteSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import { HEAL_COMPLETE_SENTINEL } from '../../session-script-writer.ts';
 import { parseReplayScriptDetailed } from '../../../replay/script.ts';
 import type { DaemonRequest } from '../../types.ts';
@@ -426,23 +429,21 @@ test('BLOCKER 1: a --from continuation on a reaped session returns SESSION_NOT_F
 
 /** A COMPLETE, committable repair-armed session at the default healed sibling path. */
 function makeCompleteRepairSession(sessionStore: SessionStore, sessionName: string, root: string) {
-  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
-  session.recordSession = true;
-  session.saveScriptBoundary = 0;
-  session.saveScriptComplete = true;
-  session.saveScriptPath = path.join(root, 'flow.healed.ad');
-  session.saveScriptDefaultedHealedPath = true;
-  session.actions = [
-    { ts: 1, command: 'open', positionals: ['Demo'], flags: {} },
-    {
-      ts: 2,
-      command: 'press',
-      positionals: ['@e7'],
-      flags: {},
-      result: { selectorChain: ['id="save-v2"'] },
-      targetEvidence: freshEvidence('save-v2', 'Save V2'),
-    },
-  ];
+  const session = makeRepairCompleteSession(sessionName, {
+    appBundleId: 'com.example.app',
+    saveScriptPath: path.join(root, 'flow.healed.ad'),
+    actions: [
+      { ts: 1, command: 'open', positionals: ['Demo'], flags: {} },
+      {
+        ts: 2,
+        command: 'press',
+        positionals: ['@e7'],
+        flags: {},
+        result: { selectorChain: ['id="save-v2"'] },
+        targetEvidence: freshEvidence('save-v2', 'Save V2'),
+      },
+    ],
+  });
   sessionStore.set(sessionName, session);
   return session;
 }

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -11,7 +11,10 @@ import path from 'node:path';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';
 import { SessionStore } from '../../session-store.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
-import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  makeIosSession,
+  makeRepairArmedSession,
+} from '../../../__tests__/test-utils/session-factories.ts';
 import {
   baseReplayRequest as baseReq,
   writeReplayFile,
@@ -384,9 +387,7 @@ test('Maestro YAML cannot append commands to an active .ad repair session', asyn
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-typed-maestro-active-repair-'));
   const sessionStore = new SessionStore(path.join(root, 'sessions'));
   const sessionName = 'default';
-  const session = makeIosSession(sessionName);
-  session.recordSession = true;
-  session.saveScriptBoundary = 0;
+  const session = makeRepairArmedSession(sessionName);
   sessionStore.set(sessionName, session);
   const yamlPath = path.join(root, 'flow.yaml');
   fs.writeFileSync(yamlPath, 'appId: com.example.app\n---\n- launchApp\n');

--- a/src/daemon/handlers/__tests__/session-script-publication.test.ts
+++ b/src/daemon/handlers/__tests__/session-script-publication.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { beforeEach, expect, test } from 'vitest';
 import { INTERNAL_COMMANDS } from '../../../command-catalog.ts';
-import { makeIosSession } from '../../../__tests__/test-utils/index.ts';
+import { makeIosSession, makeAuthoringSession } from '../../../__tests__/test-utils/index.ts';
 import type { TargetAnnotationV1 } from '../../../replay/target-identity.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, SessionState } from '../../types.ts';
@@ -39,8 +39,7 @@ beforeEach(() => {
 });
 
 function armedSession(overrides: Partial<SessionState> = {}): SessionState {
-  return makeIosSession('authoring', {
-    recordSession: true,
+  return makeAuthoringSession('authoring', {
     scriptRecordingState: 'armed',
     actions: [
       { ts: 1, command: 'open', positionals: ['Demo'], flags: { saveScript: true } },

--- a/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
+++ b/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
@@ -79,8 +79,9 @@ function waitReq(overrides: Partial<DaemonRequest> = {}): DaemonRequest {
 
 async function runWait(options: { recordSession?: boolean; req?: DaemonRequest } = {}) {
   const sessionStore = makeSessionStore();
-  const session = makeAndroidSession('default');
-  session.recordSession = options.recordSession ?? false;
+  const session = makeAndroidSession('default', {
+    recordSession: options.recordSession ?? false,
+  });
   sessionStore.set('default', session);
   const response = await dispatchWaitViaRuntime({
     req: options.req ?? waitReq(),

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -856,18 +856,14 @@ function armReplaySaveScriptStep(params: {
   if (!session) return;
   session.recordSession = true;
   if (typeof saveScript === 'string') {
-    // An EXPLICIT `--save-script=<path>` clears the defaulted marker
-    // (invariant: the marker is set iff the current `saveScriptPath` was
-    // defaulted, not caller-directed). This no longer affects the publish
-    // decision either way — the writer's refuse-on-exist guard is uniform
-    // (`publishHealedScriptAtomically`) and refuses ANY pre-existing target,
-    // an explicit caller-directed path included, exactly like the default
-    // healed sibling.
+    // An EXPLICIT `--save-script=<path>` retargets. Which of the two ways the
+    // path was chosen does not affect the publish decision: the writer's
+    // refuse-on-exist guard is uniform (`publishHealedScriptAtomically`) and
+    // refuses ANY pre-existing target, an explicit caller-directed path
+    // included, exactly like the default healed sibling.
     applySaveScriptRetarget(session, expandSessionPath(saveScript), force);
-    session.saveScriptDefaultedHealedPath = false;
   } else if (session.saveScriptPath === undefined) {
     session.saveScriptPath = healedScriptSiblingPath(sourcePath);
-    session.saveScriptDefaultedHealedPath = true;
   }
   // #1258: force is per-target — a LIVE `--force`/`--overwrite` persists onto
   // the session (`saveScriptForce`) so a LATER `--from` continuation leg or an

--- a/src/daemon/server/daemon-idle-reap.test.ts
+++ b/src/daemon/server/daemon-idle-reap.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, test, vi } from 'vitest';
-import { IOS_SIMULATOR } from '../../__tests__/test-utils/index.ts';
+import { makeIosSession } from '../../__tests__/test-utils/index.ts';
 import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 import {
@@ -28,13 +28,7 @@ afterEach(() => {
 });
 
 function makeSession(overrides: Partial<SessionState> = {}): SessionState {
-  return {
-    name: 'default',
-    device: IOS_SIMULATOR,
-    createdAt: Date.now(),
-    actions: [],
-    ...overrides,
-  };
+  return makeIosSession('default', overrides);
 }
 
 test('resolveDaemonIdleReapMs falls back to the 5 minute default', () => {

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -69,18 +69,17 @@ export function recordActionEntry(
     session.recordSession = true;
     if (typeof entry.flags.saveScript === 'string') {
       // ADR 0012 decision 6: an explicit `--save-script=<path>` (e.g. `close
-      // --save-script=<path>`) clears the defaulted-healed marker, since this
-      // path was no longer defaulted to the healed sibling. This marker plays
-      // no role in the publish decision itself: the writer's refuse-on-exist
-      // guard is uniform (see `publishHealedScriptAtomically`) and refuses
-      // ANY pre-existing target — an explicit, caller-DIRECTED path included.
-      // Directing the path is not the same as authorizing an overwrite.
+      // --save-script=<path>`) retargets away from the defaulted healed
+      // sibling. How the path was chosen plays no role in the publish
+      // decision: the writer's refuse-on-exist guard is uniform (see
+      // `publishHealedScriptAtomically`) and refuses ANY pre-existing target —
+      // an explicit, caller-DIRECTED path included. Directing the path is not
+      // the same as authorizing an overwrite.
       applySaveScriptRetarget(
         session,
         expandSessionPath(entry.flags.saveScript),
         entry.flags.force,
       );
-      session.saveScriptDefaultedHealedPath = false;
     }
     // #1258: persist `--force`/`--overwrite`, like `saveScriptPath`, so a
     // LATER write that does not repeat the flag (a bare `close` finishing a

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -397,17 +397,6 @@ export type SessionState = {
    */
   saveScriptBoundary?: number;
   /**
-   * ADR 0012 decision 6: set when `saveScriptPath` was DEFAULTED to the
-   * `<original-stem>.healed.ad` sibling (no explicit `--save-script=<out>`).
-   * Bookkeeping only — it does not gate the writer's refuse-on-exist
-   * decision, which is uniform regardless of this flag (see
-   * `publishHealedScriptAtomically`): a second repair against the same
-   * original is refused at the default healed sibling exactly like an
-   * explicit `--save-script=<path>` or an ordinary recording's target would
-   * be, never destroying an unreviewed prior `.healed.ad` diff.
-   */
-  saveScriptDefaultedHealedPath?: boolean;
-  /**
    * ADR 0012 decision 6, R7 + commit semantics (C2): the repair TRANSACTION
    * completion flag. `true` iff the last repair-armed replay run reached its
    * final EXECUTABLE step with no outstanding divergence (the terminal source


### PR DESCRIPTION
Preparatory slice for P4a (#1478). **This introduces no aggregate.** No `ReplaySessionTransaction`, no `SessionScriptPublication`, no tagged session-script cluster, and no production publication writer is migrated — all of that is the separate P4a PR. This exists so that PR is reviewable.

## 1. Session-script test factories

~250 direct writes of `saveScript*`/`recordSession` were spread across the daemon test tree as inline object literals. P4a proper has to change the shape of every one of them, so they get a name first.

Three factories next to the existing `makeIosSession` in `src/__tests__/test-utils/session-factories.ts`:

| factory | state |
| --- | --- |
| `makeAuthoringSession` | ADR 0016 ordinary authoring recording — `recordSession`, no repair boundary |
| `makeRepairArmedSession` | ADR 0012 decision 6 ARMED — plus `saveScriptBoundary`, the flag the writer's `repairArmed` keys off |
| `makeRepairCompleteSession` | ARMED -> COMPLETE — committable |

**40 inline session literals across 11 test files** now go through them. The heaviest is `session-script-writer.test.ts` (24 literals, 20+ of which spelled out the same three-to-five-field combination). Named "authoring" rather than "recording" because `session.recording` is the unrelated screen-capture state, and `daemon-runtime-recording-teardown.test.ts` already has a local `makeRecordingSession` meaning that.

The factories write **today's** fields — pure refactor, no production change, no behavior change, no assertion weakened.

### Deliberately left explicit

- `session-action-recorder.test.ts` / `selector-recording.test.ts` (9 sites) set `saveScriptBoundary: 0` with **no** `recordSession`. That is the repair-armed *marker* in isolation, which is exactly the predicate those tests exercise; forcing them through a factory would add a field production couples but these tests deliberately don't.
- `request-router-repair-expired.test.ts`'s `tombstonedSession` — a boundary plus `repairSourcePath` with no recording, one site, no repetition to remove.
- `session-store.test.ts` keeps its own `makeSession`: one test mutates `session.device.name`, and the shared factories hand back the module-level `IOS_SIMULATOR` **by reference**, so routing it through them would make that mutation leak across tests. Only the dead-field lines were removed there.
- `request-router-typed-error.test.ts` keeps its tenant-scoped simulator (`simulatorSetPath`), now passed into the shared factories as `TENANT_SESSION_DEFAULTS` rather than re-spelled per test.
- Assertion-only references (`session-replay-repair-loop/-empty-tail/-acceptance`, the two integration scenarios, `request-save-script-transports.test.ts`) were left alone — they read the fields, they don't construct them.

## 2. `saveScriptDefaultedHealedPath` deleted

**Zero production readers, verified.** A repo-wide grep finds only three writers (`session-replay-runtime.ts:867/870`, `session-action-recorder.ts:83`), the type declaration, the R7 ownership row, and one test assertion. Nothing branches on it: the writer's refuse-on-exist guard (`publishHealedScriptAtomically`) has been uniform since #1235 — an explicit `--save-script=<path>` and the default `.healed.ad` sibling are refused identically — so the flag has been bookkeeping with no consumer.

Deleting it required, in the same commit:

- dropping its row from `SESSION_STATE_FIELD_OWNERS` in `scripts/layering/session-state.ts`;
- lowering the R10 baseline in `scripts/layering/daemon-modularity.ts`: **`writerOwnedFields` 30 -> 29, `ownerFileClaims` 42 -> 40** (the field claimed two owner files). The ratchet fails on a *drop* as well as a growth, so this could not be deferred.

`scripts/layering/daemon-modularity.test.ts` needed no change — it asserts against `DAEMON_MODULARITY_BASELINE` dynamically rather than against literals. `scripts/layering/model.test.ts` was checked: its AST fixture string uses `saveScriptComplete`, not the deleted field, and its field-count assertions derive from the tables, so it is unaffected.

The one test that asserted on the flag (`session-script-writer.test.ts`) kept its other concern — that `close --save-script=<explicit path>` re-points a defaulted-healed repair and publishes cleanly to the new target — and lost only the marker assertion.

## Gates

```
pnpm check:layering
Layering guard: OK — ... all 40 SessionState fields are classified and every write is
inside its declared owner (R7); ... R10 pins R7 at 29 writer-owned fields / 40 owner
claims, ...
```

`pnpm check:affected --base origin/main --run`: `format`, `lint`, `typecheck`, `layering`, `fallow`, `mcp-metadata` and `build` all pass. `vitest-related` runs 236 files / 2269 tests with **1 pre-existing failure**: `src/daemon/handlers/__tests__/session-test-runner.test.ts` ("test dispatches per-platform scripts", `['ios','android']` vs `['android','ios']`). It reproduces unchanged on `origin/main` (`32b9db2d7`) with this branch stashed, is in the P3 worker's `session-test*.ts` territory, and is pulled into the related set only because this PR touches `src/daemon/types.ts`. Every test this PR actually edits passes.

## Coordination

The only shared-file edit is the two-line `writerOwnedFields`/`ownerFileClaims` baseline in `scripts/layering/daemon-modularity.ts` — localized, well away from the R10 logical-module policies the P3 worker is editing. `session-replay-runtime.ts` is touched only at ~867 (the arming step), disjoint from P3's ~461.

Refs #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXQLYV7etZx3gcXsUsrQJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXQLYV7etZx3gcXsUsrQJ8)_