### PR TITLE
test(replay-test): cover failFast, retry exhaustion, plan-prep failure, JUnit escaping

### DIFF
--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -102,6 +102,88 @@ test('test does not retry infrastructure startup failures and stops the suite', 
   expect(tests[0]?.attempts).toBe(1);
 });
 
+test('test --fail-fast stops the suite after the first failure and leaves the rest notRun', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-fail-fast-'));
+  const firstPath = path.join(root, '01-first.ad');
+  const secondPath = path.join(root, '02-second.ad');
+  const thirdPath = path.join(root, '03-third.ad');
+  fs.writeFileSync(firstPath, 'context platform=ios\nopen "Demo"\n');
+  fs.writeFileSync(secondPath, 'context platform=ios\nopen "Demo"\n');
+  fs.writeFileSync(thirdPath, 'context platform=ios\nopen "Demo"\n');
+
+  const invoked: DaemonRequest[] = [];
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'test',
+      // Explicit files (not a directory) so discovery preserves input order — directory scans
+      // use native DFS order, which is not guaranteed to be lexicographic.
+      positionals: [firstPath, secondPath, thirdPath],
+      meta: { cwd: root, requestId: 'suite-fail-fast' },
+      flags: { failFast: true },
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req);
+      return {
+        ok: false,
+        error: { code: 'COMMAND_FAILED', message: 'assertion failed' },
+      };
+    },
+  });
+
+  const data = expectOkData(response);
+  expect(invoked.length).toBe(1);
+  expect(data.total).toBe(3);
+  expect(data.executed).toBe(1);
+  expect(data.failed).toBe(1);
+  expect(data.notRun).toBe(2);
+  const tests = data.tests as Array<Record<string, unknown>>;
+  expect(tests).toHaveLength(1);
+  expect(tests[0]?.file).toBe(firstPath);
+});
+
+test('test surfaces a suite-level failure when a source fails to parse', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-bad-source-'));
+  // Malformed env directive (missing "="): readReplayScriptMetadata throws during source
+  // discovery, before any entry is runnable. The suite-level try/catch in session-test.ts must
+  // convert that throw into a failed outcome rather than letting it escape the handler.
+  fs.writeFileSync(
+    path.join(root, '01-malformed.ad'),
+    'env BROKEN\ncontext platform=ios\nopen "Demo"\n',
+  );
+
+  const invoked: DaemonRequest[] = [];
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'test',
+      positionals: [root],
+      meta: { cwd: root, requestId: 'suite-bad-source' },
+      flags: {},
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req);
+      return { ok: true, data: { replayed: 1, healed: 0 } };
+    },
+  });
+
+  expect(invoked.length).toBe(0);
+  expect(response?.ok).toBe(false);
+  if (response?.ok !== false) throw new Error('Expected failed daemon response.');
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toMatch(/Invalid env directive on line 1/);
+});
+
 test('test discovers Maestro YAML suites when replay backend is set', async () => {
   const sessionStore = makeSessionStore();
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-maestro-'));
@@ -242,6 +324,43 @@ test('test emits progress when attempts retry and pass', async () => {
     attempt: 2,
     maxAttempts: 2,
   });
+});
+
+test('test stops retrying after maxAttempts when every attempt fails', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-retry-exhaust-'));
+  fs.writeFileSync(path.join(root, '01-always-fails.ad'), 'context platform=ios\nopen "Demo"\n');
+
+  let attemptCount = 0;
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'test',
+      positionals: [root],
+      meta: { cwd: root, requestId: 'suite-retry-exhaust' },
+      flags: { retries: 2 },
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async () => {
+      attemptCount += 1;
+      return {
+        ok: false,
+        error: { code: 'COMMAND_FAILED', message: `attempt ${attemptCount} failed` },
+      };
+    },
+  });
+
+  const data = expectOkData(response);
+  // maxAttempts = retries + 1 = 3. The loop bound is attemptIndex <= retries, so a fix-off-by-one
+  // in that bound would run either 2 or 4 attempts instead of exactly 3.
+  expect(attemptCount).toBe(3);
+  expect(data.failed).toBe(1);
+  const tests = data.tests as Array<Record<string, unknown>>;
+  expect(tests[0]?.attempts).toBe(3);
+  expect(tests[0]?.status).toBe('failed');
 });
 
 test('test emits skip progress without synthetic duration', async () => {

--- a/src/replay/test/reporters/__tests__/junit.test.ts
+++ b/src/replay/test/reporters/__tests__/junit.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import type { ReplaySuiteResult } from '@agent-device/contracts/replay';
+import { parseXmlDocumentSync, type XmlNode } from '@agent-device/xml';
+import { createJunitReplayTestReporter } from '../junit.ts';
+import type { ReplayTestReporterContext } from '../types.ts';
+
+const context: ReplayTestReporterContext = {
+  stdout: { isTTY: false, write() {} },
+  stderr: { isTTY: false, write() {} },
+};
+
+// Characters that are individually significant to an XML parser: `<` opens a tag, `&` starts an
+// entity reference, `"` closes an attribute value, and a raw newline inside an attribute must
+// survive as a literal character rather than breaking the attribute boundary.
+const TRICKY_TITLE = 'Sign in <required> & "quoted"\nsecond line';
+const TRICKY_MESSAGE = 'Expected <button id="ok"> & none found\nsecond line';
+
+function writeSuiteAndParse(suite: ReplaySuiteResult): XmlNode[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-junit-reporter-'));
+  const reportPath = path.join(dir, 'report.xml');
+  const reporter = createJunitReplayTestReporter(reportPath);
+  reporter.onSuiteEnd?.(suite, context);
+  const xml = fs.readFileSync(reportPath, 'utf8');
+  return parseXmlDocumentSync(xml);
+}
+
+function findChild(node: XmlNode, name: string): XmlNode | undefined {
+  return node.children.find((child) => child.name === name);
+}
+
+test('buildReplayJunitXml escapes tricky failure title/message and round-trips through the XML parser', () => {
+  const suite: ReplaySuiteResult = {
+    total: 1,
+    executed: 1,
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    notRun: 0,
+    durationMs: 1500,
+    failures: [],
+    tests: [
+      {
+        file: '/tmp/flows/login.ad',
+        title: TRICKY_TITLE,
+        session: 'default',
+        status: 'failed',
+        durationMs: 1500,
+        attempts: 1,
+        error: { code: 'COMMAND_FAILED', message: TRICKY_MESSAGE },
+      },
+    ],
+  };
+  suite.failures = suite.tests.filter((result) => result.status === 'failed');
+
+  // Well-formed XML: a broken escape would make this throw instead of returning nodes.
+  const nodes = writeSuiteAndParse(suite);
+
+  const testsuites = nodes[0];
+  assert.ok(testsuites);
+  assert.equal(testsuites.name, 'testsuites');
+  const testsuite = findChild(testsuites, 'testsuite');
+  assert.ok(testsuite);
+  const testcase = findChild(testsuite, 'testcase');
+  assert.ok(testcase);
+
+  // Attribute round-trip: the raw title survives escaping into an attribute value and decoding
+  // back out, newline included.
+  assert.equal(testcase.attributes.name, TRICKY_TITLE);
+  assert.equal(testcase.attributes.file, '/tmp/flows/login.ad');
+
+  const failure = findChild(testcase, 'failure');
+  assert.ok(failure);
+  assert.equal(failure.attributes.message, TRICKY_MESSAGE);
+  // The failure body opens with the raw error message (buildFailureDetails' first line).
+  assert.ok(failure.text?.startsWith(TRICKY_MESSAGE));
+});
+
+test('buildReplayJunitXml escapes tricky skip message', () => {
+  const suite: ReplaySuiteResult = {
+    total: 1,
+    executed: 0,
+    passed: 0,
+    failed: 0,
+    skipped: 1,
+    notRun: 0,
+    durationMs: 0,
+    failures: [],
+    tests: [
+      {
+        file: '/tmp/flows/skipped.ad',
+        status: 'skipped',
+        durationMs: 0,
+        reason: 'skipped-by-filter',
+        message: TRICKY_TITLE,
+      },
+    ],
+  };
+
+  const nodes = writeSuiteAndParse(suite);
+  const testcase = findChild(findChild(nodes[0]!, 'testsuite')!, 'testcase');
+  assert.ok(testcase);
+  const skipped = findChild(testcase, 'skipped');
+  assert.ok(skipped);
+  assert.equal(skipped.attributes.message, TRICKY_TITLE);
+});


### PR DESCRIPTION
## Summary

Closes four untested failure paths in the replay test harness, flagged by the 2026-08-01 test-strength audit of `packages/replay-test`:

1. **`failFast`** — no test anywhere set `request.failFast=true`. Added a test with 3 explicit entries where the first fails: asserts the suite invokes only the first entry, and `notRun` accounts for the other two (`shouldStopReplayTestExecution` in `packages/replay-test/src/internal/session-test.ts`).
2. **Retry exhaustion** — every existing retry test ends in a pass. Added a case with `retries: 2` where every attempt fails: asserts `attempts === 3` exactly, guarding the `attemptIndex <= params.retries` loop bound in `packages/replay-test/src/internal/session-test-attempt.ts`.
3. **Suite-level plan-prep failure** — fed an unparseable `.ad` source (`env BROKEN` — missing `=`) through discovery so `readReplayScriptMetadata` throws before any entry is runnable. Asserts the suite-level try/catch (`packages/replay-test/src/internal/session-test.ts` ~L73-132) converts the thrown `AppError` into `{ok: false, error: {code: 'INVALID_ARGS', ...}}` instead of letting it escape.
4. **JUnit XML escaping** — `src/replay/test/reporters/junit.ts` had no direct test, only reporter-spec parsing. Added `src/replay/test/reporters/__tests__/junit.test.ts`: writes a suite with a failing case whose title/message contain `<`, `&`, `"`, and a newline, then parses the written file back with `@agent-device/xml`'s `parseXmlDocumentSync` and asserts the values round-trip.

All four tests were verified red per `docs/agents/testing.md`'s counterfactual rule — the production condition was temporarily broken, the test observed failing, then restored:

- **failFast**: disabled the `failFast` branch in `shouldStopReplayTestExecution` → `invoked.length` went from expected `1` to actual `3` (`notRun` from `2` to `0`).
- **retry exhaustion**: changed the loop bound from `attemptIndex <= params.retries` to `attemptIndex < params.retries` → `attemptCount` went from expected `3` to actual `2`.
- **plan-prep failure**: moved `prepareReplayTestSuitePlan` outside the try/catch → the `AppError` escaped uncaught instead of the daemon returning `{ok: false}`.
- **JUnit escaping**: dropped `escapeXmlTextAndAttribute` on the testcase `name` attribute → `parseXmlDocumentSync` threw `Missing value for XML attribute "quoted".` on the tricky title.

## Design question for @thymikee

While writing the retry-exhaustion test I hit a contract asymmetry in `packages/contracts/src/replay.ts`: `ReplaySuiteTestPassed` carries `attemptFailures` (so a flaky-then-passed test reports its earlier failed attempts), but `ReplaySuiteTestFailed` does not. So when every attempt fails, only the *last* attempt's error survives in the result — the earlier attempts' failure messages are silently dropped. I did not change this (out of scope, and it's an API-widening decision), but flagging it: should `ReplaySuiteTestFailed` also carry `attemptFailures` for the attempts prior to the final one?

## Test plan

- [x] `npx vitest run packages/replay-test src/daemon/handlers/__tests__/session-test-suite.test.ts src/replay/test` — 75 tests passed
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] All four new tests independently verified red before the fix/restore (see above)