### PR TITLE
fix: stabilize Replay Nightly fixture boundaries

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -23,10 +23,9 @@
     "scripts/vitest-runner-timeout-setup.ts",
     "test/contention-retry-fixtures/vitest.fixture.config.ts",
     "test/contention-retry-fixtures/timeout-provenance.fixture.ts",
-    // #1596 regression fixtures: run as real `node --experimental-strip-types`
-    // subprocesses (test/integration/daemon-replace-exit-flush.test.ts), so
-    // dependency analysis cannot follow the runCmdSync string path to either.
-    "test/integration/support/exit-naive.ts",
+    // #1596 regression fixture: runs as a real `node --experimental-strip-types`
+    // subprocess (test/integration/daemon-replace-exit-flush.test.ts), so
+    // dependency analysis cannot follow the runCmdSync string path to it.
     "test/integration/support/exit-after-flush.ts",
     "src/utils/update-check-entry.ts",
     "examples/sdk/client-session.ts",

--- a/test/integration/android-emulator-e2e/live-lifecycle-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-lifecycle-scenario.ts
@@ -7,6 +7,7 @@ import { type LiveContext, runStep, verifyBehavior, verifyCommand } from './live
 const C = PUBLIC_COMMANDS;
 const AUTOMATION_DEEP_LINK =
   'agent-device-test-app:///automation?event=full.lifecycle&payload=%7B%22source%22%3A%22android-nightly%22%7D';
+export const ANDROID_PERMISSION_PROMPT_COMMAND = ['alert', 'wait', '10000'] as const;
 
 export async function assertLifecycleAndSystem(context: LiveContext): Promise<void> {
   await runStep(context, 'open Android fixture lifecycle route', [
@@ -73,8 +74,7 @@ async function resetAndRequestMicrophonePermission(
     'id="automation-request-microphone"',
   ]);
   const prompt = await runStep(context, `inspect Android microphone prompt for ${action}`, [
-    'alert',
-    'get',
+    ...ANDROID_PERMISSION_PROMPT_COMMAND,
   ]);
   assert.equal(prompt.json?.data?.alert?.source, 'permission', JSON.stringify(prompt.json));
   const alertAction = action === 'deny' ? 'dismiss' : 'accept';

--- a/test/integration/daemon-replace-exit-flush.test.ts
+++ b/test/integration/daemon-replace-exit-flush.test.ts
@@ -86,22 +86,10 @@ test('daemon replace mid-command returns a structured, parseable error and exits
   }
 });
 
-// Isolates the exact mechanism from the end-to-end test above: Node flushes
-// stdout/stderr synchronously only to a file or TTY, so `process.exit()`
-// called right after a write can drop that write when the stream is a pipe
-// (this CLI's normal condition, driven as a subprocess). Runs the write+exit
-// sequence directly as a real piped child process, independent of any
-// daemon/device setup, so the mechanism itself is proven deterministically.
-test('a bare process.exit() after a large write truncates it on a piped stream', () => {
-  const { exitCode, stderr } = runFixture('exit-naive.ts');
-  assert.equal(exitCode, 1);
-  assert.ok(
-    !stderr.includes(PAYLOAD_MARKER),
-    'expected the naive exit to truncate before the trailing marker; the pipe-buffer ' +
-      'reproduction this test depends on may not hold on this platform',
-  );
-});
-
+// Isolates the delivery guarantee from the end-to-end test above. The fixture
+// writes a large payload through a real piped subprocess without asserting
+// that the unsafe alternative must truncate under a particular OS, Node
+// version, pipe configuration, or scheduler interleaving.
 test('exitAfterFlush (the #1596 fix) delivers the full write before the process exits', () => {
   const { exitCode, stderr } = runFixture('exit-after-flush.ts');
   assert.equal(exitCode, 1);

--- a/test/integration/replays/ios/fixture/01-navigation-scroll.ad
+++ b/test/integration/replays/ios/fixture/01-navigation-scroll.ad
@@ -3,7 +3,7 @@ context platform=ios kind=simulator timeout=120000
 
 env APP_TARGET="Agent Device Tester"
 
-open "${APP_TARGET}" --relaunch
+open "${APP_TARGET}" --relaunch --launch-url "agent-device-test-app:///"
 wait "Agent Device Tester" 30000
 click "label=\"Catalog\""
 wait "Search, filter, scroll, favorite, and drill into detail without extra dependencies." 5000

--- a/test/integration/smoke-android-emulator-coverage.test.ts
+++ b/test/integration/smoke-android-emulator-coverage.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
 import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
 import { ANDROID_EMULATOR_BEHAVIOR_COVERAGE } from './android-emulator-e2e/behavior-coverage.ts';
+import { ANDROID_PERMISSION_PROMPT_COMMAND } from './android-emulator-e2e/live-lifecycle-scenario.ts';
 import {
   ANDROID_EMULATOR_COVERAGE_CLASSIFICATION_SUMMARY,
   ANDROID_EMULATOR_E2E_COVERAGE,
@@ -134,6 +135,10 @@ test('Android app scenarios declare deterministic starting surfaces and IME mode
       { id: 'full:fixture-replays', start: undefined },
     ],
   );
+});
+
+test('Android permission recovery waits for the asynchronous native prompt', () => {
+  assert.deepEqual(ANDROID_PERMISSION_PROMPT_COMMAND, ['alert', 'wait', '10000']);
 });
 
 test('Android emulator scenarios can be selected as an ordered subset', () => {

--- a/test/integration/smoke-ios-simulator-coverage.test.ts
+++ b/test/integration/smoke-ios-simulator-coverage.test.ts
@@ -225,6 +225,18 @@ test('fixture navigation uses edge-aware traversal without losing direct swipe e
   );
 });
 
