### PR TITLE
test(daemon): pin resolveScriptTarget's retention table directly

### DIFF
--- a/src/daemon/__tests__/session-script-publication-state.test.ts
+++ b/src/daemon/__tests__/session-script-publication-state.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest';
+import { armRepair, resolveScriptTarget } from '../session-script-publication-state.ts';
+
+// The retention table for the per-target force model (#1258). The repair suites pin these
+// transitively through healed-sibling paths; this pins the transition itself, so a regression
+// names the rule it broke instead of a downstream path assertion.
+
+test('a bare re-arm keeps a materialized explicit target and its grant', () => {
+  const previous = { kind: 'explicit', path: '/flows/a.healed.ad', force: true } as const;
+  expect(resolveScriptTarget(previous, { force: false })).toEqual(previous);
+});
+
+test('a bare re-arm with live force adds the grant without touching the path', () => {
+  expect(
+    resolveScriptTarget(
+      { kind: 'explicit', path: '/flows/a.healed.ad', force: false },
+      { force: true },
+    ),
+  ).toEqual({ kind: 'explicit', path: '/flows/a.healed.ad', force: true });
+});
+
+test('re-arming the same explicit path keeps an existing grant', () => {
+  expect(
+    resolveScriptTarget(
+      { kind: 'explicit', path: '/flows/a.ad', force: true },
+      { path: '/flows/a.ad', force: false },
+    ),
+  ).toEqual({ kind: 'explicit', path: '/flows/a.ad', force: true });
+});
+
+test('retargeting to a different explicit path without live force drops the grant', () => {
+  expect(
+    resolveScriptTarget(
+      { kind: 'explicit', path: '/flows/a.ad', force: true },
+      { path: '/flows/b.ad', force: false },
+    ),
+  ).toEqual({ kind: 'explicit', path: '/flows/b.ad', force: false });
+});
+
+test('moving from default to an explicit path keeps the grant (#1258 flagged retention)', () => {
+  expect(
+    resolveScriptTarget({ kind: 'default', force: true }, { path: '/flows/out.ad', force: false }),
+  ).toEqual({ kind: 'explicit', path: '/flows/out.ad', force: true });
+});
+
+test('per-step repair re-arms never move the boundary or wipe the healed sibling', () => {
+  const armed = armRepair(
+    { kind: 'none' },
+    {
+      requested: { path: '/flows/login.healed.ad', force: false },
+      boundary: 3,
+      sourcePath: '/flows/login.ad',
+    },
+  );
+  const rearmed = armRepair(armed, { requested: { force: false }, boundary: 0 });
+  expect(rearmed).toEqual(armed);
+});


### PR DESCRIPTION
Follow-up to #1532's "bug the migration caught": the bare-re-arm target collapse was caught (and is still pinned) only transitively, through the repair suites' healed-sibling path and persisted-force assertions. This adds the direct table on the transition itself — bare re-arm keeps target and grant, live force adds without retargeting, same-path re-arm keeps the grant, different-path retarget drops it, default→explicit keeps it (the retention flagged on #1258), and per-step `armRepair` re-arms never move the boundary or wipe the healed sibling.

Test-only; 6 new tests, typecheck/format clean.