### PR TITLE
refactor(ios): drop the transport seam usbmux-first made dead

### DIFF
--- a/src/platforms/apple/core/__tests__/physical-device-control.test.ts
+++ b/src/platforms/apple/core/__tests__/physical-device-control.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { IOS_DEVICE as SHARED_IOS_DEVICE } from '../../../../__tests__/test-utils/index.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { AppError } from '@agent-device/kernel/errors';
 import { createAppleInteractor } from '../../interactor.ts';
 import { installIosApp } from '../app-install.ts';
 import { closeIosApp, openIosApp } from '../app-launch.ts';
@@ -47,11 +48,15 @@ test('XCTest readiness uses xcdevice instead of devicectl', async () => {
       args: ['xcdevice', 'wait', '--both', '--timeout=15', XCTEST_IOS_DEVICE.id],
     },
   ]);
-  assert.deepEqual(
-    await resolveIosPhysicalDeviceControl(XCTEST_IOS_DEVICE).resolveRunnerTransport(
-      XCTEST_IOS_DEVICE,
-    ),
-    { kind: 'usbmux' },
+  // An XCTest-backed device has no CoreDevice tunnel, and the route resolver
+  // never asks it for one: it returns a usbmux route before reaching this.
+  await assert.rejects(
+    async () =>
+      await resolveIosPhysicalDeviceControl(XCTEST_IOS_DEVICE).resolveTunnel(XCTEST_IOS_DEVICE),
+    (error: unknown) => {
+      assert.equal((error as AppError).code, 'UNSUPPORTED_OPERATION');
+      return true;
+    },
   );
 });
 

--- a/src/platforms/apple/core/physical-device-control.ts
+++ b/src/platforms/apple/core/physical-device-control.ts
@@ -32,9 +32,12 @@ import {
 import { runXcrun } from './tool-provider.ts';
 
 export type IosPhysicalDeviceBackend = 'coredevice' | 'xctest';
-export type IosPhysicalDeviceRunnerTransport =
-  | { kind: 'network'; tunnelIp: string | null }
-  | { kind: 'usbmux' };
+/**
+ * Only the CoreDevice tunnel address is resolved here. Which transport a runner
+ * command uses is decided by the route resolver, which reaches this at all only
+ * after usbmux has reported the device unattached.
+ */
+export type IosPhysicalDeviceTunnel = { tunnelIp: string | null };
 
 type IosPhysicalDeviceLaunchOptions = {
   payloadUrl?: string;
@@ -75,10 +78,7 @@ export type IosPhysicalDeviceControl = {
     outPath: string,
     timeoutMs?: number,
   ): Promise<void>;
-  resolveRunnerTransport(
-    device: DeviceInfo,
-    timeoutBudgetMs?: number,
-  ): Promise<IosPhysicalDeviceRunnerTransport>;
+  resolveTunnel(device: DeviceInfo, timeoutBudgetMs?: number): Promise<IosPhysicalDeviceTunnel>;
 };
 
 const CONTROLS: Record<IosPhysicalDeviceBackend, IosPhysicalDeviceControl> = {
@@ -94,8 +94,7 @@ const CONTROLS: Record<IosPhysicalDeviceBackend, IosPhysicalDeviceControl> = {
     resolveAppProcesses: resolveCoreDeviceAppProcesses,
     captureScreenshot: captureCoreDeviceScreenshot,
     copyRunnerFile: copyCoreDeviceRunnerFile,
-    resolveRunnerTransport: async (device, timeoutBudgetMs) => ({
-      kind: 'network',
+    resolveTunnel: async (device, timeoutBudgetMs) => ({
       tunnelIp: await resolveCoreDeviceTunnelIp(device, timeoutBudgetMs),
     }),
   },
@@ -111,7 +110,7 @@ const CONTROLS: Record<IosPhysicalDeviceBackend, IosPhysicalDeviceControl> = {
     resolveAppProcesses: rejectXctestProcessLookup,
     captureScreenshot: captureXctestDeviceScreenshot,
     copyRunnerFile: rejectXctestRunnerFileCopy,
-    resolveRunnerTransport: async () => ({ kind: 'usbmux' }),
+    resolveTunnel: rejectXctestTunnelLookup,
   },
 };
 
@@ -155,6 +154,18 @@ async function rejectXctestProcessLookup(device: DeviceInfo): Promise<never> {
       deviceId: device.id,
       backend: 'xctest',
       hint: 'Use a CoreDevice-backed iOS device for performance sampling.',
+    },
+  );
+}
+
+async function rejectXctestTunnelLookup(device: DeviceInfo): Promise<never> {
+  throw new AppError(
+    'UNSUPPORTED_OPERATION',
+    'XCTest-backed physical iOS devices have no CoreDevice tunnel.',
+    {
+      deviceId: device.id,
+      backend: 'xctest',
+      hint: 'Connect the device by cable so it is reachable through usbmux.',
     },
   );
 }

--- a/src/platforms/apple/core/runner/runner-command-route.ts
+++ b/src/platforms/apple/core/runner/runner-command-route.ts
@@ -61,11 +61,7 @@ export function createRunnerCommandRouteResolver(device: DeviceInfo, port: numbe
           return buildNetworkRoute(device, port, requestTunnelIp, false);
         }
       }
