### PR TITLE
build: eliminate tsdown bundle warnings

### DIFF
--- a/src/daemon/request-platform-providers.ts
+++ b/src/daemon/request-platform-providers.ts
@@ -13,11 +13,11 @@ import type {
 } from '../platforms/apple/core/tool-provider.ts';
 import type { LinuxToolProvider } from '../platforms/linux/tool-provider.ts';
 import type { VegaToolProvider } from '../platforms/vega/tool-provider.ts';
-import type { WebProvider } from '../platforms/web/provider.ts';
+import { withWebProvider, type WebProvider } from '../platforms/web/provider.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { AppLogProvider } from './app-log.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
-import type { RecordingProvider } from './recording-provider.ts';
+import { withRecordingProvider, type RecordingProvider } from './recording-provider.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
 import { resolveProviderDeviceResolutionIntent } from './daemon-command-registry.ts';
 
@@ -261,7 +261,6 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     },
     async appendWrapper(scopedProviders, wrappers) {
       if (!scopedProviders.web?.provider) return;
-      const { withWebProvider } = await import('../platforms/web/provider.ts');
       appendRequestProviderWrapper(wrappers, scopedProviders.web, withWebProvider);
     },
   },
@@ -287,7 +286,6 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     },
     async appendWrapper(scopedProviders, wrappers) {
       if (!scopedProviders.recording?.provider) return;
-      const { withRecordingProvider } = await import('./recording-provider.ts');
       appendRequestProviderWrapper(wrappers, scopedProviders.recording, withRecordingProvider);
     },
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
   },
   deps: {
     alwaysBundle: [/^@agent-device\//, 'pngjs'],
+    onlyBundle: ['pngjs'],
   },
   inputOptions: {
     // A build with missing workspace links resolves nothing under `alwaysBundle` and emits the


### PR DESCRIPTION
## Summary

Allowlist the intentionally bundled `pngjs` dependency and replace two dynamic provider imports that Rolldown confirmed could not split.

The emitted bundle is 307 bytes smaller overall (114 bytes gzip); the daemon entry is 310 bytes smaller (134 bytes gzip). Build output no longer reports the dependency or ineffective-dynamic-import warnings.

## Validation

`pnpm check:affected --run` passed all runnable checks, including affected coverage, provider-backed integration, Node integration, package verification, and replay-compat provenance.
