### PR TITLE
refactor(android): enforce transport lowering in the type system

### DIFF
--- a/docs/adr/0013-unified-gesture-plans.md
+++ b/docs/adr/0013-unified-gesture-plans.md
@@ -74,7 +74,9 @@ Platform adapters consume the canonical plan:
   the physical movement for scroll and long-press, to provider-native touch injection when
   available, otherwise to the bundled instrumentation helper. One-contact endpoint plans lower in
   `src/platforms/android/touch-plan.ts` to 16 ms linear transport samples before either injection
-  path; two-contact plans retain their exact planned samples. A stationary long-press needs no
+  path; two-contact plans retain their exact planned samples. Transport samples are typed as
+  strictly denser than the canonical endpoint pair, so skipping that lowering is a type error at
+  the injection seams instead of a silently sparse gesture. A stationary long-press needs no
   viewport on the helper path; the executor adds the paired provider-owned viewport only for
   provider-native touch. Android touch execution never falls back to `adb input swipe`. Public
   scroll durations below one 16 ms planner frame normalize to that physical minimum and report the

--- a/packages/contracts/src/gesture-plan.ts
+++ b/packages/contracts/src/gesture-plan.ts
@@ -328,9 +328,10 @@ function initialSpanRatioForIntent(intent: MultiTouchGesturePlan['intent']): num
   return intent === 'pinch' ? GESTURE_PINCH_INITIAL_SPAN_RATIO : GESTURE_INITIAL_SPAN_RATIO;
 }
 
