### PR TITLE
fix(android): re-capture past a transient helper content verdict

### DIFF
--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -843,6 +843,54 @@ test('snapshotAndroid fails closed when helper returns only system windows', asy
   );
 });
 
+test('snapshotAndroid re-captures past a transient system-window-only sample', async () => {
+  const instrumentCalls: string[][] = [];
+  const helperAdb = createHelperAdb({
+    instrument: async (args) => {
+      instrumentCalls.push(args);
+      // First sample lands mid-transition with no application window; the screen
+      // settles by the next one.
+      if (instrumentCalls.length === 1) {
+        return {
+          exitCode: 0,
+          stdout: helperOutput(androidSystemWindowOnlyXml(), { nodeCount: 3 }),
+          stderr: '',
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: helperOutput('<hierarchy><node text="helper" bounds="[0,0][10,10]" /></hierarchy>'),
+        stderr: '',
+      };
+    },
+  });
+
+  const snapshot = await snapshotAndroidWithHelper(helperAdb);
+
+  assert.equal(instrumentCalls.length, 2);
+  assert.equal(snapshot.nodes.length > 0, true);
+});
+
+test('snapshotAndroid still fails closed when every re-capture stays unreadable', async () => {
+  const instrumentCalls: string[][] = [];
+  const helperAdb = createHelperAdb({
+    instrument: async (args) => {
+      instrumentCalls.push(args);
+      return {
+        exitCode: 0,
+        stdout: helperOutput(androidSystemWindowOnlyXml(), { nodeCount: 3 }),
+        stderr: '',
+      };
+    },
+  });
+
+  await assert.rejects(
+    () => snapshotAndroidWithHelper(helperAdb),
+    /Android snapshot helper returned only non-application windows/,
+  );
+  assert.equal(instrumentCalls.length, 3);
+});
+
 test('snapshotAndroid fails closed when helper returns no nodes', async () => {
   const helperXml = '<?xml version="1.0" encoding="UTF-8"?><hierarchy rotation="0"></hierarchy>';
   const helperAdb = createHelperAdb({

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -47,11 +47,20 @@ import {
   classifyAndroidHelperContent,
   type AndroidHelperContentRecoveryDecision,
 } from './snapshot-content-recovery.ts';
+import type { AndroidContentRecoveryReason } from '../../snapshot/snapshot-quality.ts';
 
 const HELPER_INSTALL_TIMEOUT_MS = 30_000;
 const HELPER_CAPTURE_TIMEOUT_MS = 5_000;
 const HELPER_COMMAND_TIMEOUT_MS = 30_000;
 const HELPER_RUNTIME_RESET_DELAY_MS = 150;
+/**
+ * A content verdict means the capture mechanism worked but sampled a screen
+ * mid-transition, which resolves on its own within a frame or two. Sampling
+ * once turns that instant into a command failure, so re-capture a bounded
+ * number of times before reporting the verdict.
+ */
+const HELPER_CONTENT_CAPTURE_ATTEMPTS = 3;
+const HELPER_CONTENT_RECAPTURE_DELAY_MS = 250;
 const HELPER_RUNTIME_RESET_TIMEOUT_MS = 2_000;
 export type AndroidSnapshotOptions = SnapshotOptions & {
   appBundleId?: string;
@@ -180,56 +189,30 @@ async function captureAndroidUiHierarchyWithHelper(
   const adbProvider = resolveAndroidAdbProvider(device, options.helperAdb);
   const commandScopedHelperSession = options.helperSessionScope !== 'daemon-session';
   try {
-    let helperCapture: { xml: string; metadata: AndroidSnapshotBackendMetadata };
-    try {
-      const install = await installAndroidSnapshotHelper(
+    let previousContentReason: AndroidContentRecoveryReason | undefined;
+    for (let attempt = 0; ; attempt += 1) {
+      if (attempt > 0) await delayBeforeContentRecapture(options.signal);
+      const settled = await captureAndroidHelperContentAttempt({
         options,
         adb,
         adbProvider,
         artifact,
         helperDeviceKey,
-      );
-      if (install.installed) {
-        await stopAndroidSnapshotHelperSession(helperDeviceKey);
+        attempt,
+        previousContentReason,
+      });
+      if (settled.outcome === 'captured') return settled.capture;
+      if (attempt + 1 >= HELPER_CONTENT_CAPTURE_ATTEMPTS) {
+        return await rejectAndroidHelperContentUnavailable({
+          contentRecovery: settled.decision,
+          attempts: attempt + 1,
+          helperDeviceKey,
+          artifact,
+          adb,
+        });
       }
-      const capture = await captureAndroidUiHierarchyFromHelper({
-        signal: options.signal,
-        adb,
-        adbProvider,
-        artifact,
-        helperDeviceKey,
-      });
-      helperCapture = formatAndroidHelperCaptureResult(capture, artifact, install.reason);
-    } catch (error) {
-      options.signal?.throwIfAborted();
-      return await rejectAndroidHelperCaptureFailure({
-        error,
-        helperDeviceKey,
-        artifact,
-        adb,
-      });
+      previousContentReason = settled.decision.reason;
     }
-
-    const content = classifyAndroidHelperContent(helperCapture.xml, helperCapture.metadata, {
-      foregroundAppPackage: options.appBundleId,
-    });
-    if (content.outcome === 'system-surface-only') {
-      emitDiagnostic({
-        phase: 'android_snapshot_helper_system_surface',
-        data: { foregroundAppPackage: options.appBundleId },
-      });
-      return {
-        xml: helperCapture.xml,
-        metadata: { ...helperCapture.metadata, systemSurfaceOnly: true },
-      };
-    }
-    if (content.outcome === 'ok') return helperCapture;
-    return await rejectAndroidHelperContentUnavailable({
-      contentRecovery: content.decision,
-      helperDeviceKey,
-      artifact,
-      adb,
-    });
   } finally {
     if (commandScopedHelperSession) {
       await stopAndroidSnapshotHelperSession(helperDeviceKey);
@@ -363,8 +346,90 @@ function formatAndroidHelperCaptureResult(
   };
 }
 
+type AndroidHelperContentAttempt =
+  | { outcome: 'captured'; capture: { xml: string; metadata: AndroidSnapshotBackendMetadata } }
+  | { outcome: 'unusable'; decision: AndroidHelperContentRecoveryDecision };
+
+async function captureAndroidHelperContentAttempt(params: {
+  options: AndroidSnapshotOptions;
+  adb: AndroidAdbExecutor;
+  adbProvider: AndroidAdbProvider;
+  artifact: AndroidSnapshotHelperArtifact;
+  helperDeviceKey: string;
+  attempt: number;
+  previousContentReason: AndroidContentRecoveryReason | undefined;
+}): Promise<AndroidHelperContentAttempt> {
+  const { options, adb, adbProvider, artifact, helperDeviceKey, attempt } = params;
+  let helperCapture: { xml: string; metadata: AndroidSnapshotBackendMetadata };
+  try {
+    const install = await installAndroidSnapshotHelper(
+      options,
+      adb,
+      adbProvider,
+      artifact,
+      helperDeviceKey,
+    );
+    if (install.installed) {
+      await stopAndroidSnapshotHelperSession(helperDeviceKey);
+    }
+    const capture = await captureAndroidUiHierarchyFromHelper({
+      signal: options.signal,
+      adb,
+      adbProvider,
+      artifact,
+      helperDeviceKey,
+    });
+    helperCapture = formatAndroidHelperCaptureResult(capture, artifact, install.reason);
+  } catch (error) {
+    options.signal?.throwIfAborted();
+    return {
+      outcome: 'captured',
+      capture: await rejectAndroidHelperCaptureFailure({
+        error,
+        helperDeviceKey,
+        artifact,
+        adb,
+      }),
+    };
+  }
+
+  const content = classifyAndroidHelperContent(helperCapture.xml, helperCapture.metadata, {
+    foregroundAppPackage: options.appBundleId,
+  });
+  if (content.outcome === 'system-surface-only') {
+    emitDiagnostic({
+      phase: 'android_snapshot_helper_system_surface',
+      data: { foregroundAppPackage: options.appBundleId },
+    });
+    return {
+      outcome: 'captured',
+      capture: {
+        xml: helperCapture.xml,
+        metadata: { ...helperCapture.metadata, systemSurfaceOnly: true },
+      },
+    };
+  }
+  if (content.outcome === 'ok') {
+    if (attempt > 0) {
+      emitDiagnostic({
+        phase: 'android_snapshot_helper_content_recaptured',
+        data: { attempts: attempt + 1, recoveredFromReason: params.previousContentReason },
+      });
+    }
+    return { outcome: 'captured', capture: helperCapture };
+  }
+  return { outcome: 'unusable', decision: content.decision };
+}
+
+async function delayBeforeContentRecapture(signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  await sleep(HELPER_CONTENT_RECAPTURE_DELAY_MS);
+  signal?.throwIfAborted();
+}
+
 async function rejectAndroidHelperContentUnavailable(params: {
   contentRecovery: AndroidHelperContentRecoveryDecision;
+  attempts: number;
   helperDeviceKey: string;
   artifact: AndroidSnapshotHelperArtifact;
   adb: AndroidAdbExecutor;
@@ -375,6 +440,7 @@ async function rejectAndroidHelperContentUnavailable(params: {
     data: {
       reason: params.contentRecovery.reason,
       failureReason: params.contentRecovery.failureReason,
+      attempts: params.attempts,
       ...params.contentRecovery.diagnostics,
     },
   });
@@ -382,6 +448,7 @@ async function rejectAndroidHelperContentUnavailable(params: {
   throw new AppError('COMMAND_FAILED', params.contentRecovery.failureReason, {
     ...params.contentRecovery.diagnostics,
     androidSnapshotHelperFailureReason: params.contentRecovery.reason,
+    attempts: params.attempts,
     retriable: true,
     hint: 'Retry after the app UI stabilizes. If this persists, capture a screenshot and report the helper diagnostics; agent-device does not substitute a second snapshot engine.',
   });


### PR DESCRIPTION
## Problem

The Android smoke E2E failed in [#1510's run](https://github.com/callstack/agent-device/actions/runs/30606764293/job/91080530358) at `alert dismiss`, one step after `alert get` had just read the same dialog successfully:

```
Android snapshot helper returned only non-application windows
helperWindowRootCount: 1, helperApplicationWindowRootCount: 0,
helperWindowTypes: [3], helperNodeCount: 30, helperSystemUiNodeCount: 30
```

One capture landed while no application window was attached — a mid-transition instant that resolves itself within a frame or two. The classification was correct and the error was even stamped `retriable: true`, but nothing retried it: `captureAndroidUiHierarchyWithHelper` sampled **once** and threw.

That asymmetry is the root cause. `isUnreadableCaptureContentError` already declares these content verdicts ride-out-able, but only the polling `wait` loop rides them out; every other command turns the first mistimed sample into a hard failure. The same branch had passed this job 9 hours earlier with no Android-relevant delta — a machinery-caused flake, not a product bug on the screen.

## Fix

Re-capture a bounded number of times (3 attempts, 250 ms apart) before reporting a content verdict. Mechanism failures (helper timeout, adb failure, missing artifact) are untouched and still fail on the first occurrence — only the enumerated content verdicts retry.

**This does not soften the "one-shot reads fail loudly" contract** documented in `snapshot-quality.ts`: a screen that stays unreadable still fails with the same error, same hint, same runtime reset — just after 3 samples instead of 1. The failure now carries `attempts` so the logs distinguish "caught it mid-transition" from "this screen is genuinely unreadable", and a recovered capture emits `android_snapshot_helper_content_recaptured` with the reason it recovered from.

## Testing

Two new tests in `snapshot.test.ts`, both verified revert-sensitive (they fail with attempts=1, pass at 3):

- transient case: first sample is system-window-only, second is clean → snapshot succeeds, exactly 2 instrument calls
- persistent case: every sample unreadable → still rejects with the same message, exactly 3 instrument calls

`pnpm check:affected --run` passes (46/46 in the touched file). The retry loop's per-attempt body is extracted into `captureAndroidHelperContentAttempt` to stay under the complexity gate.

Root-causes the Android half of the flaky-CI investigation on #1510.