### PR TITLE
refactor: sink backend.ts's cycle-closing types — R9 cycle 76 → 49

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -322,16 +322,20 @@ The perfect-shape refactor is complete and merged. Its end-state:
   theirs.
 - Type-cycle growth (R9). R4 keeps the VALUE import graph acyclic, so every remaining cycle is
   created by type-only imports — free at runtime, invisible to R5/R6, and the largest single
-  obstacle to reading a subsystem in isolation: inside a strongly-connected component of 76 files,
+  obstacle to reading a subsystem in isolation: inside a strongly-connected component of 49 files,
   no file has a self-contained slice. `TYPE_CYCLE_BASELINE`, derived from the zone ceilings in
   `scripts/layering/daemon-modularity.ts`, ratchets it for **growth only**, deliberately unlike R6: reducing it
   is a real refactor rather than a file move, so a hard equality would turn every unrelated
   improvement into a baseline edit. A shrunk tree is reported in the success line instead of
-  failing. Hubs by in-component dependents: `runtime-contract.ts` (25),
-  `commands/runtime-types.ts` (21), `backend.ts` (15), `commands/runtime-common.ts` (12).
+  failing. Hubs by in-component dependents: `core/dispatch.ts` (8),
+  `command-catalog.ts` (7), `commands/interaction/runtime/resolution.ts` (6),
+  `core/command-descriptor/registry.ts` (6). The former type hubs (`runtime-contract.ts`,
+  `commands/runtime-types.ts`, `backend.ts`, `commands/runtime-common.ts`) left the cycle when
+  #1632 sank `backend.ts`'s two upward type imports — 27 files stranded out of the component at
+  once.
 - Daemon modularity ratchets (R10). The same tooling-only declaration pins R7's writer-owned
-  field/owner-claim counts, R9's 76 members by zone (`commands` 33, `daemon-server` 20, `core` 10,
-  `platforms` 7, root 5, `client` 1), and the external production importers of `daemon/types.ts`
+  field/owner-claim counts, R9's 49 members by zone (`commands` 14, `daemon-server` 19, `core` 10,
+  `platforms` 2, root 3, `client` 1), and the external production importers of `daemon/types.ts`
   (down to 2: the client normalizers and remote artifacts). R7 counts and external importers may
   only shrink; no zone may grow inside R9, and replay/Maestro/replay-test engine files remain outside
   it. This per-zone ratchet is intentionally stricter than R9's ordinary total-growth rule: even

--- a/packages/contracts/src/facades/interaction.ts
+++ b/packages/contracts/src/facades/interaction.ts
@@ -94,6 +94,7 @@ export type {
   PressCommandResult,
   RecordingTargetOverride,
   RefTarget,
+  RepeatedInput,
   ResolutionDiagnosticEntry,
   ResolutionDisclosure,
   ResolvedInteractionTarget,

--- a/packages/contracts/src/interaction.ts
+++ b/packages/contracts/src/interaction.ts
@@ -373,3 +373,18 @@ export type FindCommandResponseData = {
   settle?: SettleObservation;
   cost?: ResponseCost;
 };
+
+/**
+ * Repeated-activation options shared by tap-like interactions: how many
+ * times, how fast, how long each contact holds, and whether the pair is a
+ * double-tap. Declared here (below both its consumers) so the backend
+ * surface and the command-input parsers agree on one shape without either
+ * importing the other.
+ */
+export type RepeatedInput = {
+  count?: number;
+  intervalMs?: number;
+  holdMs?: number;
+  jitterPx?: number;
+  doubleTap?: boolean;
+};

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -51,8 +51,8 @@ test('daemon modularity baseline records the measured R7 ownership pressure', ()
     Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
     DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
   );
-  assert.equal(TYPE_CYCLE_BASELINE, 76);
-  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 20);
+  assert.equal(TYPE_CYCLE_BASELINE, 49);
+  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 19);
   assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);
 });
 
@@ -174,7 +174,7 @@ test('R9 records zone ceilings and keeps engine files outside the largest compon
   ]);
 
   assert.equal(violations.length, 3);
