### PR TITLE
docs(agents): a green check is evidence only once you have seen it red

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ prose in this repo, including this file.
   succeed on a candidate the shared rules would refuse.
 - Do not measure before confirming the code path can fire. An A/B whose B-arm cannot execute returns
   two green runs masquerading as evidence.
+- A green check is evidence only once you have seen it red. Prove a new regression test against the
+  pre-fix code (revert, run, quote the failing number), a moved test against its gates (planted type
+  error, discovered-count delta), a structural gate against a planted violation. Three vacuous
+  regression tests shipped in one day before this rule; review caught all three.
 - Typed signals over message sniffing: key on structured details (`details.timeoutMs`, reason codes),
   never on error text. Remaining sniffs are owned debt with in-code rationale — do not copy them.
 - Snapshot output is the token budget. Never add per-node bytes to the tree; response-level metadata

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,10 @@ the new thing — never to suppress or allowlist it.
   `runCmdBackground`, `runCmdDetached`). Do not import raw `spawn`/`spawnSync` elsewhere — extend an
   exec helper instead. Plain `.mjs` packaging fixtures that cannot import TS helpers keep
   child-process usage local and prefer `execFile`/`execFileSync`.
+- Interactions use the daemon session flow: `open` before, `close` after.
 - `keyboard dismiss` is the iOS keyboard dismissal path. It may tap safe native controls such as
   `Done`, but must not fall back to system back navigation.
+- Do not remove shared snapshot/session model behavior without full migration.
 - Apple-family target changes keep `packages/kernel/src/device.ts`, `src/core/capabilities.ts`,
   `src/core/dispatch-resolve.ts`, `src/platforms/apple/core/devices.ts`, and
   `src/platforms/apple/core/runner/runner-xctestrun.ts` in sync.
@@ -154,6 +156,8 @@ one question so `rg` → read-whole-file stays one cheap bounded read.
   under `~/.agent-device/dev/<basename-slug>-<hash>`. Inspect with `pnpm daemon:state-dir`, override
   with `--state-dir`/`AGENT_DEVICE_STATE_DIR`, prune with `pnpm clean:daemon --prune-dev`. Daemons
   are isolated per worktree; **devices are not** — target different devices for concurrent worktrees.
+- Node ≥22. Prefer built-ins (`fetch`, Web Streams, `AbortSignal.timeout`) over compatibility
+  wrappers unless the surrounding code needs a lower-level transport.
 - Emit with `tsdown` (Rolldown), typecheck with TypeScript 7 via `tsc`. Declaration generation uses
   the TS7 native executable and is stricter than a plain typecheck: if it fails, inspect
   `tsconfig.lib.json` (it needs an explicit `rootDir: "./src"`) and `tsdown.config.ts` first, and run
@@ -161,9 +165,8 @@ one question so `rg` → read-whole-file stays one cheap bounded read.
 - Prefer the aggregate `package.json` scripts; they encode the expected validation bundles better
   than ad hoc command lists. `pnpm format` formats the whole repo (`oxfmt` with no path list), and
   the only exclusion list is `.oxfmtrc.json` `ignorePatterns` — Markdown, the Maestro conformance
-  corpus, and generated baselines. Run `pnpm format`, never `oxfmt <path>`: a path argument not only
-  hides drift elsewhere, it bypasses `ignorePatterns` — one path-scoped run re-quoted 44 conformance
-  corpus files that the config excludes.
+  corpus, and generated baselines. Run `pnpm format`, never `oxfmt <path>`: a path argument
+  reformats a subset and hides whatever else drifted.
 - Before pushing, default to **`pnpm check:affected --run`**. It selects the relevant local gates and
   reports native/device checks left to GitHub. Use **`pnpm check`**
   (`check:tooling && check:fallow && check:unit`) for broad refactors or an explicitly requested full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,10 +93,8 @@ the new thing — never to suppress or allowlist it.
   `runCmdBackground`, `runCmdDetached`). Do not import raw `spawn`/`spawnSync` elsewhere — extend an
   exec helper instead. Plain `.mjs` packaging fixtures that cannot import TS helpers keep
   child-process usage local and prefer `execFile`/`execFileSync`.
-- Interactions use the daemon session flow: `open` before, `close` after.
 - `keyboard dismiss` is the iOS keyboard dismissal path. It may tap safe native controls such as
   `Done`, but must not fall back to system back navigation.
