### PR TITLE
perf(devices): probe platform inventories concurrently

### DIFF
--- a/src/core/platform-inventory.test.ts
+++ b/src/core/platform-inventory.test.ts
@@ -2,14 +2,29 @@ import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
-const { listVegaDevices } = vi.hoisted(() => ({
-  listVegaDevices: vi.fn(),
-}));
+const { listVegaDevices, listAndroidDevices, listAppleDevices, listLinuxDevices } = vi.hoisted(
+  () => ({
+    listVegaDevices: vi.fn(),
+    listAndroidDevices: vi.fn(),
+    listAppleDevices: vi.fn(),
+    listLinuxDevices: vi.fn(),
+  }),
+);
 
 vi.mock('../platforms/vega/devices.ts', () => ({
   listVegaDevices,
 }));
+vi.mock('../platforms/android/devices.ts', () => ({
+  listAndroidDevices,
+}));
+vi.mock('../platforms/apple/core/devices.ts', () => ({
+  listAppleDevices,
+}));
+vi.mock('../platforms/linux/devices.ts', () => ({
+  listLinuxDevices,
+}));
 
+import { LOCAL_DEVICE_INVENTORY_PLATFORM_SELECTORS } from '@agent-device/contracts/device';
 import { listLocalDeviceInventory } from './platform-inventory.ts';
 
 const VEGA_EMULATOR: DeviceInfo = {
@@ -33,3 +48,63 @@ test('explicit Vega inventory delegates to the Vega device module', async () => 
   assert.deepEqual(result, [VEGA_EMULATOR]);
   assert.deepEqual(listVegaDevices.mock.calls[0], []);
 });
+
+test('probes every platform concurrently and keeps selector order in the result', async () => {
+  // Sequential awaits made an unfiltered lookup cost the sum of every
+  // toolchain probe. Each stub records when it starts and resolves only once
+  // all four have started, so this deadlocks unless they genuinely overlap.
+  const PLATFORM_COUNT = LOCAL_DEVICE_INVENTORY_PLATFORM_SELECTORS.length;
+  let started = 0;
+  let allStarted!: () => void;
+  const everyProbeStarted = new Promise<void>((resolve) => {
+    allStarted = resolve;
+  });
+  const gate = async () => {
+    started += 1;
+    if (started === PLATFORM_COUNT) allStarted();
+    await everyProbeStarted;
+  };
+
+  listAndroidDevices.mockImplementation(async () => {
+    await gate();
+    return [device('android', 'android-1')];
+  });
+  listAppleDevices.mockImplementation(async () => {
+    await gate();
+    return [device('apple', 'apple-1')];
+  });
+  listVegaDevices.mockImplementation(async () => {
+    await gate();
+    return [device('vega', 'vega-1')];
+  });
+  listLinuxDevices.mockImplementation(async () => {
+    await gate();
+    return [device('linux', 'linux-1')];
+  });
+
+  const result = await listLocalDeviceInventory({});
+
+  assert.equal(started, PLATFORM_COUNT);
+  assert.deepEqual(
+    result.map((entry) => entry.id),
+    ['android-1', 'apple-1', 'vega-1', 'linux-1'],
+  );
+});
+
+test('a failing platform probe does not drop the devices found by the others', async () => {
+  listAndroidDevices.mockRejectedValue(new Error('adb exploded'));
+  listAppleDevices.mockResolvedValue([device('apple', 'apple-1')]);
+  listVegaDevices.mockRejectedValue(new Error('vega exploded'));
+  listLinuxDevices.mockResolvedValue([device('linux', 'linux-1')]);
+
+  const result = await listLocalDeviceInventory({});
+
+  assert.deepEqual(
+    result.map((entry) => entry.id),
+    ['apple-1', 'linux-1'],
+  );
+});
+
+function device(platform: DeviceInfo['platform'], id: string): DeviceInfo {
+  return { platform, id, name: id, kind: 'device', booted: true };
+}

