### PR TITLE
fix: treat Android permission prompts as pending alerts, not tap escapes

### DIFF
--- a/src/commands/interaction/output.test.ts
+++ b/src/commands/interaction/output.test.ts
@@ -81,6 +81,23 @@ describe('press CLI output', () => {
     );
   });
 
+  test('prints the response warning after the tap line', () => {
+    const output = formatPress({
+      message: 'Tapped (278, 817)',
+      x: 278,
+      y: 817,
+      warning:
+        'press id="request-mic" opened an Android permission dialog (com.google.android.permissioncontroller) over com.example.app. Use "alert get" to inspect it, then "alert accept" or "alert dismiss" to respond.',
+    });
+
+    expect(output.text).toBe(
+      [
+        'Tapped (278, 817)',
+        'Warning: press id="request-mic" opened an Android permission dialog (com.google.android.permissioncontroller) over com.example.app. Use "alert get" to inspect it, then "alert accept" or "alert dismiss" to respond.',
+      ].join('\n'),
+    );
+  });
+
   test('appends the unchanged interactive tail after a removals-only diff', () => {
     const output = formatPress({
       message: 'Tapped @e4 (100, 200)',

--- a/src/commands/interaction/output.ts
+++ b/src/commands/interaction/output.ts
@@ -52,19 +52,23 @@ function tapCliOutput(result: CommandRequestResult): CliOutput {
   const y = data.y;
   if (!ref || typeof x !== 'number' || typeof y !== 'number') {
     const output = defaultCommandCliOutput(data);
-    return { data: output.data, text: appendSettleText(output.text, data.settle) };
+    return { data: output.data, text: appendResponseNotes(output.text, data) };
   }
-  return { data, text: appendSettleText(`Tapped @${ref} (${x}, ${y})`, data.settle) };
+  return { data, text: appendResponseNotes(`Tapped @${ref} (${x}, ${y})`, data) };
 }
 
 function messageWithSettleCliOutput(result: CommandRequestResult): CliOutput {
   const data = result as Record<string, unknown>;
   const output = defaultCommandCliOutput(data);
-  return { data: output.data, text: appendSettleText(output.text, data.settle) };
+  return { data: output.data, text: appendResponseNotes(output.text, data) };
 }
 
-function appendSettleText(text: string | null | undefined, settle: unknown): string {
-  return `${text ?? ''}${formatSettleText(settle)}`;
+function appendResponseNotes(
+  text: string | null | undefined,
+  data: Record<string, unknown>,
+): string {
+  const warning = typeof data.warning === 'string' ? `\nWarning: ${data.warning}` : '';
+  return `${text ?? ''}${warning}${formatSettleText(data.settle)}`;
 }
 
 type SettleTextView = {

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -1843,7 +1843,14 @@ test('press @ref fails when Android tap escapes to Settings', async () => {
   });
 });
 
-test.each(['com.google.android.permissioncontroller', 'com.android.permissioncontroller'])(
+const ANDROID_PERMISSION_PROMPT_PACKAGES = [
+  'com.android.permissioncontroller',
+  'com.google.android.permissioncontroller',
+  'com.google.android.packageinstaller',
+  'com.android.packageinstaller',
+] as const;
+
+test.each(ANDROID_PERMISSION_PROMPT_PACKAGES)(
   'press @ref succeeds with a pending-alert warning when %s foregrounds',
   async (packageName) => {
     const sessionStore = makeSessionStore();

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -1843,6 +1843,56 @@ test('press @ref fails when Android tap escapes to Settings', async () => {
   });
 });
 
+test.each([
+  'com.google.android.permissioncontroller',
+  'com.android.permissioncontroller',
+])('press @ref succeeds with a pending-alert warning when %s foregrounds', async (packageName) => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-permission-prompt';
+  const session = makeAndroidSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'android.widget.Button',
+        label: 'Request microphone',
+        rect: { x: 16, y: 40, width: 120, height: 48 },
+        enabled: true,
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({ pressed: true });
+  mockGetAndroidAppState.mockResolvedValue({
+    package: packageName,
+    activity: 'com.android.permissioncontroller.permission.ui.GrantPermissionsActivity',
+  });
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['@e1'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toMatch(/opened an Android permission dialog/);
+    expect(response.data?.warning).toMatch(/"alert get"/);
+  }
+  expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
+});
+
 test('press @ref --verify surfaces evidence through the interactionResultExtra allowlist', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'verify-press';

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -1843,55 +1843,55 @@ test('press @ref fails when Android tap escapes to Settings', async () => {
   });
 });
 
-test.each([
-  'com.google.android.permissioncontroller',
-  'com.android.permissioncontroller',
-])('press @ref succeeds with a pending-alert warning when %s foregrounds', async (packageName) => {
-  const sessionStore = makeSessionStore();
-  const sessionName = 'android-permission-prompt';
-  const session = makeAndroidSession(sessionName);
-  session.snapshot = {
-    nodes: attachRefs([
-      {
-        index: 0,
-        type: 'android.widget.Button',
-        label: 'Request microphone',
-        rect: { x: 16, y: 40, width: 120, height: 48 },
-        enabled: true,
-        hittable: true,
+test.each(['com.google.android.permissioncontroller', 'com.android.permissioncontroller'])(
+  'press @ref succeeds with a pending-alert warning when %s foregrounds',
+  async (packageName) => {
+    const sessionStore = makeSessionStore();
+    const sessionName = 'android-permission-prompt';
+    const session = makeAndroidSession(sessionName);
+    session.snapshot = {
+      nodes: attachRefs([
+        {
+          index: 0,
+          type: 'android.widget.Button',
+          label: 'Request microphone',
+          rect: { x: 16, y: 40, width: 120, height: 48 },
+          enabled: true,
+          hittable: true,
+        },
+      ]),
+      createdAt: Date.now(),
+      backend: 'android',
+    };
+    sessionStore.set(sessionName, session);
+
+    mockDispatch.mockResolvedValue({ pressed: true });
+    mockGetAndroidAppState.mockResolvedValue({
+      package: packageName,
+      activity: 'com.android.permissioncontroller.permission.ui.GrantPermissionsActivity',
+    });
+
+    const response = await handleInteractionCommands({
+      req: {
+        token: 't',
+        session: sessionName,
+        command: 'press',
+        positionals: ['@e1'],
+        flags: {},
       },
-    ]),
-    createdAt: Date.now(),
-    backend: 'android',
-  };
-  sessionStore.set(sessionName, session);
+      sessionName,
+      sessionStore,
+      contextFromFlags,
+    });
 
-  mockDispatch.mockResolvedValue({ pressed: true });
-  mockGetAndroidAppState.mockResolvedValue({
-    package: packageName,
-    activity: 'com.android.permissioncontroller.permission.ui.GrantPermissionsActivity',
-  });
-
-  const response = await handleInteractionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'press',
-      positionals: ['@e1'],
-      flags: {},
-    },
-    sessionName,
-    sessionStore,
-    contextFromFlags,
-  });
-
-  expect(response?.ok).toBe(true);
-  if (response?.ok) {
-    expect(response.data?.warning).toMatch(/opened an Android permission dialog/);
-    expect(response.data?.warning).toMatch(/"alert get"/);
-  }
-  expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
-});
+    expect(response?.ok).toBe(true);
+    if (response?.ok) {
+      expect(response.data?.warning).toMatch(/opened an Android permission dialog/);
+      expect(response.data?.warning).toMatch(/"alert get"/);
+    }
+    expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
+  },
+);
 
 test('press @ref --verify surfaces evidence through the interactionResultExtra allowlist', async () => {
   const sessionStore = makeSessionStore();

--- a/src/daemon/handlers/interaction-android-escape.ts
+++ b/src/daemon/handlers/interaction-android-escape.ts
@@ -1,4 +1,5 @@
 import { getAndroidAppState } from '../../platforms/android/app-lifecycle.ts';
+import { isAndroidPermissionPackage } from '../../platforms/android/alert-detection.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import type { SessionState } from '../types.ts';
 
@@ -9,12 +10,22 @@ export type AndroidEscapeSurface = {
   hint: string;
 };
 
+/**
+ * Post-press escape guard. Throws when the tap left the app for a genuine
+ * escape surface (settings/systemui/launcher). A foregrounded permission
+ * prompt is NOT an escape — the press succeeded and raised a system dialog
+ * the agent consumes via `alert` — so it returns a response warning instead.
+ */
 export async function assertAndroidPressStayedInApp(
   session: SessionState,
   targetLabel: string,
-): Promise<void> {
+): Promise<string | undefined> {
   const surface = await detectAndroidEscapeSurface(session);
-  if (!surface) return;
+  if (!surface) return undefined;
+
+  if (isAndroidPermissionPackage(surface.foregroundPackage)) {
+    return `press ${targetLabel} opened an Android permission dialog (${surface.foregroundPackage}) over ${surface.expectedPackage}. ${surface.hint}`;
+  }
 
   throw new AppError(
     'COMMAND_FAILED',
@@ -42,7 +53,7 @@ export async function detectAndroidEscapeSurface(
 }
 
 export function describeAndroidEscapeSurface(surface: AndroidEscapeSurface): string {
-  if (surface.foregroundPackage === 'com.google.android.permissioncontroller') {
+  if (isAndroidPermissionPackage(surface.foregroundPackage)) {
     return `Android permission dialog is blocking ${surface.expectedPackage}`;
   }
   return `${surface.foregroundPackage} is foreground instead of ${surface.expectedPackage}`;
@@ -57,8 +68,8 @@ export function isAndroidEscapeError(error: AppError): boolean {
 }
 
 function buildAndroidEscapeHint(packageName: string): string {
-  if (packageName === 'com.google.android.permissioncontroller') {
-    return 'Dismiss or allow the permission prompt, then retry the smoke assertion.';
+  if (isAndroidPermissionPackage(packageName)) {
+    return 'Use "alert get" to inspect it, then "alert accept" or "alert dismiss" to respond.';
   }
   return 'Use screenshot as visual truth, then take a fresh snapshot -i before retrying.';
 }
@@ -67,7 +78,7 @@ function looksLikeAndroidEscapeSurface(packageName: string): boolean {
   return (
     packageName === 'com.android.settings' ||
     packageName === 'com.android.systemui' ||
-    packageName === 'com.google.android.permissioncontroller' ||
+    isAndroidPermissionPackage(packageName) ||
     packageName.includes('launcher')
   );
 }

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -209,8 +209,8 @@ async function dispatchTargetedTouchViaRuntime(
         expectedResolvedTarget: replayTargetGuard,
       }),
     afterRun: async (result) => {
-      if (session.lease?.leaseProvider) return;
-      await assertAndroidPressStayedInApp(
+      if (session.lease?.leaseProvider) return undefined;
+      return await assertAndroidPressStayedInApp(
         session,
         formatTouchTargetLabel(parsedTarget.target, result),
       );
@@ -766,7 +766,8 @@ async function dispatchRuntimeInteraction<
      */
     refContext?: RefAdmissionContext;
     run(runtime: ReturnType<typeof createInteractionRuntime>): Promise<TResult>;
-    afterRun?(result: TResult): Promise<void>;
+    /** May return a warning to append to the successful response (e.g. a pending Android permission dialog). */
+    afterRun?(result: TResult): Promise<string | undefined>;
     buildPayloads(
       result: TResult,
     ): InteractionResponsePayloads | Promise<InteractionResponsePayloads>;
@@ -777,13 +778,14 @@ async function dispatchRuntimeInteraction<
   const runtime = createInteractionRuntime(params);
   const actionStartedAt = Date.now();
   try {
+    let afterRunWarning: string | undefined;
     const outcome = await runWithAndroidDialogReadinessCheck(
       session,
       params.req.command,
       { refContext: options.refContext },
       async () => {
         const result = await options.run(runtime);
-        await options.afterRun?.(result);
+        afterRunWarning = await options.afterRun?.(result);
         return result;
       },
     );
@@ -791,13 +793,17 @@ async function dispatchRuntimeInteraction<
     const { readiness, runtimeResult } = outcome;
     const actionFinishedAt = Date.now();
     const { result, responseData, recordedTarget } = await options.buildPayloads(runtimeResult);
-    if (readiness.status === 'recovered') {
-      // Append, don't clobber — the builder may already carry a warning
-      // (e.g. stale-refs, #1076).
-      const warning =
-        typeof responseData.warning === 'string'
-          ? `${responseData.warning} ${readiness.warning}`
-          : readiness.warning;
+    // Append, don't clobber — the builder may already carry a warning
+    // (e.g. stale-refs, #1076).
+    const appendedWarnings = [
+      ...(readiness.status === 'recovered' ? [readiness.warning] : []),
+      ...(afterRunWarning ? [afterRunWarning] : []),
+    ];
+    if (appendedWarnings.length > 0) {
+      const warning = [
+        ...(typeof responseData.warning === 'string' ? [responseData.warning] : []),
+        ...appendedWarnings,
+      ].join(' ');
       result.warning = warning;
       responseData.warning = warning;
     }

--- a/src/platforms/android/alert-detection.ts
+++ b/src/platforms/android/alert-detection.ts
@@ -30,6 +30,11 @@ const ANDROID_PERMISSION_PACKAGES = new Set([
   'com.google.android.packageinstaller',
   'com.android.packageinstaller',
 ]);
+
+/** Packages that host runtime-permission and install prompts — a legitimate `alert` source, never an app escape. */
+export function isAndroidPermissionPackage(packageName: string): boolean {
+  return ANDROID_PERMISSION_PACKAGES.has(packageName);
+}
 const ANDROID_SYSTEM_DIALOG_PACKAGES = new Set(['android', 'com.android.systemui']);
 const ANDROID_ALERT_ID_PATTERN =
   /^android:id\/(?:alertTitle|message|button[123]|parentPanel|buttonPanel|contentPanel)$/i;


### PR DESCRIPTION
## Problem

The Android full-tier live scenario `full:lifecycle-system` (`resetAndRequestMicrophonePermission`) fails deterministically: `click id="automation-request-microphone"` intentionally raises the system microphone permission dialog, but the post-press escape guard (`assertAndroidPressStayedInApp`) sees `com.google.android.permissioncontroller` foregrounded and throws `COMMAND_FAILED "The tap likely escaped the app"`. The harness then never reaches its `alert get` / `alert accept` steps — which are designed to consume exactly that prompt (alert-detection already classifies the permission-controller packages as a legitimate `permission` alert source).

Reproduced 3/3 locally on a Pixel 9 Pro XL API 36 emulator. The full tier has never executed in CI (both nightlies since #1482/#1484 died on Android infra before the suite ran), so this is the first exercise of that path.

## Product decision

A press that foregrounds an Android **permission-prompt package** is a *successful* press — raising the dialog is the intended outcome, and `alert` is the designed consumer. The press now succeeds and carries a response warning telling the agent what to do next. Genuine escapes (settings, systemui, launcher) still throw exactly as before.

## Changes

- `alert-detection.ts` exports `isAndroidPermissionPackage()` so a single authority enumerates the permission packages. The escape guard previously hardcoded only `com.google.android.permissioncontroller`, so the AOSP `com.android.permissioncontroller` / packageinstaller packages weren't detected at all.
- `interaction-android-escape.ts`: `assertAndroidPressStayedInApp` returns a warning for permission surfaces instead of throwing; the stale "retry the smoke assertion" hint became `Use "alert get" to inspect it, then "alert accept" or "alert dismiss" to respond.` The selector-runtime foreground-blocker path (`is`/`get` failing while a dialog blocks) is unchanged.
- `interaction-touch.ts`: `afterRun` may return a warning, appended to the successful response alongside the existing dialog-recovery readiness warning (append, never clobber).
- `output.ts` (interaction formatters): tap/press/fill/longpress plain-text output now prints a `Warning:` line — previously `data.warning` was JSON-only, so plain-CLI agents (the live harness included) never saw response warnings at all.

## Verification

- New unit tests: press succeeds with the pending-alert warning for both permission-controller packages and the action is recorded; existing launcher/settings escape tests still throw; a formatter test locks the `Warning:` text line. Typecheck, lint, and the full unit suites over the touched areas (2390 tests) pass.
- Live on the Pixel 9 Pro XL emulator, exact harness sequence (`settings permission reset microphone` → `scroll bottom` → `click id="automation-request-microphone"` → `alert get` → `alert accept`): the click that previously threw now returns `Tapped … Warning: press … opened an Android permission dialog … Use "alert get" …`; `alert get` reports `source: permission` with the real buttons (`While using the app` / `Only this time` / `Don't allow`); accept lands and `dumpsys` confirms `RECORD_AUDIO: granted=true`. The deny leg (`alert dismiss` → `denied`) was verified live too.

## Notes for review

- #1280 (press classification) is related but orthogonal — untouched here.
- The permission-package widening also enriches the selector-runtime blocker message on AOSP images, consistent with alert-detection.