### PR TITLE
fix: surface AMBIGUOUS_MATCH candidates and name find's supported actions

### DIFF
--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -46,6 +46,7 @@ import {
   parseFindSelectorExpression,
   FIND_LOCATORS,
   FIND_VALUE_REQUIRED_MESSAGE,
+  UNSUPPORTED_FIND_ACTION_HINT,
 } from './internal/find.ts';
 import {
   buildSelectorCandidates,
@@ -108,6 +109,7 @@ export {
   SELECTOR_EXPRESSION_REQUIRED_MESSAGE,
   SELECTOR_KEY_NAMES,
   STALE_REF_HINT,
+  UNSUPPORTED_FIND_ACTION_HINT,
 };
 
 /** A single native runner selector suitable for direct iOS lookup. */

--- a/packages/selectors/src/internal/find.ts
+++ b/packages/selectors/src/internal/find.ts
@@ -135,6 +135,18 @@ export type ParsedFindArgs = {
 /** Shared by `checkFindArgs` and `findCommand`, which validates already-parsed options. */
 export const FIND_VALUE_REQUIRED_MESSAGE = 'find requires a value';
 
+/**
+ * Shared by both `Unsupported find action` throw sites (this file's raw-token
+ * parser and `src/commands/interaction/selectors.ts`'s typed CLI reader) so
+ * the recovery guidance cannot drift between them. `find` has no press/
+ * longpress/swipe action of its own — the fix is to resolve the ref through
+ * `find`, then dispatch the gesture as its own top-level command.
+ */
+export const UNSUPPORTED_FIND_ACTION_HINT =
+  'find actions: click (default), focus, fill, type, exists, wait, get text, get attrs — ' +
+  'there is no press/longpress/swipe find action. Run find "<text>" to list matches, then ' +
+  'act on the resolved @ref directly, e.g. press @eNN.';
+
 export type FindArgumentCheck =
   | { ok: true; parsed: ParsedFindArgs }
   | { ok: false; code: 'INVALID_ARGS'; message: string };
@@ -206,7 +218,9 @@ export function parseFindArgs(args: string[]): ParsedFindArgs {
     const value = actionTokens.slice(1).join(' ');
     return { locator, query, action: 'type', value };
   }
-  throw new AppError('INVALID_ARGS', `Unsupported find action: ${actionTokens[0]}`);
+  throw new AppError('INVALID_ARGS', `Unsupported find action: ${actionTokens[0]}`, {
+    hint: UNSUPPORTED_FIND_ACTION_HINT,
+  });
 }
 
 export function parseFindSelectorExpression(locator: FindLocator, query: string): string | null {

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -244,9 +244,9 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
     sample: AMBIGUOUS_MATCH_SAMPLE,
     render: () => {
       const matches = [
-        { ref: 'e2', label: 'Follow' },
-        { ref: 'e5', label: 'Follow' },
-        { ref: 'e9', label: 'Follow' },
+        { ref: 'e2', type: 'Button', label: 'Follow' },
+        { ref: 'e5', type: 'Button', label: 'Follow' },
+        { ref: 'e9', type: 'Button', label: 'Follow' },
       ] as Parameters<typeof buildAmbiguousMatchError>[0];
       const response = buildAmbiguousMatchError(matches, 'text', 'Follow');
       assertErrorResponse(response, 'an ambiguous find');

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -428,7 +428,7 @@ Use the output already shown to determine whether the feed-search UI is present,
     recovery: { code: 'AMBIGUOUS_MATCH', sample: AMBIGUOUS_MATCH_SAMPLE },
     task: quiz(
       AMBIGUOUS_MATCH_SAMPLE,
-      'The intent is to follow the @callstack.com account row. The candidate refs were not shown. What command should run next?',
+      'The intent is to follow the @callstack.com account row. The candidate refs shown (@e2, @e5, @e9) all carry the identical "Follow" label, so this output alone cannot tell them apart. What command should run next?',
     ),
     expectations: ['validPlanCommands', 'fullPrefix'],
     matchers: [
@@ -439,12 +439,13 @@ Use the output already shown to determine whether the feed-search UI is present,
       },
     ],
     forbidden: [
-      // The candidates live in error details the human output never printed,
-      // so a ref-targeting command here would be a guess.
+      // #1597: candidates now print (ref, role, label), but all 3 here share
+      // the exact same "Follow" label — picking any single @eN from this
+      // output alone would still be an unverified guess, not a resolved match.
       { id: 'noGuessedRef', pattern: /(?:^|\n)agent-device\s+(?:press|click)\s+@e\d/i },
       {
         id: 'noVerbatimRetry',
-        pattern: /(?:^|\n)agent-device\s+find\s+text\s+"?follow"?\s+press\b/i,
+        pattern: /(?:^|\n)agent-device\s+find\s+text\s+"?follow"?\s*(?:\n|$)/i,
       },
       { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
     ],

--- a/scripts/help-conformance-sample-outputs.mjs
+++ b/scripts/help-conformance-sample-outputs.mjs
@@ -86,13 +86,21 @@ Hint: Ref @e12 was minted from snapshot s5 but the session's ref frame is now s7
 
 // AMBIGUOUS_MATCH from buildAmbiguousMatchError (src/daemon/handlers/find.ts)
 // — the parity test drives that exact producer. The by-design rejection
-// instead of silent disambiguation: candidate refs live in details, which the
-// human rendering does not print, so the agent must re-observe or narrow, not
-// guess a ref it never saw.
+// instead of silent disambiguation: #1597 made the candidate refs (ref, role,
+// label/identifier — the same compact rendering as snapshot -i) print
+// unconditionally via formatAmbiguousMatchCandidateLines
+// (src/utils/output.ts), capped at AMBIGUOUS_MATCH_CANDIDATE_LIMIT (5) with a
+// "+N more" marker. Here all 3 candidates share the identical "Follow" label,
+// so the printed refs still cannot be told apart from this output alone —
+// the agent must re-observe or narrow, not guess which @ref is the right row.
 export const AMBIGUOUS_MATCH_SAMPLE = {
-  command: 'agent-device find text "Follow" press',
+  command: 'agent-device find text "Follow"',
   output: `Error (AMBIGUOUS_MATCH): find matched 3 elements for text "Follow". Use a more specific locator or selector.
-Hint: Multiple candidates matched. Narrow the query or pass an exact identifier.`,
+Hint: Multiple candidates matched. Narrow the query or pass an exact identifier.
+Candidates:
+  @e2 [button] "Follow"
+  @e5 [button] "Follow"
+  @e9 [button] "Follow"`,
 };
 
 // APP_NOT_INSTALLED from buildAppNotInstalledError

--- a/scripts/layering/facade-symbols.ts
+++ b/scripts/layering/facade-symbols.ts
@@ -37,6 +37,7 @@ export const FACADE_SYMBOLS: readonly (readonly [string, readonly string[]])[] =
       'SelectorProjection',
       'SelectorResolution',
       'SimpleSelectorTarget',
+      'UNSUPPORTED_FIND_ACTION_HINT',
       'buildSelectorCandidates',
       'buildSelectorChainForNode',
       'checkElementTargetArgs',

--- a/src/commands/interaction/selectors.test.ts
+++ b/src/commands/interaction/selectors.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest';
+import { UNSUPPORTED_FIND_ACTION_HINT } from '@agent-device/selectors';
+import { AppError } from '@agent-device/kernel/errors';
+import type { CliFlags } from '@agent-device/contracts/command';
+import { selectorCliReaders } from './selectors.ts';
+
+const BASE_FLAGS: CliFlags = { json: false, help: false, version: false };
+
+// #1597: this CLI reader has its own "Unsupported find action" throw site,
+// separate from packages/selectors/src/internal/find.ts's raw-positional
+// parser (the daemon-side path). Both must carry the same recovery hint —
+// this pins the reader actually reachable from `agent-device find <text>
+// press` on the terminal.
+test('find CLI reader attaches the supported-actions hint on an unsupported action', () => {
+  try {
+    selectorCliReaders.find(['text', 'Follow', 'press'], BASE_FLAGS);
+    expect.unreachable('find CLI reader should have thrown for an unsupported action');
+  } catch (error) {
+    expect(error).toBeInstanceOf(AppError);
+    const appError = error as AppError;
+    expect(appError.code).toBe('INVALID_ARGS');
+    expect(appError.message).toBe('Unsupported find action: press');
+    expect(appError.details?.hint).toBe(UNSUPPORTED_FIND_ACTION_HINT);
+  }
+});

--- a/src/commands/interaction/selectors.ts
+++ b/src/commands/interaction/selectors.ts
@@ -2,7 +2,11 @@ import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { FindOptions, IsOptions } from '@agent-device/contracts/client';
 import type { CliFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import { checkIsPredicate, normalizeIsPositionals } from '@agent-device/selectors';
+import {
+  checkIsPredicate,
+  normalizeIsPositionals,
+  UNSUPPORTED_FIND_ACTION_HINT,
+} from '@agent-device/selectors';
 import {
   direct,
   optionalCliNumber,
@@ -102,7 +106,9 @@ function readFindOptionsFromPositionals(positionals: string[], flags: CliFlags):
   if (action === 'click' || action === 'focus' || action === 'exists') {
     return { ...base, locator, query: readRequiredQuery(query), action };
   }
-  throw new AppError('INVALID_ARGS', `Unsupported find action: ${action}`);
+  throw new AppError('INVALID_ARGS', `Unsupported find action: ${action}`, {
+    hint: UNSUPPORTED_FIND_ACTION_HINT,
+  });
 }
 
 function readIsOptionsFromPositionals(positionals: string[], flags: CliFlags): IsOptions {

--- a/src/daemon/handlers/__tests__/find-args.test.ts
+++ b/src/daemon/handlers/__tests__/find-args.test.ts
@@ -3,6 +3,7 @@ import {
   isReadOnlyFindAction,
   parseFindArgs,
   parseFindSelectorExpression,
+  UNSUPPORTED_FIND_ACTION_HINT,
 } from '@agent-device/selectors';
 
 test('parseFindArgs defaults to click with any locator', () => {
@@ -40,6 +41,33 @@ test('parseFindArgs throws on unsupported action', () => {
       message: expect.stringContaining('Unsupported find action: swipe'),
     }),
   );
+});
+
+// #1597: a bare "Unsupported find action" left the agent no path forward
+// besides guessing — the hint must name every action find actually supports
+// and show the two-command recovery shape (resolve the ref via find, then
+// dispatch the gesture, e.g. press, as its own command).
+test('parseFindArgs attaches the supported-actions hint with the two-step recovery shape on an unsupported action', () => {
+  try {
+    parseFindArgs(['text', 'Follow', 'press']);
+    expect.unreachable('parseFindArgs should have thrown for an unsupported action');
+  } catch (error) {
+    expect(error).toMatchObject({
+      code: 'INVALID_ARGS',
+      message: 'Unsupported find action: press',
+      details: { hint: UNSUPPORTED_FIND_ACTION_HINT },
+    });
+  }
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('click (default)');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('focus');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('fill');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('type');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('exists');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('wait');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('get text');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toContain('get attrs');
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toMatch(/find "<text>" to list matches/);
+  expect(UNSUPPORTED_FIND_ACTION_HINT).toMatch(/press @eNN/);
 });
 
 test('parseFindArgs with bare locator yields empty query', () => {

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -508,6 +508,95 @@ test('handleFindCommands click prefers semantic controls over matching container
   expect(invokeCalls[0]!.positionals?.[0]).toBe('@e5');
 });
 
+// #1597: an ambiguous find must let the agent act on the right @ref straight
+// from the error, so the response carries snapshot-line-rendered candidates
+// (ref, role, label) instead of a bare "matched N elements" message. Capped
+// at AMBIGUOUS_MATCH_CANDIDATE_LIMIT (5); the true total keeps riding
+// `matches` so a "+N more" marker can be computed at render time.
+test('handleFindCommands ambiguous match lists snapshot-line candidates capped at 5', async () => {
+  const followButton = (ref: string, index: number, x: number) => ({
+    index,
+    ref,
+    type: 'Button',
+    label: 'Follow',
+    hittable: true,
+    rect: { x, y: 100, width: 80, height: 40 },
+    parentIndex: 0,
+  });
+
+  const { response } = await runFindClickScenario({
+    positionals: ['Follow', 'click'],
+    nodes: [
+      { index: 0, ref: 'e1', type: 'Application', rect: { x: 0, y: 0, width: 800, height: 1200 } },
+      followButton('e2', 1, 0),
+      followButton('e3', 2, 90),
+      followButton('e4', 3, 180),
+      followButton('e5', 4, 270),
+      followButton('e6', 5, 360),
+      followButton('e7', 6, 450),
+    ],
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('AMBIGUOUS_MATCH');
+  // The old bare message ("find matched 6 elements ... Use a more specific
+  // locator or selector.") gave the agent nothing to act on directly — this
+  // proves the fix red against that shape: `candidates` must exist, be
+  // snapshot-line rendered, and be capped below the true match count.
+  expect(response.error.details?.matches).toBe(6);
+  const candidates = response.error.details?.candidates;
+  expect(Array.isArray(candidates)).toBe(true);
+  expect(candidates).toHaveLength(5);
+  expect(candidates).toEqual([
+    '@e2 [button] "Follow"',
+    '@e3 [button] "Follow"',
+    '@e4 [button] "Follow"',
+    '@e5 [button] "Follow"',
+    '@e6 [button] "Follow"',
+  ]);
+});
+
+test('handleFindCommands ambiguous match with few candidates lists them all uncapped', async () => {
+  const { response } = await runFindClickScenario({
+    positionals: ['Follow', 'click'],
+    nodes: [
+      { index: 0, ref: 'e1', type: 'Application', rect: { x: 0, y: 0, width: 800, height: 1200 } },
+      {
+        index: 1,
+        ref: 'e2',
+        type: 'Button',
+        label: 'Follow',
+        hittable: true,
+        rect: { x: 0, y: 100, width: 80, height: 40 },
+        parentIndex: 0,
+      },
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'Button',
+        // No label — exact-matches "Follow" via its identifier instead, so
+        // this candidate exercises the label/identifier fallback.
+        identifier: 'FOLLOW',
+        hittable: true,
+        rect: { x: 90, y: 100, width: 80, height: 40 },
+        parentIndex: 0,
+      },
+    ],
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('AMBIGUOUS_MATCH');
+  expect(response.error.details?.matches).toBe(2);
+  // No label on e3, so the candidate line falls back to its identifier —
+  // "label/identifier" per #1597, same as any other snapshot line.
+  expect(response.error.details?.candidates).toEqual([
+    '@e2 [button] "Follow"',
+    '@e3 [button] "FOLLOW"',
+  ]);
+});
+
 test('handleFindCommands focus uses the promoted actionable node center', async () => {
   const { response } = await runFindClickScenario({
     positionals: ['Account', 'focus'],

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -12,12 +12,12 @@ import { expireRefFrame } from '../ref-frame.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
-import { extractNodeText } from '@agent-device/contracts/snapshot';
 import {
   resolveActionableTouchNode,
   resolveActionableTouchResolution,
 } from '../../core/interaction-targeting.ts';
 import { isSnapshotNodeInteractionBlocked } from '../../snapshot/snapshot-occlusion.ts';
+import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
 import { readCommandMessage, successText } from '../../utils/success-text.ts';
 import { errorResponse, noActiveSessionError } from './response.ts';
 import { withSystemSurfaceDisclosure } from './system-surface-disclosure.ts';
@@ -540,6 +540,15 @@ function publicFindFlags(flags: DaemonRequest['flags']): Record<string, unknown>
   return { ...(stripInternalInteractionFlags(flags) ?? {}) };
 }
 
+// #1597: an agent reading an ambiguous-match error must be able to act on the
+// right @ref immediately, without a follow-up snapshot round trip. Candidate
+// lines reuse the exact snapshot-line renderer (`formatSnapshotLine`) so a
+// candidate reads identically to its row in `snapshot -i` output: ref, role,
+// label/identifier. Capped at AMBIGUOUS_MATCH_CANDIDATE_LIMIT to bound the
+// error payload — `matches` (the true total) is what a "+N more" marker is
+// computed from at render time (src/utils/output.ts, src/mcp/tool-error.ts).
+export const AMBIGUOUS_MATCH_CANDIDATE_LIMIT = 5;
+
 // Exported as the single AMBIGUOUS_MATCH producer so the help-benchmark
 // sample parity test renders the exact error this handler returns; a message
 // change here fails that gate instead of drifting past it.
@@ -548,11 +557,9 @@ export function buildAmbiguousMatchError(
   locator: FindLocator,
   query: string,
 ): DaemonResponse {
-  const candidates = matches.slice(0, 8).map((candidate) => {
-    const label =
-      extractNodeText(candidate) || candidate.label || candidate.identifier || candidate.type || '';
-    return `@${candidate.ref}${label ? `(${label})` : ''}`;
-  });
+  const candidates = matches
+    .slice(0, AMBIGUOUS_MATCH_CANDIDATE_LIMIT)
+    .map((candidate) => formatSnapshotLine(candidate, 0, false));
   return errorResponse(
     'AMBIGUOUS_MATCH',
     `find matched ${matches.length} elements for ${locator} "${query}". Use a more specific locator or selector.`,

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -547,7 +547,9 @@ function publicFindFlags(flags: DaemonRequest['flags']): Record<string, unknown>
 // label/identifier. Capped at AMBIGUOUS_MATCH_CANDIDATE_LIMIT to bound the
 // error payload — `matches` (the true total) is what a "+N more" marker is
 // computed from at render time (src/utils/output.ts, src/mcp/tool-error.ts).
-export const AMBIGUOUS_MATCH_CANDIDATE_LIMIT = 5;
+// Module-local: no consumer outside this file needs the raw cap, only the
+// already-capped `candidates` array on the response.
+const AMBIGUOUS_MATCH_CANDIDATE_LIMIT = 5;
 
 // Exported as the single AMBIGUOUS_MATCH producer so the help-benchmark
 // sample parity test renders the exact error this handler returns; a message

--- a/src/mcp/__tests__/tool-error.test.ts
+++ b/src/mcp/__tests__/tool-error.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AppError } from '@agent-device/kernel/errors';
+import { formatToolErrorText, normalizeToolError } from '../tool-error.ts';
+
+// #1597: an MCP-connected agent reads this text, not the CLI's stderr — the
+// candidate refs must render here too, unconditionally, same as
+// printHumanError (src/utils/output.ts, src/utils/__tests__/output.test.ts).
+test('formatToolErrorText lists AMBIGUOUS_MATCH candidates capped with a "+N more" marker', () => {
+  const err = new AppError(
+    'AMBIGUOUS_MATCH',
+    'find matched 6 elements for text "Follow". Use a more specific locator or selector.',
+    {
+      matches: 6,
+      candidates: [
+        '@e2 [button] "Follow"',
+        '@e3 [button] "Follow"',
+        '@e4 [button] "Follow"',
+        '@e5 [button] "Follow"',
+        '@e6 [button] "Follow"',
+      ],
+    },
+  );
+
+  const text = formatToolErrorText(normalizeToolError(err));
+
+  assert.match(text, /^Error \(AMBIGUOUS_MATCH\): find matched 6 elements/);
+  assert.match(text, /Hint: Multiple candidates matched\./);
+  assert.match(text, /Candidates:\n {2}@e2 \[button\] "Follow"/);
+  assert.match(text, /@e6 \[button\] "Follow"\n {2}\+1 more/);
+});
+
+test('formatToolErrorText omits the candidates block for non-ambiguous errors', () => {
+  const err = new AppError('COMMAND_FAILED', 'find did not match any element');
+
+  const text = formatToolErrorText(normalizeToolError(err));
+
+  assert.equal(text.includes('Candidates:'), false);
+});

--- a/src/mcp/__tests__/tool-error.test.ts
+++ b/src/mcp/__tests__/tool-error.test.ts
@@ -37,3 +37,26 @@ test('formatToolErrorText omits the candidates block for non-ambiguous errors', 
 
   assert.equal(text.includes('Candidates:'), false);
 });
+
+// P2 review on #1597: device-domain AMBIGUOUS_MATCH (findBootedAppleSimulatorWithApp,
+// src/core/dispatch-resolve.ts) reuses `details.candidates` for `{ id, name }`
+// device objects with no `matches` field — must never render as
+// "Candidates:\n  [object Object]" on the MCP text path either.
+test('formatToolErrorText renders device-domain candidate objects as nothing, never [object Object]', () => {
+  const err = new AppError(
+    'AMBIGUOUS_MATCH',
+    'Multiple booted iOS simulators have com.example.app installed',
+    {
+      appTarget: 'com.example.app',
+      candidates: [
+        { id: 'SIM-001', name: 'iPhone 17 Pro' },
+        { id: 'SIM-002', name: 'iPhone 17' },
+      ],
+    },
+  );
+
+  const text = formatToolErrorText(normalizeToolError(err));
+
+  assert.equal(text.includes('[object Object]'), false);
+  assert.equal(text.includes('Candidates:'), false);
+});

--- a/src/mcp/tool-error.ts
+++ b/src/mcp/tool-error.ts
@@ -1,5 +1,6 @@
 import { normalizeError, type NormalizedError } from '@agent-device/kernel/errors';
 import { formatReplayDivergenceReport } from '@agent-device/contracts/divergence';
+import { formatAmbiguousMatchCandidateLines } from '../utils/output.ts';
 
 /**
  * Shared MCP error normalization + text rendering (executor and router
@@ -12,6 +13,10 @@ export function normalizeToolError(error: unknown): NormalizedError {
 export function formatToolErrorText(normalized: NormalizedError): string {
   const lines = [`Error (${normalized.code}): ${normalized.message}`];
   if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
+  // #1597: printed unconditionally, same as the CLI text path
+  // (src/utils/output.ts printHumanError) — an MCP-connected agent must see
+  // the candidate refs directly in the tool result text.
+  lines.push(...formatAmbiguousMatchCandidateLines(normalized.details));
   if (normalized.supportedOn) lines.push(`Supported on: ${normalized.supportedOn}`);
   // ADR 0012: the MCP text path must carry the same repair data as
   // structuredContent — a text-only divergence loses the screen refs and

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
 import {
+  formatAmbiguousMatchCandidateLines,
   formatScreenshotDiffText,
   formatSnapshotDiffText,
   formatSnapshotText,
@@ -1729,6 +1730,60 @@ test('printHumanError renders a compact divergence report unconditionally (not g
   assert.match(output, /\[id\] "Save" id="save"/);
   assert.match(output, /Repair hint: record-and-heal/);
   // Not gated behind --debug: showDetails defaults to false/undefined here.
+});
+
+// --- #1597: AMBIGUOUS_MATCH candidates print unconditionally, capped at 5 ---
+
+test('printHumanError lists AMBIGUOUS_MATCH candidates unconditionally, not gated behind --debug', () => {
+  const err = new AppError(
+    'AMBIGUOUS_MATCH',
+    'find matched 3 elements for text "Follow". Use a more specific locator or selector.',
+    {
+      locator: 'text',
+      query: 'Follow',
+      matches: 3,
+      candidates: ['@e2 [button] "Follow"', '@e5 [button] "Follow"', '@e9 [button] "Follow"'],
+    },
+  );
+
+  // This is the exact old-message shape the bug reported: the human render
+  // used to stop at "Error (...): ...\nHint: ...", so an agent reading it had
+  // no @ref to act on. Asserting the candidate lines appear proves this red
+  // against that shape (it would fail before formatAmbiguousMatchCandidateLines
+  // was wired into printHumanError).
+  const output = captureStderr(() => printHumanError(err));
+
+  assert.match(output, /^Error \(AMBIGUOUS_MATCH\): find matched 3 elements/);
+  assert.match(
+    output,
+    /Candidates:\n {2}@e2 \[button\] "Follow"\n {2}@e5 \[button\] "Follow"\n {2}@e9 \[button\] "Follow"/,
+  );
+  // 3 candidates for 3 matches: nothing was capped, so no "+N more" marker.
+  assert.equal(/\+\d+ more/.test(output), false);
+  // Not gated behind --debug: showDetails defaults to false/undefined here.
+});
+
+test('printHumanError appends a "+N more" marker when candidates were capped', () => {
+  const err = new AppError('AMBIGUOUS_MATCH', 'find matched 7 elements for text "Row". ...', {
+    matches: 7,
+    candidates: [
+      '@e2 [button] "Row"',
+      '@e3 [button] "Row"',
+      '@e4 [button] "Row"',
+      '@e5 [button] "Row"',
+      '@e6 [button] "Row"',
+    ],
+  });
+
+  const output = captureStderr(() => printHumanError(err));
+
+  assert.match(output, /@e6 \[button\] "Row"\n {2}\+2 more/);
+});
+
+test('formatAmbiguousMatchCandidateLines returns nothing when details carry no candidates', () => {
+  assert.deepEqual(formatAmbiguousMatchCandidateLines(undefined), []);
+  assert.deepEqual(formatAmbiguousMatchCandidateLines({ matches: 3 }), []);
+  assert.deepEqual(formatAmbiguousMatchCandidateLines({ candidates: [] }), []);
 });
 
 test('printHumanError shows an unavailable screen reason and omitted suggestions hint', () => {

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -1786,6 +1786,48 @@ test('formatAmbiguousMatchCandidateLines returns nothing when details carry no c
   assert.deepEqual(formatAmbiguousMatchCandidateLines({ candidates: [] }), []);
 });
 
+// P2 review on #1597: `details.candidates` is not unique to the find
+// handler's element-match shape. The device-domain resolver
+// (findBootedAppleSimulatorWithApp, src/core/dispatch-resolve.ts) reuses the
+// same key for `{ id, name }` device objects on both AMBIGUOUS_MATCH and
+// APP_NOT_INSTALLED, and never sets `details.matches` — this must render
+// nothing (its behavior before this renderer existed), never
+// "Candidates:\n  [object Object]".
+test('printHumanError renders device-domain candidate objects as nothing, never [object Object]', () => {
+  const deviceCandidates = [
+    { id: 'SIM-001', name: 'iPhone 17 Pro' },
+    { id: 'SIM-002', name: 'iPhone 17' },
+  ];
+
+  const ambiguousDeviceErr = new AppError(
+    'AMBIGUOUS_MATCH',
+    'Multiple booted iOS simulators have com.example.app installed',
+    { appTarget: 'com.example.app', candidates: deviceCandidates },
+  );
+  const ambiguousOutput = captureStderr(() => printHumanError(ambiguousDeviceErr));
+  assert.equal(ambiguousOutput.includes('[object Object]'), false);
+  assert.equal(ambiguousOutput.includes('Candidates:'), false);
+
+  const notInstalledErr = new AppError(
+    'APP_NOT_INSTALLED',
+    'No booted iOS simulator has com.example.app installed',
+    { appTarget: 'com.example.app', candidates: deviceCandidates },
+  );
+  const notInstalledOutput = captureStderr(() => printHumanError(notInstalledErr));
+  assert.equal(notInstalledOutput.includes('[object Object]'), false);
+  assert.equal(notInstalledOutput.includes('Candidates:'), false);
+
+  // The formatter itself, not just the CLI render, must reject this shape —
+  // both the missing `matches` and the object-shaped entries disqualify it.
+  assert.deepEqual(
+    formatAmbiguousMatchCandidateLines({
+      appTarget: 'com.example.app',
+      candidates: deviceCandidates,
+    }),
+    [],
+  );
+});
+
 test('printHumanError shows an unavailable screen reason and omitted suggestions hint', () => {
   const err = new AppError('REPLAY_DIVERGENCE', 'Replay failed at step 1', {
     divergence: {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -70,16 +70,28 @@ export function printHumanError(
 // AMBIGUOUS_MATCH_CANDIDATE_LIMIT by buildAmbiguousMatchError,
 // src/daemon/handlers/find.ts) and `details.matches` (the true total) to
 // compute the "+N more" marker for whatever the cap omitted.
+//
+// `details.candidates` is NOT unique to that one producer: the device-domain
+// AMBIGUOUS_MATCH/APP_NOT_INSTALLED resolvers (findBootedAppleSimulatorWithApp,
+// src/core/dispatch-resolve.ts) reuse the same key for `{ id, name }` device
+// objects, and never set `details.matches` at all. Both guards below —
+// numeric `matches` and every candidate being a pre-rendered string — must
+// hold together, or this renders "[object Object]" for that shape instead of
+// silently rendering nothing (its prior, pre-#1597 behavior).
 export function formatAmbiguousMatchCandidateLines(
   details: Record<string, unknown> | undefined,
 ): string[] {
   const candidates = details?.candidates;
   if (!Array.isArray(candidates) || candidates.length === 0) return [];
-  const totalMatches = typeof details?.matches === 'number' ? details.matches : candidates.length;
+  if (typeof details?.matches !== 'number') return [];
+  if (!candidates.every((candidate): candidate is string => typeof candidate === 'string')) {
+    return [];
+  }
+  const totalMatches = details.matches;
   const remaining = totalMatches - candidates.length;
   return [
     'Candidates:',
-    ...candidates.map((candidate) => `  ${String(candidate)}`),
+    ...candidates.map((candidate) => `  ${candidate}`),
     ...(remaining > 0 ? [`  +${remaining} more`] : []),
   ];
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -39,6 +39,13 @@ export function printHumanError(
   if (normalized.hint) {
     process.stderr.write(`Hint: ${normalized.hint}\n`);
   }
+  // #1597: printed unconditionally (not gated behind --debug), same as the
+  // divergence report below — an agent must see the candidate refs without a
+  // follow-up round trip.
+  const ambiguousMatchLines = formatAmbiguousMatchCandidateLines(normalized.details);
+  if (ambiguousMatchLines.length > 0) {
+    process.stderr.write(`${ambiguousMatchLines.join('\n')}\n`);
+  }
   if (normalized.diagnosticId) {
     process.stderr.write(`Diagnostic ID: ${normalized.diagnosticId}\n`);
   }
@@ -54,6 +61,27 @@ export function printHumanError(
   if (options.showDetails && normalized.details) {
     process.stderr.write(`${JSON.stringify(normalized.details, null, 2)}\n`);
   }
+}
+
+// #1597: shared by printHumanError (CLI) and formatToolErrorText (MCP,
+// src/mcp/tool-error.ts) so an AMBIGUOUS_MATCH's candidate refs render
+// identically on every text surface, never only in --json/--debug. Reads
+// `details.candidates` (pre-rendered snapshot-lines, capped at
+// AMBIGUOUS_MATCH_CANDIDATE_LIMIT by buildAmbiguousMatchError,
+// src/daemon/handlers/find.ts) and `details.matches` (the true total) to
+// compute the "+N more" marker for whatever the cap omitted.
+export function formatAmbiguousMatchCandidateLines(
+  details: Record<string, unknown> | undefined,
+): string[] {
+  const candidates = details?.candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) return [];
+  const totalMatches = typeof details?.matches === 'number' ? details.matches : candidates.length;
+  const remaining = totalMatches - candidates.length;
+  return [
+    'Candidates:',
+    ...candidates.map((candidate) => `  ${String(candidate)}`),
+    ...(remaining > 0 ? [`  +${remaining} more`] : []),
+  ];
 }
 
 type SnapshotDiffLine = {


### PR DESCRIPTION
## Summary

Fixes #1597 — two error-UX gaps where an agent got a bare error with nothing to act on.

**1. AMBIGUOUS_MATCH now lists candidates.** `buildAmbiguousMatchError` (the single producer for element-match ambiguity — `src/daemon/handlers/find.ts`) now builds `details.candidates` from `formatSnapshotLine`, the same compact renderer `snapshot -i` uses: `@ref [role] "label/identifier"`. Capped at 5 (`AMBIGUOUS_MATCH_CANDIDATE_LIMIT`); `details.matches` keeps the true total.

Critically, the candidates previously lived *only* in `details`, which neither text surface an agent actually reads ever printed — the CLI's `printHumanError` and MCP's `formatToolErrorText` both stopped at `Error: ...` + `Hint: ...`. A new shared renderer, `formatAmbiguousMatchCandidateLines` (`src/utils/output.ts`), prints the candidate lines unconditionally (not gated behind `--debug`) on both surfaces, with a `+N more` marker when the cap trimmed the list:

```
Error (AMBIGUOUS_MATCH): find matched 6 elements for text "Follow". Use a more specific locator or selector.
Hint: Multiple candidates matched. Narrow the query or pass an exact identifier.
Candidates:
  @e2 [button] "Follow"
  @e3 [button] "Follow"
  @e4 [button] "Follow"
  @e5 [button] "Follow"
  @e6 [button] "Follow"
  +1 more
```

I audited every `AMBIGUOUS_MATCH` emission site (`grep -rn "AMBIGUOUS_MATCH"`) to confirm `buildAmbiguousMatchError` really is the one shared producer for element-match ambiguity — the other two throw sites (`dispatch-resolve.ts` device selection, `session-doctor-app.ts` app selection) are a different domain (devices/apps, not elements) and already carry their own appropriate candidate shape. The direct-iOS-runner fast path for `wait`/`get`/`is` can also raise a bare runner-native `AMBIGUOUS_MATCH` (ADR 0011, deliberately not delegated) — that one has no node list available at the point it's raised, so enriching it is out of scope here and its existing tests are untouched.

**2. `find <text> <action>` with an unsupported action now hints at the fix.** `find <text> press` used to return a bare `INVALID_ARGS: Unsupported find action: press`. There were actually *two* throw sites for this (`packages/selectors/src/internal/find.ts`'s raw-token parser, reachable from direct daemon/MCP dispatch, and `src/commands/interaction/selectors.ts`'s typed CLI reader, reachable from the terminal) — both now attach the same hint via one shared exported constant, `UNSUPPORTED_FIND_ACTION_HINT`:

> find actions: click (default), focus, fill, type, exists, wait, get text, get attrs — there is no press/longpress/swipe find action. Run find "<text>" to list matches, then act on the resolved @ref directly, e.g. press @eNN.

Matching semantics are unchanged — ambiguous rejection stays by-design; this is purely an error-message/UX fix.

## Red evidence

Before this change:
- `buildAmbiguousMatchError` capped candidates at 8 and formatted them as `@e2(Follow)` inside `details.candidates` — but neither `printHumanError` nor `formatToolErrorText` read that field at all, so the agent-visible text was just `Error (AMBIGUOUS_MATCH): find matched N elements... \n Hint: Multiple candidates matched...` with no refs.
- `Unsupported find action: press` had no `details.hint`, so it fell through to the generic `INVALID_ARGS` default hint ("Check command arguments and run --help for usage examples."), with no mention of what find *does* support or how to recover.

New tests in `src/utils/__tests__/output.test.ts`, `src/mcp/__tests__/tool-error.test.ts`, `src/daemon/handlers/__tests__/find.test.ts`, `src/daemon/handlers/__tests__/find-args.test.ts`, and `src/commands/interaction/selectors.test.ts` assert the new candidate lines / hint text directly and would fail against the old shapes.

The help-conformance benchmark corpus's `AMBIGUOUS_MATCH` quiz case previously taught models the opposite lesson on purpose ("candidate refs live in details, which the human rendering does not print"); it's updated to reflect that candidates now print, while keeping its core lesson intact (all 3 sample candidates share an identical label, so picking a specific `@eN` from this output alone is still a guess).

## Test plan

- [x] `pnpm check:quick` (lint + typecheck) — clean
- [x] `pnpm check:layering` — clean (added `UNSUPPORTED_FIND_ACTION_HINT` to the pinned `@agent-device/selectors` façade symbol list)
- [x] `pnpm format:check` — clean
- [x] Targeted vitest files (find/output/tool-error/help-conformance) — all pass
- [x] `pnpm test:unit` — 5297/5299 pass; the 2 failures (`src/daemon/__tests__/runtime-hints.test.ts`, unrelated Android/adb mocked tests) pass cleanly in isolation (15/15) — pre-existing timeout flakiness under parallel CPU contention, not touched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
