### PR TITLE
fix(ios): synthesize hidden-keyboard text through responder

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -392,6 +392,7 @@ extension RunnerTests {
 
     XCTAssertTrue(typeResponse.ok, String(describing: typeResponse.error))
     XCTAssertFalse(didRecordXCTestFailure(since: failureCountBefore))
+    XCTAssertEqual(typeResponse.data?.textEntryRoute, "synthesized-first-responder")
     XCTAssertEqual(String(describing: textField.value ?? ""), "hardware-keyboard")
 
     let secondFailureCountBefore = currentXCTestFailureCount()

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -151,6 +151,14 @@ extension RunnerTests {
     !hasResolvedElement && hasRefreshPoint && xCTestChannelPenalized
   }
 
+  static func shouldUseSynthesizedFirstResponderType(
+    repairMode: TextTypingRepairMode,
+    fromTapWitness: Bool,
+    softwareKeyboardVisible: Bool
+  ) -> Bool {
+    repairMode == .none && fromTapWitness && !softwareKeyboardVisible
+  }
+
   static func shouldUseResolvedCoordinateTextEntryRoute(
     repairMode: TextTypingRepairMode,
     hasX: Bool,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
@@ -6,11 +6,14 @@ import XCTest
 extension RunnerTests {
   enum TextEntryFailure: String {
     case notFocused = "TEXT_INPUT_NOT_FOCUSED"
+    case synthesisUnavailable = "TEXT_INPUT_SYNTHESIS_UNAVAILABLE"
 
     var message: String {
       switch self {
       case .notFocused:
         return "No focused text input was available for typing."
+      case .synthesisUnavailable:
+        return "Reliable text synthesis is unavailable while the software keyboard is hidden."
       }
     }
 
@@ -18,6 +21,8 @@ extension RunnerTests {
       switch self {
       case .notFocused:
         return "Focus a visible text input, then retry type or fill. If the input is not exposed by accessibility, use a coordinate focus command before typing."
+      case .synthesisUnavailable:
+        return "Show the software keyboard, then retry type or fill."
       }
     }
   }
@@ -50,6 +55,19 @@ extension RunnerTests {
     let element: XCUIElement?
     let refreshPoint: CGPoint?
     let prefersFocusedElement: Bool
+    let fromTapWitness: Bool
+
+    init(
+      element: XCUIElement?,
+      refreshPoint: CGPoint?,
+      prefersFocusedElement: Bool,
+      fromTapWitness: Bool = false
+    ) {
+      self.element = element
+      self.refreshPoint = refreshPoint
+      self.prefersFocusedElement = prefersFocusedElement
+      self.fromTapWitness = fromTapWitness
+    }
 
     func withElement(_ nextElement: XCUIElement?) -> TextEntryTarget {
       guard let nextElement else {
@@ -60,7 +78,8 @@ extension RunnerTests {
       return TextEntryTarget(
         element: nextElement,
         refreshPoint: point,
-        prefersFocusedElement: prefersFocusedElement
+        prefersFocusedElement: prefersFocusedElement,
+        fromTapWitness: fromTapWitness
       )
     }
   }
@@ -165,7 +184,12 @@ extension RunnerTests {
     // Keep the target scoped to the element that the preceding tap actually selected. Do not
     // attach a refresh point: if that element disappeared, bare type must fail closed rather
     // than rediscovering a different field or dispatching unscoped app.typeText.
-    return TextEntryTarget(element: element, refreshPoint: nil, prefersFocusedElement: false)
+    return TextEntryTarget(
+      element: element,
+      refreshPoint: nil,
+      prefersFocusedElement: false,
+      fromTapWitness: true
+    )
   }
 
   func stabilizeTextInputBeforeTyping(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
@@ -41,6 +41,26 @@ extension RunnerTests {
     }
   }
 
+  func testSynthesizedFirstResponderTypeRequiresHiddenKeyboardTapWitness() {
+    let cases: [(TextTypingRepairMode, Bool, Bool, Bool)] = [
+      (.none, true, false, true),
+      (.none, true, true, false),
+      (.none, false, false, false),
+      (.append, true, false, false),
+      (.replacement, true, false, false),
+    ]
+    for (mode, fromTapWitness, softwareKeyboardVisible, expected) in cases {
+      XCTAssertEqual(
+        Self.shouldUseSynthesizedFirstResponderType(
+          repairMode: mode,
+          fromTapWitness: fromTapWitness,
+          softwareKeyboardVisible: softwareKeyboardVisible
+        ),
+        expected
+      )
+    }
+  }
+
 #if os(iOS)
   func testSynthesizedTextEntryFallsBackOnlyWhenPrivateSynthesisIsUnavailable() {
     XCTAssertEqual(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -45,6 +45,11 @@ extension RunnerTests {
         activeTarget = fallbackTarget
       }
     }
+    let shouldUseSynthesizedFirstResponderType = Self.shouldUseSynthesizedFirstResponderType(
+      repairMode: repairMode,
+      fromTapWitness: activeTarget.fromTapWitness,
+      softwareKeyboardVisible: isKeyboardVisible(app: app)
+    )
     let initialResolveStartedAt = Date()
     let initialTarget = resolveTextEntryElement(app: app, target: activeTarget)
     activeTarget = activeTarget.withElement(initialTarget)
@@ -99,11 +104,30 @@ extension RunnerTests {
       }
     }
 
-    func typeIntoCurrentTarget(_ value: String) -> (element: XCUIElement?, dispatched: Bool) {
+    func typeIntoCurrentTarget(_ value: String) -> (element: XCUIElement?, dispatched: Bool, failure: TextEntryFailure?) {
+#if os(iOS)
+      if shouldUseSynthesizedFirstResponderType,
+        let currentTarget = resolveTextEntryElement(app: app, target: activeTarget)
+      {
+        textEntryRoute = "synthesized-first-responder"
+        NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=synthesized-first-responder")
+        switch synthesizer.enterText(app: app, text: value, replacingExistingText: false) {
+        case .continueTyping:
+          return (currentTarget, true, nil)
+        case .fallback:
+          return (nil, false, .synthesisUnavailable)
+        case .raise(let message):
+          NSException(
+            name: NSExceptionName.internalInconsistencyException,
+            reason: message ?? "private XCTest text synthesis failed"
+          ).raise()
+        }
+      }
+#endif
       if let currentTarget = resolveTextEntryElement(app: app, target: activeTarget) {
         textEntryRoute = "xctest-element"
         currentTarget.typeText(value)
-        return (currentTarget, true)
+        return (currentTarget, true, nil)
       } else if activeTarget.prefersFocusedElement && isKeyboardVisible(app: app) {
 #if os(iOS)
         textEntryRoute = "synthesized-first-responder"
@@ -128,19 +152,19 @@ extension RunnerTests {
 #else
         app.typeText(value)
 #endif
-        return (resolveTextEntryElement(app: app, target: activeTarget), true)
+        return (resolveTextEntryElement(app: app, target: activeTarget), true, nil)
       }
-      return (nil, false)
+      return (nil, false, .notFocused)
     }
 
-    func dispatchFailureResult() -> TextEntryResult {
+    func dispatchFailureResult(_ failure: TextEntryFailure) -> TextEntryResult {
       TextEntryResult(
         verified: nil,
         repaired: false,
         expectedText: expectedText,
         observedText: nil,
         textEntryRoute: textEntryRoute,
-        failure: .notFocused
+        failure: failure
       )
     }
 
@@ -165,7 +189,7 @@ extension RunnerTests {
       for (index, character) in characters.enumerated() {
         let dispatch = typeIntoCurrentTarget(String(character))
         guard dispatch.dispatched else {
-          return dispatchFailureResult()
+          return dispatchFailureResult(dispatch.failure ?? .notFocused)
         }
         typedTarget = dispatch.element ?? typedTarget
         if index + 1 < characters.count {
@@ -214,7 +238,7 @@ extension RunnerTests {
       let firstStartedAt = Date()
       let firstDispatch = typeIntoCurrentTarget(firstCharacter)
       guard firstDispatch.dispatched else {
-        return dispatchFailureResult()
+        return dispatchFailureResult(firstDispatch.failure ?? .notFocused)
       }
       var firstTypedTarget = firstDispatch.element
       logTextEntryPhase(
@@ -243,7 +267,7 @@ extension RunnerTests {
       let remainingStartedAt = Date()
       let remainingDispatch = typeIntoCurrentTarget(remainingText)
       guard remainingDispatch.dispatched else {
-        return dispatchFailureResult()
+        return dispatchFailureResult(remainingDispatch.failure ?? .notFocused)
       }
       firstTypedTarget = remainingDispatch.element ?? firstTypedTarget
       logTextEntryPhase(
@@ -258,7 +282,7 @@ extension RunnerTests {
       let typeStartedAt = Date()
       let dispatch = typeIntoCurrentTarget(text)
       guard dispatch.dispatched else {
-        return dispatchFailureResult()
+        return dispatchFailureResult(dispatch.failure ?? .notFocused)
       }
       typedTarget = dispatch.element
       logTextEntryPhase(

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -386,6 +386,7 @@ agent-device gesture transform 200 420 80 -40 2 35 700 # combined pan, zoom, and
 `fill` clears then types. `type` does not clear.
 `type` accepts text only. Do not pass `@ref` to `type`; use `fill @ref "text"` to target a field directly, or `press @ref` then `type "text"` to append in the focused field.
 If `type` reports `TEXT_INPUT_NOT_FOCUSED`, focus a visible text input and retry; when accessibility does not expose the input, use a coordinate focus command before typing.
+On iOS, if `type` reports `TEXT_INPUT_SYNTHESIS_UNAVAILABLE` while the software keyboard is hidden, show the software keyboard, then retry `type` or `fill`. The runner reports this error instead of risking partial input through an unreliable text-entry path.
 Use plain `fill` or `type` first for ordinary login and form fields. Use `--delay-ms` on `type` or `fill` only when a debounced search field or search-as-you-type input actually misses characters, or when the app must receive incremental updates.
 Delayed typing intentionally prefers paced character entry over clipboard-style fallbacks so the target field receives each incremental update.
 On Android, `fill` also verifies text and treats IME-owned capture as a terminal failure instead of retrying against the wrong field.


### PR DESCRIPTION
## Summary

Route bare iOS `type` after a tapped input with a hidden software keyboard through the runner's process-targeted first-responder synthesis path.

This avoids XCTest's flaky `XCUIElement.typeText` behavior that could deliver only the first character. Tap-witness provenance is now explicit, the regression test pins the synthesized route, and an unavailable synthesis bridge returns a typed error instead of falling back to the unreliable path.

Document `TEXT_INPUT_SYNTHESIS_UNAVAILABLE` and its “show the software keyboard, then retry” recovery in the command reference. Generated help/metadata and skills are unchanged because they do not own error-specific recovery guidance.

Scope: five iOS runner files and one command-reference file; no expansion beyond iOS text entry.

## Validation

- iPhone 17 Pro simulator, iOS 26.2: `testBareTypeUsesTappedInputWhenSoftwareKeyboardIsHidden` passed with all 17 characters and `synthesized-first-responder`
- Same simulator: `testBareDelayedTypeFailsWhenTappedInputDisappearsMidCommand` passed
- Same simulator: route-policy and private-synthesis status tests passed
- `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest:ios`
- `pnpm check:affected --run`
