### PR TITLE
fix: clear the polynomial-redos class across main

### DIFF
--- a/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
+++ b/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
@@ -5,6 +5,7 @@ import {
   discoverReplayTestEntries,
   buildReplayTestInvocationId,
 } from '../session-test-discovery.ts';
+import { trimEdgeDashes } from '../session-test-artifacts.ts';
 import type { ReplayTestManifest, ReplayTestSource } from '../session-test-types.ts';
 
 // Scheduler-owned discovery policy (#1478 P3b): which sources a --platform filter runs, which
@@ -79,10 +80,16 @@ test('a suite that matched nothing after filtering is rejected', () => {
   );
 });
 
-test('slug building stays linear on adversarial dash runs (CodeQL js/polynomial-redos)', () => {
-  const adversarial = `${'-'.repeat(50_000)}x${'-'.repeat(50_000)}`;
+test('edge-dash trimming stays linear on an interior dash run (CodeQL js/polynomial-redos)', () => {
+  // The slug pipeline collapses character runs before trimming, so only a
+  // direct call can carry a long interior run — which is exactly the shape
+  // the retired /^-+|-+$/g form re-scans quadratically (each interior dash
+  // restarts a -+$ attempt that fails at the trailing x). 100k dashes take
+  // seconds there and must stay well under a second here, with the input
+  // returned byte-identical since nothing sits at the edges.
+  const interiorRun = `x${'-'.repeat(100_000)}x`;
   const startedAt = performance.now();
-  const slugged = buildReplayTestInvocationId(adversarial);
+  const trimmed = trimEdgeDashes(interiorRun);
   assert.ok(performance.now() - startedAt < 1000);
-  assert.ok(slugged.startsWith('x'));
+  assert.equal(trimmed, interiorRun);
 });

--- a/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
+++ b/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
@@ -1,10 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { AppError } from '@agent-device/kernel/errors';
-import {
-  discoverReplayTestEntries,
-  buildReplayTestInvocationId,
-} from '../session-test-discovery.ts';
+import { discoverReplayTestEntries } from '../session-test-discovery.ts';
 import { trimEdgeDashes } from '../session-test-artifacts.ts';
 import type { ReplayTestManifest, ReplayTestSource } from '../session-test-types.ts';
 

--- a/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
+++ b/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
@@ -1,8 +1,12 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { AppError } from '@agent-device/kernel/errors';
-import { discoverReplayTestEntries } from '../session-test-discovery.ts';
-import { trimEdgeDashes } from '../session-test-artifacts.ts';
+import {
+  buildReplayTestInvocationId,
+  buildReplayTestSessionName,
+  discoverReplayTestEntries,
+} from '../session-test-discovery.ts';
+import { buildReplayTestArtifactSlug, trimEdgeDashes } from '../session-test-artifacts.ts';
 import type { ReplayTestManifest, ReplayTestSource } from '../session-test-types.ts';
 
 // Scheduler-owned discovery policy (#1478 P3b): which sources a --platform filter runs, which
@@ -89,4 +93,14 @@ test('edge-dash trimming stays linear on an interior dash run (CodeQL js/polynom
   const trimmed = trimEdgeDashes(interiorRun);
   assert.ok(performance.now() - startedAt < 1000);
   assert.equal(trimmed, interiorRun);
+});
+
+test('all-dash inputs land on the documented fallbacks instead of empty identifiers', () => {
+  assert.equal(buildReplayTestArtifactSlug('/tmp/####', '/tmp'), 'test');
+  assert.equal(buildReplayTestInvocationId('----'), 'suite');
+  // A session-name slug that trims to nothing is omitted entirely — no dangling separator.
+  assert.equal(
+    buildReplayTestSessionName('s', 'suite1', '/tmp/----.ad', 0),
+    's:test:suite1:1:attempt-1',
+  );
 });

--- a/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
+++ b/packages/replay-test/src/internal/__tests__/session-test-discovery.test.ts
@@ -1,7 +1,10 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { AppError } from '@agent-device/kernel/errors';
-import { discoverReplayTestEntries } from '../session-test-discovery.ts';
+import {
+  discoverReplayTestEntries,
+  buildReplayTestInvocationId,
+} from '../session-test-discovery.ts';
 import type { ReplayTestManifest, ReplayTestSource } from '../session-test-types.ts';
 
 // Scheduler-owned discovery policy (#1478 P3b): which sources a --platform filter runs, which
@@ -74,4 +77,12 @@ test('a suite that matched nothing after filtering is rejected', () => {
       }),
     (error: unknown) => error instanceof AppError && /No replay tests matched/.test(error.message),
   );
