### PR TITLE
test(replay-test): pin the retry-path reporter hint

### DIFF
--- a/src/daemon/handlers/__tests__/session-test-reporter-values.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-reporter-values.test.ts
@@ -160,7 +160,17 @@ async function runRetrySuite(): Promise<{
     invoke: async () => {
       attempts += 1;
       return attempts === 1
-        ? { ok: false, error: { code: 'COMMAND_FAILED', message: 'first attempt failed' } }
+        ? {
+            ok: false,
+            error: {
+              code: 'COMMAND_FAILED',
+              message: 'first attempt failed',
+              // Carried so the retry-path `hint` below is asserted on a real hook value. The
+              // final-attempt path has its own hint coverage; without a hint here the retry
+              // emit site was reachable by no assertion at all.
+              hint: 'retry hint from the failed attempt',
+            },
+          }
         : { ok: true, data: { replayed: 1, healed: 0 } };
     },
   });
@@ -276,6 +286,10 @@ test('reporter step and result sessions track the running attempt, not the start
     retrying: true,
     session: 'default:test:suite-reporter:1-02-retry:attempt-1',
     message: 'Replay failed at step 1 (open "Demo"): first attempt failed',
+    // The retry emit site publishes `hint` separately from the final one. Assert it on the
+    // real hook value so deleting it from the scheduler fails here rather than shipping a
+    // reporter that silently loses the field on every retried failure.
+    hint: 'retry hint from the failed attempt',
   });
   const finalResult = hookValue(hooks, 6, 'onTestResult');
   expect(finalResult).toMatchObject({


### PR DESCRIPTION
A one-assertion ratchet that has to land **before** P3b relocates `session-test-attempt.ts` into `packages/replay-test`, so the move cannot drop a shipped reporter field silently.

## The gap

`hint` reaches reporters from **two** emit sites in `src/daemon/handlers/session-test-attempt.ts`:

| site | when | asserted before this PR |
|---|---|---|
| `emitReplayTestRetryProgress` (~:287) | every retried failure | **no** |
| final failure progress (~:374) | terminal failure | yes, via #1505 |

#1505 added hint coverage, but only for the final path. The retry emit site was reachable by no assertion at all — and could not have been caught even in principle, because the retry fixture's first-attempt error carried no `hint` for the scheduler to forward.

## Change

`runRetrySuite`'s first-attempt error now carries a hint, and the retry result value asserts it. Test-only; **`git diff` on `session-test-attempt.ts` is empty.**

## Counterfactual — run, not assumed

Deleting `hint: attempt.outcome.error.hint` from the retry emit site:

```
 ✓ a reporter sees the shipped suite-start, skip, and test-start values
 × reporter step and result sessions track the running attempt, not the start value
 ✓ a failing suite reaches the reporter with the failure message, hint fields, and exit code
 ✓ sharded runs give the reporter shard-scoped sessions and device identity

-   "hint": "retry hint from the failed attempt",
+   "hint": undefined,

 Tests  1 failed | 3 passed (4)
```

Only the new pin fails. **The existing final-path hint test keeps passing** — which is precisely the gap being closed. Restored afterwards; production diff empty; both reporter suites green (6/6).

## Why now

P3b moves this file. A field that no test asserts is a field a large mechanical move can drop without any gate objecting — the exact failure mode #1505's ratchet exists to prevent, left half-covered. Cheaper to pin it here than to detect it after a 3,000-line relocation.

Refs #1478

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXQLYV7etZx3gcXsUsrQJ8)_