### PR TITLE
fix(test): give the iOS scroll search a capture-sized wait budget

### DIFF
--- a/test/integration/ios-simulator-e2e/live-assertions.ts
+++ b/test/integration/ios-simulator-e2e/live-assertions.ts
@@ -19,25 +19,51 @@ export const { assertElementText, assertWaitText, capturePng } = createLiveDevic
   LiveContext
 >(runStep, verifyCommand, PUBLIC_COMMANDS.wait);
 
+// The whole budget goes to the first capture of each attempt, so it has to cover one snapshot of
+// the current surface — 1s did not on a loaded simulator, and every sibling wait in these scenarios
+// already budgets 2.5s or more.
+const SCROLL_SEARCH_WAIT_MS = 2500;
+const SCROLL_SEARCH_ATTEMPTS = 4;
+// A stalled capture says nothing about where the element is, so it must not consume the scroll
+// budget outright; a couple of retries absorb a slow runner without masking a real absence.
+const SCROLL_SEARCH_STALL_RETRIES = 2;
+
 export async function assertElementTextAfterScrolling(
   context: LiveContext,
   selector: string,
   expected: string,
 ): Promise<void> {
-  for (let attempt = 1; attempt <= 4; attempt += 1) {
+  let stallRetriesLeft = SCROLL_SEARCH_STALL_RETRIES;
+  let lastFailure: CliJsonResult | undefined;
+
+  for (let attempt = 1; attempt <= SCROLL_SEARCH_ATTEMPTS; ) {
     const visible = await runStep(
       context,
       `wait for ${selector} after scroll (attempt ${attempt})`,
-      ['wait', selector, '1000'],
-      { allowFailure: attempt < 4 },
+      ['wait', selector, String(SCROLL_SEARCH_WAIT_MS)],
+      { allowFailure: true },
     );
     if (visible.status === 0) {
       await assertElementText(context, selector, expected);
       return;
     }
-    await runStep(context, `scroll toward ${selector}`, ['scroll', 'down', '0.75']);
+    lastFailure = visible;
+
+    // The snapshot never came back, so the surface was never read. Scrolling here would move the
+    // surface for a reason unrelated to visibility and spend an attempt on no evidence.
+    if (visible.json?.error?.details?.captureStalled === true && stallRetriesLeft > 0) {
+      stallRetriesLeft -= 1;
+      continue;
+    }
+
+    attempt += 1;
+    if (attempt <= SCROLL_SEARCH_ATTEMPTS) {
+      await runStep(context, `scroll toward ${selector}`, ['scroll', 'down', '0.75']);
+    }
   }
-  assert.fail(`${selector} did not become visible after scrolling`);
+  assert.fail(
+    `${selector} did not become visible after scrolling\nlast wait: ${JSON.stringify(lastFailure?.json ?? null)}`,
+  );
 }
 
 function requireNode(


### PR DESCRIPTION
Fixes the **iOS Smoke Tests** lane, red on `main` for the last three runs.

## The failure

```
✖ live iOS simulator fixture E2E
  AssertionError: step: wait for id="automation-longpress" after scroll (attempt 4)
  command: agent-device wait id="automation-longpress" 1000 --platform ios --udid … --json
  "message": "wait timed out for selector: id=\"automation-longpress\"",
  "details": { "reason": "wait_capture_stalled", "captureStalled": true, "timeoutMs": 1000 }
  scenario: smoke:automation-input
      at assertElementTextAfterScrolling (…/ios-simulator-e2e/live-assertions.ts:28:21)
```

`ios.yml` on `main`: `209ac83df` ❌, `1fc916918` ❌, `6067b9a48` ❌, `32b9db2d7` ⚪ cancelled, `0e51007b0` ⚪ cancelled, `e70fac7b4` ✅ last green.

## Why it started failing

`wait_capture_stalled` is not "element not found". `createWaitPolling` only classifies a timeout as `capture-stalled` when the capture that timed out was the **first** one — the one handed the wait's entire budget (`src/commands/interaction/runtime/wait-polling.ts:40-56`). So the message is precisely: *one snapshot of the current surface did not complete within 1000 ms.*

`assertElementTextAfterScrolling` has budgeted 1000 ms per attempt since #1408, but until recently it was only reached from `live-full-scenarios.ts`. #1484 rewrote the smoke automation scenario to route `automation-press` and `automation-longpress` through it, replacing a fixed `scroll down --pixels 120` plus `is visible` checks. That put the tight budget on the smoke lane, where a single capture of that surface exceeds it on a loaded runner.

The budget is also an outlier among its own neighbours — every other wait in that scenario allows far more:

| wait | budget |
|---|---:|
| `label="Settings"` | 10000 ms |
| `alert wait` | 5000 ms |
| `wait text "Automation lab"` | 2500 ms |
| **scroll search (this helper)** | **1000 ms** |

Because the stall repeats on every attempt, the loop scrolls three times on no evidence and then fails — the element's actual visibility is never established either way.

## The change

Two edits to `assertElementTextAfterScrolling`, both in `test/integration/ios-simulator-e2e/live-assertions.ts`:

1. **Per-attempt budget 1000 ms → 2500 ms**, matching the nearest sibling wait, so one capture of the surface fits inside it.
2. **A stalled capture no longer consumes a scroll attempt.** A stall means the surface was never read, so scrolling on it moves the surface for a reason unrelated to visibility. Two stall retries absorb a slow runner. A genuine absence is unaffected — it still spends attempts, still scrolls, and still fails.

The terminal assertion now includes the last wait's JSON, so the next failure distinguishes "stalled" from "genuinely never appeared" without needing the raw job log.

This is deliberately confined to the test harness. I found no product-side regression on the capture path between the last green commit and now — the only non-test changes there in that window are a dead-export deletion in `src/snapshot/snapshot-processing.ts` and Maestro-specific adapters that plain `wait` does not use.

## Verification

`pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm exec oxfmt --check` ✅ on the changed file · `smoke-ios-simulator-coverage.test.ts` 12/12 ✅ (the device-free contract guarding these scenarios).

**I could not execute the live simulator lane** — no macOS, no Xcode, and this fix is by nature only exercised against a real simulator. CI on this PR is the verification that matters; the iOS lane running green here is the pass criterion.

One caveat worth stating plainly: raising a timeout makes a lane that stalls *occasionally* pass, but if a capture of this surface routinely takes over ~2.5 s that is a product-side problem this PR would only be masking. The `wait_capture_stalled` diagnostic added to the final assertion exists so that case is visible rather than silent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXQLYV7etZx3gcXsUsrQJ8)_