### PR TITLE
refactor: import package types directly — no internal re-export laundering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -322,7 +322,7 @@ The perfect-shape refactor is complete and merged. Its end-state:
   theirs.
 - Type-cycle growth (R9). R4 keeps the VALUE import graph acyclic, so every remaining cycle is
   created by type-only imports — free at runtime, invisible to R5/R6, and the largest single
-  obstacle to reading a subsystem in isolation: inside a strongly-connected component of 49 files,
+  obstacle to reading a subsystem in isolation: inside a strongly-connected component of 47 files,
   no file has a self-contained slice. `TYPE_CYCLE_BASELINE`, derived from the zone ceilings in
   `scripts/layering/daemon-modularity.ts`, ratchets it for **growth only**, deliberately unlike R6: reducing it
   is a real refactor rather than a file move, so a hard equality would turn every unrelated
@@ -334,7 +334,7 @@ The perfect-shape refactor is complete and merged. Its end-state:
   #1632 sank `backend.ts`'s two upward type imports — 27 files stranded out of the component at
   once.
 - Daemon modularity ratchets (R10). The same tooling-only declaration pins R7's writer-owned
-  field/owner-claim counts, R9's 49 members by zone (`commands` 14, `daemon-server` 19, `core` 10,
+  field/owner-claim counts, R9's 47 members by zone (`commands` 14, `daemon-server` 17, `core` 10,
   `platforms` 2, root 3, `client` 1), and the external production importers of `daemon/types.ts`
   (down to 2: the client normalizers and remote artifacts). R7 counts and external importers may
   only shrink; no zone may grow inside R9, and replay/Maestro/replay-test engine files remain outside

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -51,8 +51,8 @@ test('daemon modularity baseline records the measured R7 ownership pressure', ()
     Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
     DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
   );
-  assert.equal(TYPE_CYCLE_BASELINE, 49);
-  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 19);
+  assert.equal(TYPE_CYCLE_BASELINE, 47);
+  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 17);
   assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);
 });
 

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -7,7 +7,7 @@ const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
   client: 1,
   commands: 14,
   core: 10,
-  'daemon-server': 19,
+  'daemon-server': 17,
   platforms: 2,
 };
 

--- a/src/__tests__/daemon-client-progress.test.ts
+++ b/src/__tests__/daemon-client-progress.test.ts
@@ -1,9 +1,9 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import type { Socket } from 'node:net';
 import { test } from 'vitest';
 import type { DaemonRequest, DaemonResponse } from '../daemon/types.ts';
-import type { RequestProgressEvent } from '../request/progress.ts';
 import { readDaemonSocketProgressResponse } from '../daemon/client/daemon-client-progress.ts';
 import { AppError } from '@agent-device/kernel/errors';
 

