### PR TITLE
feat(ios): extend depth-capped private-AX captures via element-rooted requests

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -106,6 +106,8 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrainForSnapshotRaw \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotTraversalIdentityPreservesSameOriginNodesWithDifferentBounds \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXDepthLimitedRequiresEveryFrontierResolved \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDeepExtensionCountsMissedFrontiers \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledNeedsEnoughSamples \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledTrueWhenWindowMatches \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledFalseOnMidWindowMismatch \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -11,6 +11,16 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionPendingKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
 
+/// A depth-capped childless node awaiting an element-rooted follow-up request.
+/// Public so the runner unit bundle can drive the extension's miss paths with
+/// fabricated snapshots — the executed contract that missed frontiers are
+/// counted, never silently dropped.
+@interface RunnerAXSnapshotFrontier : NSObject
+@property(nonatomic, strong, nullable) id snapshot;
+@property(nonatomic, strong, nullable) NSMutableDictionary *node;
+@property(nonatomic, assign) NSInteger depth;
+@end
+
 @interface RunnerAXSnapshotBridge : NSObject
 
 /// Captures the app's accessibility tree, then chains element-rooted follow-up
@@ -26,6 +36,20 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
                                                     deadline:(nullable NSDate *)deadline;
 
 + (NSInteger)processIdentifierForApplication:(XCUIApplication *)application;
+
+/// The frontier-extension loop, exposed for the runner unit bundle: a frontier
+/// whose element vanished or whose re-rooted request fails must count as
+/// missed (see the deepExtension keys above) — an all-miss extension reporting
+/// itself drained would present a capped capture as complete.
++ (nullable NSDictionary *)extendSnapshotFrontiers:(NSMutableArray<RunnerAXSnapshotFrontier *> *)frontiers
+                                          axClient:(id)axClient
+                                        attributes:(NSArray *)attributes
+                                          maxDepth:(NSInteger)maxDepth
+                                          maxNodes:(NSInteger)maxNodes
+                                         nodeCount:(NSInteger *)nodeCount
+                                         truncated:(BOOL *)truncated
+                                      callsAllowed:(NSInteger)callsAllowed
+                                          deadline:(nullable NSDate *)deadline;
 
 @end
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -9,6 +9,17 @@ NS_ASSUME_NONNULL_BEGIN
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes;
 
