### PR TITLE
perf(cli): lazy-load dedicated client command handlers

### DIFF
--- a/src/cli/commands/router-types.ts
+++ b/src/cli/commands/router-types.ts
@@ -16,4 +16,6 @@ export type ClientCommandParams = {
  * intentionally produced no output and declined so the router can try the generic route.
  */
 export type ClientCommandHandler = (params: ClientCommandParams) => Promise<boolean>;
-export type ClientCommandHandlerMap = Partial<Record<CliCommandName, ClientCommandHandler>>;
+export type ClientCommandHandlerMap = Partial<
+  Record<CliCommandName, () => Promise<ClientCommandHandler>>
+>;

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -1,28 +1,24 @@
 import type { CliFlags } from '@agent-device/contracts/command';
 import type { AgentDeviceClient } from '../../agent-device-client.ts';
 import { isClientBackedCliCommandName, type ClientBackedCliCommandName } from './client-backed.ts';
-import { connectCommand, connectionCommand, disconnectCommand } from './connection.ts';
-import { authCommand } from './auth.ts';
-import { daemonCommand } from './daemon.ts';
-import { deviceCommand } from './device.ts';
-import { proxyCommand } from './proxy.ts';
-import { replayCommand } from './replay.ts';
-import { screenshotCommand, diffCommand } from './screenshot.ts';
 import type { ClientCommandHandlerMap, ClientCommandParams } from './router-types.ts';
 
 export type { ClientCommandParams } from './router-types.ts';
 
-const dedicatedCliCommandHandlers = {
-  connect: connectCommand,
-  disconnect: disconnectCommand,
-  connection: connectionCommand,
-  auth: authCommand,
-  daemon: daemonCommand,
-  device: deviceCommand,
-  proxy: proxyCommand,
-  replay: replayCommand,
-  screenshot: screenshotCommand,
-  diff: diffCommand,
+// Some dedicated handlers pull in sizeable dependency subtrees (e.g.
+// replay.ts -> @agent-device/maestro), so they're loaded lazily, on demand,
+// the same way runGenericClientBackedCommand lazy-loads generic.ts below.
+const dedicatedCliCommandHandlerLoaders = {
+  connect: async () => (await import('./connection.ts')).connectCommand,
+  disconnect: async () => (await import('./connection.ts')).disconnectCommand,
+  connection: async () => (await import('./connection.ts')).connectionCommand,
+  auth: async () => (await import('./auth.ts')).authCommand,
+  daemon: async () => (await import('./daemon.ts')).daemonCommand,
+  device: async () => (await import('./device.ts')).deviceCommand,
+  proxy: async () => (await import('./proxy.ts')).proxyCommand,
+  replay: async () => (await import('./replay.ts')).replayCommand,
+  screenshot: async () => (await import('./screenshot.ts')).screenshotCommand,
+  diff: async () => (await import('./screenshot.ts')).diffCommand,
 } satisfies ClientCommandHandlerMap;
 
 export async function tryRunClientBackedCommand(params: {
@@ -34,9 +30,12 @@ export async function tryRunClientBackedCommand(params: {
   replayTestReporterRuntime?: ClientCommandParams['replayTestReporterRuntime'];
 }): Promise<boolean> {
   const flags = { ...params.flags };
-  const dedicatedHandler =
-    dedicatedCliCommandHandlers[params.command as keyof typeof dedicatedCliCommandHandlers];
-  if (dedicatedHandler) {
+  const loadDedicatedHandler =
+    dedicatedCliCommandHandlerLoaders[
+      params.command as keyof typeof dedicatedCliCommandHandlerLoaders
+    ];
+  if (loadDedicatedHandler) {
+    const dedicatedHandler = await loadDedicatedHandler();
     const handled = await dedicatedHandler({ ...params, flags });
     if (handled) return true;
   }


### PR DESCRIPTION
## Summary

Profiled where a warm `agent-device` CLI invocation's wall time goes (node boot / import graph / daemon RPC / device work), on an isolated throwaway simulator + daemon (own `AGENT_DEVICE_STATE_DIR`, `com.apple.Preferences`). Found and fixed one concrete import-graph win; everything else checked out as already-optimized or not worth the risk/complexity within this pass.

## Decomposition (warm daemon, `snapshot -i` / `press --settle`, iPhone 16 Pro / iOS 18.6 sim)

| Phase | What it covers | Before (median) |
|---|---|---|
| shell spawn | `zsh -lc true` / `zsh -c true` | 14ms / 8ms |
| node boot | `node -e 0` | 35ms |
| **CLI import graph + parse** ("pre-daemon": from process start to first daemon contact) | `cli.ts`'s eager `import` graph (router.ts pulled in all 10 dedicated command handler modules unconditionally) | **~121-125ms** |
| daemon connect + RPC (`daemon_request`, incl. device capture/settle) | daemon dispatch + Apple runner round-trip | ~118ms (quiet) - ~350-900ms (this host was under heavy concurrent load from other agents' simulators during measurement, load avg 15-116) |
| response serialize + print + exit | JSON stringify, stdout flush, process exit | ~7ms |

The `--version`/`--help`/no-arg fast paths (added in a prior PR, #1065) already skip `cli.ts` entirely and cost ~37ms total — confirming the ~121-125ms "pre-daemon" figure for real commands is import-graph cost, not baseline node startup.

`node --cpu-prof` on the pre-daemon phase showed `readFileUtf8`/`internalModuleStat`/`wrapSafe`/`compileSourceTextModule` (module resolution + compile I/O) dominating on-CPU time — i.e. the cost of resolving and loading `cli.ts`'s ~700kB transitive eager import closure, not CPU-bound app logic.

## The fix

`src/cli/commands/router.ts` statically imported all 10 "dedicated" command handlers (`connect`, `disconnect`, `connection`, `auth`, `daemon`, `device`, `proxy`, `replay`, `screenshot`, `diff`) at module top level. Every real CLI invocation paid to load all of them — including `replay.ts`'s `@agent-device/maestro`/`@agent-device/ad-script`/`@agent-device/selectors` subtree — regardless of which command actually ran. The generic client-backed commands (`snapshot`, `press`, `tap`, `fill`, `scroll`, `get`, `is`, `find`, `wait`, ...) already lazy-load their handler via `await import('./generic.ts')`; this brings the 10 dedicated handlers in line with that existing convention. No behavior change — handlers still run synchronously within the same request, just imported on first use instead of at process start.

(Most of the remaining ~700kB eager closure — `registry.js`, `agent-device-client.js`, `screenshot-result.js`, etc. — is pulled in via `agent-device-client.ts`, which every client-backed command genuinely needs to construct. Splitting command metadata from runtime handlers there (the "facet restructure") was previously scoped and measured for the help-path specifically and found not worth it (~11ms, non-hot path, artifact-maintenance cost). It may be worth revisiting for the *general* dispatch path since it's hit on every call, but that's a much larger, riskier refactor than this PR and out of scope here.)

## Before / after (10-20x interleaved runs, alternating order each round to cancel drift; both dist trees built inside the repo tree so `node_modules` resolution is apples-to-apples)

| Command | Metric | Before (median) | After (median) | Delta |
|---|---|---|---|---|
| `snapshot -i` | pre-daemon | 121.4-165.7ms | 76.4-85.5ms | **-37% to -48%** |
| `snapshot -i` | total wall | 512.9-601.3ms | 459.6-497.2ms | **-10.4% to -17.3%** |
| `press --settle` | pre-daemon | 124.4-307.9ms | 76.8-158.2ms | **-38% to -49%** |
| `press --settle` | total wall | 960.3-1658.9ms | 887.9-1314.9ms | **-7.5% to -20.7%** |

(Ranges reflect two separate interleaved runs at different background-load levels on a shared dev machine with other concurrent agent sessions running simulators; the pre-daemon delta — the part this change actually touches — is stable at ~45ms across both. Total-wall percentage varies with how much the daemon/device RPC portion dominates under load.)

## Test plan

- [x] `pnpm build` succeeds
- [x] `node ./node_modules/oxfmt/bin/oxfmt --check src/cli/commands/router.ts` clean
- [x] Targeted tests for touched command handlers all pass: `cli-client-commands.test.ts`, `cli-diff.test.ts`, `cli-device-status.test.ts`, `cli-close.test.ts`, `cli-auth-diagnostics.test.ts`, `remote-connection.test.ts`, `proxy-command.test.ts` (103/103)
- [x] Full `pnpm test:unit`: 5591/5591 passing (one `request-router-replay-scope.test.ts` timeout on the first run under heavy host CPU contention, passed cleanly in isolation on retry — matches the known "timeouts under contention, not assertion failures" flake pattern, unrelated to this change)
- [x] Live-validated on an isolated throwaway simulator (`claude-floor-test`, deleted after use) + isolated `AGENT_DEVICE_STATE_DIR`; never touched `bench-golden*` sims
