### PR TITLE
perf(ios): halve hostile-screen capture cost under the XCTest-channel penalty

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -10,6 +10,45 @@ extension RunnerTests {
   /// apps where the AX surface is genuinely unavailable.
   static let privateAXSnapshotDepthLadder = [56, 40, 24, 12]
 
+  /// Ladder rungs for one capture. A remembered accepted depth (recorded when a prior capture's
+  /// deep request was rejected) drops the rungs above it, so the known-rejected deep request is
+  /// not re-paid on every capture of the same screen class.
+  static func privateAXAttemptDepths(requestedDepth: Int, rememberedDepth: Int?) -> [Int] {
+    var depths = [requestedDepth]
+    depths.append(contentsOf: privateAXSnapshotDepthLadder.filter { $0 < requestedDepth })
+    guard let remembered = rememberedDepth, remembered < requestedDepth else { return depths }
+    return depths.filter { $0 <= remembered }
+  }
+
+  func rememberPrivateAXAcceptedDepth(bundleId: String?, depth: Int) {
+    privateAXAcceptedDepthLock.lock()
+    privateAXAcceptedDepthBundleId = bundleId
+    privateAXAcceptedDepth = depth
+    privateAXAcceptedDepthUntil = Date().addingTimeInterval(snapshotXCTestChannelPenaltyDuration)
+    privateAXAcceptedDepthLock.unlock()
+    NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_DEPTH_REMEMBERED depth=%ld bundle=%@", depth, bundleId ?? "")
+  }
+
+  func rememberedPrivateAXAcceptedDepth(bundleId: String?) -> Int? {
+    privateAXAcceptedDepthLock.lock()
+    defer { privateAXAcceptedDepthLock.unlock() }
+    guard Date() < privateAXAcceptedDepthUntil else { return nil }
+    guard privateAXAcceptedDepthBundleId == bundleId else { return nil }
+    return privateAXAcceptedDepth
+  }
+
+  func clearPrivateAXAcceptedDepth(reason: String) {
+    privateAXAcceptedDepthLock.lock()
+    let hadMemory = privateAXAcceptedDepth != nil && Date() < privateAXAcceptedDepthUntil
+    privateAXAcceptedDepthBundleId = nil
+    privateAXAcceptedDepth = nil
+    privateAXAcceptedDepthUntil = .distantPast
+    privateAXAcceptedDepthLock.unlock()
+    if hadMemory {
+      NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_DEPTH_MEMORY_CLEARED reason=%@", reason)
+    }
+  }
+
   func privateAXSnapshotCapture(
     app: XCUIApplication,
     options: SnapshotOptions,
@@ -17,9 +56,13 @@ extension RunnerTests {
   ) -> SnapshotBackendCapture? {
     #if os(iOS) && targetEnvironment(simulator)
       let requestedDepth = options.depth ?? 64
-      var attemptDepths = [requestedDepth]
-      attemptDepths.append(
-        contentsOf: Self.privateAXSnapshotDepthLadder.filter { $0 < requestedDepth }
+      // An explicit --depth request is honored as asked; only default-depth captures consult
+      // (and feed) the accepted-depth memory.
+      let rememberedDepth =
+        options.depth == nil ? rememberedPrivateAXAcceptedDepth(bundleId: currentBundleId) : nil
+      let attemptDepths = Self.privateAXAttemptDepths(
+        requestedDepth: requestedDepth,
+        rememberedDepth: rememberedDepth
       )
       var response: [String: Any] = [:]
       var effectiveDepth = requestedDepth
@@ -51,6 +94,12 @@ extension RunnerTests {
       guard response["ok"] as? Bool == true else {
         NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_FAILED=%@", lastError)
         return nil
+      }
+      // Only a capture that actually descended records memory: a first-rung success on a
+      // remembered depth deliberately does NOT refresh the TTL, so expiry re-probes the full
+      // requested depth once per window instead of capping this screen class forever.
+      if options.depth == nil, effectiveDepth != attemptDepths.first {
+        rememberPrivateAXAcceptedDepth(bundleId: currentBundleId, depth: effectiveDepth)
       }
       guard let root = response["root"] as? [String: Any] else {
         NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_FAILED=missing root")
@@ -91,7 +140,13 @@ extension RunnerTests {
 
   private func privateAXSnapshotViewport(app: XCUIApplication, rootFrame: CGRect) -> CGRect {
     let fallback = rootFrame.isEmpty ? CGRect.infinite : rootFrame
-    guard !hasAbandonedTreeCapture() else {
+    // The viewport read is XCTest main-thread work — the exact channel the penalty marks as
+    // grinding on this screen class. Under penalty it reliably burns its full timeout and
+    // falls back anyway (~1s added to every private AX capture on the Bluesky bench feed),
+    // so honor the penalty here the same way capture plans do.
+    guard !hasAbandonedTreeCapture(),
+      !isSnapshotXCTestChannelPenalized(bundleId: currentBundleId)
+    else {
       return fallback
     }
     do {
@@ -237,6 +292,37 @@ extension RunnerTests {
 // MARK: - In-bundle unit tests
 
 extension RunnerTests {
+  func testPrivateAXAttemptDepthsAppliesRememberedDepth() {
+    XCTAssertEqual(
+      Self.privateAXAttemptDepths(requestedDepth: 64, rememberedDepth: nil),
+      [64, 56, 40, 24, 12]
+    )
+    XCTAssertEqual(
+      Self.privateAXAttemptDepths(requestedDepth: 64, rememberedDepth: 56),
+      [56, 40, 24, 12]
+    )
+    XCTAssertEqual(Self.privateAXAttemptDepths(requestedDepth: 64, rememberedDepth: 12), [12])
+    // Remembered at/above the requested depth changes nothing.
+    XCTAssertEqual(
+      Self.privateAXAttemptDepths(requestedDepth: 64, rememberedDepth: 64),
+      [64, 56, 40, 24, 12]
+    )
+    // A shallower explicit request keeps its own rungs; deeper stale memory is ignored.
+    XCTAssertEqual(Self.privateAXAttemptDepths(requestedDepth: 24, rememberedDepth: 56), [24, 12])
+  }
+
+  func testPrivateAXAcceptedDepthMemoryMatchesBundleAndExpires() {
+    defer { clearPrivateAXAcceptedDepth(reason: "test-cleanup") }
+
+    rememberPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", depth: 56)
+    XCTAssertEqual(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app"), 56)
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "com.other.app"))
+
+    // Expired memory stops applying (the expiry re-probes the full requested depth).
+    privateAXAcceptedDepthUntil = Date(timeIntervalSinceNow: -1)
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app"))
+  }
+
   func testPrivateAXScopeSelectsSubtreeNotMatchingLabels() {
     let tree: [String: Any] = [
       "type": 1, "label": "App",

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -20,20 +20,27 @@ extension RunnerTests {
     return depths.filter { $0 <= remembered }
   }
 
-  func rememberPrivateAXAcceptedDepth(bundleId: String?, depth: Int) {
+  func rememberPrivateAXAcceptedDepth(bundleId: String?, processIdentifier: Int?, depth: Int) {
+    // No PID means no way to notice a relaunch later; record nothing rather than risk serving
+    // a stale shallow rung to a fresh process.
+    guard let processIdentifier else { return }
     privateAXAcceptedDepthLock.lock()
     privateAXAcceptedDepthBundleId = bundleId
+    privateAXAcceptedDepthProcessIdentifier = processIdentifier
     privateAXAcceptedDepth = depth
     privateAXAcceptedDepthUntil = Date().addingTimeInterval(snapshotXCTestChannelPenaltyDuration)
     privateAXAcceptedDepthLock.unlock()
     NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_DEPTH_REMEMBERED depth=%ld bundle=%@", depth, bundleId ?? "")
   }
 
-  func rememberedPrivateAXAcceptedDepth(bundleId: String?) -> Int? {
+  func rememberedPrivateAXAcceptedDepth(bundleId: String?, processIdentifier: Int?) -> Int? {
     privateAXAcceptedDepthLock.lock()
     defer { privateAXAcceptedDepthLock.unlock() }
     guard Date() < privateAXAcceptedDepthUntil else { return nil }
     guard privateAXAcceptedDepthBundleId == bundleId else { return nil }
+    guard let processIdentifier, privateAXAcceptedDepthProcessIdentifier == processIdentifier else {
+      return nil
+    }
     return privateAXAcceptedDepth
   }
 
@@ -41,6 +48,7 @@ extension RunnerTests {
     privateAXAcceptedDepthLock.lock()
     let hadMemory = privateAXAcceptedDepth != nil && Date() < privateAXAcceptedDepthUntil
     privateAXAcceptedDepthBundleId = nil
+    privateAXAcceptedDepthProcessIdentifier = nil
     privateAXAcceptedDepth = nil
     privateAXAcceptedDepthUntil = .distantPast
     privateAXAcceptedDepthLock.unlock()
@@ -59,7 +67,12 @@ extension RunnerTests {
       // An explicit --depth request is honored as asked; only default-depth captures consult
       // (and feed) the accepted-depth memory.
       let rememberedDepth =
-        options.depth == nil ? rememberedPrivateAXAcceptedDepth(bundleId: currentBundleId) : nil
+        options.depth == nil
+        ? rememberedPrivateAXAcceptedDepth(
+          bundleId: currentBundleId,
+          processIdentifier: currentAppProcessIdentifier
+        )
+        : nil
       let attemptDepths = Self.privateAXAttemptDepths(
         requestedDepth: requestedDepth,
         rememberedDepth: rememberedDepth
@@ -99,7 +112,11 @@ extension RunnerTests {
       // remembered depth deliberately does NOT refresh the TTL, so expiry re-probes the full
       // requested depth once per window instead of capping this screen class forever.
       if options.depth == nil, effectiveDepth != attemptDepths.first {
-        rememberPrivateAXAcceptedDepth(bundleId: currentBundleId, depth: effectiveDepth)
+        rememberPrivateAXAcceptedDepth(
+          bundleId: currentBundleId,
+          processIdentifier: currentAppProcessIdentifier,
+          depth: effectiveDepth
+        )
       }
       guard let root = response["root"] as? [String: Any] else {
         NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_FAILED=missing root")
@@ -138,15 +155,17 @@ extension RunnerTests {
     #endif
   }
 
+  /// The viewport read is XCTest main-thread work — the exact channel the penalty marks as
+  /// grinding on this screen class. Under penalty it reliably burns its full timeout and
+  /// falls back anyway (~1s added to every private AX capture on the Bluesky bench feed),
+  /// so honor the penalty here the same way capture plans do.
+  func shouldReadPrivateAXViewportViaXCTest() -> Bool {
+    !hasAbandonedTreeCapture() && !isSnapshotXCTestChannelPenalized(bundleId: currentBundleId)
+  }
+
   private func privateAXSnapshotViewport(app: XCUIApplication, rootFrame: CGRect) -> CGRect {
     let fallback = rootFrame.isEmpty ? CGRect.infinite : rootFrame
-    // The viewport read is XCTest main-thread work — the exact channel the penalty marks as
-    // grinding on this screen class. Under penalty it reliably burns its full timeout and
-    // falls back anyway (~1s added to every private AX capture on the Bluesky bench feed),
-    // so honor the penalty here the same way capture plans do.
-    guard !hasAbandonedTreeCapture(),
-      !isSnapshotXCTestChannelPenalized(bundleId: currentBundleId)
-    else {
+    guard shouldReadPrivateAXViewportViaXCTest() else {
       return fallback
     }
     do {
@@ -311,16 +330,54 @@ extension RunnerTests {
     XCTAssertEqual(Self.privateAXAttemptDepths(requestedDepth: 24, rememberedDepth: 56), [24, 12])
   }
 
-  func testPrivateAXAcceptedDepthMemoryMatchesBundleAndExpires() {
+  func testPrivateAXAcceptedDepthMemoryMatchesBundleProcessAndExpires() {
     defer { clearPrivateAXAcceptedDepth(reason: "test-cleanup") }
 
-    rememberPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", depth: 56)
-    XCTAssertEqual(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app"), 56)
-    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "com.other.app"))
+    rememberPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: 111, depth: 56)
+    XCTAssertEqual(
+      rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: 111),
+      56
+    )
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "com.other.app", processIdentifier: 111))
+    // A relaunch changes the PID; the new process must re-probe the full depth even inside the
+    // TTL, and an unknown current PID (post-invalidation) must never match.
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: 222))
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: nil))
 
     // Expired memory stops applying (the expiry re-probes the full requested depth).
     privateAXAcceptedDepthUntil = Date(timeIntervalSinceNow: -1)
-    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app"))
+    XCTAssertNil(rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: 111))
+  }
+
+  func testPrivateAXAcceptedDepthMemoryRequiresProcessIdentifierToRecord() {
+    defer { clearPrivateAXAcceptedDepth(reason: "test-cleanup") }
+
+    rememberPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: nil, depth: 56)
+    XCTAssertNil(
+      rememberedPrivateAXAcceptedDepth(bundleId: "xyz.blueskyweb.app", processIdentifier: nil)
+    )
+  }
+
+  func testViewportReadSkippedWhileXCTestChannelPenalized() {
+    // Pins the viewport fast path (#1587 review): every penalized private AX capture used to burn
+    // the full 1s main-thread timeout on a doomed viewport read before falling back.
+    currentBundleId = "xyz.blueskyweb.app"
+    defer {
+      currentBundleId = nil
+      clearSnapshotXCTestChannelPenalty(reason: "test-cleanup")
+      abandonedTreeCaptureCount = 0
+    }
+
+    XCTAssertTrue(shouldReadPrivateAXViewportViaXCTest())
+
+    penalizeSnapshotXCTestChannel(bundleId: "xyz.blueskyweb.app", reason: "test")
+    XCTAssertFalse(shouldReadPrivateAXViewportViaXCTest())
+
+    clearSnapshotXCTestChannelPenalty(reason: "test")
+    XCTAssertTrue(shouldReadPrivateAXViewportViaXCTest())
+
+    abandonedTreeCaptureCount = 1
+    XCTAssertFalse(shouldReadPrivateAXViewportViaXCTest())
   }
 
   func testPrivateAXScopeSelectsSubtreeNotMatchingLabels() {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
@@ -122,6 +122,7 @@ extension RunnerTests {
     currentApp = candidate
     currentAppProcessIdentifier = observedProcessIdentifier
     clearSnapshotXCTestChannelPenalty(reason: "target_process_changed")
+    clearPrivateAXAcceptedDepth(reason: "target_process_changed")
     snapshotXCTestPenaltyWarmupExemptionPending = true
     needsFirstInteractionDelay = true
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -144,6 +144,30 @@ extension RunnerTests {
     return pending
   }
 
+  /// The pre-seeded first-failure a penalized plan stamps into its verdict. The deferred case
+  /// uses the dedicated 'deferred' code: the breaker pre-selected the backend, nothing new
+  /// degraded on this capture, and the daemon keys warning suppression and the settle budget
+  /// reset off exactly that distinction. The bounded probe keeps 'budget': its short XCTest
+  /// slice genuinely constrains what this capture could read.
+  static func xcTestChannelStateFirstFailure(
+    _ state: SnapshotXCTestChannelPlanState
+  ) -> (reason: String, code: String)? {
+    switch state {
+    case .normal:
+      return nil
+    case .deferredToIndependentBackend:
+      return (
+        "XCTest-backed snapshot tiers were deferred after recent slow accessibility work on this screen",
+        "deferred"
+      )
+    case .boundedXCTestProbe:
+      return (
+        "XCTest-backed snapshot tiers are running with a short recovery probe after recent slow accessibility work on this screen",
+        "budget"
+      )
+    }
+  }
+
   /// Pure plan-reorder rule: a penalized XCTest accessibility channel uses independent backends
   /// when the platform has one, otherwise it keeps XCTest work on a short probe. The raw
   /// diagnostic plan keeps tree-first errors, and unknown plans are left untouched.
@@ -208,20 +232,13 @@ extension RunnerTests {
       availableBackends: Set(SnapshotBackendKind.allCases.filter(\.isAvailableOnCurrentPlatform))
     )
     let effectivePlan = effective.plan
+    firstFailure = Self.xcTestChannelStateFirstFailure(effective.xCTestChannelState)
     switch effective.xCTestChannelState {
     case .normal:
       break
     case .deferredToIndependentBackend:
-      firstFailure = (
-        "XCTest-backed snapshot tiers were deferred after recent slow accessibility work on this screen",
-        "budget"
-      )
       NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_XCTEST_CHANNEL_DEFERRED bundle=%@", currentBundleId ?? "")
     case .boundedXCTestProbe:
-      firstFailure = (
-        "XCTest-backed snapshot tiers are running with a short recovery probe after recent slow accessibility work on this screen",
-        "budget"
-      )
       NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_XCTEST_CHANNEL_PROBE_BOUNDED bundle=%@", currentBundleId ?? "")
     }
 
@@ -519,7 +536,7 @@ extension RunnerTests {
     guard quality.state != "healthy" || quality.collapsedLeafIndexes != nil else { return nil }
     var parts: [String] = []
     if quality.state == "recovered" {
-      let meaning = quality.reasonCode == "budget"
+      let meaning = quality.reasonCode == "budget" || quality.reasonCode == "deferred"
         ? " The primary capture ran out of its time budget (busy app or simulator); the recovered tree is authoritative for this screen."
         : " This usually means the app publishes an unhealthy accessibility tree — fixing the app's accessibility is the real cure. Treat screenshot as visual truth when this warning appears."
       parts.append(
@@ -643,6 +660,12 @@ extension RunnerTests {
       Self.resolveSnapshotPlanTerminal(terminal: .throwOnAXFailure, interactiveOnly: true),
       .throwAxFailure
     )
+  }
+
+  func testXCTestChannelStateFirstFailureStampsDeferredCodeOnlyForDeferral() {
+    XCTAssertNil(Self.xcTestChannelStateFirstFailure(.normal))
+    XCTAssertEqual(Self.xcTestChannelStateFirstFailure(.deferredToIndependentBackend)?.code, "deferred")
+    XCTAssertEqual(Self.xcTestChannelStateFirstFailure(.boundedXCTestProbe)?.code, "budget")
   }
 
   func testEffectiveSnapshotCapturePlanDefersXCTestBackedTiersOnlyWhenPenalizedRegularPlan() {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -87,6 +87,15 @@ final class RunnerTests: XCTestCase {
   var snapshotXCTestChannelPenaltyUntil = Date.distantPast
   let snapshotXCTestChannelPenaltyDuration: TimeInterval = 120
   var snapshotXCTestPenaltyWarmupExemptionPending = false
+  // Sticky per-bundle hint for the private AX depth ladder: deep RN screens reject the default
+  // depth with kAXErrorIllegalArgument on EVERY capture, so once a shallower rung is accepted
+  // later captures start there instead of re-paying the rejected deep request (~300ms per
+  // capture on the Bluesky feed). Shares the penalty's lifetime model: same duration, cleared
+  // on target process change, so screens that regain deep-capture ability are re-probed.
+  let privateAXAcceptedDepthLock = NSLock()
+  var privateAXAcceptedDepthBundleId: String?
+  var privateAXAcceptedDepth: Int?
+  var privateAXAcceptedDepthUntil = Date.distantPast
   // Bluesky-class screens can grind ~4-8s before an XCTest-backed snapshot tier fails; anything
   // past this threshold marks the screen hostile so the next capture uses non-XCTest recovery.
   let snapshotXCTestSlowCaptureThreshold: TimeInterval = 3

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -94,6 +94,10 @@ final class RunnerTests: XCTestCase {
   // on target process change, so screens that regain deep-capture ability are re-probed.
   let privateAXAcceptedDepthLock = NSLock()
   var privateAXAcceptedDepthBundleId: String?
+  // PID-bound: a relaunch (external or A->B->A while inactive) changes the process, and the new
+  // tree may accept the full depth again. Any invalidation path that drops the cached PID makes
+  // the memory unmatchable, so every fresh activation re-probes the full requested depth.
+  var privateAXAcceptedDepthProcessIdentifier: Int?
   var privateAXAcceptedDepth: Int?
   var privateAXAcceptedDepthUntil = Date.distantPast
   // Bluesky-class screens can grind ~4-8s before an XCTest-backed snapshot tier fails; anything

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -12,7 +12,13 @@ export type SnapshotQualityVerdict = {
   reason?: string;
   // 'deferred' = the penalty circuit breaker pre-selected a non-XCTest backend; nothing new
   // degraded on THIS capture (no repeated warning, no settle budget reset).
-  reasonCode?: 'ax-rejected' | 'sparse-tree' | 'budget' | 'no-nodes' | 'capture-failed' | 'deferred';
+  reasonCode?:
+    | 'ax-rejected'
+    | 'sparse-tree'
+    | 'budget'
+    | 'no-nodes'
+    | 'capture-failed'
+    | 'deferred';
   effectiveDepth?: number;
   collapsedLeafIndexes?: number[];
 };

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -10,7 +10,9 @@ export type SnapshotQualityVerdict = {
   state: 'healthy' | 'recovered' | 'sparse';
   backend: 'tree' | 'queries' | 'private-ax';
   reason?: string;
-  reasonCode?: 'ax-rejected' | 'sparse-tree' | 'budget' | 'no-nodes' | 'capture-failed';
+  // 'deferred' = the penalty circuit breaker pre-selected a non-XCTest backend; nothing new
+  // degraded on THIS capture (no repeated warning, no settle budget reset).
+  reasonCode?: 'ax-rejected' | 'sparse-tree' | 'budget' | 'no-nodes' | 'capture-failed' | 'deferred';
   effectiveDepth?: number;
   collapsedLeafIndexes?: number[];
 };

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -207,6 +207,44 @@ test('private-ax recovery resets the settle budget once', async () => {
   assert.equal(captures, 4);
 });
 
+test('penalty-deferred private-ax captures do not reset the settle budget', async () => {
+  // Same shape as the reset test above, but the verdict says the circuit breaker PRE-selected
+  // private AX ('deferred'): the capture paid no grind, so the loop keeps its original budget
+  // and times out instead of being extended.
+  const before = buttonSnapshot();
+  const deferredAfter = welcomeSnapshot();
+  deferredAfter.snapshotQuality = {
+    state: 'recovered',
+    backend: 'private-ax',
+    reasonCode: 'deferred',
+    reason: 'XCTest-backed snapshot tiers were deferred after recent slow accessibility work',
+  };
+  let captures = 0;
+  const clock = createFakeClock();
+  const device = createSettleDevice({
+    stored: before,
+    clock,
+    captureSnapshot: () => {
+      captures += 1;
+      if (captures === 1) return { snapshot: before };
+      if (captures === 2) {
+        clock.advance(900);
+      }
+      return { snapshot: deferredAfter };
+    },
+  });
+
+  const result = await device.interactions.press(selector('label=Continue'), {
+    session: 'default',
+    settle: { quietMs: 500, timeoutMs: 1_000 },
+  });
+
+  const settle = result.settle;
+  assert.ok(settle);
+  assert.equal(settle.settled, false);
+  assert.equal(settle.hint, NEVER_SETTLED_HINT);
+});
+
 test('a broken settle capture never fails the action', async () => {
   const before = buttonSnapshot();
   let captures = 0;

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -11,6 +11,7 @@ import {
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
 import { ref, selector } from './selector-read-utils.ts';
 import { buildSettleTailEntries, NEVER_SETTLED_HINT } from './settle.ts';
+import { readSnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 
 // #1101 --settle: quiet-window settle loop composition on the interaction
 // commands. Budgets are injected (fake clock) — no real waiting.
@@ -213,12 +214,15 @@ test('penalty-deferred private-ax captures do not reset the settle budget', asyn
   // and times out instead of being extended.
   const before = buttonSnapshot();
   const deferredAfter = welcomeSnapshot();
-  deferredAfter.snapshotQuality = {
+  // Parsed from a raw runner-wire object on purpose: if 'deferred' is ever dropped from the
+  // accepted reason-code set, the parser strips it, the reset fires again, and this test fails.
+  deferredAfter.snapshotQuality = readSnapshotQualityVerdict({
     state: 'recovered',
     backend: 'private-ax',
     reasonCode: 'deferred',
     reason: 'XCTest-backed snapshot tiers were deferred after recent slow accessibility work',
-  };
+  });
+  assert.equal(deferredAfter.snapshotQuality?.reasonCode, 'deferred');
   let captures = 0;
   const clock = createFakeClock();
   const device = createSettleDevice({

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -135,7 +135,13 @@ export async function runStableCaptureLoop(
 }
 
 function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boolean {
-  return verdict?.state === 'recovered' && verdict.backend === 'private-ax';
+  // 'deferred' = the penalty circuit breaker routed straight to private AX; the capture paid no
+  // grind, so there is nothing to give the settle budget back for.
+  return (
+    verdict?.state === 'recovered' &&
+    verdict.backend === 'private-ax' &&
+    verdict.reasonCode !== 'deferred'
+  );
 }
 
 /**

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -20,6 +20,7 @@ const SNAPSHOT_QUALITY_REASON_CODES = new Set<NonNullable<SnapshotQualityVerdict
   'budget',
   'no-nodes',
   'capture-failed',
+  'deferred',
 ]);
 
 export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdict | undefined {
@@ -80,6 +81,9 @@ export function renderSnapshotQualityWarnings(
 
 function stateWarning(verdict: SnapshotQualityVerdict): string[] {
   if (verdict.state === 'recovered') {
+    // Penalty-deferred captures repeat on every capture of a hostile screen; the capture that
+    // ARMED the penalty already carried the full warning, so repeating it is pure noise.
+    if (verdict.reasonCode === 'deferred') return [];
     return [
       `Detected an overly complex or slow accessibility tree. Fell back to the ${verdict.backend} snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`,
     ];

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -45,6 +45,20 @@ test('readSnapshotQualityVerdict keeps the verdict but drops an unknown reasonCo
   assert.equal(verdict?.reasonCode, undefined);
 });
 
+test("the runner-wire 'deferred' reasonCode survives parsing into warning suppression", () => {
+  // End-to-end through the raw wire parser: 'deferred' must be a member of the accepted
+  // reason-code set, or it is silently stripped and every downstream deferred behavior
+  // (warning suppression, settle budget-reset skip) quietly reverts.
+  const verdict = readSnapshotQualityVerdict({
+    state: 'recovered',
+    backend: 'private-ax',
+    reason: 'XCTest-backed snapshot tiers were deferred after recent slow accessibility work',
+    reasonCode: 'deferred',
+  });
+  assert.equal(verdict?.reasonCode, 'deferred');
+  assert.deepEqual(renderSnapshotQualityWarnings(verdict!, []), []);
+});
+
 test('penalty-deferred recovered captures suppress the fallback warning but keep depth copy', () => {
   // Every capture of a hostile screen re-stamps recovered/deferred; the capture that armed the
   // penalty already carried the full warning, so repeating it each capture is context noise.

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -45,6 +45,25 @@ test('readSnapshotQualityVerdict keeps the verdict but drops an unknown reasonCo
   assert.equal(verdict?.reasonCode, undefined);
 });
 
+test('penalty-deferred recovered captures suppress the fallback warning but keep depth copy', () => {
+  // Every capture of a hostile screen re-stamps recovered/deferred; the capture that armed the
+  // penalty already carried the full warning, so repeating it each capture is context noise.
+  const warnings = renderSnapshotQualityWarnings(
+    {
+      state: 'recovered',
+      backend: 'private-ax',
+      reason: 'XCTest-backed snapshot tiers were deferred after recent slow accessibility work',
+      reasonCode: 'deferred',
+      effectiveDepth: 56,
+    },
+    [],
+  );
+
+  assert.deepEqual(warnings, [
+    'Some deeper accessibility nodes were omitted; this tree is capped at depth 56. Re-run with --depth 56 --scope <container> only if you need deeper content.',
+  ]);
+});
+
 test('renderSnapshotQualityWarnings keeps recovered snapshot copy concise', () => {
   const warnings = renderSnapshotQualityWarnings(
     {


### PR DESCRIPTION
## What

Two changes to how iOS private-AX captures behave once the XCTest-channel penalty (#1105/#1156) has marked a screen class hostile, plus a verdict-semantics fix the second change exposed:

1. **Skip the viewport read while the channel is penalized** ([RunnerTests+AXSnapshotFallback.swift](../blob/HEAD/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests%2BAXSnapshotFallback.swift)). The viewport read is XCTest main-thread work — the exact channel the penalty marks as grinding. Live measurement on the AppControlBench Bluesky feed showed it burning its full 1s `runMainThreadWork` timeout and falling back to the root frame on **every** capture. Under penalty it now goes straight to the fallback, same policy as the existing abandoned-tree-capture guard.

2. **Remember the accepted private-AX ladder depth per bundle.** Deep RN screens reject the default depth-64 request with `kAXErrorIllegalArgument` on every capture (~310ms each) before succeeding at 56. The accepted rung is now remembered per bundle with the penalty's lifetime model (120s TTL, cleared on target process change). A first-rung success on remembered depth deliberately does not refresh the TTL, so expiry re-probes the full requested depth — screens that regain deep-capture ability are never capped forever. Explicit `--depth` requests bypass the memory in both directions.

3. **New `deferred` reasonCode for penalty-preselected captures.** The plan runner stamped penalty-preselected captures with the same `recovered` verdict as a capture that ground through a live failure. On hostile screens that meant the full "Detected an overly complex or slow accessibility tree…" warning repeated on every capture (130× in one 30-task bench run — pure context noise for the driving agent), and settle's one-shot private-AX budget reset fired on every loop even though the capture paid no grind. The deferred case now carries `reasonCode: 'deferred'`; the daemon keeps the verdict `recovered` but suppresses the repeated warning (depth-cap line stays) and skips the settle budget reset. Older daemons drop unknown reason codes and keep today's behavior, so the runner/daemon pairing is forward/backward safe.

## Why

Software Mansion's AppControlBench re-run at 0.20.5 showed Bluesky tasks ~2× slower than the published 0.17.6 numbers. Decomposing the transcripts: ~half the delta was environmental (model transport startup, Expo dev-client popup absent from SWM's golden), but the largest tool-side cost was private-AX capture overhead multiplied through `--settle` (2 captures per settle, 227 settle requests per 30-task run) and every press target resolution.

Runner-side timeline per hostile capture before this change: ~310ms failed depth-64 rung + ~350ms real work + ~1000ms doomed viewport read ≈ 1.65s, ×2 per settle.

## Measured (live, seeded bench Bluesky feed, 139–171-node tree)

| operation | before | after |
|---|---:|---:|
| `snapshot -i` steady-state (CLI wall) | 2.65s | **~0.55s** |
| `press --settle` round-trip | ~5.4s+ | **~2.0s** (settled after ~1.0s) |
| runner-side capture | ~1.65s | ~0.35s |
| bench task bsky-04 end-to-end | 271s / 26 tool calls | **130s / 11 tool calls** |

Healthy-screen behavior is unchanged (verified on Settings: healthy verdict, no memory involvement, penalty+memory cleared on app switch).

## Reviewer notes

- The budget-reset skip for `deferred` is intentionally conservative: genuine recoveries (a capture that ground through XCTest and then fell back mid-plan) keep the reset — that path still needs its budget back.
- `xcTestChannelStateFirstFailure` was extracted pure so the deferred-vs-budget stamping is pinned by an in-bundle test; the bounded-XCTest-probe case (physical devices) keeps `budget` since its short probe slice genuinely constrains the capture.
- Tests: 2 new in-bundle Swift tests (attempt-depth ladder math, memory match/expiry) + 1 stamping test, new TS tests for warning suppression and the no-reset settle path. Full unit suite green (5291 tests).

## Review round 1 (3696f338b)

- **Depth memory is now PID-bound** (P1): it stores the process identifier it was learned under and matches only the same live process; recording without a PID is refused. All invalidation paths (`invalidateCachedTarget`, external relaunch, A→B→A with restart while inactive) are covered automatically because they all drop `currentAppProcessIdentifier`.
- **`deferred` is pinned through the raw wire parser**: the settle no-reset test and warning-suppression test now build their verdict via `readSnapshotQualityVerdict` on a raw runner payload, plus a direct membership test.
- **Viewport skip has a structural regression test**: `shouldReadPrivateAXViewportViaXCTest()` extracted and pinned (penalized → skip, cleared → read, abandoned-capture → skip).

### Pre-fix red evidence (new tests on base `80feff42d`)

```
FAIL  the runner-wire 'deferred' reasonCode survives parsing into warning suppression
      + undefined  - 'deferred'                       (parser strips the unknown code)
FAIL  penalty-deferred recovered captures suppress the fallback warning but keep depth copy
      + 'Detected an overly complex or slow accessibility tree…'   (warning re-appears)
FAIL  penalty-deferred private-ax captures do not reset the settle budget
      settled: true instead of false                  (budget reset fires again)
```

The Swift-side tests reference symbols introduced by this PR (`privateAXAttemptDepths`, `shouldReadPrivateAXViewportViaXCTest`, PID-bound memory), so their base state is "does not compile" rather than red.
