### PR TITLE
fix(ios): keep the baseline presentation when a tap corroboration has no request flags

### DIFF
--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
+import { buildSnapshotPresentationKey } from '@agent-device/kernel/snapshot';
 import { handleInteractionCommands } from '../interaction.ts';
 import { handleSnapshotCommands } from '../snapshot.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
@@ -339,6 +340,52 @@ test('a changed capture with a different presentation keeps the tap failure', as
   expect(response?.ok).toBe(false);
   if (response && !response.ok) expect(response.error.code).toBe('XCTEST_RECORDED_FAILURE');
   expect(sessionStore.get(sessionName)?.actions).toHaveLength(0);
+});
+
+test('corroborates a tap when the request carries no flags and the baseline used a non-default scope', async () => {
+  const sessionName = 'ios-no-flags-tap-corroboration';
+  const sessionStore = makeSessionStore();
+  const baseline = snapshot(profileNodes);
+  baseline.presentationKey = buildSnapshotPresentationKey({ depth: 2, raw: false });
+  sessionStore.set(
+    sessionName,
+    makeIosSession(sessionName, {
+      appBundleId: 'com.example.app',
+      snapshot: baseline,
+    }),
+  );
+  mockDispatch.mockImplementation(async (_device, command) => {
+    if (command === 'press') {
+      throw new AppError(
+        'XCTEST_RECORDED_FAILURE',
+        'XCTest recorded a failure while executing tap; the action may not have been performed.',
+      );
+    }
+    if (command === 'snapshot') return snapshotPayload(imageViewerNodes);
+    return {};
+  });
+
+  // Deliberately built without a `flags` key at all (not `flags: {}`) — this
+  // mirrors the real production paths (batch steps with no flags, JSON-RPC
+  // requests that omit the key) that hide the bug this test pins.
+  const response = await handleInteractionCommands({
+    req: {
+      token: 'test',
+      session: sessionName,
+      command: 'click',
+      positionals: ['id="unfollow"'],
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toMatch(/post-action accessibility capture changed/);
+    expect(response.data?.selector).toBe('id="unfollow"');
+  }
+  expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
 });
 
 test('a changed capture against a stale baseline keeps the tap failure', async () => {

--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -366,8 +366,8 @@ test('corroborates a tap when the request carries no flags and the baseline used
   });
 
   // Deliberately built without a `flags` key at all (not `flags: {}`) — this
-  // mirrors the real production paths (batch steps with no flags, JSON-RPC
-  // requests that omit the key) that hide the bug this test pins.
+  // mirrors the raw daemon/JSON-RPC production boundary, which can omit the
+  // key entirely. CLI and batch paths always materialize a flags object.
   const response = await handleInteractionCommands({
     req: {
       token: 'test',

--- a/src/daemon/handlers/interaction-ios-tap-outcome.ts
+++ b/src/daemon/handlers/interaction-ios-tap-outcome.ts
@@ -247,9 +247,9 @@ function matchingCaptureFlags(
   flags: CommandFlags | undefined,
   presentation: SnapshotPresentation | undefined,
 ): CommandFlags | undefined {
-  if (!flags) return undefined;
+  if (!flags && !presentation) return undefined;
   return {
-    ...flags,
+    ...(flags ?? {}),
     out: undefined,
     ...(presentation
       ? {


### PR DESCRIPTION
## Summary

`matchingCaptureFlags` returned `undefined` whenever a raw daemon/JSON-RPC request omitted `flags`, discarding the baseline's `depth`, `scope`, and `raw` presentation. The corroboration probe then used default presentation, could not match a non-default baseline, and silently declined to rescue a tap that XCTest recorded as failed even when the tap landed.

This complements #1634: that PR pinned the probe's capture backend; this PR preserves the baseline presentation. Both conditions must match for corroboration to fail safely.

The affected production boundary is raw daemon/JSON-RPC (`http-server.ts` passes an omitted `params.flags` through). CLI, legacy batch, and structured batch always materialize a flags object, so they cannot produce `flags: undefined`.

## Validation

- Regression test proven red without the fix:

  ```text
  × corroborates a tap when the request carries no flags and the baseline used a non-default scope
  AssertionError: expected false to be true
  Tests  1 failed | 11 passed (12)
  ```

- The test omits the `flags` key entirely; using an empty object would exercise the already-working path.
- Exact-runtime-head iPhone 17 Pro / Bluesky evidence reproduced the recorded-failure → matched-presentation corroboration path three times (attempts 8–10), with zero scope/backend mismatch diagnostics: https://github.com/callstack/agent-device/pull/1646#issuecomment-5208564816
- `pnpm check:affected --run` passed after rebasing onto current `main` (75 files, 430 tests).

## Scope

Two files: the presentation-preservation fix and its regression test. The final follow-up commit only corrects the test's reachability comment after the batch-path claim was disproved during live verification.
