### PR TITLE
refactor(ios): share one private-XCTest event bridge between gesture and text synthesis

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
@@ -1,63 +1,57 @@
 #import "RunnerSynthesizedGesture.h"
+#import "RunnerXCTestEventBridge.h"
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <objc/message.h>
 
-typedef NSInteger (*RunnerMsgSendInteger)(id, SEL);
+static NSString *const RunnerGestureSynthesisSurface = @"event";
+
 typedef id (*RunnerMsgSendInitRecord)(id, SEL, NSString *, NSInteger);
 typedef id (*RunnerMsgSendInitPath)(id, SEL, CGPoint, NSTimeInterval);
 typedef void (*RunnerMsgSendPathMove)(id, SEL, CGPoint, NSTimeInterval);
 typedef void (*RunnerMsgSendPathOffset)(id, SEL, NSTimeInterval);
-typedef void (*RunnerMsgSendAddPath)(id, SEL, id);
-typedef void (*RunnerMsgSendSetInteger)(id, SEL, NSInteger);
-typedef BOOL (*RunnerMsgSendSynthesize)(id, SEL, NSError **);
 
+// Gesture-specific extension of the shared bridge: the 2-arg
+// `initWithName:interfaceOrientation:` record initializer and the touch-path
+// factory/mutator selectors, none of which text-entry synthesis needs.
 typedef struct {
-  Class recordClass;
-  Class pathClass;
+  RunnerXCTestEventBridge core;
   SEL initRecordSelector;
-  SEL addPathSelector;
-  SEL setTargetProcessIDSelector;
-  SEL synthesizeSelector;
   SEL interfaceOrientationSelector;
-  SEL processIDSelector;
   SEL initPathSelector;
   SEL moveSelector;
   SEL liftSelector;
-} RunnerXCTestEventBridge;
+} RunnerGestureEventBridge;
 
 typedef id (*RunnerDragPointerPathFactory)(
-  const RunnerXCTestEventBridge *,
+  const RunnerGestureEventBridge *,
   CGPoint,
   CGPoint,
   double
 );
 
-static NSString * _Nullable RunnerResolveXCTestEventBridge(
+static NSString * _Nullable RunnerResolveGestureEventBridge(
   id application,
-  RunnerXCTestEventBridge *bridge
+  RunnerGestureEventBridge *bridge
 );
-static NSString * _Nullable RunnerRequireClass(Class cls, NSString *className);
-static NSString * _Nullable RunnerRequireSelector(Class cls, SEL selector, NSString *selectorName);
-static NSString * _Nullable RunnerRequireApplicationSelector(id application, SEL selector, NSString *selectorName);
 static NSString * _Nullable RunnerCreateEventRecord(
   id application,
   NSString *recordName,
-  RunnerXCTestEventBridge *bridge,
+  RunnerGestureEventBridge *bridge,
   id *record
 );
 static NSString * _Nullable RunnerSynthesizeEventRecord(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   id record
 );
 static id RunnerSwipePointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint start,
   CGPoint end,
   double durationMs
 );
 static id RunnerContinuousDragPointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint start,
   CGPoint end,
   double durationMs
@@ -75,7 +69,7 @@ static NSString * _Nullable RunnerTrySynthesizeTap(id application, CGPoint point
 // fling duration. Fast movement is what lets UIKit distinguish a fling from a timed pan.
 static const NSTimeInterval RunnerSwipeMovementDurationSeconds = 0.1;
 static id RunnerTapPointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint point
 );
 
@@ -97,9 +91,7 @@ static id RunnerTapPointerPath(
       RunnerSwipePointerPath
     );
   } @catch (NSException *exception) {
-    NSString *name = exception.name ?: @"NSException";
-    NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
-    return [NSString stringWithFormat:@"%@: %@", name, reason];
+    return RunnerFormatXCTestException(exception, @"private XCTest event synthesis failed");
   }
 }
 
@@ -119,9 +111,7 @@ static id RunnerTapPointerPath(
       RunnerContinuousDragPointerPath
     );
   } @catch (NSException *exception) {
-    NSString *name = exception.name ?: @"NSException";
-    NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
-    return [NSString stringWithFormat:@"%@: %@", name, reason];
+    return RunnerFormatXCTestException(exception, @"private XCTest event synthesis failed");
   }
 }
 
