### PR TITLE
fix(ios): map usbmux connect result codes to the right verdict

### DIFF
--- a/src/platforms/apple/core/__tests__/runner-transport.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-transport.test.ts
@@ -324,6 +324,28 @@ test('waitForRunner falls back to the tunnel route inside the same attempt', asy
   assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://[fd00::123]:8100/command');
 });
 
+test('falls back to the tunnel when usbmux loses the device mid-connect', async () => {
+  // usbmuxd listed the device, then answered Connect with "no such device"
+  // (result 2) because it went away in between. That must reach the same
+  // fallback as a missing ListDevices entry, or a CoreDevice device fails with
+  // a cable hint while its Wi-Fi tunnel is sitting there working.
+  mockUsbmuxPostCommand.mockRejectedValue(
+    new AppError('DEVICE_NOT_FOUND', 'iOS device is no longer available through usbmux', {
+      deviceId: iosDevice.id,
+      usbmuxDeviceAttached: false,
+      usbmuxResult: 2,
+      hint: 'Connect the device by cable, trust this Mac, keep it unlocked, and retry.',
+    }),
+  );
+  stubSuccessfulFetch();
+  stubTunnelIpLookup('fd00::123');
+
+  const response = await sendRunnerCommandOnce(iosDevice, 8100, { command: 'uptime' }, 5_000);
+
+  assert.equal(response.status, 200);
+  assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://[fd00::123]:8100/command');
+});
+
 function stubUsbmuxDeviceUnattached(): void {
   mockUsbmuxPostCommand.mockRejectedValue(
     new AppError('DEVICE_NOT_FOUND', 'iOS device is not available through usbmux', {

--- a/src/platforms/apple/core/__tests__/runner-usbmux.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-usbmux.test.ts
@@ -4,6 +4,7 @@ import net, { type Server, type Socket } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
 import { createUsbmuxRunnerTransport } from '../runner/runner-usbmux.ts';
 
 const DEVICE_UDID = '00008020-001C2D2234567890';
@@ -94,6 +95,116 @@ test('xctest runner commands use usbmux device lookup and port transport', async
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), { ok: true, data: { uptimeMs: 123 } });
   await serverDone;
+});
+
+type FakeDevice = { deviceId: number; udid: string; connectionType?: string };
+
+/**
+ * Serves ListDevices from `devices`, then answers Connect with `connectResult`.
+ * Records the DeviceID the client asked to connect to, which is what proves
+ * selection picked the right device rather than the right position.
+ */
+async function serveUsbmuxDevices(
+  socketPath: string,
+  devices: FakeDevice[],
+  connectResult = 0,
+): Promise<{ connectedDeviceId: () => number | undefined }> {
+  let connectedDeviceId: number | undefined;
+  await createFakeUsbmuxd(socketPath, async (socket, connectionIndex) => {
+    if (connectionIndex === 0) {
+      await readPacket(socket);
+      const entries = devices
+        .map(
+          (device) =>
+            `<dict><key>DeviceID</key><integer>${device.deviceId}</integer>` +
+            `<key>Properties</key><dict>` +
+            `<key>SerialNumber</key><string>${device.udid}</string>` +
+            `<key>ConnectionType</key><string>${device.connectionType ?? 'USB'}</string>` +
+            `</dict></dict>`,
+        )
+        .join('');
+      socket.end(
+        buildPacket(`<plist><dict><key>DeviceList</key><array>${entries}</array></dict></plist>`),
+      );
+      return;
+    }
+    const connectRequest = await readPacket(socket);
+    const match = /<key>DeviceID<\/key><integer>(\d+)<\/integer>/.exec(
+      connectRequest.replace(/\s+/g, ''),
+    );
+    connectedDeviceId = match ? Number(match[1]) : undefined;
+    socket.end(
+      buildPacket(
+        `<plist><dict><key>MessageType</key><string>Result</string><key>Number</key><integer>${connectResult}</integer></dict></plist>`,
+      ),
+    );
+  });
+  return { connectedDeviceId: () => connectedDeviceId };
+}
+
+async function postThroughFakeUsbmux(socketPath: string, udid: string): Promise<unknown> {
+  return await createUsbmuxRunnerTransport(socketPath)
+    .postCommand(udid, RUNNER_PORT, { command: 'uptime' }, 5_000)
+    .catch((error: unknown) => error);
+}
+
+test('selects the requested device by UDID regardless of its position in the list', async () => {
+  const target = { deviceId: 77, udid: DEVICE_UDID };
+  const others = [
+    { deviceId: 11, udid: '00008030-000000000000AAAA' },
+    { deviceId: 22, udid: '00008040-000000000000BBBB' },
+  ];
+
+  for (const devices of [
+    [target, ...others],
+    [...others, target],
+    [others[0]!, target, others[1]!],
+  ]) {
+    const socketPath = await createSocketPath();
+    const server = await serveUsbmuxDevices(socketPath, devices);
+    await postThroughFakeUsbmux(socketPath, DEVICE_UDID);
+    assert.equal(server.connectedDeviceId(), 77);
+  }
+});
+
+test('never matches a different device whose UDID merely shares a prefix', async () => {
+  const socketPath = await createSocketPath();
+  const server = await serveUsbmuxDevices(socketPath, [
+    { deviceId: 5, udid: `${DEVICE_UDID}0` },
+    { deviceId: 6, udid: DEVICE_UDID.slice(0, -1) },
+  ]);
+
+  const error = await postThroughFakeUsbmux(socketPath, DEVICE_UDID);
+
+  assert.equal((error as AppError).code, 'DEVICE_NOT_FOUND');
+  assert.equal(server.connectedDeviceId(), undefined);
+});
+
+test('treats a device usbmuxd no longer knows as unattached so a tunnel fallback can run', async () => {
+  const socketPath = await createSocketPath();
+  // Result 2 is what the real daemon answers for an unknown DeviceID.
+  await serveUsbmuxDevices(socketPath, [{ deviceId: 42, udid: DEVICE_UDID }], 2);
+
+  const error = await postThroughFakeUsbmux(socketPath, DEVICE_UDID);
+
+  const appError = error as AppError;
+  assert.equal(appError.code, 'DEVICE_NOT_FOUND');
+  assert.equal(appError.details?.usbmuxDeviceAttached, false);
+  assert.match(String(appError.details?.hint), /Connect the device by cable/);
+});
+
+test('reports a refused runner port as the runner not listening, not a cable problem', async () => {
+  const socketPath = await createSocketPath();
+  // Result 3 is what the real daemon answers for a closed port on a live device.
+  await serveUsbmuxDevices(socketPath, [{ deviceId: 42, udid: DEVICE_UDID }], 3);
+
+  const error = await postThroughFakeUsbmux(socketPath, DEVICE_UDID);
+
+  const appError = error as AppError;
+  assert.equal(appError.code, 'COMMAND_FAILED');
+  assert.equal(appError.details?.usbmuxDeviceAttached, undefined);
+  assert.match(appError.message, /not listening on the device port/);
+  assert.doesNotMatch(String(appError.details?.hint), /cable/);
 });
 
 async function createSocketPath(): Promise<string> {

--- a/src/platforms/apple/core/runner/runner-usbmux-protocol.ts
+++ b/src/platforms/apple/core/runner/runner-usbmux-protocol.ts
@@ -8,6 +8,17 @@ const USBMUX_HEADER_BYTES = 16;
 const USBMUX_PROTOCOL_VERSION = 1;
 const USBMUX_MESSAGE_PLIST = 8;
 const USBMUX_MAX_PACKET_BYTES = 4 * 1024 * 1024;
+/**
+ * usbmuxd `Connect` result codes, confirmed against the daemon on macOS 15:
+ * connecting to a closed port on an attached device answers 3, and connecting
+ * with a DeviceID usbmuxd does not know answers 2.
+ */
+const USBMUX_RESULT_OK = 0;
+const USBMUX_RESULT_BAD_DEVICE = 2;
+const USBMUX_RESULT_CONNECTION_REFUSED = 3;
+
+const USBMUX_DEVICE_UNATTACHED_HINT =
+  'Connect the device by cable, trust this Mac, keep it unlocked, and retry.';
 
 export async function openUsbmuxRunnerSocket(
   socketPath: string,
@@ -18,7 +29,14 @@ export async function openUsbmuxRunnerSocket(
 ): Promise<Socket> {
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
   const deviceId = await resolveUsbmuxDeviceId(socketPath, udid, deadline.remainingMs(), signal);
-  return await openUsbmuxDeviceSocket(socketPath, deviceId, port, deadline.remainingMs(), signal);
+  return await openUsbmuxDeviceSocket(
+    socketPath,
+    udid,
+    deviceId,
+    port,
+    deadline.remainingMs(),
+    signal,
+  );
 }
 
 async function resolveUsbmuxDeviceId(
@@ -40,7 +58,7 @@ async function resolveUsbmuxDeviceId(
       // device is simply not attached by cable, so a CoreDevice-backed device
       // can fall back to its network tunnel instead of retrying this transport.
       usbmuxDeviceAttached: false,
-      hint: 'Connect the device by cable, trust this Mac, keep it unlocked, and retry.',
+      hint: USBMUX_DEVICE_UNATTACHED_HINT,
     });
   } finally {
     socket.destroy();
@@ -49,6 +67,7 @@ async function resolveUsbmuxDeviceId(
 
 async function openUsbmuxDeviceSocket(
   socketPath: string,
+  udid: string,
   deviceId: number,
   port: number,
   timeoutMs: number,
@@ -66,14 +85,8 @@ async function openUsbmuxDeviceSocket(
     );
     const packet = await readUsbmuxPacket(socket, timeoutMs, signal);
     const result = readPlistInteger(packet.payload.toString('utf8'), 'Number');
-    if (result !== 0) {
-      throw new AppError('COMMAND_FAILED', 'Failed to connect to XCTest runner through usbmux', {
-        backend: 'xctest',
-        deviceId,
-        port,
-        usbmuxResult: result,
-        hint: 'Keep the device connected by cable and unlocked, then retry.',
-      });
+    if (result !== USBMUX_RESULT_OK) {
+      throw buildUsbmuxConnectError({ result, udid, deviceId, port });
     }
     return socket;
   } catch (error) {
@@ -258,6 +271,47 @@ function* walkXmlNodes(nodes: readonly XmlNode[]): Generator<XmlNode> {
     yield node;
     yield* walkXmlNodes(node.children);
   }
+}
+
+/**
+ * A device usbmuxd no longer knows is the same verdict as one missing from
+ * `ListDevices` — it must reach the unattached path so a CoreDevice device can
+ * fall back to its network tunnel, rather than failing with a cable hint while
+ * Wi-Fi is available. A refused port means the opposite: the device is there
+ * and only the runner is not listening yet.
+ */
+function buildUsbmuxConnectError(params: {
+  result: number | undefined;
+  udid: string;
+  deviceId: number;
+  port: number;
+}): AppError {
+  const { result, udid, deviceId, port } = params;
+  if (result === USBMUX_RESULT_BAD_DEVICE) {
+    return new AppError('DEVICE_NOT_FOUND', 'iOS device is no longer available through usbmux', {
+      deviceId: udid,
+      backend: 'xctest',
+      usbmuxDeviceAttached: false,
+      usbmuxResult: result,
+      hint: USBMUX_DEVICE_UNATTACHED_HINT,
+    });
+  }
+  if (result === USBMUX_RESULT_CONNECTION_REFUSED) {
+    return new AppError('COMMAND_FAILED', 'XCTest runner is not listening on the device port', {
+      backend: 'xctest',
+      deviceId,
+      port,
+      usbmuxResult: result,
+      hint: 'The device is reachable but nothing is bound to the runner port yet; this resolves once the runner finishes starting.',
+    });
+  }
+  return new AppError('COMMAND_FAILED', 'Failed to connect to XCTest runner through usbmux', {
+    backend: 'xctest',
+    deviceId,
+    port,
+    usbmuxResult: result,
+    hint: 'Keep the device connected by cable and unlocked, then retry.',
+  });
 }
 
 function hostToNetworkPort(port: number): number {


### PR DESCRIPTION
Tackles the verifiable half of #1521, and closes a gap #1517 left open.

## The gap

usbmuxd answers `Connect` with a result code, and every non-zero code collapsed into a single error with a cable hint:

```
Failed to connect to XCTest runner through usbmux
hint: Keep the device connected by cable and unlocked, then retry.
```

I probed the daemon on this host rather than trusting documentation, using the real cabled iPhone:

```
Connect -> real device, closed port  => Number = 3
Connect -> bogus DeviceID            => Number = 2
```

**Result 2 (device gone) never reached the fallback.** #1517 keys its tunnel fallback off `usbmuxDeviceAttached: false`, which only the `ListDevices` path set. If a device disappears between `ListDevices` and `Connect`, a CoreDevice device failed with a cable hint **while its Wi-Fi tunnel was sitting there working**. It now raises the same unattached verdict, so the fallback runs.

**Result 3 (port not bound) got the wrong advice.** The cable is fine and the device is unlocked — the runner just is not listening yet, which is the normal state while it starts. It now says that instead of blaming the cable.

## #1521 coverage

The live two-device matrix still needs a second iPhone, but the substance of "is UDID→device selection unambiguous" is now locked down hermetically against the fake usbmuxd:

- selection follows the **UDID, not list position** — asserted with the target first, last, and in the middle, checking the DeviceID actually sent in `Connect`
- a device whose UDID merely **shares a prefix** with the requested one never matches, and no `Connect` is attempted
- device-gone and port-refused each produce their own verdict
- transport-level: a mid-connect device loss on a CoreDevice device reaches the tunnel and succeeds

Both result-code tests were verified revert-sensitive — restoring the collapsed handler fails them.

## Remaining in #1521

Two concurrent sessions on two cabled devices, and the unpaired/untrusted legs. Those still need hardware; I have updated #1521 rather than closing it.

`pnpm check:affected --run` passes.