### PR TITLE
fix(snapshot): one-shot recovered warning for internally armed penalties

### DIFF
--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -13,8 +13,8 @@ const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
 
 export const DAEMON_MODULARITY_BASELINE = {
   sessionState: {
-    writerOwnedFields: 22,
-    ownerFileClaims: 28,
+    writerOwnedFields: 23,
+    ownerFileClaims: 29,
   },
   largestTypeCycle: {
     zoneMembers: LARGEST_TYPE_CYCLE_ZONE_CEILINGS,

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -48,6 +48,9 @@ export const SESSION_STATE_FIELD_OWNERS: Readonly<Record<string, readonly string
   snapshotGeneration: ['src/daemon/session-snapshot.ts'],
   lastComparisonSafeSnapshot: ['src/daemon/session-snapshot.ts'],
   androidSnapshotFreshness: ['src/daemon/android-snapshot-freshness.ts'],
+  // One-shot deferred-warning latch (#1587 follow-up): the transition function is the only
+  // writer, so the latch's window semantics live in a single module.
+  recoveredSnapshotWarningLatch: ['src/daemon/snapshot-quality-latch.ts'],
 
   // #1478 P4a script publication. The tagged aggregate replaced the eight co-resident
   // `saveScript*`/`scriptRecordingState`/`repair*` fields; its ONLY writers are the two

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -293,6 +293,20 @@ test('an empty ref-scoped diff latches on the captured verdict, not the retained
   expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
 });
 
+test('an app switch supersedes the held latch through the dispatch seam', async () => {
+  const input = scenario();
+  seedCapture(deferredVerdict());
+  await dispatchPublicSnapshot(input);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
+
+  // The runner clears its penalty per target process, so a latch held for the
+  // previous app must not silence the new app's first deferred verdict.
+  input.sessionStore.get(input.sessionName)!.appBundleId = 'com.example.other';
+  const switched = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(switched).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.other' });
+});
+
 test('a genuine recovered render keeps later deferred captures quiet without doubling', async () => {
   const input = scenario();
   seedCapture(genuineRecoveredVerdict());

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -138,9 +138,9 @@ test('internal observation responses neither consume nor clear the latch', () =>
 
 test('sessionless responses pass through unchanged', () => {
   const data = { snapshotQuality: deferredVerdict() };
-  expect(
-    applyRecoveredWarningLatch({ session: undefined, data, internalObservation: false }),
-  ).toBe(data);
+  expect(applyRecoveredWarningLatch({ session: undefined, data, internalObservation: false })).toBe(
+    data,
+  );
 });
 
 function scenario() {
@@ -184,7 +184,9 @@ function responseWarnings(response: Awaited<ReturnType<typeof dispatchSnapshotVi
   return (response.data?.warnings ?? []) as string[];
 }
 
-function storedLatch(input: ReturnType<typeof scenario>): SessionState['recoveredSnapshotWarningLatch'] {
+function storedLatch(
+  input: ReturnType<typeof scenario>,
+): SessionState['recoveredSnapshotWarningLatch'] {
   return input.sessionStore.get(input.sessionName)?.recoveredSnapshotWarningLatch;
 }
 

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -11,7 +11,7 @@ import {
   applyRecoveredWarningLatch,
   resolveRecoveredWarningLatch,
 } from '../snapshot-quality-latch.ts';
-import { dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
+import { dispatchSnapshotDiffViaRuntime, dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
 import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 
@@ -121,7 +121,8 @@ test('internal observation responses neither consume nor clear the latch', () =>
 
   const internal = applyRecoveredWarningLatch({
     session,
-    data: { snapshotQuality: deferredVerdict() },
+    data: {},
+    verdict: deferredVerdict(),
     internalObservation: true,
   });
   expect(internal.warnings).toBeUndefined();
@@ -130,17 +131,23 @@ test('internal observation responses neither consume nor clear the latch', () =>
   session.recoveredSnapshotWarningLatch = { appBundleId: 'com.example.app' };
   applyRecoveredWarningLatch({
     session,
-    data: { snapshotQuality: { state: 'healthy', backend: 'tree' } },
+    data: {},
+    verdict: { state: 'healthy', backend: 'tree' },
     internalObservation: true,
   });
   expect(session.recoveredSnapshotWarningLatch).toEqual({ appBundleId: 'com.example.app' });
 });
 
 test('sessionless responses pass through unchanged', () => {
-  const data = { snapshotQuality: deferredVerdict() };
-  expect(applyRecoveredWarningLatch({ session: undefined, data, internalObservation: false })).toBe(
-    data,
-  );
+  const data = {};
+  expect(
+    applyRecoveredWarningLatch({
+      session: undefined,
+      data,
+      verdict: deferredVerdict(),
+      internalObservation: false,
+    }),
+  ).toBe(data);
 });
 
 function scenario() {
@@ -152,7 +159,7 @@ function scenario() {
   return { sessionStore, sessionName, logPath: path.join(root, 'daemon.log') };
 }
 
-function seedCapture(verdict: SnapshotQualityVerdict) {
+function seedCapture(verdict: SnapshotQualityVerdict, label = 'Continue') {
   dispatchCommandMock.mockResolvedValue({
     backend: 'xctest',
     truncated: false,
@@ -162,7 +169,7 @@ function seedCapture(verdict: SnapshotQualityVerdict) {
         index: 0,
         depth: 0,
         type: 'Button',
-        label: 'Continue',
+        label,
         rect: { x: 0, y: 0, width: 100, height: 44 },
         hittable: true,
       },
@@ -234,6 +241,56 @@ test('a healthy public capture re-arms the one-shot warning', async () => {
   seedCapture(deferredVerdict());
   const rearmed = await dispatchPublicSnapshot(input);
   expect(responseWarnings(rearmed).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+});
+
+test('an empty ref-scoped diff latches on the captured verdict, not the retained snapshot', async () => {
+  const input = scenario();
+  // The stored snapshot is healthy and carries the ref the diff will scope to;
+  // the fresh capture is deferred and contains no node matching that scope, so
+  // the empty scoped result deliberately retains the stored snapshot
+  // (`shouldKeepCurrentSnapshot`) — a seam reading the verdict back from the
+  // session would consult the retained healthy verdict and omit the warning.
+  const session = input.sessionStore.get(input.sessionName)!;
+  session.snapshot = {
+    createdAt: Date.now(),
+    snapshotQuality: { state: 'healthy', backend: 'tree' },
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        ref: 'e1',
+        label: 'Continue',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+  };
+  // The deferred capture holds no node labeled 'Continue', so the '@e1' scope
+  // resolves to zero nodes and the retention path runs.
+  seedCapture(deferredVerdict(), 'Something else');
+
+  const diff = await dispatchSnapshotDiffViaRuntime({
+    req: {
+      command: 'diff',
+      positionals: [],
+      token: 't',
+      session: input.sessionName,
+      flags: { snapshotScope: '@e1' },
+    },
+    sessionName: input.sessionName,
+    logPath: input.logPath,
+    sessionStore: input.sessionStore,
+  });
+
+  // The retention actually happened: the stored snapshot (and its healthy
+  // verdict) survived the empty scoped capture.
+  const retained = input.sessionStore.get(input.sessionName)?.snapshot;
+  expect(retained?.nodes[0]?.label).toBe('Continue');
+  expect(retained?.snapshotQuality?.state).toBe('healthy');
+
+  expect(responseWarnings(diff).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
 });
 
 test('a genuine recovered render keeps later deferred captures quiet without doubling', async () => {

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -1,0 +1,248 @@
+import os from 'node:os';
+import path from 'node:path';
+import { expect, test, vi } from 'vitest';
+import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
+import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import {
+  recoveredSnapshotQualityWarning,
+  renderSnapshotQualityWarnings,
+} from '../../snapshot/snapshot-quality.ts';
+import {
+  applyRecoveredWarningLatch,
+  resolveRecoveredWarningLatch,
+} from '../snapshot-quality-latch.ts';
+import { dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
+import { SessionStore } from '../session-store.ts';
+import type { SessionState } from '../types.ts';
+
+const dispatchCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: dispatchCommandMock,
+  };
+});
+
+const FULL_WARNING = recoveredSnapshotQualityWarning('private-ax');
+
+function deferredVerdict(): SnapshotQualityVerdict {
+  return {
+    state: 'recovered',
+    backend: 'private-ax',
+    reason: 'XCTest-backed snapshot tiers were deferred after recent slow accessibility work',
+    reasonCode: 'deferred',
+  };
+}
+
+function genuineRecoveredVerdict(): SnapshotQualityVerdict {
+  return {
+    state: 'recovered',
+    backend: 'private-ax',
+    reason: 'iOS XCTest snapshot failed while serializing the accessibility tree',
+    reasonCode: 'ax-rejected',
+  };
+}
+
+test('the injected warning is the exact line a genuine recovery renders', () => {
+  // The latch exists to restore the warning an internal arming capture never rendered;
+  // wording drift between the two paths would defeat one-shot deduplication.
+  expect(renderSnapshotQualityWarnings(genuineRecoveredVerdict(), [])).toEqual([FULL_WARNING]);
+});
+
+test('resolveRecoveredWarningLatch transitions', () => {
+  const app = 'com.example.app';
+
+  // First deferred verdict with no latch held: inject once and hold the latch.
+  const first = resolveRecoveredWarningLatch({
+    verdict: deferredVerdict(),
+    appBundleId: app,
+    latch: undefined,
+  });
+  expect(first.warning).toBe(FULL_WARNING);
+  expect(first.latch).toEqual({ appBundleId: app });
+
+  // Held latch: further deferred verdicts stay quiet.
+  const repeat = resolveRecoveredWarningLatch({
+    verdict: deferredVerdict(),
+    appBundleId: app,
+    latch: first.latch,
+  });
+  expect(repeat.warning).toBeUndefined();
+  expect(repeat.latch).toEqual({ appBundleId: app });
+
+  // A genuine recovery renders through the runtime, so it sets the latch silently.
+  const genuine = resolveRecoveredWarningLatch({
+    verdict: genuineRecoveredVerdict(),
+    appBundleId: app,
+    latch: undefined,
+  });
+  expect(genuine.warning).toBeUndefined();
+  expect(genuine.latch).toEqual({ appBundleId: app });
+
+  // Healthy ends the penalty window; the next arming warns again.
+  const healthy = resolveRecoveredWarningLatch({
+    verdict: { state: 'healthy', backend: 'tree' },
+    appBundleId: app,
+    latch: first.latch,
+  });
+  expect(healthy.latch).toBeUndefined();
+
+  // Sparse and verdict-less captures carry no penalty signal either way.
+  const sparse = resolveRecoveredWarningLatch({
+    verdict: { state: 'sparse', backend: 'private-ax' },
+    appBundleId: app,
+    latch: first.latch,
+  });
+  expect(sparse.warning).toBeUndefined();
+  expect(sparse.latch).toEqual({ appBundleId: app });
+  const absent = resolveRecoveredWarningLatch({
+    verdict: undefined,
+    appBundleId: app,
+    latch: first.latch,
+  });
+  expect(absent.warning).toBeUndefined();
+  expect(absent.latch).toEqual({ appBundleId: app });
+
+  // The runner clears its penalty on app switch, so a latch held for another
+  // app never suppresses the new app's first deferred verdict.
+  const switched = resolveRecoveredWarningLatch({
+    verdict: deferredVerdict(),
+    appBundleId: 'com.example.other',
+    latch: first.latch,
+  });
+  expect(switched.warning).toBe(FULL_WARNING);
+  expect(switched.latch).toEqual({ appBundleId: 'com.example.other' });
+});
+
+test('internal observation responses neither consume nor clear the latch', () => {
+  const session = makeIosSession('default', { appBundleId: 'com.example.app' });
+
+  const internal = applyRecoveredWarningLatch({
+    session,
+    data: { snapshotQuality: deferredVerdict() },
+    internalObservation: true,
+  });
+  expect(internal.warnings).toBeUndefined();
+  expect(session.recoveredSnapshotWarningLatch).toBeUndefined();
+
+  session.recoveredSnapshotWarningLatch = { appBundleId: 'com.example.app' };
+  applyRecoveredWarningLatch({
+    session,
+    data: { snapshotQuality: { state: 'healthy', backend: 'tree' } },
+    internalObservation: true,
+  });
+  expect(session.recoveredSnapshotWarningLatch).toEqual({ appBundleId: 'com.example.app' });
+});
+
+test('sessionless responses pass through unchanged', () => {
+  const data = { snapshotQuality: deferredVerdict() };
+  expect(
+    applyRecoveredWarningLatch({ session: undefined, data, internalObservation: false }),
+  ).toBe(data);
+});
+
+function scenario() {
+  const root = path.join(os.tmpdir(), `agent-device-quality-latch-${crypto.randomUUID()}`);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  const session = makeIosSession(sessionName, { appBundleId: 'com.example.app' });
+  sessionStore.set(sessionName, session);
+  return { sessionStore, sessionName, logPath: path.join(root, 'daemon.log') };
+}
+
+function seedCapture(verdict: SnapshotQualityVerdict) {
+  dispatchCommandMock.mockResolvedValue({
+    backend: 'xctest',
+    truncated: false,
+    quality: verdict,
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Continue',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+  });
+}
+
+async function dispatchPublicSnapshot(input: ReturnType<typeof scenario>) {
+  return await dispatchSnapshotViaRuntime({
+    req: { command: 'snapshot', positionals: [], token: 't', session: input.sessionName },
+    sessionName: input.sessionName,
+    logPath: input.logPath,
+    sessionStore: input.sessionStore,
+  });
+}
+
+function responseWarnings(response: Awaited<ReturnType<typeof dispatchSnapshotViaRuntime>>) {
+  if (!response.ok) throw new Error('expected ok response');
+  return (response.data?.warnings ?? []) as string[];
+}
+
+function storedLatch(input: ReturnType<typeof scenario>): SessionState['recoveredSnapshotWarningLatch'] {
+  return input.sessionStore.get(input.sessionName)?.recoveredSnapshotWarningLatch;
+}
+
+test('an internally armed penalty warns once on the first public deferred snapshot', async () => {
+  const input = scenario();
+  seedCapture(deferredVerdict());
+
+  // The internal capture that armed the penalty (settle observation, selector
+  // resolution) rendered nothing; without the latch the deferred suppression
+  // would hide the warning from the user entirely.
+  const internal = await dispatchSnapshotViaRuntime({
+    req: {
+      command: 'snapshot',
+      positionals: [],
+      token: 't',
+      session: input.sessionName,
+      internal: { observationOnly: true },
+    },
+    sessionName: input.sessionName,
+    logPath: input.logPath,
+    sessionStore: input.sessionStore,
+  });
+  expect(responseWarnings(internal)).not.toContain(FULL_WARNING);
+  expect(storedLatch(input)).toBeUndefined();
+
+  const first = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(first).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
+
+  const second = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(second)).not.toContain(FULL_WARNING);
+});
+
+test('a healthy public capture re-arms the one-shot warning', async () => {
+  const input = scenario();
+  seedCapture(deferredVerdict());
+  await dispatchPublicSnapshot(input);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
+
+  seedCapture({ state: 'healthy', backend: 'tree' });
+  const healthy = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(healthy)).not.toContain(FULL_WARNING);
+  expect(storedLatch(input)).toBeUndefined();
+
+  seedCapture(deferredVerdict());
+  const rearmed = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(rearmed).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+});
+
+test('a genuine recovered render keeps later deferred captures quiet without doubling', async () => {
+  const input = scenario();
+  seedCapture(genuineRecoveredVerdict());
+
+  const genuine = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(genuine).filter((line) => line === FULL_WARNING)).toHaveLength(1);
+  expect(storedLatch(input)).toEqual({ appBundleId: 'com.example.app' });
+
+  seedCapture(deferredVerdict());
+  const deferred = await dispatchPublicSnapshot(input);
+  expect(responseWarnings(deferred)).not.toContain(FULL_WARNING);
+});

--- a/src/daemon/snapshot-quality-latch.ts
+++ b/src/daemon/snapshot-quality-latch.ts
@@ -1,0 +1,86 @@
+import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
+import {
+  readSnapshotQualityVerdict,
+  recoveredSnapshotQualityWarning,
+} from '../snapshot/snapshot-quality.ts';
+import type { DaemonResponseData, SessionState } from './types.ts';
+
+type RecoveredWarningLatch = NonNullable<SessionState['recoveredSnapshotWarningLatch']>;
+
+type LatchDecision = {
+  /** Full recovered warning to prepend to the response, when the latch was not held. */
+  warning?: string;
+  latch: RecoveredWarningLatch | undefined;
+};
+
+/**
+ * One-shot warning latch for penalty-deferred captures (PR #1587 follow-up).
+ *
+ * `renderSnapshotQualityWarnings` suppresses the full recovered warning for
+ * `reasonCode: 'deferred'` on the assumption that the capture which ARMED the
+ * XCTest-channel penalty already rendered it. Internal captures (selector
+ * resolution, settle observation loops, system-modal probes) can arm the
+ * penalty without any user-facing render, and the runner cannot tell the two
+ * apart — so the daemon tracks per session whether a recovered warning actually
+ * reached this client for the currently penalized app, and re-renders it once
+ * when it has not.
+ *
+ * Transitions (evaluated only on user-facing snapshot/diff responses):
+ * - genuine `recovered` — the same response already carries the full warning
+ *   (rendered by the runtime), so the latch is set without injecting anything;
+ * - `deferred` with the latch not held for this app — inject the full warning
+ *   once and set the latch;
+ * - `healthy` — the penalty window is over; clear the latch so the next arming
+ *   renders again;
+ * - `sparse` or no verdict — no penalty signal either way; latch unchanged.
+ *
+ * The daemon cannot observe penalty arming directly (a 120s TTL held
+ * runner-side), so "penalty window" is approximated by the verdicts of public
+ * captures: as long as no public capture reports healthy, an unbroken hostile
+ * stretch of the same app warns once.
+ */
+export function resolveRecoveredWarningLatch(params: {
+  verdict: SnapshotQualityVerdict | undefined;
+  appBundleId: string | undefined;
+  latch: RecoveredWarningLatch | undefined;
+}): LatchDecision {
+  const { verdict, appBundleId, latch } = params;
+  if (!verdict) return { latch };
+  if (verdict.state === 'healthy') return { latch: undefined };
+  if (verdict.state !== 'recovered') return { latch };
+  if (verdict.reasonCode !== 'deferred') {
+    return { latch: { appBundleId } };
+  }
+  if (latch !== undefined && latch.appBundleId === appBundleId) return { latch };
+  return { warning: recoveredSnapshotQualityWarning(verdict.backend), latch: { appBundleId } };
+}
+
+/**
+ * Applies the latch to a user-facing snapshot/diff response: updates the
+ * session's latch state and prepends the full recovered warning when this is
+ * the penalty window's first user-facing render. Internal observation captures
+ * (`req.internal.observationOnly`) must pass `internalObservation: true` — they
+ * never reach the user, so they neither consume nor clear the latch.
+ */
+export function applyRecoveredWarningLatch(params: {
+  session: SessionState | undefined;
+  data: DaemonResponseData;
+  internalObservation: boolean;
+}): DaemonResponseData {
+  const { session, data, internalObservation } = params;
+  if (internalObservation || !session) return data;
+  // The snapshot command carries the capture's verdict in the response; diff
+  // publishes only warnings, so its verdict is read from the session snapshot
+  // the capture just stored.
+  const verdict =
+    readSnapshotQualityVerdict(data.snapshotQuality) ?? session.snapshot?.snapshotQuality;
+  const decision = resolveRecoveredWarningLatch({
+    verdict,
+    appBundleId: session.appBundleId,
+    latch: session.recoveredSnapshotWarningLatch,
+  });
+  session.recoveredSnapshotWarningLatch = decision.latch;
+  if (!decision.warning) return data;
+  const warnings = Array.isArray(data.warnings) ? data.warnings : [];
+  return { ...data, warnings: [decision.warning, ...warnings] };
+}

--- a/src/daemon/snapshot-quality-latch.ts
+++ b/src/daemon/snapshot-quality-latch.ts
@@ -1,8 +1,5 @@
 import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
-import {
-  readSnapshotQualityVerdict,
-  recoveredSnapshotQualityWarning,
-} from '../snapshot/snapshot-quality.ts';
+import { recoveredSnapshotQualityWarning } from '../snapshot/snapshot-quality.ts';
 import type { DaemonResponseData, SessionState } from './types.ts';
 
 type RecoveredWarningLatch = NonNullable<SessionState['recoveredSnapshotWarningLatch']>;
@@ -56,6 +53,16 @@ export function resolveRecoveredWarningLatch(params: {
 }
 
 /**
+ * The verdict slot the daemon snapshot backend fills on every capture, so the
+ * latch seam sees the verdict of THE capture that produced this response.
+ * Reading it back from `session.snapshot` instead would be wrong: an empty
+ * ref-scoped capture deliberately retains the previous stored snapshot
+ * (`shouldKeepCurrentSnapshot`), so a deferred capture could consult a retained
+ * healthy verdict — clearing the latch and omitting the one-shot warning.
+ */
+export type CapturedSnapshotQuality = { value?: SnapshotQualityVerdict };
+
+/**
  * Applies the latch to a user-facing snapshot/diff response: updates the
  * session's latch state and prepends the full recovered warning when this is
  * the penalty window's first user-facing render. Internal observation captures
@@ -65,15 +72,12 @@ export function resolveRecoveredWarningLatch(params: {
 export function applyRecoveredWarningLatch(params: {
   session: SessionState | undefined;
   data: DaemonResponseData;
+  /** The just-captured verdict (`CapturedSnapshotQuality`), never a stored one. */
+  verdict: SnapshotQualityVerdict | undefined;
   internalObservation: boolean;
 }): DaemonResponseData {
-  const { session, data, internalObservation } = params;
+  const { session, data, verdict, internalObservation } = params;
   if (internalObservation || !session) return data;
-  // The snapshot command carries the capture's verdict in the response; diff
-  // publishes only warnings, so its verdict is read from the session snapshot
-  // the capture just stored.
-  const verdict =
-    readSnapshotQualityVerdict(data.snapshotQuality) ?? session.snapshot?.snapshotQuality;
   const decision = resolveRecoveredWarningLatch({
     verdict,
     appBundleId: session.appBundleId,

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -18,7 +18,10 @@ import {
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
 import { activateCompleteRefFrame } from './ref-frame.ts';
-import { applyRecoveredWarningLatch } from './snapshot-quality-latch.ts';
+import {
+  applyRecoveredWarningLatch,
+  type CapturedSnapshotQuality,
+} from './snapshot-quality-latch.ts';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 import { isInteractiveObservation } from './session-action-recorder.ts';
@@ -145,6 +148,7 @@ async function dispatchSnapshotRuntimeCommand(
   if (iosAppSessionGuard) return iosAppSessionGuard;
 
   return await withSessionlessRunnerCleanup(session, device, async () => {
+    const capturedQuality: CapturedSnapshotQuality = {};
     const runtime = createSnapshotRuntime({
       req,
       sessionName,
@@ -153,6 +157,7 @@ async function dispatchSnapshotRuntimeCommand(
       session,
       device,
       snapshotScope: resolvedScope.scope,
+      capturedQuality,
     });
     let result: Awaited<ReturnType<SnapshotRuntimeCommandParams['execute']>>;
     try {
@@ -184,6 +189,7 @@ async function dispatchSnapshotRuntimeCommand(
       data: applyRecoveredWarningLatch({
         session: sessionStore.get(sessionName),
         data: result.data,
+        verdict: capturedQuality.value,
         internalObservation: req.internal?.observationOnly === true,
       }),
     };
@@ -212,6 +218,7 @@ function createSnapshotRuntime(params: {
   session: SessionState | undefined;
   device: SessionState['device'];
   snapshotScope: string | undefined;
+  capturedQuality: CapturedSnapshotQuality;
 }) {
   const { req, sessionName, logPath, sessionStore, session, device, snapshotScope } = params;
   return createAgentDevice({
@@ -221,6 +228,7 @@ function createSnapshotRuntime(params: {
       session,
       device,
       snapshotScope,
+      capturedQuality: params.capturedQuality,
     }),
     ...createDaemonRuntimePolicy('snapshot'),
     sessions: createDaemonRuntimeSessionStore({
@@ -328,6 +336,7 @@ function createDaemonSnapshotBackend(params: {
   session: SessionState | undefined;
   device: SessionState['device'];
   snapshotScope: string | undefined;
+  capturedQuality: CapturedSnapshotQuality;
 }): AgentDeviceBackend {
   const { req, logPath, session, device, snapshotScope } = params;
   return {
@@ -341,10 +350,15 @@ function createDaemonSnapshotBackend(params: {
         logPath,
         snapshotScope,
       });
+      const annotations = snapshotCaptureAnnotationsFrom(capture);
+      // Feed the latch seam the capture's own verdict: the stored session
+      // snapshot is not a substitute (an empty ref-scoped capture retains the
+      // previous snapshot, and diff never publishes the verdict).
+      params.capturedQuality.value = annotations.quality;
       const snapshotDiagnostics = summarizeSnapshotDiagnostics(session);
       return {
         snapshot: capture.snapshot,
-        ...snapshotCaptureAnnotationsFrom(capture),
+        ...annotations,
         ...(snapshotDiagnostics ? { snapshotDiagnostics } : {}),
         appName: session?.appBundleId ? (session.appName ?? session.appBundleId) : undefined,
         appBundleId: session?.appBundleId,

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -18,6 +18,7 @@ import {
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
 import { activateCompleteRefFrame } from './ref-frame.ts';
+import { applyRecoveredWarningLatch } from './snapshot-quality-latch.ts';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 import { isInteractiveObservation } from './session-action-recorder.ts';
@@ -180,7 +181,11 @@ async function dispatchSnapshotRuntimeCommand(
     });
     return {
       ok: true,
-      data: result.data,
+      data: applyRecoveredWarningLatch({
+        session: sessionStore.get(sessionName),
+        data: result.data,
+        internalObservation: req.internal?.observationOnly === true,
+      }),
     };
   });
 }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -319,6 +319,18 @@ export type SessionState = {
    * probabilistic (seeded), NOT identity-based.
    */
   snapshotGeneration?: number;
+  /**
+   * One-shot latch: the full "overly complex or slow accessibility tree" warning has been
+   * rendered to this session's client for the app currently under the XCTest-channel
+   * penalty. Penalty-deferred verdicts (`reasonCode: 'deferred'`) suppress the repeated
+   * warning in `renderSnapshotQualityWarnings`, but internal captures (selector
+   * resolution, settle observation, system-modal probes) can arm the runner-side penalty
+   * without any user-facing render — when the latch is not held, the first public
+   * deferred verdict re-renders the warning once. Managed only through
+   * `src/daemon/snapshot-quality-latch.ts`: a genuine recovered render sets it, a healthy
+   * public verdict clears it, and an app switch supersedes it.
+   */
+  recoveredSnapshotWarningLatch?: { appBundleId?: string };
   /** Source snapshot used to resolve repeated `snapshot -s @ref` after scoped output replaces refs. */
   snapshotScopeSource?: SnapshotState;
   /**

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -79,14 +79,25 @@ export function renderSnapshotQualityWarnings(
   ];
 }
 
+/**
+ * The full recovered-state warning line. Shared with the daemon's one-shot deferred
+ * latch (`src/daemon/snapshot-quality-latch.ts`), which re-renders it exactly once when
+ * the penalty was armed by an internal capture that never reached the user.
+ */
+export function recoveredSnapshotQualityWarning(
+  backend: SnapshotQualityVerdict['backend'],
+): string {
+  return `Detected an overly complex or slow accessibility tree. Fell back to the ${backend} snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`;
+}
+
 function stateWarning(verdict: SnapshotQualityVerdict): string[] {
   if (verdict.state === 'recovered') {
-    // Penalty-deferred captures repeat on every capture of a hostile screen; the capture that
-    // ARMED the penalty already carried the full warning, so repeating it is pure noise.
+    // Penalty-deferred captures repeat on every capture of a hostile screen, so the full
+    // warning is suppressed here. When the capture that ARMED the penalty was internal
+    // (selector resolution, settle observation, system-modal probe) and never rendered it,
+    // the daemon's session latch re-renders the warning once at the response seam.
     if (verdict.reasonCode === 'deferred') return [];
-    return [
-      `Detected an overly complex or slow accessibility tree. Fell back to the ${verdict.backend} snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`,
-    ];
+    return [recoveredSnapshotQualityWarning(verdict.backend)];
   }
   if (verdict.state === 'sparse') {
     return [


### PR DESCRIPTION
## What

Follow-up hardening from the [#1587 review](https://github.com/callstack/agent-device/pull/1587#issuecomment-5180203834) — rebased onto main after #1587 merged..

The deferred-capture warning suppression assumes the capture that armed the XCTest-channel penalty already rendered the full "Detected an overly complex or slow accessibility tree…" warning. Internal captures — selector resolution, settle observation loops (`updateSession: false`), system-modal probes — can arm the penalty without any user-facing render, so the next public snapshot exposed only the structured verdict with no CLI warning line.

The runner cannot distinguish user-facing from internal captures, so the latch is daemon-side session state (`SessionState.recoveredSnapshotWarningLatch`), applied at the snapshot/diff response seam (`dispatchSnapshotRuntimeCommand`) — the only place quality warnings actually reach a client:

- a **genuine `recovered`** render sets the latch silently (the same response already carries the full warning from the runtime);
- the first public **`deferred`** verdict without the latch re-renders the full warning once (prepended, so line order matches a genuine render) and sets the latch;
- a **`healthy`** public verdict clears it — the penalty window is over, the next arming warns again;
- an **app switch** supersedes it: the latch stores the `appBundleId`, mirroring the runner's process-scoped penalty, so a latch held for app A never suppresses app B's first deferred verdict;
- **`sparse`/verdict-less** captures leave it untouched;
- **internal observation** responses (`req.internal.observationOnly`) neither consume nor clear it.

The daemon cannot observe penalty arming directly (a 120s TTL held runner-side), so the "penalty window" is approximated by public-capture verdicts: as long as no public capture reports healthy, an unbroken hostile stretch of the same app warns exactly once. The full warning line is extracted as `recoveredSnapshotQualityWarning()` so the runtime render and the daemon injection share one wording (pinned by a test).

No runner/Swift changes; the `deferred` wire contract is unchanged.

## Tests

7 new tests in `src/daemon/__tests__/snapshot-quality-latch.test.ts`: pure transition coverage plus 3 integration tests through `dispatchSnapshotViaRuntime` (mocked `dispatchCommand`) covering the review's exact scenario — internal capture arms, first public deferred snapshot warns once, second stays quiet, healthy re-arms.

### Red evidence (seam wiring reverted, latch module kept)

```
× an internally armed penalty warns once on the first public deferred snapshot
× a healthy public capture re-arms the one-shot warning
× a genuine recovered render keeps later deferred captures quiet without doubling
```

Typecheck, lint, and the neighboring suites (snapshot-quality, internal-observation, session-snapshot, response-views, settle) are green.