@@ -131,16 +121,14 @@ static id RunnerTapPointerPath(
   @try {
     return RunnerTrySynthesizeTap(application, CGPointMake(x, y));
   } @catch (NSException *exception) {
-    NSString *name = exception.name ?: @"NSException";
-    NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
-    return [NSString stringWithFormat:@"%@: %@", name, reason];
+    return RunnerFormatXCTestException(exception, @"private XCTest event synthesis failed");
   }
 }
 
 + (NSString * _Nullable)synthesizeGestureWithApplication:(id)application
                                           pointerSamples:(NSArray<NSArray<NSDictionary<NSString *, NSNumber *> *> *> *)pointerSamples {
   @try {
-    RunnerXCTestEventBridge bridge;
+    RunnerGestureEventBridge bridge;
     id record = nil;
     NSString *error = RunnerCreateEventRecord(
       application,
@@ -155,7 +143,7 @@ static id RunnerTapPointerPath(
       if (first == nil) return @"private XCTest event synthesis failed: empty pointer path";
       CGPoint start = CGPointMake(first[@"x"].doubleValue, first[@"y"].doubleValue);
       id path = ((RunnerMsgSendInitPath)objc_msgSend)(
-        [bridge.pathClass alloc],
+        [bridge.core.pathClass alloc],
         bridge.initPathSelector,
         start,
         first[@"offsetMs"].doubleValue / 1000.0
@@ -179,14 +167,12 @@ static id RunnerTapPointerPath(
         bridge.liftSelector,
         last[@"offsetMs"].doubleValue / 1000.0
       );
-      ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
+      ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.core.addPathSelector, path);
     }
 
     return RunnerSynthesizeEventRecord(&bridge, record);
   } @catch (NSException *exception) {
-    NSString *name = exception.name ?: @"NSException";
-    NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
-    return [NSString stringWithFormat:@"%@: %@", name, reason];
+    return RunnerFormatXCTestException(exception, @"private XCTest event synthesis failed");
   }
 }
 
@@ -206,7 +192,7 @@ static NSString * _Nullable RunnerTrySynthesizeDrag(
   NSString *recordName,
   RunnerDragPointerPathFactory pathFactory
 ) {
-  RunnerXCTestEventBridge bridge;
+  RunnerGestureEventBridge bridge;
   id record = nil;
   NSString *error = RunnerCreateEventRecord(application, recordName, &bridge, &record);
   if (error != nil) return error;
@@ -215,13 +201,13 @@ static NSString * _Nullable RunnerTrySynthesizeDrag(
   if (path == nil) {
     return @"private XCTest event synthesis failed: could not create pointer path";
   }
-  ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
+  ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.core.addPathSelector, path);
 
   return RunnerSynthesizeEventRecord(&bridge, record);
 }
 
 static NSString * _Nullable RunnerTrySynthesizeTap(id application, CGPoint point) {
-  RunnerXCTestEventBridge bridge;
+  RunnerGestureEventBridge bridge;
   id record = nil;
   NSString *error = RunnerCreateEventRecord(
     application,
@@ -235,58 +221,49 @@ static NSString * _Nullable RunnerTrySynthesizeTap(id application, CGPoint point
   if (path == nil) {
     return @"private XCTest event synthesis failed: could not create pointer path";
   }
-  ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
+  ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.core.addPathSelector, path);
   return RunnerSynthesizeEventRecord(&bridge, record);
 }
 
-static NSString * _Nullable RunnerResolveXCTestEventBridge(
+static NSString * _Nullable RunnerResolveGestureEventBridge(
   id application,
-  RunnerXCTestEventBridge *bridge
+  RunnerGestureEventBridge *bridge
 ) {
-  Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
-  Class pathClass = NSClassFromString(@"XCPointerEventPath");
+  RunnerXCTestEventBridge core;
+  NSString *missing = RunnerResolveXCTestEventBridge(application, RunnerGestureSynthesisSurface, &core);
+  if (missing != nil) return missing;
+
   SEL initRecordSelector = NSSelectorFromString(@"initWithName:interfaceOrientation:");
-  SEL addPathSelector = NSSelectorFromString(@"addPointerEventPath:");
-  SEL setTargetProcessIDSelector = NSSelectorFromString(@"setTargetProcessID:");
-  SEL synthesizeSelector = NSSelectorFromString(@"synthesizeWithError:");
   SEL interfaceOrientationSelector = NSSelectorFromString(@"interfaceOrientation");
-  SEL processIDSelector = NSSelectorFromString(@"processID");
   SEL initPathSelector = NSSelectorFromString(@"initForTouchAtPoint:offset:");
   SEL moveSelector = NSSelectorFromString(@"moveToPoint:atOffset:");
   SEL liftSelector = NSSelectorFromString(@"liftUpAtOffset:");
 
-  NSString *missing = RunnerRequireClass(recordClass, @"XCSynthesizedEventRecord");
+  missing = RunnerRequireSelector(
+    core.recordClass, initRecordSelector, @"initWithName:interfaceOrientation:", RunnerGestureSynthesisSurface
+  );
   if (missing != nil) return missing;
-  missing = RunnerRequireClass(pathClass, @"XCPointerEventPath");
+  missing = RunnerRequireSelector(
+    core.pathClass, initPathSelector, @"initForTouchAtPoint:offset:", RunnerGestureSynthesisSurface
+  );
   if (missing != nil) return missing;
-  missing = RunnerRequireSelector(recordClass, initRecordSelector, @"initWithName:interfaceOrientation:");
+  missing = RunnerRequireSelector(
+    core.pathClass, moveSelector, @"moveToPoint:atOffset:", RunnerGestureSynthesisSurface
+  );
   if (missing != nil) return missing;
-  missing = RunnerRequireSelector(recordClass, addPathSelector, @"addPointerEventPath:");
+  missing = RunnerRequireSelector(
+    core.pathClass, liftSelector, @"liftUpAtOffset:", RunnerGestureSynthesisSurface
+  );
   if (missing != nil) return missing;
-  missing = RunnerRequireSelector(recordClass, setTargetProcessIDSelector, @"setTargetProcessID:");
-  if (missing != nil) return missing;
-  missing = RunnerRequireSelector(recordClass, synthesizeSelector, @"synthesizeWithError:");
-  if (missing != nil) return missing;
-  missing = RunnerRequireSelector(pathClass, initPathSelector, @"initForTouchAtPoint:offset:");
-  if (missing != nil) return missing;
-  missing = RunnerRequireSelector(pathClass, moveSelector, @"moveToPoint:atOffset:");
-  if (missing != nil) return missing;
-  missing = RunnerRequireSelector(pathClass, liftSelector, @"liftUpAtOffset:");
-  if (missing != nil) return missing;
-  missing = RunnerRequireApplicationSelector(application, interfaceOrientationSelector, @"interfaceOrientation");
-  if (missing != nil) return missing;
-  missing = RunnerRequireApplicationSelector(application, processIDSelector, @"processID");
+  missing = RunnerRequireApplicationSelector(
+    application, interfaceOrientationSelector, @"interfaceOrientation", RunnerGestureSynthesisSurface
+  );
   if (missing != nil) return missing;
 
-  *bridge = (RunnerXCTestEventBridge){
-    .recordClass = recordClass,
-    .pathClass = pathClass,
+  *bridge = (RunnerGestureEventBridge){
+    .core = core,
     .initRecordSelector = initRecordSelector,
-    .addPathSelector = addPathSelector,
-    .setTargetProcessIDSelector = setTargetProcessIDSelector,
-    .synthesizeSelector = synthesizeSelector,
     .interfaceOrientationSelector = interfaceOrientationSelector,
-    .processIDSelector = processIDSelector,
     .initPathSelector = initPathSelector,
     .moveSelector = moveSelector,
     .liftSelector = liftSelector,
@@ -294,57 +271,25 @@ static NSString * _Nullable RunnerResolveXCTestEventBridge(
   return nil;
 }
 
-static NSString * _Nullable RunnerRequireClass(Class cls, NSString *className) {
-  if (cls == Nil) {
-    return [NSString stringWithFormat:@"private XCTest event synthesis unavailable: missing %@", className];
-  }
-  return nil;
-}
-
-static NSString * _Nullable RunnerRequireSelector(Class cls, SEL selector, NSString *selectorName) {
-  if (![cls instancesRespondToSelector:selector]) {
-    return [NSString stringWithFormat:
-      @"private XCTest event synthesis unavailable: %@ missing %@",
-      NSStringFromClass(cls),
-      selectorName
-    ];
-  }
-  return nil;
-}
-
-static NSString * _Nullable RunnerRequireApplicationSelector(
-  id application,
-  SEL selector,
-  NSString *selectorName
-) {
-  if (![application respondsToSelector:selector]) {
-    return [NSString stringWithFormat:
-      @"private XCTest event synthesis unavailable: XCUIApplication missing %@",
-      selectorName
-    ];
-  }
-  return nil;
-}
-
 static NSString * _Nullable RunnerCreateEventRecord(
   id application,
   NSString *recordName,
-  RunnerXCTestEventBridge *bridge,
+  RunnerGestureEventBridge *bridge,
   id *record
 ) {
-  NSString *missing = RunnerResolveXCTestEventBridge(application, bridge);
+  NSString *missing = RunnerResolveGestureEventBridge(application, bridge);
   if (missing != nil) return missing;
 
   NSInteger interfaceOrientation =
     ((RunnerMsgSendInteger)objc_msgSend)(application, bridge->interfaceOrientationSelector);
   NSInteger targetProcessID =
-    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge->processIDSelector);
+    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge->core.processIDSelector);
   if (targetProcessID <= 0) {
     return @"private XCTest event synthesis unavailable: could not resolve target process ID";
   }
 
   id eventRecord = ((RunnerMsgSendInitRecord)objc_msgSend)(
-    [bridge->recordClass alloc],
+    [bridge->core.recordClass alloc],
     bridge->initRecordSelector,
     recordName,
     interfaceOrientation
@@ -354,7 +299,7 @@ static NSString * _Nullable RunnerCreateEventRecord(
   }
   ((RunnerMsgSendSetInteger)objc_msgSend)(
     eventRecord,
-    bridge->setTargetProcessIDSelector,
+    bridge->core.setTargetProcessIDSelector,
     targetProcessID
   );
   *record = eventRecord;
@@ -362,11 +307,11 @@ static NSString * _Nullable RunnerCreateEventRecord(
 }
 
 static NSString * _Nullable RunnerSynthesizeEventRecord(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   id record
 ) {
   NSError *error = nil;
-  BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge->synthesizeSelector, &error);
+  BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge->core.synthesizeSelector, &error);
   if (!ok) {
     NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
     return [NSString stringWithFormat:@"private XCTest event synthesis failed: %@", detail];
@@ -375,13 +320,13 @@ static NSString * _Nullable RunnerSynthesizeEventRecord(
 }
 
 static id RunnerSwipePointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint start,
   CGPoint end,
   double durationMs
 ) {
   id path =
-    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->pathClass alloc], bridge->initPathSelector, start, 0.0);
+    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->core.pathClass alloc], bridge->initPathSelector, start, 0.0);
   if (path == nil) {
     return nil;
   }
@@ -402,13 +347,13 @@ static id RunnerSwipePointerPath(
 }
 
 static id RunnerContinuousDragPointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint start,
   CGPoint end,
   double durationMs
 ) {
   id path =
-    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->pathClass alloc], bridge->initPathSelector, start, 0.0);
+    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->core.pathClass alloc], bridge->initPathSelector, start, 0.0);
   if (path == nil) {
     return nil;
   }
