### PR TITLE
fix(test): repair Android replay fixtures against live device reality

### DIFF
--- a/examples/test-app/README.md
+++ b/examples/test-app/README.md
@@ -232,6 +232,13 @@ pnpm test-app:replay:android
 
 These run the `.ad` replay suite in `examples/test-app/replays`.
 
+The Android gesture replay pins coordinates to the CI emulator profile —
+**pixel_7, 1080x2400 @ 420 dpi** (`gh workflow` uses exactly this AVD). Run it
+on a matching emulator; on a different size or density the gesture card moves
+and the canary waits fail with a wait timeout naming the missed state, which
+is fixture geometry, not a product regression. The checkout replay is
+selector-driven and runs on any emulator.
+
 The iOS `gesture-lab.ad` and Android `gesture-lab-android.ad` replays verify
 `gesture pan`, `gesture fling`, `gesture pinch`, and `gesture rotate` against the
 gesture metrics rendered by the Home screen. They also prove that the default pan

--- a/examples/test-app/replays/checkout-form-android.ad
+++ b/examples/test-app/replays/checkout-form-android.ad
@@ -1,3 +1,4 @@
+# Selector-driven; safe on any emulator size. The gesture twin is geometry-pinned.
 context platform=android timeout=60000
 env APP_TARGET="com.callstack.agentdevicelab"
 env APP_URL=""

--- a/examples/test-app/replays/checkout-form-android.ad
+++ b/examples/test-app/replays/checkout-form-android.ad
@@ -1,5 +1,5 @@
 context platform=android timeout=60000
-env APP_TARGET="Agent Device Tester"
+env APP_TARGET="com.callstack.agentdevicelab"
 env APP_URL=""
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
 react-native dismiss-overlay

--- a/examples/test-app/replays/gesture-lab-android.ad
+++ b/examples/test-app/replays/gesture-lab-android.ad
@@ -9,16 +9,16 @@ wait "Gesture lab" 30000
 wait "gesture canary ready" 5000
 wait "two-pointer pan activations 0" 5000
 
-gesture pan 220 700 180 0 500
+gesture pan 220 1040 180 0 500
 wait "two-pointer pan activations 0" 5000
 
-gesture pan 220 700 180 0 500 --pointer-count 2
+gesture pan 220 1040 180 0 500 --pointer-count 2
 wait "two-pointer pan activations 1" 5000
 
-gesture fling right 500 700 300
+gesture fling right 700 1040 300
 wait "fling 1" 5000
 
-gesture fling left 500 700 300
+gesture fling left 700 1040 300
 wait "fling 2" 5000
 
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
@@ -26,7 +26,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture pinch 1.5 360 700
+gesture pinch 1.5 540 1040
 wait "pan changed no, pinch changed yes, rotate changed no" 5000
 
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
@@ -34,7 +34,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture rotate 35 360 700
+gesture rotate 35 540 1040
 wait "pan changed no, pinch changed no, rotate changed yes" 5000
 
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
@@ -42,7 +42,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture transform 360 700 60 0 1.75 30 600
+gesture transform 540 1040 60 0 1.75 30 600
 wait "pan changed yes, pinch changed yes, rotate changed yes" 5000
 
 close

--- a/examples/test-app/replays/gesture-lab-android.ad
+++ b/examples/test-app/replays/gesture-lab-android.ad
@@ -1,3 +1,6 @@
+# Coordinates target the CI emulator profile: pixel_7, 1080x2400 @ 420 dpi
+# (gesture card spans y=754-1329 there). Another size/density moves the card
+# and the canary waits below fail honestly rather than silently passing.
 context platform=android kind=emulator timeout=60000
 
 env APP_TARGET="com.callstack.agentdevicelab"

--- a/test/integration/replays/android/fixture/01-navigation-scroll.ad
+++ b/test/integration/replays/android/fixture/01-navigation-scroll.ad
@@ -5,7 +5,7 @@ env APP_TARGET="com.callstack.agentdevicelab"
 
 open "${APP_TARGET}" --relaunch
 wait "Agent Device Tester" 30000
-click "label=Catalog"
+click "label=\"Catalog, 0 new notifications\""
 wait "Catalog scroll: top" 5000
 swipe 220 700 220 380
 wait "Catalog scroll: down" 5000


### PR DESCRIPTION
Three Android fixture defects from the #1482/#1484 full-tier suite, none of which ever executed in CI (both nightlies since failed on adb infra before the suite ran). All three verified live during the #1525 evidence arc on a fresh API 36 emulator with pixel_7 geometry and a Release fixture APK:

- **01-navigation-scroll.ad** clicked `label=Catalog`, but the expo-router NativeTabs cart badge leaks '0 new notifications' into the tab's content description even while hidden, and unselected native tabs expose no child text node — exact match can never hit. Target the composed label the device actually exposes (deterministic at fixture start: cart is 0 after `--relaunch`). The badge does not leak on iOS, so the iOS twin keeps `label="Catalog"`.
- **checkout-form-android.ad** opened by iOS display name 'Agent Device Tester'; Android `open` resolves packages (the APK label is 'Agentdevicelab'), so APP_NOT_INSTALLED was guaranteed. Use the package id, matching gesture-lab-android.ad.
- **gesture-lab-android.ad** aimed every gesture at y=700, above the gesture card (targets span y754–1329 on pixel_7 geometry; the home screen gained content above the card since authoring). Re-aim pans inside the exact-two-pointer zone, flings on the image clear of that zone, and pinch/rotate/transform at the card center. Verified: full suite passes 2/2 via the public `test` command (20 + 32 steps replayed).

## Validation
Live evidence from the #1525 arc (2026-07-31, documented in its PR comment): consolidated suite green 2/2 on emulator-5556 (Pixel_7_CI, API 36, freezer disabled), checkout 20/20 + gesture-lab 32/32 steps replayed through the public `test` command, JUnit non-empty. These fixture fixes are also a prerequisite for the `test-app:replay:android` live-evidence requirement on #1536.

Refs #1478