### PR TITLE
refactor: tidy three post-extraction seams

### DIFF
--- a/packages/ad-script/src/index.ts
+++ b/packages/ad-script/src/index.ts
@@ -12,7 +12,9 @@
  * canonical field order, normalization, size caps, payload parsing). The
  * companion classification core (`classifyTargetBindingMatch`, local-identity
  * + ancestry-prefix matching) is NOT part of this codec — it stays in
- * `src/replay/target-identity.ts`, which imports the types below.
+ * `src/replay/target-identity.ts`. The annotation SHAPE is not exported here
+ * either: it lives in `@agent-device/contracts/replay`, which every consumer
+ * (this package included) imports directly.
  */
 
 export {
@@ -48,10 +50,4 @@ export {
   TARGET_ANNOTATION_MAX_ANCESTRY,
   TARGET_ANNOTATION_MAX_FIELD_BYTES,
   TARGET_ANNOTATION_MAX_PAYLOAD_BYTES,
-} from './internal/target-annotation-serde.ts';
-export type {
-  TargetAncestryEntry,
-  TargetAnnotationV1,
-  TargetScrollRegion,
-  TargetVerification,
 } from './internal/target-annotation-serde.ts';

--- a/packages/ad-script/src/internal/__tests__/script.test.ts
+++ b/packages/ad-script/src/internal/__tests__/script.test.ts
@@ -7,7 +7,7 @@ import {
   REPLAY_METADATA_PLATFORMS,
 } from '../script.ts';
 import { formatPortableActionLine, formatTargetAnnotationLines } from '../script-formatting.ts';
-import type { TargetAnnotationV1 } from '../target-annotation-serde.ts';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { SessionAction } from '@agent-device/contracts/session';
 
 // `writeReplayScript` (the `--update` heal-and-rewrite serializer) was

--- a/packages/ad-script/src/internal/__tests__/target-annotation-serde.test.ts
+++ b/packages/ad-script/src/internal/__tests__/target-annotation-serde.test.ts
@@ -11,9 +11,9 @@ import {
   TARGET_ANNOTATION_MAX_ANCESTRY,
   TARGET_ANNOTATION_MAX_FIELD_BYTES,
   TARGET_ANNOTATION_MAX_PAYLOAD_BYTES,
-  type TargetAnnotationV1,
   TARGET_ANNOTATION_LINE_RE,
 } from '../target-annotation-serde.ts';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 
 function baseEvidence(overrides: Partial<TargetAnnotationV1> = {}): TargetAnnotationV1 {
   return {

--- a/packages/ad-script/src/internal/target-annotation-serde.ts
+++ b/packages/ad-script/src/internal/target-annotation-serde.ts
@@ -8,8 +8,9 @@
  *
  * The record/replay-shared CLASSIFICATION core (`classifyTargetBindingMatch`,
  * local-identity + ancestry-prefix matching) is not part of this codec — it
- * stays in `src/replay/target-identity.ts`, which imports the types below
- * from this package (#1478 P5 scoping dossier, "the codec seam").
+ * stays in `src/replay/target-identity.ts`, which imports the shared shape
+ * types from `@agent-device/contracts/replay` (#1478 P5 scoping dossier,
+ * "the codec seam").
  */
 
 import { AppError } from '@agent-device/kernel/errors';
@@ -36,14 +37,7 @@ export const TARGET_ANNOTATION_MAX_PAYLOAD_BYTES = 4096;
 export const TARGET_ANNOTATION_MAX_ANCESTRY = 8;
 
 // The annotation SHAPE lives in contracts/ so the recorded-action type can be stated without
-// depending on this zone; re-exported here for existing consumers.
-export type {
-  TargetAncestryEntry,
-  TargetAnnotationV1,
-  TargetRect,
-  TargetScrollRegion,
-  TargetVerification,
-} from '@agent-device/contracts/replay';
+// depending on this zone; every consumer imports it from there directly.
 import type {
   TargetAncestryEntry,
   TargetAnnotationV1,

--- a/src/commands/interaction/runtime/selector-wait.ts
+++ b/src/commands/interaction/runtime/selector-wait.ts
@@ -11,7 +11,7 @@ import {
   filterIdentitySet,
 } from '../../../replay/target-evidence-tree.ts';
 import { annotationLocalIdentity } from '../../../replay/target-identity.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { PublicPlatform } from '@agent-device/kernel/device';
 import { checkWaitText } from '../../../selectors/arguments.ts';
 import { listSelectorChainMatches } from '../../../selectors/index.ts';

--- a/src/daemon/__tests__/session-script-active-publication.test.ts
+++ b/src/daemon/__tests__/session-script-active-publication.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { SessionAction } from '../types.ts';
 import {
   assertActivePublicationPortability,

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -7,7 +7,8 @@ import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 import { buildRequestFinishedEvent } from '../session-event-log.ts';
 import { HEAL_COMPLETE_SENTINEL } from '../session-script-writer.ts';
-import { parseReplayScriptDetailed, type TargetAnnotationV1 } from '@agent-device/ad-script';
+import { parseReplayScriptDetailed } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { repairPublication } from '../../__tests__/test-utils/session-factories.ts';
 
 type RecordActionEntry = Parameters<SessionStore['recordAction']>[1];

--- a/src/daemon/handlers/__tests__/session-replay-repair-hint.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair-hint.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapshot';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import {
   computeReplayRepairHint,
   type ReplayRepairHintCapture,

--- a/src/daemon/handlers/__tests__/session-replay-repair.fixtures.ts
+++ b/src/daemon/handlers/__tests__/session-replay-repair.fixtures.ts
@@ -10,7 +10,7 @@ import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../../types.
 import { SessionStore } from '../../session-store.ts';
 import { isInteractiveObservation } from '../../session-action-recorder.ts';
 import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 
 export function freshEvidence(id: string, label: string): TargetAnnotationV1 {
   return {

--- a/src/daemon/handlers/__tests__/session-replay-target-classification-fixtures.ts
+++ b/src/daemon/handlers/__tests__/session-replay-target-classification-fixtures.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapshot';
 import { computeTargetEvidence } from '../../session-target-evidence.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 
 export function toSnapshotNodes(raw: RawSnapshotNode[]): SnapshotNode[] {
   return raw.map((node, position) => ({ ...node, ref: `e${position + 1}` }));

--- a/src/daemon/handlers/__tests__/session-replay-target-classification.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-target-classification.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapshot';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { computeTargetEvidence } from '../../session-target-evidence.ts';
 import { buildSelectorChainForNode } from '../../../selectors/build.ts';
 import { parseSelectorChain, resolveSelectorChain } from '../../../selectors/index.ts';

--- a/src/daemon/handlers/__tests__/session-replay-target-guard.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-target-guard.test.ts
@@ -6,7 +6,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import {
   readNodeLocalIdentity,
   readNodeStructuralDenotation,

--- a/src/daemon/handlers/__tests__/session-script-publication.test.ts
+++ b/src/daemon/handlers/__tests__/session-script-publication.test.ts
@@ -8,7 +8,7 @@ import {
   authoringPublication,
   repairPublication,
 } from '../../../__tests__/test-utils/session-factories.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, SessionState } from '../../types.ts';
 import { handleSessionScriptPublication } from '../session-script-publication.ts';

--- a/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
+++ b/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
@@ -15,7 +15,7 @@ import { test, expect, vi, beforeEach } from 'vitest';
 import { dispatchWaitViaRuntime } from '../../selector-runtime.ts';
 import type { DaemonRequest } from '../../types.ts';
 import { WAIT_LANDMARK_MISMATCH_REASON } from '../../../replay/target-identity-node.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import { makeAndroidSession } from '../../../__tests__/test-utils/session-factories.ts';
 

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -32,6 +32,7 @@ import {
   isRepairArmedSession,
   recordRepairPlatformClose,
 } from '../session-replay-transaction.ts';
+import { isAuthoringArmedSession } from '../session-script-publication-capability.ts';
 import {
   reportSessionCleanupFailures,
   restoreSessionAndroidIme,
@@ -286,8 +287,9 @@ async function stopOrRetainAppleRunnerAfterClose(
 
 function assertTerminalRecordingCloseAllowed(req: DaemonRequest, session: SessionState): void {
   if (!req.flags?.saveScript) return;
+  if (isAuthoringArmedSession(session)) return;
   const state = session.scriptPublication;
-  if (state?.kind !== 'authoring' || state.status === 'armed') return;
+  if (state?.kind !== 'authoring') return;
   throw new AppError(
     'INVALID_ARGS',
     `close --save-script cannot ${state.status === 'published' ? 're-publish' : 'publish'} this terminal recording. Retry with plain close; it will tear down the session without writing.`,

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -3,6 +3,7 @@ import { dispatchCommand, resolveTargetDevice } from '../../core/dispatch.ts';
 import {
   abortAuthoringOnSecondOpen,
   armAuthoringOnOpen,
+  isAuthoringArmedSession,
 } from '../session-script-publication-capability.ts';
 import type { SessionSurface } from '@agent-device/contracts/session';
 import { contextFromFlags } from '../context.ts';
@@ -103,8 +104,7 @@ function applyOrdinaryScriptRecordingOpenOutcome(params: {
     armAuthoringOnOpen(session, {});
     return;
   }
-  const existingState = existingSession?.scriptPublication;
-  if (existingState?.kind !== 'authoring' || existingState.status !== 'armed') return;
+  if (!isAuthoringArmedSession(existingSession)) return;
   abortAuthoringOnSecondOpen(session);
   const warnings = Array.isArray(responseData.warnings)
     ? responseData.warnings.filter((warning): warning is string => typeof warning === 'string')

--- a/src/daemon/handlers/session-replay-repair-hint.ts
+++ b/src/daemon/handlers/session-replay-repair-hint.ts
@@ -24,7 +24,7 @@
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import type { ReplayDivergenceKind, ReplayRepairHint } from '@agent-device/contracts/divergence';
 import { matchesAncestryPrefix } from '../../replay/target-identity.ts';
-import type { TargetAnnotationV1, TargetScrollRegion } from '@agent-device/ad-script';
+import type { TargetAnnotationV1, TargetScrollRegion } from '@agent-device/contracts/replay';
 import { buildAncestryChain, buildIndexMap } from '../../replay/target-evidence-tree.ts';
 import { computeScrollRegionKey, scrollRegionKeysEqual } from '../session-target-evidence.ts';
 

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -12,7 +12,6 @@ import { SessionStore } from '../session-store.ts';
 import { expandSessionPath } from '../session-paths.ts';
 import { buildReplayScriptPlatformFlags } from '../replay-device-selection.ts';
 import { computeReplayPlanDigest } from '../../replay/plan-digest.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
 import { errorResponse, noActiveSessionError } from './response.ts';
 import { invokeReplayAction } from './session-replay-action-runtime.ts';
 import { tryParseSelectorChain } from '../../selectors/index.ts';
@@ -29,7 +28,7 @@ import {
   summarizeSnapshotTimingSamples,
   type SnapshotTimingSample,
 } from '@agent-device/contracts/capture';
-import type { ReplayCommandResult } from '@agent-device/contracts/replay';
+import type { ReplayCommandResult, TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import {
   isMaestroYamlPath,
   maestroBackendRequiredMessage,

--- a/src/daemon/handlers/session-replay-target-classification.ts
+++ b/src/daemon/handlers/session-replay-target-classification.ts
@@ -57,7 +57,7 @@ import {
   classifyTargetBindingMatch,
   type LocalIdentity,
 } from '../../replay/target-identity.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { ReplayDivergenceTargetBindingKind } from '@agent-device/contracts/divergence';
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/handlers/session-replay-target-verification.ts
+++ b/src/daemon/handlers/session-replay-target-verification.ts
@@ -2,7 +2,8 @@ import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import type { DaemonError } from '@agent-device/kernel/errors';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { displayLabel, formatRole } from '../../snapshot/snapshot-lines.ts';
-import { formatDivergenceActionLabel, type TargetAnnotationV1 } from '@agent-device/ad-script';
+import { formatDivergenceActionLabel } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import {
   collectReplayScrubbableVarValues,
   resolveReplayAction,

--- a/src/daemon/handlers/session-script-publication.ts
+++ b/src/daemon/handlers/session-script-publication.ts
@@ -3,6 +3,7 @@ import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import { successText } from '../../utils/success-text.ts';
 import {
   effectiveWriteForce,
+  isAuthoringArmedSession,
   markActivePublicationDone,
   retargetActivePublication,
 } from '../session-script-publication-capability.ts';
@@ -72,9 +73,8 @@ type PublicationIneligibility = 'repair' | 'aborted' | 'published' | 'not-armed'
 function publicationIneligibility(session: SessionState): PublicationIneligibility | undefined {
   if (isRepairArmedSession(session)) return 'repair';
   const state = session.scriptPublication;
-  if (state?.kind !== 'authoring') return 'not-armed';
-  if (state.status === 'armed') return session.recordSession ? undefined : 'not-armed';
-  return state.status;
+  if (state?.kind === 'authoring' && state.status !== 'armed') return state.status;
+  return isAuthoringArmedSession(session) && session.recordSession ? undefined : 'not-armed';
 }
 
 const PUBLICATION_INELIGIBILITY_ERRORS: Record<PublicationIneligibility, () => AppError> = {

--- a/src/daemon/parameterized-recorded-fill.ts
+++ b/src/daemon/parameterized-recorded-fill.ts
@@ -1,4 +1,4 @@
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { tryParseSelectorChain } from '../selectors/parse.ts';
 
 const VALUE_BEARING_SELECTOR_KEYS = new Set(['text', 'label', 'value']);

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -33,7 +33,7 @@ import {
   toDaemonWaitData,
 } from './selector-recording.ts';
 import type { RecordedTargetCapture } from './session-target-evidence.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { maybeWaitTimeoutSurfaceResponse } from './wait-current-surface.ts';
 import { withSystemSurfaceDisclosure } from './handlers/system-surface-disclosure.ts';
 import {

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -4,7 +4,7 @@ import { emitDiagnostic } from '../utils/diagnostics.ts';
 import type { DaemonRequest, SessionAction, SessionRuntimeHints, SessionState } from './types.ts';
 import { applyRecordedSaveScriptFlags } from './session-script-publication-capability.ts';
 import { repairSessionBoundary } from './session-replay-transaction.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import { inferFillText } from './action-utils.ts';
 import {
   recordedInputPlaceholder,

--- a/src/daemon/session-script-publication-capability.ts
+++ b/src/daemon/session-script-publication-capability.ts
@@ -20,8 +20,19 @@ import { expandSessionPath } from './session-paths.ts';
  * construction of the aggregate. Engines can reach neither.
  */
 
-function publicationState(session: SessionState) {
-  return session.scriptPublication ?? NO_SCRIPT_PUBLICATION;
+function publicationState(session: SessionState | undefined) {
+  return session?.scriptPublication ?? NO_SCRIPT_PUBLICATION;
+}
+
+/**
+ * An ordinary authoring session still open to recording: the ADR 0016 lifecycle before it aborts
+ * or publishes. The authoring counterpart of `isRepairArmedSession`, and the one shape the
+ * handlers ask about — a second `open` aborts it, `close --save-script` may still publish it, and
+ * active publication is eligible only from it.
+ */
+export function isAuthoringArmedSession(session: SessionState | undefined): boolean {
+  const state = publicationState(session);
+  return state.kind === 'authoring' && state.status === 'armed';
 }
 
 /** ADR 0016: `open <app> --save-script[=<path>]` on a fresh session arms ordinary authoring. */

--- a/src/daemon/session-target-evidence.ts
+++ b/src/daemon/session-target-evidence.ts
@@ -37,11 +37,13 @@ import {
   utf8ByteLength,
   TARGET_ANNOTATION_MAX_ANCESTRY,
   TARGET_ANNOTATION_MAX_PAYLOAD_BYTES,
-  type TargetAncestryEntry,
-  type TargetAnnotationV1,
-  type TargetScrollRegion,
-  type TargetVerification,
 } from '@agent-device/ad-script';
+import type {
+  TargetAncestryEntry,
+  TargetAnnotationV1,
+  TargetScrollRegion,
+  TargetVerification,
+} from '@agent-device/contracts/replay';
 
 /** ADR 0012 decision 3: the resolved winner and the tree it was resolved from. */
 export type RecordedTargetCapture = {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -32,7 +32,7 @@ import type {
   AppleXctracePerfMode,
 } from '../platforms/apple/core/perf-xctrace.ts';
 import type { ReplayTargetGuardDenotation } from '../replay/target-identity-node.ts';
-import type { TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { AppLogFailure, AppLogState } from './app-log-process.ts';
 import type { RefFrameScope, RefFrameState } from './ref-frame.ts';
 export type DaemonInstallSource = PublicDaemonInstallSource;

--- a/src/replay/recorded-input.ts
+++ b/src/replay/recorded-input.ts
@@ -1,5 +1,5 @@
 import { AppError } from '@agent-device/kernel/errors';
-import { REPLAY_VAR_KEY_RE } from './vars.ts';
+import { REPLAY_VAR_KEY_RE } from '@agent-device/ad-script';
 
 const RECORDED_INPUT_PLACEHOLDER_RE = /^\$\{([A-Z_][A-Z0-9_]*)\}$/;
 

--- a/src/replay/target-evidence-tree.ts
+++ b/src/replay/target-evidence-tree.ts
@@ -16,7 +16,7 @@ import {
   matchesLocalIdentity,
   type LocalIdentity,
 } from './target-identity.ts';
-import type { TargetAncestryEntry } from '@agent-device/ad-script';
+import type { TargetAncestryEntry } from '@agent-device/contracts/replay';
 
 export function buildIndexMap(nodes: readonly SnapshotNode[]): Map<number, SnapshotNode> {
   const map = new Map<number, SnapshotNode>();

--- a/src/replay/target-identity.ts
+++ b/src/replay/target-identity.ts
@@ -11,7 +11,7 @@
  * this module imports the shared types from there rather than declaring them.
  */
 
-import type { TargetAncestryEntry, TargetAnnotationV1 } from '@agent-device/ad-script';
+import type { TargetAncestryEntry, TargetAnnotationV1 } from '@agent-device/contracts/replay';
 
 // ---------------------------------------------------------------------------
 // Local identity + ancestry-prefix matching (decision 3 "Local identity" /

--- a/src/replay/vars.ts
+++ b/src/replay/vars.ts
@@ -1,8 +1,7 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { SessionAction } from '@agent-device/contracts/session';
 // The env/var key shape is `.ad` script grammar (env directive parsing lives
-// in the codec package); re-exported here rather than duplicated (#1478 P5).
-export { REPLAY_VAR_KEY_RE } from '@agent-device/ad-script';
+// in the codec package).
 import { REPLAY_VAR_KEY_RE } from '@agent-device/ad-script';
 
 export type ReplayVarScope = {


### PR DESCRIPTION
Three small mechanical cleanups from a 2026-08-01 audit of the #1478 extraction seams. Behavior-preserving throughout: two are pure import re-pointing, the third names an existing predicate.

### 1. `REPLAY_VAR_KEY_RE` shim (`5f1be5c0e`)

`src/replay/vars.ts` re-exported the constant from `@agent-device/ad-script` for exactly one consumer, `src/replay/recorded-input.ts`. That consumer now imports from the package directly and the re-export line is gone (`vars.ts` keeps its own import; it uses the constant internally). This also makes `packages/ad-script/src/internal/script.ts`'s doc comment true — it already claimed `recorded-input.ts` imports from the package.

### 2. Target-annotation shape imports (`4e3e75c4b`)

The annotation shape types live in `@agent-device/contracts/replay`; `target-annotation-serde.ts` re-exported them and the façade re-exported that, so 21 files reached the shape through the detour. Every consumer now imports from contracts directly — the 10 type-only production files from the audit, the two mixed value+type files (type half split out), root tests, and the package's own tests — and both re-exports are dropped.

Type-only, so nothing changes at runtime. The package.json `exports` map is untouched, so the R11 assertion in `scripts/layering/package-boundaries.test.ts` (which pins the subpath list, not the named-export list) still holds as written; `pnpm check:layering` confirms.

### 3. `isAuthoringArmedSession` (`42b3cefd3`)

`kind === 'authoring' && status === 'armed'` was spelled out at three handler sites asking the same question (`session-close.ts`, `session-open.ts`, `session-script-publication.ts`). It now has a name in `session-script-publication-capability.ts` next to `isSessionScriptPublished`, mirroring how `isRepairArmedSession` is housed in the repair projection, and the three sites route through it.

`abortAuthoring`'s own guard keeps its inline check — that one is the transition's legality test, not a session-level read. The helper is read-only, so `scripts/layering/session-state.ts`'s writer-ownership registry is unaffected (R7 still reports 22 writer-owned fields / 28 owner claims).

## Verification

```
pnpm typecheck && pnpm lint && pnpm format:check && pnpm check:layering
npx vitest run scripts/layering src/daemon packages/ad-script src/replay
```

All green — 215 files / 1883 tests passed; layering guard OK.