@@ -433,11 +378,11 @@ static id RunnerContinuousDragPointerPath(
 }
 
 static id RunnerTapPointerPath(
-  const RunnerXCTestEventBridge *bridge,
+  const RunnerGestureEventBridge *bridge,
   CGPoint point
 ) {
   id path =
-    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->pathClass alloc], bridge->initPathSelector, point, 0.0);
+    ((RunnerMsgSendInitPath)objc_msgSend)([bridge->core.pathClass alloc], bridge->initPathSelector, point, 0.0);
   if (path == nil) {
     return nil;
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedTextEntry.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedTextEntry.m
@@ -1,18 +1,31 @@
 #import "RunnerSynthesizedTextEntry.h"
+#import "RunnerXCTestEventBridge.h"
 
 #import <objc/message.h>
 
-typedef NSInteger (*RunnerTextMsgSendInteger)(id, SEL);
+static NSString *const RunnerTextSynthesisSurface = @"text";
+
 typedef id (*RunnerTextMsgSendInit)(id, SEL, NSString *);
 typedef id (*RunnerTextMsgSendInitPath)(id, SEL);
 typedef void (*RunnerTextMsgSendType)(id, SEL, NSString *, NSTimeInterval, NSUInteger, BOOL);
 typedef void (*RunnerTextMsgSendTypeKey)(id, SEL, NSString *, NSUInteger, NSTimeInterval);
-typedef void (*RunnerTextMsgSendObject)(id, SEL, id);
-typedef void (*RunnerTextMsgSendSetInteger)(id, SEL, NSInteger);
-typedef BOOL (*RunnerTextMsgSendSynthesize)(id, SEL, NSError **);
 
-static NSString * _Nullable RunnerRequireTextClass(Class cls, NSString *name);
-static NSString * _Nullable RunnerRequireTextSelector(Class cls, SEL selector, NSString *name);
+// Text-entry-specific extension of the shared bridge: the 1-arg `initWithName:`
+// record initializer and the text-input path selectors, none of which gesture
+// synthesis needs.
+typedef struct {
+  RunnerXCTestEventBridge core;
+  SEL initRecordSelector;
+  SEL initPathSelector;
+  SEL typeTextSelector;
+  SEL typeKeySelector;  // only required in `replace` mode
+} RunnerTextEventBridge;
+
+static NSString * _Nullable RunnerResolveTextEventBridge(
+  id application,
+  BOOL replace,
+  RunnerTextEventBridge *bridge
+);
 static RunnerSynthesizedTextEntryResult *RunnerTextEntryResult(
   RunnerSynthesizedTextEntryStatus status,
   NSString * _Nullable message
@@ -56,45 +69,12 @@ static RunnerSynthesizedTextEntryResult *RunnerSynthesizeTextWithMode(
   BOOL replace
 ) {
   @try {
-    Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
-    Class pathClass = NSClassFromString(@"XCPointerEventPath");
-    SEL initRecord = NSSelectorFromString(@"initWithName:");
-    SEL initPath = NSSelectorFromString(@"initForTextInput");
-    SEL typeText = NSSelectorFromString(@"typeText:atOffset:typingSpeed:shouldRedact:");
-    SEL typeKey = NSSelectorFromString(@"typeKey:modifiers:atOffset:");
-    SEL addPath = NSSelectorFromString(@"addPointerEventPath:");
-    SEL setTargetProcessID = NSSelectorFromString(@"setTargetProcessID:");
-    SEL synthesize = NSSelectorFromString(@"synthesizeWithError:");
-    SEL processID = NSSelectorFromString(@"processID");
-
-    NSString *missing = RunnerRequireTextClass(recordClass, @"XCSynthesizedEventRecord");
+    RunnerTextEventBridge bridge;
+    NSString *missing = RunnerResolveTextEventBridge(application, replace, &bridge);
     if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextClass(pathClass, @"XCPointerEventPath");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(recordClass, initRecord, @"initWithName:");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(recordClass, addPath, @"addPointerEventPath:");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(recordClass, setTargetProcessID, @"setTargetProcessID:");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(recordClass, synthesize, @"synthesizeWithError:");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(pathClass, initPath, @"initForTextInput");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    missing = RunnerRequireTextSelector(pathClass, typeText, @"typeText:atOffset:typingSpeed:shouldRedact:");
-    if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    if (replace) {
-      missing = RunnerRequireTextSelector(pathClass, typeKey, @"typeKey:modifiers:atOffset:");
-      if (missing != nil) return RunnerTextEntryUnavailable(missing);
-    }
-    if (![application respondsToSelector:processID]) {
-      return RunnerTextEntryUnavailable(
-        @"private XCTest text synthesis unavailable: XCUIApplication missing processID"
-      );
-    }
 
     NSInteger targetProcessID =
-      ((RunnerTextMsgSendInteger)objc_msgSend)(application, processID);
+      ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.core.processIDSelector);
     if (targetProcessID <= 0) {
       return RunnerTextEntryUnavailable(
         @"private XCTest text synthesis unavailable: could not resolve target process ID"
@@ -103,16 +83,17 @@ static RunnerSynthesizedTextEntryResult *RunnerSynthesizeTextWithMode(
 
     if (replace) {
       id selectionRecord = ((RunnerTextMsgSendInit)objc_msgSend)(
-        [recordClass alloc], initRecord, @"agent-device-fill-select-all"
+        [bridge.core.recordClass alloc], bridge.initRecordSelector, @"agent-device-fill-select-all"
       );
-      id selectionPath = ((RunnerTextMsgSendInitPath)objc_msgSend)([pathClass alloc], initPath);
+      id selectionPath =
+        ((RunnerTextMsgSendInitPath)objc_msgSend)([bridge.core.pathClass alloc], bridge.initPathSelector);
       if (selectionRecord == nil || selectionPath == nil) {
         return RunnerTextEntryFailed(
           @"private XCTest text synthesis failed: could not create the selection event"
         );
       }
-      ((RunnerTextMsgSendSetInteger)objc_msgSend)(
-        selectionRecord, setTargetProcessID, targetProcessID
+      ((RunnerMsgSendSetInteger)objc_msgSend)(
+        selectionRecord, bridge.core.setTargetProcessIDSelector, targetProcessID
       );
       // XCUIKeyModifierCommand is public XCTest API (1 << 4). Keeping the value local
       // avoids importing XCUIAutomation headers into the bridging helper. A text-input
@@ -120,12 +101,12 @@ static RunnerSynthesizedTextEntryResult *RunnerSynthesizeTextWithMode(
       // use ordered records rather than one multi-operation path.
       NSUInteger commandModifier = 1UL << 4;
       ((RunnerTextMsgSendTypeKey)objc_msgSend)(
-        selectionPath, typeKey, @"a", commandModifier, 0.0
+        selectionPath, bridge.typeKeySelector, @"a", commandModifier, 0.0
       );
-      ((RunnerTextMsgSendObject)objc_msgSend)(selectionRecord, addPath, selectionPath);
+      ((RunnerMsgSendAddPath)objc_msgSend)(selectionRecord, bridge.core.addPathSelector, selectionPath);
       NSError *selectionError = nil;
-      BOOL selected = ((RunnerTextMsgSendSynthesize)objc_msgSend)(
-        selectionRecord, synthesize, &selectionError
+      BOOL selected = ((RunnerMsgSendSynthesize)objc_msgSend)(
+        selectionRecord, bridge.core.synthesizeSelector, &selectionError
       );
       if (!selected) {
         NSString *detail = selectionError.localizedDescription ?: @"synthesizeWithError returned false";
@@ -136,20 +117,22 @@ static RunnerSynthesizedTextEntryResult *RunnerSynthesizeTextWithMode(
     }
 
     id record = ((RunnerTextMsgSendInit)objc_msgSend)(
-      [recordClass alloc], initRecord, replace ? @"agent-device-fill-text" : @"agent-device-type"
+      [bridge.core.recordClass alloc],
+      bridge.initRecordSelector,
+      replace ? @"agent-device-fill-text" : @"agent-device-type"
     );
-    id path = ((RunnerTextMsgSendInitPath)objc_msgSend)([pathClass alloc], initPath);
+    id path = ((RunnerTextMsgSendInitPath)objc_msgSend)([bridge.core.pathClass alloc], bridge.initPathSelector);
     if (record == nil || path == nil) {
       return RunnerTextEntryFailed(
         @"private XCTest text synthesis failed: could not create the text event"
       );
     }
-    ((RunnerTextMsgSendSetInteger)objc_msgSend)(record, setTargetProcessID, targetProcessID);
-    ((RunnerTextMsgSendType)objc_msgSend)(path, typeText, text, 0.0, 60, YES);
-    ((RunnerTextMsgSendObject)objc_msgSend)(record, addPath, path);
+    ((RunnerMsgSendSetInteger)objc_msgSend)(record, bridge.core.setTargetProcessIDSelector, targetProcessID);
+    ((RunnerTextMsgSendType)objc_msgSend)(path, bridge.typeTextSelector, text, 0.0, 60, YES);
+    ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.core.addPathSelector, path);
 
     NSError *error = nil;
-    BOOL ok = ((RunnerTextMsgSendSynthesize)objc_msgSend)(record, synthesize, &error);
+    BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge.core.synthesizeSelector, &error);
     if (!ok) {
       NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
       return RunnerTextEntryFailed(
@@ -158,10 +141,56 @@ static RunnerSynthesizedTextEntryResult *RunnerSynthesizeTextWithMode(
     }
     return RunnerTextEntryResult(RunnerSynthesizedTextEntryStatusSucceeded, nil);
   } @catch (NSException *exception) {
-    NSString *name = exception.name ?: @"NSException";
-    NSString *reason = exception.reason ?: @"private XCTest text synthesis failed";
-    return RunnerTextEntryFailed([NSString stringWithFormat:@"%@: %@", name, reason]);
+    return RunnerTextEntryFailed(
+      RunnerFormatXCTestException(exception, @"private XCTest text synthesis failed")
+    );
   }
+}
+
+static NSString * _Nullable RunnerResolveTextEventBridge(
+  id application,
+  BOOL replace,
+  RunnerTextEventBridge *bridge
+) {
+  RunnerXCTestEventBridge core;
+  NSString *missing = RunnerResolveXCTestEventBridge(application, RunnerTextSynthesisSurface, &core);
+  if (missing != nil) return missing;
+
+  SEL initRecordSelector = NSSelectorFromString(@"initWithName:");
+  SEL initPathSelector = NSSelectorFromString(@"initForTextInput");
+  SEL typeTextSelector = NSSelectorFromString(@"typeText:atOffset:typingSpeed:shouldRedact:");
+  SEL typeKeySelector = NSSelectorFromString(@"typeKey:modifiers:atOffset:");
+
+  missing = RunnerRequireSelector(
+    core.recordClass, initRecordSelector, @"initWithName:", RunnerTextSynthesisSurface
+  );
+  if (missing != nil) return missing;
+  missing = RunnerRequireSelector(
+    core.pathClass, initPathSelector, @"initForTextInput", RunnerTextSynthesisSurface
+  );
+  if (missing != nil) return missing;
+  missing = RunnerRequireSelector(
+    core.pathClass,
+    typeTextSelector,
+    @"typeText:atOffset:typingSpeed:shouldRedact:",
+    RunnerTextSynthesisSurface
+  );
+  if (missing != nil) return missing;
+  if (replace) {
+    missing = RunnerRequireSelector(
+      core.pathClass, typeKeySelector, @"typeKey:modifiers:atOffset:", RunnerTextSynthesisSurface
+    );
+    if (missing != nil) return missing;
+  }
+
+  *bridge = (RunnerTextEventBridge){
+    .core = core,
+    .initRecordSelector = initRecordSelector,
+    .initPathSelector = initPathSelector,
+    .typeTextSelector = typeTextSelector,
+    .typeKeySelector = typeKeySelector,
+  };
+  return nil;
 }
 
 static RunnerSynthesizedTextEntryResult *RunnerTextEntryResult(
@@ -180,22 +209,4 @@ static RunnerSynthesizedTextEntryResult *RunnerTextEntryUnavailable(NSString *me
 
 static RunnerSynthesizedTextEntryResult *RunnerTextEntryFailed(NSString *message) {
   return RunnerTextEntryResult(RunnerSynthesizedTextEntryStatusFailed, message);
-}
-
-static NSString * _Nullable RunnerRequireTextClass(Class cls, NSString *name) {
-  if (cls == Nil) {
-    return [NSString stringWithFormat:@"private XCTest text synthesis unavailable: missing %@", name];
-  }
-  return nil;
-}
-
-static NSString * _Nullable RunnerRequireTextSelector(Class cls, SEL selector, NSString *name) {
-  if (![cls instancesRespondToSelector:selector]) {
-    return [NSString stringWithFormat:
-      @"private XCTest text synthesis unavailable: %@ missing %@",
-      NSStringFromClass(cls),
-      name
-    ];
-  }
-  return nil;
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerXCTestEventBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerXCTestEventBridge.h
@@ -1,0 +1,72 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Shared reflection surface for XCTest's private event-synthesis API
+// (XCSynthesizedEventRecord / XCPointerEventPath). Both gesture synthesis
+// (RunnerSynthesizedGesture) and text-entry synthesis (RunnerSynthesizedTextEntry)
+// reflect into this same private API; resolving the part they have in common here
+// means a selector rename only has to be found in one place.
+//
+// Each caller additionally resolves whichever XCSynthesizedEventRecord init
+// overload and XCPointerEventPath factory/mutator selectors its own event kind
+// needs: gesture uses the 2-arg `initWithName:interfaceOrientation:` plus
+// touch-path selectors (`initForTouchAtPoint:offset:`, `moveToPoint:atOffset:`,
+// `liftUpAtOffset:`); text entry uses the 1-arg `initWithName:` plus text-input
+// selectors (`initForTextInput`, `typeText:atOffset:typingSpeed:shouldRedact:`,
+// `typeKey:modifiers:atOffset:`). Those genuinely differ and are resolved by
+// each caller on top of this shared core, not forced into one shape here.
+typedef struct {
+  Class recordClass;  // XCSynthesizedEventRecord
+  Class pathClass;  // XCPointerEventPath
+  SEL addPathSelector;  // addPointerEventPath: (on recordClass)
+  SEL setTargetProcessIDSelector;  // setTargetProcessID: (on recordClass)
+  SEL synthesizeSelector;  // synthesizeWithError: (on recordClass)
+  SEL processIDSelector;  // processID, read on the XCUIApplication
+} RunnerXCTestEventBridge;
+
+typedef NSInteger (*RunnerMsgSendInteger)(id, SEL);
+typedef void (*RunnerMsgSendSetInteger)(id, SEL, NSInteger);
+typedef void (*RunnerMsgSendAddPath)(id, SEL, id);
+typedef BOOL (*RunnerMsgSendSynthesize)(id, SEL, NSError **);
+
+// Resolves the shared core described above against the live XCTest runtime.
+// Returns nil and populates `bridge` on success. Returns a non-nil
+// "private XCTest <surface> synthesis unavailable: ..." message and leaves
+// `bridge` unspecified when a class or selector the private API is expected to
+// expose is missing (the API changed, or is unavailable on this OS/Xcode).
+// `surface` names the calling feature ("event" or "text") so the message text
+// matches what that caller has always reported.
+FOUNDATION_EXPORT NSString * _Nullable RunnerResolveXCTestEventBridge(
+  id application,
+  NSString *surface,
+  RunnerXCTestEventBridge *bridge
+);
+
+FOUNDATION_EXPORT NSString * _Nullable RunnerRequireClass(
+  Class cls,
+  NSString *className,
+  NSString *surface
+);
+FOUNDATION_EXPORT NSString * _Nullable RunnerRequireSelector(
+  Class cls,
+  SEL selector,
+  NSString *selectorName,
+  NSString *surface
+);
+FOUNDATION_EXPORT NSString * _Nullable RunnerRequireApplicationSelector(
+  id application,
+  SEL selector,
+  NSString *selectorName,
+  NSString *surface
+);
+
+// Formats an NSException the way every synthesis @catch block reports failure:
+// "<name>: <reason>", falling back to "NSException" / `fallbackReason` when
+// either is nil.
+FOUNDATION_EXPORT NSString *RunnerFormatXCTestException(
+  NSException *exception,
+  NSString *fallbackReason
+);
+
+NS_ASSUME_NONNULL_END

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerXCTestEventBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerXCTestEventBridge.m
@@ -1,0 +1,89 @@
+#import "RunnerXCTestEventBridge.h"
+
+NSString * _Nullable RunnerResolveXCTestEventBridge(
+  id application,
+  NSString *surface,
+  RunnerXCTestEventBridge *bridge
+) {
+  Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
+  Class pathClass = NSClassFromString(@"XCPointerEventPath");
+  SEL addPathSelector = NSSelectorFromString(@"addPointerEventPath:");
+  SEL setTargetProcessIDSelector = NSSelectorFromString(@"setTargetProcessID:");
+  SEL synthesizeSelector = NSSelectorFromString(@"synthesizeWithError:");
+  SEL processIDSelector = NSSelectorFromString(@"processID");
+
+  NSString *missing = RunnerRequireClass(recordClass, @"XCSynthesizedEventRecord", surface);
+  if (missing != nil) return missing;
+  missing = RunnerRequireClass(pathClass, @"XCPointerEventPath", surface);
+  if (missing != nil) return missing;
+  missing = RunnerRequireSelector(recordClass, addPathSelector, @"addPointerEventPath:", surface);
+  if (missing != nil) return missing;
+  missing = RunnerRequireSelector(
+    recordClass, setTargetProcessIDSelector, @"setTargetProcessID:", surface
+  );
+  if (missing != nil) return missing;
+  missing = RunnerRequireSelector(recordClass, synthesizeSelector, @"synthesizeWithError:", surface);
+  if (missing != nil) return missing;
+  missing = RunnerRequireApplicationSelector(application, processIDSelector, @"processID", surface);
+  if (missing != nil) return missing;
+
+  *bridge = (RunnerXCTestEventBridge){
+    .recordClass = recordClass,
+    .pathClass = pathClass,
+    .addPathSelector = addPathSelector,
+    .setTargetProcessIDSelector = setTargetProcessIDSelector,
+    .synthesizeSelector = synthesizeSelector,
+    .processIDSelector = processIDSelector,
+  };
+  return nil;
+}
+
+NSString * _Nullable RunnerRequireClass(Class cls, NSString *className, NSString *surface) {
+  if (cls == Nil) {
+    return [NSString stringWithFormat:
+      @"private XCTest %@ synthesis unavailable: missing %@",
+      surface,
+      className
+    ];
+  }
+  return nil;
+}
+
+NSString * _Nullable RunnerRequireSelector(
+  Class cls,
+  SEL selector,
+  NSString *selectorName,
+  NSString *surface
+) {
+  if (![cls instancesRespondToSelector:selector]) {
+    return [NSString stringWithFormat:
+      @"private XCTest %@ synthesis unavailable: %@ missing %@",
+      surface,
+      NSStringFromClass(cls),
+      selectorName
+    ];
+  }
+  return nil;
+}
+
+NSString * _Nullable RunnerRequireApplicationSelector(
+  id application,
+  SEL selector,
+  NSString *selectorName,
+  NSString *surface
+) {
+  if (![application respondsToSelector:selector]) {
+    return [NSString stringWithFormat:
+      @"private XCTest %@ synthesis unavailable: XCUIApplication missing %@",
+      surface,
+      selectorName
+    ];
+  }
+  return nil;
+}
+
+NSString *RunnerFormatXCTestException(NSException *exception, NSString *fallbackReason) {
+  NSString *name = exception.name ?: @"NSException";
+  NSString *reason = exception.reason ?: fallbackReason;
+  return [NSString stringWithFormat:@"%@: %@", name, reason];
+}


### PR DESCRIPTION
## Summary

`RunnerSynthesizedGesture.m` and `RunnerSynthesizedTextEntry.m` (added in #1588) each independently reflected into the same private XCTest event-synthesis API (`XCSynthesizedEventRecord` / `XCPointerEventPath`). A selector rename in that private surface had to be found and fixed in two files with two different failure shapes. This PR extracts the duplicated resolution into a shared `RunnerXCTestEventBridge.h` / `.m`.

**Unified into the shared bridge:**
- The `RunnerXCTestEventBridge` struct holding the *common core*: `recordClass`/`pathClass`, `addPointerEventPath:`, `setTargetProcessID:`, `synthesizeWithError:`, and `processID`.
- `RunnerResolveXCTestEventBridge`, which resolves and validates that core against the live XCTest runtime.
- `RunnerRequireClass` / `RunnerRequireSelector` / `RunnerRequireApplicationSelector` — now take a `surface` parameter (`"event"` or `"text"`) so each caller's existing message wording ("private XCTest event synthesis unavailable: ..." vs "private XCTest text synthesis unavailable: ...") is preserved byte-for-byte instead of being forced to one wording.
- The shared `RunnerMsgSend*` objc_msgSend typedefs both callers use (`RunnerMsgSendInteger`, `RunnerMsgSendSetInteger`, `RunnerMsgSendAddPath`, `RunnerMsgSendSynthesize`).
- `RunnerFormatXCTestException`, the `@catch (NSException *)` → `"name: reason"` formatter that was byte-identical in both files.

**Deliberately kept per-caller (not force-unified):**
- The record-init overload: gesture uses the 2-arg `initWithName:interfaceOrientation:` (plus `interfaceOrientation` and the touch-path selectors `initForTouchAtPoint:offset:` / `moveToPoint:atOffset:` / `liftUpAtOffset:`); text entry uses the 1-arg `initWithName:` (plus the text-input selectors `initForTextInput` / `typeText:atOffset:typingSpeed:shouldRedact:` / `typeKey:modifiers:atOffset:`, the last only required in `replace` mode). These are genuinely different selectors, not a naming coincidence, so each file resolves its own extension of the shared core (`RunnerGestureEventBridge` / `RunnerTextEventBridge`, each embedding `RunnerXCTestEventBridge core`).
- The external result shape: `RunnerSynthesizedGesture` still returns a nullable `NSString *` message; `RunnerSynthesizedTextEntry` still returns a `RunnerSynthesizedTextEntryResult` with a status enum. Swift-visible signatures are unchanged, so `AgentDeviceRunnerUITests-Bridging-Header.h` did not need a change.
- Unifying those two error-reporting shapes (nullable string vs. status enum) is a real follow-up worth doing but out of scope here.

Pure deduplication — no behavior change. Net: +318/-202 across the 4 touched files (2 new, 2 edited).

## Validation

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`: all clean (no TS files touched).
- `pnpm exec vitest run src/__tests__/apple-runner-package-source.test.ts`: 5/5 passing — the new `.h`/`.m` files are picked up automatically by the packaging script's directory walk (no manifest to update).
- `pnpm test:unit`: 610 files / 5382 tests passing.
- **Runner compile evidence (this is a private-API `objc_msgSend` refactor, so this is the load-bearing gate):** built both shared targets locally with a real Xcode toolchain (Xcode 26.2) since this changes code shared between iOS and macOS per `docs/agents/testing.md`:
  - `pnpm build:xcuitest:macos` -> `** TEST BUILD SUCCEEDED **`, clang compiled `RunnerXCTestEventBridge.m`, `RunnerSynthesizedGesture.m`, and `RunnerSynthesizedTextEntry.m` with zero errors/warnings.
  - `pnpm build:xcuitest:ios` (iphonesimulator destination) -> `** TEST BUILD SUCCEEDED **`, same three files compiled cleanly.
- `pnpm check:affected --run`: selects only the GitHub-authoritative `swift-runner` check (already covered by the local builds above); reports "all runnable checks passed."
- The project uses Xcode 16's `PBXFileSystemSynchronizedRootGroup` for this test target, so the new files needed no `project.pbxproj` edit — they were picked up automatically by both the local builds and by `check:affected`'s file-based classification.

## Follow-up (optional, out of scope)

Unify `RunnerSynthesizedGesture`'s nullable-message-string error shape with `RunnerSynthesizedTextEntry`'s status-enum shape, if a future caller needs to distinguish "unavailable" from "failed" for gestures the way text entry already can.
