### PR TITLE
feat(ios): reach physical devices through usbmux first, tunnel as fallback

### DIFF
--- a/docs/usbmux-runner-transport-experiment.md
+++ b/docs/usbmux-runner-transport-experiment.md
@@ -59,16 +59,27 @@ xctestrun prep (~13 s cold) and runner startup; fresh device resolution costs
    devices; DeviceID (10) is the mux handle. Multi-device disambiguation is
    structural. (Multi-attached-device matrix not exercised: one device only.)
 
-## Implied design (matches the issue's desired outcome, minus full deletion)
+## Shipped design (matches the issue's desired outcome, minus full deletion)
 
-- One private route resolver: physical devices try usbmux first; on usbmux
-  DEVICE_NOT_FOUND (not attached via USB) resolve the CoreDevice tunnel and
-  use the network route. Tunnel cache/invalidations stay but only run on the
-  fallback path, so cabled devices never pay the probe/TTL tax.
-- Failure semantics: usbmux DEVICE_NOT_FOUND → immediate fallback attempt;
-  if the fallback also fails, surface the usbmux hint (cable/trust/unlock).
-- The xctest backend keeps usbmux-only (CoreDevice unavailable by definition)
-  but needs the same non-retryable classification for DEVICE_NOT_FOUND.
+Implemented on top of this evidence; the experiment's
+`AGENT_DEVICE_IOS_RUNNER_ROUTE` override is gone because usbmux-first is now
+the real behaviour rather than something to opt into.
+
+- One private route resolver: physical devices resolve to usbmux first. When
+  usbmuxd answers that the device is not attached, the resolver is marked for
+  the rest of the request and re-resolves to the CoreDevice tunnel route.
+  Callers never choose a transport; `waitForRunner` and `sendRunnerCommandOnce`
+  both go through the same resolver.
+- The tunnel lookup, its 30 s cache, and the cache invalidation now only run on
+  the fallback path, so a cabled device never pays the probe/TTL tax that cost
+  ~4.5 s per idle gap.
+- Failure semantics: the usbmux "device not attached" verdict carries
+  `usbmuxDeviceAttached: false`, and `isUsbmuxDeviceUnattachedError` is the only
+  thing that triggers fallback. It is answered inside the same connect attempt
+  rather than by burning a retry, so a Wi-Fi-only device is not slowed down.
+- The xctest backend stays usbmux-only (it has no CoreDevice tunnel by
+  definition), so its verdict is terminal and surfaces the cable/trust/unlock
+  hint instead of being retried for the full budget.
 
 ## Pitfalls for whoever implements/re-measures
 

--- a/src/platforms/apple/core/__tests__/runner-transport.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-transport.test.ts
@@ -21,11 +21,15 @@ vi.mock('../../../../utils/exec.ts', async () => {
   };
 });
 
-vi.mock('../runner/runner-usbmux.ts', () => ({
-  usbmuxRunnerTransport: {
-    postCommand: mockUsbmuxPostCommand,
-  },
-}));
+vi.mock('../runner/runner-usbmux.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../runner/runner-usbmux.ts')>();
+  return {
+    ...actual,
+    usbmuxRunnerTransport: {
+      postCommand: mockUsbmuxPostCommand,
+    },
+  };
+});
 
 import { clearDeviceTunnelIpCache } from '../runner/runner-command-route.ts';
 import { sendRunnerCommandOnce, waitForRunner } from '../runner/runner-transport.ts';
