### PR TITLE
fix(ios): name Developer Mode and pairing as the real launch blockers

### DIFF
--- a/src/platforms/apple/core/__tests__/devicectl.test.ts
+++ b/src/platforms/apple/core/__tests__/devicectl.test.ts
@@ -1,6 +1,10 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { parseIosDeviceAppsPayload, parseIosDeviceProcessesPayload } from '../devicectl.ts';
+import {
+  parseIosDeviceAppsPayload,
+  parseIosDeviceProcessesPayload,
+  resolveIosDevicectlHint,
+} from '../devicectl.ts';
 
 test('parseIosDeviceAppsPayload maps devicectl app entries', () => {
   const apps = parseIosDeviceAppsPayload({
@@ -64,4 +68,40 @@ test('parseIosDeviceProcessesPayload maps running process entries', () => {
       pid: 72,
     },
   ]);
+});
+
+test('resolveIosDevicectlHint points at Developer Mode when the disk image cannot mount', () => {
+  // Observed on a freshly paired iPhone: unlocked, trusted, `available (paired)`
+  // in Xcode, and still unusable because Developer Mode was off. The default
+  // hint sent the user to re-check trust, which was already fine.
+  const hint = resolveIosDevicectlHint(
+    '',
+    'Failed to launch iOS app: The developer disk image could not be mounted on this device. (com.apple.dt.CoreDeviceError error 12040 (0x2F08))',
+  );
+
+  assert.match(String(hint), /Developer Mode/);
+  assert.match(String(hint), /Privacy & Security/);
+});
+
+test('resolveIosDevicectlHint reports the Developer Mode status devicectl states outright', () => {
+  const hint = resolveIosDevicectlHint(
+    '',
+    'The operation failed because Developer Mode is disabled.',
+  );
+
+  assert.match(String(hint), /Developer Mode/);
+});
+
+test('resolveIosDevicectlHint explains how to pair an unpaired device', () => {
+  const hint = resolveIosDevicectlHint(
+    '',
+    'The device must be paired before it can be connected. (com.apple.dt.CoreDeviceError error 2 (0x02))',
+  );
+
+  assert.match(String(hint), /Trust prompt/);
+  assert.match(String(hint), /passcode/);
+});
+
+test('resolveIosDevicectlHint still returns null for an unrecognised failure', () => {
+  assert.equal(resolveIosDevicectlHint('', 'some unrelated devicectl explosion'), null);
 });

--- a/src/platforms/apple/core/devicectl.ts
+++ b/src/platforms/apple/core/devicectl.ts
@@ -299,5 +299,16 @@ export function resolveIosDevicectlHint(stdout: string, stderr: string): string 
   if (text.includes('coredeviceservice') && text.includes('timed out')) {
     return 'CoreDevice service timed out. Reconnect the device and retry; if it persists restart Xcode and the iOS device.';
   }
+  // A device that is unlocked, trusted and `available (paired)` still cannot
+  // mount its developer disk image while Developer Mode is off, which is the
+  // usual state of a phone that has never been used for development. The
+  // default hint sends people to check trust and Xcode, none of which is wrong
+  // yet none of which is the cause.
+  if (text.includes('developer disk image') || text.includes('developer mode is disabled')) {
+    return 'Enable Developer Mode on the iOS device (Settings > Privacy & Security > Developer Mode), restart it when prompted, unlock it, then retry.';
+  }
+  if (text.includes('must be paired')) {
+    return 'Pair the iOS device with this Mac: connect it by cable, unlock it, accept the Trust prompt, and enter the device passcode, then retry.';
+  }
   return null;
 }


### PR DESCRIPTION
Found while running the #1521 hardware matrix on a second iPhone that had never been used for development.

## The problem

The device was unlocked, trusted, and reported by Xcode as `available (paired)`. Every launch still failed:

```
Error (COMMAND_FAILED): Failed to launch iOS app: The developer disk image could not be
mounted on this device. (com.apple.dt.CoreDeviceError error 12040 (0x2F08))
Hint: Ensure the iOS device is unlocked, trusted, and available in Xcode > Devices, then retry.
```

Every instruction in that hint was **already satisfied**, so it sends you to re-check the things that are fine. The actual cause is stated plainly by devicectl:

```
Error: The operation failed because Developer Mode is disabled.
• Developer Mode Status: Disabled
```

Developer Mode being off is the normal state of a phone that has never been used for development, so this is the *first* thing a new device hits — and the one thing the hint never mentions. The product already understands the concept: runner startup has a `verify_developer_mode` step, and `cli-help` documents "have Developer Mode enabled". It just never reached this failure path.

## Change

Two cases added to `resolveIosDevicectlHint`, which already maps specific devicectl failures to specific advice:

- disk-image mount failure / explicit "Developer Mode is disabled" → point at Settings > Privacy & Security > Developer Mode, including the restart
- "must be paired" → explain the full pairing flow **including entering the device passcode**, which is the step that actually completes it. Tapping Trust alone leaves the device unpaired, which is exactly what happened here — the device sat unpaired through several retries until pairing was completed properly.

Unrecognised failures still fall through to the default hint.

## Verification

Not just unit-tested — checked against the real device that was failing:

```
Error (COMMAND_FAILED): Failed to launch iOS app: The developer disk image could not be mounted…
Hint: Enable Developer Mode on the iOS device (Settings > Privacy & Security > Developer Mode),
      restart it when prompted, unlock it, then retry.
```

Unit tests cover both new cases, the "must be paired" text captured verbatim from the live unpaired run, and that an unrecognised failure still returns null.

`pnpm check:affected --run` passes except provider-integration Android timeouts that pass 21/21 in isolation — the known contention signature, in modules this diff does not touch (it changes hint strings only).