### PR TITLE
fix(device): state when nothing is claimed and reap dead claims

### DIFF
--- a/src/__tests__/cli-device-status.test.ts
+++ b/src/__tests__/cli-device-status.test.ts
@@ -132,3 +132,37 @@ test('keeps corrupt and state-dir-gone claims visible in normal status', async (
     fs.rmSync(claimsDir, { recursive: true, force: true });
   }
 });
+
+test('states that nothing is claimed when every claim is stale', async () => {
+  // Regression: the all-stale case rendered only the hidden-claim notice, so a
+  // user asking what holds a device saw a maintenance warning and no answer.
+  const claimsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-cli-claims-'));
+  try {
+    fs.writeFileSync(
+      path.join(claimsDir, 'stale.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        deviceKey: 'local:apple:ios:stale-phone',
+        device: { platform: 'ios', id: 'stale-phone', name: 'Dead iPhone', kind: 'device' },
+        session: 'dead-session',
+        workspace: '/worktrees/dead',
+        stateDir: process.cwd(),
+        ownerPid: 999_999_999,
+        ownerStartTime: 'old-start-time',
+        ownerToken: 'stale-token',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    );
+
+    const result = await runCliCapture(['device', 'status'], {
+      env: { AGENT_DEVICE_CLAIMS_DIR: claimsDir },
+    });
+
+    assert.match(result.stdout, /No live local advisory device claims found\./);
+    assert.match(result.stdout, /1 stale claim hidden/);
+    assert.doesNotMatch(result.stdout, /Dead iPhone/);
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});

--- a/src/__tests__/daemon-entrypoint.test.ts
+++ b/src/__tests__/daemon-entrypoint.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -292,5 +293,69 @@ test('daemon entrypoint publishes HTTP metadata and cleans up on shutdown', asyn
     }
     await daemon.wait.catch(() => {});
     fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon runtime records the startup device-claim prune in daemon.log', async () => {
+  // Regression: the prune ran before publishDaemonInfo, which truncates
+  // daemon.log — so the event was written and then wiped, leaving nothing in
+  // the log users are told to inspect. Asserted against a real runtime start
+  // rather than the prune in isolation, since the ordering is the bug.
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-daemon-prune-log-'));
+  const claimsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-daemon-prune-claims-'));
+  const paths = resolveDaemonPaths(stateDir);
+  const deviceKey = 'local:android:none:prune-log';
+  // resolveDeviceClaimRoot reads process.env directly, not the env passed to
+  // startDaemonRuntime, so the store has to be redirected on the process.
+  const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  let exitCode: number | undefined;
+
+  try {
+    fs.writeFileSync(
+      path.join(claimsDir, `${crypto.createHash('sha256').update(deviceKey).digest('hex')}.json`),
+      JSON.stringify({
+        schemaVersion: 1,
+        deviceKey,
+        device: { platform: 'android', id: 'prune-log', name: 'Prune Log', kind: 'emulator' },
+        session: 'dead-session',
+        workspace: '/worktrees/dead',
+        stateDir: process.cwd(),
+        ownerPid: 999_999_999,
+        ownerStartTime: 'old-start-time',
+        ownerToken: 'dead-token',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    );
+
+    const runtime = await startDaemonRuntime({
+      env: {
+        ...process.env,
+        AGENT_DEVICE_STATE_DIR: stateDir,
+        AGENT_DEVICE_DAEMON_SERVER_MODE: 'http',
+        AGENT_DEVICE_CLAIMS_DIR: claimsDir,
+      },
+      exit: (code) => {
+        exitCode = code;
+      },
+      registerProcessHandlers: false,
+      stderr: { write: () => {} },
+      stdout: { write: () => {} },
+    });
+
+    assert.notEqual(runtime, null);
+    assert.deepEqual(fs.readdirSync(claimsDir), [], 'the dead claim should be pruned');
+
+    const log = fs.readFileSync(paths.logPath, 'utf8');
+    assert.match(log, /"phase":"device_claim_prune"/);
+    assert.match(log, /"pruned":1/);
+
+    await runtime?.shutdown();
+    assert.equal(exitCode, 0);
+  } finally {
+    process.env.AGENT_DEVICE_CLAIMS_DIR = previousClaimsDir;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    fs.rmSync(claimsDir, { recursive: true, force: true });
   }
 });

--- a/src/cli/commands/device.ts
+++ b/src/cli/commands/device.ts
@@ -73,7 +73,9 @@ function renderDeviceStatus(
     if (options.hiddenStaleClaims === 0) return 'No local advisory device claims found.';
   }
   return [
-    ...claimLines,
+    // Without this the all-stale case renders only the hidden-claim notice, so
+    // the answer to "what holds this device" reads as a maintenance warning.
+    ...(claimLines.length === 0 ? ['No live local advisory device claims found.'] : claimLines),
     !options.staleOnly && options.hiddenStaleClaims > 0
       ? `${options.hiddenStaleClaims} stale ${options.hiddenStaleClaims === 1 ? 'claim' : 'claims'} hidden; inspect with: ${options.staleCommand}`
       : null,

--- a/src/daemon/__tests__/device-claim-prune.test.ts
+++ b/src/daemon/__tests__/device-claim-prune.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'vitest';
+import { pruneDeadDeviceClaims } from '../device-claim-inspection.ts';
+import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
+
+const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
+
+afterEach(() => {
+  process.env.AGENT_DEVICE_CLAIMS_DIR = previousClaimsDir;
+});
+
+function writeClaim(
+  claimsDir: string,
+  fileName: string,
+  overrides: { ownerPid: number; ownerStartTime?: string | null; stateDir?: string },
+): void {
+  fs.writeFileSync(
+    path.join(claimsDir, fileName),
+    JSON.stringify({
+      schemaVersion: 1,
+      deviceKey: `local:android:none:${fileName}`,
+      device: { platform: 'android', id: fileName, name: fileName, kind: 'emulator' },
+      session: `${fileName}-session`,
+      workspace: '/worktrees/x',
+      stateDir: overrides.stateDir ?? process.cwd(),
+      ownerPid: overrides.ownerPid,
+      ownerStartTime: overrides.ownerStartTime ?? undefined,
+      ownerToken: `${fileName}-token`,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    }),
+  );
+}
+
+test('prunes claims whose owner is gone and keeps every other claim', () => {
+  const claimsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-prune-claims-'));
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const owner = readCurrentOwnerIdentity();
+  try {
+    writeClaim(claimsDir, 'dead.json', { ownerPid: 999_999_999, ownerStartTime: 'old' });
+    writeClaim(claimsDir, 'live.json', { ownerPid: owner.pid, ownerStartTime: owner.startTime });
+    // Live process whose state dir vanished: pruning this could hand its device
+    // to a second session, so it is reported stale but never deleted.
+    writeClaim(claimsDir, 'state-dir-gone.json', {
+      ownerPid: owner.pid,
+      ownerStartTime: owner.startTime,
+      stateDir: path.join(claimsDir, 'missing-state-dir'),
+    });
+    fs.writeFileSync(path.join(claimsDir, 'garbage.json'), 'not json');
+
+    const { pruned } = pruneDeadDeviceClaims();
+
+    assert.equal(pruned, 1);
+    assert.equal(fs.existsSync(path.join(claimsDir, 'dead.json')), false);
+    assert.equal(fs.existsSync(path.join(claimsDir, 'live.json')), true);
+    assert.equal(fs.existsSync(path.join(claimsDir, 'state-dir-gone.json')), true);
+    assert.equal(fs.existsSync(path.join(claimsDir, 'garbage.json')), true);
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});
+
+test('prunes nothing when the claim store does not exist', () => {
+  process.env.AGENT_DEVICE_CLAIMS_DIR = path.join(os.tmpdir(), 'agent-device-prune-absent-store');
+  assert.deepEqual(pruneDeadDeviceClaims(), { pruned: 0 });
+});

--- a/src/daemon/__tests__/device-claim-prune.test.ts
+++ b/src/daemon/__tests__/device-claim-prune.test.ts
@@ -3,7 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test } from 'vitest';
-import { pruneDeadDeviceClaims } from '../device-claim-inspection.ts';
+import { pruneDeadDeviceClaims } from '../device-claims.ts';
+import { resolveDeviceClaimPath } from '../device-claim-paths.ts';
+import { acquireProcessLock } from '../../utils/process-lock.ts';
 import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
 
 const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
@@ -12,16 +14,19 @@ afterEach(() => {
   process.env.AGENT_DEVICE_CLAIMS_DIR = previousClaimsDir;
 });
 
+// Claims live at the hash of their device key; the prune only touches a file
+// that is the canonical path for the key it contains.
 function writeClaim(
-  claimsDir: string,
+  _claimsDir: string,
   fileName: string,
   overrides: { ownerPid: number; ownerStartTime?: string | null; stateDir?: string },
 ): void {
+  const deviceKey = `local:android:none:${fileName}`;
   fs.writeFileSync(
-    path.join(claimsDir, fileName),
+    resolveDeviceClaimPath(deviceKey),
     JSON.stringify({
       schemaVersion: 1,
-      deviceKey: `local:android:none:${fileName}`,
+      deviceKey,
       device: { platform: 'android', id: fileName, name: fileName, kind: 'emulator' },
       session: `${fileName}-session`,
       workspace: '/worktrees/x',
@@ -35,7 +40,7 @@ function writeClaim(
   );
 }
 
-test('prunes claims whose owner is gone and keeps every other claim', () => {
+test('prunes claims whose owner is gone and keeps every other claim', async () => {
   const claimsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-prune-claims-'));
   process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
   const owner = readCurrentOwnerIdentity();
@@ -51,19 +56,72 @@ test('prunes claims whose owner is gone and keeps every other claim', () => {
     });
     fs.writeFileSync(path.join(claimsDir, 'garbage.json'), 'not json');
 
-    const { pruned } = pruneDeadDeviceClaims();
+    const { pruned } = await pruneDeadDeviceClaims();
 
+    const claimPathFor = (name: string) => resolveDeviceClaimPath(`local:android:none:${name}`);
     assert.equal(pruned, 1);
-    assert.equal(fs.existsSync(path.join(claimsDir, 'dead.json')), false);
-    assert.equal(fs.existsSync(path.join(claimsDir, 'live.json')), true);
-    assert.equal(fs.existsSync(path.join(claimsDir, 'state-dir-gone.json')), true);
+    assert.equal(fs.existsSync(claimPathFor('dead.json')), false);
+    assert.equal(fs.existsSync(claimPathFor('live.json')), true);
+    assert.equal(fs.existsSync(claimPathFor('state-dir-gone.json')), true);
     assert.equal(fs.existsSync(path.join(claimsDir, 'garbage.json')), true);
   } finally {
     fs.rmSync(claimsDir, { recursive: true, force: true });
   }
 });
 
-test('prunes nothing when the claim store does not exist', () => {
+test('prunes nothing when the claim store does not exist', async () => {
   process.env.AGENT_DEVICE_CLAIMS_DIR = path.join(os.tmpdir(), 'agent-device-prune-absent-store');
-  assert.deepEqual(pruneDeadDeviceClaims(), { pruned: 0 });
+  assert.deepEqual(await pruneDeadDeviceClaims(), { pruned: 0 });
+});
+
+test('leaves a live successor written while the prune waited for the claim lock', async () => {
+  // Claim paths are derived from the device key, so a concurrent daemon can
+  // prune the same dead claim and a new session can write its live successor
+  // to that exact path. Holding the lock here reproduces that window: the scan
+  // sees a dead claim, then the file is replaced before the prune can unlink.
+  const claimsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-prune-race-'));
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const owner = readCurrentOwnerIdentity();
+  const deviceKey = 'local:android:none:contested';
+  const claimPath = resolveDeviceClaimPath(deviceKey);
+  const writeContested = (ownerPid: number, ownerStartTime: string | null, token: string) => {
+    fs.writeFileSync(
+      claimPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        deviceKey,
+        device: { platform: 'android', id: 'contested', name: 'Contested', kind: 'emulator' },
+        session: 'contested-session',
+        workspace: '/worktrees/x',
+        stateDir: process.cwd(),
+        ownerPid,
+        ownerStartTime: ownerStartTime ?? undefined,
+        ownerToken: token,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    );
+  };
+
+  try {
+    writeContested(999_999_999, 'old', 'dead-token');
+
+    const release = await acquireProcessLock({
+      lockDirPath: `${claimPath}.lock`,
+      owner: { pid: owner.pid, startTime: owner.startTime, acquiredAtMs: Date.now() },
+      timeoutMs: 5_000,
+      description: 'test-held device claim lock',
+    });
+
+    const pruning = pruneDeadDeviceClaims();
+    // The prune is now blocked on the lock; stand in the live successor.
+    writeContested(owner.pid, owner.startTime, 'live-token');
+    await release();
+
+    assert.deepEqual(await pruning, { pruned: 0 });
+    assert.equal(fs.existsSync(claimPath), true);
+    assert.equal(JSON.parse(fs.readFileSync(claimPath, 'utf8')).ownerToken, 'live-token');
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
 });

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -153,3 +153,34 @@ function isPositiveInteger(value: unknown): value is number {
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
+
+/**
+ * Deletes claim files whose owning process is provably gone.
+ *
+ * Claims are released on session close and daemon shutdown, but a process that
+ * dies abruptly leaves its file behind forever, and nothing else reaps them.
+ * The conflict path already steps over such a claim, so removing it changes no
+ * behaviour — it only stops the store from growing without bound.
+ *
+ * Deliberately narrower than the CLI's stale filter: `owner-state-dir-gone`
+ * describes a LIVE process whose state dir vanished, and deleting that claim
+ * could hand its device to a second session.
+ */
+export function pruneDeadDeviceClaims(): { pruned: number } {
+  const root = resolveDeviceClaimRoot();
+  const listed = readClaimEntries(root);
+  if ('claims' in listed) return { pruned: 0 };
+  let pruned = 0;
+  for (const entry of listed.entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const filePath = path.join(root, entry.name);
+    if (inspectDeviceClaimFile(filePath)?.classification !== 'owner-process-dead') continue;
+    try {
+      fs.rmSync(filePath);
+      pruned += 1;
+    } catch {
+      // Another daemon may be pruning the same store; leave it to that one.
+    }
+  }
+  return { pruned };
+}

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -153,34 +153,3 @@ function isPositiveInteger(value: unknown): value is number {
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
-
-/**
- * Deletes claim files whose owning process is provably gone.
- *
- * Claims are released on session close and daemon shutdown, but a process that
- * dies abruptly leaves its file behind forever, and nothing else reaps them.
- * The conflict path already steps over such a claim, so removing it changes no
- * behaviour — it only stops the store from growing without bound.
- *
- * Deliberately narrower than the CLI's stale filter: `owner-state-dir-gone`
- * describes a LIVE process whose state dir vanished, and deleting that claim
- * could hand its device to a second session.
- */
-export function pruneDeadDeviceClaims(): { pruned: number } {
-  const root = resolveDeviceClaimRoot();
-  const listed = readClaimEntries(root);
-  if ('claims' in listed) return { pruned: 0 };
-  let pruned = 0;
-  for (const entry of listed.entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
-    const filePath = path.join(root, entry.name);
-    if (inspectDeviceClaimFile(filePath)?.classification !== 'owner-process-dead') continue;
-    try {
-      fs.rmSync(filePath);
-      pruned += 1;
-    } catch {
-      // Another daemon may be pruning the same store; leave it to that one.
-    }
-  }
-  return { pruned };
-}

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -6,7 +6,7 @@ import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { acquireProcessLock } from '../utils/process-lock.ts';
 import { ownerIdentityMatches, readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
 import { inspectDeviceClaimFile, type InspectedDeviceClaim } from './device-claim-inspection.ts';
-import { resolveDeviceClaimPath } from './device-claim-paths.ts';
+import { resolveDeviceClaimPath, resolveDeviceClaimRoot } from './device-claim-paths.ts';
 
 const DEVICE_CLAIM_SCHEMA_VERSION = 1;
 const DEVICE_CLAIM_LOCK_TIMEOUT_MS = 30_000;
@@ -147,6 +147,55 @@ export async function clearAdvisoryDeviceClaim(
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
   });
+}
+
+/**
+ * Deletes claim files whose owning process is provably gone.
+ *
+ * Claims are released on session close and daemon shutdown, but a process that
+ * dies abruptly leaves its file behind forever and nothing else reaps them.
+ *
+ * The liveness check is repeated under the per-device lock immediately before
+ * unlinking: claim paths are derived from the device key, so a concurrent
+ * daemon can prune the same dead claim and a new session can write its live
+ * successor to that exact path while this scan is still running. Deleting on
+ * the first read would take the successor with it.
+ *
+ * Deliberately narrower than the CLI's stale filter: `owner-state-dir-gone`
+ * describes a LIVE process whose state dir vanished, and deleting that claim
+ * could hand its device to a second session.
+ */
+export async function pruneDeadDeviceClaims(): Promise<{ pruned: number }> {
+  const root = resolveDeviceClaimRoot();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return { pruned: 0 };
+  }
+  let pruned = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const filePath = path.join(root, entry.name);
+    const scanned = inspectDeviceClaimFile(filePath);
+    if (scanned?.classification !== 'owner-process-dead' || !scanned.claim) continue;
+    const { deviceKey, ownerToken } = scanned.claim;
+    // A file whose name is not the hash of its own device key is not the file
+    // the lock protects, so leave it rather than unlink something else.
+    if (resolveDeviceClaimPath(deviceKey) !== filePath) continue;
+    await withDeviceClaimLock(deviceKey, async () => {
+      const current = inspectDeviceClaimFile(filePath);
+      if (current?.classification !== 'owner-process-dead') return;
+      if (current.claim?.ownerToken !== ownerToken) return;
+      try {
+        fs.unlinkSync(filePath);
+        pruned += 1;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    });
+  }
+  return { pruned };
 }
 
 function writeClaim(claim: DeviceClaim): void {

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -330,7 +330,6 @@ export async function startDaemonRuntime(
   let socketPort: number | undefined;
   let httpPort: number | undefined;
   try {
-    await pruneDeviceClaimsForDaemonStartup(logPath);
     await cleanupWebBrowserOrphansForDaemonStartup({ stateDir: baseDir, sessionStore });
     // Fire-and-forget: gated on a state-dir marker so it only touches adb when a prior run here
     // actually activated the test IME (never on hosts that don't use it, e.g. the macOS runner).
@@ -343,6 +342,9 @@ export async function startDaemonRuntime(
     socketPort = opened.socketPort;
     httpPort = opened.httpPort;
     publishDaemonInfo(socketPort, httpPort);
+    // After publication: publishDaemonInfo truncates daemon.log, so anything
+    // written before it is lost — including the prune's own diagnostic.
+    await pruneDeviceClaimsForDaemonStartup(logPath);
     // Arms the initial idle-reap timer: a daemon that starts and never
     // receives a request must still be able to reap itself.
     idleReap.noteActivity();

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -20,8 +20,7 @@ import { closeDaemonServers } from './server-shutdown.ts';
 import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';
 import { finalizeDaemonSessionLease } from './daemon-session-lease-finalizer.ts';
-import { clearAdvisoryDeviceClaim } from '../device-claims.ts';
-import { pruneDeadDeviceClaims } from '../device-claim-inspection.ts';
+import { clearAdvisoryDeviceClaim, pruneDeadDeviceClaims } from '../device-claims.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -331,7 +330,7 @@ export async function startDaemonRuntime(
   let socketPort: number | undefined;
   let httpPort: number | undefined;
   try {
-    pruneDeviceClaimsForDaemonStartup();
+    await pruneDeviceClaimsForDaemonStartup(logPath);
     await cleanupWebBrowserOrphansForDaemonStartup({ stateDir: baseDir, sessionStore });
     // Fire-and-forget: gated on a state-dir marker so it only touches adb when a prior run here
     // actually activated the test IME (never on hosts that don't use it, e.g. the macOS runner).
@@ -450,19 +449,28 @@ export async function startDaemonRuntime(
   };
 }
 
-function pruneDeviceClaimsForDaemonStartup(): void {
-  try {
-    const { pruned } = pruneDeadDeviceClaims();
-    if (pruned > 0) {
-      emitDiagnostic({ phase: 'device_claim_prune', data: { pruned } });
-    }
-  } catch (error) {
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'device_claim_prune_failed',
-      data: { error: error instanceof Error ? error.message : String(error) },
-    });
-  }
+async function pruneDeviceClaimsForDaemonStartup(logPath: string): Promise<void> {
+  // Startup runs outside any diagnostics scope, where emitDiagnostic is a no-op,
+  // so the prune has to open one of its own for its events to be recorded.
+  await withDiagnosticsScope(
+    { command: 'daemon', session: 'daemon', logPath, debug: true },
+    async () => {
+      try {
+        const { pruned } = await pruneDeadDeviceClaims();
+        if (pruned > 0) {
+          emitDiagnostic({ phase: 'device_claim_prune', data: { pruned } });
+          flushDiagnosticsToSessionFile({ force: true });
+        }
+      } catch (error) {
+        emitDiagnostic({
+          level: 'warn',
+          phase: 'device_claim_prune_failed',
+          data: { error: error instanceof Error ? error.message : String(error) },
+        });
+        flushDiagnosticsToSessionFile({ force: true });
+      }
+    },
+  );
 }
 
 export async function cleanupWebBrowserOrphansForDaemonStartup(params: {

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -21,6 +21,7 @@ import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';
 import { finalizeDaemonSessionLease } from './daemon-session-lease-finalizer.ts';
 import { clearAdvisoryDeviceClaim } from '../device-claims.ts';
+import { pruneDeadDeviceClaims } from '../device-claim-inspection.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -330,6 +331,7 @@ export async function startDaemonRuntime(
   let socketPort: number | undefined;
   let httpPort: number | undefined;
   try {
+    pruneDeviceClaimsForDaemonStartup();
     await cleanupWebBrowserOrphansForDaemonStartup({ stateDir: baseDir, sessionStore });
     // Fire-and-forget: gated on a state-dir marker so it only touches adb when a prior run here
     // actually activated the test IME (never on hosts that don't use it, e.g. the macOS runner).
@@ -446,6 +448,21 @@ export async function startDaemonRuntime(
     socketPort,
     token,
   };
+}
+
+function pruneDeviceClaimsForDaemonStartup(): void {
+  try {
+    const { pruned } = pruneDeadDeviceClaims();
+    if (pruned > 0) {
+      emitDiagnostic({ phase: 'device_claim_prune', data: { pruned } });
+    }
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'device_claim_prune_failed',
+      data: { error: error instanceof Error ? error.message : String(error) },
+    });
+  }
 }
 
 export async function cleanupWebBrowserOrphansForDaemonStartup(params: {


### PR DESCRIPTION
Found while investigating "the iPhone is connected to an agent but `device status` shows nothing except a stale-agents message". Two separate defects; the command was telling the truth, but in a way that reads as broken.

## Bug 1 — the empty-state verdict is swallowed

```
$ agent-device device status
21 stale claims hidden; inspect with: agent-device device status --stale
```

In [`renderDeviceStatus`](https://github.com/callstack/agent-device/blob/main/src/cli/commands/device.ts), `'No local advisory device claims found.'` is gated on `hiddenStaleClaims === 0`. So when live claims are empty **and** stale ones exist, both early returns are skipped and the output falls through to just the hidden-stale notice. The one case where a user most needs to hear "nothing holds this device" is exactly the case that never says it. `--json` had the answer all along: `{"claims": [], "hiddenStaleClaims": 21}`.

Now:

```
No live local advisory device claims found.
21 stale claims hidden; inspect with: agent-device device status --stale
```

## Bug 2 — dead claims are never reaped

Claims are released on session close and daemon shutdown, but a process that dies abruptly leaves its file behind and nothing collects it. My real store had **21 claims spanning Jul 17 → Jul 31, every single owner dead** (verified per-claim with `kill(pid, 0)`) — including the iPhone's, orphaned by a session from Jul 23.

Daemon startup now prunes them, right next to the existing web-browser orphan cleanup, best-effort and non-fatal with a `device_claim_prune` diagnostic.

**Pruning is deliberately narrower than the CLI's stale filter.** It removes only `owner-process-dead`. `owner-state-dir-gone` describes a **live** process whose state dir vanished — deleting that claim could hand its device to a second session. The CLI may hide both; only one is safe to delete.

This changes no behaviour beyond housekeeping: the conflict path already steps over a dead-owner claim (`device_claim_advisory_conflict … classification: owner-process-dead`), so these files were inert — just unbounded and noisy.

## Testing

- `states that nothing is claimed when every claim is stale` — verified revert-sensitive (fails when the render change is reverted).
- `prunes claims whose owner is gone and keeps every other claim` — asserts the dead claim is deleted while a live claim, a live-but-state-dir-gone claim, and an unparseable file all survive.
- Ran the reaper against a **copy** of the real 21-claim store: pruned 21, and the real store was left untouched.
- `pnpm check:affected --run` passes.