+test('fixture navigation establishes the home route before selecting Catalog', () => {
+  const actions = parseReplayScriptDetailed(
+    fs.readFileSync('test/integration/replays/ios/fixture/01-navigation-scroll.ad', 'utf8'),
+  ).actions;
+  const open = actions[0];
+  assert.equal(open?.command, 'open');
+  assert.equal(open?.flags.relaunch, true);
+  assert.equal(open?.runtime?.launchUrl, 'agent-device-test-app:///');
+  assert.equal(actions[2]?.command, 'click');
+  assert.equal(actions[2]?.positionals?.[0], 'label="Catalog"');
+});
+
 test('event timeline coverage follows cursors beyond the first page', async () => {
   const requestedCursors: Array<string | undefined> = [];
   const timeline = await collectPagedEventTimeline(async (cursor) => {

--- a/test/integration/support/exit-after-flush.ts
+++ b/test/integration/support/exit-after-flush.ts
@@ -1,5 +1,5 @@
-// Counterpart to exit-naive.ts using the #1596 fix: same oversized write,
-// exited through `exitAfterFlush` instead of a bare `process.exit()`.
+// #1596 fixture: writes an oversized payload to piped stderr, then exits
+// through `exitAfterFlush` so the parent must receive the trailing marker.
 import { exitAfterFlush } from '../../../src/utils/process-exit.ts';
 import { buildPayload } from './exit-payload.ts';
 

--- a/test/integration/support/exit-naive.ts
+++ b/test/integration/support/exit-naive.ts
@@ -1,9 +1,0 @@
-// Regression fixture for #1596: writes a payload larger than a pipe's kernel
-// buffer to stderr, then exits the way `src/cli.ts` used to (a bare
-// `process.exit()` right after the write). Run as a real subprocess by
-// process-exit.test.ts — Node flushes stdout/stderr synchronously only to a
-// file or TTY, so a piped parent reliably observes the write truncated.
-import { buildPayload } from './exit-payload.ts';
-
-process.stderr.write(buildPayload());
-process.exit(1);

--- a/test/integration/support/exit-payload.ts
+++ b/test/integration/support/exit-payload.ts
@@ -1,6 +1,5 @@
-// Shared payload for the #1596 exit-flush fixtures: sized past a pipe's
-// kernel buffer (64 KiB on macOS/Linux) so a truncated write is observable,
-// and ends with a marker that only survives the write if it wasn't cut off.
+// Large payload for the #1596 exit-flush fixture, ending with a marker that
+// proves the whole write reached the parent process.
 export const PAYLOAD_MARKER = 'EXIT_PAYLOAD_END_MARKER';
 const PAYLOAD_BYTES = 200_000;
 


### PR DESCRIPTION
## Summary

- Pin the iOS fixture navigation replay to the fixture home deep link so prior full-suite navigation state cannot leak across the relaunch boundary.
- Wait for Android's asynchronous microphone permission prompt through the public `alert wait` contract while retaining the exact `source: "permission"` assertion.
- Add focused coverage pins for both boundary requirements.

Root cause: the iOS replay relaunched without establishing a destination after earlier scenarios left the app on Automation, while the Android lifecycle scenario performed a one-shot alert read immediately after requesting a native prompt. This addresses the persistent failures in [Replay Nightly run 30974032723](https://github.com/callstack/agent-device/actions/runs/30974032723); unrelated alert-wait and recording-stop flakes are outside this change.

Touched files: 8. Scope stays within the two fixture-backed live scenarios, their coverage tests, and the shared exit-flush integration harness. No production command behavior changed.

## Validation

Red-before proof with `node --test test/integration/smoke-ios-simulator-coverage.test.ts test/integration/smoke-android-emulator-coverage.test.ts`:

- Android failed with actual `["alert", "get"]` versus expected `["alert", "wait", "10000"]`.
- iOS failed with missing `runtime.launchUrl` versus expected `agent-device-test-app:///`.

Post-fix, the same focused run passed all 23 tests.

Live device evidence:

- iOS 26.2 simulator: the fixed navigation replay completed all 16 steps in 13.9s, including Catalog navigation and down/bottom/up/top recovery; the script closed its session.
- Android `emulator-5554`: the fixture snapshot used `android-helper` 0.20.5; `alert wait 10000` observed the permission-controller prompt after 386ms with `source: "permission"`. The prompt was dismissed, microphone permission reset, and the session closed.
- `pnpm build` and `pnpm build:android` passed.
- `pnpm check:affected --run` passed before push, including format, lint, typecheck, layering, fallow, package verification, integration-node, integration-progress, and replay-compat.

The affected selector leaves test-app typecheck, Swift runner, macOS helper, and live web smoke to GitHub. No changed-path device evidence is deferred. Residual risk is limited to the complete hosted Replay Nightly scenario order and hosted-runner load; the exact two failing transitions are covered locally and on live targets.

Hosted CI passed every platform smoke, including the 18-minute iOS fixture-backed E2E lane, plus coverage and all affected gates. The shared `Integration Tests` lane then exposed a nondeterministic negative control: it required bare `process.exit()` to truncate a piped write, but Linux Node 24 delivered the whole write on both attempts. The follow-up removes that environment-dependent assertion and unused fixture while retaining the real daemon takeover E2E, the oversized piped-output positive assertion, and the deterministic backlogged-stream unit coverage. Locally, 51 Node integration tests, 149 provider integration tests, and the post-commit `pnpm check:affected --run` all pass; the replacement hosted Linux Node 24 `Integration Tests` job is also green.

Docs and skills were not changed because this only corrects fixture scenario setup and uses the already-documented public alert synchronization contract.
