### PR TITLE
test: stop two tests failing on timing and megapixels

### DIFF
--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -751,7 +751,13 @@ test('handleFindCommands wait captures fresh snapshots while polling', async () 
   if (!response.ok) {
     expect(response.error.message).toContain('find wait timed out');
   }
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  // What this test guards is that every poll re-captures instead of reusing the first tree.
+  // The exact poll count is a timing artifact and is not assertable: the loop's last sleep
+  // consumes whatever remains of the budget, so it lands on `remainingMs() === 0`, and a
+  // sleep that returns a millisecond early admits one more poll. Pinning this to 2 made the
+  // test fail under CI load on unrelated PRs. Assert the property, not the artifact.
+  expect(mockDispatch.mock.calls.length).toBeGreaterThanOrEqual(2);
+  expect(mockDispatch.mock.calls.every(([, command]) => command === 'snapshot')).toBe(true);
 });
 
 test('handleFindCommands click omits refsGeneration — a mutating find never issues a pinnable ref (ADR 0014)', async () => {

--- a/src/platforms/apple/core/__tests__/apps.test.ts
+++ b/src/platforms/apple/core/__tests__/apps.test.ts
@@ -127,7 +127,11 @@ test('screenshotIos retries simulator capture timeouts and eventually succeeds',
   const outPath = path.join(tmpDir, 'screen.png');
   const sourcePngPath = path.join(tmpDir, 'source.png');
 
-  await fs.writeFile(sourcePngPath, PNG.sync.write(new PNG({ width: 1206, height: 2622 })));
+  // Dimensions divisible by 3 so the implicit density-1 rescale (against the stub's native
+  // scale 3) stays exact. This test is about capture retry, not resolution, so the source is
+  // small rather than the 1206x2622 iPhone 16 Pro frame it used to allocate and resize —
+  // 3.2 megapixels to prove arithmetic that 34k pixels prove just as well (1176ms -> 233ms).
+  await fs.writeFile(sourcePngPath, PNG.sync.write(new PNG({ width: 126, height: 273 })));
 
   await fs.writeFile(
     xcrunPath,
@@ -205,8 +209,8 @@ test('screenshotIos retries simulator capture timeouts and eventually succeeds',
   try {
     await screenshotIos(IOS_TEST_SIMULATOR, outPath);
     const png = PNG.sync.read(await fs.readFile(outPath));
-    assert.equal(png.width, 402);
-    assert.equal(png.height, 874);
+    assert.equal(png.width, 42);
+    assert.equal(png.height, 91);
     assert.equal(await fs.readFile(screenshotCountPath, 'utf8'), '3\n');
 
     const logLines = (await fs.readFile(commandLogPath, 'utf8')).trim().split('\n').filter(Boolean);
@@ -246,7 +250,11 @@ test('screenshotIos keeps requested simulator pixel density', async () => {
   const outPath = path.join(tmpDir, 'screen.png');
   const sourcePngPath = path.join(tmpDir, 'source.png');
 
-  await fs.writeFile(sourcePngPath, PNG.sync.write(new PNG({ width: 1206, height: 2622 })));
+  // Both dimensions divisible by 3 so the 2/3 rescale (density 2 against the stub's native
+  // scale 3) stays exact. What this pins is that ratio, not an absolute resolution: it used
+  // to allocate and resize a 1206x2622 iPhone 16 Pro frame — 3.2 megapixels, ~90x more than
+  // the arithmetic needs (1021ms -> 34ms).
+  await fs.writeFile(sourcePngPath, PNG.sync.write(new PNG({ width: 126, height: 273 })));
   await fs.writeFile(
     xcrunPath,
     [
@@ -279,8 +287,8 @@ test('screenshotIos keeps requested simulator pixel density', async () => {
   try {
     await screenshotIos(IOS_TEST_SIMULATOR, outPath, { pixelDensity: 2 });
     const png = PNG.sync.read(await fs.readFile(outPath));
-    assert.equal(png.width, 804);
-    assert.equal(png.height, 1748);
+    assert.equal(png.width, 84);
+    assert.equal(png.height, 182);
   } finally {
     process.env.PATH = previousPath;
     if (previousScreenshotSourceFile === undefined)


### PR DESCRIPTION
Two tests blocked unrelated PRs today. Neither is auto-retryable: #1419's contention retry declines `find.test.ts` as outside its enumerated list, and slow-gate failures cannot be re-checked by a rerun. Every occurrence costs someone a manual re-run.

## `find.test.ts` — an un-assertable poll count

`wait captures fresh snapshots while polling` asserted exactly 2 dispatches.

The wait loop polls at a 300 ms interval against a 350 ms budget, and its final sleep consumes whatever remains — so it lands on exactly `remainingMs() === 0`. A sleep that returns even a millisecond early makes `hasTimeRemaining()` true and admits a third poll. The count was never assertable; it just usually came out at 2.

The test's actual subject is that **each poll re-captures rather than reusing the first tree**. It now asserts that directly: at least two captures, and every one a `snapshot`.

The sibling exact-count assertion earlier in the file is deliberately left alone — it takes its count from `mockResolvedValueOnce` ordering (the match appears in the second tree), not from the clock, so it is deterministic.

## `apps.test.ts` — 3.2 megapixels to prove a ratio

Two tests built 1206×2622 source PNGs (iPhone 16 Pro native) purely to verify rescale arithmetic. Both are now 126×273 — still divisible by 3, so the `/3` and `2/3` rescales stay exact — with expectations updated to match.

Measured locally:

| test | before | after |
|---|---:|---:|
| `keeps requested simulator pixel density` | 1021 ms | 34 ms |
| `retries simulator capture timeouts` | 1176 ms | 233 ms |
| file test time | 2.48 s | 1.00 s |

## Verification

18/18 `find.test.ts`, 54/54 `apps.test.ts`. Typecheck, lint and oxfmt clean.

Neither change weakens what the tests cover: the polling test still proves fresh captures, and both rescale tests still assert exact output dimensions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXQLYV7etZx3gcXsUsrQJ8)_