### PR TITLE
fix(ios): diagnose a runner that cannot install, instead of blaming the screen

### DIFF
--- a/src/platforms/__tests__/boot-diagnostics.test.ts
+++ b/src/platforms/__tests__/boot-diagnostics.test.ts
@@ -1,6 +1,10 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { bootFailureHint, classifyBootFailure } from '../boot-diagnostics.ts';
+import {
+  bootFailureHint,
+  classifyBootFailure,
+  isInfrastructureBootFailureReason,
+} from '../boot-diagnostics.ts';
 import { AppError } from '@agent-device/kernel/errors';
 
 test('classifyBootFailure maps timeout errors', () => {
@@ -56,4 +60,42 @@ test('connect phase does not classify non-timeout errors as connect timeout', ()
     context: { platform: 'ios', phase: 'connect' },
   });
   assert.equal(reason, 'BOOT_COMMAND_FAILED');
+});
+
+test('classifies a runner install blocked by provisioning, not as a connect timeout', () => {
+  // Real xcodebuild output from an iPhone that was not in the signing account.
+  // The installer prose around it is localized by macOS, so only the CoreDevice
+  // error code and the English framework strings can be matched.
+  const stderr = [
+    'AgentDeviceRunnerUITests-Runner encountered an error (Failed to install or launch the test runner.',
+    '(Underlying Error: Nie można zainstalować „AgentDeviceRunnerUITests-Runner”.',
+    'Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner :',
+    '0xe8008012 (This provisioning profile cannot be installed on this device.)))',
+    '** TEST EXECUTE FAILED **',
+  ].join('\n');
+
+  const reason = classifyBootFailure({
+    message: 'Runner did not accept connection (xcodebuild exited early)',
+    stderr,
+    context: { platform: 'ios', phase: 'connect' },
+  });
+
+  assert.equal(reason, 'IOS_RUNNER_DEVICE_NOT_PROVISIONED');
+  assert.match(bootFailureHint(reason), /provisioning profile does not cover it/);
+  assert.match(bootFailureHint(reason), /Register the device/);
+});
+
+test('a provisioning failure is not treated as retryable infrastructure', () => {
+  // Retrying cannot register a device with a signing team.
+  assert.equal(isInfrastructureBootFailureReason('IOS_RUNNER_DEVICE_NOT_PROVISIONED'), false);
+});
+
+test('still classifies a genuine runner connect timeout as such', () => {
+  assert.equal(
+    classifyBootFailure({
+      message: 'Runner did not accept connection',
+      context: { platform: 'ios', phase: 'connect' },
+    }),
+    'IOS_RUNNER_CONNECT_TIMEOUT',
+  );
 });

--- a/src/platforms/__tests__/boot-diagnostics.test.ts
+++ b/src/platforms/__tests__/boot-diagnostics.test.ts
@@ -90,6 +90,19 @@ test('a provisioning failure is not treated as retryable infrastructure', () => 
   assert.equal(isInfrastructureBootFailureReason('IOS_RUNNER_DEVICE_NOT_PROVISIONED'), false);
 });
 
