### PR TITLE
test: pin own-pid start time in device-claim tests to stop load flakes

### DIFF
--- a/src/__tests__/cli-device-status.test.ts
+++ b/src/__tests__/cli-device-status.test.ts
@@ -6,33 +6,9 @@ import { readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
 import { runCliCapture } from './cli-capture.ts';
 import { mkdtempForTestSync } from './test-utils/tmp-dir.ts';
 
-// readProcessStartTime shells out to `ps` with a 1s timeout (see
-// utils/host-process.ts). This file's fixtures read our own start time once
-// to build a "live" claim, then production re-reads it during classification
-// to confirm identity; under full-suite CPU contention that second `ps` call
-// can miss its deadline and return null, mismatching the cached value and
-// flipping a genuinely-live claim to 'owner-process-dead'. Cache our own
-// pid's start time after the first (real) read so every later read is
-// self-consistent with the fixtures instead of racing a fresh `ps` call.
-// isProcessAlive is left real (a plain `kill(pid, 0)` syscall, not a
-// subprocess), so the fabricated-dead-pid fixtures below still classify as
-// stale through that real, non-flaky check.
-vi.mock('../utils/host-process.ts', async () => {
-  const actual = await vi.importActual<typeof import('../utils/host-process.ts')>(
-    '../utils/host-process.ts',
-  );
-  let cachedOwnStartTime: string | null | undefined;
-  return {
-    ...actual,
-    readProcessStartTime: (pid: number) => {
-      if (pid !== process.pid) return null;
-      if (cachedOwnStartTime === undefined) {
-        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
-      }
-      return cachedOwnStartTime;
-    },
-  };
-});
+vi.mock('../utils/host-process.ts', async (importOriginal) =>
+  (await import('./test-utils/host-process-mock.ts')).pinOwnProcessStartTime(importOriginal),
+);
 
 test('device status is daemonless and does not send a daemon request', async () => {
   const result = await runCliCapture(['device', 'status', '--json']);

--- a/src/__tests__/test-utils/host-process-mock.ts
+++ b/src/__tests__/test-utils/host-process-mock.ts
@@ -1,0 +1,35 @@
+type HostProcessModule = typeof import('../../utils/host-process.ts');
+
+/**
+ * `vi.mock` factory for `utils/host-process.ts` in tests that seed a "live"
+ * owner from the test process's own identity (readCurrentOwnerIdentity and
+ * friends) and later have production code re-read it during classification.
+ *
+ * readProcessStartTime shells out to `ps` with a 1s timeout; under full-suite
+ * CPU contention a re-read can miss that deadline and return null, mismatching
+ * the seeded value and flipping a genuinely-live owner to 'owner-process-dead'.
+ * This factory reads our own pid's start time once for real, then serves the
+ * cached value so every read is self-consistent. Other pids read as null, same
+ * as a real `ps` miss. isProcessAlive stays real (a plain `kill(pid, 0)`
+ * syscall, not a subprocess), so fabricated dead-pid fixtures still classify
+ * as dead through that non-flaky check.
+ *
+ * Usage: `vi.mock('<path>/utils/host-process.ts', async (importOriginal) =>
+ * (await import('<path>/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(importOriginal))`
+ */
+export async function pinOwnProcessStartTime(
+  importOriginal: () => Promise<HostProcessModule>,
+): Promise<HostProcessModule> {
+  const actual = await importOriginal();
+  let cachedOwnStartTime: string | null | undefined;
+  return {
+    ...actual,
+    readProcessStartTime: (pid: number) => {
+      if (pid !== process.pid) return null;
+      if (cachedOwnStartTime === undefined) {
+        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
+      }
+      return cachedOwnStartTime;
+    },
+  };
+}

--- a/src/daemon/__tests__/device-claim-prune.test.ts
+++ b/src/daemon/__tests__/device-claim-prune.test.ts
@@ -9,32 +9,11 @@ import { acquireProcessLock } from '../../utils/process-lock.ts';
 import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
-// readProcessStartTime shells out to `ps` with a 1s timeout (see
-// utils/host-process.ts). This file seeds "live" claims from our own identity
-// via readCurrentOwnerIdentity(), then the prune's classification re-reads our
-// start time; under full-suite CPU contention that second `ps` call can miss
-// its deadline and return null, mismatching the seeded value and flipping a
-// genuinely-live claim to 'owner-process-dead'. Cache our own pid's start time
-// after the first (real) read so every later read is self-consistent with the
-// fixtures instead of racing a fresh `ps` call. isProcessAlive is left real (a
-// plain `kill(pid, 0)` syscall, not a subprocess), so the fabricated dead-pid
-// fixtures still classify as dead through that real, non-flaky check.
-vi.mock('../../utils/host-process.ts', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/host-process.ts')>(
-    '../../utils/host-process.ts',
-  );
-  let cachedOwnStartTime: string | null | undefined;
-  return {
-    ...actual,
-    readProcessStartTime: (pid: number) => {
-      if (pid !== process.pid) return null;
-      if (cachedOwnStartTime === undefined) {
-        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
-      }
-      return cachedOwnStartTime;
-    },
-  };
-});
+vi.mock('../../utils/host-process.ts', async (importOriginal) =>
+  (await import('../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
+    importOriginal,
+  ),
+);
 
 const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
 

--- a/src/daemon/__tests__/device-claim-prune.test.ts
+++ b/src/daemon/__tests__/device-claim-prune.test.ts
@@ -2,12 +2,39 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, test } from 'vitest';
+import { afterEach, test, vi } from 'vitest';
 import { pruneDeadDeviceClaims } from '../device-claims.ts';
 import { resolveDeviceClaimPath } from '../device-claim-paths.ts';
 import { acquireProcessLock } from '../../utils/process-lock.ts';
 import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+
+// readProcessStartTime shells out to `ps` with a 1s timeout (see
+// utils/host-process.ts). This file seeds "live" claims from our own identity
+// via readCurrentOwnerIdentity(), then the prune's classification re-reads our
+// start time; under full-suite CPU contention that second `ps` call can miss
+// its deadline and return null, mismatching the seeded value and flipping a
+// genuinely-live claim to 'owner-process-dead'. Cache our own pid's start time
+// after the first (real) read so every later read is self-consistent with the
+// fixtures instead of racing a fresh `ps` call. isProcessAlive is left real (a
+// plain `kill(pid, 0)` syscall, not a subprocess), so the fabricated dead-pid
+// fixtures still classify as dead through that real, non-flaky check.
+vi.mock('../../utils/host-process.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/host-process.ts')>(
+    '../../utils/host-process.ts',
+  );
+  let cachedOwnStartTime: string | null | undefined;
+  return {
+    ...actual,
+    readProcessStartTime: (pid: number) => {
+      if (pid !== process.pid) return null;
+      if (cachedOwnStartTime === undefined) {
+        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
+      }
+      return cachedOwnStartTime;
+    },
+  };
+});
 
 const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
 

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -12,6 +12,33 @@ import { inspectDeviceClaims } from '../device-claim-inspection.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
+// readProcessStartTime shells out to `ps` with a 1s timeout (see
+// utils/host-process.ts). acquireAdvisoryDeviceClaim records our own identity
+// into each claim, then later acquire/inspect calls classify that claim by
+// re-reading our start time; under full-suite CPU contention that second `ps`
+// call can miss its deadline and return null, mismatching the recorded value
+// and flipping a genuinely-live claim to 'owner-process-dead'. Cache our own
+// pid's start time after the first (real) read so every later read is
+// self-consistent instead of racing a fresh `ps` call. isProcessAlive is left
+// real (a plain `kill(pid, 0)` syscall, not a subprocess), so the fabricated
+// dead-pid fixture still classifies as dead through that real, non-flaky check.
+vi.mock('../../utils/host-process.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/host-process.ts')>(
+    '../../utils/host-process.ts',
+  );
+  let cachedOwnStartTime: string | null | undefined;
+  return {
+    ...actual,
+    readProcessStartTime: (pid: number) => {
+      if (pid !== process.pid) return null;
+      if (cachedOwnStartTime === undefined) {
+        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
+      }
+      return cachedOwnStartTime;
+    },
+  };
+});
+
 const device: DeviceInfo = {
   platform: 'android',
   id: 'emulator-5554',

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -12,32 +12,11 @@ import { inspectDeviceClaims } from '../device-claim-inspection.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
-// readProcessStartTime shells out to `ps` with a 1s timeout (see
-// utils/host-process.ts). acquireAdvisoryDeviceClaim records our own identity
-// into each claim, then later acquire/inspect calls classify that claim by
-// re-reading our start time; under full-suite CPU contention that second `ps`
-// call can miss its deadline and return null, mismatching the recorded value
-// and flipping a genuinely-live claim to 'owner-process-dead'. Cache our own
-// pid's start time after the first (real) read so every later read is
-// self-consistent instead of racing a fresh `ps` call. isProcessAlive is left
-// real (a plain `kill(pid, 0)` syscall, not a subprocess), so the fabricated
-// dead-pid fixture still classifies as dead through that real, non-flaky check.
-vi.mock('../../utils/host-process.ts', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/host-process.ts')>(
-    '../../utils/host-process.ts',
-  );
-  let cachedOwnStartTime: string | null | undefined;
-  return {
-    ...actual,
-    readProcessStartTime: (pid: number) => {
-      if (pid !== process.pid) return null;
-      if (cachedOwnStartTime === undefined) {
-        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
-      }
-      return cachedOwnStartTime;
-    },
-  };
-});
+vi.mock('../../utils/host-process.ts', async (importOriginal) =>
+  (await import('../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
+    importOriginal,
+  ),
+);
 
 const device: DeviceInfo = {
   platform: 'android',

--- a/src/daemon/handlers/__tests__/session-test-reporter-values.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-reporter-values.test.ts
@@ -97,6 +97,7 @@ function makeSessionStore(): SessionStore {
 async function runSuiteThroughReporter(params: {
   root: string;
   requestId: string;
+  inputs?: string[];
   flags?: DaemonRequest['flags'];
   invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
   devices?: DeviceInfo[];
@@ -112,7 +113,7 @@ async function runSuiteThroughReporter(params: {
             token: 't',
             session: 'default',
             command: 'test',
-            positionals: [params.root],
+            positionals: params.inputs ?? [params.root],
             meta: { cwd: params.root, requestId: params.requestId },
             flags: params.flags,
           },
@@ -157,6 +158,9 @@ async function runRetrySuite(): Promise<{
   const run = await runSuiteThroughReporter({
     root,
     requestId: 'suite-reporter',
+    // Explicit file inputs keep argument order; a directory input enumerates
+    // in native readdir order, which is not lexicographic on every filesystem.
+    inputs: [path.join(root, '01-untyped.ad'), path.join(root, '02-retry.ad')],
     flags: { platform: 'android' },
     invoke: async () => {
       attempts += 1;


### PR DESCRIPTION
## What

Hardens two intermittently-flaky test files against full-suite CPU contention, test-side only (no product code changed):

- `src/daemon/__tests__/device-claim-prune.test.ts` ("prunes claims whose owner is gone and keeps every other claim")
- `src/daemon/__tests__/device-claims.test.ts` ("preserves a live foreign advisory claim without blocking or overwriting it")

## Why

Both tests seed a "live" claim from `readCurrentOwnerIdentity()` — a real `ps -p <pid> -o lstart=` read of the vitest worker's own pid + start time. Classification later re-reads that start time through a second `ps` shell-out with a 1s timeout (`classifyOwnerLiveness` / `ownerIdentityMatches`). Under parallel full-suite load the second read can miss its deadline and return null, mismatching the seeded value and misclassifying the genuinely-live owner as `owner-process-dead` — producing intermittent assertion failures (e.g. `2 !== 1`) that vanish in isolation.

## How

Same pattern as 4551fb7aa (#1556, `cli-device-status.test.ts`): `vi.mock` `utils/host-process.ts` so `readProcessStartTime` reads our own pid's start time once for real, caches it, and returns the cached value on every later call; any other pid returns null (same as a real `ps` miss). `isProcessAlive` stays real and un-mocked, so the fabricated dead-pid fixtures (`999_999_999`) still classify as dead through the genuine `kill(pid, 0)` syscall — the dead-owner path is not weakened.

## Verification

- 3× full `npx vitest run src` with 6 CPU-burner processes saturating cores: 610 files / 5379 tests green each run (one run had the pre-existing environment-guarded skip in `daemon-client.test.ts`, which is expected).
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` all pass.