### PR TITLE
docs: pin the version-skew invariant and the four legitimate compat axes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,20 +61,13 @@ task touches:
 - Daemon RPC protocol version: integer advertised by daemon/proxy `/health` and checked by remote
   clients before HTTP JSON-RPC; bump only for breaking transport/request/response compatibility
   across the remote daemon boundary.
-- Version-skew invariant: a client and a LOCAL daemon can never disagree on version — daemon reuse
-  requires exact version AND code-signature equality, otherwise the client replaces the daemon
-  (`isReusableDaemonInfo`, `src/daemon/client/daemon-client-lifecycle.ts`), in both directions.
-  Version-skew compat code is therefore justified on exactly four axes, and a comment defending it
-  must name one: (1) the remote daemon boundary (`daemonBaseUrl`), both directions — the protocol
-  version gates breaking changes, but additive optional fields ride the same protocol version and an
-  older remote daemon silently ignores them (the #1617 `--scale` residual gap); (2) separately
-  versioned device binaries — the iOS/macOS XCTest runner and Android helper are built/cached
-  independently of the daemon, so runner/helper skew is real; (3) persisted artifacts — `.ad`
-  scripts, config files, env vars, and session logs outlive every release and must be handled (or
-  explicitly refused with migration guidance) forever; (4) released public API consumers — Node/MCP
-  callers built against shipped input/result shapes. Compat code that only tolerates an older LOCAL
-  daemon or client is dead by construction: delete it, or re-scope its comment to the remote
-  boundary.
+- Version-skew invariant: a client replaces any local daemon whose version or code signature
+  differs (`isReusableDaemonInfo`, both directions), so local client↔daemon skew cannot exist.
+  Version-skew compat code is legitimate on exactly four axes and its comment must name one:
+  the remote daemon boundary (the protocol version gates breaking changes only — older remote
+  daemons silently ignore additive optional fields), separately versioned runner/helper binaries,
+  persisted artifacts (`.ad`/config/env/session logs — handle or refuse with migration guidance,
+  forever), and released API consumers. "Older local daemon" tolerance is dead code.
 
 ### Interaction, refs, and guarantees
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,20 @@ task touches:
 - Daemon RPC protocol version: integer advertised by daemon/proxy `/health` and checked by remote
   clients before HTTP JSON-RPC; bump only for breaking transport/request/response compatibility
   across the remote daemon boundary.
+- Version-skew invariant: a client and a LOCAL daemon can never disagree on version — daemon reuse
+  requires exact version AND code-signature equality, otherwise the client replaces the daemon
+  (`isReusableDaemonInfo`, `src/daemon/client/daemon-client-lifecycle.ts`), in both directions.
+  Version-skew compat code is therefore justified on exactly four axes, and a comment defending it
+  must name one: (1) the remote daemon boundary (`daemonBaseUrl`), both directions — the protocol
+  version gates breaking changes, but additive optional fields ride the same protocol version and an
+  older remote daemon silently ignores them (the #1617 `--scale` residual gap); (2) separately
+  versioned device binaries — the iOS/macOS XCTest runner and Android helper are built/cached
+  independently of the daemon, so runner/helper skew is real; (3) persisted artifacts — `.ad`
+  scripts, config files, env vars, and session logs outlive every release and must be handled (or
+  explicitly refused with migration guidance) forever; (4) released public API consumers — Node/MCP
+  callers built against shipped input/result shapes. Compat code that only tolerates an older LOCAL
+  daemon or client is dead by construction: delete it, or re-scope its comment to the remote
+  boundary.
 
 ### Interaction, refs, and guarantees
 

--- a/src/mcp/tool-ref-pins.ts
+++ b/src/mcp/tool-ref-pins.ts
@@ -130,8 +130,9 @@ function mergeCommandResult(
  * MERGE-ONLY update rule: refs present in the issuing response move to its
  * generation; absent refs keep their older pins (an old pin on a replaced
  * tree is exactly what makes the daemon warn). A ref-issuing response WITHOUT
- * a `refsGeneration` (older daemon, find with no ref match) clears the whole
- * scope — never guess.
+ * a `refsGeneration` (older remote daemon, find with no ref match) clears the
+ * whole scope — never guess. (A local daemon always matches the client
+ * version; see the version-skew invariant in CONTEXT.md.)
  */
 type SnapshotPinView = {
   refsGeneration?: number;


### PR DESCRIPTION
Follow-up from the #1617 review discussion: a newer client **replaces** a local daemon on any version or code-signature mismatch (`isReusableDaemonInfo`, both directions), so local client↔daemon version skew is impossible by construction — only the remote daemon boundary can skew, and only there do additive optional fields (like #1617's `--scale`) degrade silently.

This PR pins that invariant in CONTEXT.md Terms (next to the RPC protocol-version entry) together with the only four axes that justify version-skew compat code: remote daemon boundary, separately versioned runner/helper binaries, persisted artifacts, released API consumers. A comment defending compat code must name one.

I swept `src/` and `packages/` for fallbacks that exist only to tolerate an older **local** daemon/client: none exist today — every compat site maps to one of the four axes (runner-verdict fallbacks → runner skew; `DaemonArtifact` optional fields → remote + JSON-drops-undefined; `.ad`/config/env handling → persisted artifacts; rotate wrapper → API consumers). The one comment that said "older daemon" without scoping it (`tool-ref-pins.ts`) is now explicit about the remote boundary and points at the invariant.

No behavior change; docs + one comment.