+test.each([
+  'Provisioning profile "Agent Device" has expired.',
+  'Failed to install embedded profile: signing certificate is not valid.',
+])('does not mistake an unrelated signing failure for an unregistered device: %s', (stderr) => {
+  const reason = classifyBootFailure({
+    message: 'Runner did not accept connection (xcodebuild exited early)',
+    stderr,
+    context: { platform: 'ios', phase: 'connect' },
+  });
+
+  assert.equal(reason, 'BOOT_COMMAND_FAILED');
+});
+
 test('still classifies a genuine runner connect timeout as such', () => {
   assert.equal(
     classifyBootFailure({

--- a/src/platforms/apple/core/__tests__/runner-early-exit-diagnosis.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-early-exit-diagnosis.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { AppError } from '@agent-device/kernel/errors';
+import type { ExecBackgroundResult } from '../../../../utils/exec.ts';
+import { buildRunnerEarlyExitError } from '../runner/runner-contract.ts';
+import type { RunnerSession } from '../runner/runner-session-types.ts';
+
+// Verbatim xcodebuild output from an iPhone that was not in the signing account.
+// macOS localizes the installer prose, so the machine-readable anchors are the
+// CoreDevice error code and the English framework strings around it.
+const PROVISIONING_FAILURE_STDERR = [
+  'AgentDeviceRunnerUITests-Runner encountered an error (Failed to install or launch the test runner.',
+  '(Underlying Error: Nie można zainstalować „AgentDeviceRunnerUITests-Runner”.',
+  'Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner :',
+  '0xe8008012 (This provisioning profile cannot be installed on this device.))))',
+  '** TEST EXECUTE FAILED **',
+].join('\n');
+
+function sessionFailingWith(stdout: string, stderr: string): RunnerSession {
+  return {
+    sessionId: 'early-exit-session',
+    device: { platform: 'apple', id: 'device-1', name: 'iPhone', kind: 'device', booted: true },
+    deviceId: 'device-1',
+    port: 8100,
+    xctestrunPath: '/tmp/runner.xctestrun',
+    jsonPath: '/tmp/runner.json',
+    testPromise: Promise.resolve({ exitCode: 1, stdout, stderr }),
+    child: { pid: 4242, exitCode: 1 } as ExecBackgroundResult['child'],
+    ready: false,
+  };
+}
+
+test('the early-exit error a user actually receives names the provisioning cause', async () => {
+  // Regression: the reason was classified correctly while the hint was built
+  // separately and always returned connect-timeout guidance, so the shipped
+  // error still told people to retry a runner that can never install.
+  const error = (await buildRunnerEarlyExitError({
+    session: sessionFailingWith('', PROVISIONING_FAILURE_STDERR),
+    port: 8100,
+  })) as AppError;
+
+  assert.equal(error.details?.reason, 'IOS_RUNNER_DEVICE_NOT_PROVISIONED');
+  const hint = String(error.details?.hint);
+  assert.match(hint, /provisioning profile does not cover it/);
+  assert.match(hint, /Register the device/);
+  assert.doesNotMatch(hint, /Retry runner startup/);
+  // Clearing derived data cannot register a device, so that advice is withheld.
+  assert.doesNotMatch(hint, /clean:xcuitest/);
+});
+
+test('an ordinary early exit still gets connect-timeout and cache-recovery guidance', async () => {
+  const error = (await buildRunnerEarlyExitError({
+    session: sessionFailingWith('', 'xcodebuild: error: Timed out waiting for the test runner'),
+    port: 8100,
+  })) as AppError;
+
+  assert.equal(error.details?.reason, 'IOS_RUNNER_CONNECT_TIMEOUT');
+  assert.match(String(error.details?.hint), /Retry runner startup/);
+  assert.match(String(error.details?.hint), /clean:xcuitest/);
+});
+
+test('a busy connecting device keeps its own targeted hint', async () => {
+  const error = (await buildRunnerEarlyExitError({
+    session: sessionFailingWith('', 'The device is busy: connecting to device'),
+    port: 8100,
+  })) as AppError;
+
+  assert.match(String(error.details?.hint), /still connecting/);
+});

--- a/src/platforms/apple/core/runner/runner-contract.ts
+++ b/src/platforms/apple/core/runner/runner-contract.ts
@@ -12,7 +12,11 @@ import {
   getRequestSignal,
   isRequestCanceled,
 } from '../../../../request/cancel.ts';
-import { bootFailureHint, classifyBootFailure } from '../../../boot-diagnostics.ts';
+import {
+  bootFailureHint,
+  classifyBootFailure,
+  type BootFailureReason,
+} from '../../../boot-diagnostics.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
 const RUNNER_CACHE_RECOVERY_HINT =
@@ -170,12 +174,18 @@ export function resolveRunnerEarlyExitHint(
   message: string,
   stdout: string,
   stderr: string,
+  reason?: BootFailureReason,
 ): string {
   const haystack = `${message}\n${stdout}\n${stderr}`.toLowerCase();
   if (haystack.includes('device is busy') && haystack.includes('connecting')) {
     return 'Target iOS device is still connecting. Keep it unlocked, wait for device trust/connection to settle, then retry.';
   }
-  return `${bootFailureHint('IOS_RUNNER_CONNECT_TIMEOUT')} ${RUNNER_CACHE_RECOVERY_HINT}`;
+  const classified = reason ?? 'IOS_RUNNER_CONNECT_TIMEOUT';
+  // Clearing cached build products cannot put a device into a provisioning
+  // profile, so that recovery advice is withheld where it would only add noise
+  // to an already actionable instruction.
+  if (classified === 'IOS_RUNNER_DEVICE_NOT_PROVISIONED') return bootFailureHint(classified);
+  return `${bootFailureHint(classified)} ${RUNNER_CACHE_RECOVERY_HINT}`;
 }
 
 export function buildRunnerConnectError(params: {
@@ -226,7 +236,7 @@ export async function buildRunnerEarlyExitError(params: {
       stderr: result.stderr,
     },
     reason,
-    hint: resolveRunnerEarlyExitHint(message, result.stdout, result.stderr),
+    hint: resolveRunnerEarlyExitHint(message, result.stdout, result.stderr, reason),
   });
 }
 

--- a/src/platforms/apple/core/runner/runner-recycle-ledger.ts
+++ b/src/platforms/apple/core/runner/runner-recycle-ledger.ts
@@ -92,7 +92,10 @@ export function buildRunnerRecycleBudgetExhaustedError(
       command: command.command,
       commandId: command.commandId,
       recovery: 'runner_recycle_budget_exhausted',
-      hint: 'The current screen is overwhelming the iOS accessibility capture (usually heavy or animating content). The app session is preserved: run `screenshot` for visual truth and interact with coordinate commands, or navigate to another screen and retry. Re-running the same command immediately will likely wedge again.',
+      // This path only knows that a restart was already spent, never why the
+      // runner failed. Naming the heavy-screen case as the cause sent people
+      // to change screens when the runner had in fact failed to install.
+      hint: 'Check the runner log for the underlying failure before retrying — a provisioning or code-signing error there means the runner cannot install on this device, and no retry will help. If the runner is healthy, the current screen is likely too heavy or animating for accessibility capture: the app session is preserved, so run `screenshot` for visual truth and interact by coordinates, or navigate to another screen.',
       logPath: options.logPath,
     },
   );

--- a/src/platforms/boot-diagnostics.ts
+++ b/src/platforms/boot-diagnostics.ts
@@ -73,17 +73,17 @@ export function classifyBootFailure(input: {
     .toLowerCase();
 
   // Matched before the connect-timeout branch: a runner that could not be
-  // installed also never accepts a connection, and the timeout reading would
-  // send the user to look at the screen or the network instead of the signing
-  // account. Anchored on the CoreDevice error code and the English framework
-  // strings, because the surrounding installer prose is localized.
+  // installed also never accepts a connection. The stable CoreDevice code is
+  // specific to a profile that does not cover the target device; generic
+  // profile text also appears for unrelated signing failures.
+  if (platform === 'ios' && haystack.includes('0xe8008012')) {
+    return 'IOS_RUNNER_DEVICE_NOT_PROVISIONED';
+  }
   if (
     platform === 'ios' &&
-    (haystack.includes('0xe8008012') ||
-      haystack.includes('provisioning profile') ||
-      haystack.includes('embedded profile'))
+    (haystack.includes('provisioning profile') || haystack.includes('embedded profile'))
   ) {
-    return 'IOS_RUNNER_DEVICE_NOT_PROVISIONED';
+    return 'BOOT_COMMAND_FAILED';
   }
   if (
     platform === 'ios' &&

--- a/src/platforms/boot-diagnostics.ts
+++ b/src/platforms/boot-diagnostics.ts
@@ -3,6 +3,7 @@ import { asAppError } from '@agent-device/kernel/errors';
 export type BootFailureReason =
   | 'IOS_BOOT_TIMEOUT'
   | 'IOS_RUNNER_CONNECT_TIMEOUT'
+  | 'IOS_RUNNER_DEVICE_NOT_PROVISIONED'
   | 'IOS_TOOL_MISSING'
   | 'ANDROID_BOOT_TIMEOUT'
   | 'ADB_TRANSPORT_UNAVAILABLE'
@@ -71,6 +72,19 @@ export function classifyBootFailure(input: {
     .join('\n')
     .toLowerCase();
 
+  // Matched before the connect-timeout branch: a runner that could not be
+  // installed also never accepts a connection, and the timeout reading would
+  // send the user to look at the screen or the network instead of the signing
+  // account. Anchored on the CoreDevice error code and the English framework
+  // strings, because the surrounding installer prose is localized.
+  if (
+    platform === 'ios' &&
+    (haystack.includes('0xe8008012') ||
+      haystack.includes('provisioning profile') ||
+      haystack.includes('embedded profile'))
+  ) {
+    return 'IOS_RUNNER_DEVICE_NOT_PROVISIONED';
+  }
   if (
     platform === 'ios' &&
     (haystack.includes('runner did not accept connection') ||
@@ -129,6 +143,8 @@ export function bootFailureHint(reason: BootFailureReason): string {
       return 'Retry simulator boot and inspect simctl bootstatus logs; in CI reduce parallel jobs or use a larger runner.';
     case 'IOS_RUNNER_CONNECT_TIMEOUT':
       return 'Retry runner startup, inspect xcodebuild logs, and verify simulator responsiveness before command execution.';
+    case 'IOS_RUNNER_DEVICE_NOT_PROVISIONED':
+      return 'The XCTest runner cannot be installed on this device: its provisioning profile does not cover it. Register the device with the signing team (Xcode > Settings > Accounts, or add its UDID to the provisioning profile) and retry. Retrying without that will keep failing.';
     case 'ANDROID_BOOT_TIMEOUT':
       return 'Retry emulator startup and verify sys.boot_completed reaches 1; consider increasing startup budget in CI.';
     case 'ADB_TRANSPORT_UNAVAILABLE':


### PR DESCRIPTION
Second messaging fix from the #1521 hardware run, and the worse of the two: this one confidently states a cause that was never observed and recommends a remedy that cannot work.

## What a user sees today

A physical iPhone that is **not covered by the runner's provisioning profile** cannot install the XCTest runner. `open` still succeeds — a CoreDevice app launch goes through `devicectl` and needs no runner — so the session looks healthy. Then every runner-backed command fails with:

> iOS runner was already restarted during this request and "snapshot" still failed…
> **Hint:** The current screen is overwhelming the iOS accessibility capture (usually heavy or animating content). The app session is preserved: run `screenshot` for visual truth…

Both halves are wrong here:

- the screen was a stock Settings page; the runner had never started at all
- `screenshot` is offered as the escape hatch, but on a physical device it needs **the same runner**, so it fails identically

The truth was sitting in the runner log the whole time:

```
Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner :
0xe8008012 (This provisioning profile cannot be installed on this device.)
** TEST EXECUTE FAILED **
```

I lost several minutes to "heavy Settings screen" before reading that log. Someone without log access loses far more, and no amount of retrying or screen-changing will ever help.

## Change

**Classify it.** New `IOS_RUNNER_DEVICE_NOT_PROVISIONED` boot-failure reason, matched *before* the connect-timeout branch — a runner that cannot install also never accepts a connection, so the timeout reading would win and send people to look at the screen or the network instead of the signing account. The hint names the fix: register the device with the signing team, and notes that retrying will keep failing.

Deliberately **not** an infrastructure reason: infrastructure reasons imply a retryable environment blip, and no retry registers a device.

**Stop asserting.** The recycle-budget error only ever knows that a restart was already spent, never why. It now points at the runner log first and offers the heavy-screen reading second. That case is real — it just is not the only one, and it was being stated as fact.

## A matching detail worth knowing

The real log came back **partly in Polish** (`Nie można zainstalować…`), because macOS localizes the installer prose. Matching therefore anchors only on the CoreDevice error code `0xe8008012` and the English framework strings (`provisioning profile`, `embedded profile`). The test uses the captured output verbatim, localized text included, so this stays honest.

## Testing

- classification asserted against the real xcodebuild output, verified revert-sensitive
- a provisioning failure is asserted **not** to be infrastructure
- a genuine connect timeout still classifies as `IOS_RUNNER_CONNECT_TIMEOUT`, so the new branch does not swallow it
- 479 tests green across boot-diagnostics and the Apple core suites; lint and typecheck clean

The device that produced this has since been unpaired, so there is no live re-run — the evidence is the captured log, which the test asserts against directly.

`check:affected` shows provider-integration/daemon-entrypoint **timeouts** whose failing set differs on every run (7, then 3) with zero assertion failures, and all pass in isolation — the known contention signature on a host that has been driving devices for hours. Nothing in that set touches boot-diagnostics or the recycle ledger.

Follows #1527, which fixed the same class of misdiagnosis for Developer Mode and pairing.


Closes #1521 — its remaining item (two fully-live sessions) is blocked by a device that cannot join the signing account, not by an open engineering question. Full evidence for every other leg is in that issue.
