### PR TITLE
test: make pid-liveness fixtures deterministic under load

### DIFF
--- a/src/__tests__/cli-device-status.test.ts
+++ b/src/__tests__/cli-device-status.test.ts
@@ -2,9 +2,37 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 import { readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
 import { runCliCapture } from './cli-capture.ts';
+
+// readProcessStartTime shells out to `ps` with a 1s timeout (see
+// utils/host-process.ts). This file's fixtures read our own start time once
+// to build a "live" claim, then production re-reads it during classification
+// to confirm identity; under full-suite CPU contention that second `ps` call
+// can miss its deadline and return null, mismatching the cached value and
+// flipping a genuinely-live claim to 'owner-process-dead'. Cache our own
+// pid's start time after the first (real) read so every later read is
+// self-consistent with the fixtures instead of racing a fresh `ps` call.
+// isProcessAlive is left real (a plain `kill(pid, 0)` syscall, not a
+// subprocess), so the fabricated-dead-pid fixtures below still classify as
+// stale through that real, non-flaky check.
+vi.mock('../utils/host-process.ts', async () => {
+  const actual = await vi.importActual<typeof import('../utils/host-process.ts')>(
+    '../utils/host-process.ts',
+  );
+  let cachedOwnStartTime: string | null | undefined;
+  return {
+    ...actual,
+    readProcessStartTime: (pid: number) => {
+      if (pid !== process.pid) return null;
+      if (cachedOwnStartTime === undefined) {
+        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
+      }
+      return cachedOwnStartTime;
+    },
+  };
+});
 
 test('device status is daemonless and does not send a daemon request', async () => {
   const result = await runCliCapture(['device', 'status', '--json']);

--- a/src/platforms/apple/core/__tests__/runner-session.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-session.test.ts
@@ -24,6 +24,7 @@ const {
   mockIsProcessAlive,
   mockIsProcessGroupAlive,
   mockPrepareXctestrunWithEnv,
+  mockReadProcessStartTime,
   mockResolveExpectedRunnerCacheMetadata,
   mockResolveRunnerDerivedPath,
   mockRunAppleToolCommand,
@@ -40,6 +41,12 @@ const {
   mockIsProcessAlive: vi.fn(),
   mockIsProcessGroupAlive: vi.fn(),
   mockPrepareXctestrunWithEnv: vi.fn(),
+  // Non-empty default: RUNNER_OWNER_START_TIME below is computed at module
+  // load (before beforeEach), and readProcessStartTime's real implementation
+  // shells out to `ps` with a 1s timeout that can miss under CPU contention,
+  // flipping a live owner to 'owner-process-dead'. Deterministic value, no
+  // shell-out; identity is still enforced by pid in beforeEach below.
+  mockReadProcessStartTime: vi.fn((_pid: number) => 'fixed-test-owner-start-time' as string | null),
   mockResolveExpectedRunnerCacheMetadata: vi.fn(),
   mockResolveRunnerDerivedPath: vi.fn(),
   mockRunAppleToolCommand: vi.fn(),
@@ -68,6 +75,7 @@ vi.mock('../../../../utils/host-process.ts', async () => {
     ...actual,
     isProcessAlive: mockIsProcessAlive,
     isProcessGroupAlive: mockIsProcessGroupAlive,
+    readProcessStartTime: mockReadProcessStartTime,
   };
 });
 
@@ -156,6 +164,12 @@ beforeEach(async () => {
   mockRunAppleToolCommand.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
   mockIsProcessAlive.mockReturnValue(true);
   mockIsProcessGroupAlive.mockReturnValue(false);
+  // Our pid reads back its fixed start time; any other pid reads as
+  // not-found, same as a real `ps` miss. Dead-lease tests use fabricated
+  // pids already rejected by mockIsProcessAlive before this is consulted.
+  mockReadProcessStartTime.mockImplementation((pid: number) =>
+    pid === process.pid ? RUNNER_OWNER_START_TIME : null,
+  );
   mockWaitForRunner.mockResolvedValue(runnerResponse({ uptimeMs: 1 }));
 });
 

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import net from 'node:net';
@@ -35,6 +35,36 @@ import {
 } from '../host-process.ts';
 import { stopProcessForTakeover } from '../../daemon/daemon-process.ts';
 import { findProjectRoot, readVersion } from '../version.ts';
+
+// readProcessStartTime/readProcessCommand shell out to `ps` with a 1s
+// timeout (see host-process.ts). isAgentDeviceDaemonProcess re-reads both for
+// every liveness check, so a spawned-daemon fixture that is proven live once
+// (a real read, right after the process starts) can still be misclassified
+// as dead later if a *subsequent* `ps` call happens to miss its deadline
+// under full-suite CPU contention. mockReadProcessStartTime/mockReadProcessCommand
+// default to `undefined`, which falls through to the real implementation for
+// every pid in every test in this file; only the one test below that needs a
+// stable answer for its spawned pid configures an override, and clears it
+// afterward.
+const { mockReadProcessStartTime, mockReadProcessCommand } = vi.hoisted(() => ({
+  mockReadProcessStartTime: vi.fn<(pid: number) => string | null | undefined>(),
+  mockReadProcessCommand: vi.fn<(pid: number) => string | null | undefined>(),
+}));
+
+vi.mock('../host-process.ts', async () => {
+  const actual = await vi.importActual<typeof import('../host-process.ts')>('../host-process.ts');
+  return {
+    ...actual,
+    readProcessStartTime: (pid: number) => {
+      const overridden = mockReadProcessStartTime(pid);
+      return overridden !== undefined ? overridden : actual.readProcessStartTime(pid);
+    },
+    readProcessCommand: (pid: number) => {
+      const overridden = mockReadProcessCommand(pid);
+      return overridden !== undefined ? overridden : actual.readProcessCommand(pid);
+    },
+  };
+});
 
 type MockHttpResponse = EventEmitter & {
   headers?: Record<string, string>;
@@ -413,11 +443,25 @@ test('cleanupFailedDaemonStartupMetadata retains live startup daemon on timeout'
 
   try {
     await new Promise((resolve) => setTimeout(resolve, 50));
+    // Read the spawned daemon's real identity once (ground truth: it is
+    // genuinely alive, with this real start time and command line), then
+    // pin readProcessStartTime/readProcessCommand to keep returning these
+    // same proven-real values for this pid. isAgentDeviceDaemonProcess reads
+    // both again internally on every call inside cleanupFailedDaemonStartupMetadata;
+    // without pinning, a second real `ps` call could miss its 1s timeout
+    // under load and misclassify this genuinely-live daemon as dead.
     const processStartTime = readProcessStartTime(pid) ?? undefined;
-    if (readProcessCommand(pid) === null || processStartTime === undefined) {
+    const command = readProcessCommand(pid);
+    if (command === null || processStartTime === undefined) {
       t.skip('process command/start inspection is unavailable in this environment');
       return;
     }
+    mockReadProcessStartTime.mockImplementation((queriedPid: number) =>
+      queriedPid === pid ? processStartTime : undefined,
+    );
+    mockReadProcessCommand.mockImplementation((queriedPid: number) =>
+      queriedPid === pid ? command : undefined,
+    );
 
     const paths = resolveDaemonPaths(stateDir);
     fs.mkdirSync(paths.baseDir, { recursive: true });
@@ -450,6 +494,8 @@ test('cleanupFailedDaemonStartupMetadata retains live startup daemon on timeout'
     assert.equal(fs.existsSync(paths.infoPath), true);
     assert.equal(fs.existsSync(paths.lockPath), true);
   } finally {
+    mockReadProcessStartTime.mockReset();
+    mockReadProcessCommand.mockReset();
     if (isProcessAlive(pid)) {
       process.kill(pid, 'SIGKILL');
       await waitForProcessExit(pid, 1_500);


### PR DESCRIPTION
## Summary

Three tests fail intermittently with **assertions** (not timeouts) during full-suite runs while passing in isolation. All three share one root cause: their fixture represents a live owner via a real pid, and the production liveness check re-reads that owner's process start time (or command line) with a second, independent `ps` shell-out (`utils/host-process.ts`, `PS_TIMEOUT_MS = 1000`). Under full-suite CPU contention, that second `ps` call can miss its 1s deadline and return `null`, which mismatches the value captured earlier and flips a genuinely-live owner to `owner-process-dead`. This is exactly the "liveness can race under CPU load" shape the repo's timeouts-only flake taxonomy doesn't cover, since the failure surfaces as a wrong assertion, not a hang.

## Per-test root cause, fix, and counterfactual

### 1. `runner-session.test.ts` — "runner session startup rejects live foreign runner lease"

**Root cause:** The fixture uses `ownerPid: process.pid, ownerStartTime: RUNNER_OWNER_START_TIME` (`runner-lease.ts:123`, `classifyRunnerLease` → `isRunnerLeaseOwnerProcessAlive` → `classifyOwnerLiveness`). `RUNNER_OWNER_START_TIME` is captured once via a real `ps` call at module import; `classifyOwnerLiveness` re-reads `readProcessStartTime(pid)` at classification time. Under load the second call can time out and return `null`, mismatching the cached value and flipping `live` → `stale('owner-process-dead')`.

**Fix:** Added `mockReadProcessStartTime` to the file's existing `vi.mock('.../host-process.ts', ...)`. It returns a fixed deterministic string for `process.pid` (used both at module-import time, so `RUNNER_OWNER_START_TIME` itself becomes deterministic, and during classification) and `null` for any other pid — removing the real subprocess call entirely while still requiring an exact pid match. `isProcessAlive` stays mocked as before (unchanged), so the existing dead-lease test (fabricated huge pid, short-circuits before `readProcessStartTime` is ever consulted) is untouched and still proves the dead-owner path.

**Counterfactual:** Inverted `owner-identity.ts`'s `if (!isProcessAlive(owner.pid))` to `if (isProcessAlive(owner.pid))`:
```
AssertionError: Missing expected rejection.
 ❯ src/platforms/apple/core/__tests__/runner-session.test.ts:873:5
```
Restored, test passes again.

### 2. `cli-device-status.test.ts` — "keeps normal status compact while retaining proven-stale claims for explicit inspection"

**Root cause:** This is a black-box CLI integration test (`runCliCapture` runs the real `runCli` in-process, no mocks). `readCurrentOwnerIdentity()` captures the test's own pid+startTime once via a real `ps` call to build a "live" claim fixture; `device-claim-inspection.ts` → `classifyOwnerLiveness` re-reads `readProcessStartTime(pid)` again when classifying claims for `device status`. Under load, the second real `ps` call can time out, misclassifying the live claim as stale — inflating the stale count from the expected 1 (the deliberately-fabricated dead claim) to 2.

**Fix:** Added a scoped `vi.mock('../utils/host-process.ts', ...)` that keeps everything real except `readProcessStartTime`, which now caches the *first* real read for our own pid and returns that same value on every subsequent call (self-consistent with the fixture regardless of whether that first `ps` call itself succeeds or times out — if it times out, both the fixture and the classifier consistently see `null`, which `classifyOwnerLiveness` treats as "skip the freshness check", not as a mismatch). `isProcessAlive` is untouched/real, so the fabricated-dead-pid (`999_999_999`) fixtures in this file still classify as stale through a real, non-flaky syscall check.

**Counterfactual:** Same inversion in `owner-identity.ts`:
```
AssertionError: The input did not match the regular expression /Live Pixel: live/. Input:
'No live local advisory device claims found.\n' +
  '2 stale claims hidden; inspect with: agent-device device status --stale\n'
```
Restored, test passes again.

### 3. `daemon-client.test.ts` — "cleanupFailedDaemonStartupMetadata retains live startup daemon on timeout" (third sighting, same mechanism, in scope)

**Root cause:** This test spawns a *real* child process to stand in for a daemon (needed because `isAgentDeviceDaemonProcess` also checks the command line against daemon patterns, so `process.pid` alone won't do). It reads the child's real start time/command once to build the fixture, then `cleanupFailedDaemonStartupMetadata` → `isAgentDeviceDaemonProcess` (`daemon-process.ts:20`) re-reads both via real `ps` calls (once per info-file check, once per lock-file check) to confirm liveness. Any of those re-reads can time out under load and return `null`/mismatch, flipping the live daemon to "not live" and failing `retainedInfoProcess`/`retainedLockProcess`.

**Fix:** Added a file-scoped `vi.mock('../host-process.ts', ...)` for `readProcessStartTime`/`readProcessCommand` that defaults to the real implementation for every pid in every other test in the file (pure passthrough, zero behavior change elsewhere), and only this one test configures a pinned override for its spawned pid — using the real values it already captured — clearing the override in `finally`.

**Counterfactual:** Inverted `daemon-process.ts`'s identity check (`if (actualStartTime === expectedStartTime) return false;`):
```
AssertionError: Expected values to be strictly equal:
+ actual - expected
+ undefined
- true
 ❯ src/utils/__tests__/daemon-client.test.ts:489:12
```
Restored, test passes again.

## Validation

- `pnpm typecheck && pnpm lint && pnpm format:check` — all clean.
- `npx vitest run` on all three touched files — 107/107 pass.
- 10x loop of the three touched files — 107/107 pass every run, zero flakes.
- Same three files run once while 4 `node -e 'while(true){}'` CPU-load processes ran concurrently in the same foreground command — 107/107 pass; load processes killed within the same command.

_Generated by [Claude Code](https://claude.ai/code)_
