### PR TITLE
fix(daemon): surface proven no-effect gestures to the agent

### DIFF
--- a/src/daemon/__tests__/post-gesture-stabilization-fixtures.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization-fixtures.ts
@@ -62,6 +62,45 @@ export function pickupSnapshotWithExtraText(y = 500) {
   };
 }
 
+/**
+ * Fixed tab-bar chrome + a list whose visible cells sit at stable row rects.
+ * Two captures with DIFFERENT cell ids model a successful scroll that
+ * replaced every list row while the chrome (a discriminating, shared,
+ * unmoved entry) stayed put: `classifyBaselineSurfaceEvidence` reads
+ * 'unchanged' from the shared chrome alone (#1601 review P1) — the exact
+ * accept-stale false negative that must never surface as an agent-facing
+ * no-effect claim.
+ */
+export function chromeWithListSnapshot(cellIds: [string, string]) {
+  return makeSnapshotState([
+    { index: 0, type: 'Application', label: 'App', rect: { x: 0, y: 0, width: 390, height: 844 } },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'Button',
+      identifier: 'tab-home',
+      label: 'Home',
+      rect: { x: 0, y: 800, width: 195, height: 44 },
+    },
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'Cell',
+      identifier: cellIds[0],
+      label: cellIds[0],
+      rect: { x: 0, y: 100, width: 390, height: 60 },
+    },
+    {
+      index: 3,
+      parentIndex: 0,
+      type: 'Cell',
+      identifier: cellIds[1],
+      label: cellIds[1],
+      rect: { x: 0, y: 160, width: 390, height: 60 },
+    },
+  ]);
+}
+
 export function applicationRootNode() {
   return {
     ref: 'e-root',

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -5,6 +5,7 @@ import { countDiagnosticEventsByPhase, withDiagnosticsScope } from '../../utils/
 import { buildInteractionSurfaceSignature } from '../interaction-outcome-policy.ts';
 import {
   capturePostGestureStabilizedResult,
+  formatGestureNoEffectWarning,
   markPostGestureStabilization,
 } from '../post-gesture-stabilization.ts';
 import {
@@ -143,14 +144,30 @@ test('capturePostGestureStabilizedResult keeps polling past the normal deadline 
   });
 
   await vi.advanceTimersByTimeAsync(10_000);
-  const { staleAccepts, settled } = await resultPromise;
+  const { result, staleAccepts, settled } = await resultPromise;
 
   assert.equal(staleAccepts, 1);
   assert.equal(settled, 0);
   assert.equal(session.postGestureStabilization, undefined);
+  // #1600: a stale-accept is the daemon PROVING the gesture moved nothing —
+  // that verdict must reach the caller, not only the diagnostics stream.
+  assert.equal(result.gestureNoEffect?.action, 'scroll');
   // Proves it kept polling well past the OLD 1.5s accept point (2 attempts,
   // ~200ms) instead of trusting the first quiet match.
   assert.ok(captureCount > 8, `expected sustained polling, saw ${captureCount} captures`);
+});
+
+test('formatGestureNoEffectWarning names the gesture and the raw-drag escape hatch', () => {
+  const scrollWarning = formatGestureNoEffectWarning('scroll', ['down', '1']);
+  assert.match(scrollWarning, /scroll down produced no visible change/);
+  assert.match(scrollWarning, /swipe x1 y1 x2 y2/);
+  assert.match(scrollWarning, /already at its edge/);
+
+  const gestureWarning = formatGestureNoEffectWarning('gesture', ['swipe', 'left']);
+  assert.match(gestureWarning, /gesture swipe left produced no visible change/);
+
+  const bareWarning = formatGestureNoEffectWarning('swipe', []);
+  assert.match(bareWarning, /swipe produced no visible change/);
 });
 
 test('capturePostGestureStabilizedResult trusts a quiet signature once content genuinely differs from the baseline (iOS)', async () => {
@@ -175,10 +192,12 @@ test('capturePostGestureStabilizedResult trusts a quiet signature once content g
   });
 
   await vi.advanceTimersByTimeAsync(1_000);
-  const { staleAccepts, settled } = await resultPromise;
+  const { result, staleAccepts, settled } = await resultPromise;
 
   assert.equal(settled, 1);
   assert.equal(staleAccepts, 0);
+  // A genuine settle carries no no-effect claim.
+  assert.equal(result.gestureNoEffect, undefined);
   // Accepted at the first quiet match (initial capture + one poll = 2
   // attempts): no distrust cost for a genuine settle.
   assert.equal(capture.mock.calls.length, 2);

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -9,6 +9,7 @@ import {
   markPostGestureStabilization,
 } from '../post-gesture-stabilization.ts';
 import {
+  chromeWithListSnapshot,
   deliverySnapshot,
   keyboardWindowNodes,
   makeSession,
@@ -155,6 +156,38 @@ test('capturePostGestureStabilizedResult keeps polling past the normal deadline 
   // Proves it kept polling well past the OLD 1.5s accept point (2 attempts,
   // ~200ms) instead of trusting the first quiet match.
   assert.ok(captureCount > 8, `expected sustained polling, saw ${captureCount} captures`);
+});
+
+test('a replaced list under fixed chrome accepts stale but never claims no-effect (#1601 P1)', async () => {
+  // The reviewer's counterexample: a SUCCESSFUL scroll swapped every list
+  // cell while the tab-bar chrome (discriminating, shared, unmoved) kept the
+  // subset-tolerant classifier at 'unchanged'. The loop may still accept the
+  // stale read — but the agent-facing no-effect claim must be vetoed by the
+  // unmatched discriminating cells on both sides.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = chromeWithListSnapshot(['row-1', 'row-2']);
+  markPostGestureStabilization(session, 'scroll');
+
+  const capture = vi.fn(async () => chromeWithListSnapshot(['row-3', 'row-4']));
+
+  const resultPromise = withDiagnosticsScope({}, async () => {
+    const result = await capturePostGestureStabilizedResult({
+      session,
+      capture,
+      readSnapshot: (snapshot) => snapshot,
+    });
+    return {
+      result,
+      staleAccepts: countDiagnosticEventsByPhase(['post_gesture_snapshot_stale_accept']),
+    };
+  });
+
+  await vi.advanceTimersByTimeAsync(10_000);
+  const { result, staleAccepts } = await resultPromise;
+
+  assert.equal(staleAccepts, 1);
+  assert.equal(result.gestureNoEffect, undefined);
 });
 
 test('formatGestureNoEffectWarning names the gesture and the raw-drag escape hatch', () => {

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -45,7 +45,10 @@ import {
   getActivePendingInteractionOutcome,
   retryPendingInteractionOutcome,
 } from '../interaction-outcome-policy.ts';
-import { capturePostGestureStabilizedResult } from '../post-gesture-stabilization.ts';
+import {
+  capturePostGestureStabilizedResult,
+  formatGestureNoEffectWarning,
+} from '../post-gesture-stabilization.ts';
 import { presentIosInteractiveSnapshot } from '../snapshot-presentation/ios/index.ts';
 import type { SessionState } from '../types.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
@@ -153,12 +156,13 @@ async function captureInteractionOutcomeAwareSnapshot(
   }
 
   clearPendingInteractionOutcome(session);
-  latest = await capturePostGestureStabilizedResult({
+  const stabilized = await capturePostGestureStabilizedResult({
     session,
     initial: latest,
     capture: async () => await capturePostActionSnapshotAttempt(params),
     readSnapshot: (attempt) => attempt.snapshot,
   });
+  latest = stabilized.value;
   if (outcome.change !== 'ambiguous' && latest.annotations.freshness?.staleAfterRetries !== true) {
     clearAndroidSnapshotFreshness(session);
   }
@@ -175,7 +179,7 @@ async function captureInteractionOutcomeAwareSnapshot(
 
   return {
     snapshot: latest.snapshot,
-    ...latest.annotations,
+    ...withGestureNoEffectWarning(latest.annotations, stabilized.gestureNoEffect),
   };
 }
 
@@ -288,14 +292,35 @@ async function captureAndroidFreshnessAwareAttempt(
 async function capturePostGestureAwareSnapshot(
   params: CaptureSnapshotParams & { session: SessionState },
 ): Promise<CaptureSnapshotResult> {
-  const latest = await capturePostGestureStabilizedResult({
+  const stabilized = await capturePostGestureStabilizedResult({
     session: params.session,
     capture: async () => await capturePostActionSnapshotAttempt(params),
     readSnapshot: (attempt) => attempt.snapshot,
   });
+  const latest = stabilized.value;
   return {
     snapshot: latest.snapshot,
-    ...latest.annotations,
+    ...withGestureNoEffectWarning(latest.annotations, stabilized.gestureNoEffect),
+  };
+}
+
+/**
+ * #1600: a proven no-effect gesture must reach the agent inside the very
+ * response it reads next, not only the diagnostics stream. Warnings ride the
+ * existing annotations channel so every renderer that already prints capture
+ * warnings picks this up with no new plumbing.
+ */
+function withGestureNoEffectWarning(
+  annotations: SnapshotCaptureAnnotations,
+  gestureNoEffect: { action: string; positionals: string[] } | undefined,
+): SnapshotCaptureAnnotations {
+  if (!gestureNoEffect) return annotations;
+  return {
+    ...annotations,
+    warnings: [
+      ...(annotations.warnings ?? []),
+      formatGestureNoEffectWarning(gestureNoEffect.action, gestureNoEffect.positionals),
+    ],
   };
 }
 

--- a/src/daemon/interaction-outcome-policy.ts
+++ b/src/daemon/interaction-outcome-policy.ts
@@ -251,6 +251,44 @@ export function classifyBaselineSurfaceEvidence(
   return discriminatingOverlap > 0 ? 'unchanged' : 'ambiguous';
 }
 
+/**
+ * Full-surface agreement over DISCRIMINATING entries, in BOTH directions —
+ * the stronger bar an agent-facing no-effect claim needs (#1601 review P1).
+ *
+ * `classifyBaselineSurfaceEvidence` is deliberately subset-tolerant for the
+ * distrust loop, where a false 'unchanged' only buys extra polling. But a
+ * fixed-chrome screen whose list cells were fully replaced by a SUCCESSFUL
+ * scroll classifies 'unchanged' on the shared chrome alone — new cells are
+ * absent from the baseline and silently ignored. Requiring the discriminating
+ * entry sets to match exactly (same keys both ways, every rect within
+ * tolerance) vetoes that shape: any appeared or vanished real element kills
+ * the claim. Scope drift between baseline and capture vetoes too — silence
+ * is the safe failure mode for a message that steers the agent's next move.
+ */
+export function haveIdenticalDiscriminatingSurfaces(
+  left: InteractionSurfaceSignature,
+  right: InteractionSurfaceSignature,
+): boolean {
+  const leftEntries = left.filter((entry) => entry.discriminating);
+  const rightEntries = right.filter((entry) => entry.discriminating);
+  if (leftEntries.length === 0 || leftEntries.length !== rightEntries.length) return false;
+  // Keys carry an occurrence ordinal (`|#N`), so a map by key is lossless.
+  const rightByKey = new Map(rightEntries.map((entry) => [entry.key, entry]));
+  for (const entry of leftEntries) {
+    const other = rightByKey.get(entry.key);
+    if (!other) return false;
+    if (
+      Math.abs(entry.x - other.x) > RECT_TOLERANCE_PX ||
+      Math.abs(entry.y - other.y) > RECT_TOLERANCE_PX ||
+      Math.abs(entry.width - other.width) > RECT_TOLERANCE_PX ||
+      Math.abs(entry.height - other.height) > RECT_TOLERANCE_PX
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function supportsInteractionOutcomePolicy(session: SessionState): boolean {
   return isMobilePlatform(session.device);
 }

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -207,18 +207,7 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       }
       clearPostGestureStabilization(session);
       emitPostGestureSettleDiagnostic(verdict, pending.action, attempts, elapsedMs);
-      return {
-        value: current.value,
-        ...(verdict === 'accept-stale' &&
-        haveIdenticalDiscriminatingSurfaces(pending.baselineSignature ?? [], current.signature)
-          ? {
-              gestureNoEffect: {
-                action: pending.action,
-                positionals: pending.positionals ?? [],
-              },
-            }
-          : {}),
-      };
+      return buildAcceptedStabilizedResult(verdict, pending, current);
     }
     previous = current;
   }
@@ -252,6 +241,30 @@ export function formatGestureNoEffectWarning(action: string, positionals: string
     'Either the container is already at its edge, or it ignores synthesized scrolls — ' +
     'a raw drag moves such lists: swipe x1 y1 x2 y2 (start inside the list).'
   );
+}
+
+/**
+ * The no-effect claim needs BOTH the accept-stale verdict AND full-surface
+ * corroboration (`haveIdenticalDiscriminatingSurfaces`): the verdict alone is
+ * subset-tolerant, and a successful scroll that replaced every list cell
+ * under fixed chrome still reads accept-stale (#1601 review P1).
+ */
+function buildAcceptedStabilizedResult<T>(
+  verdict: 'trust' | 'accept-stale',
+  pending: NonNullable<SessionState['postGestureStabilization']>,
+  current: CapturedSurface<T>,
+): PostGestureStabilizedResult<T> {
+  const corroborated =
+    verdict === 'accept-stale' &&
+    haveIdenticalDiscriminatingSurfaces(pending.baselineSignature ?? [], current.signature);
+  if (!corroborated) return { value: current.value };
+  return {
+    value: current.value,
+    gestureNoEffect: {
+      action: pending.action,
+      positionals: pending.positionals ?? [],
+    },
+  };
 }
 
 function isPostGestureStabilizingAction(

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -41,6 +41,7 @@ export function markPostGestureStabilization(
   if (!isPostGestureStabilizingAction(action, positionals, flags)) return;
   session.postGestureStabilization = {
     action,
+    positionals,
     markedAt: Date.now(),
     // No extra capture: `session.snapshot` is still whatever was captured
     // before this gesture dispatched (this call happens post-dispatch,
@@ -150,16 +151,27 @@ function emitPostGestureSettleDiagnostic(
   });
 }
 
+export type PostGestureStabilizedResult<T> = {
+  value: T;
+  /**
+   * Present when the loop accepted a stale read: the quiet capture PROVABLY
+   * still equals the pre-gesture baseline after the distrust cap (#1600).
+   * Callers surface this to the agent — a diagnostics-only verdict let one
+   * benchmark run burn 40 calls re-issuing scrolls the daemon knew did nothing.
+   */
+  gestureNoEffect?: { action: string; positionals: string[] };
+};
+
 export async function capturePostGestureStabilizedResult<T>(params: {
   session: SessionState | undefined;
   capture: () => Promise<T>;
   readSnapshot: (result: T) => SnapshotState;
   initial?: T;
-}): Promise<T> {
+}): Promise<PostGestureStabilizedResult<T>> {
   const { session, capture, readSnapshot } = params;
   const pending = session?.postGestureStabilization;
   if (!session || !supportsPostGestureStabilization(session.device) || !pending) {
-    return params.initial ?? (await capture());
+    return { value: params.initial ?? (await capture()) };
   }
 
   const needsBaselineDistrust = requiresPostGestureBaselineDistrust(session.device);
@@ -190,7 +202,17 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       }
       clearPostGestureStabilization(session);
       emitPostGestureSettleDiagnostic(verdict, pending.action, attempts, elapsedMs);
-      return current.value;
+      return {
+        value: current.value,
+        ...(verdict === 'accept-stale'
+          ? {
+              gestureNoEffect: {
+                action: pending.action,
+                positionals: pending.positionals ?? [],
+              },
+            }
+          : {}),
+      };
     }
     previous = current;
   }
@@ -205,7 +227,25 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       durationMs: Date.now() - startedAt,
     },
   });
-  return previous.value;
+  return { value: previous.value };
+}
+
+/**
+ * The agent-facing wording for a proven no-effect gesture. Names the exact
+ * gesture, admits the honest ambiguity (at-edge is a legitimate no-op the
+ * platform cannot distinguish), and hands over the one escape hatch that
+ * moved a stuck list when synthesized scrolls did not (#1600, element-18:
+ * raw `swipe` worked where scroll/fling/pan all silently no-opped).
+ */
+export function formatGestureNoEffectWarning(action: string, positionals: string[]): string {
+  const gesture = [action, ...positionals.filter((value) => !/^[\d.-]+$/.test(value))]
+    .join(' ')
+    .trim();
+  return (
+    `${gesture} produced no visible change: the tree still matches its pre-gesture state. ` +
+    'Either the container is already at its edge, or it ignores synthesized scrolls — ' +
+    'a raw drag moves such lists: swipe x1 y1 x2 y2 (start inside the list).'
+  );
 }
 
 function isPostGestureStabilizingAction(

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -7,6 +7,7 @@ import {
   areInteractionSurfaceSignaturesStable,
   buildInteractionSurfaceSignature,
   classifyBaselineSurfaceEvidence,
+  haveIdenticalDiscriminatingSurfaces,
   type InteractionSurfaceSignature,
 } from './interaction-outcome-policy.ts';
 import type { SessionState } from './types.ts';
@@ -154,10 +155,14 @@ function emitPostGestureSettleDiagnostic(
 export type PostGestureStabilizedResult<T> = {
   value: T;
   /**
-   * Present when the loop accepted a stale read: the quiet capture PROVABLY
-   * still equals the pre-gesture baseline after the distrust cap (#1600).
-   * Callers surface this to the agent — a diagnostics-only verdict let one
-   * benchmark run burn 40 calls re-issuing scrolls the daemon knew did nothing.
+   * Present ONLY when the accept-stale verdict is corroborated by full-surface
+   * evidence: every discriminating entry of the quiet capture matches the
+   * pre-gesture baseline exactly, in both directions
+   * (`haveIdenticalDiscriminatingSurfaces`). The bare verdict is NOT enough —
+   * it is subset-tolerant by design, and a successful scroll that replaced
+   * every list cell under fixed chrome still reads accept-stale (#1601 review
+   * P1). Callers surface this to the agent: a diagnostics-only signal let one
+   * benchmark run burn 40 calls re-issuing scrolls that moved nothing (#1600).
    */
   gestureNoEffect?: { action: string; positionals: string[] };
 };
@@ -204,7 +209,8 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       emitPostGestureSettleDiagnostic(verdict, pending.action, attempts, elapsedMs);
       return {
         value: current.value,
-        ...(verdict === 'accept-stale'
+        ...(verdict === 'accept-stale' &&
+        haveIdenticalDiscriminatingSurfaces(pending.baselineSignature ?? [], current.signature)
           ? {
               gestureNoEffect: {
                 action: pending.action,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -198,6 +198,9 @@ export type AndroidSnapshotFreshness = {
 
 export type PostGestureStabilization = {
   action: string;
+  /** The gesture's own positionals (e.g. scroll direction) — wording input for
+   * the #1600 no-effect warning; never re-dispatched. */
+  positionals?: string[];
   markedAt: number;
   /**
    * Pre-gesture interaction-surface signature, captured from the session's


### PR DESCRIPTION
Fixes #1600.

## What

The #1542 post-gesture stabilization loop already **proves** when a scroll/swipe/pan moved nothing: its `accept-stale` verdict fires only when the quiet post-gesture capture still equals the pre-gesture baseline after the 3.5s distrust cap — with scope-drift and root/keyboard-chrome subtleties already handled by `classifyBaselineSurfaceEvidence`. But the verdict only reached the diagnostics stream; the agent-facing response reported plain success.

This PR returns the verdict from `capturePostGestureStabilizedResult` alongside the capture value, and the snapshot handler appends a warning through the existing `annotations.warnings` channel (already rendered by every client path — zero new plumbing):

```
scroll up produced no visible change: the tree still matches its pre-gesture state. Either the container is already at its edge, or it ignores synthesized scrolls — a raw drag moves such lists: swipe x1 y1 x2 y2 (start inside the list).
```

The wording deliberately admits the at-edge ambiguity: iOS has no authoritative can-scroll signal (Android does), so "at edge" vs "container ignores synthesized scrolls" cannot be distinguished platform-side — but either way the agent's next move is informed instead of blind.

## Why

AppControlBench element-18 (gpt_high): reaching "Manage sessions" in Element's settings table cost 433s / 80 tool calls, ~40 of which were scroll/fling/pan attempts that all reported success over a byte-identical tree — only a raw `swipe` moved the list. The daemon's stabilization loop (post-#1542) detects exactly this condition; it just never told the agent.

## Red evidence

Both new tests fail on base `3696f338b` / current main pre-fix:

```
× capturePostGestureStabilizedResult keeps polling past the normal deadline when the AX tree is stuck at the pre-gesture baseline (iOS)
  → result.gestureNoEffect is undefined (verdict never surfaced)
× formatGestureNoEffectWarning names the gesture and the raw-drag escape hatch
  → function did not exist
```

## Live verification (seeded bench Bluesky feed, worktree build)

| action | ground truth | response |
|---|---|---|
| `scroll up 1` at feed top | no movement (at edge) | **warning** ✓ |
| `scroll down --pixels 600` mid-feed | first item whiskers→buddy | no warning ✓ |
| raw fling at feed bottom | first item unchanged (verified) | **warning** ✓ |

## Notes

- `positionals` stored on the stabilization marker feed the wording only (numeric args filtered out); nothing is re-dispatched.
- Android is untouched: its captures are fresh by construction (#1254), so no baseline distrust and no stale-accept verdict exists there.
- The interaction-outcome-aware path (tap + trailing gesture) surfaces the same warning through the same helper.