@@ -88,6 +92,7 @@ test('waitForRunner propagates request cancellation without fallback', async () 
 });
 
 test('waitForRunner reuses cached physical-device tunnel IP across commands', async () => {
+  stubUsbmuxDeviceUnattached();
   stubSuccessfulFetch();
   mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
     const jsonPath = args[args.indexOf('--json-output') + 1]!;
@@ -112,6 +117,7 @@ test('waitForRunner reuses cached physical-device tunnel IP across commands', as
 });
 
 test('waitForRunner keeps tunnel IP lookup request-local when no tunnel IP is available', async () => {
+  stubUsbmuxDeviceUnattached();
   stubSuccessfulFetch();
   mockRunCmd.mockImplementation(async () => ({ exitCode: 1, stdout: '', stderr: '' }));
 
@@ -153,6 +159,7 @@ test('waitForRunner uses simulator fallback within the attempt for ready session
 });
 
 test('waitForRunner invalidates cached tunnel IP when localhost fallback succeeds', async () => {
+  stubUsbmuxDeviceUnattached();
   const tunnelIps = ['fd00::123', 'fd00::456'];
   mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
     const jsonPath = args[args.indexOf('--json-output') + 1]!;
@@ -225,8 +232,7 @@ test('sendRunnerCommandOnce routes xctest physical devices through usbmux', asyn
   ]);
 });
 
-test('sendRunnerCommandOnce routes coredevice physical devices through usbmux when overridden', async () => {
-  vi.stubEnv('AGENT_DEVICE_IOS_RUNNER_ROUTE', 'usbmux');
+test('sendRunnerCommandOnce routes coredevice physical devices through usbmux first', async () => {
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 
@@ -234,6 +240,7 @@ test('sendRunnerCommandOnce routes coredevice physical devices through usbmux wh
 
   assert.equal(response.status, 200);
   assert.equal(fetchMock.mock.calls.length, 0);
+  // The devicectl tunnel probe is the cost usbmux-first exists to avoid.
   assert.equal(mockRunCmd.mock.calls.length, 0);
   assert.deepEqual(mockUsbmuxPostCommand.mock.calls[0]?.slice(0, 3), [
     iosDevice.id,
@@ -242,27 +249,34 @@ test('sendRunnerCommandOnce routes coredevice physical devices through usbmux wh
   ]);
 });
 
-test('runner route override follows the daemon process env across resolves', async () => {
-  // The override is daemon-scoped: resolves re-read the daemon's process env,
-  // which is fixed at daemon launch. Clearing it here models a fresh daemon
-  // launched without the variable — the only way the route can change.
-  vi.stubEnv('AGENT_DEVICE_IOS_RUNNER_ROUTE', 'usbmux');
+test('sendRunnerCommandOnce falls back to the tunnel route when usbmux reports the device unattached', async () => {
+  stubUsbmuxDeviceUnattached();
   stubSuccessfulFetch();
-  mockRunCmd.mockImplementation(async () => ({ exitCode: 1, stdout: '', stderr: '' }));
+  stubTunnelIpLookup('fd00::123');
 
-  await sendRunnerCommandOnce(iosDevice, 8100, { command: 'uptime' }, 5_000);
+  const response = await sendRunnerCommandOnce(iosDevice, 8100, { command: 'uptime' }, 5_000);
+
+  assert.equal(response.status, 200);
   assert.equal(mockUsbmuxPostCommand.mock.calls.length, 1);
-  assert.equal(vi.mocked(fetch).mock.calls.length, 0);
-
-  vi.unstubAllEnvs();
-  await sendRunnerCommandOnce(iosDevice, 8100, { command: 'uptime' }, 5_000);
-
-  assert.equal(mockUsbmuxPostCommand.mock.calls.length, 1);
-  assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://127.0.0.1:8100/command');
+  assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://[fd00::123]:8100/command');
 });
 
-test('waitForRunner routes coredevice physical devices through usbmux when overridden', async () => {
-  vi.stubEnv('AGENT_DEVICE_IOS_RUNNER_ROUTE', 'usbmux');
+test('sendRunnerCommandOnce keeps the usbmux verdict for xctest devices that have no tunnel', async () => {
+  stubUsbmuxDeviceUnattached();
+  stubSuccessfulFetch();
+
+  await assert.rejects(
+    () => sendRunnerCommandOnce(xctestIosDevice, 8100, { command: 'uptime' }, 5_000),
+    (error: unknown) => {
+      assert.equal((error as AppError).code, 'DEVICE_NOT_FOUND');
+      return true;
+    },
+  );
+  assert.equal(vi.mocked(fetch).mock.calls.length, 0);
+  assert.equal(mockRunCmd.mock.calls.length, 0);
+});
+
+test('waitForRunner routes coredevice physical devices through usbmux first', async () => {
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 
@@ -273,6 +287,42 @@ test('waitForRunner routes coredevice physical devices through usbmux when overr
   assert.equal(mockRunCmd.mock.calls.length, 0);
   assert.equal(mockUsbmuxPostCommand.mock.calls.length, 1);
 });
+
+test('waitForRunner falls back to the tunnel route inside the same attempt', async () => {
+  stubUsbmuxDeviceUnattached();
+  stubSuccessfulFetch();
+  stubTunnelIpLookup('fd00::123');
+
+  const response = await waitForRunner(iosDevice, 8100, { command: 'snapshot' }, undefined, 5_000);
+
+  assert.equal(response.status, 200);
+  // One usbmux probe, then the tunnel endpoint — no retry round trip in between.
+  assert.equal(mockUsbmuxPostCommand.mock.calls.length, 1);
+  assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://[fd00::123]:8100/command');
+});
+
+function stubUsbmuxDeviceUnattached(): void {
+  mockUsbmuxPostCommand.mockRejectedValue(
+    new AppError('DEVICE_NOT_FOUND', 'iOS device is not available through usbmux', {
+      deviceId: iosDevice.id,
+      usbmuxDeviceAttached: false,
+    }),
+  );
+}
+
+function stubTunnelIpLookup(tunnelIp: string): void {
+  mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
+    const jsonPath = args[args.indexOf('--json-output') + 1]!;
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        info: { outcome: 'success' },
+        result: { connectionProperties: { tunnelIPAddress: tunnelIp } },
+      }),
+    );
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+}
 
 function stubSuccessfulFetch(): void {
   vi.stubGlobal(

--- a/src/platforms/apple/core/__tests__/runner-transport.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-transport.test.ts
@@ -276,6 +276,29 @@ test('sendRunnerCommandOnce keeps the usbmux verdict for xctest devices that hav
   assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
+test('waitForRunner reports the usbmux verdict for xctest devices without retrying', async () => {
+  // Regression: an XCTest device has no tunnel, so retrying cannot attach a
+  // cable. Before this was terminal, readiness preflight and read-only
+  // commands burned the whole connect budget and lost the recovery hint.
+  stubUsbmuxDeviceUnattached();
+  stubSuccessfulFetch();
+
+  await assert.rejects(
+    () => waitForRunner(xctestIosDevice, 8100, { command: 'snapshot' }, undefined, 5_000),
+    (error: unknown) => {
+      const appError = error as AppError;
+      assert.equal(appError.code, 'DEVICE_NOT_FOUND');
+      assert.match(String(appError.details?.hint), /Connect the device by cable/);
+      assert.equal(appError.message.includes('Runner did not accept connection'), false);
+      return true;
+    },
+  );
+
+  assert.equal(mockUsbmuxPostCommand.mock.calls.length, 1);
+  assert.equal(vi.mocked(fetch).mock.calls.length, 0);
+  assert.equal(mockRunCmd.mock.calls.length, 0);
+});
+
 test('waitForRunner routes coredevice physical devices through usbmux first', async () => {
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
@@ -306,6 +329,7 @@ function stubUsbmuxDeviceUnattached(): void {
     new AppError('DEVICE_NOT_FOUND', 'iOS device is not available through usbmux', {
       deviceId: iosDevice.id,
       usbmuxDeviceAttached: false,
+      hint: 'Connect the device by cable, trust this Mac, keep it unlocked, and retry.',
     }),
   );
 }

--- a/src/platforms/apple/core/runner/runner-command-route.ts
+++ b/src/platforms/apple/core/runner/runner-command-route.ts
@@ -3,15 +3,6 @@ import { resolveIosPhysicalDeviceControl } from '../physical-device-control.ts';
 
 const RUNNER_DEVICE_TUNNEL_IP_CACHE_TTL_MS = 30_000;
 
-/**
- * Experimental override for #1403: forces physical-device runner commands
- * through usbmux regardless of backend. Daemon-scoped: the value is re-read
- * on every resolve, but from the daemon's environment, which is captured at
- * daemon launch — a later CLI invocation cannot change it. Use a fresh
- * isolated state-dir/daemon per experiment route leg.
- */
-const RUNNER_ROUTE_OVERRIDE_ENV = 'AGENT_DEVICE_IOS_RUNNER_ROUTE';
-
 type DeviceTunnelIpCacheEntry = {
   ip: string;
   expiresAt: number;
@@ -31,9 +22,28 @@ export type RunnerCommandRoute =
 
 const deviceTunnelIpCache = new Map<string, DeviceTunnelIpCacheEntry>();
 
+/**
+ * Physical iOS devices are reached through usbmux whenever they are attached by
+ * cable (#1403): usbmuxd answers in milliseconds and the connection stays
+ * usable across idle gaps, where the CoreDevice tunnel route re-probes
+ * `devicectl` — seconds per command once its short-lived cache expires.
+ *
+ * A CoreDevice-backed device that usbmuxd does not list is Wi-Fi-only (modern
+ * CoreDevice Wi-Fi runs over `remoted`, which usbmuxd never sees), so it falls
+ * back to the tunnel route. The tunnel lookup and its cache therefore only run
+ * for devices that genuinely need them, and cabled devices never pay for them.
+ */
 export function createRunnerCommandRouteResolver(device: DeviceInfo, port: number) {
   let requestTunnelIp: string | null | undefined;
+  let usbmuxUnattached = false;
   return {
+    /**
+     * Records that usbmux cannot reach this device, so the remaining resolves
+     * in this request go straight to the CoreDevice tunnel route.
+     */
+    markUsbmuxUnattached: (): void => {
+      usbmuxUnattached = true;
+    },
     resolveRoute: async (
       timeoutBudgetMs?: number,
       forceRefresh = false,
@@ -42,9 +52,8 @@ export function createRunnerCommandRouteResolver(device: DeviceInfo, port: numbe
         return buildNetworkRoute(device, port, null, false);
       }
       const control = resolveIosPhysicalDeviceControl(device);
-      if (control.backend === 'xctest' || readRunnerRouteOverride() === 'usbmux') {
-        return buildUsbmuxRoute(device, port);
-      }
+      if (control.backend === 'xctest') return buildUsbmuxRoute(device, port);
+      if (!usbmuxUnattached) return buildUsbmuxRoute(device, port);
       if (!forceRefresh) {
         const cached = readDeviceTunnelIpCache(device.id);
         if (cached) return buildNetworkRoute(device, port, cached, true);
@@ -73,10 +82,6 @@ export function invalidateDeviceTunnelIpCache(deviceId: string): void {
  */
 export function clearDeviceTunnelIpCache(): void {
   deviceTunnelIpCache.clear();
-}
-
-function readRunnerRouteOverride(): 'usbmux' | null {
-  return process.env[RUNNER_ROUTE_OVERRIDE_ENV]?.trim() === 'usbmux' ? 'usbmux' : null;
 }
 
 function buildUsbmuxRoute(device: DeviceInfo, port: number): RunnerCommandRoute {

--- a/src/platforms/apple/core/runner/runner-contract.ts
+++ b/src/platforms/apple/core/runner/runner-contract.ts
@@ -139,7 +139,26 @@ export function isRetryableRunnerError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * True when usbmuxd answered and the device is simply not attached by cable.
+ * A CoreDevice-backed device falls back to its network tunnel; an XCTest-backed
+ * device has no second route, so this verdict is terminal rather than retryable.
+ *
+ * Lives here rather than beside the usbmux transport because the retry policy
+ * below needs it, and that transport already depends on this module.
+ */
+export function isUsbmuxDeviceUnattachedError(error: unknown): boolean {
+  if (!(error instanceof AppError) || error.code !== 'DEVICE_NOT_FOUND') return false;
+  return (
+    (error.details as { usbmuxDeviceAttached?: unknown } | undefined)?.usbmuxDeviceAttached ===
+    false
+  );
+}
+
 export function shouldRetryRunnerConnectError(error: unknown): boolean {
+  // Retrying cannot attach a cable, and the typed verdict carries the recovery
+  // hint that a generic connect failure would replace.
+  if (isUsbmuxDeviceUnattachedError(error)) return false;
   if (!(error instanceof AppError)) return true;
   if (error.code !== 'COMMAND_FAILED') return true;
   const message = String(error.message ?? '').toLowerCase();

--- a/src/platforms/apple/core/runner/runner-transport.ts
+++ b/src/platforms/apple/core/runner/runner-transport.ts
@@ -15,11 +15,12 @@ import {
 import {
   buildRunnerConnectError,
   buildRunnerEarlyExitError,
+  isUsbmuxDeviceUnattachedError,
   shouldRetryRunnerConnectError,
   type RunnerCommand,
 } from './runner-contract.ts';
 import type { RunnerSession } from './runner-session-types.ts';
-import { isUsbmuxDeviceUnattachedError, usbmuxRunnerTransport } from './runner-usbmux.ts';
+import { usbmuxRunnerTransport } from './runner-usbmux.ts';
 
 export { cleanupTempFile, getFreePort, logChunk } from './runner-io.ts';
 
@@ -88,6 +89,7 @@ export async function waitForRunner(
     if (signal?.aborted || isRequestCanceledError(error)) {
       throw createRequestCanceledError();
     }
+    if (isUsbmuxDeviceUnattachedError(error)) throw error;
     if (!lastError) {
       lastError = error;
     }
@@ -382,7 +384,13 @@ async function tryRunnerRoute(
     if (params.signal?.aborted || isRequestCanceledError(error)) {
       throw createRequestCanceledError();
     }
-    if (canFallBackFromUsbmux(device, error)) {
+    if (isUsbmuxDeviceUnattachedError(error)) {
+      if (!canFallBackFromUsbmux(device, error)) {
+        // No tunnel exists for this device, so retrying cannot attach a cable.
+        // Throw the typed verdict so its recovery hint survives instead of
+        // being replaced by a generic connect failure.
+        throw error;
+      }
       params.onUsbmuxUnattached?.();
       return null;
     }

--- a/src/platforms/apple/core/runner/runner-transport.ts
+++ b/src/platforms/apple/core/runner/runner-transport.ts
@@ -4,6 +4,7 @@ import { requireExecSuccess } from '../../../../utils/exec.ts';
 import { Deadline, retryWithPolicy } from '../../../../utils/retry.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { classifyBootFailure, bootFailureHint } from '../../../boot-diagnostics.ts';
+import { resolveIosPhysicalDeviceControl } from '../physical-device-control.ts';
 import { buildSimctlArgsForDevice } from '../simctl.ts';
 import { runXcrun } from '../tool-provider.ts';
 import {
@@ -18,7 +19,7 @@ import {
   type RunnerCommand,
 } from './runner-contract.ts';
 import type { RunnerSession } from './runner-session-types.ts';
-import { usbmuxRunnerTransport } from './runner-usbmux.ts';
+import { isUsbmuxDeviceUnattachedError, usbmuxRunnerTransport } from './runner-usbmux.ts';
 
 export { cleanupTempFile, getFreePort, logChunk } from './runner-io.ts';
 
@@ -40,7 +41,7 @@ export async function waitForRunner(
   signal?: AbortSignal,
 ): Promise<Response> {
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const { resolveRoute } = createRunnerCommandRouteResolver(device, port);
+  const { resolveRoute, markUsbmuxUnattached } = createRunnerCommandRouteResolver(device, port);
   let route = await resolveRoute(deadline.remainingMs());
   let lastError: unknown = null;
   const maxAttempts = Math.max(1, Math.ceil(timeoutMs / RUNNER_CONNECT_ATTEMPT_INTERVAL_MS));
@@ -56,6 +57,7 @@ export async function waitForRunner(
           session,
           route,
           resolveRoute,
+          markUsbmuxUnattached,
           signal,
           attemptDeadline,
           setRoute: (nextRoute) => {
@@ -118,6 +120,7 @@ async function attemptRunnerConnection(params: {
   session?: RunnerSession;
   route: RunnerCommandRoute;
   resolveRoute: RunnerRouteResolver;
+  markUsbmuxUnattached: () => void;
   signal?: AbortSignal;
   attemptDeadline?: Deadline;
   setRoute: (route: RunnerCommandRoute) => void;
@@ -167,6 +170,7 @@ async function tryPrimaryRunnerRoute(params: {
   attemptDeadline?: Deadline;
   setRoute: (route: RunnerCommandRoute) => void;
   setLastError: (error: unknown) => void;
+  markUsbmuxUnattached: () => void;
 }): Promise<{ response: Response | null; usedCachedTunnelIp: boolean }> {
   let route = params.route;
   let usedCachedTunnelIp = false;
@@ -176,21 +180,35 @@ async function tryPrimaryRunnerRoute(params: {
     params.setRoute(route);
   }
 
-  const cachedTunnelEndpoint = usedCachedTunnelIp ? route.endpoints[0] : null;
-  const response = await tryRunnerRoute(params.device, route, {
-    command: params.command,
-    port: params.port,
-    timeoutMs: params.timeoutMs,
-    signal: params.signal,
-    attemptDeadline: params.attemptDeadline,
-    onError: (endpoint, err) => {
-      params.setLastError(err);
-      if (params.device.kind === 'device' && endpoint === cachedTunnelEndpoint) {
-        invalidateDeviceTunnelIpCache(params.device.id);
-      }
-    },
-  });
-  return { response, usedCachedTunnelIp };
+  const runRoute = async (current: RunnerCommandRoute) => {
+    // Derived per route: a usbmux-first attempt only learns its cached tunnel
+    // endpoint after falling back, and a stale one must still be invalidated.
+    const cachedTunnelEndpoint = current.cachedTunnelIp ? current.endpoints[0] : null;
+    return await tryRunnerRoute(params.device, current, {
+      command: params.command,
+      port: params.port,
+      timeoutMs: params.timeoutMs,
+      signal: params.signal,
+      attemptDeadline: params.attemptDeadline,
+      onUsbmuxUnattached: params.markUsbmuxUnattached,
+      onError: (endpoint, err) => {
+        params.setLastError(err);
+        if (params.device.kind === 'device' && endpoint === cachedTunnelEndpoint) {
+          invalidateDeviceTunnelIpCache(params.device.id);
+        }
+      },
+    });
+  };
+
+  const response = await runRoute(route);
+  if (response || route.kind !== 'usbmux') return { response, usedCachedTunnelIp };
+
+  // usbmux reported the device as unattached: resolve the CoreDevice tunnel
+  // route and try it within the same attempt instead of burning a retry.
+  const fallback = await params.resolveRoute(params.attemptDeadline?.remainingMs());
+  if (fallback.kind === 'usbmux') return { response: null, usedCachedTunnelIp };
+  params.setRoute(fallback);
+  return { response: await runRoute(fallback), usedCachedTunnelIp: fallback.cachedTunnelIp };
 }
 
 async function tryReadySimulatorEndpoint(params: {
@@ -267,14 +285,20 @@ export async function sendRunnerCommandOnce(
     throw createRequestCanceledError();
   }
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const { resolveRoute } = createRunnerCommandRouteResolver(device, port);
-  const route = await resolveRoute(deadline.remainingMs());
+  const resolver = createRunnerCommandRouteResolver(device, port);
+  let route = await resolver.resolveRoute(deadline.remainingMs());
+  if (route.kind === 'usbmux') {
+    try {
+      return await postUsbmuxRunnerCommand(device, port, command, deadline, signal);
+    } catch (error) {
+      if (!canFallBackFromUsbmux(device, error)) throw error;
+      resolver.markUsbmuxUnattached();
+      route = await resolver.resolveRoute(deadline.remainingMs());
+    }
+  }
   const remainingMs = deadline.remainingMs();
   if (remainingMs <= 0) {
     throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', { timeoutMs });
-  }
-  if (route.kind === 'usbmux') {
-    return await usbmuxRunnerTransport.postCommand(device.id, port, command, remainingMs, signal);
   }
   const endpoint = route.endpoints[0];
   if (!endpoint) {
@@ -295,6 +319,33 @@ export async function sendRunnerCommandOnce(
   );
 }
 
+async function postUsbmuxRunnerCommand(
+  device: DeviceInfo,
+  port: number,
+  command: RunnerCommand,
+  deadline: Deadline,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const remainingMs = deadline.remainingMs();
+  if (remainingMs <= 0) {
+    throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', {
+      port,
+      timeoutMs: remainingMs,
+    });
+  }
+  return await usbmuxRunnerTransport.postCommand(device.id, port, command, remainingMs, signal);
+}
+
+/**
+ * A CoreDevice-backed device that usbmuxd does not list is reachable over its
+ * network tunnel instead. XCTest-backed devices have no such tunnel, so their
+ * usbmux verdict stands.
+ */
+function canFallBackFromUsbmux(device: DeviceInfo, error: unknown): boolean {
+  if (!isUsbmuxDeviceUnattachedError(error)) return false;
+  return resolveIosPhysicalDeviceControl(device).backend !== 'xctest';
+}
+
 async function tryRunnerRoute(
   device: DeviceInfo,
   route: RunnerCommandRoute,
@@ -304,6 +355,7 @@ async function tryRunnerRoute(
     timeoutMs: number;
     signal?: AbortSignal;
     attemptDeadline?: Deadline;
+    onUsbmuxUnattached?: () => void;
     onError: (endpoint: string, error: unknown) => void;
   },
 ): Promise<Response | null> {
@@ -329,6 +381,10 @@ async function tryRunnerRoute(
   } catch (error) {
     if (params.signal?.aborted || isRequestCanceledError(error)) {
       throw createRequestCanceledError();
+    }
+    if (canFallBackFromUsbmux(device, error)) {
+      params.onUsbmuxUnattached?.();
+      return null;
     }
     params.onError(endpoint, error);
     return null;

--- a/src/platforms/apple/core/runner/runner-usbmux-protocol.ts
+++ b/src/platforms/apple/core/runner/runner-usbmux-protocol.ts
@@ -36,6 +36,10 @@ async function resolveUsbmuxDeviceId(
     throw new AppError('DEVICE_NOT_FOUND', 'iOS device is not available through usbmux', {
       deviceId: udid,
       backend: 'xctest',
+      // Discriminator for the usbmux-first route: usbmuxd answered and the
+      // device is simply not attached by cable, so a CoreDevice-backed device
+      // can fall back to its network tunnel instead of retrying this transport.
+      usbmuxDeviceAttached: false,
       hint: 'Connect the device by cable, trust this Mac, keep it unlocked, and retry.',
     });
   } finally {

--- a/src/platforms/apple/core/runner/runner-usbmux.ts
+++ b/src/platforms/apple/core/runner/runner-usbmux.ts
@@ -19,6 +19,19 @@ export type UsbmuxRunnerTransport = {
   ): Promise<Response>;
 };
 
+/**
+ * True when usbmuxd answered and the device is simply not attached by cable.
+ * A CoreDevice-backed device falls back to its network tunnel; an XCTest-backed
+ * device has no second route, so this verdict is terminal rather than retryable.
+ */
+export function isUsbmuxDeviceUnattachedError(error: unknown): boolean {
+  if (!(error instanceof AppError) || error.code !== 'DEVICE_NOT_FOUND') return false;
+  return (
+    (error.details as { usbmuxDeviceAttached?: unknown } | undefined)?.usbmuxDeviceAttached ===
+    false
+  );
+}
+
 export function createUsbmuxRunnerTransport(socketPath: string): UsbmuxRunnerTransport {
   return {
     postCommand: async (deviceId, port, command, timeoutMs, signal) => {

--- a/src/platforms/apple/core/runner/runner-usbmux.ts
+++ b/src/platforms/apple/core/runner/runner-usbmux.ts
@@ -19,19 +19,6 @@ export type UsbmuxRunnerTransport = {
   ): Promise<Response>;
 };
 
-/**
- * True when usbmuxd answered and the device is simply not attached by cable.
- * A CoreDevice-backed device falls back to its network tunnel; an XCTest-backed
- * device has no second route, so this verdict is terminal rather than retryable.
- */
-export function isUsbmuxDeviceUnattachedError(error: unknown): boolean {
-  if (!(error instanceof AppError) || error.code !== 'DEVICE_NOT_FOUND') return false;
-  return (
-    (error.details as { usbmuxDeviceAttached?: unknown } | undefined)?.usbmuxDeviceAttached ===
-    false
-  );
-}
-
 export function createUsbmuxRunnerTransport(socketPath: string): UsbmuxRunnerTransport {
   return {
     postCommand: async (deviceId, port, command, timeoutMs, signal) => {


### PR DESCRIPTION
Implements #1403 on the evidence gathered in #1510 ([results doc](https://github.com/callstack/agent-device/blob/main/docs/usbmux-runner-transport-experiment.md)).

## What changes

Physical iOS runner commands resolve to **usbmux first**. Only when usbmuxd reports the device unattached does the resolver fall back to the CoreDevice tunnel route — so the tunnel lookup, its 30 s cache, and the cache invalidation now run **only** for devices that genuinely need them.

Callers never pick a transport: `waitForRunner` and `sendRunnerCommandOnce` both go through the same resolver, which owns the decision and the fallback (an acceptance criterion of #1403).

The experiment override `AGENT_DEVICE_IOS_RUNNER_ROUTE` from #1510 is deleted — usbmux-first is the real behaviour now, not something to opt into.

## Why (measured, iPhone 17 Pro)

| Scenario | tunnel route | usbmux |
|---|---|---:|
| Steady-state snapshot | 350–450 ms | 440 ms |
| Snapshot after 40 s idle | **4.5–4.6 s** | **440 ms** |

Steady state is a wash; the win is the idle gap. Past the cache TTL the network route pays a devicectl re-probe plus session re-establish on the *next* command — the exact shape of an agent workflow (think, then act). Cabled devices no longer pay it at all.

## Failure semantics

- The unattached verdict carries `usbmuxDeviceAttached: false`; `isUsbmuxDeviceUnattachedError` is the only trigger for fallback, so genuine usbmux/mechanism failures still surface.
- Fallback happens **inside the same connect attempt**, not by burning a retry, so Wi-Fi-only devices are not slowed down.
- XCTest-backed devices have no tunnel, so their verdict is terminal — this fixes the 2×45 s retry hang documented in the results doc, where a detached device burned the full budget before reporting a generic "Runner did not accept connection".

## Live evidence

Wi-Fi-only leg (device paired, cable out) on this branch's build: `open` succeeded, and a `snapshot` reached `request_success` through the fallback — the per-request ndjson shows the usbmux attempt followed by `devicectl device info details` tunnel probes, confirming the route actually switched rather than silently working for another reason.

The cabled leg (usbmux auto-selected end to end) was measured in #1510 through the forced override, which exercises the identical transport; I'll attach a fresh capture on this build once the device is cabled again.

## Testing

`runner-transport.test.ts` 12/12, including new cases for usbmux-first on CoreDevice devices (asserting **zero** devicectl spawns), fallback to the tunnel on the unattached verdict, the terminal verdict for XCTest devices, and same-attempt fallback in `waitForRunner`. The existing tunnel-IP cache/invalidation tests were kept and now establish the unattached precondition first. `pnpm check:affected --run` passes.