--- a/src/agent-device-client.ts
+++ b/src/agent-device-client.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import {
   readSerializedSnapshotCaptureAnnotations,
   readSnapshotDiagnosticsSummary,
@@ -68,7 +69,6 @@ import {
 import { systemCommandFamily } from './commands/system/index.ts';
 import type { ProjectedNavigationCommandClient } from './commands/system/navigation-projection.ts';
 import type { CommandResult } from './core/command-descriptor/command-result.ts';
-import type { CommandFlags } from './core/dispatch-context.ts';
 import { sendToDaemon } from './daemon/client/daemon-client.ts';
 import { resolveDaemonPaths } from './daemon/config.ts';
 import { prepareMetroRuntime, reloadMetro } from './metro/client-metro.ts';

--- a/src/cli-schema/cli-config.ts
+++ b/src/cli-schema/cli-config.ts
@@ -1,8 +1,9 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import fs from 'node:fs';
 import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
 import { mergeDefinedFlags } from '../utils/merge-flags.ts';
-import { type CliFlags, type FlagKey } from '../commands/cli-grammar/flag-types.ts';
+import { type FlagKey } from '../commands/cli-grammar/flag-types.ts';
 import { expandUserHomePath, resolveUserPath } from '../utils/path-resolution.ts';
 import {
   getConfigurableOptionSpecs,

--- a/src/cli-schema/command-schema.ts
+++ b/src/cli-schema/command-schema.ts
@@ -1,3 +1,4 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import type { CliCommandName } from '../command-catalog.ts';
 import { listCommandMetadata } from '../commands/command-metadata.ts';
 import type { CommandSchema } from './types.ts';
@@ -7,11 +8,7 @@ import {
   COMMON_COMMAND_SUPPORTED_FLAG_KEYS,
   GLOBAL_FLAG_KEYS,
 } from '../commands/cli-grammar/flag-groups.ts';
-import {
-  type CliFlags,
-  type FlagDefinition,
-  type FlagKey,
-} from '../commands/cli-grammar/flag-types.ts';
+import { type FlagDefinition, type FlagKey } from '../commands/cli-grammar/flag-types.ts';
 import { AppError } from '@agent-device/kernel/errors';
 
 export type { CliFlags, FlagDefinition, FlagKey };

--- a/src/cli-schema/command-schema.ts
+++ b/src/cli-schema/command-schema.ts
@@ -1,4 +1,3 @@
-import type { CliFlags } from '@agent-device/contracts/command';
 import type { CliCommandName } from '../command-catalog.ts';
 import { listCommandMetadata } from '../commands/command-metadata.ts';
 import type { CommandSchema } from './types.ts';
@@ -11,7 +10,7 @@ import {
 import { type FlagDefinition, type FlagKey } from '../commands/cli-grammar/flag-types.ts';
 import { AppError } from '@agent-device/kernel/errors';
 
-export type { CliFlags, FlagDefinition, FlagKey };
+export type { FlagDefinition, FlagKey };
 export type { CommandSchema };
 export { getFlagDefinition, getFlagDefinitions, GLOBAL_FLAG_KEYS };
 

--- a/src/cli/commands/connection-runtime.ts
+++ b/src/cli/commands/connection-runtime.ts
@@ -1,3 +1,4 @@
+import type { MetroBridgeScope } from '@agent-device/contracts/remote';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
 import { stopReactDevtoolsCompanion } from '../../client/client-react-devtools-companion.ts';
 import { stopMetroTunnel } from '../../metro/metro.ts';
@@ -10,7 +11,6 @@ import {
   type DeviceInfo,
 } from '@agent-device/kernel/device';
 import { shouldAgentCdpUseRemoteBridgeUrl } from './agent-cdp.ts';
-import type { MetroBridgeScope } from '../../client/client-companion-tunnel-contract.ts';
 import {
   buildRemoteConnectionDaemonState,
   buildRemoteConnectionRequestMetadata,

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -1,3 +1,4 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
 import { mergeDefinedFlags } from '../../utils/merge-flags.ts';
 import {
@@ -6,7 +7,6 @@ import {
   getCommandSchema,
   getFlagDefinition,
   getFlagDefinitions,
-  type CliFlags,
   type FlagDefinition,
   type FlagKey,
 } from '../../cli-schema/command-schema.ts';

--- a/src/client/client-companion-tunnel-contract.ts
+++ b/src/client/client-companion-tunnel-contract.ts
@@ -19,7 +19,6 @@ export const ENV_COMPANION_TUNNEL_SESSION = 'AGENT_DEVICE_COMPANION_TUNNEL_SESSI
 
 // The scope SHAPE is declared in contracts/ so zones that only need the shape do not have to
 // declare themselves in terms of client/. Re-exported here for this module's existing consumers.
-export type { CompanionTunnelScope, MetroBridgeScope } from '@agent-device/contracts/remote';
 import type { CompanionTunnelScope } from '@agent-device/contracts/remote';
 
 export class MissingCompanionEnvError extends Error {

--- a/src/client/client-companion-tunnel.ts
+++ b/src/client/client-companion-tunnel.ts
@@ -1,3 +1,4 @@
+import type { CompanionTunnelScope } from '@agent-device/contracts/remote';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -16,7 +17,6 @@ import {
   ENV_COMPANION_TUNNEL_STATE_PATH,
   ENV_COMPANION_TUNNEL_UNREGISTER_PATH,
 } from './client-companion-tunnel-contract.ts';
-import type { CompanionTunnelScope } from './client-companion-tunnel-contract.ts';
 import { normalizeBaseUrl } from '../utils/url.ts';
 import { runCmdDetached } from '../utils/exec.ts';
 import {

--- a/src/client/client-react-devtools-companion.ts
+++ b/src/client/client-react-devtools-companion.ts
@@ -1,13 +1,11 @@
+import type { CompanionTunnelScope } from '@agent-device/contracts/remote';
 import {
   ensureCompanionTunnel,
   stopCompanionTunnel,
   type CompanionTunnelDefinition,
   type EnsureCompanionTunnelResult,
 } from './client-companion-tunnel.ts';
-import {
-  REACT_DEVTOOLS_COMPANION_RUN_ARG,
-  type CompanionTunnelScope,
-} from './client-companion-tunnel-contract.ts';
+import { REACT_DEVTOOLS_COMPANION_RUN_ARG } from './client-companion-tunnel-contract.ts';
 
 const REACT_DEVTOOLS_LOCAL_BASE_URL = 'http://127.0.0.1:8097';
 const REACT_DEVTOOLS_DEVICE_PORT = 8097;

--- a/src/client/client-types.ts
+++ b/src/client/client-types.ts
@@ -38,7 +38,7 @@ export type {
 // fallow-ignore-next-line unused-type
 export type { TargetShutdownResult } from '@agent-device/contracts/device';
 // fallow-ignore-next-line unused-type
-export type { MetroBridgeScope } from './client-companion-tunnel-contract.ts';
+export type { MetroBridgeScope } from '@agent-device/contracts/remote';
 // fallow-ignore-next-line unused-type
 export type { AppsFilter } from '@agent-device/contracts/device';
 // fallow-ignore-next-line unused-type

--- a/src/commands/batch/projection.ts
+++ b/src/commands/batch/projection.ts
@@ -7,8 +7,8 @@ import {
   parseBatchStepRuntime,
   readBatchStepInputObject,
   readBatchStepRecord,
+  type DaemonBatchStep,
 } from '@agent-device/contracts/command';
-import type { DaemonBatchStep } from '../../core/batch.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { request } from '../cli-grammar/common.ts';
 import type { CommandInput, DaemonCommandRequest, DaemonWriter } from '../cli-grammar/types.ts';

--- a/src/commands/capture/runtime/index.ts
+++ b/src/commands/capture/runtime/index.ts
@@ -1,3 +1,4 @@
+import type { DiffSnapshotCommandResult } from '@agent-device/contracts/capture';
 import type {
   BoundOf,
   DiffSnapshotCommandOptions,
@@ -11,12 +12,7 @@ import {
   type DiffScreenshotCommandResult,
 } from './diff-screenshot.ts';
 import { screenshotCommand, type ScreenshotCommandResult } from './screenshot.ts';
-import {
-  diffSnapshotCommand,
-  snapshotCommand,
-  type DiffSnapshotCommandResult,
-  type SnapshotCommandResult,
-} from './snapshot.ts';
+import { diffSnapshotCommand, snapshotCommand, type SnapshotCommandResult } from './snapshot.ts';
 
 export type CaptureCommands = {
   screenshot: RuntimeCommand<ScreenshotCommandOptions, ScreenshotCommandResult>;

--- a/src/commands/capture/runtime/snapshot.ts
+++ b/src/commands/capture/runtime/snapshot.ts
@@ -44,8 +44,6 @@ export type SnapshotCommandResult = {
   snapshotDiagnostics?: SnapshotDiagnosticsSummary;
 } & PublicSnapshotCaptureAnnotations;
 
-export type { DiffSnapshotCommandResult } from '@agent-device/contracts/capture';
-
 type SnapshotCapture = {
   snapshot: SnapshotState;
   result: BackendSnapshotResult;

--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -1,8 +1,8 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { WaitCommandOptions } from '@agent-device/contracts/client';
 import { parseWaitPositionals } from '../../core/wait-positionals.ts';
 import { SELECTOR_SNAPSHOT_FLAGS } from '../cli-grammar/flag-groups.ts';
-import { type CliFlags } from '../cli-grammar/flag-types.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { isValidSelectorExpression } from '@agent-device/selectors';
 import {

--- a/src/commands/cli-grammar/flag-types.ts
+++ b/src/commands/cli-grammar/flag-types.ts
@@ -1,7 +1,5 @@
 import type { CliFlags } from '@agent-device/contracts/command';
 
-export type { CliFlags } from '@agent-device/contracts/command';
-
 export type FlagKey = keyof CliFlags;
 type FlagType = 'boolean' | 'int' | 'enum' | 'string' | 'booleanOrString';
 

--- a/src/commands/cli-grammar/types.ts
+++ b/src/commands/cli-grammar/types.ts
@@ -1,6 +1,5 @@
 import type { InternalRequestOptions } from '@agent-device/contracts/client';
-import type { CommandFlags } from '../../core/dispatch-context.ts';
-import type { CliFlags } from '@agent-device/contracts/command';
+import type { CliFlags, CommandFlags } from '@agent-device/contracts/command';
 import type { ClickButton } from '@agent-device/contracts/interaction';
 
 export type DaemonCommandRequest = {

--- a/src/commands/command-flags.ts
+++ b/src/commands/command-flags.ts
@@ -1,5 +1,5 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { screenshotFlagsFromOptions } from '@agent-device/contracts/capture';
-import type { CommandFlags } from '../core/dispatch-context.ts';
 import { leaseScopeFromOptions, leaseScopeToCommandFlags } from '../core/lease-scope.ts';
 import { stripUndefined } from '../utils/parsing.ts';
 import { getFlagDefinitions } from './cli-grammar/flag-registry.ts';

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -44,8 +44,6 @@ export type ElementTargetInput =
   | { kind: 'ref'; ref: string; label?: string }
   | { kind: 'selector'; selector: string };
 
-export type { RepeatedInput } from '@agent-device/contracts/interaction';
-
 export type SelectorSnapshotInput = {
   depth?: number;
   scope?: string;

--- a/src/commands/interaction/runtime/interactions.ts
+++ b/src/commands/interaction/runtime/interactions.ts
@@ -2,6 +2,7 @@ import type {
   ClickButton,
   FillCommandResult,
   PressCommandResult,
+  RepeatedInput,
   ResolvedTarget,
 } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
@@ -12,7 +13,6 @@ import { successText } from '../../../utils/success-text.ts';
 import { findMistargetedTypeRefToken } from '../../../utils/type-target-warning.ts';
 import { requireIntInRange } from '../../../utils/validation.ts';
 import { attachResolvedInteractionTarget } from '../../../contracts/interaction-outcome.ts';
-import type { RepeatedInput } from '../../command-input.ts';
 import { toBackendContext } from '../../runtime-common.ts';
 import {
   toBackendResult,

--- a/src/commands/interaction/runtime/selector-read-utils.ts
+++ b/src/commands/interaction/runtime/selector-read-utils.ts
@@ -1,6 +1,6 @@
+import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
 import type { RefTarget, SelectorTarget } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
-import type { SnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import type { FindLocator } from '@agent-device/selectors';
 
 export { findNodeByLabel, resolveRefLabel } from '../../../snapshot/snapshot-processing.ts';

--- a/src/compat/replay-input.ts
+++ b/src/compat/replay-input.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   parseReplayScriptDetailed,

--- a/src/core/__tests__/batch.test.ts
+++ b/src/core/__tests__/batch.test.ts
@@ -1,11 +1,7 @@
+import type { DaemonBatchStep } from '@agent-device/contracts/command';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import {
-  runBatch,
-  validateAndNormalizeBatchSteps,
-  type BatchRequest,
-  type DaemonBatchStep,
-} from '../batch.ts';
+import { runBatch, validateAndNormalizeBatchSteps, type BatchRequest } from '../batch.ts';
 import type { DaemonResponse, ResponseLevel } from '@agent-device/kernel/contracts';
 
 test('validateAndNormalizeBatchSteps rejects unknown top-level step fields', () => {

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,6 +1,5 @@
 // The step SHAPE lives in contracts/ so the public API vocabulary can be stated in terms of it
 // without depending on core/; re-exported here for this module's existing consumers.
-export type { DaemonBatchStep } from '@agent-device/contracts/command';
 import type { DaemonBatchStep } from '@agent-device/contracts/command';
 import {
   type DaemonRequest,

--- a/src/core/command-descriptor/__tests__/ref-frame-effect.test.ts
+++ b/src/core/command-descriptor/__tests__/ref-frame-effect.test.ts
@@ -1,10 +1,10 @@
+import type { RefFrameEffect } from '@agent-device/contracts/replay';
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
 import {
   DAEMON_COMMAND_DESCRIPTORS,
   resolveRefFrameEffect,
-  type RefFrameEffect,
 } from '../../../daemon/daemon-command-registry.ts';
 import type { DaemonRequest } from '../../../daemon/types.ts';
 

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -1,7 +1,6 @@
 // CommandFlags and MaestroRuntimeFlags are declared in contracts/ so both sides of the process
 // boundary can be stated in terms of them; re-exported here because this is where consumers
 // already import them from.
-export type { CommandFlags } from '@agent-device/contracts/command';
 import type { ScreenshotDispatchFlags } from '@agent-device/contracts/capture';
 import type {
   BackMode,

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -33,7 +33,7 @@ import { readNotificationPayload } from './dispatch-payload.ts';
 import { getInteractor } from './interactors.ts';
 import { readViewportDimension } from './viewport-dimension.ts';
 
-export type { CommandFlags, DispatchContext } from './dispatch-context.ts';
+export type { DispatchContext } from './dispatch-context.ts';
 export { resolveTargetDevice } from './dispatch-resolve.ts';
 
 export async function dispatchCommand(

--- a/src/daemon/__tests__/context.test.ts
+++ b/src/daemon/__tests__/context.test.ts
@@ -1,6 +1,6 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import { contextFromFlags } from '../context.ts';
 
 test('contextFromFlags propagates back mode into the dispatch context', () => {

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -1,9 +1,9 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import assert from 'node:assert/strict';
 import { afterEach, test, vi } from 'vitest';
 import { makeSnapshotState } from '../../__tests__/test-utils/index.ts';
 import { countDiagnosticEventsByPhase, withDiagnosticsScope } from '../../utils/diagnostics.ts';
 import { buildInteractionSurfaceSignature } from '../interaction-outcome-policy.ts';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import {
   capturePostGestureStabilizedResult,
   markDeferredInteractionOutcome,

--- a/src/daemon/__tests__/session-event-action.test.ts
+++ b/src/daemon/__tests__/session-event-action.test.ts
@@ -1,8 +1,8 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { buildActionEventResult } from '../session-event-action-presentation.ts';
 import { buildActionDetails, buildActionSummary } from '../session-event-action.ts';
-import type { SessionAction } from '../types.ts';
 
 function action(
   command: string,

--- a/src/daemon/__tests__/session-script-active-publication.test.ts
+++ b/src/daemon/__tests__/session-script-active-publication.test.ts
@@ -1,6 +1,6 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { describe, expect, test } from 'vitest';
 import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
-import type { SessionAction } from '../types.ts';
 import {
   assertActivePublicationPortability,
   validateActivePublicationActions,

--- a/src/daemon/__tests__/session-script-writer.test.ts
+++ b/src/daemon/__tests__/session-script-writer.test.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { test, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -13,7 +14,6 @@ import {
 import { markRepairTransactionComplete } from '../session-replay-transaction.ts';
 import { NO_SCRIPT_PUBLICATION, scriptTargetPath } from '../session-script-publication-state.ts';
 import { parseReplayScriptDetailed } from '@agent-device/ad-script';
-import type { SessionAction } from '../types.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
 function action(overrides: Partial<SessionAction> = {}): SessionAction {

--- a/src/daemon/action-utils.ts
+++ b/src/daemon/action-utils.ts
@@ -1,4 +1,4 @@
-import type { SessionAction } from './types.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
 
 export function inferFillText(action: SessionAction): string {
   const resultText = action.result?.text;

--- a/src/daemon/adapters/maestro/daemon-runtime-port-support.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-support.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import path from 'node:path';
 import type {
   MaestroObservation,
@@ -7,7 +8,6 @@ import type {
   MaestroTargetMatch,
   MaestroTargetQuery,
 } from '@agent-device/maestro';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import type {
   DaemonInvokeFn,
   DaemonRequest,

--- a/src/daemon/adapters/maestro/daemon-runtime-public-operation.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-public-operation.ts
@@ -1,8 +1,8 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type {
   MaestroDispatchSelector,
   MaestroSinglePointerGestureInput,
 } from '@agent-device/maestro';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import type { DaemonRequest } from '../../types.ts';
 import type { Point, Rect } from '@agent-device/kernel/snapshot';
 

--- a/src/daemon/client/daemon-client-progress.ts
+++ b/src/daemon/client/daemon-client-progress.ts
@@ -1,8 +1,8 @@
+import type { RequestProgressEvent, RequestProgressSink } from '@agent-device/contracts/progress';
 import http from 'node:http';
 import type { Socket } from 'node:net';
 import { AppError } from '@agent-device/kernel/errors';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
-import type { RequestProgressEvent, RequestProgressSink } from '../../request/progress.ts';
 import { consumeTextLines } from '../../utils/line-stream.ts';
 import { markDoctorProgressRendered } from '../../utils/doctor-progress.ts';
 import {

--- a/src/daemon/client/daemon-client-transport.ts
+++ b/src/daemon/client/daemon-client-transport.ts
@@ -1,3 +1,4 @@
+import type { RequestProgressSink } from '@agent-device/contracts/progress';
 import net from 'node:net';
 import http from 'node:http';
 import https from 'node:https';
@@ -17,7 +18,6 @@ import { handleRequestTimeout } from './daemon-client-timeout.ts';
 import { isRemoteDaemon, type DaemonInfo } from './daemon-client-metadata.ts';
 import { DAEMON_RPC_PROTOCOL_VERSION } from '../http-health.ts';
 import { readVersion } from '../../utils/version.ts';
-import type { RequestProgressSink } from '../../request/progress.ts';
 
 type ResolvedDaemonTransport = 'socket' | 'http';
 type SendRequestOptions = {

--- a/src/daemon/client/daemon-client.ts
+++ b/src/daemon/client/daemon-client.ts
@@ -1,9 +1,9 @@
+import type { RequestProgressSink } from '@agent-device/contracts/progress';
 import type {
   DaemonRequest as SharedDaemonRequest,
   DaemonResponse as SharedDaemonResponse,
 } from '../types.ts';
 import type { AgentDeviceDaemonTransportContext } from '@agent-device/contracts/client';
-import type { RequestProgressSink } from '../../request/progress.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { createRequestId, emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,4 +1,5 @@
-import type { CommandFlags, DispatchContext } from '../core/dispatch-context.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import type { DispatchContext } from '../core/dispatch-context.ts';
 import { resolveClickButton } from '@agent-device/contracts/interaction';
 import {
   screenshotFlagsFromOptions,

--- a/src/daemon/daemon-command-registry.ts
+++ b/src/daemon/daemon-command-registry.ts
@@ -9,7 +9,6 @@ export type SessionCommandKind = 'inventory' | 'state' | 'observability' | 'publ
 
 // Declared in contracts/ so core/ can classify commands without importing the daemon;
 // re-exported here because the descriptor shape below is stated in terms of it.
-export type { RefFrameEffect } from '@agent-device/contracts/replay';
 import type { RefFrameEffect } from '@agent-device/contracts/replay';
 
 /**

--- a/src/daemon/deferred-interaction-outcome.ts
+++ b/src/daemon/deferred-interaction-outcome.ts
@@ -1,7 +1,7 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { SnapshotCaptureAnnotations } from '@agent-device/contracts/capture';
 import { isApplePlatform, isMobilePlatform } from '@agent-device/kernel/device';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';
-import type { CommandFlags } from '../core/dispatch.ts';
 import { sleep } from '../utils/timeouts.ts';
 import {
   captureAndroidFreshnessRecoveredAttempt,

--- a/src/daemon/device-selector-intent.ts
+++ b/src/daemon/device-selector-intent.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 
 const EXPLICIT_DEVICE_SELECTOR_KEYS: ReadonlyArray<keyof CommandFlags> = [
   'platform',

--- a/src/daemon/handlers/__tests__/interaction-common.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-common.test.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   makeIosSession,
@@ -5,7 +6,6 @@ import {
 } from '../../../__tests__/test-utils/session-factories.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import { attachRefs, type RawSnapshotNode } from '@agent-device/kernel/snapshot';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import { handleInteractionCommands } from '../interaction.ts';
 import { finalizeTouchInteraction } from '../interaction-common.ts';
 

--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { beforeEach, expect, test, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -8,7 +9,6 @@ import { handleSnapshotCommands } from '../snapshot.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
 import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import { SessionScriptWriter } from '../../session-script-writer.ts';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';
 import {

--- a/src/daemon/handlers/__tests__/interaction-settle.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-settle.test.ts
@@ -1,8 +1,8 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { test, expect, vi, beforeEach } from 'vitest';
 import { handleInteractionCommands } from '../interaction.ts';
 import type { SessionStore } from '../../session-store.ts';
 import type { SessionState } from '../../types.ts';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import type { SnapshotBackend } from '@agent-device/kernel/snapshot';
 import { buildSnapshotState } from '../snapshot-capture.ts';
 import { setSessionSnapshot } from '../../session-snapshot.ts';

--- a/src/daemon/handlers/__tests__/interaction-target-evidence.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-target-evidence.test.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { test, expect, vi, beforeEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -9,7 +10,6 @@ import {
   makeAuthoringSession,
 } from '../../../__tests__/test-utils/session-factories.ts';
 import { SessionScriptWriter } from '../../session-script-writer.ts';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import type { SessionState } from '../../types.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -1,8 +1,8 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { test, expect, vi, beforeEach } from 'vitest';
 import { handleInteractionCommands } from '../interaction.ts';
 import type { SessionStore } from '../../session-store.ts';
 import type { SessionState } from '../../types.ts';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import { attachRefs, type SnapshotBackend } from '@agent-device/kernel/snapshot';
 import { AppError } from '@agent-device/kernel/errors';
 import { buildSnapshotState } from '../snapshot-capture.ts';

--- a/src/daemon/handlers/__tests__/session-replay-action-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-action-runtime.test.ts
@@ -1,7 +1,8 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { expect, test } from 'vitest';
 import { makeIosSession } from '../../../__tests__/test-utils/index.ts';
 import { recordActionEntry } from '../../session-action-recorder.ts';
-import type { DaemonRequest, SessionAction } from '../../types.ts';
+import type { DaemonRequest } from '../../types.ts';
 import { invokeReplayAction } from '../session-replay-action-runtime.ts';
 import { resolveReplayAction } from '@agent-device/ad-script';
 

--- a/src/daemon/handlers/__tests__/session-replay-resume.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-resume.test.ts
@@ -1,8 +1,9 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { buildReplayDivergenceResume } from '../session-replay-resume.ts';
 import { stampPendingRecordAndHealWatermark } from '../../session-replay-coordinator.ts';
-import type { SessionAction, SessionState } from '../../types.ts';
+import type { SessionState } from '../../types.ts';
 import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
 
 function action(overrides: Partial<SessionAction> = {}): SessionAction {

--- a/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { test, vi } from 'vitest';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 
@@ -53,7 +54,6 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { PNG } from '../../../utils/png.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../../types.ts';
-import type { CommandFlags } from '../../../core/dispatch.ts';
 import { SessionStore } from '../../session-store.ts';
 import { makeAndroidSession, makeIosSession } from '../../../__tests__/test-utils/index.ts';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';

--- a/src/daemon/handlers/__tests__/session-replay-target-token.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-target-token.test.ts
@@ -1,8 +1,8 @@
 // extractReplayTargetToken / readRefLabel — token extraction for each
 // eligible command shape, and the point-target / ineligible-command guards.
+import type { SessionAction } from '@agent-device/contracts/session';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import type { SessionAction } from '../../types.ts';
 import { extractReplayTargetToken, readRefLabel } from '../session-replay-target-token.ts';
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -1,3 +1,4 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import { test, expect, vi } from 'vitest';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 
@@ -23,7 +24,7 @@ import path from 'node:path';
 import { handleSessionCommands } from '../session.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../../types.ts';
-import { type RequestProgressEvent, withRequestProgressSink } from '../../../request/progress.ts';
+import { withRequestProgressSink } from '../../../request/progress.ts';
 import {
   clearRequestCanceled,
   getRequestSignal,

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -8,7 +8,11 @@ import {
   type FindLocator,
   resolveSelectorChain,
 } from '@agent-device/selectors';
-import { centerOfRect, type SnapshotState } from '@agent-device/kernel/snapshot';
+import {
+  centerOfRect,
+  type SnapshotQualityVerdict,
+  type SnapshotState,
+} from '@agent-device/kernel/snapshot';
 import { expireRefFrame } from '../ref-frame.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
@@ -27,10 +31,7 @@ import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
 import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
-import {
-  isSparseSnapshotQualityVerdict,
-  type SnapshotQualityVerdict,
-} from '../../snapshot/snapshot-quality.ts';
+import { isSparseSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
 type FindContext = {
   req: DaemonRequest;
   sessionName: string;

--- a/src/daemon/handlers/handler-utils.ts
+++ b/src/daemon/handlers/handler-utils.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 

--- a/src/daemon/handlers/install-source.ts
+++ b/src/daemon/handlers/install-source.ts
@@ -1,7 +1,8 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { isIosFamily } from '@agent-device/kernel/device';
 import type { ProviderDeviceInstallResult } from '@agent-device/contracts/device';
 import { installProviderDeviceInstallablePath } from '../../provider-device-runtime.ts';
-import { resolveTargetDevice, type CommandFlags } from '../../core/dispatch.ts';
+import { resolveTargetDevice } from '../../core/dispatch.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 import { getRequestSignal } from '../../request/cancel.ts';
 import {

--- a/src/daemon/handlers/interaction-common.ts
+++ b/src/daemon/handlers/interaction-common.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';
 import type { DaemonCommandContext } from '../context.ts';
 import { recordTouchVisualizationEvent } from '../recording-gestures.ts';

--- a/src/daemon/handlers/interaction-flags.ts
+++ b/src/daemon/handlers/interaction-flags.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { PostActionObservationCommandName } from '../../core/command-descriptor/post-action-observation.ts';
 import type { SettleParams } from '@agent-device/contracts/interaction';
 import type { DaemonResponse } from '../types.ts';

--- a/src/daemon/handlers/interaction-ios-tap-outcome.ts
+++ b/src/daemon/handlers/interaction-ios-tap-outcome.ts
@@ -1,7 +1,7 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { InteractionTarget } from '@agent-device/contracts/interaction';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';
 import { asAppError } from '@agent-device/kernel/errors';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import { isSparseSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
 import { summarizeAxEvidence } from '../../utils/ax-digest.ts';
 import { getRequestSignal } from '../../request/cancel.ts';

--- a/src/daemon/handlers/interaction-read.ts
+++ b/src/daemon/handlers/interaction-read.ts
@@ -1,5 +1,6 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { isIosFamily } from '@agent-device/kernel/device';
-import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
+import { dispatchCommand } from '../../core/dispatch.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { extractNodeReadText } from '../../snapshot/snapshot-processing.ts';
 import type { SessionState } from '../types.ts';

--- a/src/daemon/handlers/interaction-recorded-input.ts
+++ b/src/daemon/handlers/interaction-recorded-input.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
 import { validateRecordedInputVariableName } from '../../replay/recorded-input.ts';
 import type { SessionState } from '../types.ts';

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';

--- a/src/daemon/handlers/interaction-touch-reference-frame.ts
+++ b/src/daemon/handlers/interaction-touch-reference-frame.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { GestureReferenceFrame } from '@agent-device/contracts/interaction';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { getAndroidScreenSize } from '../../platforms/android/input-actions.ts';

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type {
   FillCommandResult,
   GestureReferenceFrame,
@@ -17,7 +18,7 @@ import {
   commandSupportsSettleObservation,
   commandSupportsVerifyEvidence,
 } from '../../core/command-descriptor/registry.ts';
-import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
+import { dispatchCommand } from '../../core/dispatch.ts';
 import {
   transformInteractionResponseData,
   type InteractionResponseDataTransformCommand,

--- a/src/daemon/handlers/react-native.ts
+++ b/src/daemon/handlers/react-native.ts
@@ -7,11 +7,8 @@ import {
 import { normalizeError } from '@agent-device/kernel/errors';
 import { stripUndefined } from '../../utils/parsing.ts';
 import { successText } from '../../utils/success-text.ts';
-import type { SnapshotState } from '@agent-device/kernel/snapshot';
-import {
-  isSparseSnapshotQualityVerdict,
-  type SnapshotQualityVerdict,
-} from '../../snapshot/snapshot-quality.ts';
+import type { SnapshotQualityVerdict, SnapshotState } from '@agent-device/kernel/snapshot';
+import { isSparseSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
 import type { DaemonResponse, SessionState } from '../types.ts';
 import { errorResponse, noActiveSessionError, requireCommandSupported } from './response.ts';
 import { captureSnapshotForSession } from './interaction-snapshot.ts';

--- a/src/daemon/handlers/session-perf.ts
+++ b/src/daemon/handlers/session-perf.ts
@@ -1,5 +1,6 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import path from 'node:path';
-import type { SessionAction, SessionState } from '../types.ts';
+import type { SessionState } from '../types.ts';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import { isApplePlatform, publicPlatformString } from '@agent-device/kernel/device';
 import { tryGetPlugin } from '../../core/platform-plugin-registry.ts';

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -1,5 +1,6 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
-import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 import { mergeParentFlags } from '../../core/batch.ts';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import {

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -1,10 +1,11 @@
+import type { SessionAction } from '@agent-device/contracts/session';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { sleep } from '../../utils/timeouts.ts';
 import {
   isSparseSnapshotQualityVerdict,
   isUnreadableCaptureContentError,
 } from '../../snapshot/snapshot-quality.ts';
 import { displayLabel, formatRole } from '../../snapshot/snapshot-lines.ts';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import type { DaemonError } from '@agent-device/kernel/errors';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
@@ -27,7 +28,7 @@ import {
 import { boundReplayDivergenceForSession } from './session-replay-divergence-publication.ts';
 import type { ReplayReportAction } from './session-replay-report-action.ts';
 import { rankAndDedupeReplaySuggestions } from './session-replay-suggestion-ranking.ts';
-import type { SessionAction, SessionState } from '../types.ts';
+import type { SessionState } from '../types.ts';
 import {
   REPLAY_DIVERGENCE_SUGGESTION_LIMIT,
   createReplayDivergenceSanitizer,

--- a/src/daemon/handlers/session-replay-maestro-runtime.ts
+++ b/src/daemon/handlers/session-replay-maestro-runtime.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import fs from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
@@ -7,11 +8,7 @@ import {
   type MaestroPlatform,
 } from '@agent-device/maestro';
 import { AppError } from '@agent-device/kernel/errors';
-import {
-  dispatchGestureViewport,
-  resolveTargetDevice,
-  type CommandFlags,
-} from '../../core/dispatch.ts';
+import { dispatchGestureViewport, resolveTargetDevice } from '../../core/dispatch.ts';
 import { getRequestSignal } from '../../request/cancel.ts';
 import { stripUndefined } from '../../utils/parsing.ts';
 import {

--- a/src/daemon/handlers/session-replay-resume.ts
+++ b/src/daemon/handlers/session-replay-resume.ts
@@ -1,4 +1,4 @@
-import type { SessionAction } from '../types.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
 import type { ReplayDivergenceResume, ReplayRepairHint } from '@agent-device/contracts/divergence';
 import type { ReplayResumeStamper } from '../session-replay-coordinator.ts';
 

--- a/src/daemon/handlers/session-replay-runtime-engine-adapter.ts
+++ b/src/daemon/handlers/session-replay-runtime-engine-adapter.ts
@@ -1,4 +1,5 @@
-import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import { errorResponse } from './response.ts';
 import { readReplaySelectorDisplayValue } from '@agent-device/selectors';

--- a/src/daemon/handlers/session-replay-runtime-failure-response.ts
+++ b/src/daemon/handlers/session-replay-runtime-failure-response.ts
@@ -1,8 +1,9 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { scrubReplayVarValues, type ReplayVarScrubEntry } from '@agent-device/contracts/divergence';
 import { formatDivergenceActionLabel } from '@agent-device/ad-script';
 import type { SnapshotDiagnosticsSummary } from '@agent-device/contracts/capture';
 import { buildDisplayPositionals } from '../session-event-action.ts';
-import type { DaemonResponse, SessionAction } from '../types.ts';
+import type { DaemonResponse } from '../types.ts';
 
 export type ReplayFailureCause = Extract<DaemonResponse, { ok: false }>['error'];
 

--- a/src/daemon/handlers/session-replay-runtime-failure.ts
+++ b/src/daemon/handlers/session-replay-runtime-failure.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import type { AdReplayScrubValue } from '@agent-device/ad-replay';
 import {
   summarizeSnapshotTimingSamples,
@@ -6,7 +7,7 @@ import {
 } from '@agent-device/contracts/capture';
 import type { SessionStore } from '../session-store.ts';
 import type { ReplayResumeStamper } from '../session-replay-coordinator.ts';
-import type { DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { buildReplayFailureDivergence } from './session-replay-divergence.ts';
 import {
   buildReplayDivergenceFailureResponse,

--- a/src/daemon/handlers/session-replay-runtime-plan.ts
+++ b/src/daemon/handlers/session-replay-runtime-plan.ts
@@ -1,11 +1,6 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
-import type {
-  DaemonInvokeFn,
-  DaemonRequest,
-  DaemonResponse,
-  SessionAction,
-  SessionState,
-} from '../types.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { ReplayCoordinator } from '../session-replay-coordinator.ts';
 import { errorResponse } from './response.ts';

--- a/src/daemon/handlers/session-replay-target-token.ts
+++ b/src/daemon/handlers/session-replay-target-token.ts
@@ -1,7 +1,7 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { isTouchTargetCommand } from '@agent-device/ad-script';
 import { dragGesturePayloadFromPositionals } from '@agent-device/contracts/interaction';
 import { readSelectorExpression } from '@agent-device/selectors';
-import type { SessionAction } from '../types.ts';
 
 /** Returns the resolved-target token carried by an eligible replay action. */
 export function extractReplayTargetToken(

--- a/src/daemon/handlers/session-replay-target-verification.ts
+++ b/src/daemon/handlers/session-replay-target-verification.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import type { DaemonError } from '@agent-device/kernel/errors';
 import type { Platform, PublicPlatform } from '@agent-device/kernel/device';
@@ -29,7 +30,7 @@ import {
 } from '@agent-device/contracts/replay';
 import { resolveTargetIdentityVerification } from '../../core/command-descriptor/registry.ts';
 import { parseWaitPositionals } from '../../core/wait-positionals.ts';
-import type { DaemonResponse, SessionAction, SessionState } from '../types.ts';
+import type { DaemonResponse, SessionState } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { ReplayResumeStamper } from '../session-replay-coordinator.ts';
 import type { InternalObservationEvidence } from '../internal-observation.ts';

--- a/src/daemon/handlers/session-replay-test-policy.ts
+++ b/src/daemon/handlers/session-replay-test-policy.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 
 export const REPLAY_ONLY_TEST_FLAG_REJECTIONS = [
   {

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { ReplayScriptMetadata } from '@agent-device/ad-script';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';

--- a/src/daemon/handlers/session-runtime.ts
+++ b/src/daemon/handlers/session-runtime.ts
@@ -1,6 +1,6 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import { publicPlatformString, type DeviceInfo } from '@agent-device/kernel/device';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import type { DaemonRequest, SessionRuntimeHints, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import {

--- a/src/daemon/handlers/session-test-shard-devices.ts
+++ b/src/daemon/handlers/session-test-shard-devices.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { listDeviceInventory, type DeviceInventoryRequest } from '../../core/dispatch-resolve.ts';
 import {
   resolveAndroidSerialAllowlist,
@@ -10,7 +11,6 @@ import {
   type DeviceInfo,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import type { CommandFlags } from '../../core/dispatch.ts';
 import type {
   ReplayTestShardMode,
   ReplayTestResolveShardTargets,

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -1,3 +1,4 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import {
   recordSnapshotTiming,
   snapshotCaptureAnnotationsFrom,
@@ -14,7 +15,7 @@ import {
   type SnapshotBackend,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
-import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
+import { dispatchCommand } from '../../core/dispatch.ts';
 import { runMacOsSnapshotAction } from '../../platforms/apple/os/macos/helper.ts';
 import { snapshotLinux } from '../../platforms/linux/snapshot.ts';
 import { isAndroidInputMethodSnapshotNode } from '../../snapshot/android-input-method-overlays.ts';

--- a/src/daemon/interaction-outcome-policy.ts
+++ b/src/daemon/interaction-outcome-policy.ts
@@ -1,4 +1,5 @@
-import { dispatchCommand, type CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import { dispatchCommand } from '../core/dispatch.ts';
 import { isMobilePlatform } from '@agent-device/kernel/device';
 import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
 import { collectKeyboardChromeRefs } from '../core/snapshot-chrome.ts';

--- a/src/daemon/replay-device-selection.ts
+++ b/src/daemon/replay-device-selection.ts
@@ -1,14 +1,14 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import fs from 'node:fs';
 import { inspectMaestroFlow } from '@agent-device/maestro';
 import { resolveDeclaredScriptPlatform } from '@agent-device/ad-script';
 import { parseReplayInput } from '../compat/replay-input.ts';
 import type { ResolveTargetDeviceOptions } from '../core/dispatch-resolve.ts';
-import { isDeepLinkTarget } from '@agent-device/contracts/command';
+import { isDeepLinkTarget, type CommandFlags } from '@agent-device/contracts/command';
 import { resolveReplayFormat } from '../replay/format.ts';
 import { appleSimulatorAppTargetForOpenTarget } from './open-device-selection.ts';
 import { SessionStore } from './session-store.ts';
-import type { CommandFlags } from '../core/dispatch.ts';
-import type { DaemonRequest, SessionAction } from './types.ts';
+import type { DaemonRequest } from './types.ts';
 
 export type ReplayTargetDeviceResolution = {
   flags: CommandFlags;

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { DaemonArtifactType } from '@agent-device/kernel/contracts';
 import {
   emitDiagnostic,

--- a/src/daemon/request-generic-dispatch.ts
+++ b/src/daemon/request-generic-dispatch.ts
@@ -1,4 +1,5 @@
-import { dispatchCommand, type CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import { dispatchCommand } from '../core/dispatch.ts';
 import { requireCommandSupported } from './handlers/response.ts';
 import { SessionStore } from './session-store.ts';
 import type { DaemonCommandContext } from './context.ts';

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -1,4 +1,4 @@
-import type { CommandFlags } from '../core/dispatch.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { CloudArtifactProvider } from '@agent-device/contracts/observability';
 import type { AndroidAdbExecutor } from '../platforms/android/adb-executor.ts';
 import { AppError } from '@agent-device/kernel/errors';

--- a/src/daemon/request-lock-policy.ts
+++ b/src/daemon/request-lock-policy.ts
@@ -1,5 +1,5 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import type { CommandFlags } from '../core/dispatch.ts';
 import type { SessionState, DaemonRequest } from './types.ts';
 import {
   formatSessionSelectorConflict,

--- a/src/daemon/request-progress-protocol.ts
+++ b/src/daemon/request-progress-protocol.ts
@@ -1,5 +1,5 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import type { DaemonRequest, DaemonResponse } from './types.ts';
-import type { RequestProgressEvent } from '../request/progress.ts';
 
 export type DaemonProgressEnvelope = {
   type: 'progress';

--- a/src/daemon/selector-capture-runtime.ts
+++ b/src/daemon/selector-capture-runtime.ts
@@ -1,5 +1,5 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { BackendSnapshotResult } from '../backend.ts';
-import type { CommandFlags } from '../core/dispatch.ts';
 import {
   buildSnapshotPresentationKey,
   snapshotPresentationOptionsFromFlags,

--- a/src/daemon/selector-runtime-backend.ts
+++ b/src/daemon/selector-runtime-backend.ts
@@ -1,9 +1,10 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type {
   AgentDeviceBackend,
   BackendSnapshotOptions,
   BackendSnapshotResult,
 } from '../backend.ts';
-import { resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
+import { resolveTargetDevice } from '../core/dispatch.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { isMacOs, isApplePlatform, publicPlatformString } from '@agent-device/kernel/device';
 import { noActiveSessionError, requireCommandSupported } from './handlers/response.ts';

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -1,3 +1,4 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import http, { type IncomingHttpHeaders } from 'node:http';
 import { AppError, normalizeError, toAppErrorCode } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
@@ -19,7 +20,7 @@ import {
 } from '../../request/cancel.ts';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { type RequestProgressEvent, withRequestProgressSink } from '../../request/progress.ts';
+import { withRequestProgressSink } from '../../request/progress.ts';
 import {
   serializeDaemonProgressEnvelope,
   serializeDaemonRpcResponseEnvelope,

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -1,7 +1,8 @@
-import type { CommandFlags } from '../core/dispatch.ts';
+import type { SessionAction } from '@agent-device/contracts/session';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { SCREENSHOT_ACTION_FLAG_KEYS } from '@agent-device/contracts/capture';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import type { DaemonRequest, SessionAction, SessionRuntimeHints, SessionState } from './types.ts';
+import type { DaemonRequest, SessionRuntimeHints, SessionState } from './types.ts';
 import { applyRecordedSaveScriptFlags } from './session-script-publication-capability.ts';
 import { repairSessionBoundary } from './session-replay-transaction.ts';
 import type { MultiTargetAnnotationV1, TargetAnnotationV1 } from '@agent-device/contracts/replay';

--- a/src/daemon/session-event-action-presentation.ts
+++ b/src/daemon/session-event-action-presentation.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { DEVICE_ROTATIONS } from '@agent-device/contracts/device';
 import { BACK_MODES, TV_REMOTE_BUTTONS } from '@agent-device/contracts/interaction';
 import { PUBLIC_COMMANDS } from '../command-catalog.ts';
@@ -12,7 +13,7 @@ import {
   readSessionEventNumber,
   readSessionEventString,
 } from './session-event-request.ts';
-import type { DaemonRequest, SessionAction } from './types.ts';
+import type { DaemonRequest } from './types.ts';
 
 const SCROLL_DIRECTIONS = ['up', 'down', 'left', 'right'] as const;
 const SCROLL_EDGES = ['top', 'bottom'] as const;

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,6 +1,6 @@
 import { BACK_MODES, CLICK_BUTTONS, SWIPE_PATTERNS } from '@agent-device/contracts/interaction';
 import { RECORDING_SCOPE_VALUES } from '@agent-device/contracts/recording';
-import { SESSION_SURFACES } from '@agent-device/contracts/session';
+import { SESSION_SURFACES, type SessionAction } from '@agent-device/contracts/session';
 import { DEVICE_TARGETS, PLATFORM_SELECTORS, PUBLIC_PLATFORMS } from '@agent-device/kernel/device';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
 import {
@@ -15,7 +15,6 @@ import {
   readSessionEventNumber as readNumber,
   readBoundedSessionEventString as readString,
 } from './session-event-request.ts';
-import type { SessionAction } from './types.ts';
 
 export function buildActionSummary(action: SessionAction): string {
   switch (action.command) {

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import fs from 'node:fs';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
@@ -6,7 +7,7 @@ import { AppError } from '@agent-device/kernel/errors';
 import { redactDiagnosticData } from '@agent-device/kernel/redaction';
 import { emitDiagnostic, getDiagnosticsMeta } from '../utils/diagnostics.ts';
 import { isRecord } from '../utils/parsing.ts';
-import type { DaemonRequest, DaemonResponse, SessionAction } from './types.ts';
+import type { DaemonRequest, DaemonResponse } from './types.ts';
 import { buildActionDetails, buildActionSummary } from './session-event-action.ts';
 import { buildRequestSuccessEventPresentation } from './session-event-request.ts';
 

--- a/src/daemon/session-replay-coordinator.ts
+++ b/src/daemon/session-replay-coordinator.ts
@@ -1,6 +1,7 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import path from 'node:path';
 import type { ReplayDivergenceResume, ReplayRepairHint } from '@agent-device/contracts/divergence';
-import type { DaemonResponse, SessionAction, SessionState } from './types.ts';
+import type { DaemonResponse, SessionState } from './types.ts';
 import type { SessionStore } from './session-store.ts';
 import { isRecord } from '../utils/parsing.ts';
 import {

--- a/src/daemon/session-routing.ts
+++ b/src/daemon/session-routing.ts
@@ -1,9 +1,9 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { DaemonRequest, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
-import type { CommandFlags } from '../core/dispatch.ts';
 
 const DEFAULT_SESSION_NAME = 'default';
 const IMPLICIT_SESSION_KEY_PREFIX = 'cwd';

--- a/src/daemon/session-script-active-publication.ts
+++ b/src/daemon/session-script-active-publication.ts
@@ -1,10 +1,10 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import { resolveCommandRecordingEffect } from '../core/command-descriptor/registry.ts';
 import { parseWaitPositionals } from '../core/wait-positionals.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { isTouchTargetCommand } from '@agent-device/ad-script';
 import { dragGesturePayloadFromPositionals } from '@agent-device/contracts/interaction';
 import { isValidSelectorExpression } from '@agent-device/selectors';
-import type { SessionAction } from './types.ts';
 
 export function validateActivePublicationActions(actions: SessionAction[]): void {
   const openIndexes = actions.flatMap((action, index) =>

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -1,3 +1,4 @@
+import type { SessionAction } from '@agent-device/contracts/session';
 import fs from 'node:fs';
 import path from 'node:path';
 import { publicPlatformString } from '@agent-device/kernel/device';
@@ -16,7 +17,7 @@ import {
   stripRecordedRefGeneration,
 } from '@agent-device/ad-script';
 import { expandSessionPath, safeSessionName } from './session-paths.ts';
-import type { SessionAction, SessionState } from './types.ts';
+import type { SessionState } from './types.ts';
 import {
   NO_SCRIPT_PUBLICATION,
   commitRepair,

--- a/src/daemon/session-selector.ts
+++ b/src/daemon/session-selector.ts
@@ -1,5 +1,5 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import type { CommandFlags } from '../core/dispatch.ts';
 import type { SessionState } from './types.ts';
 import {
   isIosFamily,

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,6 +1,7 @@
 import {
   snapshotCaptureAnnotationsFrom,
   summarizeSnapshotDiagnostics,
+  type SnapshotDiffSummary,
 } from '@agent-device/contracts/capture';
 import { stripAndroidSystemChromeProvenance } from '@agent-device/contracts/platform';
 import { isIosFamily, publicPlatformString } from '@agent-device/kernel/device';
@@ -8,7 +9,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import type { CommandSessionRecord } from '../runtime.ts';
 import { createAgentDevice } from '../runtime.ts';
-import type { SnapshotDiffSummary } from '../snapshot/snapshot-diff.ts';
 import { maybeBuildAndroidSnapshotTimeoutFailure } from './android-snapshot-timeout-evidence.ts';
 import { errorResponse, requireCommandSupported } from './handlers/response.ts';
 import { captureSnapshot, resolveSnapshotScope } from './handlers/snapshot-capture.ts';

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -529,4 +529,3 @@ export type SessionState = {
 
 // The recorded-action SHAPE lives in contracts/ so replay/ and compat/ can read a script
 // without depending on the server; re-exported here for the daemon's own consumers.
-export type { SessionAction } from '@agent-device/contracts/session';

--- a/src/metro/client-metro.ts
+++ b/src/metro/client-metro.ts
@@ -2,6 +2,7 @@
 // without depending on this zone; re-exported here for existing consumers.
 export type { PrepareMetroRuntimeResult, ReloadMetroResult } from '@agent-device/contracts/remote';
 import type {
+  MetroBridgeScope,
   MetroPrepareKind,
   PrepareMetroRuntimeResult,
   ReloadMetroResult,
@@ -11,7 +12,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { sleep } from '../utils/timeouts.ts';
 import { ensureMetroCompanion } from './client-metro-companion.ts';
-import type { MetroBridgeScope } from '../client/client-companion-tunnel-contract.ts';
 import type {
   MetroBridgeDescriptor,
   MetroBridgeResult,
@@ -41,7 +41,7 @@ const METRO_KILL_TIMEOUT_MS = 1_000;
 type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
 type RepackBundlerKind = 'rspack' | 'webpack';
 
-export type { MetroBridgeScope } from '../client/client-companion-tunnel-contract.ts';
+export type { MetroBridgeScope } from '@agent-device/contracts/remote';
 
 type PackageManagerConfig = {
   command: string;

--- a/src/platforms/apple/core/__tests__/runner-client.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-client.test.ts
@@ -1,3 +1,4 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import { beforeEach, test, onTestFinished, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -40,10 +41,7 @@ vi.mock('../../../../utils/host-process.ts', async (importOriginal) => {
 });
 
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import {
-  type RequestProgressEvent,
-  withRequestProgressSink,
-} from '../../../../request/progress.ts';
+import { withRequestProgressSink } from '../../../../request/progress.ts';
 import { createRequestCanceledError, isRequestCanceledError } from '../../../../request/cancel.ts';
 import {
   flushDiagnosticsToSessionFile,

--- a/src/platforms/apple/core/__tests__/runner-session.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-session.test.ts
@@ -1,13 +1,11 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
 import { beforeEach, test, vi } from 'vitest';
 import { IOS_DEVICE, IOS_SIMULATOR } from '../../../../__tests__/test-utils/index.ts';
-import {
-  type RequestProgressEvent,
-  withRequestProgressSink,
-} from '../../../../request/progress.ts';
+import { withRequestProgressSink } from '../../../../request/progress.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   flushDiagnosticsToSessionFile,

--- a/src/platforms/apple/interactor.ts
+++ b/src/platforms/apple/interactor.ts
@@ -23,17 +23,14 @@ import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { isMacOs, isTvOsDevice, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { withMethodScope } from '../../utils/method-scope.ts';
-import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import type { RawSnapshotNode, SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
 import type {
   Interactor,
   RunnerCallOptions,
   RunnerContext,
   ScreenshotOptions,
 } from '@agent-device/contracts/interaction';
-import {
-  readSnapshotQualityVerdict,
-  type SnapshotQualityVerdict,
-} from '../../snapshot/snapshot-quality.ts';
+import { readSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
 
 export function createAppleInteractor(
   device: DeviceInfo,

--- a/src/request/progress.ts
+++ b/src/request/progress.ts
@@ -4,7 +4,6 @@ import type { RequestProgressEvent, RequestProgressSink } from '@agent-device/co
 // The event vocabulary is a wire contract shared with the CLI reporter path, so it lives in
 // `@agent-device/contracts/progress`. This module owns only the request-global plumbing that
 // carries it: the per-request sink and its AsyncLocalStorage binding.
-export type { RequestProgressEvent, RequestProgressSink } from '@agent-device/contracts/progress';
 
 const requestProgress = new AsyncLocalStorage<RequestProgressSink | undefined>();
 

--- a/src/snapshot/snapshot-diff.ts
+++ b/src/snapshot/snapshot-diff.ts
@@ -7,8 +7,6 @@ import {
   formatSnapshotLine,
 } from './snapshot-lines.ts';
 
-export type { SnapshotDiffLine, SnapshotDiffSummary } from '@agent-device/contracts/capture';
-
 export type SnapshotDiffResult = {
   summary: SnapshotDiffSummary;
   lines: SnapshotDiffLine[];

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -2,7 +2,6 @@ import type { SnapshotNode, SnapshotQualityVerdict } from '@agent-device/kernel/
 
 // The type lives in snapshot.ts (the foundational type module) to avoid a cyclic
 // import with SnapshotNode; re-exported here so existing callers are unaffected.
-export type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
 
 const SNAPSHOT_QUALITY_STATES = new Set<SnapshotQualityVerdict['state']>([
   'healthy',

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1,3 +1,4 @@
+import type { RequestProgressEvent } from '@agent-device/contracts/progress';
 import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import http from 'node:http';
@@ -25,7 +26,6 @@ import {
   shouldResetDaemonAfterRequestTimeout,
 } from '../../daemon/client/daemon-client-timeout.ts';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
-import type { RequestProgressEvent } from '../../request/progress.ts';
 import {
   isProcessAlive,
   readProcessCommand,

--- a/src/utils/screenshot-density.ts
+++ b/src/utils/screenshot-density.ts
@@ -1,6 +1,6 @@
+import type { ScreenshotResultData } from '@agent-device/contracts/capture';
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import type { ScreenshotResultData } from './screenshot-result.ts';
 import { readPngSize } from './png-size.ts';
 
 type ScreenshotDensityDevice = Pick<DeviceInfo, 'platform' | 'appleOs' | 'kind'>;

--- a/src/utils/screenshot-result.ts
+++ b/src/utils/screenshot-result.ts
@@ -2,8 +2,6 @@ import type { ScreenshotResultData } from '@agent-device/contracts/capture';
 import type { ScreenshotOverlayRef } from '@agent-device/kernel/snapshot';
 import { isRecord, parsePoint, parseRect } from './parsing.ts';
 
-export type { ScreenshotResultData } from '@agent-device/contracts/capture';
-
 export function pickScreenshotResultData(value: ScreenshotResultData): ScreenshotResultData {
   return {
     ...(typeof value.path === 'string' ? { path: value.path } : {}),

--- a/test/integration/android-emulator-e2e/live-assertions.ts
+++ b/test/integration/android-emulator-e2e/live-assertions.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
-import type { SnapshotDiffLine } from '../../../src/snapshot/snapshot-diff.ts';
+import type { SnapshotDiffLine } from '@agent-device/contracts/capture';
 import {
   assertFilesDiffer,
   assertJsonContains,

--- a/test/integration/nightly/concurrency-torture/bindings.ts
+++ b/test/integration/nightly/concurrency-torture/bindings.ts
@@ -19,7 +19,7 @@
 // hand-off cannot be reproduced from a seed.
 
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { CommandFlags } from '../../../../src/core/dispatch-context.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { DaemonRequest } from '../../../../src/daemon/types.ts';
 import type { SessionStore } from '../../../../src/daemon/session-store.ts';
 import { resolveRequestExecutionLockKeys } from '../../../../src/daemon/request-binding.ts';

--- a/test/integration/nightly/concurrency-torture/real-scope-serialization.ts
+++ b/test/integration/nightly/concurrency-torture/real-scope-serialization.ts
@@ -19,7 +19,7 @@ import { createRequestExecutionScope } from '../../../../src/daemon/request-exec
 import { LeaseRegistry } from '../../../../src/daemon/lease-registry.ts';
 import { SessionStore } from '../../../../src/daemon/session-store.ts';
 import { withDeviceInventoryProvider } from '../../../../src/core/dispatch-resolve.ts';
-import type { CommandFlags } from '../../../../src/core/dispatch-context.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { DaemonRequest } from '../../../../src/daemon/types.ts';
 
 import { DEVICE_POOL } from './bindings.ts';


### PR DESCRIPTION
Follow-up to #1636 review feedback (the `export type { ScreenshotResultData } from '@agent-device/contracts/capture'` in `utils/screenshot-result.ts`): internal modules should not re-export package types — consumers import directly from the owning package. This PR applies that rule repo-wide.

## The rule

**Internal src modules import package types directly from `@agent-device/*`. Only published entry surfaces may re-export.** The kept re-export surfaces (all feed the npm exports map or the public client type surface): `src/sdk/*` entries, `src/client/client-types.ts`, `src/finders.ts`, `src/metro/{client-metro,metro-types}.ts`, `src/remote/remote-config-schema.ts`.

## What moved

Eleven internal re-exports removed; ~110 import sites across 115 files redirected to the packages (`git diff` is one-line import rewrites, −24 net):

| removed from | symbol(s) | sites |
|---|---|---:|
| `core/dispatch.ts` + `core/dispatch-context.ts` | `CommandFlags` | 39 |
| `daemon/types.ts` | `SessionAction` | 19 |
| `request/progress.ts` | `RequestProgressEvent`/`Sink` | 5 |
| `snapshot/snapshot-quality.ts` | `SnapshotQualityVerdict` | 4 |
| `client/client-companion-tunnel-contract.ts` | `CompanionTunnelScope`, `MetroBridgeScope` | 4 |
| `commands/cli-grammar/flag-types.ts` | `CliFlags` | 3 |
| `utils/screenshot-result.ts` | `ScreenshotResultData` | 1 |
| `commands/command-input.ts` | `RepeatedInput` | 1 |
| `snapshot/snapshot-diff.ts` | `SnapshotDiffLine`/`Summary` | 1 |
| `daemon/daemon-command-registry.ts` | `RefFrameEffect` | dead |
| `commands/capture/runtime/snapshot.ts` | `DiffSnapshotCommandResult` | dead |
| `core/batch.ts` | `DaemonBatchStep` | 0 internal (entry takes `runBatch` only) |

Entry-surface chains that previously laundered through a *second* internal module now re-export from the package (`client-types.ts` / `client-metro.ts` → `MetroBridgeScope` from `contracts/remote`).

## Measured side effect

The R9 type cycle shrinks again: **49 → 47** (`daemon-server` 19 → 17) — `core/dispatch.ts`'s type re-export was itself a cycle edge. Ceilings lowered to the measured values.

## Verification

- Typecheck, lint, format, `check:layering` (47/17), fallow audit (115 changed files) + production-exports: green.
- Full `src` suite: 609 files / 5,341 tests green. (One earlier run hit two pid-liveness assertion flakes in device-claim tests — pass in isolation and on rerun, pre-existing class per #1556's own commit message; test-side hardening flagged separately, no product code involved.)