-- Do not remove shared snapshot/session model behavior without full migration.
 - Apple-family target changes keep `packages/kernel/src/device.ts`, `src/core/capabilities.ts`,
   `src/core/dispatch-resolve.ts`, `src/platforms/apple/core/devices.ts`, and
   `src/platforms/apple/core/runner/runner-xctestrun.ts` in sync.
@@ -156,8 +154,6 @@ one question so `rg` → read-whole-file stays one cheap bounded read.
   under `~/.agent-device/dev/<basename-slug>-<hash>`. Inspect with `pnpm daemon:state-dir`, override
   with `--state-dir`/`AGENT_DEVICE_STATE_DIR`, prune with `pnpm clean:daemon --prune-dev`. Daemons
   are isolated per worktree; **devices are not** — target different devices for concurrent worktrees.
-- Node ≥22. Prefer built-ins (`fetch`, Web Streams, `AbortSignal.timeout`) over compatibility
-  wrappers unless the surrounding code needs a lower-level transport.
 - Emit with `tsdown` (Rolldown), typecheck with TypeScript 7 via `tsc`. Declaration generation uses
   the TS7 native executable and is stricter than a plain typecheck: if it fails, inspect
   `tsconfig.lib.json` (it needs an explicit `rootDir: "./src"`) and `tsdown.config.ts` first, and run
@@ -165,8 +161,9 @@ one question so `rg` → read-whole-file stays one cheap bounded read.
 - Prefer the aggregate `package.json` scripts; they encode the expected validation bundles better
   than ad hoc command lists. `pnpm format` formats the whole repo (`oxfmt` with no path list), and
   the only exclusion list is `.oxfmtrc.json` `ignorePatterns` — Markdown, the Maestro conformance
-  corpus, and generated baselines. Run `pnpm format`, never `oxfmt <path>`: a path argument
-  reformats a subset and hides whatever else drifted.
+  corpus, and generated baselines. Run `pnpm format`, never `oxfmt <path>`: a path argument not only
+  hides drift elsewhere, it bypasses `ignorePatterns` — one path-scoped run re-quoted 44 conformance
+  corpus files that the config excludes.
 - Before pushing, default to **`pnpm check:affected --run`**. It selects the relevant local gates and
   reports native/device checks left to GitHub. Use **`pnpm check`**
   (`check:tooling && check:fallow && check:unit`) for broad refactors or an explicitly requested full

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -55,6 +55,17 @@ it through the barrel.
 
 Keep tests behavioral. Do not assert shapes or cases TypeScript already proves.
 
+A test added as a regression pin must be shown to fail without the change it pins — vacuity is the
+default failure mode, not the exception, because the adversarial input you imagine is rarely the one
+the old code was slow or wrong on (edge runs that the old regex handled in one pass; invariants the
+old implementation already satisfied; entry points whose trimming defuses the exploit before it
+reaches the flagged pattern). The proof is mechanical: revert the production change locally, watch
+the test fail, note the failing number, restore. Same rule at other layers: after relocating tests,
+prove the runner discovers them (file/test counts must move) and the typechecker reaches them (plant
+a type error, watch it surface, remove it); after adding an ownership/structural gate, plant a
+violation and watch it name the invariant. Quote the red run in the PR — a reviewer who cannot see
+the red has to re-derive it.
+
 Test through public interfaces where practical, and do not add unrelated production exports solely
 to make a test easier — widening the public surface for a test is a product change, and the exports
 outlive the test that motivated them. If a seam is genuinely missing, add it as a real one rather


### PR DESCRIPTION
Distills this week's review pattern into the guidance docs. Three regression tests shipped vacuous in one day — each passed against the code it claimed to pin (#1541's invariant tests, #1546's edge-run ReDoS case, #1536's trim-defused adversarial input) — and each was caught by the reviewer counterfactual-testing the test, then fixed by the mechanical proof: revert the production change, watch the test fail, quote the number (3,751ms / 3,201ms), restore.

- **AGENTS.md**: one bullet beside its sibling lesson (the A/B whose B-arm cannot fire), stating the rule and the three proof shapes.
- **docs/agents/testing.md**: the detail next to "Keep tests behavioral" — why vacuity is the default failure mode (the imagined adversarial input is rarely the one the old code was wrong on), the mechanical proof, the same rule applied to relocated tests (discovery counts, planted type error) and structural gates (planted violation), and the requirement to quote the red run in the PR.

Docs-only.