### PR TITLE
docs: clarify iOS drag synthesis profiles

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
@@ -422,6 +422,9 @@ static id RunnerContinuousDragPointerPath(
     return nil;
   }
 
+  // This is velocity shaping, not just interpolation density: smoothstep's endpoint slope is zero,
+  // while a planned linear segment reaches lift with nonzero velocity unless a destination hold
+  // follows it. UIKit uses finger-up velocity for scroll deceleration. See ADR 0013 and issue #1586.
   int frameCount = MAX(3, (int)(durationMs / 16.0));
   NSTimeInterval durationSeconds = durationMs / 1000.0;
   for (int index = 1; index <= frameCount; index += 1) {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
@@ -40,6 +40,16 @@ static NSString * _Nullable RunnerResolveXCTestEventBridge(
 static NSString * _Nullable RunnerRequireClass(Class cls, NSString *className);
 static NSString * _Nullable RunnerRequireSelector(Class cls, SEL selector, NSString *selectorName);
 static NSString * _Nullable RunnerRequireApplicationSelector(id application, SEL selector, NSString *selectorName);
+static NSString * _Nullable RunnerCreateEventRecord(
+  id application,
+  NSString *recordName,
+  RunnerXCTestEventBridge *bridge,
+  id *record
+);
+static NSString * _Nullable RunnerSynthesizeEventRecord(
+  const RunnerXCTestEventBridge *bridge,
+  id record
+);
 static id RunnerSwipePointerPath(
   const RunnerXCTestEventBridge *bridge,
   CGPoint start,
@@ -60,6 +70,7 @@ static NSString * _Nullable RunnerTrySynthesizeDrag(
   NSString *recordName,
   RunnerDragPointerPathFactory pathFactory
 );
+static NSString * _Nullable RunnerTrySynthesizeTap(id application, CGPoint point);
 // XCTest's proven swipe profile reaches the endpoint in 100 ms, then holds for the planned
 // fling duration. Fast movement is what lets UIKit distinguish a fling from a timed pan.
 static const NSTimeInterval RunnerSwipeMovementDurationSeconds = 0.1;
@@ -118,7 +129,7 @@ static id RunnerTapPointerPath(
                                                    x:(double)x
                                                    y:(double)y {
   @try {
-    return [self trySynthesizeTapWithApplication:application x:x y:y];
+    return RunnerTrySynthesizeTap(application, CGPointMake(x, y));
   } @catch (NSException *exception) {
     NSString *name = exception.name ?: @"NSException";
     NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
@@ -130,27 +141,14 @@ static id RunnerTapPointerPath(
                                           pointerSamples:(NSArray<NSArray<NSDictionary<NSString *, NSNumber *> *> *> *)pointerSamples {
   @try {
     RunnerXCTestEventBridge bridge;
-    NSString *missing = RunnerResolveXCTestEventBridge(application, &bridge);
-    if (missing != nil) return missing;
-
-    NSInteger interfaceOrientation =
-      ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.interfaceOrientationSelector);
-    NSInteger targetProcessID =
-      ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.processIDSelector);
-    if (targetProcessID <= 0) {
-      return @"private XCTest event synthesis unavailable: could not resolve target process ID";
-    }
-
-    id record = ((RunnerMsgSendInitRecord)objc_msgSend)(
-      [bridge.recordClass alloc],
-      bridge.initRecordSelector,
+    id record = nil;
+    NSString *error = RunnerCreateEventRecord(
+      application,
       @"agent-device-gesture-plan",
-      interfaceOrientation
+      &bridge,
+      &record
     );
-    if (record == nil) {
-      return @"private XCTest event synthesis failed: could not create event record";
-    }
-    ((RunnerMsgSendSetInteger)objc_msgSend)(record, bridge.setTargetProcessIDSelector, targetProcessID);
+    if (error != nil) return error;
 
     for (NSArray<NSDictionary<NSString *, NSNumber *> *> *samples in pointerSamples) {
       NSDictionary<NSString *, NSNumber *> *first = samples.firstObject;
@@ -184,13 +182,7 @@ static id RunnerTapPointerPath(
       ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
     }
 
-    NSError *error = nil;
-    BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge.synthesizeSelector, &error);
-    if (!ok) {
-      NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
-      return [NSString stringWithFormat:@"private XCTest event synthesis failed: %@", detail];
-    }
-    return nil;
+    return RunnerSynthesizeEventRecord(&bridge, record);
   } @catch (NSException *exception) {
     NSString *name = exception.name ?: @"NSException";
     NSString *reason = exception.reason ?: @"private XCTest event synthesis failed";
@@ -215,28 +207,9 @@ static NSString * _Nullable RunnerTrySynthesizeDrag(
   RunnerDragPointerPathFactory pathFactory
 ) {
   RunnerXCTestEventBridge bridge;
-  NSString *missing = RunnerResolveXCTestEventBridge(application, &bridge);
-  if (missing != nil) {
-    return missing;
-  }
-
-  NSInteger interfaceOrientation =
-    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.interfaceOrientationSelector);
-  NSInteger targetProcessID = ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.processIDSelector);
-  if (targetProcessID <= 0) {
-    return @"private XCTest event synthesis unavailable: could not resolve target process ID";
-  }
-
-  id record = ((RunnerMsgSendInitRecord)objc_msgSend)(
-    [bridge.recordClass alloc],
-    bridge.initRecordSelector,
-    recordName,
-    interfaceOrientation
-  );
-  if (record == nil) {
-    return @"private XCTest event synthesis failed: could not create event record";
-  }
-  ((RunnerMsgSendSetInteger)objc_msgSend)(record, bridge.setTargetProcessIDSelector, targetProcessID);
+  id record = nil;
+  NSString *error = RunnerCreateEventRecord(application, recordName, &bridge, &record);
+  if (error != nil) return error;
 
   id path = pathFactory(&bridge, start, end, durationMs);
   if (path == nil) {
@@ -244,55 +217,26 @@ static NSString * _Nullable RunnerTrySynthesizeDrag(
   }
   ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
 
-  NSError *error = nil;
-  BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge.synthesizeSelector, &error);
-  if (!ok) {
-    NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
-    return [NSString stringWithFormat:@"private XCTest event synthesis failed: %@", detail];
-  }
-  return nil;
+  return RunnerSynthesizeEventRecord(&bridge, record);
 }
 
-+ (NSString * _Nullable)trySynthesizeTapWithApplication:(id)application
-                                                      x:(double)x
-                                                      y:(double)y {
+static NSString * _Nullable RunnerTrySynthesizeTap(id application, CGPoint point) {
   RunnerXCTestEventBridge bridge;
-  NSString *missing = RunnerResolveXCTestEventBridge(application, &bridge);
-  if (missing != nil) {
-    return missing;
-  }
-
-  NSInteger interfaceOrientation =
-    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.interfaceOrientationSelector);
-  NSInteger targetProcessID = ((RunnerMsgSendInteger)objc_msgSend)(application, bridge.processIDSelector);
-  if (targetProcessID <= 0) {
-    return @"private XCTest event synthesis unavailable: could not resolve target process ID";
-  }
-
-  id record = ((RunnerMsgSendInitRecord)objc_msgSend)(
-    [bridge.recordClass alloc],
-    bridge.initRecordSelector,
+  id record = nil;
+  NSString *error = RunnerCreateEventRecord(
+    application,
     @"agent-device-tap",
-    interfaceOrientation
+    &bridge,
+    &record
   );
-  if (record == nil) {
-    return @"private XCTest event synthesis failed: could not create event record";
-  }
-  ((RunnerMsgSendSetInteger)objc_msgSend)(record, bridge.setTargetProcessIDSelector, targetProcessID);
+  if (error != nil) return error;
 
-  id path = RunnerTapPointerPath(&bridge, CGPointMake(x, y));
+  id path = RunnerTapPointerPath(&bridge, point);
   if (path == nil) {
     return @"private XCTest event synthesis failed: could not create pointer path";
   }
   ((RunnerMsgSendAddPath)objc_msgSend)(record, bridge.addPathSelector, path);
-
-  NSError *error = nil;
-  BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge.synthesizeSelector, &error);
-  if (!ok) {
-    NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
-    return [NSString stringWithFormat:@"private XCTest event synthesis failed: %@", detail];
-  }
-  return nil;
+  return RunnerSynthesizeEventRecord(&bridge, record);
 }
 
 static NSString * _Nullable RunnerResolveXCTestEventBridge(
@@ -382,6 +326,53 @@ static NSString * _Nullable RunnerRequireApplicationSelector(
   return nil;
 }
 
+static NSString * _Nullable RunnerCreateEventRecord(
+  id application,
+  NSString *recordName,
+  RunnerXCTestEventBridge *bridge,
+  id *record
+) {
+  NSString *missing = RunnerResolveXCTestEventBridge(application, bridge);
+  if (missing != nil) return missing;
+
+  NSInteger interfaceOrientation =
+    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge->interfaceOrientationSelector);
+  NSInteger targetProcessID =
+    ((RunnerMsgSendInteger)objc_msgSend)(application, bridge->processIDSelector);
+  if (targetProcessID <= 0) {
+    return @"private XCTest event synthesis unavailable: could not resolve target process ID";
+  }
+
+  id eventRecord = ((RunnerMsgSendInitRecord)objc_msgSend)(
+    [bridge->recordClass alloc],
+    bridge->initRecordSelector,
+    recordName,
+    interfaceOrientation
+  );
+  if (eventRecord == nil) {
+    return @"private XCTest event synthesis failed: could not create event record";
+  }
+  ((RunnerMsgSendSetInteger)objc_msgSend)(
+    eventRecord,
+    bridge->setTargetProcessIDSelector,
+    targetProcessID
+  );
+  *record = eventRecord;
+  return nil;
+}
+
+static NSString * _Nullable RunnerSynthesizeEventRecord(
+  const RunnerXCTestEventBridge *bridge,
+  id record
+) {
+  NSError *error = nil;
+  BOOL ok = ((RunnerMsgSendSynthesize)objc_msgSend)(record, bridge->synthesizeSelector, &error);
+  if (!ok) {
+    NSString *detail = error.localizedDescription ?: @"synthesizeWithError returned false";
+    return [NSString stringWithFormat:@"private XCTest event synthesis failed: %@", detail];
+  }
+  return nil;
+}
 
 static id RunnerSwipePointerPath(
   const RunnerXCTestEventBridge *bridge,

--- a/docs/adr/0013-unified-gesture-plans.md
+++ b/docs/adr/0013-unified-gesture-plans.md
@@ -96,6 +96,32 @@ Platform adapters consume the canonical plan:
   macOS lowers a one-contact plan to its drag executor and tvOS lowers it to remote direction. Core
   admission and the Apple adapter both consume the same shared multi-touch support policy;
   multi-touch remains capability-gated to iOS simulators.
+
+  iOS deliberately retains three one-contact motion schedules behind the shared private-XCTest event
+  bridge. Apple's public drag API models the phases independently as an
+  [initial hold, movement velocity, and destination hold](https://developer.apple.com/documentation/xcuiautomation/xcuicoordinate/press%28forduration%3Athendragto%3Awithvelocity%3Athenholdforduration%3A%29).
+  UIKit likewise reports the velocity at finger-up together with the scroll view's predicted
+  [resting content offset](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/scrollviewwillenddragging%28_%3Awithvelocity%3Atargetcontentoffset%3A%29),
+  then applies the scroll view's configured
+  [post-lift deceleration rate](https://developer.apple.com/documentation/uikit/uiscrollview/decelerationrate-swift.property).
+  The distribution of movement over time is therefore observable gesture input, not an adapter
+  implementation detail.
+
+  The three schedules shape that velocity differently. `endpoint-hold` moves quickly for 100 ms and
+  becomes stationary before lift. `timed-pan` and target-authored drag submit the authored samples
+  unchanged, preserving piecewise-linear movement plus explicit source and destination holds. The
+  runner's coordinate `drag` and fused `scroll` compatibility path instead expands the movement to
+  roughly 16 ms samples using smoothstep `s(t) = 3t² - 2t³`. A linear segment has constant movement
+  velocity through its endpoint unless a destination hold follows it; smoothstep has zero slope at
+  both endpoints and a peak velocity 1.5 times its average. Identical endpoints and total durations
+  can consequently produce different recognizer and deceleration outcomes.
+
+  Live iOS characterization in [issue #1586](https://github.com/callstack/agent-device/issues/1586)
+  confirmed that distinction: the schedules crossed the same fling-recognizer thresholds in the
+  tested range but produced materially different post-release ScrollView positions and
+  long-duration recognition behavior. The distinction is intentional policy at the Apple adapter
+  boundary, not a second interpretation of a `GesturePlan`; changes require live evidence for both
+  recognizer activation and post-release content movement.
 - WebDriver lowers a supported plan to synchronized W3C pointer action sources. A one-contact
   endpoint plan becomes pointer down, one timed W3C `pointerMove` from start to end, and pointer up;
   the driver owns interpolation across that W3C tick. Multi-touch remains capability-gated until a


### PR DESCRIPTION
## Summary

Preserves iOS's distinct one-contact velocity profiles while consolidating the XCTest event-record lifecycle they share.

- documents how endpoint-hold, planned timed-pan/target-drag, and smoothstep coordinate drag/scroll map to Apple's hold, velocity, release, and deceleration model
- centralizes private bridge discovery, event-record creation, target PID binding, synthesis, and error normalization
- keeps tap, fast-swipe, smoothstep, and authored-sample path builders separate so their timing semantics do not regress

Apple references:

- [XCUICoordinate drag phases](https://developer.apple.com/documentation/xcuiautomation/xcuicoordinate/press%28forduration%3Athendragto%3Awithvelocity%3Athenholdforduration%3A%29)
- [UIScrollView finger-up velocity and predicted target offset](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/scrollviewwillenddragging%28_%3Awithvelocity%3Atargetcontentoffset%3A%29)
- [UIScrollView post-lift deceleration rate](https://developer.apple.com/documentation/uikit/uiscrollview/decelerationrate-swift.property)

No public behavior or wire-format changes. Scope expanded from documentation to the owning native bridge: 2 files touched.

Closes #1586

## Validation

- Xcode 26.2 `build-for-testing` passed for both iOS Simulator and macOS runner targets
- fresh iOS 26.2 simulator, rebuilt runner, public CLI:
  - synthesized selector/ref taps succeeded and produced settled diffs
  - planned one-pointer pan succeeded with `timed-pan` and preserved its 500 ms duration
  - fling succeeded with `endpoint-hold` and preserved its 100 ms planned duration
  - 300 ms fused scroll succeeded through the smoothstep coordinate path
- live characterization retained from the initial investigation:
  - identical 160 pt horizontal motion crossed the fixture fling recognizer through both profiles at 150, 300, 600, and 1000 ms
  - identical 300 pt upward ScrollView motion produced materially different first post-release positions across the profiles
- affected and fallow gates passed; CI remains authoritative for runner/smoke lanes
