### PR TITLE
fix(daemon): SESSION_NOT_FOUND hint names the detected foreground app

### DIFF
--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -383,7 +383,7 @@ test('snapshot on iOS rejects sessions without a tracked app', async () => {
 test('snapshot on iOS without a tracked app carries the detected open command as its hint', async () => {
   mockBuildIosOpenCommandHint.mockResolvedValue(
     'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app ' +
-      'running. Run: agent-device open xyz.blueskyweb.app --platform ios',
+      'running. Run: agent-device open xyz.blueskyweb.app --platform ios --udid sim-1',
   );
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-sim-no-app-hinted';
@@ -407,7 +407,7 @@ test('snapshot on iOS without a tracked app carries the detected open command as
     expect(response.error.code).toBe('SESSION_NOT_FOUND');
     expect(response.error.details?.hint).toBe(
       'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app ' +
-        'running. Run: agent-device open xyz.blueskyweb.app --platform ios',
+        'running. Run: agent-device open xyz.blueskyweb.app --platform ios --udid sim-1',
     );
   }
   expect(mockBuildIosOpenCommandHint).toHaveBeenCalledWith(iosSimulatorDevice);

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -382,8 +382,8 @@ test('snapshot on iOS rejects sessions without a tracked app', async () => {
 
 test('snapshot on iOS without a tracked app carries the detected open command as its hint', async () => {
   mockBuildIosOpenCommandHint.mockResolvedValue(
-    'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app in ' +
-      'the foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+    'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app ' +
+      'running. Run: agent-device open xyz.blueskyweb.app --platform ios',
   );
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-sim-no-app-hinted';
@@ -406,8 +406,8 @@ test('snapshot on iOS without a tracked app carries the detected open command as
   if (response?.ok === false) {
     expect(response.error.code).toBe('SESSION_NOT_FOUND');
     expect(response.error.details?.hint).toBe(
-      'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app in ' +
-        'the foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+      'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app ' +
+        'running. Run: agent-device open xyz.blueskyweb.app --platform ios',
     );
   }
   expect(mockBuildIosOpenCommandHint).toHaveBeenCalledWith(iosSimulatorDevice);

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -41,17 +41,27 @@ vi.mock('../../../platforms/apple/core/apps.ts', async (importOriginal) => {
   };
 });
 
+// The real implementation shells out to simctl to probe for a hint-worthy
+// unambiguous environment; that live-probe logic is covered by
+// ios-app-session-hint.test.ts. Stubbed here so this suite stays hermetic and
+// fast — defaults to "no enrichment", matching the current-behavior fallback.
+vi.mock('../../ios-app-session-hint.ts', () => ({
+  buildIosOpenCommandHint: vi.fn(async () => undefined),
+}));
+
 import { dispatchCommand } from '../../../core/dispatch.ts';
 import {
   runAppleRunnerCommand,
   stopIosRunnerSession,
 } from '../../../platforms/apple/core/runner/runner-client.ts';
 import { closeIosApp } from '../../../platforms/apple/core/apps.ts';
+import { buildIosOpenCommandHint } from '../../ios-app-session-hint.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
 const mockRunnerCommand = vi.mocked(runAppleRunnerCommand);
 const mockStopIosRunnerSession = vi.mocked(stopIosRunnerSession);
 const mockCloseIosApp = vi.mocked(closeIosApp);
+const mockBuildIosOpenCommandHint = vi.mocked(buildIosOpenCommandHint);
 
 function makeSessionStore(): SessionStore {
   const root = mkdtempForTestSync('agent-device-snapshot-handler-');
@@ -103,6 +113,8 @@ beforeEach(() => {
   mockStopIosRunnerSession.mockResolvedValue();
   mockCloseIosApp.mockReset();
   mockCloseIosApp.mockResolvedValue();
+  mockBuildIosOpenCommandHint.mockReset();
+  mockBuildIosOpenCommandHint.mockResolvedValue(undefined);
 });
 
 function writeSolidPng(filePath: string, width = 390, height = 844): void {
@@ -362,8 +374,43 @@ test('snapshot on iOS rejects sessions without a tracked app', async () => {
   if (response?.ok === false) {
     expect(response.error.code).toBe('SESSION_NOT_FOUND');
     expect(response.error.message).toMatch(/iOS snapshot requires an active app session/i);
+    expect(response.error.details?.reason).toBe('ios_app_session_required');
+    expect(response.error.details?.hint).toBeUndefined();
   }
   expect(mockDispatch).not.toHaveBeenCalled();
+});
+
+test('snapshot on iOS without a tracked app carries the detected open command as its hint', async () => {
+  mockBuildIosOpenCommandHint.mockResolvedValue(
+    'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app in ' +
+      'the foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+  );
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-sim-no-app-hinted';
+  sessionStore.set(sessionName, makeSession(sessionName, iosSimulatorDevice));
+
+  const response = await handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'snapshot',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  expect(response?.ok).toBe(false);
+  if (response?.ok === false) {
+    expect(response.error.code).toBe('SESSION_NOT_FOUND');
+    expect(response.error.details?.hint).toBe(
+      'One booted device found ("My iPhone Simulator", udid sim-1) with xyz.blueskyweb.app in ' +
+        'the foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+    );
+  }
+  expect(mockBuildIosOpenCommandHint).toHaveBeenCalledWith(iosSimulatorDevice);
 });
 
 test('snapshot on iOS runs when the session tracks an app', async () => {

--- a/src/daemon/ios-app-session-hint.test.ts
+++ b/src/daemon/ios-app-session-hint.test.ts
@@ -26,9 +26,64 @@ test('an unambiguous environment gets the exact runnable open command', async ()
 
   expect(hint).toBe(
     'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app running. ' +
-      'Run: agent-device open xyz.blueskyweb.app --platform ios',
+      'Run: agent-device open xyz.blueskyweb.app --platform ios --udid booted-1',
   );
   expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
+});
+
+test('a custom simulator set is echoed back so the printed command is the one that was run', async () => {
+  const soleBootedDevice = {
+    ...IOS_SIMULATOR,
+    id: 'booted-1',
+    name: 'iPhone 16',
+    simulatorSetPath: '/tmp/agent-device sim set',
+  };
+  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue({
+    bundleId: 'xyz.blueskyweb.app',
+    name: 'Bluesky',
+  });
+
+  const hint = await buildIosOpenCommandHint(soleBootedDevice);
+
+  expect(hint).toBe(
+    'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app running. ' +
+      'Run: agent-device open xyz.blueskyweb.app --platform ios --udid booted-1 ' +
+      "--ios-simulator-device-set '/tmp/agent-device sim set'",
+  );
+});
+
+test('a hint that would exceed the wire-redaction truncation length falls back to undefined', async () => {
+  // A truncated mid-command hint (see redactDiagnosticData in
+  // packages/kernel/src/redaction.ts, which silently truncates any details
+  // string over 400 chars) is worse than the generic default — it looks
+  // actionable but isn't copy-paste-safe.
+  const soleBootedDevice = {
+    ...IOS_SIMULATOR,
+    id: 'booted-1',
+    name: 'iPhone 16',
+    simulatorSetPath: `/very/long/simulator/set/path/${'segment/'.repeat(30)}`,
+  };
+  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue({
+    bundleId: 'xyz.blueskyweb.app',
+    name: 'Bluesky',
+  });
+
+  await expect(buildIosOpenCommandHint(soleBootedDevice)).resolves.toBeUndefined();
+});
+
+test('a rejecting probe (timeout or spawn failure) is caught, not propagated', async () => {
+  listBootedIosSimulators.mockRejectedValue(new Error('simctl timed out'));
+
+  await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).resolves.toBeUndefined();
+});
+
+test('a rejecting foreground-app probe is caught, not propagated', async () => {
+  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
+  detectSoleRunningIosSimulatorApp.mockRejectedValue(new Error('launchctl timed out'));
+
+  await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).resolves.toBeUndefined();
 });
 
 test('more than one booted simulator stays ambiguous and returns no hint', async () => {

--- a/src/daemon/ios-app-session-hint.test.ts
+++ b/src/daemon/ios-app-session-hint.test.ts
@@ -25,8 +25,8 @@ test('an unambiguous environment gets the exact runnable open command', async ()
   const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
 
   expect(hint).toBe(
-    'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app in the ' +
-      'foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+    'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app running. ' +
+      'Run: agent-device open xyz.blueskyweb.app --platform ios',
   );
   expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
 });
@@ -52,7 +52,7 @@ test('no booted simulator returns no hint', async () => {
   expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
 });
 
-test('a failed or inconclusive foreground-app probe returns no hint', async () => {
+test('a failed or inconclusive running-app probe returns no hint', async () => {
   listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
   detectSoleRunningIosSimulatorApp.mockResolvedValue(undefined);
 

--- a/src/daemon/ios-app-session-hint.test.ts
+++ b/src/daemon/ios-app-session-hint.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const listBootedIosSimulators = vi.hoisted(() => vi.fn());
+const detectSoleRunningIosSimulatorApp = vi.hoisted(() => vi.fn());
+
+vi.mock('../platforms/apple/core/devices.ts', () => ({ listBootedIosSimulators }));
+vi.mock('../platforms/apple/core/app-resolution.ts', () => ({ detectSoleRunningIosSimulatorApp }));
+
+import { IOS_DEVICE, IOS_SIMULATOR } from '../__tests__/test-utils/index.ts';
+import { buildIosOpenCommandHint } from './ios-app-session-hint.ts';
+
+beforeEach(() => {
+  listBootedIosSimulators.mockReset();
+  detectSoleRunningIosSimulatorApp.mockReset();
+});
+
+test('an unambiguous environment gets the exact runnable open command', async () => {
+  const soleBootedDevice = { ...IOS_SIMULATOR, id: 'booted-1', name: 'iPhone 16' };
+  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue({
+    bundleId: 'xyz.blueskyweb.app',
+    name: 'Bluesky',
+  });
+
+  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
+
+  expect(hint).toBe(
+    'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app in the ' +
+      'foreground. Run: agent-device open xyz.blueskyweb.app --platform ios',
+  );
+  expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
+});
+
+test('more than one booted simulator stays ambiguous and returns no hint', async () => {
+  listBootedIosSimulators.mockResolvedValue([
+    { ...IOS_SIMULATOR, id: 'booted-1' },
+    { ...IOS_SIMULATOR, id: 'booted-2' },
+  ]);
+
+  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
+
+  expect(hint).toBeUndefined();
+  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
+});
+
+test('no booted simulator returns no hint', async () => {
+  listBootedIosSimulators.mockResolvedValue([]);
+
+  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
+
+  expect(hint).toBeUndefined();
+  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
+});
+
+test('a failed or inconclusive foreground-app probe returns no hint', async () => {
+  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue(undefined);
+
+  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
+
+  expect(hint).toBeUndefined();
+});
+
+test('a physical iOS device never probes for a hint', async () => {
+  const hint = await buildIosOpenCommandHint(IOS_DEVICE);
+
+  expect(hint).toBeUndefined();
+  expect(listBootedIosSimulators).not.toHaveBeenCalled();
+});

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -1,6 +1,7 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { detectSoleRunningIosSimulatorApp } from '../platforms/apple/core/app-resolution.ts';
 import { listBootedIosSimulators } from '../platforms/apple/core/devices.ts';
+import { shellQuoteIfNeeded } from '../utils/shell-quote.ts';
 
 /**
  * Enriches the generic "Run open first" SESSION_NOT_FOUND hint with the exact
@@ -11,20 +12,52 @@ import { listBootedIosSimulators } from '../platforms/apple/core/devices.ts';
  * than one running app, or a probe failure — returns `undefined` so the
  * caller keeps the generic hint. This must never guess: a wrong-but-confident
  * command is worse than the default guidance.
+ *
+ * The whole probe is strictly best-effort: it runs on an error path, so a
+ * throw here (a bounded probe still rejects on timeout or a spawn failure —
+ * see app-resolution.ts) must fall back to `undefined`, never replace the
+ * caller's deterministic error with a probe failure.
  */
+// Wire-level details are redacted before send (packages/kernel/src/redaction.ts),
+// which silently truncates any string field over 400 chars — a truncated
+// mid-command hint is a worse failure mode than the generic default (it looks
+// actionable but isn't). A long --ios-simulator-device-set path (the
+// bench-clone case) can push the composed hint past that, so this stays
+// comfortably under it and falls back rather than risk truncation.
+const MAX_HINT_LENGTH = 350;
+
 export async function buildIosOpenCommandHint(device: DeviceInfo): Promise<string | undefined> {
   if (!isIosFamily(device) || device.kind !== 'simulator') return undefined;
 
-  const booted = await listBootedIosSimulators({ simulatorSetPath: device.simulatorSetPath });
-  if (booted.length !== 1) return undefined;
-  const [soleBootedDevice] = booted;
-  if (!soleBootedDevice) return undefined;
+  try {
+    const booted = await listBootedIosSimulators({ simulatorSetPath: device.simulatorSetPath });
+    if (booted.length !== 1) return undefined;
+    const [soleBootedDevice] = booted;
+    if (!soleBootedDevice) return undefined;
 
-  const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
-  if (!app) return undefined;
+    const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
+    if (!app) return undefined;
 
-  return (
-    `One booted device found ("${soleBootedDevice.name}", udid ${soleBootedDevice.id}) with ` +
-    `${app.bundleId} running. Run: agent-device open ${app.bundleId} --platform ios`
-  );
+    const command = buildOpenCommand(soleBootedDevice, app.bundleId);
+    const hint =
+      `One booted device found ("${soleBootedDevice.name}", udid ${soleBootedDevice.id}) with ` +
+      `${app.bundleId} running. Run: ${command}`;
+    return hint.length <= MAX_HINT_LENGTH ? hint : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Always pins --udid: the sole-booted-device check only proves there is one
+// booted simulator within `device`'s own simulator set, not that a fresh CLI
+// invocation (no --ios-simulator-device-set) would land on it too — a custom
+// device set (the bench-clone case) is otherwise invisible to the default
+// set. --ios-simulator-device-set is echoed back whenever the detected
+// device carries one, so the printed command is the actual command that was
+// live-validated, not a shorter one that happens to work by coincidence.
+function buildOpenCommand(device: DeviceInfo, bundleId: string): string {
+  const deviceSetFlag = device.simulatorSetPath
+    ? ` --ios-simulator-device-set ${shellQuoteIfNeeded(device.simulatorSetPath)}`
+    : '';
+  return `agent-device open ${bundleId} --platform ios --udid ${device.id}${deviceSetFlag}`;
 }

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -1,0 +1,30 @@
+import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
+import { detectSoleRunningIosSimulatorApp } from '../platforms/apple/core/app-resolution.ts';
+import { listBootedIosSimulators } from '../platforms/apple/core/devices.ts';
+
+/**
+ * Enriches the generic "Run open first" SESSION_NOT_FOUND hint with the exact
+ * runnable command, but only when the environment is unambiguous: exactly one
+ * booted iOS simulator with exactly one app running on it.
+ *
+ * Any ambiguity — no booted simulator, more than one, no running app, more
+ * than one running app, or a probe failure — returns `undefined` so the
+ * caller keeps the generic hint. This must never guess: a wrong-but-confident
+ * command is worse than the default guidance.
+ */
+export async function buildIosOpenCommandHint(device: DeviceInfo): Promise<string | undefined> {
+  if (!isIosFamily(device) || device.kind !== 'simulator') return undefined;
+
+  const booted = await listBootedIosSimulators({ simulatorSetPath: device.simulatorSetPath });
+  if (booted.length !== 1) return undefined;
+  const [soleBootedDevice] = booted;
+  if (!soleBootedDevice) return undefined;
+
+  const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
+  if (!app) return undefined;
+
+  return (
+    `One booted device found ("${soleBootedDevice.name}", udid ${soleBootedDevice.id}) with ` +
+    `${app.bundleId} in the foreground. Run: agent-device open ${app.bundleId} --platform ios`
+  );
+}

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -25,6 +25,6 @@ export async function buildIosOpenCommandHint(device: DeviceInfo): Promise<strin
 
   return (
     `One booted device found ("${soleBootedDevice.name}", udid ${soleBootedDevice.id}) with ` +
-    `${app.bundleId} in the foreground. Run: agent-device open ${app.bundleId} --platform ios`
+    `${app.bundleId} running. Run: agent-device open ${app.bundleId} --platform ios`
   );
 }

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -11,6 +11,7 @@ import type { CommandSessionRecord } from '../runtime.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { maybeBuildAndroidSnapshotTimeoutFailure } from './android-snapshot-timeout-evidence.ts';
 import { errorResponse, requireCommandSupported } from './handlers/response.ts';
+import { buildIosOpenCommandHint } from './ios-app-session-hint.ts';
 import { captureSnapshot, resolveSnapshotScope } from './handlers/snapshot-capture.ts';
 import {
   buildSnapshotSession,
@@ -144,7 +145,7 @@ async function dispatchSnapshotRuntimeCommand(
   if (unsupported) return unsupported;
   const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
   if (!resolvedScope.ok) return resolvedScope;
-  const iosAppSessionGuard = requireIosAppSessionForSnapshot(params.command, session, device);
+  const iosAppSessionGuard = await requireIosAppSessionForSnapshot(params.command, session, device);
   if (iosAppSessionGuard) return iosAppSessionGuard;
 
   return await withSessionlessRunnerCleanup(session, device, async () => {
@@ -196,17 +197,25 @@ async function dispatchSnapshotRuntimeCommand(
   });
 }
 
-function requireIosAppSessionForSnapshot(
+async function requireIosAppSessionForSnapshot(
   command: 'snapshot' | 'diff',
   session: SessionState | undefined,
   device: SessionState['device'],
-): DaemonResponse | null {
+): Promise<DaemonResponse | null> {
   if (!isIosFamily(device) || session?.appBundleId) {
     return null;
   }
+  // An unambiguous environment (one booted simulator, one foreground app)
+  // gets the exact `open` command instead of the generic "run open first"
+  // nudge — cheap, error-path only, never guesses.
+  const openCommandHint = await buildIosOpenCommandHint(device);
   return errorResponse(
     'SESSION_NOT_FOUND',
     `iOS ${command} requires an active app session on the target device. Run open first (for example: open --session ${session?.name ?? 'sim'} --platform ios --device "<name>" <app>).`,
+    {
+      reason: 'ios_app_session_required',
+      ...(openCommandHint ? { hint: openCommandHint } : {}),
+    },
   );
 }
 

--- a/src/platforms/apple/core/__tests__/app-resolution.test.ts
+++ b/src/platforms/apple/core/__tests__/app-resolution.test.ts
@@ -5,7 +5,10 @@ const { mockRunSimctl } = vi.hoisted(() => ({ mockRunSimctl: vi.fn() }));
 
 vi.mock('../apps-simctl.ts', () => ({ runSimctl: mockRunSimctl }));
 
-import { findIosSimulatorInstalledApp } from '../app-resolution.ts';
+import {
+  detectSoleRunningIosSimulatorApp,
+  findIosSimulatorInstalledApp,
+} from '../app-resolution.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
 const bootedSimulator: DeviceInfo = {
@@ -44,6 +47,71 @@ test('findIosSimulatorInstalledApp verifies exact bundle ids and app-name aliase
 test('findIosSimulatorInstalledApp does not probe a stopped simulator', async () => {
   assert.equal(
     await findIosSimulatorInstalledApp({ ...bootedSimulator, booted: false }, 'com.example.demo'),
+    undefined,
+  );
+  assert.equal(mockRunSimctl.mock.calls.length, 0);
+});
+
+function mockLaunchctlAndListapps(runningBundleIds: string[]): void {
+  mockRunSimctl.mockImplementation(async (_device: DeviceInfo, args: string[]) => {
+    if (args[0] === 'spawn') {
+      const lines = runningBundleIds.map(
+        (bundleId, index) => `${1000 + index}\t0\tUIKitApplication:${bundleId}[abcd][rb-legacy]`,
+      );
+      // Non-UIKitApplication launchd jobs (system daemons) are mixed in on a
+      // real device and must be ignored, not just absent.
+      return {
+        exitCode: 0,
+        stdout: `PID\tStatus\tLabel\n-\t0\tcom.apple.cfprefsd\n${lines.join('\n')}`,
+      };
+    }
+    return {
+      stdout: JSON.stringify({
+        'com.example.demo': { CFBundleDisplayName: 'Demo' },
+        'com.apple.Preferences': { CFBundleDisplayName: 'Settings' },
+      }),
+    };
+  });
+}
+
+test('detectSoleRunningIosSimulatorApp cross-references launchctl against installed apps', async () => {
+  // com.apple.family is a launchd job that shows up as UIKitApplication but
+  // is not a real installed app (not in `simctl listapps`) — it must be
+  // filtered out, leaving Preferences as the sole confident candidate.
+  mockLaunchctlAndListapps(['com.apple.Preferences', 'com.apple.family']);
+
+  assert.deepEqual(await detectSoleRunningIosSimulatorApp(bootedSimulator), {
+    bundleId: 'com.apple.Preferences',
+    name: 'Settings',
+  });
+});
+
+test('detectSoleRunningIosSimulatorApp refuses to guess between two running apps', async () => {
+  mockLaunchctlAndListapps(['com.apple.Preferences', 'com.example.demo']);
+
+  assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
+});
+
+test('detectSoleRunningIosSimulatorApp returns undefined when nothing is running', async () => {
+  mockLaunchctlAndListapps([]);
+
+  assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
+});
+
+test('detectSoleRunningIosSimulatorApp treats a failed probe as inconclusive', async () => {
+  mockRunSimctl.mockImplementation(async (_device: DeviceInfo, args: string[]) => {
+    if (args[0] === 'spawn') return { exitCode: 1, stdout: '' };
+    return {
+      stdout: JSON.stringify({ 'com.apple.Preferences': { CFBundleDisplayName: 'Settings' } }),
+    };
+  });
+
+  assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
+});
+
+test('detectSoleRunningIosSimulatorApp does not probe a stopped simulator', async () => {
+  assert.equal(
+    await detectSoleRunningIosSimulatorApp({ ...bootedSimulator, booted: false }),
     undefined,
   );
   assert.equal(mockRunSimctl.mock.calls.length, 0);

--- a/src/platforms/apple/core/__tests__/app-resolution.test.ts
+++ b/src/platforms/apple/core/__tests__/app-resolution.test.ts
@@ -109,6 +109,42 @@ test('detectSoleRunningIosSimulatorApp treats a failed probe as inconclusive', a
   assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
 });
 
+test('detectSoleRunningIosSimulatorApp catches a rejecting launchctl probe (timeout/spawn failure)', async () => {
+  mockRunSimctl.mockImplementation(async (_device: DeviceInfo, args: string[]) => {
+    if (args[0] === 'spawn') throw new Error('xcrun timed out after 3000ms');
+    return {
+      stdout: JSON.stringify({ 'com.apple.Preferences': { CFBundleDisplayName: 'Settings' } }),
+    };
+  });
+
+  assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
+});
+
+test('detectSoleRunningIosSimulatorApp catches a rejecting listapps probe (timeout/spawn failure)', async () => {
+  mockRunSimctl.mockImplementation(async (_device: DeviceInfo, args: string[]) => {
+    if (args[0] === 'spawn') {
+      return {
+        exitCode: 0,
+        stdout:
+          'PID\tStatus\tLabel\n1000\t0\tUIKitApplication:com.apple.Preferences[abcd][rb-legacy]',
+      };
+    }
+    throw new Error('xcrun timed out after 3000ms');
+  });
+
+  assert.equal(await detectSoleRunningIosSimulatorApp(bootedSimulator), undefined);
+});
+
+test('detectSoleRunningIosSimulatorApp bounds the listapps probe with a timeout', async () => {
+  mockLaunchctlAndListapps(['com.apple.Preferences']);
+
+  await detectSoleRunningIosSimulatorApp(bootedSimulator);
+
+  const listappsCall = mockRunSimctl.mock.calls.find(([, args]) => args[0] === 'listapps');
+  assert.equal(typeof listappsCall?.[2]?.timeoutMs, 'number');
+  assert.ok((listappsCall?.[2]?.timeoutMs ?? 0) > 0);
+});
+
 test('detectSoleRunningIosSimulatorApp does not probe a stopped simulator', async () => {
   assert.equal(
     await detectSoleRunningIosSimulatorApp({ ...bootedSimulator, booted: false }),

--- a/src/platforms/apple/core/__tests__/devices.test.ts
+++ b/src/platforms/apple/core/__tests__/devices.test.ts
@@ -7,6 +7,7 @@ import {
   isAppleTvProductType,
   isSupportedAppleDevicectlDevice,
   listAppleDevices,
+  listBootedIosSimulators,
   parseXctracePhysicalAppleDevices,
   resolveAppleTargetFromDevicectlDevice,
 } from '../devices.ts';
@@ -706,6 +707,51 @@ test('listAppleDevices keeps physical discovery when explicit udid is not a simu
     toolCalls.some(([, args]) => args.includes('xctrace')),
     true,
   );
+});
+
+test('listBootedIosSimulators returns only booted simulators, not shutdown ones or the host Mac', async () => {
+  mockRunCommand = async (_cmd, args) => {
+    if (args.join(' ') === 'simctl list devices -j') {
+      return {
+        stdout: JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+              { name: 'iPhone 16', udid: 'sim-booted', state: 'Booted', isAvailable: true },
+              { name: 'iPhone 15', udid: 'sim-shutdown', state: 'Shutdown', isAvailable: true },
+            ],
+          },
+        }),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    throw new Error(`unexpected xcrun args: ${args.join(' ')}`);
+  };
+
+  const booted = await withMockedAppleTools(async () => await listBootedIosSimulators());
+
+  assert.deepEqual(
+    booted.map((device) => device.id),
+    ['sim-booted'],
+  );
+});
+
+test('listBootedIosSimulators returns an empty list instead of throwing on tool failure', async () => {
+  mockRunCommand = async () => {
+    throw new Error('xcrun not found');
+  };
+
+  const booted = await withMockedAppleTools(async () => await listBootedIosSimulators());
+
+  assert.deepEqual(booted, []);
+});
+
+test('listBootedIosSimulators returns an empty list on malformed simctl JSON', async () => {
+  mockRunCommand = async () => ({ stdout: 'not json', stderr: '', exitCode: 0 });
+
+  const booted = await withMockedAppleTools(async () => await listBootedIosSimulators());
+
+  assert.deepEqual(booted, []);
 });
 
 async function withMockedAppleTools<T>(fn: () => Promise<T>): Promise<T> {

--- a/src/platforms/apple/core/app-resolution.ts
+++ b/src/platforms/apple/core/app-resolution.ts
@@ -100,6 +100,60 @@ export function resolveIosAppAlias(app: string): string {
   return ALIASES[trimmed.toLowerCase()] ?? app;
 }
 
+// Bounded so an error-path probe never turns into a long wait.
+const IOS_FOREGROUND_APP_PROBE_TIMEOUT_MS = 3_000;
+const UIKIT_APPLICATION_JOB_PATTERN = /UIKitApplication:([^[\s]+)\[/;
+
+/**
+ * Identifies the sole installed app currently running on a booted simulator,
+ * for enriching error hints — never for functional resolution (ambiguity
+ * must fail, not guess).
+ *
+ * `launchctl list` reports every running job, including simulator-internal
+ * services (Spotlight, widget renderers, parental controls) that are not
+ * real apps. Cross-referencing against `simctl listapps` (the installed-app
+ * registry) filters those out without hardcoding a system bundle-id
+ * denylist that would drift across iOS versions. Returns `undefined`
+ * whenever this isn't a single confident answer: no running app, more than
+ * one, or the probe itself failed.
+ */
+export async function detectSoleRunningIosSimulatorApp(
+  device: DeviceInfo,
+): Promise<IosAppInfo | undefined> {
+  if (!isIosFamily(device) || device.kind !== 'simulator' || device.booted !== true) {
+    return undefined;
+  }
+
+  const [runningBundleIds, installedApps] = await Promise.all([
+    listRunningIosSimulatorBundleIds(device),
+    listSimulatorApps(device),
+  ]);
+  if (runningBundleIds.length === 0) return undefined;
+
+  const installedById = new Map(installedApps.map((app) => [app.bundleId, app] as const));
+  const candidates = new Map<string, IosAppInfo>();
+  for (const bundleId of runningBundleIds) {
+    const app = installedById.get(bundleId);
+    if (app) candidates.set(app.bundleId, app);
+  }
+  return candidates.size === 1 ? [...candidates.values()][0] : undefined;
+}
+
+async function listRunningIosSimulatorBundleIds(device: DeviceInfo): Promise<string[]> {
+  const result = await runSimctl(device, ['spawn', device.id, 'launchctl', 'list'], {
+    allowFailure: true,
+    timeoutMs: IOS_FOREGROUND_APP_PROBE_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) return [];
+
+  const bundleIds: string[] = [];
+  for (const line of (result.stdout as string).split('\n')) {
+    const match = UIKIT_APPLICATION_JOB_PATTERN.exec(line);
+    if (match?.[1]) bundleIds.push(match[1]);
+  }
+  return bundleIds;
+}
+
 type SimulatorAppMetadata = {
   bundleId: string;
   name: string;

--- a/src/platforms/apple/core/app-resolution.ts
+++ b/src/platforms/apple/core/app-resolution.ts
@@ -124,19 +124,28 @@ export async function detectSoleRunningIosSimulatorApp(
     return undefined;
   }
 
-  const [runningBundleIds, installedApps] = await Promise.all([
-    listRunningIosSimulatorBundleIds(device),
-    listSimulatorApps(device),
-  ]);
-  if (runningBundleIds.length === 0) return undefined;
+  // Both probes are bounded, but a timeout still REJECTS (exec.ts's
+  // `allowFailure` only suppresses non-zero exit codes, not a timeout or a
+  // spawn failure) — this is an error-path enrichment, so any throw here
+  // must fall back to "inconclusive", never propagate and replace the
+  // caller's deterministic error with a probe failure.
+  try {
+    const [runningBundleIds, installedApps] = await Promise.all([
+      listRunningIosSimulatorBundleIds(device),
+      listSimulatorApps(device, { timeoutMs: IOS_FOREGROUND_APP_PROBE_TIMEOUT_MS }),
+    ]);
+    if (runningBundleIds.length === 0) return undefined;
 
-  const installedById = new Map(installedApps.map((app) => [app.bundleId, app] as const));
-  const candidates = new Map<string, IosAppInfo>();
-  for (const bundleId of runningBundleIds) {
-    const app = installedById.get(bundleId);
-    if (app) candidates.set(app.bundleId, app);
+    const installedById = new Map(installedApps.map((app) => [app.bundleId, app] as const));
+    const candidates = new Map<string, IosAppInfo>();
+    for (const bundleId of runningBundleIds) {
+      const app = installedById.get(bundleId);
+      if (app) candidates.set(app.bundleId, app);
+    }
+    return candidates.size === 1 ? [...candidates.values()][0] : undefined;
+  } catch {
+    return undefined;
   }
-  return candidates.size === 1 ? [...candidates.values()][0] : undefined;
 }
 
 async function listRunningIosSimulatorBundleIds(device: DeviceInfo): Promise<string[]> {
@@ -202,16 +211,30 @@ export async function listIosApps(device: DeviceInfo, filter: AppsFilter): Promi
   return await resolveIosPhysicalDeviceControl(device).listApps(device, filter);
 }
 
-async function listSimulatorApps(device: DeviceInfo): Promise<IosAppInfo[]> {
-  const apps = await listSimulatorAppMetadata(device);
+type SimulatorAppListOptions = {
+  /** Unset (default) preserves prior unbounded behavior for normal command flow. */
+  timeoutMs?: number;
+};
+
+async function listSimulatorApps(
+  device: DeviceInfo,
+  options?: SimulatorAppListOptions,
+): Promise<IosAppInfo[]> {
+  const apps = await listSimulatorAppMetadata(device, options);
   return apps.map((app) => ({
     bundleId: app.bundleId,
     name: app.name,
   }));
 }
 
-async function listSimulatorAppMetadata(device: DeviceInfo): Promise<SimulatorAppMetadata[]> {
-  const result = await runSimctl(device, ['listapps', device.id], { allowFailure: true });
+async function listSimulatorAppMetadata(
+  device: DeviceInfo,
+  options?: SimulatorAppListOptions,
+): Promise<SimulatorAppMetadata[]> {
+  const result = await runSimctl(device, ['listapps', device.id], {
+    allowFailure: true,
+    timeoutMs: options?.timeoutMs,
+  });
   const stdout = result.stdout as string;
   const trimmed = stdout.trim();
   if (!trimmed) return [];
@@ -248,6 +271,7 @@ async function listSimulatorAppMetadata(device: DeviceInfo): Promise<SimulatorAp
       const converted = await runAppleToolCommand('plutil', ['-convert', 'json', '-o', '-', '-'], {
         allowFailure: true,
         stdin: trimmed,
+        timeoutMs: options?.timeoutMs,
       });
       if (converted.exitCode === 0 && converted.stdout.trim().startsWith('{')) {
         parsed = JSON.parse(converted.stdout) as Record<

--- a/src/platforms/apple/core/devices.ts
+++ b/src/platforms/apple/core/devices.ts
@@ -202,6 +202,46 @@ export async function findBootableIosSimulator(
   return simulators.find((simulator) => !targetFilter || simulator.target === targetFilter) ?? null;
 }
 
+// Bounded so an error-path probe (e.g. enriching a SESSION_NOT_FOUND hint)
+// never turns into a long wait — `simctl list` normally answers in well under
+// a second (see the memo comment in simulator.ts).
+const IOS_BOOTED_SIMULATOR_PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * Lists every currently booted iOS simulator via a single `simctl list`
+ * call. Unlike `findBootableIosSimulator`, this returns all booted matches
+ * instead of the first sorted candidate — callers that need to detect
+ * ambiguity (more than one booted device) read this directly rather than
+ * inferring it from device resolution, which silently picks one.
+ *
+ * Returns `[]` on any discovery failure (tool missing, timeout, bad JSON) so
+ * callers on an error path can treat "unknown" the same as "ambiguous" and
+ * fall back safely.
+ */
+export async function listBootedIosSimulators(
+  options: IosDeviceDiscoveryOptions = {},
+): Promise<DeviceInfo[]> {
+  const simulatorSetPath = resolveIosSimulatorDeviceSetPath(options.simulatorSetPath);
+
+  let simResult;
+  try {
+    simResult = await runXcrun(buildSimctlArgs(['list', 'devices', '-j'], { simulatorSetPath }), {
+      timeoutMs: IOS_BOOTED_SIMULATOR_PROBE_TIMEOUT_MS,
+    });
+  } catch {
+    return [];
+  }
+
+  try {
+    const payload = JSON.parse(simResult.stdout as string) as SimctlListDevicesPayload;
+    return parseSimctlAppleDevices(payload, simulatorSetPath).filter(
+      (device) => device.kind === 'simulator' && device.booted === true,
+    );
+  } catch {
+    return [];
+  }
+}
+
 function parseSimctlAppleDevices(
   payload: SimctlListDevicesPayload,
   simulatorSetPath: string | undefined,


### PR DESCRIPTION
## Summary

- In 27 of 30 benchmark tasks, an agent's first `agent-device snapshot -i` failed with `SESSION_NOT_FOUND` and a generic hint, even though the environment was completely unambiguous (one booted simulator, one app already running). The agent then burned 2-3 extra turns and ~20s figuring out the bundle id itself.
- This is **not** auto-attach — ambiguous-input rejection stays a hard rule (fail fast, never guess across ambiguity). It's a smarter hint: when the failure occurs on iOS and the environment is provably unambiguous, the hint now names the exact runnable `open` command.
- Scoped to the iOS simulator `snapshot`/`diff` "no app session" guard (`requireIosAppSessionForSnapshot` in `src/daemon/snapshot-runtime.ts`), which is the exact site the benchmark's error text comes from. `appstate`'s analogous iOS-session-required messages in `src/daemon/handlers/session-state.ts` are a natural follow-up but out of scope here to keep this PR reviewable.
- Android has no equivalent "no app session" SESSION_NOT_FOUND shape on this path, so it isn't touched.

## How the detection works

- `listBootedIosSimulators` (`src/platforms/apple/core/devices.ts`): one bounded (3s) `simctl list devices -j` call, returns every currently booted simulator. Used to detect true device-level ambiguity — device *resolution* (`resolveTargetDevice`) silently picks one candidate even when several are booted, so the hint can't infer ambiguity from the already-resolved device.
- `detectSoleRunningIosSimulatorApp` (`src/platforms/apple/core/app-resolution.ts`): cross-references `simctl spawn <udid> launchctl list` (running `UIKitApplication:` jobs) against `simctl listapps` (the installed-app registry). Jobs that show up in `launchctl list` but aren't real installed apps (Spotlight, widget renderers, parental-controls daemons, etc.) get filtered out — without hardcoding a system-bundle-id denylist that would drift across iOS versions. Returns `undefined` (never guesses) unless there's exactly one confident candidate.
- `ios-app-session-hint.ts` composes both: hint only fires when exactly one booted simulator AND exactly one running installed app are found. Any ambiguity, zero candidates, or probe failure keeps the existing generic hint.
- Both probes are bounded (3s timeouts), read-only (no session creation, no device mutation), error-path only, and now fully caught end-to-end (see "Review updates" below) so a probe failure can never replace the caller's deterministic error.

## Before / after (live)

Booted a fresh throwaway simulator, isolated `--ios-simulator-device-set` so exactly one simulator was booted, and `xcrun simctl launch <udid> com.apple.Preferences`, no agent-device session.

**Before:**
```
Error (SESSION_NOT_FOUND): iOS snapshot requires an active app session on the target device. Run open first (for example: open --session sim --platform ios --device "<name>" <app>).
Hint: Run open first or pass an explicit device selector.
```

**After (same setup, custom device set):**
```
Error (SESSION_NOT_FOUND): iOS snapshot requires an active app session on the target device. Run open first (for example: open --session sim --platform ios --device "<name>" <app>).
Hint: One booted device found ("claude-hint-demo2", udid 20DC29DB-EA03-4D82-8A89-8DF384B26DED) with com.apple.Preferences running. Run: agent-device open com.apple.Preferences --platform ios --udid 20DC29DB-EA03-4D82-8A89-8DF384B26DED --ios-simulator-device-set /tmp/ad-hint-demo-simset
```

**After (default device set, one booted simulator):**
```
Hint: One booted device found ("claude-hint-demo1", udid 71C0536F-E613-4875-B1B2-F3DC29FE08A4) with com.apple.Preferences running. Run: agent-device open com.apple.Preferences --platform ios --udid 71C0536F-E613-4875-B1B2-F3DC29FE08A4
```

Ran the second hinted command **verbatim** — `agent-device open com.apple.Preferences --platform ios --udid 71C0536F-E613-4875-B1B2-F3DC29FE08A4`, no substitutions — which succeeded, and `snapshot -i` immediately returned a real snapshot afterward. No more guessing round trip, and the printed command is now provably the exact command that was run, not a shorter one that happens to work by coincidence (see P2 below).

**Ambiguous path preserved:** with a second simulator booted, the same no-session `snapshot -i` request still returns the original generic hint (`Run open first or pass an explicit device selector.`) — verified live, and covered by unit tests.

**Known environmental quirk (not a correctness bug):** on some simulator boots, WidgetKit spontaneously launches a bundled app (observed: Calendar) in the background shortly after boot to render a widget preview. When that happens, the probe correctly sees two running installed apps and falls back to the generic hint (safe — never a wrong-but-confident guess); it clears itself once that transient process exits. Documented in `detectSoleRunningIosSimulatorApp`'s neighborhood for future readers.

## Review updates

1. **Wording**: `launchctl list` only confirms the app's process is alive, not that it's the frontmost scene — a resident-but-backgrounded app (launched, then sent home) would match the probe the same way a truly foregrounded app would. The actionable `open` command is correct either way, but "in the foreground" overclaimed what the probe verifies. The hint now says the app is "running" instead.

2. **[P1] Probe wasn't strictly best-effort.** `allowFailure: true` only suppresses a non-zero exit code in `exec.ts` — a timeout or spawn failure still rejects regardless. `listSimulatorApps`'s `simctl listapps` call had no timeout at all (could hang the error path indefinitely under contention), and neither `detectSoleRunningIosSimulatorApp` nor `buildIosOpenCommandHint` caught a rejection from either probe (a timeout/spawn failure would have propagated and replaced the deterministic `SESSION_NOT_FOUND` with a probe error). Fixed: threaded an optional `timeoutMs` through `listSimulatorApps`/`listSimulatorAppMetadata` (including its `plutil` fallback), and wrapped both `detectSoleRunningIosSimulatorApp` and `buildIosOpenCommandHint` in `try/catch` so any throw anywhere in the probe chain falls back to `undefined`. Added regression tests with **rejecting** mocks (not just `exitCode: 1`) at both layers, plus a test asserting the `listapps` call actually carries a `timeoutMs`.

3. **[P2] Printed command wasn't the one that was validated.** The original hint printed only `agent-device open <bundle> --platform ios`, but the PR's own live validation had to add `--udid` to make it work — the unambiguous-device check only proves uniqueness within the probed device's own simulator set, not that a fresh CLI invocation without `--ios-simulator-device-set` would resolve to the same device. Fixed: the command now always pins `--udid <id>`, and echoes `--ios-simulator-device-set` (shell-quoted via the existing `shellQuoteIfNeeded` helper, same one `session-recovery-hints.ts` uses) whenever the detected device carries one. Also added a length guard: wire-level error `details` are redacted before send and silently truncate any string over 400 chars (`packages/kernel/src/redaction.ts`) — a truncated mid-command hint is worse than the generic default (looks actionable, isn't copy-paste-safe). A long device-set path can push the composed hint past that budget, so it now falls back to the generic hint rather than risk truncation, with a regression test.

Both re-validated live end-to-end after the fix (see updated before/after transcripts above) — the printed `--udid`/device-set command was run character-for-character and worked.

## Tests

- `src/daemon/ios-app-session-hint.test.ts`: hint composition — unambiguous, custom-device-set echoing, multi-device, zero-booted, probe-failure (rejecting, not just falsy), physical-device, and over-length-truncation-risk branches.
- `src/platforms/apple/core/__tests__/app-resolution.test.ts`: `detectSoleRunningIosSimulatorApp` — cross-reference filtering, ambiguous/empty/rejecting-probe branches (both the `launchctl` and `listapps` probes), stopped-simulator short-circuit, and a `timeoutMs`-is-actually-passed assertion.
- `src/platforms/apple/core/__tests__/devices.test.ts`: `listBootedIosSimulators` — booted-only filtering, tool-failure and malformed-JSON fallback to `[]`.
- `src/daemon/handlers/__tests__/snapshot-handler.test.ts`: wires `ios-app-session-hint.ts` through a mock (kept hermetic/fast — the real probe is exercised only in its own dedicated tests) and asserts the composed `SESSION_NOT_FOUND` response carries `details.reason: 'ios_app_session_required'` and the detected hint.
- `errors-code-policy.test.ts` and full `pnpm test:unit` (5605 tests) run clean; 2 unrelated timeouts in untouched files (`request-router-replay-scope.test.ts`, `runner-client.test.ts`) reproduced as pure CPU-contention flakes and passed cleanly in isolated re-runs.

## Checks

- `npm run typecheck` — clean
- `npm run check:layering` — clean
- `npx oxlint <changed files> --deny-warnings` — clean
- `node ./node_modules/oxfmt/bin/oxfmt --check .` — clean
- `npm run check:production-exports`, `npm run check:fallow` — clean