+/// Same as above, plus chained element-rooted follow-up requests from
+/// depth-capped frontier nodes (the AX depth limit is per-request, so
+/// re-rooting reaches content the app-rooted request could not). The response
+/// gains a `deepExtension` {calls, nodesAdded, pendingFrontiers} dictionary
+/// when any frontier existed and calls were allowed.
++ (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
+                                                    maxDepth:(NSInteger)maxDepth
+                                                    maxNodes:(NSInteger)maxNodes
+                                          deepExtensionCalls:(NSInteger)deepExtensionCalls
+                                                    deadline:(nullable NSDate *)deadline;
+
 + (NSInteger)processIdentifierForApplication:(XCUIApplication *)application;
 
 @end

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -3,21 +3,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Keys of the `deepExtension` dictionary in the snapshot response, shared
+/// with the Swift consumer so the response shape has one spelling.
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionCallsKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionPendingKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
+
 @interface RunnerAXSnapshotBridge : NSObject
 
-+ (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
-                                                    maxDepth:(NSInteger)maxDepth
-                                                    maxNodes:(NSInteger)maxNodes;
-
-/// Same as above, plus chained element-rooted follow-up requests from
-/// depth-capped frontier nodes (the AX depth limit is per-request, so
-/// re-rooting reaches content the app-rooted request could not). The response
-/// gains a `deepExtension` {calls, nodesAdded, pendingFrontiers} dictionary
-/// when any frontier existed and calls were allowed.
+/// Captures the app's accessibility tree, then chains element-rooted follow-up
+/// requests from depth-capped frontier nodes (the AX depth limit is
+/// per-request, so re-rooting reaches content the app-rooted request could
+/// not). The response gains a `deepExtension` {calls, nodesAdded,
+/// pendingFrontiers, missedFrontiers} dictionary when any frontier existed and
+/// the call limit allowed extension. Pass 0 to disable extension entirely.
 + (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes
-                                          deepExtensionCalls:(NSInteger)deepExtensionCalls
+                                      deepExtensionCallLimit:(NSInteger)deepExtensionCallLimit
                                                     deadline:(nullable NSDate *)deadline;
 
 + (NSInteger)processIdentifierForApplication:(XCUIApplication *)application;

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -18,17 +18,12 @@ typedef id (*RunnerAXObjectMsgSend)(id, SEL);
 typedef NSInteger (*RunnerAXIntegerMsgSend)(id, SEL);
 typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 
-/// A childless serialized node remembered with its depth. Nodes at the deepest
-/// observed level of a depth-capped capture are the truncation frontier: the AX
-/// server withholds children uniformly at its per-request cap, so every capped
-/// branch ends at the same level (observed one BELOW the requested maxDepth —
-/// the server counts node levels, not edges).
-@interface RunnerAXSnapshotFrontier : NSObject
-@property(nonatomic, strong) id snapshot;
-@property(nonatomic, strong) NSMutableDictionary *node;
-@property(nonatomic, assign) NSInteger depth;
-@end
-
+// A childless serialized node remembered with its depth (interface in the
+// header for the unit bundle). Nodes at the deepest observed level of a
+// depth-capped capture are the truncation frontier: the AX server withholds
+// children uniformly at its per-request cap, so every capped branch ends at
+// the same level (observed one BELOW the requested maxDepth — the server
+// counts node levels, not edges).
 @implementation RunnerAXSnapshotFrontier
 @end
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -7,7 +7,12 @@ static NSString *const RunnerAXSnapshotOkKey = @"ok";
 static NSString *const RunnerAXSnapshotErrorKey = @"error";
 static NSString *const RunnerAXSnapshotRootKey = @"root";
 static NSString *const RunnerAXSnapshotTruncatedKey = @"truncated";
-static NSString *const RunnerAXSnapshotDeepExtensionKey = @"deepExtension";
+
+NSString *const RunnerAXSnapshotDeepExtensionKey = @"deepExtension";
+NSString *const RunnerAXSnapshotDeepExtensionCallsKey = @"calls";
+NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey = @"nodesAdded";
+NSString *const RunnerAXSnapshotDeepExtensionPendingKey = @"pendingFrontiers";
+NSString *const RunnerAXSnapshotDeepExtensionMissedKey = @"missedFrontiers";
 
 typedef id (*RunnerAXObjectMsgSend)(id, SEL);
 typedef NSInteger (*RunnerAXIntegerMsgSend)(id, SEL);
@@ -32,18 +37,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 + (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes
-{
-  return [self snapshotTreeForApplication:application
-                                 maxDepth:maxDepth
-                                 maxNodes:maxNodes
-                       deepExtensionCalls:0
-                                 deadline:nil];
-}
-
-+ (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
-                                                    maxDepth:(NSInteger)maxDepth
-                                                    maxNodes:(NSInteger)maxNodes
-                                          deepExtensionCalls:(NSInteger)deepExtensionCalls
+                                      deepExtensionCallLimit:(NSInteger)deepExtensionCallLimit
                                                     deadline:(nullable NSDate *)deadline
 {
   @try {
@@ -71,7 +65,10 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 
     BOOL truncated = NO;
     NSInteger nodeCount = 0;
-    NSMutableArray<RunnerAXSnapshotFrontier *> *candidates = [NSMutableArray array];
+    // nil disables candidate collection entirely — exact --depth captures pay
+    // zero extension bookkeeping.
+    NSMutableArray<RunnerAXSnapshotFrontier *> *candidates =
+        deepExtensionCallLimit > 0 ? [NSMutableArray array] : nil;
     NSMutableDictionary *rootNode = [self dictionaryForSnapshot:root
                                                           depth:0
                                                        maxDepth:maxDepth
@@ -84,7 +81,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     }
 
     NSMutableArray<RunnerAXSnapshotFrontier *> *frontiers =
-        [self cappedFrontiersFromCandidates:candidates maxDepth:maxDepth];
+        [self cappedFrontiersFromCandidates:candidates ?: @[] maxDepth:maxDepth];
     NSDictionary *deepExtension = [self extendSnapshotFrontiers:frontiers
                                                        axClient:axClient
                                                      attributes:attributes
@@ -92,7 +89,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                        maxNodes:maxNodes
                                                       nodeCount:&nodeCount
                                                       truncated:&truncated
-                                                   callsAllowed:deepExtensionCalls
+                                                   callsAllowed:deepExtensionCallLimit
                                                        deadline:deadline];
 
     NSMutableDictionary *response = [NSMutableDictionary dictionaryWithDictionary:@{
@@ -130,6 +127,11 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   }
   NSInteger callsUsed = 0;
   NSInteger nodesAdded = 0;
+  // A frontier whose live element vanished (list churn between serialization
+  // and extension) or whose re-rooted request failed leaves its subtree
+  // unresolved — it must count as missed, never as drained, or an all-miss
+  // extension would present a capped capture as complete.
+  NSInteger missedFrontiers = 0;
   while (frontiers.count > 0) {
     if (callsUsed >= callsAllowed || *nodeCount >= maxNodes
         || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
@@ -140,6 +142,8 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     [frontiers removeObjectAtIndex:0];
     id element = [self accessibilityElementForSnapshot:frontier.snapshot];
     if (nil == element) {
+      missedFrontiers += 1;
+      NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION_MISS=element unavailable");
       continue;
     }
     callsUsed += 1;
@@ -151,6 +155,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                         maxNodes:maxNodes - *nodeCount
                                            error:&error];
     if (nil == subRoot) {
+      missedFrontiers += 1;
       NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION_MISS=%@",
             error.localizedDescription ?: @"nil subtree");
       continue;
@@ -181,12 +186,13 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     [frontiers addObjectsFromArray:[self cappedFrontiersFromCandidates:subCandidates
                                                               maxDepth:maxDepth]];
   }
-  NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION calls=%ld nodes=%ld pending=%ld",
-        (long)callsUsed, (long)nodesAdded, (long)frontiers.count);
+  NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION calls=%ld nodes=%ld pending=%ld missed=%ld",
+        (long)callsUsed, (long)nodesAdded, (long)frontiers.count, (long)missedFrontiers);
   return @{
-    @"calls": @(callsUsed),
-    @"nodesAdded": @(nodesAdded),
-    @"pendingFrontiers": @(frontiers.count),
+    RunnerAXSnapshotDeepExtensionCallsKey: @(callsUsed),
+    RunnerAXSnapshotDeepExtensionNodesAddedKey: @(nodesAdded),
+    RunnerAXSnapshotDeepExtensionPendingKey: @(frontiers.count),
+    RunnerAXSnapshotDeepExtensionMissedKey: @(missedFrontiers),
   };
 }
 
@@ -223,6 +229,14 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 {
   SEL requestSelector = NSSelectorFromString(@"requestSnapshotForElement:attributes:parameters:error:");
   if (![axClient respondsToSelector:requestSelector]) {
+    if (NULL != error) {
+      *error = [NSError errorWithDomain:@"agent-device.runner"
+                                   code:1
+                               userInfo:@{
+                                 NSLocalizedDescriptionKey:
+                                     @"AX client does not support requestSnapshotForElement"
+                               }];
+    }
     return nil;
   }
   NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
@@ -411,11 +425,13 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
       }
     }
   }
-  if (children.count == 0 && nil != frontiers) {
-    // Childless node: either a real leaf or a branch whose children the AX
-    // server withheld at its cap. The two are indistinguishable here, so all
-    // childless nodes become candidates; the caller keeps only the deepest
-    // observed level, where every capped branch necessarily ends.
+  if (children.count == 0 && nil != frontiers && depth >= maxDepth - 1) {
+    // Childless node at the cap boundary: either a real leaf or a branch whose
+    // children the AX server withheld. The two are indistinguishable here, so
+    // boundary childless nodes become candidates; the caller keeps only the
+    // deepest observed level, where every capped branch necessarily ends.
+    // Shallower childless nodes are provably real leaves and are never
+    // collected.
     RunnerAXSnapshotFrontier *frontier = [[RunnerAXSnapshotFrontier alloc] init];
     frontier.snapshot = snapshot;
     frontier.node = result;

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -7,16 +7,44 @@ static NSString *const RunnerAXSnapshotOkKey = @"ok";
 static NSString *const RunnerAXSnapshotErrorKey = @"error";
 static NSString *const RunnerAXSnapshotRootKey = @"root";
 static NSString *const RunnerAXSnapshotTruncatedKey = @"truncated";
+static NSString *const RunnerAXSnapshotDeepExtensionKey = @"deepExtension";
 
 typedef id (*RunnerAXObjectMsgSend)(id, SEL);
 typedef NSInteger (*RunnerAXIntegerMsgSend)(id, SEL);
 typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
+
+/// A childless serialized node remembered with its depth. Nodes at the deepest
+/// observed level of a depth-capped capture are the truncation frontier: the AX
+/// server withholds children uniformly at its per-request cap, so every capped
+/// branch ends at the same level (observed one BELOW the requested maxDepth —
+/// the server counts node levels, not edges).
+@interface RunnerAXSnapshotFrontier : NSObject
+@property(nonatomic, strong) id snapshot;
+@property(nonatomic, strong) NSMutableDictionary *node;
+@property(nonatomic, assign) NSInteger depth;
+@end
+
+@implementation RunnerAXSnapshotFrontier
+@end
 
 @implementation RunnerAXSnapshotBridge
 
 + (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes
+{
+  return [self snapshotTreeForApplication:application
+                                 maxDepth:maxDepth
+                                 maxNodes:maxNodes
+                       deepExtensionCalls:0
+                                 deadline:nil];
+}
+
++ (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
+                                                    maxDepth:(NSInteger)maxDepth
+                                                    maxNodes:(NSInteger)maxNodes
+                                          deepExtensionCalls:(NSInteger)deepExtensionCalls
+                                                    deadline:(nullable NSDate *)deadline
 {
   @try {
     id axClient = [self objectFrom:XCUIDevice.sharedDevice selectorName:@"accessibilityInterface"];
@@ -29,101 +57,255 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
       return [self failure:@"Could not match active AX application for XCTest application"];
     }
 
-    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    id defaults = [self objectFrom:axClient selectorName:@"defaultParameters"];
-    if ([defaults isKindOfClass:NSDictionary.class]) {
-      [parameters addEntriesFromDictionary:(NSDictionary *)defaults];
-    }
-    parameters[@"maxDepth"] = @(MAX(0, maxDepth));
-    parameters[@"maxChildren"] = @(MAX(1, maxNodes));
-    parameters[@"maxArrayCount"] = @(MAX(1, maxNodes));
-    parameters[@"traverseFromParentsToChildren"] = @YES;
-
-    SEL requestSelector = NSSelectorFromString(@"requestSnapshotForElement:attributes:parameters:error:");
-    if (![axClient respondsToSelector:requestSelector]) {
-      return [self failure:@"AX client does not support requestSnapshotForElement"];
-    }
-
+    NSArray *attributes = [self snapshotAttributes];
     NSError *error = nil;
-    NSArray<NSString *> *keyPaths = @[
-      @"elementType",
-      @"identifier",
-      @"label",
-      @"value",
-      @"frame",
-      @"enabled",
-      @"selected",
-      @"hasFocus",
-      @"children",
-    ];
-    // The AX server expects real accessibility attribute identifiers, not snapshot keypath
-    // strings; passing raw keypaths silently drops attributes it does not recognize (frame
-    // came back zeroed). XCElementSnapshot owns the keypath -> AX attribute mapping.
-    NSArray *attributes = keyPaths;
-    Class snapshotClass = NSClassFromString(@"XCElementSnapshot");
-    SEL mapSelector = NSSelectorFromString(@"axAttributesForElementSnapshotKeyPaths:isMacOS:");
-    if ([snapshotClass respondsToSelector:mapSelector]) {
-      typedef id (*RunnerAXMapMsgSend)(id, SEL, id, BOOL);
-      RunnerAXMapMsgSend mapSend = (RunnerAXMapMsgSend)objc_msgSend;
-      id mapped = mapSend(snapshotClass, mapSelector, keyPaths, NO);
-      if ([mapped isKindOfClass:NSSet.class]) {
-        mapped = [(NSSet *)mapped allObjects];
-      }
-      if ([mapped isKindOfClass:NSArray.class] && [(NSArray *)mapped count] > 0) {
-        // The mapper expands keypaths with extra attributes (automation type, window display
-        // id, base type) that are disproportionately expensive for the AX server to compute
-        // on large React Native trees. Keep only the attributes we actually consume.
-        NSArray *needed = @[ @"ElementType", @"Identifier", @"Label", @"Value", @"Frame",
-                             @"Enabled", @"Selected", @"Focus" ];
-        NSMutableArray *filtered = [NSMutableArray array];
-        for (id attribute in (NSArray *)mapped) {
-          NSString *name = [attribute description];
-          for (NSString *suffix in needed) {
-            if ([name hasSuffix:suffix]) {
-              [filtered addObject:attribute];
-              break;
-            }
-          }
-        }
-        attributes = filtered.count > 0 ? filtered : mapped;
-      }
-    }
-    RunnerAXSnapshotMsgSend send = (RunnerAXSnapshotMsgSend)objc_msgSend;
-    id result = send(axClient, requestSelector, target, attributes, parameters.copy, &error);
-    if (nil == result) {
-      return [self failure:error.localizedDescription ?: @"AX snapshot request returned nil"];
-    }
-
-    id root = nil;
-    @try {
-      root = [result valueForKey:@"_rootElementSnapshot"];
-    } @catch (NSException *exception) {
-      root = nil;
-    }
+    id root = [self requestSnapshotFromClient:axClient
+                                      target:target
+                                  attributes:attributes
+                                    maxDepth:maxDepth
+                                    maxNodes:maxNodes
+                                       error:&error];
     if (nil == root) {
-      root = result;
+      return [self failure:error.localizedDescription ?: @"AX snapshot request returned nil"];
     }
 
     BOOL truncated = NO;
     NSInteger nodeCount = 0;
-    NSDictionary *rootNode = [self dictionaryForSnapshot:root
-                                                   depth:0
-                                                maxDepth:maxDepth
-                                                maxNodes:maxNodes
-                                               nodeCount:&nodeCount
-                                               truncated:&truncated];
+    NSMutableArray<RunnerAXSnapshotFrontier *> *candidates = [NSMutableArray array];
+    NSMutableDictionary *rootNode = [self dictionaryForSnapshot:root
+                                                          depth:0
+                                                       maxDepth:maxDepth
+                                                       maxNodes:maxNodes
+                                                      nodeCount:&nodeCount
+                                                      truncated:&truncated
+                                                      frontiers:candidates];
     if (nil == rootNode) {
       return [self failure:@"AX snapshot root could not be serialized"];
     }
 
-    return @{
+    NSMutableArray<RunnerAXSnapshotFrontier *> *frontiers =
+        [self cappedFrontiersFromCandidates:candidates maxDepth:maxDepth];
+    NSDictionary *deepExtension = [self extendSnapshotFrontiers:frontiers
+                                                       axClient:axClient
+                                                     attributes:attributes
+                                                       maxDepth:maxDepth
+                                                       maxNodes:maxNodes
+                                                      nodeCount:&nodeCount
+                                                      truncated:&truncated
+                                                   callsAllowed:deepExtensionCalls
+                                                       deadline:deadline];
+
+    NSMutableDictionary *response = [NSMutableDictionary dictionaryWithDictionary:@{
       RunnerAXSnapshotOkKey: @YES,
       RunnerAXSnapshotRootKey: rootNode,
       RunnerAXSnapshotTruncatedKey: @(truncated),
-    };
+    }];
+    if (nil != deepExtension) {
+      response[RunnerAXSnapshotDeepExtensionKey] = deepExtension;
+    }
+    return response.copy;
   } @catch (NSException *exception) {
     return [self failure:exception.reason ?: exception.name ?: @"AX snapshot bridge exception"];
   }
+}
+
+/// Chains element-rooted snapshot requests from depth-capped frontier nodes.
+/// The AX server's depth limit is per-request (kAXErrorIllegalArgument above a
+/// tree-size-dependent value), so re-rooting the SAME request at a frontier
+/// node's live accessibility element reaches content the app-rooted request
+/// could not, without ever passing a larger depth parameter. Bounded by call
+/// count, the shared node budget, and the capture-plan deadline.
++ (nullable NSDictionary *)extendSnapshotFrontiers:(NSMutableArray<RunnerAXSnapshotFrontier *> *)frontiers
+                                          axClient:(id)axClient
+                                        attributes:(NSArray *)attributes
+                                          maxDepth:(NSInteger)maxDepth
+                                          maxNodes:(NSInteger)maxNodes
+                                         nodeCount:(NSInteger *)nodeCount
+                                         truncated:(BOOL *)truncated
+                                      callsAllowed:(NSInteger)callsAllowed
+                                          deadline:(nullable NSDate *)deadline
+{
+  if (callsAllowed <= 0 || frontiers.count == 0) {
+    return nil;
+  }
+  NSInteger callsUsed = 0;
+  NSInteger nodesAdded = 0;
+  while (frontiers.count > 0) {
+    if (callsUsed >= callsAllowed || *nodeCount >= maxNodes
+        || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
+      *truncated = YES;
+      break;
+    }
+    RunnerAXSnapshotFrontier *frontier = frontiers.firstObject;
+    [frontiers removeObjectAtIndex:0];
+    id element = [self accessibilityElementForSnapshot:frontier.snapshot];
+    if (nil == element) {
+      continue;
+    }
+    callsUsed += 1;
+    NSError *error = nil;
+    id subRoot = [self requestSnapshotFromClient:axClient
+                                          target:element
+                                      attributes:attributes
+                                        maxDepth:maxDepth
+                                        maxNodes:maxNodes - *nodeCount
+                                           error:&error];
+    if (nil == subRoot) {
+      NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION_MISS=%@",
+            error.localizedDescription ?: @"nil subtree");
+      continue;
+    }
+    // The re-rooted snapshot's root IS the frontier element captured again;
+    // splice only its children so the frontier node is not duplicated.
+    NSInteger before = *nodeCount;
+    NSMutableArray<RunnerAXSnapshotFrontier *> *subCandidates = [NSMutableArray array];
+    NSMutableArray *children = [NSMutableArray array];
+    for (id child in [self childrenForSnapshot:subRoot]) {
+      NSMutableDictionary *childNode = [self dictionaryForSnapshot:child
+                                                             depth:1
+                                                          maxDepth:maxDepth
+                                                          maxNodes:maxNodes
+                                                         nodeCount:nodeCount
+                                                         truncated:truncated
+                                                         frontiers:subCandidates];
+      if (nil != childNode) {
+        [children addObject:childNode];
+      }
+      if (*nodeCount >= maxNodes) {
+        *truncated = YES;
+        break;
+      }
+    }
+    frontier.node[@"children"] = children;
+    nodesAdded += *nodeCount - before;
+    [frontiers addObjectsFromArray:[self cappedFrontiersFromCandidates:subCandidates
+                                                              maxDepth:maxDepth]];
+  }
+  NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_DEEP_EXTENSION calls=%ld nodes=%ld pending=%ld",
+        (long)callsUsed, (long)nodesAdded, (long)frontiers.count);
+  return @{
+    @"calls": @(callsUsed),
+    @"nodesAdded": @(nodesAdded),
+    @"pendingFrontiers": @(frontiers.count),
+  };
+}
+
+/// Keeps only candidates at the deepest observed level, and only when that
+/// level sits at the request's cap (the server emits maxDepth node LEVELS, so
+/// the deepest possible level is maxDepth - 1). A tree that ended naturally
+/// above the cap yields no frontiers and costs nothing.
++ (NSMutableArray<RunnerAXSnapshotFrontier *> *)cappedFrontiersFromCandidates:
+    (NSArray<RunnerAXSnapshotFrontier *> *)candidates
+                                                                      maxDepth:(NSInteger)maxDepth
+{
+  NSMutableArray<RunnerAXSnapshotFrontier *> *frontiers = [NSMutableArray array];
+  NSInteger deepest = -1;
+  for (RunnerAXSnapshotFrontier *candidate in candidates) {
+    deepest = MAX(deepest, candidate.depth);
+  }
+  if (deepest < maxDepth - 1) {
+    return frontiers;
+  }
+  for (RunnerAXSnapshotFrontier *candidate in candidates) {
+    if (candidate.depth == deepest) {
+      [frontiers addObject:candidate];
+    }
+  }
+  return frontiers;
+}
+
++ (nullable id)requestSnapshotFromClient:(id)axClient
+                                  target:(id)target
+                              attributes:(NSArray *)attributes
+                                maxDepth:(NSInteger)maxDepth
+                                maxNodes:(NSInteger)maxNodes
+                                   error:(NSError **)error
+{
+  SEL requestSelector = NSSelectorFromString(@"requestSnapshotForElement:attributes:parameters:error:");
+  if (![axClient respondsToSelector:requestSelector]) {
+    return nil;
+  }
+  NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+  id defaults = [self objectFrom:axClient selectorName:@"defaultParameters"];
+  if ([defaults isKindOfClass:NSDictionary.class]) {
+    [parameters addEntriesFromDictionary:(NSDictionary *)defaults];
+  }
+  parameters[@"maxDepth"] = @(MAX(0, maxDepth));
+  parameters[@"maxChildren"] = @(MAX(1, maxNodes));
+  parameters[@"maxArrayCount"] = @(MAX(1, maxNodes));
+  parameters[@"traverseFromParentsToChildren"] = @YES;
+
+  RunnerAXSnapshotMsgSend send = (RunnerAXSnapshotMsgSend)objc_msgSend;
+  id result = send(axClient, requestSelector, target, attributes, parameters.copy, error);
+  if (nil == result) {
+    return nil;
+  }
+  id root = nil;
+  @try {
+    root = [result valueForKey:@"_rootElementSnapshot"];
+  } @catch (NSException *exception) {
+    root = nil;
+  }
+  return root ?: result;
+}
+
++ (NSArray *)snapshotAttributes
+{
+  NSArray<NSString *> *keyPaths = @[
+    @"elementType",
+    @"identifier",
+    @"label",
+    @"value",
+    @"frame",
+    @"enabled",
+    @"selected",
+    @"hasFocus",
+    @"children",
+  ];
+  // The AX server expects real accessibility attribute identifiers, not snapshot keypath
+  // strings; passing raw keypaths silently drops attributes it does not recognize (frame
+  // came back zeroed). XCElementSnapshot owns the keypath -> AX attribute mapping.
+  NSArray *attributes = keyPaths;
+  Class snapshotClass = NSClassFromString(@"XCElementSnapshot");
+  SEL mapSelector = NSSelectorFromString(@"axAttributesForElementSnapshotKeyPaths:isMacOS:");
+  if ([snapshotClass respondsToSelector:mapSelector]) {
+    typedef id (*RunnerAXMapMsgSend)(id, SEL, id, BOOL);
+    RunnerAXMapMsgSend mapSend = (RunnerAXMapMsgSend)objc_msgSend;
+    id mapped = mapSend(snapshotClass, mapSelector, keyPaths, NO);
+    if ([mapped isKindOfClass:NSSet.class]) {
+      mapped = [(NSSet *)mapped allObjects];
+    }
+    if ([mapped isKindOfClass:NSArray.class] && [(NSArray *)mapped count] > 0) {
+      // The mapper expands keypaths with extra attributes (automation type, window display
+      // id, base type) that are disproportionately expensive for the AX server to compute
+      // on large React Native trees. Keep only the attributes we actually consume.
+      NSArray *needed = @[ @"ElementType", @"Identifier", @"Label", @"Value", @"Frame",
+                           @"Enabled", @"Selected", @"Focus" ];
+      NSMutableArray *filtered = [NSMutableArray array];
+      for (id attribute in (NSArray *)mapped) {
+        NSString *name = [attribute description];
+        for (NSString *suffix in needed) {
+          if ([name hasSuffix:suffix]) {
+            [filtered addObject:attribute];
+            break;
+          }
+        }
+      }
+      attributes = filtered.count > 0 ? filtered : mapped;
+    }
+  }
+  return attributes;
+}
+
++ (nullable id)accessibilityElementForSnapshot:(id)snapshot
+{
+  id element = nil;
+  @try {
+    element = [snapshot valueForKey:@"accessibilityElement"];
+  } @catch (NSException *exception) {
+    element = nil;
+  }
+  return element;
 }
 
 + (NSDictionary<NSString *, id> *)failure:(NSString *)message
@@ -186,12 +368,13 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   return nil;
 }
 
-+ (nullable NSDictionary *)dictionaryForSnapshot:(id)snapshot
-                                           depth:(NSInteger)depth
-                                        maxDepth:(NSInteger)maxDepth
-                                        maxNodes:(NSInteger)maxNodes
-                                       nodeCount:(NSInteger *)nodeCount
-                                       truncated:(BOOL *)truncated
++ (nullable NSMutableDictionary *)dictionaryForSnapshot:(id)snapshot
+                                                  depth:(NSInteger)depth
+                                               maxDepth:(NSInteger)maxDepth
+                                               maxNodes:(NSInteger)maxNodes
+                                              nodeCount:(NSInteger *)nodeCount
+                                              truncated:(BOOL *)truncated
+                                              frontiers:(NSMutableArray<RunnerAXSnapshotFrontier *> *)frontiers
 {
   if (nil == snapshot || *nodeCount >= maxNodes) {
     *truncated = YES;
@@ -212,12 +395,13 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   NSMutableArray *children = [NSMutableArray array];
   if (depth < maxDepth) {
     for (id child in [self childrenForSnapshot:snapshot]) {
-      NSDictionary *childNode = [self dictionaryForSnapshot:child
-                                                      depth:depth + 1
-                                                   maxDepth:maxDepth
-                                                   maxNodes:maxNodes
-                                                  nodeCount:nodeCount
-                                                  truncated:truncated];
+      NSMutableDictionary *childNode = [self dictionaryForSnapshot:child
+                                                             depth:depth + 1
+                                                          maxDepth:maxDepth
+                                                          maxNodes:maxNodes
+                                                         nodeCount:nodeCount
+                                                         truncated:truncated
+                                                         frontiers:frontiers];
       if (nil != childNode) {
         [children addObject:childNode];
       }
@@ -227,8 +411,19 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
       }
     }
   }
+  if (children.count == 0 && nil != frontiers) {
+    // Childless node: either a real leaf or a branch whose children the AX
+    // server withheld at its cap. The two are indistinguishable here, so all
+    // childless nodes become candidates; the caller keeps only the deepest
+    // observed level, where every capped branch necessarily ends.
+    RunnerAXSnapshotFrontier *frontier = [[RunnerAXSnapshotFrontier alloc] init];
+    frontier.snapshot = snapshot;
+    frontier.node = result;
+    frontier.depth = depth;
+    [frontiers addObject:frontier];
+  }
   result[@"children"] = children;
-  return result.copy;
+  return result;
 }
 
 + (NSArray *)childrenForSnapshot:(id)snapshot

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -366,6 +366,50 @@ extension RunnerTests {
     XCTAssertEqual(Self.privateAXAttemptDepths(requestedDepth: 24, rememberedDepth: 56), [24, 12])
   }
 
+  /// Executed producer contract for the #1627 review blocker: a frontier whose
+  /// live element vanished, and one whose re-rooted request fails, must BOTH
+  /// count as missed — an all-miss extension reporting itself drained would
+  /// present a capped capture as complete. Goes red if either miss-path
+  /// increment in extendSnapshotFrontiers is removed.
+  func testDeepExtensionCountsMissedFrontiers() {
+    // Element vanished (list churn between serialization and extension): the
+    // fabricated snapshot answers nil for accessibilityElement — missed, and
+    // no request call is consumed. (An explicit nil property: bare NSObject
+    // resolves the key through a UIKit category and would take the call path.)
+    let orphan = RunnerAXSnapshotFrontier()
+    orphan.snapshot = FrontierSnapshotWithoutElementForTesting()
+    orphan.node = NSMutableDictionary()
+    // Re-rooted request fails: the element resolves but the client cannot
+    // serve requestSnapshotForElement — one consumed call AND a miss.
+    let unreachable = RunnerAXSnapshotFrontier()
+    unreachable.snapshot = FrontierSnapshotWithElementForTesting()
+    unreachable.node = NSMutableDictionary()
+
+    var nodeCount = 0
+    var truncated = ObjCBool(false)
+    let outcome = RunnerAXSnapshotBridge.extend(
+      NSMutableArray(array: [orphan, unreachable]),
+      axClient: NSObject(),
+      attributes: [],
+      maxDepth: 56,
+      maxNodes: 5_000,
+      nodeCount: &nodeCount,
+      truncated: &truncated,
+      callsAllowed: 8,
+      deadline: nil
+    )
+
+    XCTAssertEqual(outcome?[RunnerAXSnapshotDeepExtensionMissedKey] as? Int, 2)
+    XCTAssertEqual(outcome?[RunnerAXSnapshotDeepExtensionCallsKey] as? Int, 1)
+    XCTAssertEqual(outcome?[RunnerAXSnapshotDeepExtensionPendingKey] as? Int, 0)
+    XCTAssertEqual(outcome?[RunnerAXSnapshotDeepExtensionNodesAddedKey] as? Int, 0)
+    XCTAssertFalse(truncated.boolValue)
+    // And the consumer verdict over exactly this outcome: still depth-limited.
+    XCTAssertTrue(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 56, requestedDepth: 64, pendingFrontiers: 0, missedFrontiers: 2))
+  }
+
   func testPrivateAXDepthLimitedRequiresEveryFrontierResolved() {
     // Un-capped capture is never depth-limited, extension or not.
     XCTAssertFalse(
@@ -554,5 +598,17 @@ extension RunnerTests {
     )
     XCTAssertFalse(labels.contains("Admin settings"))
   }
+}
+
+/// Minimal snapshot stand-in whose accessibilityElement resolves (so the
+/// extension proceeds to the request) while the paired fake client cannot
+/// serve it — the failed-re-root miss path.
+private final class FrontierSnapshotWithElementForTesting: NSObject {
+  @objc let accessibilityElement = NSObject()
+}
+
+/// The vanished-element case: KVC resolves the property and gets nil.
+private final class FrontierSnapshotWithoutElementForTesting: NSObject {
+  @objc let accessibilityElement: NSObject? = nil
 }
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -2,6 +2,12 @@ import XCTest
 
 extension RunnerTests {
   private static let privateAXSnapshotMaxNodes = 5_000
+
+  /// Upper bound on element-rooted follow-up snapshot requests per capture. A
+  /// depth-capped Bluesky-class tree resolves in 1-3 chained requests (~100-300ms
+  /// each); the bound exists so a pathological tree cannot stack requests past
+  /// the capture-plan deadline, which is also enforced per call.
+  static let privateAXDeepExtensionCallLimit = 8
   /// Deep React Native trees make the AX server reject bulk snapshot requests outright with
   /// kAXErrorIllegalArgument once the requested depth crosses a tree-size-dependent limit
   /// (observed between depth 56 and 64 on the Bluesky Home feed; the limit moves with live
@@ -91,7 +97,10 @@ extension RunnerTests {
         response = RunnerAXSnapshotBridge.snapshotTree(
           for: app,
           maxDepth: depth,
-          maxNodes: Self.privateAXSnapshotMaxNodes
+          maxNodes: Self.privateAXSnapshotMaxNodes,
+          // An explicit --depth request is a precise ask — no extension past it.
+          deepExtensionCalls: options.depth == nil ? Self.privateAXDeepExtensionCallLimit : 0,
+          deadline: deadline
         )
         if response["ok"] as? Bool == true {
           effectiveDepth = depth
@@ -140,11 +149,18 @@ extension RunnerTests {
         return nil
       }
 
-      let depthLimited = effectiveDepth < requestedDepth
+      // A capture whose frontier extension drained every capped node is complete
+      // despite the per-request depth cap — reporting it as depth-limited would
+      // send agents chasing a --depth re-run that cannot add anything.
+      let deepExtension = response["deepExtension"] as? [String: Any]
+      let extensionDrained =
+        deepExtension != nil && (deepExtension?["pendingFrontiers"] as? Int ?? 1) == 0
+      let depthLimited = effectiveDepth < requestedDepth && !extensionDrained
       NSLog(
-        "AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_USED nodes=%ld depth=%ld",
+        "AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_USED nodes=%ld depth=%ld extended=%ld",
         nodes.count,
-        effectiveDepth
+        effectiveDepth,
+        deepExtension?["nodesAdded"] as? Int ?? 0
       )
       return SnapshotBackendCapture(
         payload: DataPayload(nodes: nodes, truncated: (response["truncated"] as? Bool) == true),

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -7,7 +7,23 @@ extension RunnerTests {
   /// depth-capped Bluesky-class tree resolves in 1-3 chained requests (~100-300ms
   /// each); the bound exists so a pathological tree cannot stack requests past
   /// the capture-plan deadline, which is also enforced per call.
-  static let privateAXDeepExtensionCallLimit = 8
+  private static let privateAXDeepExtensionCallLimit = 8
+
+  /// A capture is depth-limited unless its frontier extension resolved every
+  /// capped node: frontiers left pending (budget/deadline) or missed (element
+  /// vanished, re-rooted request failed) mean subtrees are still absent, and
+  /// presenting such a capture as complete would hide exactly the content the
+  /// extension exists to recover. nil extension counts = extension never ran.
+  static func privateAXDepthLimited(
+    effectiveDepth: Int,
+    requestedDepth: Int,
+    pendingFrontiers: Int?,
+    missedFrontiers: Int?
+  ) -> Bool {
+    guard effectiveDepth < requestedDepth else { return false }
+    guard let pendingFrontiers, let missedFrontiers else { return true }
+    return pendingFrontiers > 0 || missedFrontiers > 0
+  }
   /// Deep React Native trees make the AX server reject bulk snapshot requests outright with
   /// kAXErrorIllegalArgument once the requested depth crosses a tree-size-dependent limit
   /// (observed between depth 56 and 64 on the Bluesky Home feed; the limit moves with live
@@ -70,15 +86,16 @@ extension RunnerTests {
   ) -> SnapshotBackendCapture? {
     #if os(iOS) && targetEnvironment(simulator)
       let requestedDepth = options.depth ?? 64
-      // An explicit --depth request is honored as asked; only default-depth captures consult
-      // (and feed) the accepted-depth memory.
+      // An explicit --depth request is honored as asked: no accepted-depth
+      // memory, no frontier extension past it.
+      let exactDepthRequested = options.depth != nil
       let rememberedDepth =
-        options.depth == nil
-        ? rememberedPrivateAXAcceptedDepth(
+        exactDepthRequested
+        ? nil
+        : rememberedPrivateAXAcceptedDepth(
           bundleId: currentBundleId,
           processIdentifier: currentAppProcessIdentifier
         )
-        : nil
       let attemptDepths = Self.privateAXAttemptDepths(
         requestedDepth: requestedDepth,
         rememberedDepth: rememberedDepth
@@ -98,8 +115,7 @@ extension RunnerTests {
           for: app,
           maxDepth: depth,
           maxNodes: Self.privateAXSnapshotMaxNodes,
-          // An explicit --depth request is a precise ask — no extension past it.
-          deepExtensionCalls: options.depth == nil ? Self.privateAXDeepExtensionCallLimit : 0,
+          deepExtensionCallLimit: exactDepthRequested ? 0 : Self.privateAXDeepExtensionCallLimit,
           deadline: deadline
         )
         if response["ok"] as? Bool == true {
@@ -120,7 +136,7 @@ extension RunnerTests {
       // Only a capture that actually descended records memory: a first-rung success on a
       // remembered depth deliberately does NOT refresh the TTL, so expiry re-probes the full
       // requested depth once per window instead of capping this screen class forever.
-      if options.depth == nil, effectiveDepth != attemptDepths.first {
+      if !exactDepthRequested, effectiveDepth != attemptDepths.first {
         rememberPrivateAXAcceptedDepth(
           bundleId: currentBundleId,
           processIdentifier: currentAppProcessIdentifier,
@@ -149,18 +165,22 @@ extension RunnerTests {
         return nil
       }
 
-      // A capture whose frontier extension drained every capped node is complete
-      // despite the per-request depth cap — reporting it as depth-limited would
-      // send agents chasing a --depth re-run that cannot add anything.
-      let deepExtension = response["deepExtension"] as? [String: Any]
-      let extensionDrained =
-        deepExtension != nil && (deepExtension?["pendingFrontiers"] as? Int ?? 1) == 0
-      let depthLimited = effectiveDepth < requestedDepth && !extensionDrained
+      // A capture whose frontier extension resolved every capped node is
+      // complete despite the per-request depth cap — reporting it as
+      // depth-limited would send agents chasing deeper content that is not
+      // there. Pending or missed frontiers keep the depth-limited verdict.
+      let deepExtension = response[RunnerAXSnapshotDeepExtensionKey] as? [String: Any]
+      let depthLimited = Self.privateAXDepthLimited(
+        effectiveDepth: effectiveDepth,
+        requestedDepth: requestedDepth,
+        pendingFrontiers: deepExtension?[RunnerAXSnapshotDeepExtensionPendingKey] as? Int,
+        missedFrontiers: deepExtension?[RunnerAXSnapshotDeepExtensionMissedKey] as? Int
+      )
       NSLog(
         "AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_USED nodes=%ld depth=%ld extended=%ld",
         nodes.count,
         effectiveDepth,
-        deepExtension?["nodesAdded"] as? Int ?? 0
+        deepExtension?[RunnerAXSnapshotDeepExtensionNodesAddedKey] as? Int ?? 0
       )
       return SnapshotBackendCapture(
         payload: DataPayload(nodes: nodes, truncated: (response["truncated"] as? Bool) == true),
@@ -344,6 +364,31 @@ extension RunnerTests {
     )
     // A shallower explicit request keeps its own rungs; deeper stale memory is ignored.
     XCTAssertEqual(Self.privateAXAttemptDepths(requestedDepth: 24, rememberedDepth: 56), [24, 12])
+  }
+
+  func testPrivateAXDepthLimitedRequiresEveryFrontierResolved() {
+    // Un-capped capture is never depth-limited, extension or not.
+    XCTAssertFalse(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 64, requestedDepth: 64, pendingFrontiers: nil, missedFrontiers: nil))
+    // Capped with no extension outcome (never ran) stays depth-limited.
+    XCTAssertTrue(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 56, requestedDepth: 64, pendingFrontiers: nil, missedFrontiers: nil))
+    // Fully drained extension clears the verdict.
+    XCTAssertFalse(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 56, requestedDepth: 64, pendingFrontiers: 0, missedFrontiers: 0))
+    // Budget exhaustion (pending frontiers) keeps it.
+    XCTAssertTrue(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 56, requestedDepth: 64, pendingFrontiers: 2, missedFrontiers: 0))
+    // The #1627 review blocker: an all-miss extension (elements vanished or
+    // re-rooted requests failed) resolved nothing — it must NOT present the
+    // capture as complete just because the queue emptied.
+    XCTAssertTrue(
+      Self.privateAXDepthLimited(
+        effectiveDepth: 56, requestedDepth: 64, pendingFrontiers: 0, missedFrontiers: 8))
   }
 
   func testPrivateAXAcceptedDepthMemoryMatchesBundleProcessAndExpires() {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -553,8 +553,11 @@ extension RunnerTests {
       )
     }
     if let depth = quality.effectiveDepth {
+      // No --depth remedy here: an explicit --depth capture disables the
+      // frontier extension, so following it would return strictly less than
+      // this capture did. A plain re-run retries with a fresh extension budget.
       parts.append(
-        "The accessibility server rejected deeper requests; this tree is capped at depth \(depth) — re-run with --depth \(depth) --scope <container> for deeper content."
+        "The accessibility server rejected deeper requests; content below depth \(depth) may be missing — re-run snapshot to retry deeper content."
       )
     }
     return parts.isEmpty ? nil : parts.joined(separator: " ")


### PR DESCRIPTION
## Why

On Bluesky-class deep React Native trees, the private-AX bulk snapshot caps at depth 56 (the AX server rejects deeper requests with kAXErrorIllegalArgument — the #758 ladder). Everything an agent needs lives BELOW that cap: the capture returned 117 nodes of unlabeled `[other]` wrapper chains, zero feed controls. Agents fell back to screenshot+coordinate guessing — AppControlBench bsky-30 burned ~20 extra tool calls doing exactly that, and the `--depth N --scope <container>` remedy the truncation hint advertises is a post-capture filter that cannot reveal anything (it slices the already-capped tree).

## What

The AX server's depth limit is **per-request**. After a capped serialization, the bridge re-issues the same snapshot request rooted at each frontier node's live `accessibilityElement` and splices the returned children in, chaining while capped subtrees remain — bounded by a call limit (8), the shared 5k node budget, and the capture-plan deadline.

Frontier detection is empirical: the server emits node *levels*, not edges (maxDepth=56 → deepest node at depth 55), so the frontier is the deepest observed level of childless nodes, kept only when it sits at the cap. Trees that end naturally above the cap yield no frontiers and pay nothing. Explicit `--depth` stays an exact capture (no extension), and a capture whose frontier drained completely no longer reports itself depth-limited (the re-run hint could not add anything).

## Evidence (live, seeded bench feed on a golden clone)

- Before: 117 nodes, all `[other]`, capped-at-56 hint, zero actionable controls.
- After: 182 nodes — post text, `feedItem-by-whiskers.test` testID links, and every control: `[button] "Reply (0 replies)"`, `"Repost (0 reposts)"`, `"Like (0 likes)"`, `"Open post options menu"`, `"Compose new post"`. Runner log: `DEEP_EXTENSION calls=8 nodes=56 pending=0`.
- `press 'role=button label="Like (0 likes)"'` resolves semantically — previously impossible on this screen.
- Cost: ~106ms per extension call; steady-state capture 0.52s → 1.37s on this screen class (still far under the 2.65s pre-#1587 hostile baseline). Observation-only captures (settle/stabilization/corroboration) paying it needlessly is filed as #1626.
- Swift unit compile (`AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1`) green locally.

This is the tree-quality gap between us and argent's Metro/CDP component-tree path, closed from the pure AX side (no app injection, no Metro dependency).

Part of the AppControlBench arc (#1599 family).