### PR TITLE
fix(ios): stop shipping runner unit tests in the npm package

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+LifecycleCacheTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+LifecycleCacheTests.swift
@@ -58,6 +58,7 @@ extension RunnerTests {
   }
 #endif
 
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
   func testCachedTargetRefreshRequiresChangedPositiveProcessIdentity() {
     XCTAssertFalse(
       Self.shouldRefreshCachedTarget(
@@ -125,4 +126,5 @@ extension RunnerTests {
     XCTAssertFalse(snapshotXCTestPenaltyWarmupExemptionPending)
     XCTAssertTrue(needsFirstInteractionDelay)
   }
+#endif
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotTraversalIdentityTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotTraversalIdentityTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 extension RunnerTests {
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
   func testSnapshotTraversalIdentityPreservesSameOriginNodesWithDifferentBounds() {
     let wrapper = Self.snapshotTraversalIdentity(
       elementType: .other,
@@ -21,4 +22,5 @@ extension RunnerTests {
     XCTAssertEqual(wrapper, leaf)
     #endif
   }
+#endif
 }

--- a/scripts/package-apple-runner-source.mjs
+++ b/scripts/package-apple-runner-source.mjs
@@ -16,6 +16,16 @@ const LEGACY_OUTPUT_DIRS = [
 ];
 const SKIPPED_DIR_NAMES = new Set(['.build', '.swiftpm', 'xcuserdata']);
 const SKIPPED_ROOT_FILES = new Set(['README.md', 'RUNNER_PROTOCOL.md']);
+// XCTest discovers instance methods named test*; anything matching this that survives stripping
+// would ship to (and compile on) every user's machine. Only the runner's command-loop entrypoint
+// is a legitimate test method in the packaged source.
+const SHIPPED_TEST_METHOD_ALLOWLIST = new Map([
+  [
+    path.join('AgentDeviceRunner', 'AgentDeviceRunnerUITests', 'RunnerTests.swift'),
+    new Set(['testCommand']),
+  ],
+]);
+const TEST_METHOD_PATTERN = /^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:\w+\s+)*func\s+(test\w*)\s*\(/;
 
 function packageAppleRunnerSource(options = {}) {
   const root = path.resolve(options.root ?? process.cwd());
@@ -106,11 +116,11 @@ function copyDirectoryEntry(entry, sourceDir, outputDir, relativeDir, summary) {
     return;
   }
   if (entry.isFile()) {
-    copyFile(sourcePath, outputPath, summary);
+    copyFile(sourcePath, outputPath, relativePath, summary);
   }
 }
 
-function copyFile(sourcePath, outputPath, summary) {
+function copyFile(sourcePath, outputPath, relativePath, summary) {
   if (path.extname(sourcePath) !== '.swift') {
     fs.copyFileSync(sourcePath, outputPath);
     summary.copiedFiles += 1;
@@ -119,11 +129,26 @@ function copyFile(sourcePath, outputPath, summary) {
 
   const source = fs.readFileSync(sourcePath, 'utf8');
   const stripped = stripRunnerUnitTestBlocks(source, sourcePath);
+  assertNoShippedTestMethods(stripped.contents, relativePath);
   fs.writeFileSync(outputPath, stripped.contents);
   summary.copiedFiles += 1;
   if (stripped.strippedBlocks > 0) {
     summary.strippedFiles += 1;
     summary.strippedBlocks += stripped.strippedBlocks;
+  }
+}
+
+function assertNoShippedTestMethods(strippedContents, relativePath) {
+  const allowedMethods = SHIPPED_TEST_METHOD_ALLOWLIST.get(relativePath) ?? new Set();
+  const shippedMethods = strippedContents
+    .split('\n')
+    .map((line) => TEST_METHOD_PATTERN.exec(line)?.[1])
+    .filter((method) => method !== undefined && !allowedMethods.has(method));
+  if (shippedMethods.length > 0) {
+    throw new Error(
+      `Unit test ${shippedMethods[0]}() in ${relativePath} would ship in the npm package; ` +
+        `wrap it in #if ${UNIT_TEST_CONDITION}.`,
+    );
   }
 }
 

--- a/src/__tests__/apple-runner-package-source.test.ts
+++ b/src/__tests__/apple-runner-package-source.test.ts
@@ -16,39 +16,7 @@ const runnerSnapshotSwiftPath = path.join(
 test('package apple runner source strips unit-test blocks without mutating checkout source', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-package-'));
   onTestFinished(() => fs.rmSync(root, { recursive: true, force: true }));
-
-  writeFixtureFile(root, 'apple/runner/README.md', 'developer docs\n');
-  writeFixtureFile(root, 'apple/runner/.build/cache.txt', 'cache\n');
-  writeFixtureFile(
-    root,
-    'apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj/project.pbxproj',
-    '',
-  );
-  writeFixtureFile(
-    root,
-    'apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj/xcuserdata/user.xcuserstate',
-    'state\n',
-  );
-  writeFixtureFile(
-    root,
-    'apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Feature.swift',
-    [
-      'extension RunnerTests {',
-      '  func runtimeHelper() {}',
-      '#if AGENT_DEVICE_RUNNER_UNIT_TESTS',
-      '  func unitOnlyHelper() {',
-      '    #if os(iOS)',
-      '    print("nested platform guard should disappear with the unit-test block")',
-      '    #endif',
-      '  }',
-      '#endif',
-      '  #if os(macOS)',
-      '  func macOnlyRuntimeHelper() {}',
-      '  #endif',
-      '}',
-      '',
-    ].join('\n'),
-  );
+  writeStripFixtureTree(root);
 
   await runCmd(process.execPath, [packageScript, '--root', root, '--quiet']);
 
@@ -84,6 +52,65 @@ test('package apple runner source strips unit-test blocks without mutating check
     ),
     false,
   );
+});
+
+test('package apple runner source rejects unit tests that would ship un-stripped', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-package-testgate-'));
+  onTestFinished(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Feature.swift',
+    [
+      'extension RunnerTests {',
+      '#if AGENT_DEVICE_RUNNER_UNIT_TESTS',
+      '  func testWrappedIsFine() {}',
+      '#endif',
+      '  func testLeaksIntoPackage() {}',
+      '}',
+      '',
+    ].join('\n'),
+  );
+
+  const result = await runCmd(process.execPath, [packageScript, '--root', root, '--quiet'], {
+    allowFailure: true,
+  });
+
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /testLeaksIntoPackage/);
+  assert.match(result.stderr, /AGENT_DEVICE_RUNNER_UNIT_TESTS/);
+});
+
+test('package apple runner source allows only the runner entrypoint test method', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-package-entry-'));
+  onTestFinished(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift',
+    ['final class RunnerTests: XCTestCase {', '  func testCommand() throws {}', '}', ''].join('\n'),
+  );
+
+  const allowed = await runCmd(process.execPath, [packageScript, '--root', root, '--quiet']);
+  assert.equal(allowed.exitCode, 0);
+
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift',
+    [
+      'final class RunnerTests: XCTestCase {',
+      '  func testCommand() throws {}',
+      '  func testExtraEntrypoint() {}',
+      '}',
+      '',
+    ].join('\n'),
+  );
+
+  const rejected = await runCmd(process.execPath, [packageScript, '--root', root, '--quiet'], {
+    allowFailure: true,
+  });
+  assert.notEqual(rejected.exitCode, 0);
+  assert.match(rejected.stderr, /testExtraEntrypoint/);
 });
 
 test('package apple runner source removes legacy dist/apple-runner output before shipping', async () => {
@@ -124,6 +151,41 @@ test('apple runner tree snapshot capture stays on the main queue', () => {
   assert.match(boundedCapture, /runMainThreadWork/);
   assert.match(boundedCapture, /captureSnapshotRoot\(element\)/);
 });
+
+function writeStripFixtureTree(root: string): void {
+  writeFixtureFile(root, 'apple/runner/README.md', 'developer docs\n');
+  writeFixtureFile(root, 'apple/runner/.build/cache.txt', 'cache\n');
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj/project.pbxproj',
+    '',
+  );
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj/xcuserdata/user.xcuserstate',
+    'state\n',
+  );
+  writeFixtureFile(
+    root,
+    'apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Feature.swift',
+    [
+      'extension RunnerTests {',
+      '  func runtimeHelper() {}',
+      '#if AGENT_DEVICE_RUNNER_UNIT_TESTS',
+      '  func unitOnlyHelper() {',
+      '    #if os(iOS)',
+      '    print("nested platform guard should disappear with the unit-test block")',
+      '    #endif',
+      '  }',
+      '#endif',
+      '  #if os(macOS)',
+      '  func macOnlyRuntimeHelper() {}',
+      '  #endif',
+      '}',
+      '',
+    ].join('\n'),
+  );
+}
 
 function writeFixtureFile(root: string, relativePath: string, contents: string): void {
   const filePath = path.join(root, relativePath);


### PR DESCRIPTION
## Why

The Apple runner ships as **source** in `dist/apple/runner` (~431 kB, ~16% of npm unpacked) and is compiled by xcodebuild on the user's machine. Packaging strips `#if AGENT_DEVICE_RUNNER_UNIT_TESTS` blocks — but unit tests written **outside** such blocks ship whole and compile on every user's first build. Nothing enforced the wrapping convention, so every runner PR could quietly leak its tests into the package (e.g. #1588's new `RunnerTests+TextEntryPolicyTests.swift` would ship un-stripped today).

## What

- **Wrap the two existing strays**: 5 tests in `RunnerTests+LifecycleCacheTests.swift` and 1 in `RunnerTests+SnapshotTraversalIdentityTests.swift` sat outside any conditional (the first file wraps *some* tests, which is how these slipped by).
- **Close the class, not the instance**: `package-apple-runner-source.mjs` now fails if any XCTest-shaped method (`func test*`) survives stripping. Sole allowlisted exception: the runner's command-loop entrypoint `testCommand` in `RunnerTests.swift`. The script runs in `prepack` and the size-report CI, so a leak now fails packaging with a message pointing at the fix (`wrap it in #if AGENT_DEVICE_RUNNER_UNIT_TESTS`).
- Vitest coverage for the gate: unwrapped test → packaging fails; wrapped test and the entrypoint → passes; extra entrypoint-file test method → fails.

No pbxproj changes needed — the project uses file-system-synchronized groups.

## Verification

- `pnpm build:xcuitest:ios` succeeds both without and with `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1` (shipped config and CI unit lane).
- The three wrapped tests that CI's targeted regression list exercises pass on an iOS 26.2 simulator via `test-without-building` (3/3; CI builds with the flag on, so its `-only-testing` list is unaffected).
- Repackaged tree: only `testCommand` remains discoverable; shipped runner source 430.9 → 428.3 kB.
- `pnpm check:affected --run` green; packaging vitest suite 5/5.

## Note for #1588

Once this merges, #1588 will need its new `RunnerTests+TextEntryPolicyTests.swift` wrapped in `#if AGENT_DEVICE_RUNNER_UNIT_TESTS` — the gate will fail packaging otherwise (that's it working as intended).