### PR TITLE
fix(ci): drop pipefail from the nightly Android emulator script

### DIFF
--- a/.github/workflows/replays-nightly.yml
+++ b/.github/workflows/replays-nightly.yml
@@ -129,7 +129,10 @@ jobs:
           target: google_apis_playstore
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
           script: |
-            set -euo pipefail
+            # android-emulator-runner executes this with /usr/bin/sh, which is dash on
+            # ubuntu runners and rejects `-o pipefail`. The serial assignment below is
+            # validated by the `test -n` guard instead.
+            set -eu
             ANDROID_SERIAL="$(adb devices | awk 'NR > 1 && $2 == "device" { print $1; exit }')"
             test -n "$ANDROID_SERIAL"
             BOOT_FINISHED_AT="$(date +%s)"


### PR DESCRIPTION
## Problem

The `Android Full Emulator Suite` job in Replay Nightly has failed on **every** run since it landed in #1484 — it never once passed. It aborts before the first command:

```
/usr/bin/sh: 1: set: Illegal option -o pipefail
##[error]The process '/usr/bin/sh' failed with exit code 2
```

`reactivecircus/android-emulator-runner` executes its `script:` with `/usr/bin/sh`, which is **dash** on ubuntu runners, and dash has no `pipefail` option. The job burns a full emulator boot (~3 min) and then dies on line 1.

Latest occurrence: [run 30603457576](https://github.com/callstack/agent-device/actions/runs/30603457576) (2026-07-31), same in the 2026-07-30 17:40 nightly. The last green nightly (2026-07-30 09:16) predates the job.

## Fix

Use `set -eu`, matching the two sibling emulator scripts that already run correctly under the same action:

- `.github/workflows/android.yml` → `set -eu`
- `.github/workflows/perf-nightly.yml` → `set -e`

Dropping `pipefail` loses nothing here: the only pipeline is the `ANDROID_SERIAL` assignment, which is already validated by the `test -n \"$ANDROID_SERIAL\"` guard on the next line — the same contract android.yml relies on.

## Verification

Reproduced and verified against a real dash (`/bin/dash`), which emits the identical error:

```
$ /bin/dash -c 'set -euo pipefail; echo reached'
/bin/dash: 1: set: Illegal option -o pipefail   # exit 2

$ /bin/dash -c 'set -eu; echo reached'
reached                                          # exit 0
```

The full 16-line script body extracted from the workflow also passes `dash -n` (no other bashisms). Swept every `android-emulator-runner` `script:` block in the repo — this was the only one affected.

Nightly is the only place this job runs, so the real proof is the next scheduled run (or a manual dispatch).