-      const transport = await control.resolveRunnerTransport(device, timeoutBudgetMs);
-      if (transport.kind === 'usbmux') {
-        return buildUsbmuxRoute(device, port);
-      }
-      const tunnelIp = transport.tunnelIp;
+      const { tunnelIp } = await control.resolveTunnel(device, timeoutBudgetMs);
       requestTunnelIp = tunnelIp;
       if (tunnelIp) writeDeviceTunnelIpCache(device.id, tunnelIp);
       return buildNetworkRoute(device, port, tunnelIp, false);


### PR DESCRIPTION
Answering "is there code we can safely drop now that usbmux is primary?" — yes, this much.

## What went dead

`IosPhysicalDeviceControl` exposed:

```ts
resolveRunnerTransport(device, timeoutBudgetMs): Promise<
  { kind: 'network'; tunnelIp: string | null } | { kind: 'usbmux' }
>
```

That predates #1517, when the control still chose the transport. Since #1517 the **route resolver** chooses: it returns a usbmux route for an XCTest device, and for a CoreDevice device too, reaching the control **only after usbmux has reported the device unattached**. At that point the sole question left is "what is the tunnel address".

So the `usbmux` arm has no live producer or consumer:

- the resolver's `if (transport.kind === 'usbmux')` branch was **unreachable** — the only control that gets that far is CoreDevice, which always answers `network`
- the XCTest implementation returning `{ kind: 'usbmux' }` was called **only from a test**; production returns a usbmux route before it

## Change

- collapse the union to `IosPhysicalDeviceTunnel = { tunnelIp: string | null }` — one shape, so no discriminator to carry
- rename `resolveRunnerTransport` → `resolveTunnel`, which is what it now does; the old name advertised a decision this seam no longer makes
- delete the unreachable branch in the resolver
- XCTest now rejects a tunnel lookup, matching how it already rejects app inventory, process lookup and runner file copy — it has no CoreDevice tunnel, which is exactly why the resolver never asks it for one

Behaviour is unchanged: every path that ran before runs the same way. This removes a false affordance rather than a feature — the interface implied XCTest devices resolve a *transport*, when the transport question was settled upstream.

## Testing

The one test that exercised the dead path now asserts the rejection instead of a value production never produced, matching its sibling tests for the other unsupported XCTest operations. `physical-device-control` and `runner-transport` suites pass (19 tests); typecheck and lint clean.

## On the gate run

`check:affected` reports failures in `help-conformance-bench`, `install-source` (`unzip exited with code 9`), `owner-identity`, `device-claims` and `android-recording`. Two of those are **assertion** failures, which I would normally treat as blocking rather than flake — so I checked rather than assumed: all 51 of those tests pass in isolation, both with and without this change, and none of them are reachable from a diff that touches only Apple physical-device control, the Apple route resolver, and one Apple test. The host has been driving real devices and xcodebuild for hours; `unzip` failing with a subprocess code and a process-liveness check flipping are both load-sensitive.

Worth a separate look if they recur on a quiet machine — I would rather flag that than bury it.