### PR TITLE
fix: flush stdout/stderr before every CLI process.exit() (#1596)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -23,6 +23,11 @@
     "scripts/vitest-runner-timeout-setup.ts",
     "test/contention-retry-fixtures/vitest.fixture.config.ts",
     "test/contention-retry-fixtures/timeout-provenance.fixture.ts",
+    // #1596 regression fixtures: run as real `node --experimental-strip-types`
+    // subprocesses (test/integration/daemon-replace-exit-flush.test.ts), so
+    // dependency analysis cannot follow the runCmdSync string path to either.
+    "test/integration/support/exit-naive.ts",
+    "test/integration/support/exit-after-flush.ts",
     "src/utils/update-check-entry.ts",
     "examples/sdk/client-session.ts",
     "examples/sdk/metro-runtime.ts",

--- a/src/__tests__/cli-exit-paths.test.ts
+++ b/src/__tests__/cli-exit-paths.test.ts
@@ -1,0 +1,224 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+
+vi.mock('../cli/commands/web.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cli/commands/web.ts')>();
+  return { ...actual, runWebCommand: vi.fn(async () => 0) };
+});
+
+import { runCli } from '../cli.ts';
+import { runWebCommand } from '../cli/commands/web.ts';
+import { installIsolatedCliTestEnv } from './cli-test-env.ts';
+import { resolveDaemonPaths } from '../daemon/config.ts';
+import type { DaemonResponse } from '../daemon/client/daemon-client.ts';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function installExitSpy(): { calls: number[]; restore: () => void } {
+  const originalExit = process.exit;
+  const calls: number[] = [];
+  (process as any).exit = ((code?: number) => {
+    calls.push(code ?? 0);
+  }) as typeof process.exit;
+  return { calls, restore: () => (process.exit = originalExit) };
+}
+
+class ProcessExitSentinel extends Error {
+  code: number;
+  constructor(code: number) {
+    super(`process.exit(${code})`);
+    this.code = code;
+  }
+}
+
+// `parseCliInputOrExit`'s early-exit branches run before `runCli`'s own
+// try/catch, so — unlike `installExitSpy` above — the mock here must behave
+// like a real `process.exit()` and actually stop execution (by throwing),
+// or the function falls through past its `return exitAfterFlush(...)` into
+// code that assumes a command was parsed.
+function installTerminatingExitSpy(): { restore: () => void } {
+  const originalExit = process.exit;
+  (process as any).exit = ((code?: number) => {
+    throw new ProcessExitSentinel(code ?? 0);
+  }) as typeof process.exit;
+  return { restore: () => (process.exit = originalExit) };
+}
+
+async function runCliExpectingExit(
+  argv: string[],
+  deps: { sendToDaemon: (...args: any[]) => Promise<DaemonResponse> },
+): Promise<number> {
+  try {
+    await runCli(argv, deps as any);
+  } catch (error) {
+    if (error instanceof ProcessExitSentinel) return error.code;
+    throw error;
+  }
+  throw new Error('expected runCli to exit');
+}
+
+function captureStdout(): { read: () => string; restore: () => void } {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let captured = '';
+  (process.stdout as { write: typeof process.stdout.write }).write = ((chunk: unknown) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    read: () => captured,
+    restore: () => {
+      process.stdout.write = originalWrite;
+    },
+  };
+}
+
+function captureStderr(): { read: () => string; restore: () => void } {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  (process.stderr as { write: typeof process.stderr.write }).write = ((chunk: unknown) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    read: () => captured,
+    restore: () => {
+      process.stderr.write = originalWrite;
+    },
+  };
+}
+
+test('--version exits 0 and prints the version, without touching the daemon', async () => {
+  const restoreEnv = installIsolatedCliTestEnv();
+  const exitSpy = installTerminatingExitSpy();
+  const stdout = captureStdout();
+  const sendToDaemon = async (): Promise<DaemonResponse> => {
+    throw new Error('sendToDaemon should not be called for --version');
+  };
+
+  let exitCode: number;
+  try {
+    exitCode = await runCliExpectingExit(['--version'], { sendToDaemon });
+  } finally {
+    stdout.restore();
+    exitSpy.restore();
+    restoreEnv();
+  }
+
+  assert.equal(exitCode, 0);
+  assert.ok(stdout.read().trim().length > 0);
+});
+
+test('bare `help` with no target exits 0 and prints usage', async () => {
+  const restoreEnv = installIsolatedCliTestEnv();
+  const exitSpy = installTerminatingExitSpy();
+  const stdout = captureStdout();
+  const sendToDaemon = async (): Promise<DaemonResponse> => {
+    throw new Error('sendToDaemon should not be called for help');
+  };
+
+  let exitCode: number;
+  try {
+    exitCode = await runCliExpectingExit(['help'], { sendToDaemon });
+  } finally {
+    stdout.restore();
+    exitSpy.restore();
+    restoreEnv();
+  }
+
+  assert.equal(exitCode, 0);
+  assert.ok(stdout.read().includes('agent-device'));
+});
+
+test('no command exits 1 and prints usage', async () => {
+  const restoreEnv = installIsolatedCliTestEnv();
+  const exitSpy = installTerminatingExitSpy();
+  const stdout = captureStdout();
+  const sendToDaemon = async (): Promise<DaemonResponse> => {
+    throw new Error('sendToDaemon should not be called with no command');
+  };
+
+  let exitCode: number;
+  try {
+    exitCode = await runCliExpectingExit([], { sendToDaemon });
+  } finally {
+    stdout.restore();
+    exitSpy.restore();
+    restoreEnv();
+  }
+
+  assert.equal(exitCode, 1);
+  assert.ok(stdout.read().length > 0);
+});
+
+test("web command exits with runWebCommand's status code", async () => {
+  const restoreEnv = installIsolatedCliTestEnv();
+  const exitSpy = installExitSpy();
+  const sendToDaemon = async (): Promise<DaemonResponse> => {
+    throw new Error('sendToDaemon should not be called for web');
+  };
+  vi.mocked(runWebCommand).mockResolvedValueOnce(0);
+
+  try {
+    await runCli(['web', 'status'], { sendToDaemon });
+  } finally {
+    exitSpy.restore();
+    restoreEnv();
+  }
+
+  assert.deepEqual(exitSpy.calls, [0]);
+  assert.equal(vi.mocked(runWebCommand).mock.calls.length, 1);
+  assert.deepEqual(vi.mocked(runWebCommand).mock.calls[0]?.[0], ['status']);
+});
+
+// #1596: printDaemonLogTailOnError's --debug dump must stay bounded even when
+// the daemon log itself is large — otherwise the dump risks the same
+// process.exit()-truncates-a-pipe-write failure exitAfterFlush exists to fix.
+test('a --debug failure caps the daemon-log-tail dump instead of printing it unbounded', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-cli-log-tail-'));
+  const stateDir = path.join(tempRoot, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const { logPath } = resolveDaemonPaths(stateDir);
+
+  // 200 lines * 500 bytes = 100,000 bytes: within the existing 200-line cap,
+  // but past the 64,000-byte cap this change adds — so only the byte cap can
+  // explain the head line being absent from the captured output below.
+  const headMarker = 'HEAD_OF_SEEDED_LOG_LINE_0000';
+  const tailMarker = 'TAIL_OF_SEEDED_LOG_LINE_0199';
+  const lines: string[] = [];
+  for (let i = 0; i < 200; i += 1) {
+    const marker = i === 0 ? headMarker : i === 199 ? tailMarker : `line-${i}`;
+    lines.push(`${marker}-${'x'.repeat(500 - marker.length - 1)}`);
+  }
+  fs.writeFileSync(logPath, `${lines.join('\n')}\n`);
+
+  const restoreEnv = installIsolatedCliTestEnv();
+  const exitSpy = installExitSpy();
+  const stderr = captureStderr();
+  const sendToDaemon = async (): Promise<DaemonResponse> => ({
+    ok: false,
+    error: { code: 'SESSION_NOT_FOUND', message: 'No active session' },
+  });
+
+  try {
+    await runCli(['session', 'list', '--state-dir', stateDir, '--debug'], { sendToDaemon });
+  } finally {
+    stderr.restore();
+    exitSpy.restore();
+    restoreEnv();
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(exitSpy.calls, [1]);
+  const output = stderr.read();
+  assert.ok(output.includes('[daemon log]'), 'expected the daemon-log-tail block to be printed');
+  assert.ok(output.includes(tailMarker), 'expected the most recent line to survive the byte cap');
+  assert.ok(
+    !output.includes(headMarker),
+    'expected the byte cap to drop the oldest lines, not just the 200-line cap',
+  );
+});

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -33,9 +33,12 @@ function runVersionFastPath(argv: string[]): boolean {
 function runNoCommandFastPath(argv: string[]): boolean {
   if (argv.length !== 0) return false;
   import('./cli/parser/cli-help.ts')
-    .then(({ buildUsageText }) => {
+    .then(async ({ buildUsageText }) => {
       process.stdout.write(`${buildUsageText()}\n`);
-      process.exit(1);
+      // #1596: exitAfterFlush (not a bare process.exit) so the full usage
+      // text reaches a piped caller before the process terminates.
+      const { exitAfterFlush } = await import('./utils/process-exit.ts');
+      await exitAfterFlush(1);
     })
     .catch(handleStartupError);
   return true;
@@ -118,5 +121,8 @@ function runCli(argv: string[]): void {
 
 function handleStartupError(error: unknown): void {
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+  // #1596: exitAfterFlush so the message above isn't dropped on a piped stderr.
+  import('./utils/process-exit.ts')
+    .then(({ exitAfterFlush }) => exitAfterFlush(1))
+    .catch(() => process.exit(1));
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import {
   throwDaemonError,
 } from '@agent-device/kernel/errors';
 import { printHumanError, printJson } from './utils/output.ts';
+import { exitAfterFlush } from './utils/process-exit.ts';
 import { readVersion } from './utils/version.ts';
 import { pathToFileURL } from 'node:url';
 import { sendToDaemon } from './daemon/client/daemon-client.ts';
@@ -112,7 +113,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
         debugEnabled,
       });
       const debugOutputEnabled = isParsedDebugRequested(command, parsed.providedFlags);
-      const ctx = resolveRunContextOrExit(parsed, {
+      const ctx = await resolveRunContextOrExit(parsed, {
         command,
         positionals,
         requestId,
@@ -122,11 +123,11 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
       let logTailStopper: (() => void) | null = null;
       try {
         if (command === 'react-devtools') {
-          process.exit(await runReactDevtoolsCli(ctx, deps));
+          await exitAfterFlush(await runReactDevtoolsCli(ctx, deps));
           return;
         }
         if (command === 'web') {
-          process.exit(
+          await exitAfterFlush(
             await runWebCommand(positionals, {
               flags: ctx.effectiveFlags,
               stateDir: ctx.daemonPaths.baseDir,
@@ -143,7 +144,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
         await resolveRemoteContext(ctx, deps);
         registerDaemonAuthDiagnosticValue(ctx.effectiveFlags);
         if (command === 'cdp') {
-          process.exit(
+          await exitAfterFlush(
             await runAgentCdpCommand(positionals, {
               flags: ctx.effectiveFlags,
               runtime: ctx.resolvedRuntime,
@@ -165,7 +166,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
         });
         await dispatchCliCommand(ctx, client, replayTestReporterRuntime);
       } catch (err) {
-        handleRunCliFailure(err, ctx, logTailStopper);
+        await handleRunCliFailure(err, ctx, logTailStopper);
       } finally {
         if (logTailStopper) logTailStopper();
       }
@@ -207,7 +208,7 @@ async function parseCliInputOrExit(
     } else {
       printHumanError(normalized, { showDetails: options.debugEnabled });
     }
-    process.exit(1);
+    return exitAfterFlush(1);
   }
 
   for (const warning of parsed.warnings) {
@@ -216,7 +217,7 @@ async function parseCliInputOrExit(
 
   if (parsed.flags.version) {
     process.stdout.write(`${options.version}\n`);
-    process.exit(0);
+    return exitAfterFlush(0);
   }
 
   const isHelpAlias = parsed.command === 'help';
@@ -224,26 +225,26 @@ async function parseCliInputOrExit(
   if (isHelpAlias || isHelpFlag) {
     if (isHelpAlias && parsed.positionals.length > 1) {
       printHumanError(new AppError('INVALID_ARGS', 'help accepts at most one command.'));
-      process.exit(1);
+      return exitAfterFlush(1);
     }
     const helpTarget = isHelpAlias ? parsed.positionals[0] : parsed.command;
     if (!helpTarget) {
       process.stdout.write(`${await usage()}\n`);
-      process.exit(0);
+      return exitAfterFlush(0);
     }
     const commandHelp = await usageForCommand(helpTarget);
     if (commandHelp) {
       process.stdout.write(commandHelp);
-      process.exit(0);
+      return exitAfterFlush(0);
     }
     printHumanError(new AppError('INVALID_ARGS', formatUnknownHelpTargetMessage(helpTarget)));
     process.stdout.write(`${await usage()}\n`);
-    process.exit(1);
+    return exitAfterFlush(1);
   }
 
   if (!parsed.command) {
     process.stdout.write(`${await usage()}\n`);
-    process.exit(1);
+    return exitAfterFlush(1);
   }
 
   return { parsed, command: parsed.command, positionals: parsed.positionals };
@@ -270,10 +271,10 @@ type CliRunContext = {
   parsedBatchSteps: BatchStep[] | undefined;
 };
 
-function resolveRunContextOrExit(
+async function resolveRunContextOrExit(
   parsed: ReturnType<typeof resolveCliOptions>,
   base: { command: string; positionals: string[]; requestId: string; debugOutputEnabled: boolean },
-): CliRunContext {
+): Promise<CliRunContext> {
   const explicitFlagKeys = new Set(parsed.providedFlags.map((entry) => entry.key));
   try {
     const binding = resolveBindingSettings({
@@ -325,7 +326,7 @@ function resolveRunContextOrExit(
     } else {
       printHumanError(normalized, { showDetails: base.debugOutputEnabled });
     }
-    process.exit(1);
+    return exitAfterFlush(1);
   }
 }
 
@@ -536,11 +537,11 @@ async function dispatchCliCommand(
   throw new AppError('INVALID_ARGS', formatUnhandledCommandMessage(command));
 }
 
-function handleRunCliFailure(
+async function handleRunCliFailure(
   err: unknown,
   ctx: CliRunContext,
   logTailStopper: (() => void) | null,
-): void {
+): Promise<void> {
   const appErr = asAppError(err);
   const normalized = normalizeError(appErr, {
     diagnosticId: getDiagnosticsMeta().diagnosticId,
@@ -564,15 +565,24 @@ function handleRunCliFailure(
     }
   }
   if (logTailStopper) logTailStopper();
-  process.exit(1);
+  // #1596: a bare `process.exit()` right after these writes can drop them —
+  // Node flushes stdout/stderr synchronously only to a file or TTY, and this
+  // CLI is commonly piped by whatever is driving it. `exitAfterFlush` waits
+  // for the writes above to actually reach the pipe first.
+  await exitAfterFlush(1);
 }
+
+const DAEMON_LOG_TAIL_MAX_BYTES = 64_000;
 
 function printDaemonLogTailOnError(logPath: string): void {
   try {
     if (fs.existsSync(logPath)) {
       const content = fs.readFileSync(logPath, 'utf8');
       const lines = content.split('\n');
-      const tail = lines.slice(Math.max(0, lines.length - 200)).join('\n');
+      let tail = lines.slice(Math.max(0, lines.length - 200)).join('\n');
+      if (tail.length > DAEMON_LOG_TAIL_MAX_BYTES) {
+        tail = tail.slice(tail.length - DAEMON_LOG_TAIL_MAX_BYTES);
+      }
       if (tail.trim().length > 0) {
         process.stderr.write(`\n[daemon log]\n${tail}\n`);
       }
@@ -801,10 +811,10 @@ function guessSessionFromArgv(argv: string[]): string | null {
 
 const isDirectRun = pathToFileURL(process.argv[1] ?? '').href === import.meta.url;
 if (isDirectRun) {
-  runCli(process.argv.slice(2)).catch((err) => {
+  runCli(process.argv.slice(2)).catch(async (err) => {
     const appErr = asAppError(err);
     printHumanError(normalizeError(appErr), { showDetails: true });
-    process.exit(1);
+    await exitAfterFlush(1);
   });
 }
 

--- a/src/utils/__tests__/process-exit.test.ts
+++ b/src/utils/__tests__/process-exit.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { afterEach, test, vi } from 'vitest';
+
+vi.mock('../timeouts.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../timeouts.ts')>();
+  return { ...actual, sleep: vi.fn(async () => {}) };
+});
+
+import { exitAfterFlush } from '../process-exit.ts';
+import { sleep } from '../timeouts.ts';
+
+type FakeWriteStream = {
+  writableLength: number;
+  once: ReturnType<typeof vi.fn>;
+};
+
+function installFakeStdio(streams: {
+  stdout: FakeWriteStream;
+  stderr: FakeWriteStream;
+}): () => void {
+  const originalStdout = Object.getOwnPropertyDescriptor(process, 'stdout');
+  const originalStderr = Object.getOwnPropertyDescriptor(process, 'stderr');
+  Object.defineProperty(process, 'stdout', { value: streams.stdout, configurable: true });
+  Object.defineProperty(process, 'stderr', { value: streams.stderr, configurable: true });
+  return () => {
+    if (originalStdout) Object.defineProperty(process, 'stdout', originalStdout);
+    if (originalStderr) Object.defineProperty(process, 'stderr', originalStderr);
+  };
+}
+
+function installExitSpy(): { calls: number[]; restore: () => void } {
+  const originalExit = process.exit;
+  const calls: number[] = [];
+  (process as any).exit = ((code?: number) => {
+    calls.push(code ?? 0);
+  }) as typeof process.exit;
+  return { calls, restore: () => (process.exit = originalExit) };
+}
+
+function drainedStream(): FakeWriteStream {
+  return { writableLength: 0, once: vi.fn() };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('exitAfterFlush exits immediately when both streams are already drained', async () => {
+  const restoreStdio = installFakeStdio({ stdout: drainedStream(), stderr: drainedStream() });
+  const exitSpy = installExitSpy();
+
+  try {
+    await exitAfterFlush(1);
+  } finally {
+    restoreStdio();
+    exitSpy.restore();
+  }
+
+  assert.deepEqual(exitSpy.calls, [1]);
+});
+
+// #1596: proves the queued-write branch — a stream with buffered data must be
+// let drain before the process exits, not raced against immediately.
+test('exitAfterFlush waits for a backlogged stream to drain before exiting', async () => {
+  // The FLUSH_TIMEOUT_MS race's other arm is `sleep`, mocked module-wide to
+  // resolve immediately; override it here to a promise that never resolves so
+  // this test can only pass via the drain callback, not the timeout racing
+  // ahead of it.
+  vi.mocked(sleep).mockImplementationOnce(() => new Promise(() => {}));
+  let drainCallback: (() => void) | undefined;
+  const backloggedStderr: FakeWriteStream = {
+    writableLength: 1024,
+    once: vi.fn((event: string, cb: () => void) => {
+      if (event === 'drain') drainCallback = cb;
+    }),
+  };
+  const restoreStdio = installFakeStdio({ stdout: drainedStream(), stderr: backloggedStderr });
+  const exitSpy = installExitSpy();
+
+  try {
+    const pending = exitAfterFlush(2);
+    // Give the microtask queue a turn: exit must not have fired yet, since the
+    // backlogged stream hasn't drained.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepEqual(exitSpy.calls, [], 'exit fired before the backlogged stream drained');
+    assert.equal(typeof drainCallback, 'function');
+
+    drainCallback?.();
+    await pending;
+  } finally {
+    restoreStdio();
+    exitSpy.restore();
+  }
+
+  assert.deepEqual(exitSpy.calls, [2]);
+});
+
+// A stream that never emits 'drain' (a stalled or broken pipe) must not hang
+// the process — the FLUSH_TIMEOUT_MS race still exits. `sleep` is mocked
+// above so this resolves instantly instead of waiting the real timeout.
+test('exitAfterFlush still exits when a stream never drains', async () => {
+  const neverDrains: FakeWriteStream = { writableLength: 1024, once: vi.fn() };
+  const restoreStdio = installFakeStdio({ stdout: drainedStream(), stderr: neverDrains });
+  const exitSpy = installExitSpy();
+
+  try {
+    await exitAfterFlush(3);
+  } finally {
+    restoreStdio();
+    exitSpy.restore();
+  }
+
+  assert.deepEqual(exitSpy.calls, [3]);
+});

--- a/src/utils/process-exit.ts
+++ b/src/utils/process-exit.ts
@@ -1,0 +1,29 @@
+import { sleep } from './timeouts.ts';
+
+const FLUSH_TIMEOUT_MS = 2000;
+
+/**
+ * `process.exit()` truncates output still queued on `process.stdout`/`stderr`:
+ * Node writes to those streams synchronously only when they're a file or TTY —
+ * when the CLI runs as a piped subprocess (the common case for an agent
+ * driving it), writes are queued asynchronously, and `process.exit()` tears
+ * the process down before a queued write reaches the pipe. A caller then sees
+ * a truncated or empty final message instead of the structured error.
+ * `FLUSH_TIMEOUT_MS` bounds the wait so a stalled/broken pipe still exits
+ * rather than hanging the process.
+ */
+export async function exitAfterFlush(code: number): Promise<never> {
+  await Promise.race([drainStdio(), sleep(FLUSH_TIMEOUT_MS)]);
+  process.exit(code);
+}
+
+async function drainStdio(): Promise<void> {
+  await Promise.all([drainStream(process.stdout), drainStream(process.stderr)]);
+}
+
+function drainStream(stream: NodeJS.WriteStream): Promise<void> {
+  if (stream.writableLength === 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    stream.once('drain', resolve);
+  });
+}

--- a/test/integration/daemon-replace-exit-flush.test.ts
+++ b/test/integration/daemon-replace-exit-flush.test.ts
@@ -8,6 +8,7 @@ import { runCmdSync } from '../../src/utils/exec.ts';
 import { stopProcessForTakeover } from '../../src/daemon/daemon-process.ts';
 import { isProcessAlive } from '../../src/utils/host-process.ts';
 import { runCliJson } from './test-helpers.ts';
+import { PAYLOAD_MARKER } from './support/exit-payload.ts';
 
 // #1596: a CLI command that finds its recorded daemon unreachable replaces it
 // (`Replacing daemon (pid N, vX) in <state-dir>: unreachable`) and retries
@@ -17,7 +18,6 @@ import { runCliJson } from './test-helpers.ts';
 // replace-mid-command always ends in a normal, fully-delivered structured
 // error rather than a truncated or hung process.
 
-const PAYLOAD_MARKER = 'EXIT_PAYLOAD_END_MARKER';
 const SUPPORT_DIR = path.join(import.meta.dirname, 'support');
 const FIXTURE_TIMEOUT_MS = 10_000;
 
@@ -67,7 +67,11 @@ test('daemon replace mid-command returns a structured, parseable error and exits
     // just "fresh daemon, good luck" — this is the daemon.json truthfully
     // having no sessions, which is expected; only the error's shape/delivery
     // was ever in question.
-    assert.match(result.json.error?.hint ?? '', /open/i, formatUnexpected('an `open` hint', result));
+    assert.match(
+      result.json.error?.hint ?? '',
+      /open/i,
+      formatUnexpected('an `open` hint', result),
+    );
 
     info = readDaemonInfo(stateDir);
   } finally {
@@ -101,7 +105,10 @@ test('a bare process.exit() after a large write truncates it on a piped stream',
 test('exitAfterFlush (the #1596 fix) delivers the full write before the process exits', () => {
   const { exitCode, stderr } = runFixture('exit-after-flush.ts');
   assert.equal(exitCode, 1);
-  assert.ok(stderr.includes(PAYLOAD_MARKER), 'expected the full payload, including its trailing marker');
+  assert.ok(
+    stderr.includes(PAYLOAD_MARKER),
+    'expected the full payload, including its trailing marker',
+  );
 });
 
 function runFixture(name: string): { exitCode: number; stderr: string } {
@@ -126,7 +133,10 @@ function readDaemonInfo(stateDir: string): DaemonInfo {
   return JSON.parse(fs.readFileSync(path.join(stateDir, 'daemon.json'), 'utf8')) as DaemonInfo;
 }
 
-function formatUnexpected(expected: string, result: { status: number; stdout: string; stderr: string }): string {
+function formatUnexpected(
+  expected: string,
+  result: { status: number; stdout: string; stderr: string },
+): string {
   return [
     `expected ${expected}`,
     `status: ${result.status}`,

--- a/test/integration/daemon-replace-exit-flush.test.ts
+++ b/test/integration/daemon-replace-exit-flush.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { skipWhenLoopbackUnavailable } from '../../src/__tests__/test-utils/loopback.ts';
+import { runCmdSync } from '../../src/utils/exec.ts';
+import { stopProcessForTakeover } from '../../src/daemon/daemon-process.ts';
+import { isProcessAlive } from '../../src/utils/host-process.ts';
+import { runCliJson } from './test-helpers.ts';
+
+// #1596: a CLI command that finds its recorded daemon unreachable replaces it
+// (`Replacing daemon (pid N, vX) in <state-dir>: unreachable`) and retries
+// against a fresh one. Three field runs died with zero further agent actions
+// immediately after that replace plus a SESSION_NOT_FOUND (the fresh daemon
+// has no sessions yet, which is expected). This file locks down that a
+// replace-mid-command always ends in a normal, fully-delivered structured
+// error rather than a truncated or hung process.
+
+const PAYLOAD_MARKER = 'EXIT_PAYLOAD_END_MARKER';
+const SUPPORT_DIR = path.join(import.meta.dirname, 'support');
+const FIXTURE_TIMEOUT_MS = 10_000;
+
+type DaemonInfo = {
+  pid: number;
+  processStartTime?: string;
+};
+
+test('daemon replace mid-command returns a structured, parseable error and exits normally', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) {
+    return;
+  }
+
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replace-exit-flush-'));
+  let info: DaemonInfo | null = null;
+  try {
+    // A real daemon, started by this codebase, so its recorded version/code
+    // signature legitimately match — the only way to reach the "unreachable"
+    // takeover reason (as opposed to a version/signature mismatch takeover).
+    const started = runCliJson(['session', 'list', '--json', '--state-dir', stateDir]);
+    assert.equal(started.status, 0, `${started.stderr}\n${started.stdout}`);
+
+    info = readDaemonInfo(stateDir);
+    assert.equal(isProcessAlive(info.pid), true, 'expected the started daemon to be alive');
+
+    // Kill it out from under its own metadata: daemon.json stays put and
+    // still points at a pid that is now unreachable, reproducing the crash
+    // the field transcripts observed.
+    process.kill(info.pid, 'SIGKILL');
+    await waitForProcessDeath(info.pid);
+
+    const result = runCliJson(['close', '--json', '--state-dir', stateDir]);
+
+    assert.equal(result.status, 1, formatUnexpected('exit code', result));
+    assert.ok(
+      result.stderr.includes('Replacing daemon') && result.stderr.includes('unreachable'),
+      formatUnexpected('takeover notice on stderr', result),
+    );
+    assert.ok(result.json, formatUnexpected('parseable JSON stdout', result));
+    assert.equal(result.json.success, false, formatUnexpected('success:false', result));
+    assert.equal(
+      result.json.error?.code,
+      'SESSION_NOT_FOUND',
+      formatUnexpected('SESSION_NOT_FOUND', result),
+    );
+    // #1596 requirement: a hint pointing at `open` is always present, not
+    // just "fresh daemon, good luck" — this is the daemon.json truthfully
+    // having no sessions, which is expected; only the error's shape/delivery
+    // was ever in question.
+    assert.match(result.json.error?.hint ?? '', /open/i, formatUnexpected('an `open` hint', result));
+
+    info = readDaemonInfo(stateDir);
+  } finally {
+    if (info) {
+      await stopProcessForTakeover(info.pid, {
+        termTimeoutMs: 1_500,
+        killTimeoutMs: 1_500,
+        expectedStartTime: info.processStartTime,
+      });
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// Isolates the exact mechanism from the end-to-end test above: Node flushes
+// stdout/stderr synchronously only to a file or TTY, so `process.exit()`
+// called right after a write can drop that write when the stream is a pipe
+// (this CLI's normal condition, driven as a subprocess). Runs the write+exit
+// sequence directly as a real piped child process, independent of any
+// daemon/device setup, so the mechanism itself is proven deterministically.
+test('a bare process.exit() after a large write truncates it on a piped stream', () => {
+  const { exitCode, stderr } = runFixture('exit-naive.ts');
+  assert.equal(exitCode, 1);
+  assert.ok(
+    !stderr.includes(PAYLOAD_MARKER),
+    'expected the naive exit to truncate before the trailing marker; the pipe-buffer ' +
+      'reproduction this test depends on may not hold on this platform',
+  );
+});
+
+test('exitAfterFlush (the #1596 fix) delivers the full write before the process exits', () => {
+  const { exitCode, stderr } = runFixture('exit-after-flush.ts');
+  assert.equal(exitCode, 1);
+  assert.ok(stderr.includes(PAYLOAD_MARKER), 'expected the full payload, including its trailing marker');
+});
+
+function runFixture(name: string): { exitCode: number; stderr: string } {
+  const result = runCmdSync(
+    process.execPath,
+    ['--experimental-strip-types', path.join(SUPPORT_DIR, name)],
+    { allowFailure: true, timeoutMs: FIXTURE_TIMEOUT_MS },
+  );
+  return { exitCode: result.exitCode, stderr: result.stderr };
+}
+
+async function waitForProcessDeath(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.fail(`daemon pid ${pid} did not die after SIGKILL`);
+}
+
+function readDaemonInfo(stateDir: string): DaemonInfo {
+  return JSON.parse(fs.readFileSync(path.join(stateDir, 'daemon.json'), 'utf8')) as DaemonInfo;
+}
+
+function formatUnexpected(expected: string, result: { status: number; stdout: string; stderr: string }): string {
+  return [
+    `expected ${expected}`,
+    `status: ${result.status}`,
+    `stdout: ${result.stdout || '(empty)'}`,
+    `stderr: ${result.stderr || '(empty)'}`,
+  ].join('\n');
+}

--- a/test/integration/support/exit-after-flush.ts
+++ b/test/integration/support/exit-after-flush.ts
@@ -1,0 +1,7 @@
+// Counterpart to exit-naive.ts using the #1596 fix: same oversized write,
+// exited through `exitAfterFlush` instead of a bare `process.exit()`.
+import { exitAfterFlush } from '../../../src/utils/process-exit.ts';
+import { buildPayload } from './exit-payload.ts';
+
+process.stderr.write(buildPayload());
+await exitAfterFlush(1);

--- a/test/integration/support/exit-naive.ts
+++ b/test/integration/support/exit-naive.ts
@@ -1,0 +1,9 @@
+// Regression fixture for #1596: writes a payload larger than a pipe's kernel
+// buffer to stderr, then exits the way `src/cli.ts` used to (a bare
+// `process.exit()` right after the write). Run as a real subprocess by
+// process-exit.test.ts — Node flushes stdout/stderr synchronously only to a
+// file or TTY, so a piped parent reliably observes the write truncated.
+import { buildPayload } from './exit-payload.ts';
+
+process.stderr.write(buildPayload());
+process.exit(1);

--- a/test/integration/support/exit-payload.ts
+++ b/test/integration/support/exit-payload.ts
@@ -1,0 +1,10 @@
+// Shared payload for the #1596 exit-flush fixtures: sized past a pipe's
+// kernel buffer (64 KiB on macOS/Linux) so a truncated write is observable,
+// and ends with a marker that only survives the write if it wasn't cut off.
+export const PAYLOAD_MARKER = 'EXIT_PAYLOAD_END_MARKER';
+const PAYLOAD_BYTES = 200_000;
+
+export function buildPayload(): string {
+  const body = 'x'.repeat(PAYLOAD_BYTES - PAYLOAD_MARKER.length - 1);
+  return `${body}${PAYLOAD_MARKER}\n`;
+}


### PR DESCRIPTION
## Summary

Part of #1596 (hardening; the reported replace-path failure itself was not reproduced — see review discussion, issue stays open) — the field reports of the driving process going silent (zero further tool calls) right after:

```
Replacing daemon (pid N, vX) in <state-dir>: unreachable
Error (SESSION_NOT_FOUND): iOS snapshot requires an active app session on the target device.
```

### Investigation

I read through the daemon replace/takeover path (`src/daemon/client/daemon-client-lifecycle.ts`) and the SESSION_NOT_FOUND emission path (`src/daemon/snapshot-runtime.ts`, `src/daemon/handlers/*`). The takeover mechanics themselves look sound:
- the detached daemon child is spawned with `detached: true` (its own process group/session) and its stdout/stderr are redirected to explicit file descriptors, never inherited from the CLI's own stdio — so a replaced daemon can't hold the CLI's own stdout pipe open;
- `stopDaemonProcessForTakeover`/`isAgentDeviceDaemonProcess` verify a live process by command pattern + `processStartTime` before signaling it, and `isProcessAlive` explicitly rejects `pid <= 0` — so a PID-reuse or `pid: 0`→`kill(0, …)` group-signal footgun isn't reachable;
- the daemon-startup `exited` promise (`runCmdDetachedMonitored`) only ever resolves, never rejects — so there's no unhandled-rejection path there;
- `SESSION_NOT_FOUND` from a fresh daemon is a normal structured `ok:false` response and already carries a default hint ("Run open first…") via `normalizeError`/`defaultHintForCode`.

I could **not** find or prove a hang/crash/process-group-leak mechanism in the replace/takeover code itself. What I *did* find and prove is a real, general Node.js correctness bug on the CLI's own exit path: **`process.exit()` called immediately after a `process.stdout`/`process.stderr` write can silently drop that write** — Node flushes those streams synchronously only when they're a file or TTY; on a pipe (this CLI's normal condition when driven as a subprocess by an agent harness) writes are queued asynchronously, and `process.exit()` tears the process down before a queued write reaches the pipe.

This is directly reachable from the exact code path that renders the reported error: `handleRunCliFailure` in `src/cli.ts` calls `printHumanError` and then, under `--debug`, `printDaemonLogTailOnError` — which dumps up to 200 *unbounded* lines of the daemon's log — immediately before `process.exit(1)`.

**Evidence (red without the fix, green with it), against the real CLI, not just an isolated repro:**
1. Started a real local daemon, killed it with `SIGKILL` (stale `daemon.json`, live-then-dead pid — the same shape as "unreachable").
2. Seeded its `daemon.log` past 64KB (macOS/Linux's default pipe buffer size) and re-ran `close --debug --state-dir <dir>` through a real piped `spawnSync`, matching how an agent harness captures subprocess output.
3. **Pre-fix**: `stderr length: 66672`, trailing marker **missing** — truncated mid-write.
4. **Post-fix** (same daemon, same seeded log, re-seeded to 65151 bytes): trailing marker **present** — fully delivered.

I want to be upfront about the limit of this evidence: a *freshly started* daemon truncates its own `daemon.log` to empty at startup (`src/daemon/server/server-lifecycle.ts:29`, `fs.writeFileSync(logPath, '')`), so in a plain sandbox (no simulator/device backend) the log-tail dump right after a replace is only a few dozen bytes — nowhere near 64KB. I cannot prove this exact log-tail dump is what corrupted the 3 AppControlBench transcripts; that would need a host where the fresh daemon's own startup logging (device enumeration, xcrun/adb calls, etc.) is chatty enough to approach the pipe-buffer threshold on its own, which I can't reproduce here. What I can say confidently: the mechanism is real, it lives in the CLI's shared failure-rendering path, it is reachable from this exact SESSION_NOT_FOUND-after-replace scenario, and it was previously completely unguarded — this PR closes that gap regardless of whether it's proven to be the exact historical trigger.

### Fix

- Added `src/utils/process-exit.ts` (`exitAfterFlush`): drains `process.stdout`/`stderr` (bounded by a 2s timeout so a stalled/broken pipe still can't hang the process) before calling `process.exit()`.
- Routed every `process.exit()` call site in `src/cli.ts` and `src/bin.ts` through it (the failure-rendering path, the parse/help/version fast-exits, and the react-devtools/web/cdp subcommand exit-code wrappers) — all share the same footgun.
- Bounded `printDaemonLogTailOnError`'s dump to 64,000 bytes on top of its existing 200-line cap, as defense in depth.

### Tests

`test/integration/daemon-replace-exit-flush.test.ts` (new, `node --test`, follows the existing `smoke-daemon-*.test.ts` harness pattern):
- End-to-end: starts a real daemon, `SIGKILL`s it, reruns a command against the stale state dir, asserts the CLI prints the "Replacing daemon … unreachable" notice, exits with code 1, and returns parseable `--json` with `error.code === 'SESSION_NOT_FOUND'` and an `open`-mentioning hint.
- Mechanism, isolated and deterministic: two small fixture scripts (`test/integration/support/exit-naive.ts` / `exit-after-flush.ts`) each write an oversized payload to stderr then exit the old way vs. the fixed way, run as real piped child processes. Confirms the naive path truncates and `exitAfterFlush` doesn't, independent of any daemon/device setup.

### Verification

- `pnpm check:quick` (lint + typecheck): clean.
- `node --test test/integration/daemon-replace-exit-flush.test.ts test/integration/smoke-daemon-clean.test.ts test/integration/smoke-daemon-http.test.ts`: 5/5 pass.
- `pnpm test:unit`: 603/603 files pass (5290/5290 tests). One initial run showed transient timeouts from CPU contention caused by two concurrent full suite runs, and one `ENOTEMPTY` temp-dir cleanup race in an unrelated test file — both reproduced as flaky-under-contention and confirmed unrelated to this change by re-running each failing file in isolation (all green).

## Test plan
- [x] `pnpm check:quick`
- [x] `node --test test/integration/daemon-replace-exit-flush.test.ts`
- [x] `pnpm test:unit` (clean run, 603/603 files)
