### PR TITLE
fix(daemon): say why a no-effect claim was withheld

### DIFF
--- a/src/daemon/__tests__/post-gesture-no-effect-claim.test.ts
+++ b/src/daemon/__tests__/post-gesture-no-effect-claim.test.ts
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import { afterEach, test, vi } from 'vitest';
+import { makeSnapshotState } from '../../__tests__/test-utils/index.ts';
+import { countDiagnosticEventsByPhase, withDiagnosticsScope } from '../../utils/diagnostics.ts';
+import {
+  buildInteractionSurfaceSignature,
+  summarizeDiscriminatingSurfaceDivergence,
+} from '../interaction-outcome-policy.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
+import {
+  capturePostGestureStabilizedResult,
+  markDeferredInteractionOutcome,
+} from '../deferred-interaction-outcome.ts';
+import { formatGestureNoEffectWarning } from '../gesture-no-effect.ts';
+import type { SessionState } from '../types.ts';
+import {
+  chromeWithListSnapshot,
+  makeSession,
+  pickupSnapshot,
+} from './post-gesture-stabilization-fixtures.ts';
+
+// When the agent-facing gestureNoEffect claim may and may not surface — split
+// by subject from post-gesture-stabilization.test.ts (the capture loop), the
+// same #1563 convention that keeps test files under the repo's 500-line
+// tripwire. Loop mechanics (rebase, distrust budget, timeouts) stay in the
+// loop file; everything here is about the claim and its veto instrumentation.
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Marking is module-private behind the deferred-interaction-outcome interface;
+// this shim drives the same public entry every shipping caller uses.
+function markPostGestureStabilization(
+  session: SessionState,
+  action: string,
+  positionals: string[] = [],
+  flags?: CommandFlags,
+): void {
+  markDeferredInteractionOutcome({ session, command: action, positionals, flags });
+}
+
+async function runStabilization(
+  session: ReturnType<typeof makeSession>,
+  capture: () => ReturnType<typeof makeSnapshotState>,
+) {
+  const captureFn = vi.fn(async () => capture());
+  const resultPromise = withDiagnosticsScope({}, async () => {
+    const result = await capturePostGestureStabilizedResult({
+      session,
+      capture: captureFn,
+      readSnapshot: (snapshot) => snapshot,
+    });
+    return {
+      result,
+      staleAccepts: countDiagnosticEventsByPhase(['post_gesture_snapshot_stale_accept']),
+      rebased: countDiagnosticEventsByPhase(['post_gesture_snapshot_baseline_rebased']),
+      vetoed: countDiagnosticEventsByPhase(['post_gesture_no_effect_vetoed']),
+    };
+  });
+  await vi.advanceTimersByTimeAsync(10_000);
+  return await resultPromise;
+}
+
+test('a backend flip mid-poll withholds the no-effect claim, and records the reason (#1620)', async () => {
+  // Corroboration reads the ORIGINAL pre-gesture baseline, so a rebase leaves
+  // the pair cross-backend and set equality cannot hold — the claim is
+  // withheld, which is correct and long-standing. What is new is that the
+  // veto says so: silence alone is indistinguishable from a gesture that
+  // worked, and that ambiguity is what left #1620 unresolvable for weeks.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = makeSnapshotState(pickupSnapshot(500).nodes, {
+    snapshotQuality: { state: 'healthy', backend: 'tree' },
+  });
+  markPostGestureStabilization(session, 'scroll', ['up']);
+
+  // Post-gesture captures from private-ax, identical to EACH OTHER — a shape
+  // equally consistent with an inert gesture and with a fast successful one
+  // that settled before the first poll. That ambiguity is the whole point.
+  const privateAxNodes = [
+    ...pickupSnapshot(500).nodes,
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'StaticText',
+      identifier: 'scrolled-away-row',
+      label: 'Above the fold',
+      rect: { x: 20, y: -80, width: 200, height: 44 },
+    },
+  ];
+  const { result, staleAccepts, rebased, vetoed } = await runStabilization(session, () =>
+    makeSnapshotState(privateAxNodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  assert.equal(rebased, 1);
+  assert.equal(staleAccepts, 1, 'the loop still accepts the stale read after the distrust budget');
+  assert.equal(result.gestureNoEffect, undefined);
+  assert.equal(vetoed, 1, 'the withheld claim must be observable (reason: baseline_rebased)');
+});
+
+test('a successful scroll that flips the capture backend must not claim no-effect', async () => {
+  // Every list cell swapped under fixed chrome — the fixture whose own comment
+  // says it "must never surface as an agent-facing no-effect claim" — while
+  // the capture backend flipped. Pinned because a rejected #1622 draft made
+  // corroboration read the REBASED baseline, which compares the settled screen
+  // with itself and fired the claim on this exact input.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = makeSnapshotState(chromeWithListSnapshot(['row-1', 'row-2']).nodes, {
+    snapshotQuality: { state: 'healthy', backend: 'tree' },
+  });
+  markPostGestureStabilization(session, 'scroll', ['down']);
+
+  const { result, rebased, vetoed } = await runStabilization(session, () =>
+    makeSnapshotState(chromeWithListSnapshot(['row-3', 'row-4']).nodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  assert.equal(rebased, 1);
+  assert.equal(
+    result.gestureNoEffect,
+    undefined,
+    'the scroll swapped every list cell — a no-effect claim here is a false positive',
+  );
+  assert.equal(vetoed, 1);
+});
+
+test('no pre-gesture snapshot means no baseline, no rebase, and no no-effect claim', async () => {
+  // Marking stores NO baseline when the session has no pre-gesture snapshot
+  // ("no usable baseline" has exactly one representation), so the loop has
+  // nothing to rebase and nothing to judge against: the quiet capture is
+  // trusted outright and no claim is invented. Previously an empty `[]` was
+  // stored, and being truthy it was rebased onto a post-gesture capture.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = undefined; // nothing captured before the gesture
+  markPostGestureStabilization(session, 'scroll', ['up']);
+  assert.equal(session.postGestureStabilization?.baselineSignature, undefined);
+
+  const { result, rebased, vetoed } = await runStabilization(session, () =>
+    makeSnapshotState(pickupSnapshot(500).nodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  assert.equal(rebased, 0);
+  assert.equal(vetoed, 0);
+  assert.equal(
+    result.gestureNoEffect,
+    undefined,
+    'a no-effect claim needs a real pre-gesture baseline, never one the loop invented for itself',
+  );
+});
+
+test('scope drift accepts stale but is vetoed from claiming no-effect, observably (#1601 P1 gate)', async () => {
+  // #1601's full-surface gate stays load-bearing: the classifier treats a
+  // one-sided difference as scope drift rather than movement, so a narrower
+  // quiet capture of an unmoved screen still reaches accept-stale — and the
+  // agent-facing claim must not follow it there, because the missing rows are
+  // unexamined, not proven absent. The veto now leaves a diagnostic trail.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = chromeWithListSnapshot(['row-1', 'row-2']);
+  markPostGestureStabilization(session, 'scroll');
+
+  // Same screen, but the quiet captures see only the chrome — the shape a
+  // broad baseline followed by an interactive-only capture produces.
+  const narrowed = makeSnapshotState(
+    chromeWithListSnapshot(['row-1', 'row-2']).nodes.filter(
+      (node) => node.type !== 'Cell',
+    ) as never,
+  );
+  const { result, staleAccepts, vetoed } = await runStabilization(session, () => narrowed);
+
+  assert.equal(staleAccepts, 1);
+  assert.equal(result.gestureNoEffect, undefined);
+  assert.equal(vetoed, 1, 'reason: surface_divergence — rows only in the baseline');
+});
+
+test('same-backend membership drift vetoes the claim and records the divergence (#1620 truncation drift)', async () => {
+  // #1620's second candidate veto: on hostile screens both sides of the pair
+  // come from private-ax, but a depth-capped capture might not return the same
+  // node set — here the quiet captures carry one deep row the baseline missed.
+  // All shared entries are unmoved, so the subset-tolerant classifier reads
+  // 'unchanged' and the loop reaches accept-stale; set equality then fails on
+  // the extra row. Measured live on the seeded Bluesky fixture this does NOT
+  // happen — membership was stable at onlyIn*=0 under the remembered depth-56
+  // cap — but the shape is cheap to pin and the veto now names it.
+  vi.useFakeTimers();
+  const session = makeSession('ios');
+  session.snapshot = makeSnapshotState(chromeWithListSnapshot(['row-1', 'row-2']).nodes, {
+    snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+  });
+  markPostGestureStabilization(session, 'scroll', ['down']);
+
+  const driftedNodes = [
+    ...chromeWithListSnapshot(['row-1', 'row-2']).nodes,
+    {
+      index: 9,
+      parentIndex: 0,
+      type: 'StaticText',
+      identifier: 'depth-56-row',
+      label: 'Sometimes captured',
+      rect: { x: 0, y: 220, width: 390, height: 60 },
+    },
+  ];
+  const { result, staleAccepts, rebased, vetoed } = await runStabilization(session, () =>
+    makeSnapshotState(driftedNodes, {
+      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+    }),
+  );
+
+  assert.equal(rebased, 0, 'same backend throughout: this is drift, not a flip');
+  assert.equal(staleAccepts, 1);
+  assert.equal(result.gestureNoEffect, undefined);
+  assert.equal(vetoed, 1);
+});
+
+test('summarizeDiscriminatingSurfaceDivergence counts one-sided keys and moved rects, excluding non-discriminating entries', () => {
+  const baseline = buildInteractionSurfaceSignature(
+    chromeWithListSnapshot(['row-1', 'row-2']).nodes,
+  );
+  const extraRow = {
+    ref: 'e-drift',
+    index: 9,
+    parentIndex: 0,
+    type: 'StaticText',
+    identifier: 'depth-56-row',
+    label: 'Sometimes captured',
+    rect: { x: 0, y: 220, width: 390, height: 60 },
+  };
+  const drifted = buildInteractionSurfaceSignature([
+    ...chromeWithListSnapshot(['row-1', 'row-2']).nodes,
+    extraRow,
+  ]);
+
+  // chromeWithListSnapshot: Application root (non-discriminating, excluded) +
+  // tab button + two cells = 3 discriminating entries shared; the deep row is
+  // current-only.
+  assert.deepEqual(summarizeDiscriminatingSurfaceDivergence(baseline, drifted), {
+    onlyInBaseline: 0,
+    onlyInCurrent: 1,
+    rectMismatched: 0,
+    shared: 3,
+  });
+  assert.deepEqual(summarizeDiscriminatingSurfaceDivergence(drifted, baseline), {
+    onlyInBaseline: 1,
+    onlyInCurrent: 0,
+    rectMismatched: 0,
+    shared: 3,
+  });
+
+  const movedNodes = chromeWithListSnapshot(['row-1', 'row-2']).nodes.map((node) =>
+    node.identifier === 'row-1' && node.rect
+      ? { ...node, rect: { ...node.rect, y: node.rect.y + 40 } }
+      : node,
+  );
+  const moved = buildInteractionSurfaceSignature(movedNodes);
+  assert.deepEqual(summarizeDiscriminatingSurfaceDivergence(baseline, moved), {
+    onlyInBaseline: 0,
+    onlyInCurrent: 0,
+    rectMismatched: 1,
+    shared: 3,
+  });
+});
+
+test('formatGestureNoEffectWarning names the gesture and the raw-drag escape hatch', () => {
+  // Positionals echo verbatim: the warning names the gesture the agent issued,
+  // and `scroll down 1` is what they issued.
+  const scrollWarning = formatGestureNoEffectWarning('scroll', ['down', '1']);
+  assert.match(scrollWarning, /scroll down 1 produced no visible change/);
+  assert.match(scrollWarning, /swipe x1 y1 x2 y2/);
+  assert.match(scrollWarning, /already at its edge/);
+
+  const gestureWarning = formatGestureNoEffectWarning('gesture', ['swipe', 'left']);
+  assert.match(gestureWarning, /gesture swipe left produced no visible change/);
+
+  const bareWarning = formatGestureNoEffectWarning('swipe', []);
+  assert.match(bareWarning, /swipe produced no visible change/);
+
+  // The regression the deleted heuristic caused: every positional of a swipe is
+  // a coordinate, so "drop anything numeric-looking" left a contentless "swipe".
+  const swipeWarning = formatGestureNoEffectWarning('swipe', ['10', '20', '30', '40']);
+  assert.match(swipeWarning, /^swipe 10 20 30 40 produced no visible change/);
+});

--- a/src/daemon/__tests__/post-gesture-no-effect-claim.test.ts
+++ b/src/daemon/__tests__/post-gesture-no-effect-claim.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import { makeSnapshotState } from '../../__tests__/test-utils/index.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 import { countDiagnosticEventsByPhase, withDiagnosticsScope } from '../../utils/diagnostics.ts';
 import {
   buildInteractionSurfaceSignature,
@@ -40,12 +43,24 @@ function markPostGestureStabilization(
   markDeferredInteractionOutcome({ session, command: action, positionals, flags });
 }
 
+/**
+ * Runs the loop under a diagnostics scope that also writes its NDJSON trace to
+ * a file, and returns the veto events parsed back out of it.
+ *
+ * The counts alone are not the behavior under test: what an operator reads on
+ * a `--debug` run is the emitted `reason` and divergence numbers, and a
+ * regression that emits the wrong reason — or drops the counts entirely —
+ * keeps every count at 1. Reading the serialized line (rather than an
+ * in-memory event array) pins what actually reaches the log, redaction
+ * included.
+ */
 async function runStabilization(
   session: ReturnType<typeof makeSession>,
   capture: () => ReturnType<typeof makeSnapshotState>,
 ) {
   const captureFn = vi.fn(async () => capture());
-  const resultPromise = withDiagnosticsScope({}, async () => {
+  const traceLogPath = path.join(mkdtempForTestSync('agent-device-veto-trace-'), 'trace.ndjson');
+  const resultPromise = withDiagnosticsScope({ traceLogPath }, async () => {
     const result = await capturePostGestureStabilizedResult({
       session,
       capture: captureFn,
@@ -59,7 +74,20 @@ async function runStabilization(
     };
   });
   await vi.advanceTimersByTimeAsync(10_000);
-  return await resultPromise;
+  const outcome = await resultPromise;
+  return { ...outcome, vetoEvents: readVetoEvents(traceLogPath) };
+}
+
+/** The `post_gesture_no_effect_vetoed` payloads written to a diagnostics trace. */
+function readVetoEvents(traceLogPath: string): Record<string, unknown>[] {
+  if (!fs.existsSync(traceLogPath)) return [];
+  return fs
+    .readFileSync(traceLogPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { phase: string; data?: Record<string, unknown> })
+    .filter((event) => event.phase === 'post_gesture_no_effect_vetoed')
+    .map((event) => event.data ?? {});
 }
 
 test('a backend flip mid-poll withholds the no-effect claim, and records the reason (#1620)', async () => {
@@ -89,16 +117,29 @@ test('a backend flip mid-poll withholds the no-effect claim, and records the rea
       rect: { x: 20, y: -80, width: 200, height: 44 },
     },
   ];
-  const { result, staleAccepts, rebased, vetoed } = await runStabilization(session, () =>
-    makeSnapshotState(privateAxNodes, {
-      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
-    }),
+  const { result, staleAccepts, rebased, vetoed, vetoEvents } = await runStabilization(
+    session,
+    () =>
+      makeSnapshotState(privateAxNodes, {
+        snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+      }),
   );
 
   assert.equal(rebased, 1);
   assert.equal(staleAccepts, 1, 'the loop still accepts the stale read after the distrust budget');
   assert.equal(result.gestureNoEffect, undefined);
-  assert.equal(vetoed, 1, 'the withheld claim must be observable (reason: baseline_rebased)');
+  assert.equal(vetoed, 1, 'the withheld claim must be observable');
+  // The reason is the point: a rebase means the corroboration pair is
+  // cross-backend, which is a categorically different answer from "the
+  // surfaces moved" and must not be reported as one. No divergence counts
+  // ride along, because there is no comparable pair to count over.
+  assert.deepEqual(vetoEvents, [
+    {
+      action: 'scroll',
+      backend: 'private-ax',
+      reason: 'baseline_rebased',
+    },
+  ]);
 });
 
 test('a successful scroll that flips the capture backend must not claim no-effect', async () => {
@@ -114,7 +155,7 @@ test('a successful scroll that flips the capture backend must not claim no-effec
   });
   markPostGestureStabilization(session, 'scroll', ['down']);
 
-  const { result, rebased, vetoed } = await runStabilization(session, () =>
+  const { result, rebased, vetoed, vetoEvents } = await runStabilization(session, () =>
     makeSnapshotState(chromeWithListSnapshot(['row-3', 'row-4']).nodes, {
       snapshotQuality: { state: 'recovered', backend: 'private-ax' },
     }),
@@ -127,6 +168,17 @@ test('a successful scroll that flips the capture backend must not claim no-effec
     'the scroll swapped every list cell — a no-effect claim here is a false positive',
   );
   assert.equal(vetoed, 1);
+  // Rebase wins the reason even though the surfaces also genuinely diverged:
+  // once the pair is cross-backend the divergence counts would describe two
+  // incomparable captures, and reporting them as movement is the exact
+  // misreading #1620 spent weeks on.
+  assert.deepEqual(vetoEvents, [
+    {
+      action: 'scroll',
+      backend: 'private-ax',
+      reason: 'baseline_rebased',
+    },
+  ]);
 });
 
 test('no pre-gesture snapshot means no baseline, no rebase, and no no-effect claim', async () => {
@@ -174,11 +226,31 @@ test('scope drift accepts stale but is vetoed from claiming no-effect, observabl
       (node) => node.type !== 'Cell',
     ) as never,
   );
-  const { result, staleAccepts, vetoed } = await runStabilization(session, () => narrowed);
+  const { result, staleAccepts, vetoed, vetoEvents } = await runStabilization(
+    session,
+    () => narrowed,
+  );
 
   assert.equal(staleAccepts, 1);
   assert.equal(result.gestureNoEffect, undefined);
-  assert.equal(vetoed, 1, 'reason: surface_divergence — rows only in the baseline');
+  assert.equal(vetoed, 1);
+  // Scope drift reads as one-sided membership, never as movement: both cells
+  // are missing from the narrowed capture, the shared chrome button has not
+  // moved. An operator seeing rectMismatched: 0 alongside onlyInBaseline: 2
+  // can tell "unexamined" from "moved" without re-deriving it.
+  // No `backend` key at all: this capture carries no snapshotQuality, and the
+  // serialized line omits the field rather than writing a null an aggregator
+  // would have to special-case.
+  assert.deepEqual(vetoEvents, [
+    {
+      action: 'scroll',
+      reason: 'surface_divergence',
+      onlyInBaseline: 2,
+      onlyInCurrent: 0,
+      rectMismatched: 0,
+      shared: 1,
+    },
+  ]);
 });
 
 test('same-backend membership drift vetoes the claim and records the divergence (#1620 truncation drift)', async () => {
@@ -208,16 +280,33 @@ test('same-backend membership drift vetoes the claim and records the divergence 
       rect: { x: 0, y: 220, width: 390, height: 60 },
     },
   ];
-  const { result, staleAccepts, rebased, vetoed } = await runStabilization(session, () =>
-    makeSnapshotState(driftedNodes, {
-      snapshotQuality: { state: 'recovered', backend: 'private-ax' },
-    }),
+  const { result, staleAccepts, rebased, vetoed, vetoEvents } = await runStabilization(
+    session,
+    () =>
+      makeSnapshotState(driftedNodes, {
+        snapshotQuality: { state: 'recovered', backend: 'private-ax' },
+      }),
   );
 
   assert.equal(rebased, 0, 'same backend throughout: this is drift, not a flip');
   assert.equal(staleAccepts, 1);
   assert.equal(result.gestureNoEffect, undefined);
   assert.equal(vetoed, 1);
+  // The counts are what distinguish this from the scope-drift case above:
+  // one extra key on the CURRENT side, everything shared unmoved. Same veto,
+  // opposite direction of membership drift — indistinguishable from an event
+  // tally alone.
+  assert.deepEqual(vetoEvents, [
+    {
+      action: 'scroll',
+      backend: 'private-ax',
+      reason: 'surface_divergence',
+      onlyInBaseline: 0,
+      onlyInCurrent: 1,
+      rectMismatched: 0,
+      shared: 3,
+    },
+  ]);
 });
 
 test('summarizeDiscriminatingSurfaceDivergence counts one-sided keys and moved rects, excluding non-discriminating entries', () => {

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -8,7 +8,6 @@ import {
   capturePostGestureStabilizedResult,
   markDeferredInteractionOutcome,
 } from '../deferred-interaction-outcome.ts';
-import { formatGestureNoEffectWarning } from '../gesture-no-effect.ts';
 import type { SessionState } from '../types.ts';
 import {
   chromeWithListSnapshot,
@@ -20,8 +19,10 @@ import {
 } from './post-gesture-stabilization-fixtures.ts';
 
 // Pure verdict/classifier coverage (decidePostGestureStabilityVerdict) lives
-// in the sibling post-gesture-stabilization-verdict.test.ts — split per
-// #1563 review to stay under the repo's 500-line test-file tripwire.
+// in the sibling post-gesture-stabilization-verdict.test.ts, and the
+// agent-facing no-effect claim (corroboration, vetoes, warning wording) in
+// post-gesture-no-effect-claim.test.ts — split by subject per #1563 review to
+// stay under the repo's 500-line test-file tripwire.
 
 afterEach(() => {
   vi.useRealTimers();
@@ -123,7 +124,10 @@ test('markPostGestureStabilization tolerates a missing pre-gesture snapshot on i
 
   markPostGestureStabilization(session, 'scroll');
 
-  assert.deepEqual(session.postGestureStabilization?.baselineSignature, []);
+  // "No usable baseline" has exactly one representation: the field is absent,
+  // so nothing downstream ever has to distinguish `undefined` from `[]` — and
+  // the loop cannot rebase a baseline that was never really there.
+  assert.equal(session.postGestureStabilization?.baselineSignature, undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -208,65 +212,6 @@ test('a replaced list under fixed chrome now settles outright, and still claims 
 
   assert.equal(staleAccepts, 0);
   assert.equal(result.gestureNoEffect, undefined);
-});
-
-test('scope drift accepts stale but is vetoed from claiming no-effect (#1601 P1 gate)', async () => {
-  // #1601's full-surface gate stays load-bearing, and #1569 makes it more so.
-  // The classifier treats a one-sided difference as scope drift rather than
-  // movement, so a narrower quiet capture of an unmoved screen still reaches
-  // accept-stale — and the agent-facing claim must not follow it there, because
-  // the missing rows are unexamined, not proven absent.
-  vi.useFakeTimers();
-  const session = makeSession('ios');
-  session.snapshot = chromeWithListSnapshot(['row-1', 'row-2']);
-  markPostGestureStabilization(session, 'scroll');
-
-  // Same screen, but the quiet captures see only the chrome — the shape a
-  // broad baseline followed by an interactive-only capture produces.
-  const narrowed = makeSnapshotState(
-    chromeWithListSnapshot(['row-1', 'row-2']).nodes.filter(
-      (node) => node.type !== 'Cell',
-    ) as never,
-  );
-  const capture = vi.fn(async () => narrowed);
-
-  const resultPromise = withDiagnosticsScope({}, async () => {
-    const result = await capturePostGestureStabilizedResult({
-      session,
-      capture,
-      readSnapshot: (snapshot) => snapshot,
-    });
-    return {
-      result,
-      staleAccepts: countDiagnosticEventsByPhase(['post_gesture_snapshot_stale_accept']),
-    };
-  });
-
-  await vi.advanceTimersByTimeAsync(10_000);
-  const { result, staleAccepts } = await resultPromise;
-
-  assert.equal(staleAccepts, 1);
-  assert.equal(result.gestureNoEffect, undefined);
-});
-
-test('formatGestureNoEffectWarning names the gesture and the raw-drag escape hatch', () => {
-  // Positionals echo verbatim: the warning names the gesture the agent issued,
-  // and `scroll down 1` is what they issued.
-  const scrollWarning = formatGestureNoEffectWarning('scroll', ['down', '1']);
-  assert.match(scrollWarning, /scroll down 1 produced no visible change/);
-  assert.match(scrollWarning, /swipe x1 y1 x2 y2/);
-  assert.match(scrollWarning, /already at its edge/);
-
-  const gestureWarning = formatGestureNoEffectWarning('gesture', ['swipe', 'left']);
-  assert.match(gestureWarning, /gesture swipe left produced no visible change/);
-
-  const bareWarning = formatGestureNoEffectWarning('swipe', []);
-  assert.match(bareWarning, /swipe produced no visible change/);
-
-  // The regression the deleted heuristic caused: every positional of a swipe is
-  // a coordinate, so "drop anything numeric-looking" left a contentless "swipe".
-  const swipeWarning = formatGestureNoEffectWarning('swipe', ['10', '20', '30', '40']);
-  assert.match(swipeWarning, /^swipe 10 20 30 40 produced no visible change/);
 });
 
 test('capturePostGestureStabilizedResult trusts a quiet signature once content genuinely differs from the baseline (iOS)', async () => {

--- a/src/daemon/deferred-interaction-outcome.ts
+++ b/src/daemon/deferred-interaction-outcome.ts
@@ -22,6 +22,7 @@ import {
   emitInteractionSettleTimeout,
   getActivePendingInteractionOutcome,
   haveIdenticalDiscriminatingSurfaces,
+  summarizeDiscriminatingSurfaceDivergence,
   markPendingInteractionOutcome,
   retryPendingInteractionOutcome,
 } from './interaction-outcome-policy.ts';
@@ -98,17 +99,23 @@ function markPostGestureStabilization(
 ): void {
   if (!supportsPostGestureStabilization(session.device)) return;
   if (!isPostGestureStabilizingAction(action, positionals, flags)) return;
+  // No extra capture: `session.snapshot` is still whatever was captured
+  // before this gesture dispatched (this call happens post-dispatch,
+  // pre-capture — the same "last known pre-action snapshot" idiom
+  // `markPendingInteractionOutcome` already relies on). Like that sibling, an
+  // empty signature is never stored: "no usable baseline" has exactly one
+  // representation (absent), so no consumer has to tell `undefined` from `[]`
+  // — and the loop cannot rebase a baseline that was never really there.
+  const baselineSignature = requiresPostGestureBaselineDistrust(session.device)
+    ? buildInteractionSurfaceSignature(session.snapshot?.nodes ?? [])
+    : undefined;
   session.postGestureStabilization = {
     action,
     positionals,
     markedAt: Date.now(),
-    // No extra capture: `session.snapshot` is still whatever was captured
-    // before this gesture dispatched (this call happens post-dispatch,
-    // pre-capture — the same "last known pre-action snapshot" idiom
-    // `markPendingInteractionOutcome` already relies on).
-    ...(requiresPostGestureBaselineDistrust(session.device)
+    ...(baselineSignature?.length
       ? {
-          baselineSignature: buildInteractionSurfaceSignature(session.snapshot?.nodes ?? []),
+          baselineSignature,
           // Recorded so the loop can tell a comparable quiet capture from one
           // served by a different backend, which is not comparable at all.
           baselineBackend: session.snapshot?.snapshotQuality?.backend,
@@ -339,6 +346,7 @@ export async function capturePostGestureStabilizedResult<T>(params: {
       signaturesStable: areInteractionSurfaceSignaturesStable,
       classifyBaselineEvidence: classifyBaselineSurfaceEvidence,
       surfacesIdentical: haveIdenticalDiscriminatingSurfaces,
+      summarizeDivergence: summarizeDiscriminatingSurfaceDivergence,
     },
   });
   clearPostGestureStabilization(session);

--- a/src/daemon/interaction-outcome-policy.ts
+++ b/src/daemon/interaction-outcome-policy.ts
@@ -332,6 +332,39 @@ export function haveIdenticalDiscriminatingSurfaces(
   return true;
 }
 
+/**
+ * Why `haveIdenticalDiscriminatingSurfaces` said no, in counts a diagnostics
+ * reader can aggregate. #1620 spent weeks unable to tell a cross-backend pair
+ * from capture drift from real movement, because a withheld no-effect claim
+ * looks identical to a gesture that simply worked: one-sided keys are
+ * membership drift (depth truncation, capture composition), `rectMismatched`
+ * is movement. Emitted on the accept-stale veto path so the distinction is
+ * readable from a `--debug` run instead of re-derived from absence.
+ */
+export function summarizeDiscriminatingSurfaceDivergence(
+  baseline: InteractionSurfaceSignature,
+  current: InteractionSurfaceSignature,
+): { onlyInBaseline: number; onlyInCurrent: number; rectMismatched: number; shared: number } {
+  const currentByKey = new Map(
+    current.filter((entry) => entry.discriminating).map((entry) => [entry.key, entry]),
+  );
+  let onlyInBaseline = 0;
+  let rectMismatched = 0;
+  let shared = 0;
+  for (const entry of baseline) {
+    if (!entry.discriminating) continue;
+    const other = currentByKey.get(entry.key);
+    if (!other) {
+      onlyInBaseline += 1;
+      continue;
+    }
+    currentByKey.delete(entry.key);
+    shared += 1;
+    if (!rectsWithinTolerance(entry, other)) rectMismatched += 1;
+  }
+  return { onlyInBaseline, onlyInCurrent: currentByKey.size, rectMismatched, shared };
+}
+
 function supportsInteractionOutcomePolicy(session: SessionState): boolean {
   return isMobilePlatform(session.device);
 }

--- a/src/daemon/post-gesture-stability.ts
+++ b/src/daemon/post-gesture-stability.ts
@@ -52,6 +52,8 @@ export type PostGestureStabilityHooks<T, S extends readonly unknown[]> = {
   classifyBaselineEvidence: (baseline: S, quiet: S) => BaselineSurfaceEvidence;
   /** Full-surface both-direction agreement — the no-effect corroboration bar. */
   surfacesIdentical: (baseline: S, current: S) => boolean;
+  /** Why `surfacesIdentical` said no, for the veto diagnostic. */
+  summarizeDivergence: (baseline: S, current: S) => Record<string, number>;
 };
 
 export type PostGestureStabilityOutcome<T> = {
@@ -108,6 +110,7 @@ export async function runPostGestureStabilityLoop<T, S extends readonly unknown[
   let previous = await captureSurface(hooks, params.initial);
   let baselineSignature = pending.baselineSignature;
   let baselineBackend = pending.baselineBackend;
+  let baselineRebased = false;
   // Extended past STABILIZATION_DEADLINE_MS only when the distrust verdict
   // fires below; the ordinary (non-distrust) timeout path is unaffected.
   let effectiveDeadlineMs = STABILIZATION_DEADLINE_MS;
@@ -131,6 +134,7 @@ export async function runPostGestureStabilityLoop<T, S extends readonly unknown[
         });
         baselineSignature = current.signature;
         baselineBackend = current.backend;
+        baselineRebased = true;
         previous = current;
         continue;
       }
@@ -148,7 +152,7 @@ export async function runPostGestureStabilityLoop<T, S extends readonly unknown[
         continue;
       }
       emitSettleDiagnostic(verdict, pending.action, attempts, elapsedMs);
-      return buildAcceptedOutcome(verdict, pending, current, hooks);
+      return buildAcceptedOutcome(verdict, pending, current, hooks, baselineRebased);
     }
     previous = current;
   }
@@ -206,23 +210,49 @@ function emitSettleDiagnostic(
  * baseline — deliberately NOT a mid-loop rebased one, so a backend flip can
  * never launder a cross-backend pair into a no-effect claim. The verdict
  * alone is subset-tolerant (#1601 review P1).
+ *
+ * A veto here is invisible from the outside: the response looks exactly like
+ * a gesture that worked. #1620 could not tell the two apart on live hostile
+ * screens, so every veto on an accept-stale verdict records WHY — a rebase
+ * (the pair is cross-backend) or the divergence counts that failed set
+ * equality.
  */
 function buildAcceptedOutcome<T, S extends readonly unknown[]>(
   verdict: 'trust' | 'accept-stale',
   pending: PostGestureStabilityPending<S>,
   current: CapturedSurface<T, S>,
   hooks: PostGestureStabilityHooks<T, S>,
+  baselineRebased: boolean,
 ): PostGestureStabilityOutcome<T> {
-  const corroborated =
-    verdict === 'accept-stale' &&
-    pending.baselineSignature !== undefined &&
-    hooks.surfacesIdentical(pending.baselineSignature, current.signature);
-  if (!corroborated) return { value: current.value };
-  return {
-    value: current.value,
-    gestureNoEffect: {
+  if (verdict !== 'accept-stale') return { value: current.value };
+  const baselineSignature = pending.baselineSignature;
+  if (
+    baselineSignature !== undefined &&
+    hooks.surfacesIdentical(baselineSignature, current.signature)
+  ) {
+    return {
+      value: current.value,
+      gestureNoEffect: {
+        action: pending.action,
+        positionals: pending.positionals,
+      },
+    };
+  }
+  emitDiagnostic({
+    level: 'info',
+    phase: 'post_gesture_no_effect_vetoed',
+    data: {
       action: pending.action,
-      positionals: pending.positionals,
+      backend: current.backend,
+      ...(baselineRebased
+        ? { reason: 'baseline_rebased' }
+        : {
+            reason: 'surface_divergence',
+            ...(baselineSignature === undefined
+              ? {}
+              : hooks.summarizeDivergence(baselineSignature, current.signature)),
+          }),
     },
-  };
+  });
+  return { value: current.value };
 }


### PR DESCRIPTION
Closes #1620. Also supplies the live-evidence artifact carried over from #1615.

## The finding

**#1620's premise does not hold: the warning fires.** Measured on the seeded Bluesky fixture and on Settings, built from this branch. Neither hypothesised veto reproduces — the backend flip never occurs on a fully-hostile screen (the tree strategy fails *before* the first capture, so every capture including the baseline is already `private-ax`, and there is nothing to flip), and truncation drift did not appear in a single sample: **every veto observed had `onlyInBaseline: 0, onlyInCurrent: 0`**. Membership is stable under the remembered depth cap; only rects ever diverged.

So this PR does not change the corroboration rule. It closes the reason the question stayed open for weeks: **a withheld claim was indistinguishable from a gesture that simply worked** — both render as a response with no warning. Every veto on an accept-stale verdict now says why.

## The artifact (#1615 carry-over)

The exact repro from #1620's description, on this head:

```
$ agent-device swipe 200 250 200 650      # drag down while already at top
Flung

$ agent-device snapshot
swipe 200 250 200 650 produced no visible change: the tree still matches its pre-gesture state.
Either the container is already at its edge, or it ignores synthesized scrolls —
a raw drag moves such lists: swipe x1 y1 x2 y2 (start inside the list).

$ agent-device scroll down                # session remains usable
Scrolled down

$ agent-device snapshot
Snapshot: 167 visible nodes (181 total) (truncated)
```

Coordinates are retained, which is #1615's contribution — before it, the numeric-token heuristic reduced this to a contentless `swipe produced no visible change`. That is the full condition #1615 was held on: *a no-effect swipe warning retaining its coordinates, followed by a successful command proving the session remains usable.*

## What the instrument showed

```
post_gesture_snapshot_stale_accept  action=swipe   attempts=12  durationMs=3755  matchedPreGestureBaseline=true
post_gesture_no_effect_vetoed       action=swipe   backend=tree  reason=surface_divergence
                                    onlyInBaseline=0  onlyInCurrent=0  rectMismatched=1  shared=103
```

That is a *correct* veto, and it is only legible because of this PR: on Settings the drag rubber-banded and left exactly one rect of 103 shifted past tolerance. A control run — two idle snapshots, no gesture — showed **0 moved rects**, confirming the screen is stable and the movement was gesture-caused rather than ambient. The other veto seen (Bluesky, `rectMismatched: 4 / shared: 158`) came from feed content updating across a deliberately unrealistic 105-second gesture→capture gap.

Both are the rule working as specified. Neither was diagnosable before.

## Changes

- **`post_gesture_no_effect_vetoed`** on every withheld claim, with `reason: baseline_rebased | surface_divergence`, and for divergence the counts above via a new pure `summarizeDiscriminatingSurfaceDivergence` — one-sided keys are membership drift, `rectMismatched` is movement. This is what produced every number in this PR.
- **Marking no longer stores an empty baseline signature.** `[]` is truthy, so a session with no pre-gesture snapshot had an *invented* baseline that the loop would then rebase onto a post-gesture capture. "No usable baseline" now has one representation — absent — matching `markPendingInteractionOutcome`'s existing rule.
- Claim-surface tests split into `post-gesture-no-effect-claim.test.ts` (#1563 convention), keeping the loop file at 525 lines. `#1615`'s updated wording assertions move with them.

No behaviour change to the verdict or the corroboration bar.

## Verification

`typecheck` / `lint` / `format:check` / `check:layering` green. Daemon suite 95 files / 711 tests. The five directly-related suites total 60 tests.

`check:affected --run` is green except the documented provider-integration contention flake — three consecutive runs produced three *different* timeout sets (`{android-lifecycle}`, `{android-lifecycle, android-recording}`, `{doctor}`), each passing in isolation. All are Android; this change cannot reach Android at all, since `requiresPostGestureBaselineDistrust` is Apple-only and every new path is behind an accept-stale verdict that needs a baseline.

## Correction to my earlier comment on #1620

I attributed some earlier missing diagnostics to daemon takeover, using `daemon_startup` in the client's `--debug` stream as the tell. That was wrong: `daemon_startup` is emitted on essentially every client request, including ones where the warning fired normally. The real discriminator in the corrupted samples was `ios_runner_session_invalidated` — the XCTest runner dying mid-capture (`** TEST EXECUTE FAILED **` in `daemon.log`), which loses the pending record. Cadence still matters when measuring, but for that reason rather than the one I gave.
