### PR TITLE
fix(daemon): corroborate the no-effect claim against the rebased baseline

### DIFF
--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -158,6 +158,64 @@ test('capturePostGestureStabilizedResult keeps polling past the normal deadline 
   assert.ok(captureCount > 8, `expected sustained polling, saw ${captureCount} captures`);
 });
 
+test('a backend flip mid-poll still yields the no-effect claim (#1620)', async () => {
+  // The screens this warning exists for are the hostile ones — #1600's
+  // element-18 was a Bluesky feed — and those are exactly the screens whose
+  // capture plan falls back mid-sequence. The loop already handles that: on a
+  // backend change it REBASES (#1569) and keeps polling against a comparable
+  // pair. The corroboration then read `pending.baselineSignature` instead, i.e.
+  // the pre-gesture signature from the OTHER backend, so set equality could
+  // never hold and the claim was vetoed on every fallback.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  // Pre-gesture baseline captured by the TREE backend. The two backends do not
+  // agree on which nodes exist — that disagreement is the entire premise of
+  // #1569 — so private-ax additionally reports a scrolled-away row the tree
+  // backend prunes. Same screen, different view of it.
+  session.snapshot = makeSnapshotState(pickupSnapshot(500).nodes, {
+    snapshotQuality: { state: 'healthy', backend: 'tree' },
+  });
+  markPostGestureStabilization(session, 'scroll', ['up']);
+
+  // Every post-gesture capture comes from private-ax: the penalty armed during
+  // the gesture. They are byte-identical to EACH OTHER — the gesture genuinely
+  // moved nothing — while differing from the tree baseline by that extra row.
+  const privateAxNodes = [
+    ...pickupSnapshot(500).nodes,
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'StaticText',
+      identifier: 'scrolled-away-row',
+      label: 'Above the fold',
+      rect: { x: 20, y: -80, width: 200, height: 44 },
+    },
+  ];
+  const capture = vi.fn(async () =>
+    makeSnapshotState(privateAxNodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  const resultPromise = withDiagnosticsScope(
+    {},
+    async () =>
+      await capturePostGestureStabilizedResult({
+        session,
+        capture,
+        readSnapshot: (snapshot) => snapshot,
+      }),
+  );
+  await vi.advanceTimersByTimeAsync(10_000);
+  const result = await resultPromise;
+
+  assert.equal(
+    result.gestureNoEffect?.action,
+    'scroll',
+    'a proven-inert gesture must still be reported after the capture backend falls back',
+  );
+});
+
 test('a replaced list under fixed chrome now settles outright, and still claims no no-effect (#1601 P1, #1569)', async () => {
   // The reviewer's counterexample: a SUCCESSFUL scroll swapped every list cell
   // while the tab-bar chrome (discriminating, shared, unmoved) kept the

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -216,6 +216,44 @@ test('a backend flip mid-poll still yields the no-effect claim (#1620)', async (
   );
 });
 
+test('no pre-gesture snapshot means no no-effect claim, even after a backend flip (#1622 P1)', async () => {
+  // `markPostGestureStabilization` records an EMPTY baseline when the session
+  // has no pre-gesture snapshot, and `[]` is truthy. Rebasing it on a backend
+  // flip would swap "no before-state" for a post-gesture capture, inventing the
+  // very evidence the claim is supposed to rest on — the loop would then agree
+  // with itself and report a gesture as inert with nothing to compare against.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = undefined; // nothing captured before the gesture
+  markPostGestureStabilization(session, 'scroll', ['up']);
+
+  // Steady private-AX captures: quiet, self-consistent, and a different backend
+  // from the (absent) baseline, so the rebase branch is reached.
+  const capture = vi.fn(async () =>
+    makeSnapshotState(pickupSnapshot(500).nodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  const resultPromise = withDiagnosticsScope(
+    {},
+    async () =>
+      await capturePostGestureStabilizedResult({
+        session,
+        capture,
+        readSnapshot: (snapshot) => snapshot,
+      }),
+  );
+  await vi.advanceTimersByTimeAsync(10_000);
+  const result = await resultPromise;
+
+  assert.equal(
+    result.gestureNoEffect,
+    undefined,
+    'a no-effect claim needs a real pre-gesture baseline, never one the loop invented for itself',
+  );
+});
+
 test('a replaced list under fixed chrome now settles outright, and still claims no no-effect (#1601 P1, #1569)', async () => {
   // The reviewer's counterexample: a SUCCESSFUL scroll swapped every list cell
   // while the tab-bar chrome (discriminating, shared, unmoved) kept the

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -239,7 +239,7 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       }
       clearPostGestureStabilization(session);
       emitPostGestureSettleDiagnostic(verdict, pending.action, attempts, elapsedMs);
-      return buildAcceptedStabilizedResult(verdict, pending, current);
+      return buildAcceptedStabilizedResult(verdict, pending, current, baselineSignature);
     }
     previous = current;
   }
@@ -280,15 +280,26 @@ export function formatGestureNoEffectWarning(action: string, positionals: string
  * corroboration (`haveIdenticalDiscriminatingSurfaces`): the verdict alone is
  * subset-tolerant, and a successful scroll that replaced every list cell
  * under fixed chrome still reads accept-stale (#1601 review P1).
+ *
+ * Corroborates against the loop's CURRENT baseline, not `pending`'s original
+ * one (#1620). When the capture backend flips mid-poll the loop rebases —
+ * `pending`'s pre-gesture signature came from a backend that does not agree
+ * with this one about which nodes exist, so #1569 already ruled it out for the
+ * verdict. Reading it back here re-introduced exactly that comparison, and set
+ * equality across two backends never holds: the corroboration was guaranteed to
+ * veto on any screen whose capture plan fell back — which is every hostile
+ * screen, i.e. the ones the warning exists for (#1600's element-18 was a
+ * Bluesky feed).
  */
 function buildAcceptedStabilizedResult<T>(
   verdict: 'trust' | 'accept-stale',
   pending: NonNullable<SessionState['postGestureStabilization']>,
   current: CapturedSurface<T>,
+  baselineSignature: InteractionSurfaceSignature | undefined,
 ): PostGestureStabilizedResult<T> {
   const corroborated =
     verdict === 'accept-stale' &&
-    haveIdenticalDiscriminatingSurfaces(pending.baselineSignature ?? [], current.signature);
+    haveIdenticalDiscriminatingSurfaces(baselineSignature ?? [], current.signature);
   if (!corroborated) return { value: current.value };
   return {
     value: current.value,

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -214,7 +214,13 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       // not agree on which nodes exist, so this pair says nothing about the
       // gesture: adopt it as the baseline and keep going rather than concluding
       // from it (#1569).
-      if (baselineSignature && baselineBackend !== current.backend) {
+      // `?.length`, not truthiness: `markPostGestureStabilization` records an
+      // EMPTY signature when there was no pre-gesture snapshot, and `[]` is
+      // truthy. Rebasing that would replace "no before-state" with a
+      // post-gesture capture — inventing a baseline the gesture is then judged
+      // against, which `decidePostGestureStabilityVerdict` (guarding on
+      // `?.length`) had deliberately refused to do (#1622 review P1).
+      if (baselineSignature?.length && baselineBackend !== current.backend) {
         emitDiagnostic({
           level: 'debug',
           phase: 'post_gesture_snapshot_baseline_rebased',


### PR DESCRIPTION
Part of #1620 — the truncation-drift half stays open.

## The defect

`capturePostGestureStabilizedResult` keeps a **local** baseline that it rebases when the capture backend changes mid-poll. Backends disagree about which nodes exist, so a cross-backend pair says nothing about the gesture — #1569 adopts the new capture as the baseline rather than concluding from it, and the verdict is computed from that comparable pair.

`buildAcceptedStabilizedResult` then corroborated against `pending.baselineSignature`: the **original pre-gesture** signature, the one the loop had just discarded as incomparable. So on any backend fallback the agent-facing claim re-introduced exactly the comparison #1569 exists to forbid — and `haveIdenticalDiscriminatingSurfaces` demands set equality, which two backends' views of one screen never satisfy.

Net effect: the `gestureNoEffect` warning could not fire on any screen whose capture plan falls back. That is every hostile screen — the only kind it was built for. #1600's motivating case, element-18, was a Bluesky feed; measured live on a seeded Bluesky fixture the capture falls back to private-ax and truncates at depth 56, and no no-effect gesture produced the warning across five attempts on two screens.

## The fix

Corroborate against the loop's live `baselineSignature`. With no rebase it *is* `pending`'s, so #1601's veto is unchanged in the ordinary case; after a rebase it is the comparable same-backend capture, which is the only pair either check should read.

## Red evidence

The new test models what the two backends actually return for one screen — private-ax additionally reports a scrolled-away row the tree backend prunes — with every post-gesture capture identical to the others, so the gesture provably moved nothing. Against the previous line it fails with *"a proven-inert gesture must still be reported after the capture backend falls back"*; with the fix 21/21.

**An earlier draft of that test was vacuous** and is worth knowing about: it used identical node content for both backends, so it passed against the unfixed code, and the green run looked no different from a real one. The defect is precisely that the two views differ, so the fixture has to differ too.

## Not fixed here

Truncation drift is the second candidate veto from #1620 and is untouched. A depth-capped tree may still fail set equality against its own baseline; whether that happens in practice needs the live re-run this fix unblocks. #1620 stays open until that is measured.

## Gates

`check:affected --run` green on this commit: 132 files / 1063 tests, "all runnable checks passed". Daemon suite 92 files / 682 tests. typecheck / lint / format / check:layering green.

One process note: a later re-run failed on `android-lifecycle` (~15s timeout, the flake this repo sees under load) and my `vitest | grep && git push` chain pushed anyway, because a pipeline returns grep's status. Wrong chain on my part. Re-checked afterwards: that test passes 2/2 on this branch and 12/12 on an unrelated branch, and this change cannot reach Android — `requiresPostGestureBaselineDistrust` is Apple-only, so `baselineSignature` is `undefined` there and the corroboration returns false either way.