--- a/src/core/platform-inventory.ts
+++ b/src/core/platform-inventory.ts
@@ -43,15 +43,27 @@ export async function listLocalDeviceInventory(
     });
   }
 
-  const devices: DeviceInfo[] = [];
-  // Linux local device is appended last so it does not displace
-  // connected Android/Apple devices in implicit auto-selection.
-  for (const platform of LOCAL_DEVICE_INVENTORY_PLATFORM_SELECTORS) {
-    try {
-      devices.push(...(await listLocalDeviceInventory({ ...request, platform })));
-    } catch {}
-  }
-  return devices;
+  // Probed concurrently: each platform shells out to its own toolchain, and
+  // awaiting them in turn made an unfiltered lookup cost their sum — measured
+  // at 6.7s on a host with the Apple, Android and Vega toolchains installed,
+  // most of it spent enumerating platforms the request could not target.
+  //
+  // Results are still concatenated in selector order, so the Linux local device
+  // stays last and does not displace connected Android/Apple devices in
+  // implicit auto-selection.
+  const perPlatform = await Promise.all(
+    LOCAL_DEVICE_INVENTORY_PLATFORM_SELECTORS.map(async (platform) => {
+      try {
+        const listed = await listLocalDeviceInventory({ ...request, platform });
+        // A platform that answers with anything but a list contributes nothing,
+        // exactly as before: spreading a non-array used to throw into the catch.
+        return Array.isArray(listed) ? listed : [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return perPlatform.flat();
 }
 
 export function resolveAndroidDiscoverySerialAllowlist(


### PR DESCRIPTION
Found while scoping #1522. The usbmux discovery idea was justified by `resolve_target_device` costing **6672 ms** in the #1517 cabled capture — but breaking that number down showed usbmux was aiming at the wrong target.

## Where the time actually went

Per-probe durations from that capture:

| probe | cost |
|---|---:|
| `vega device list` | **2833 ms** |
| `xctrace list devices` | 1814 ms |
| `devicectl list devices` | 773 ms |
| `simctl list devices` | 768 ms |
| `emulator -list-avds` | 698 ms |
| `adb devices -l` | 539 ms |

They ran essentially back to back, because `listLocalDeviceInventory` awaited each platform inside a `for` loop. An unfiltered lookup therefore cost the **sum** of every installed toolchain — and for an `open` targeting an iPhone by name, most of that was spent enumerating platforms the request could never resolve to. The single largest contributor was Vega, which has nothing to do with the request.

usbmuxd discovery would only have shaved the two Apple probes. Removing the serialization is worth more, and it helps Android and Vega users equally.

## Change

Probe the platforms concurrently and concatenate the results in selector order. Ordering is load-bearing and preserved: the Linux local device must stay last so it does not displace connected Android/Apple devices in implicit auto-selection, and `Promise.all` keeps input order.

## Measured

Alternating A/B on one host against the same cabled iPhone, rebuilding between arms, three runs each:

| arm | run 1 | run 2 | run 3 |
|---|---:|---:|---:|
| sequential | 4065 ms | 4015 ms | 3912 ms |
| concurrent | 2359 ms | 2365 ms | 2295 ms |

**~1.7x, about 1.65 s off every cold device resolution.** (Absolute numbers are below the original 6.7 s because that capture was taken on a busier host; the ratio is what alternating runs control for.)

## Behaviour preserved

- Result order is unchanged, asserted explicitly.
- A failing probe still cannot take down the others — each is caught individually.
- A probe returning a non-array still contributes nothing. That used to happen implicitly, because spreading a non-array threw into the per-platform `catch`; `.flat()` would instead have kept an `undefined` in the list. **A pre-existing test caught this**, and it is now explicit.

## Testing

- concurrency: each stubbed probe blocks until all four have started, so the test deadlocks unless they genuinely overlap. Verified revert-sensitive — the sequential loop makes it time out.
- ordering: asserts `android, apple, vega, linux` in the result.
- isolation: two probes reject, and the devices found by the other two still come back.

`pnpm check:affected --run` passes.