+});
+
+test('slug building stays linear on adversarial dash runs (CodeQL js/polynomial-redos)', () => {
+  const adversarial = `${'-'.repeat(50_000)}x${'-'.repeat(50_000)}`;
+  const startedAt = performance.now();
+  const slugged = buildReplayTestInvocationId(adversarial);
+  assert.ok(performance.now() - startedAt < 1000);
+  assert.ok(slugged.startsWith('x'));
 });

--- a/packages/replay-test/src/internal/session-test-artifacts.ts
+++ b/packages/replay-test/src/internal/session-test-artifacts.ts
@@ -23,11 +23,12 @@ export function buildReplayTestArtifactSlug(filePath: string, cwd?: string): str
       ? path.basename(filePath)
       : relativePath;
   return (
-    value
-      .toLowerCase()
-      .replace(/[\\/]+/g, '__')
-      .replace(/[^a-z0-9._-]+/g, '-')
-      .replace(/^-+|-+$/g, '') || 'test'
+    trimEdgeDashes(
+      value
+        .toLowerCase()
+        .replace(/[\\/]+/g, '__')
+        .replace(/[^a-z0-9._-]+/g, '-'),
+    ) || 'test'
   );
 }
 
@@ -134,4 +135,17 @@ function isExistingFile(filePath: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Linear-time edge trim. The regex form (`/^-+|-+$/g`) backtracks
+ * polynomially on long dash runs (CodeQL js/polynomial-redos #27/#28), and
+ * these slugs are built from caller-supplied file paths.
+ */
+export function trimEdgeDashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '-') start += 1;
+  while (end > start && value[end - 1] === '-') end -= 1;
+  return value.slice(start, end);
 }

--- a/packages/replay-test/src/internal/session-test-discovery.ts
+++ b/packages/replay-test/src/internal/session-test-discovery.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { trimEdgeDashes } from './session-test-artifacts.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { isApplePlatform, type PlatformSelector } from '@agent-device/kernel/device';
 import type {
@@ -89,20 +90,14 @@ export function buildReplayTestSessionName(
   attemptIndex = 0,
 ): string {
   const baseName = path.basename(filePath, path.extname(filePath));
-  const slug = baseName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const slug = trimEdgeDashes(baseName.toLowerCase().replace(/[^a-z0-9]+/g, '-'));
   const testNumber = caseIndex + 1;
   return `${sessionName}:test:${suiteInvocationId}:${testNumber}${slug ? `-${slug}` : ''}:attempt-${attemptIndex + 1}`;
 }
 
 export function buildReplayTestInvocationId(requestId?: string): string {
   const raw = requestId?.trim() || `${process.pid}-${Date.now().toString(36)}`;
-  const normalized = raw
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const normalized = trimEdgeDashes(raw.toLowerCase().replace(/[^a-z0-9]+/g, '-'));
   return normalized || 'suite';
 }
 

--- a/src/replay/target-identity.ts
+++ b/src/replay/target-identity.ts
@@ -13,7 +13,7 @@ import { AppError } from '@agent-device/kernel/errors';
 const TARGET_ANNOTATION_TAG = 'agent-device:target-v1';
 // Captures the rest of the line verbatim: a line claiming the tag with a
 // garbage payload is a malformed v1 annotation, never an ordinary comment.
-const TARGET_ANNOTATION_LINE_RE = /^#\s*agent-device:target-v(\d+)(?:\s+(.*))?$/;
+const TARGET_ANNOTATION_LINE_RE = /^#\s*agent-device:target-v(\d+)(?:\s+(\S.*))?$/;
 
 export const TARGET_ANNOTATION_MAX_FIELD_BYTES = 256;
 export const TARGET_ANNOTATION_MAX_PAYLOAD_BYTES = 4096;


### PR DESCRIPTION
You flagged that the CodeQL finding on #1536 exists elsewhere already — correct, and this clears the whole class on main in one small PR:

- **Alerts #27/#28** (`packages/replay-test` slug builders, from the merged #1525): `/^-+|-+$/g` edge-trim backtracks polynomially on long dash runs derived from caller-supplied file paths/request ids. Replaced with a shared linear `trimEdgeDashes` (no import cycle; discovery already sits above artifacts).
- **Main's copy of the annotation-line regex** (`src/replay/target-identity.ts:16`) — the identical `\s+(.*)` ambiguity that alert #29 flagged on #1536's moved copy. Same fix as there: anchor the payload on `\S` so the split point is unique. Behavior-preserving (the only caller matches trimmed lines); when #1536 rebases, its already-fixed package copy supersedes this file wholesale, so no conflict of substance.

Gates: typecheck, lint, format, `check:replay-compat` (frozen corpus unchanged), fallow zero at main scope; 45/45 in the touched suites plus a 100k-char adversarial slug test asserting sub-second completion.

Refs #1478