+/** The floor of three frames is what lets transport lowering claim a denser-than-endpoints path. */
 export function sampleGestureOffsets(
   durationMs: number,
-  profile: GestureSamplingProfile = 'default',
+  profile: GestureSamplingProfile,
 ): number[] {
   if (!Number.isFinite(durationMs) || durationMs <= 0) {
     throw new AppError('INVALID_ARGS', 'gesture sample duration must be a positive finite number');

--- a/src/platforms/android/__tests__/touch-helper.fixtures.ts
+++ b/src/platforms/android/__tests__/touch-helper.fixtures.ts
@@ -2,7 +2,7 @@ import { ANDROID_EMULATOR } from '../../../__tests__/test-utils/index.ts';
 import { buildGesturePlan } from '@agent-device/contracts/interaction';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { AndroidAdbExecutor } from '../adb-executor.ts';
-import type { AndroidTouchPlan } from '../touch-plan.ts';
+import type { AndroidLongPressTouchPlan } from '../touch-plan.ts';
 
 // The one-shot touch helper path now runs through the snapshot-helper APK/runner
 // (issue #1275 consolidation), so these fixtures mirror the snapshot helper's
@@ -39,7 +39,7 @@ export function makeIsolatedDevice(): DeviceInfo {
   return { ...ANDROID_EMULATOR, id: `emulator-touch-helper-${deviceSequence}` };
 }
 
-export function longPressPlan(durationMs = 120_000): AndroidTouchPlan {
+export function longPressPlan(durationMs = 120_000): AndroidLongPressTouchPlan {
   const point = { x: 20, y: 30 };
   return {
     topology: 'single',

--- a/src/platforms/android/__tests__/touch-helper.test.ts
+++ b/src/platforms/android/__tests__/touch-helper.test.ts
@@ -67,7 +67,7 @@ test('dual-pointer plans normalize to a transform request and preserve exact sam
     },
     viewport,
   );
-  const request = normalizeAndroidTouchHelperGestureRequest(pan);
+  const request = normalizeAndroidTouchHelperGestureRequest(lowerAndroidTouchPlan(pan));
 
   assert.equal(request.kind, 'transform');
   assert.equal(request.durationMs, 32);

--- a/src/platforms/android/__tests__/touch-plan.test.ts
+++ b/src/platforms/android/__tests__/touch-plan.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { test } from 'vitest';
-import { buildGesturePlan } from '@agent-device/contracts/interaction';
+import { expectTypeOf, test } from 'vitest';
+import {
+  buildGesturePlan,
+  type SinglePointerGesturePlan,
+} from '@agent-device/contracts/interaction';
 import { lowerAndroidTouchPlan, type AndroidLoweredTouchPlan } from '../touch-plan.ts';
 import { longPressPlan } from './touch-helper.fixtures.ts';
 
@@ -76,4 +79,11 @@ test('lowered endpoint plans are valid Android transport plans', () => {
   );
   const lowered: AndroidLoweredTouchPlan = lowerAndroidTouchPlan(plan);
   assert.equal(lowered.pointers[0].samples.length, 5);
+});
+
+// The transport types are the enforcement, so widening them back to a plain sample array must
+// fail a gate rather than quietly re-admit a two-sample plan at the injection seams.
+test('a canonical endpoint plan cannot reach the transport unlowered', () => {
+  expectTypeOf<SinglePointerGesturePlan>().not.toExtend<AndroidLoweredTouchPlan>();
+  expectTypeOf<ReturnType<typeof lowerAndroidTouchPlan>>().toExtend<AndroidLoweredTouchPlan>();
 });

--- a/src/platforms/android/touch-plan.ts
+++ b/src/platforms/android/touch-plan.ts
@@ -18,9 +18,21 @@ export type AndroidLongPressTouchPlan = {
 
 export type AndroidTouchPlan = GesturePlan | AndroidLongPressTouchPlan;
 
+/**
+ * Transport samples are strictly denser than the canonical endpoint pair, so the shared plan a
+ * command builds cannot satisfy the transport types: skipping the lowering below is a type error
+ * at every injection seam rather than a silently sparse gesture.
+ */
+type AndroidTransportSamples = readonly [
+  PointerTrajectorySample,
+  PointerTrajectorySample,
+  PointerTrajectorySample,
+  ...PointerTrajectorySample[],
+];
+
 type AndroidTransportSinglePointerTrajectory = {
   pointerId: 0;
-  samples: readonly PointerTrajectorySample[];
+  samples: AndroidTransportSamples;
 };
 
 export type AndroidTransportSinglePointerGesturePlan = Omit<
@@ -49,10 +61,12 @@ export function lowerAndroidTouchPlan(plan: AndroidTouchPlan): AndroidLoweredTou
       samples: [start, end],
     },
   ] = plan.pointers;
-  const samples = sampleGestureOffsets(plan.durationMs, 'android').map((offsetMs) => ({
+  const dense = sampleGestureOffsets(plan.durationMs, 'android').map((offsetMs) => ({
     offsetMs,
     point: interpolateGesturePoint(start.point, end.point, offsetMs / plan.durationMs),
   }));
+  // The sampler floors the frame count at three, so `dense` always holds at least four samples.
+  const samples: AndroidTransportSamples = [dense[0]!, dense[1]!, dense[2]!, ...dense.slice(3)];
 
   return {
     ...plan,


### PR DESCRIPTION
## Summary

Follow-up to #1572. `AndroidLoweredTouchPlan` widened the canonical two-sample trajectory to a plain `readonly PointerTrajectorySample[]`, so a plan that skipped `lowerAndroidTouchPlan` still satisfied the transport types — the type documented the requirement without enforcing it. An un-lowered plan reaching the helper or provider injects a two-sample gesture, which is exactly the sparse delivery #1572 removed from the shared plan.

Transport samples are now a minimum-arity tuple. `sampleGestureOffsets` floors the frame count at three, so lowering always yields at least four samples — "strictly denser than the canonical endpoint pair" is a true statement about the data, not a brand or a comment. A canonical `SinglePointerGesturePlan` is no longer assignable to `AndroidLoweredTouchPlan`, so skipping the lowering is a type error at every injection seam.

Tightening the type caught three call sites passing un-lowered plans straight to the helper transport, which is the evidence the previous signature enforced nothing. `longPressPlan` now returns `AndroidLongPressTouchPlan` instead of the wide union it never produced, and the dual-pointer normalize test routes through the lowering like every other transport call.

Also drops the unused `= 'default'` default on `sampleGestureOffsets`, so every caller states which platform sampling convention it wants — the point of having centralized the policy.

Sample values are unchanged by construction (`[dense[0], dense[1], dense[2], ...dense.slice(3)]` is `dense`), so Android injection stays bit-identical to #1572. The existing offset/point pins, including the `[0, 17, 33, 50, 67, 83, 100]` fling-equivalence assertion, are untouched and still pass.

## Validation

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm check:layering`: all pass on current `main`.
- 400 tests across the gesture, Android, WebDriver, and Apple suites pass.
- Enforcement verified in both directions:
  - A probe assigning a canonical plan to `AndroidLoweredTouchPlan` now fails with `TS2322: Type 'GesturePlan' is not assignable to type 'AndroidLoweredTouchPlan'`. The same probe compiled clean before this change.
  - Inverting the new `expectTypeOf(...).not.toExtend(...)` assertion produces a compile error, so the added test is a live gate: widening the transport type back to a plain sample array fails `pnpm typecheck` rather than silently re-admitting a two-sample plan.
- No CLI surface, runtime behavior, or wire payload changed; ADR 0013 gains one clause recording the enforcement.