-  assert.ok(violations.some(({ message }) => /contains 34 commands file/.test(message)));
+  assert.ok(violations.some(({ message }) => /contains 15 commands file/.test(message)));
   assert.ok(violations.some(({ message }) => /contains 1 ad-replay file/.test(message)));
   assert.ok(violations.some(({ message }) => /engine file entered/.test(message)));
 });

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -3,12 +3,12 @@ import { targetDagZone, type LayeringViolation, type ResolvedImportEdge } from '
 import { SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
 
 const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
-  '(root)': 5,
+  '(root)': 3,
   client: 1,
-  commands: 33,
+  commands: 14,
   core: 10,
-  'daemon-server': 20,
-  platforms: 7,
+  'daemon-server': 19,
+  platforms: 2,
 };
 
 export const DAEMON_MODULARITY_BASELINE = {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,4 +1,5 @@
 import type {
+  ScreenshotResultData,
   SnapshotCaptureAnnotations,
   SnapshotDiagnosticsSummary,
 } from '@agent-device/contracts/capture';
@@ -10,6 +11,7 @@ import type {
   BackMode,
   ClickButton,
   GesturePlan,
+  RepeatedInput,
   ScrollDirection,
   TvRemoteButton,
 } from '@agent-device/contracts/interaction';
@@ -29,8 +31,6 @@ import type {
   SnapshotOptions,
   SnapshotState,
 } from '@agent-device/kernel/snapshot';
-import type { RepeatedInput } from './commands/command-input.ts';
-import type { ScreenshotResultData } from './utils/screenshot-result.ts';
 
 // The backend's public leaf platform (approach b): backends distinguish iOS from
 // macOS (e.g. snapshot backend routing, the macOS surface guard), so this carries the

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -12,6 +12,7 @@ import {
   type PlatformSelector,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import type { RepeatedInput } from '@agent-device/contracts/interaction';
 import type { JsonSchema } from './command-contract.ts';
 
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
@@ -43,13 +44,7 @@ export type ElementTargetInput =
   | { kind: 'ref'; ref: string; label?: string }
   | { kind: 'selector'; selector: string };
 
-export type RepeatedInput = {
-  count?: number;
-  intervalMs?: number;
-  holdMs?: number;
-  jitterPx?: number;
-  doubleTap?: boolean;
-};
+export type { RepeatedInput } from '@agent-device/contracts/interaction';
 
 export type SelectorSnapshotInput = {
   depth?: number;

--- a/src/utils/screenshot-result.ts
+++ b/src/utils/screenshot-result.ts
@@ -1,15 +1,8 @@
+import type { ScreenshotResultData } from '@agent-device/contracts/capture';
 import type { ScreenshotOverlayRef } from '@agent-device/kernel/snapshot';
 import { isRecord, parsePoint, parseRect } from './parsing.ts';
 
-export type ScreenshotResultData = {
-  path?: string;
-  width?: number;
-  height?: number;
-  logicalWidth?: number;
-  logicalHeight?: number;
-  pixelDensity?: number;
-  overlayRefs?: ScreenshotOverlayRef[];
-};
+export type { ScreenshotResultData } from '@agent-device/contracts/capture';
 
 export function pickScreenshotResultData(value: ScreenshotResultData): ScreenshotResultData {
   return {


### PR DESCRIPTION
Closes #1632.

## What

`backend.ts` (the 57-export backend interface hub) imported two parameter types **up** from the zones that depend on it — `RepeatedInput` from `commands/command-input.ts` and `ScreenshotResultData` from `utils/screenshot-result.ts`. This PR applies R6's own prescribed remedy: declare the shared types below both zones.

- **`RepeatedInput`** → declared in `@agent-device/contracts/interaction` (source `interaction.ts`, façade export added); `command-input.ts` re-exports it so its importers are untouched.
- **`ScreenshotResultData`** → no new declaration needed: contracts already carried a **byte-identical canonical copy** in `snapshot-types.ts` (exported via `contracts/capture`, consumed by `client-capture.ts`). The utils copy was a mirror duplicate — it's now a re-export, so the repo goes from two declarations to one.
- `backend.ts` now imports **only workspace packages** — zero imports from `commands/` or `utils/`.

## Measured result (the AC's "new cluster size" note)

The R9 type-only cycle collapses **76 → 49 files**. Removing the two edges strands 27 members out of the component at once — including all four former hubs (`runtime-contract.ts` 25-dep, `commands/runtime-types.ts` 21, `backend.ts` 15, `commands/runtime-common.ts` 12). New per-zone membership, ceilings lowered to match (never raised): `commands` 33→14, `platforms` 7→2, `(root)` 5→3, `daemon-server` 20→19, `core` 10, `client` 1. CONTEXT.md's SCC narrative and hub list are recomputed (`core/dispatch.ts` 8, `command-catalog.ts` 7, `interaction/runtime/resolution.ts` 6, `command-descriptor/registry.ts` 6). No `TYPE_INVERSION_BASELINE` additions; the 7 documented deliberate inversions are untouched.

## Verification

- `check:layering` green with the ratchet at the new measured values (one test fixture updated: its synthetic-member assertion hardcoded old-ceiling+1).
- Typecheck, lint, format, fallow audit + production-exports green.
- 300 test files / 2,563 tests across `src/commands`, `src/daemon`, `src/utils` green (one earlier run hit the documented subprocess-stub contention flake — 15 timeout-only failures, clean on re-run).
- Membership measured with all files tracked, member-by-member against main (per the #1633 lesson).