### PR TITLE
feat(ios): expose AX custom actions on merged accessibility elements

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -115,7 +115,14 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledFalseOnMidWindowMismatch \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledFalseOnFailedCapture \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledOnlyLooksAtTheTrailingWindow \
-            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledRejectsDegenerateRequirement
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledRejectsDegenerateRequirement \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCustomActionsRequestPinsPrivateAXBackend \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXNodesCarryAnnotatedCustomActions \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRequestPinnedBackendReportsItsOwnReason \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCustomActionCoverageParsesOnlyCompletePairs \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPartialCustomActionPassIsDisclosedAndCompleteOneIsNot \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testActionNamesAreCappedPerElementAndReported \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testHungCustomActionReadIsContainedAndRecovers
 
       - name: Preflight iOS runner through public CLI
         run: |

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -11,6 +11,13 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionPendingKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
 
+/// Keys of the `customActions` dictionary in the snapshot response: how many
+/// merged elements were eligible for an action read, and how many the bounded
+/// pass actually reached. Present only when the capture asked for actions.
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsReadKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsCandidatesKey;
+
 /// A depth-capped childless node awaiting an element-rooted follow-up request.
 /// Public so the runner unit bundle can drive the extension's miss paths with
 /// fabricated snapshots — the executed contract that missed frontiers are

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -29,11 +29,38 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
 /// not). The response gains a `deepExtension` {calls, nodesAdded,
 /// pendingFrontiers, missedFrontiers} dictionary when any frontier existed and
 /// the call limit allowed extension. Pass 0 to disable extension entirely.
+///
+/// `customActionLimit` bounds the per-element custom-action reads described on
+/// `customActionNamesForElement:axClient:`; pass 0 to skip them entirely.
 + (NSDictionary<NSString *, id> *)snapshotTreeForApplication:(XCUIApplication *)application
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes
                                       deepExtensionCallLimit:(NSInteger)deepExtensionCallLimit
+                                           customActionLimit:(NSInteger)customActionLimit
                                                     deadline:(nullable NSDate *)deadline;
+
+/// Names of the element's UIAccessibilityCustomActions, or nil when it has
+/// none.
+///
+/// One element per call on purpose. The bulk snapshot request cannot carry this
+/// attribute: adding it makes testmanagerd's reply decoder reject the nested
+/// arrays a custom action serializes into ("value for key 'NS.objects' was of
+/// unexpected class 'NSArray'"), drop the reply, and time the request out after
+/// ~65s instead of the usual ~110ms. Per-element reads use a different XPC
+/// message and answer normally.
+///
+/// Reading is all we can do: the actions are not invocable from the runner.
+/// XCUIElement exposes no custom-action API; XCAXClient_iOS's
+/// performAction:onElement:value: answers kAXErrorCannotComplete for every AX
+/// action number; setAttribute: on the custom-actions attribute reports success
+/// and does nothing; parameterizedAttribute: answers kAXErrorNoValue; and the
+/// raw AXUIElement C API cannot be aimed at app elements because
+/// XCAccessibilityElement is token-based and answers nil for AXUIElement.
++ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element axClient:(id)axClient;
+
+/// The shared AX client (`XCUIDevice.accessibilityInterface`), or nil when the
+/// private interface is unavailable.
++ (nullable id)accessibilityClient;
 
 + (NSInteger)processIdentifierForApplication:(XCUIApplication *)application;
 
@@ -49,6 +76,7 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
                                          nodeCount:(NSInteger *)nodeCount
                                          truncated:(BOOL *)truncated
                                       callsAllowed:(NSInteger)callsAllowed
+                                      mergedLeaves:(nullable NSMutableArray<RunnerAXSnapshotFrontier *> *)mergedLeaves
                                           deadline:(nullable NSDate *)deadline;
 
 @end

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,6 +19,7 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsReadKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsCandidatesKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsTruncatedKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsBlockedKey;
 
 /// A depth-capped childless node awaiting an element-rooted follow-up request.
 /// Public so the runner unit bundle can drive the extension's miss paths with
@@ -73,6 +75,27 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsTruncatedKey;
 /// rather than silently presented as a complete list.
 + (NSArray<NSString *> *)cappedActionNames:(NSArray<NSString *> *)names
                                  truncated:(BOOL *)truncated;
+
+/// The bounded read pass over merged leaves, exposed for the runner unit
+/// bundle: the containment contract (a hung read blocks the pass and is
+/// disclosed, and adds no further dispatches) is only executable from here.
+/// Returns {read, candidates, truncated, blocked}.
++ (NSDictionary<NSString *, NSNumber *> *)
+    annotateCustomActionsOnMergedLeaves:(nullable NSArray<RunnerAXSnapshotFrontier *> *)leaves
+                               axClient:(id)axClient
+                                  limit:(NSInteger)limit
+                              rootFrame:(CGRect)rootFrame
+                               deadline:(nullable NSDate *)deadline;
+
+/// Reads dispatched but not yet returned. The AX call cannot be cancelled, so a
+/// read that blew its deadline stays counted here until it finally returns —
+/// which is precisely the state in which further reads must be refused rather
+/// than queued behind it. Consumed by the read pass to disclose the skip.
++ (NSInteger)customActionReadsInFlight;
+
+/// Total reads ever dispatched. The containment invariant is "a blocked capture
+/// adds no work", which is only observable as this counter standing still.
++ (NSInteger)customActionReadDispatchCount;
 
 /// The shared AX client (`XCUIDevice.accessibilityInterface`), or nil when the
 /// private interface is unavailable.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -17,6 +17,7 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotDeepExtensionMissedKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsReadKey;
 FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsCandidatesKey;
+FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsTruncatedKey;
 
 /// A depth-capped childless node awaiting an element-rooted follow-up request.
 /// Public so the runner unit bundle can drive the extension's miss paths with
@@ -63,7 +64,15 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsCandidatesKey;
 /// and does nothing; parameterizedAttribute: answers kAXErrorNoValue; and the
 /// raw AXUIElement C API cannot be aimed at app elements because
 /// XCAccessibilityElement is token-based and answers nil for AXUIElement.
-+ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element axClient:(id)axClient;
++ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element
+                                                    axClient:(id)axClient
+                                                   completed:(BOOL *)completed;
+
+/// Bounds one element's contribution to the response (max actions, max name
+/// length). Reports whether anything was clipped so truncation is disclosed
+/// rather than silently presented as a complete list.
++ (NSArray<NSString *> *)cappedActionNames:(NSArray<NSString *> *)names
+                                 truncated:(BOOL *)truncated;
 
 /// The shared AX client (`XCUIDevice.accessibilityInterface`), or nil when the
 /// private interface is unavailable.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -17,10 +17,23 @@ NSString *const RunnerAXSnapshotDeepExtensionMissedKey = @"missedFrontiers";
 NSString *const RunnerAXSnapshotCustomActionsKey = @"customActions";
 NSString *const RunnerAXSnapshotCustomActionsReadKey = @"read";
 NSString *const RunnerAXSnapshotCustomActionsCandidatesKey = @"candidates";
+NSString *const RunnerAXSnapshotCustomActionsTruncatedKey = @"truncated";
 
 /// The AX server's name for UIAccessibilityCustomActions (React Native's
 /// `accessibilityActions` prop lands here too).
 static NSString *const RunnerAXCustomActionsAttribute = @"XC_kAXXCAttributeCustomActions";
+
+/// A single read costs ~100ms against a responsive app. This bound exists for
+/// the unresponsive case: without it one wedged element would swallow the whole
+/// capture's budget and starve every remaining candidate, turning a bounded
+/// enrichment into a capture-length stall.
+static const NSTimeInterval RunnerAXCustomActionReadTimeout = 1.0;
+
+/// Output caps. The element budget bounds how many elements we read; these
+/// bound what any ONE element can put in the response, so a pathological app
+/// cannot spend the whole snapshot on one node's action list.
+static const NSUInteger RunnerAXCustomActionsMaxPerElement = 8;
+static const NSUInteger RunnerAXCustomActionNameMaxLength = 80;
 
 typedef id (*RunnerAXObjectMsgSend)(id, SEL);
 typedef NSInteger (*RunnerAXIntegerMsgSend)(id, SEL);
@@ -380,29 +393,49 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
         addObject:leaf];
   }
   NSInteger candidates = onScreen.count + offScreen.count;
+  NSInteger attempts = 0;
   NSInteger reads = 0;
   NSInteger annotated = 0;
+  NSInteger truncatedElements = 0;
   for (RunnerAXSnapshotFrontier *leaf in [onScreen arrayByAddingObjectsFromArray:offScreen]) {
-    if (reads >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
+    if (attempts >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
       break;
     }
     id element = [self accessibilityElementForSnapshot:leaf.snapshot];
     if (nil == element) {
       continue;
     }
+    // The attempt is what the budget buys; only a completed read counts as
+    // read, so a timed-out element stays in the undisclosed remainder instead
+    // of being reported as "read, and it has no actions".
+    attempts += 1;
+    BOOL completed = NO;
+    NSArray<NSString *> *names = [self customActionNamesForElement:element
+                                                          axClient:axClient
+                                                         completed:&completed];
+    if (!completed) {
+      continue;
+    }
     reads += 1;
-    NSArray<NSString *> *names = [self customActionNamesForElement:element axClient:axClient];
-    if (names.count > 0) {
-      leaf.node[@"actions"] = names;
+    BOOL truncated = NO;
+    NSArray<NSString *> *capped = [self cappedActionNames:names ?: @[] truncated:&truncated];
+    if (truncated) {
+      truncatedElements += 1;
+    }
+    if (capped.count > 0) {
+      leaf.node[@"actions"] = capped;
       annotated += 1;
     }
   }
   NSLog(
-    @"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld annotated=%ld candidates=%ld onScreen=%ld",
-    (long)reads, (long)annotated, (long)candidates, (long)onScreen.count);
+    @"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld attempts=%ld annotated=%ld "
+     "candidates=%ld onScreen=%ld truncated=%ld",
+    (long)reads, (long)attempts, (long)annotated, (long)candidates, (long)onScreen.count,
+    (long)truncatedElements);
   return @{
     RunnerAXSnapshotCustomActionsReadKey: @(reads),
     RunnerAXSnapshotCustomActionsCandidatesKey: @(candidates),
+    RunnerAXSnapshotCustomActionsTruncatedKey: @(truncatedElements),
   };
 }
 
@@ -423,8 +456,13 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   return !CGRectIsEmpty(rect) && CGRectIntersectsRect(rect, rootFrame);
 }
 
-+ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element axClient:(id)axClient
++ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element
+                                                    axClient:(id)axClient
+                                                   completed:(BOOL *)completed
 {
+  if (NULL != completed) {
+    *completed = NO;
+  }
   if (nil == element || nil == axClient) {
     return nil;
   }
@@ -432,15 +470,37 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   if (![axClient respondsToSelector:selector]) {
     return nil;
   }
-  typedef id (*RunnerAXAttributesMsgSend)(id, SEL, id, id, NSError **);
-  RunnerAXAttributesMsgSend send = (RunnerAXAttributesMsgSend)objc_msgSend;
-  NSError *error = nil;
-  id values = nil;
-  @try {
-    values = send(axClient, selector, element, @[ RunnerAXCustomActionsAttribute ], &error);
-  } @catch (NSException *exception) {
+  // The AX call is a synchronous XPC round trip with no timeout of its own, so
+  // it runs off-thread behind a bounded wait. On timeout the result box is
+  // never read, so a late-returning wedged call cannot race this thread.
+  NSMutableArray *box = [NSMutableArray array];
+  dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    typedef id (*RunnerAXAttributesMsgSend)(id, SEL, id, id, NSError **);
+    RunnerAXAttributesMsgSend send = (RunnerAXAttributesMsgSend)objc_msgSend;
+    NSError *error = nil;
+    id result = nil;
+    @try {
+      result = send(axClient, selector, element, @[ RunnerAXCustomActionsAttribute ], &error);
+    } @catch (NSException *exception) {
+      result = nil;
+    }
+    if (nil != result) {
+      [box addObject:result];
+    }
+    dispatch_semaphore_signal(finished);
+  });
+  long waited = dispatch_semaphore_wait(
+    finished,
+    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(RunnerAXCustomActionReadTimeout * NSEC_PER_SEC)));
+  if (waited != 0) {
+    NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS_READ_TIMEOUT");
     return nil;
   }
+  if (NULL != completed) {
+    *completed = YES;
+  }
+  id values = box.firstObject;
   if (![values isKindOfClass:NSDictionary.class]) {
     return nil;
   }
@@ -459,6 +519,41 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     }
   }
   return names.count > 0 ? names.copy : nil;
+}
+
+/// Bounds what one element can contribute to the response. The names come from
+/// the app, so their count and length are the app's choice, not ours — a list
+/// long enough to dominate a snapshot is a plausible accident (generated rows)
+/// as well as a hostile case. Truncation is reported, never silent: a clipped
+/// list is exactly as misleading as an unread element if it looks complete.
++ (NSArray<NSString *> *)cappedActionNames:(NSArray<NSString *> *)names
+                                 truncated:(BOOL *)truncated
+{
+  if (NULL != truncated) {
+    *truncated = NO;
+  }
+  NSMutableArray<NSString *> *capped = [NSMutableArray array];
+  for (NSString *name in names) {
+    if (capped.count >= RunnerAXCustomActionsMaxPerElement) {
+      if (NULL != truncated) {
+        *truncated = YES;
+      }
+      break;
+    }
+    if (name.length > RunnerAXCustomActionNameMaxLength) {
+      // Clip on composed character boundaries so a truncated name stays a
+      // valid string rather than a split grapheme.
+      NSRange clip = [name rangeOfComposedCharacterSequencesForRange:
+                             NSMakeRange(0, RunnerAXCustomActionNameMaxLength)];
+      [capped addObject:[[name substringWithRange:clip] stringByAppendingString:@"…"]];
+      if (NULL != truncated) {
+        *truncated = YES;
+      }
+      continue;
+    }
+    [capped addObject:name];
+  }
+  return capped.copy;
 }
 
 + (nullable id)accessibilityClient

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -2,6 +2,7 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <objc/message.h>
+#import <stdatomic.h>
 
 static NSString *const RunnerAXSnapshotOkKey = @"ok";
 static NSString *const RunnerAXSnapshotErrorKey = @"error";
@@ -18,6 +19,7 @@ NSString *const RunnerAXSnapshotCustomActionsKey = @"customActions";
 NSString *const RunnerAXSnapshotCustomActionsReadKey = @"read";
 NSString *const RunnerAXSnapshotCustomActionsCandidatesKey = @"candidates";
 NSString *const RunnerAXSnapshotCustomActionsTruncatedKey = @"truncated";
+NSString *const RunnerAXSnapshotCustomActionsBlockedKey = @"blocked";
 
 /// The AX server's name for UIAccessibilityCustomActions (React Native's
 /// `accessibilityActions` prop lands here too).
@@ -28,6 +30,38 @@ static NSString *const RunnerAXCustomActionsAttribute = @"XC_kAXXCAttributeCusto
 /// capture's budget and starve every remaining candidate, turning a bounded
 /// enrichment into a capture-length stall.
 static const NSTimeInterval RunnerAXCustomActionReadTimeout = 1.0;
+
+/// The AX call is a synchronous XPC round trip that cannot be cancelled once
+/// issued, so the deadline above only frees the CALLER — the call itself keeps
+/// running. Containment therefore has two parts, and both are needed:
+///
+///  1. every read runs on this one serial queue, so a wedged call can never be
+///     joined by a second concurrent user of the shared XCAXClient;
+///  2. a single-flight guard (below) refuses to dispatch while an abandoned
+///     read is still outstanding, so repeated captures cannot pile up work
+///     behind it.
+///
+/// Reads resume by themselves once the hung call returns (or the runner
+/// restarts); nothing has to be reset by hand.
+static dispatch_queue_t RunnerAXCustomActionReadQueue(void)
+{
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("com.callstack.agentdevice.runner.ax-custom-actions",
+                                  DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
+
+/// Reads dispatched but not yet returned. Non-zero after a read blew its
+/// deadline, which is exactly the condition the single-flight guard refuses on.
+static atomic_int RunnerAXCustomActionReadsInFlight = 0;
+
+/// Total dispatches. The invariant the containment fix exists to protect is
+/// "a blocked capture adds no work", which is only observable as this counter
+/// staying put, so it is recorded rather than inferred.
+static atomic_long RunnerAXCustomActionReadDispatches = 0;
 
 /// Output caps. The element budget bounds how many elements we read; these
 /// bound what any ONE element can put in the response, so a pathological app
@@ -397,8 +431,17 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   NSInteger reads = 0;
   NSInteger annotated = 0;
   NSInteger truncatedElements = 0;
+  BOOL blocked = NO;
   for (RunnerAXSnapshotFrontier *leaf in [onScreen arrayByAddingObjectsFromArray:offScreen]) {
     if (attempts >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
+      break;
+    }
+    // An abandoned read from an earlier capture is still outstanding. Stop the
+    // pass here rather than spending a deadline per element on reads that will
+    // all be refused, and record why so the response does not present the
+    // unread elements as "has no actions".
+    if ([self customActionReadsInFlight] > 0) {
+      blocked = YES;
       break;
     }
     id element = [self accessibilityElementForSnapshot:leaf.snapshot];
@@ -429,13 +472,14 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   }
   NSLog(
     @"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld attempts=%ld annotated=%ld "
-     "candidates=%ld onScreen=%ld truncated=%ld",
+     "candidates=%ld onScreen=%ld truncated=%ld blocked=%d dispatches=%ld",
     (long)reads, (long)attempts, (long)annotated, (long)candidates, (long)onScreen.count,
-    (long)truncatedElements);
+    (long)truncatedElements, (int)blocked, (long)[self customActionReadDispatchCount]);
   return @{
     RunnerAXSnapshotCustomActionsReadKey: @(reads),
     RunnerAXSnapshotCustomActionsCandidatesKey: @(candidates),
     RunnerAXSnapshotCustomActionsTruncatedKey: @(truncatedElements),
+    RunnerAXSnapshotCustomActionsBlockedKey: @(blocked),
   };
 }
 
@@ -470,12 +514,21 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   if (![axClient respondsToSelector:selector]) {
     return nil;
   }
+  // Single flight. An abandoned read still owns the serial queue, so
+  // dispatching here would only queue work behind it — and repeating the
+  // capture would keep queueing more. Refuse without dispatching instead.
+  if (atomic_load(&RunnerAXCustomActionReadsInFlight) > 0) {
+    NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS_READ_BLOCKED");
+    return nil;
+  }
   // The AX call is a synchronous XPC round trip with no timeout of its own, so
   // it runs off-thread behind a bounded wait. On timeout the result box is
   // never read, so a late-returning wedged call cannot race this thread.
+  atomic_fetch_add(&RunnerAXCustomActionReadsInFlight, 1);
+  atomic_fetch_add(&RunnerAXCustomActionReadDispatches, 1);
   NSMutableArray *box = [NSMutableArray array];
   dispatch_semaphore_t finished = dispatch_semaphore_create(0);
-  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+  dispatch_async(RunnerAXCustomActionReadQueue(), ^{
     typedef id (*RunnerAXAttributesMsgSend)(id, SEL, id, id, NSError **);
     RunnerAXAttributesMsgSend send = (RunnerAXAttributesMsgSend)objc_msgSend;
     NSError *error = nil;
@@ -488,6 +541,9 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     if (nil != result) {
       [box addObject:result];
     }
+    // Clear in-flight BEFORE signalling, so a waiter that wakes on this signal
+    // never observes its own completed read as still outstanding.
+    atomic_fetch_sub(&RunnerAXCustomActionReadsInFlight, 1);
     dispatch_semaphore_signal(finished);
   });
   long waited = dispatch_semaphore_wait(
@@ -554,6 +610,16 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     [capped addObject:name];
   }
   return capped.copy;
+}
+
++ (NSInteger)customActionReadsInFlight
+{
+  return atomic_load(&RunnerAXCustomActionReadsInFlight);
+}
+
++ (NSInteger)customActionReadDispatchCount
+{
+  return (NSInteger)atomic_load(&RunnerAXCustomActionReadDispatches);
 }
 
 + (nullable id)accessibilityClient

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -14,6 +14,10 @@ NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey = @"nodesAdded";
 NSString *const RunnerAXSnapshotDeepExtensionPendingKey = @"pendingFrontiers";
 NSString *const RunnerAXSnapshotDeepExtensionMissedKey = @"missedFrontiers";
 
+NSString *const RunnerAXSnapshotCustomActionsKey = @"customActions";
+NSString *const RunnerAXSnapshotCustomActionsReadKey = @"read";
+NSString *const RunnerAXSnapshotCustomActionsCandidatesKey = @"candidates";
+
 /// The AX server's name for UIAccessibilityCustomActions (React Native's
 /// `accessibilityActions` prop lands here too).
 static NSString *const RunnerAXCustomActionsAttribute = @"XC_kAXXCAttributeCustomActions";
@@ -95,10 +99,18 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                    callsAllowed:deepExtensionCallLimit
                                                    mergedLeaves:merged
                                                        deadline:deadline];
-    [self annotateCustomActionsOnMergedLeaves:merged
-                                     axClient:axClient
-                                        limit:customActionLimit
-                                     deadline:deadline];
+    CGRect rootFrame = CGRectZero;
+    NSDictionary *rootFrameValue = rootNode[@"frame"];
+    if ([rootFrameValue isKindOfClass:NSDictionary.class]) {
+      rootFrame = CGRectMake(
+        [rootFrameValue[@"x"] doubleValue], [rootFrameValue[@"y"] doubleValue],
+        [rootFrameValue[@"width"] doubleValue], [rootFrameValue[@"height"] doubleValue]);
+    }
+    NSDictionary *customActions = [self annotateCustomActionsOnMergedLeaves:merged
+                                                                   axClient:axClient
+                                                                      limit:customActionLimit
+                                                                  rootFrame:rootFrame
+                                                                   deadline:deadline];
 
     NSMutableDictionary *response = [NSMutableDictionary dictionaryWithDictionary:@{
       RunnerAXSnapshotOkKey: @YES,
@@ -107,6 +119,9 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     }];
     if (nil != deepExtension) {
       response[RunnerAXSnapshotDeepExtensionKey] = deepExtension;
+    }
+    if (customActions.count > 0) {
+      response[RunnerAXSnapshotCustomActionsKey] = customActions;
     }
     return response.copy;
   } @catch (NSException *exception) {
@@ -324,26 +339,52 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 /// Reads custom actions for the merged leaves in traversal order until the
 /// limit or the capture deadline is spent. Each read is its own AX round trip
 /// (~100ms on an idle simulator), so this is strictly opt-in and strictly
-/// bounded; a leaf left unvisited simply carries no `actions` key.
-+ (void)annotateCustomActionsOnMergedLeaves:(nullable NSArray<RunnerAXSnapshotFrontier *> *)leaves
-                                   axClient:(id)axClient
-                                      limit:(NSInteger)limit
-                                   deadline:(nullable NSDate *)deadline
+/// bounded.
+///
+/// Returns {read, candidates} so the response can DISCLOSE an incomplete pass.
+/// An unread element is byte-identical to one that genuinely has no actions, so
+/// silence here would teach a reader that later cards have no affordances —
+/// exactly the mis-inference this capture exists to prevent.
+///
+/// `candidates` counts only elements still eligible at read time: a leaf that
+/// deep extension filled in since serialization is not a merged element, so
+/// counting it would inflate the denominator with nodes that never needed a
+/// read. A leaf whose live element vanished stays counted and unread, because
+/// that one really is an element we failed to answer for.
+///
+/// On-screen candidates are read first. The budget is smaller than a long
+/// feed's card count, so the order decides which elements an agent can act on
+/// at all — and it also makes the disclosure's remedy true: scrolling changes
+/// the on-screen set, so a re-run reads elements the previous pass could not.
+/// Note that `--scope` deliberately is NOT the ordering key: scope is applied
+/// when the Swift walk builds nodes, long after this pass, so it cannot narrow
+/// the read budget without duplicating the scope predicate here.
++ (NSDictionary<NSString *, NSNumber *> *)
+    annotateCustomActionsOnMergedLeaves:(nullable NSArray<RunnerAXSnapshotFrontier *> *)leaves
+                               axClient:(id)axClient
+                                  limit:(NSInteger)limit
+                              rootFrame:(CGRect)rootFrame
+                               deadline:(nullable NSDate *)deadline
 {
   if (limit <= 0 || leaves.count == 0) {
-    return;
+    return @{};
   }
-  NSInteger reads = 0;
-  NSInteger annotated = 0;
+  NSMutableArray<RunnerAXSnapshotFrontier *> *onScreen = [NSMutableArray array];
+  NSMutableArray<RunnerAXSnapshotFrontier *> *offScreen = [NSMutableArray array];
   for (RunnerAXSnapshotFrontier *leaf in leaves) {
-    if (reads >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
-      break;
-    }
-    // Deep extension may have filled this leaf in since serialization; a node
-    // with real children is not a merged element and needs no action read.
     if ([leaf.node[@"children"] isKindOfClass:NSArray.class]
         && [(NSArray *)leaf.node[@"children"] count] > 0) {
       continue;
+    }
+    [([self isFrameOnScreen:leaf.node[@"frame"] rootFrame:rootFrame] ? onScreen : offScreen)
+        addObject:leaf];
+  }
+  NSInteger candidates = onScreen.count + offScreen.count;
+  NSInteger reads = 0;
+  NSInteger annotated = 0;
+  for (RunnerAXSnapshotFrontier *leaf in [onScreen arrayByAddingObjectsFromArray:offScreen]) {
+    if (reads >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
+      break;
     }
     id element = [self accessibilityElementForSnapshot:leaf.snapshot];
     if (nil == element) {
@@ -356,8 +397,30 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
       annotated += 1;
     }
   }
-  NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld annotated=%ld candidates=%ld",
-        (long)reads, (long)annotated, (long)leaves.count);
+  NSLog(
+    @"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld annotated=%ld candidates=%ld onScreen=%ld",
+    (long)reads, (long)annotated, (long)candidates, (long)onScreen.count);
+  return @{
+    RunnerAXSnapshotCustomActionsReadKey: @(reads),
+    RunnerAXSnapshotCustomActionsCandidatesKey: @(candidates),
+  };
+}
+
+/// An empty root frame means the capture has no viewport to judge against, so
+/// every candidate counts as on-screen and the order stays document order.
++ (BOOL)isFrameOnScreen:(id)frameValue rootFrame:(CGRect)rootFrame
+{
+  if (CGRectIsEmpty(rootFrame)) {
+    return YES;
+  }
+  if (![frameValue isKindOfClass:NSDictionary.class]) {
+    return NO;
+  }
+  NSDictionary *frame = (NSDictionary *)frameValue;
+  CGRect rect = CGRectMake(
+    [frame[@"x"] doubleValue], [frame[@"y"] doubleValue],
+    [frame[@"width"] doubleValue], [frame[@"height"] doubleValue]);
+  return !CGRectIsEmpty(rect) && CGRectIntersectsRect(rect, rootFrame);
 }
 
 + (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element axClient:(id)axClient

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -14,6 +14,10 @@ NSString *const RunnerAXSnapshotDeepExtensionNodesAddedKey = @"nodesAdded";
 NSString *const RunnerAXSnapshotDeepExtensionPendingKey = @"pendingFrontiers";
 NSString *const RunnerAXSnapshotDeepExtensionMissedKey = @"missedFrontiers";
 
+/// The AX server's name for UIAccessibilityCustomActions (React Native's
+/// `accessibilityActions` prop lands here too).
+static NSString *const RunnerAXCustomActionsAttribute = @"XC_kAXXCAttributeCustomActions";
+
 typedef id (*RunnerAXObjectMsgSend)(id, SEL);
 typedef NSInteger (*RunnerAXIntegerMsgSend)(id, SEL);
 typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
@@ -33,10 +37,11 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                     maxDepth:(NSInteger)maxDepth
                                                     maxNodes:(NSInteger)maxNodes
                                       deepExtensionCallLimit:(NSInteger)deepExtensionCallLimit
+                                           customActionLimit:(NSInteger)customActionLimit
                                                     deadline:(nullable NSDate *)deadline
 {
   @try {
-    id axClient = [self objectFrom:XCUIDevice.sharedDevice selectorName:@"accessibilityInterface"];
+    id axClient = [self accessibilityClient];
     if (nil == axClient) {
       return [self failure:@"XCUIDevice accessibilityInterface is unavailable"];
     }
@@ -64,13 +69,16 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     // zero extension bookkeeping.
     NSMutableArray<RunnerAXSnapshotFrontier *> *candidates =
         deepExtensionCallLimit > 0 ? [NSMutableArray array] : nil;
+    NSMutableArray<RunnerAXSnapshotFrontier *> *merged =
+        customActionLimit > 0 ? [NSMutableArray array] : nil;
     NSMutableDictionary *rootNode = [self dictionaryForSnapshot:root
                                                           depth:0
                                                        maxDepth:maxDepth
                                                        maxNodes:maxNodes
                                                       nodeCount:&nodeCount
                                                       truncated:&truncated
-                                                      frontiers:candidates];
+                                                      frontiers:candidates
+                                                    mergedLeaves:merged];
     if (nil == rootNode) {
       return [self failure:@"AX snapshot root could not be serialized"];
     }
@@ -85,7 +93,12 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                       nodeCount:&nodeCount
                                                       truncated:&truncated
                                                    callsAllowed:deepExtensionCallLimit
+                                                   mergedLeaves:merged
                                                        deadline:deadline];
+    [self annotateCustomActionsOnMergedLeaves:merged
+                                     axClient:axClient
+                                        limit:customActionLimit
+                                     deadline:deadline];
 
     NSMutableDictionary *response = [NSMutableDictionary dictionaryWithDictionary:@{
       RunnerAXSnapshotOkKey: @YES,
@@ -115,6 +128,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                          nodeCount:(NSInteger *)nodeCount
                                          truncated:(BOOL *)truncated
                                       callsAllowed:(NSInteger)callsAllowed
+                                      mergedLeaves:(nullable NSMutableArray<RunnerAXSnapshotFrontier *> *)mergedLeaves
                                           deadline:(nullable NSDate *)deadline
 {
   if (callsAllowed <= 0 || frontiers.count == 0) {
@@ -167,7 +181,8 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                           maxNodes:maxNodes
                                                          nodeCount:nodeCount
                                                          truncated:truncated
-                                                         frontiers:subCandidates];
+                                                         frontiers:subCandidates
+                                                      mergedLeaves:mergedLeaves];
       if (nil != childNode) {
         [children addObject:childNode];
       }
@@ -306,6 +321,88 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   return attributes;
 }
 
+/// Reads custom actions for the merged leaves in traversal order until the
+/// limit or the capture deadline is spent. Each read is its own AX round trip
+/// (~100ms on an idle simulator), so this is strictly opt-in and strictly
+/// bounded; a leaf left unvisited simply carries no `actions` key.
++ (void)annotateCustomActionsOnMergedLeaves:(nullable NSArray<RunnerAXSnapshotFrontier *> *)leaves
+                                   axClient:(id)axClient
+                                      limit:(NSInteger)limit
+                                   deadline:(nullable NSDate *)deadline
+{
+  if (limit <= 0 || leaves.count == 0) {
+    return;
+  }
+  NSInteger reads = 0;
+  NSInteger annotated = 0;
+  for (RunnerAXSnapshotFrontier *leaf in leaves) {
+    if (reads >= limit || (nil != deadline && deadline.timeIntervalSinceNow <= 0)) {
+      break;
+    }
+    // Deep extension may have filled this leaf in since serialization; a node
+    // with real children is not a merged element and needs no action read.
+    if ([leaf.node[@"children"] isKindOfClass:NSArray.class]
+        && [(NSArray *)leaf.node[@"children"] count] > 0) {
+      continue;
+    }
+    id element = [self accessibilityElementForSnapshot:leaf.snapshot];
+    if (nil == element) {
+      continue;
+    }
+    reads += 1;
+    NSArray<NSString *> *names = [self customActionNamesForElement:element axClient:axClient];
+    if (names.count > 0) {
+      leaf.node[@"actions"] = names;
+      annotated += 1;
+    }
+  }
+  NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=%ld annotated=%ld candidates=%ld",
+        (long)reads, (long)annotated, (long)leaves.count);
+}
+
++ (nullable NSArray<NSString *> *)customActionNamesForElement:(id)element axClient:(id)axClient
+{
+  if (nil == element || nil == axClient) {
+    return nil;
+  }
+  SEL selector = NSSelectorFromString(@"attributesForElement:attributes:error:");
+  if (![axClient respondsToSelector:selector]) {
+    return nil;
+  }
+  typedef id (*RunnerAXAttributesMsgSend)(id, SEL, id, id, NSError **);
+  RunnerAXAttributesMsgSend send = (RunnerAXAttributesMsgSend)objc_msgSend;
+  NSError *error = nil;
+  id values = nil;
+  @try {
+    values = send(axClient, selector, element, @[ RunnerAXCustomActionsAttribute ], &error);
+  } @catch (NSException *exception) {
+    return nil;
+  }
+  if (![values isKindOfClass:NSDictionary.class]) {
+    return nil;
+  }
+  id actions = ((NSDictionary *)values)[RunnerAXCustomActionsAttribute];
+  if (![actions isKindOfClass:NSArray.class]) {
+    return nil;
+  }
+  NSMutableArray<NSString *> *names = [NSMutableArray array];
+  for (id action in (NSArray *)actions) {
+    if (![action isKindOfClass:NSDictionary.class]) {
+      continue;
+    }
+    id name = ((NSDictionary *)action)[@"CustomActionName"];
+    if ([name isKindOfClass:NSString.class] && [(NSString *)name length] > 0) {
+      [names addObject:name];
+    }
+  }
+  return names.count > 0 ? names.copy : nil;
+}
+
++ (nullable id)accessibilityClient
+{
+  return [self objectFrom:XCUIDevice.sharedDevice selectorName:@"accessibilityInterface"];
+}
+
 + (nullable id)accessibilityElementForSnapshot:(id)snapshot
 {
   id element = nil;
@@ -384,6 +481,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                               nodeCount:(NSInteger *)nodeCount
                                               truncated:(BOOL *)truncated
                                               frontiers:(NSMutableArray<RunnerAXSnapshotFrontier *> *)frontiers
+                                           mergedLeaves:(NSMutableArray<RunnerAXSnapshotFrontier *> *)mergedLeaves
 {
   if (nil == snapshot || *nodeCount >= maxNodes) {
     *truncated = YES;
@@ -410,7 +508,8 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
                                                           maxNodes:maxNodes
                                                          nodeCount:nodeCount
                                                          truncated:truncated
-                                                         frontiers:frontiers];
+                                                         frontiers:frontiers
+                                                      mergedLeaves:mergedLeaves];
       if (nil != childNode) {
         [children addObject:childNode];
       }
@@ -419,6 +518,18 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
         break;
       }
     }
+  }
+  if (children.count == 0 && nil != mergedLeaves
+      && [result[@"label"] isKindOfClass:NSString.class]
+      && [(NSString *)result[@"label"] length] > 0) {
+    // A labelled childless node is the shape a merged card takes: the container
+    // is marked accessible, so its real controls never appear as children. Only
+    // these are worth an action read — unlabelled leaves are decoration.
+    RunnerAXSnapshotFrontier *candidate = [[RunnerAXSnapshotFrontier alloc] init];
+    candidate.snapshot = snapshot;
+    candidate.node = result;
+    candidate.depth = depth;
+    [mergedLeaves addObject:candidate];
   }
   if (children.count == 0 && nil != frontiers && depth >= maxDepth - 1) {
     // Childless node at the cap boundary: either a real leaf or a branch whose

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -9,6 +9,12 @@ extension RunnerTests {
   /// the capture-plan deadline, which is also enforced per call.
   private static let privateAXDeepExtensionCallLimit = 8
 
+  /// Upper bound on per-element custom-action reads per capture. Each is its own
+  /// AX round trip (~100ms on an idle simulator), so this caps the opt-in cost
+  /// at roughly a second on top of the capture; the capture-plan deadline stops
+  /// it earlier under load. A screenful of merged cards is well under this.
+  private static let privateAXCustomActionLimit = 12
+
   /// A capture is depth-limited unless its frontier extension resolved every
   /// capped node: frontiers left pending (budget/deadline) or missed (element
   /// vanished, re-rooted request failed) mean subtrees are still absent, and
@@ -116,6 +122,7 @@ extension RunnerTests {
           maxDepth: depth,
           maxNodes: Self.privateAXSnapshotMaxNodes,
           deepExtensionCallLimit: exactDepthRequested ? 0 : Self.privateAXDeepExtensionCallLimit,
+          customActionLimit: options.customActions ? Self.privateAXCustomActionLimit : 0,
           deadline: deadline
         )
         if response["ok"] as? Bool == true {
@@ -274,7 +281,8 @@ extension RunnerTests {
           depth: depth,
           parentIndex: parentIndex,
           hiddenContentAbove: nil,
-          hiddenContentBelow: nil
+          hiddenContentBelow: nil,
+          actions: rawNode["actions"] as? [String]
         )
       )
     } else {
@@ -396,6 +404,7 @@ extension RunnerTests {
       nodeCount: &nodeCount,
       truncated: &truncated,
       callsAllowed: 8,
+      mergedLeaves: nil,
       deadline: nil
     )
 
@@ -483,6 +492,92 @@ extension RunnerTests {
 
     abandonedTreeCaptureCount = 1
     XCTAssertFalse(shouldReadPrivateAXViewportViaXCTest())
+  }
+
+  /// The wire field must reach both capture options AND the backend pin: custom
+  /// actions are only readable through the private AX client, so a capture that
+  /// asked for them but planned the XCTest tree backend would return a payload
+  /// that structurally cannot carry them.
+  func testCustomActionsRequestPinsPrivateAXBackend() throws {
+    let asked = try JSONDecoder().decode(
+      Command.self, from: Data(#"{"command":"snapshot","customActions":true}"#.utf8))
+    let options = Self.snapshotOptions(from: asked)
+    XCTAssertTrue(options.customActions)
+    XCTAssertEqual(options.preferredBackend, SnapshotBackendKind.privateAX.rawValue)
+    XCTAssertTrue(
+      Self.snapshotXCTestChannelTreatedAsPenalized(
+        penalized: false, preferredBackend: options.preferredBackend))
+
+    // An explicit pin is never overwritten by the implied one.
+    let pinned = try JSONDecoder().decode(
+      Command.self,
+      from: Data(#"{"command":"snapshot","customActions":true,"preferredBackend":"tree"}"#.utf8))
+    XCTAssertEqual(Self.snapshotOptions(from: pinned).preferredBackend, "tree")
+
+    // And the default capture neither asks nor pins.
+    let bare = try JSONDecoder().decode(Command.self, from: Data(#"{"command":"snapshot"}"#.utf8))
+    XCTAssertFalse(Self.snapshotOptions(from: bare).customActions)
+    XCTAssertNil(Self.snapshotOptions(from: bare).preferredBackend)
+  }
+
+  /// A request-pinned backend degraded nothing, so its verdict must not claim
+  /// slow accessibility work — that reason drives a user-facing warning.
+  func testRequestPinnedBackendReportsItsOwnReason() {
+    let requested = Self.xcTestChannelStateFirstFailure(
+      .deferredToIndependentBackend, requestPinnedBackend: true)
+    XCTAssertEqual(requested?.code, "requested-backend")
+    XCTAssertFalse(requested?.reason.contains("slow accessibility work") ?? true)
+
+    // The circuit breaker's own deferral keeps its established code and wording.
+    let breaker = Self.xcTestChannelStateFirstFailure(.deferredToIndependentBackend)
+    XCTAssertEqual(breaker?.code, "deferred")
+
+    // The bounded probe and the healthy plan are untouched by the new flag.
+    XCTAssertEqual(
+      Self.xcTestChannelStateFirstFailure(.boundedXCTestProbe, requestPinnedBackend: true)?.code,
+      "budget")
+    XCTAssertNil(Self.xcTestChannelStateFirstFailure(.normal, requestPinnedBackend: true))
+  }
+
+  /// Action names annotated by the bridge must survive into the emitted node —
+  /// the whole point of the capture is that the merged card names its hidden
+  /// affordances.
+  func testPrivateAXNodesCarryAnnotatedCustomActions() {
+    let tree: [String: Any] = [
+      "type": Int(XCUIElement.ElementType.application.rawValue),
+      "label": "Blue Sky",
+      "frame": ["x": 0, "y": 0, "width": 390, "height": 844],
+      "children": [
+        [
+          "type": Int(XCUIElement.ElementType.link.rawValue),
+          "label": "feedItem-by-whiskers.test",
+          "frame": ["x": 0, "y": 100, "width": 390, "height": 200],
+          "actions": ["Reply", "Repost", "Open post options menu"],
+          "children": [],
+        ],
+        [
+          "type": Int(XCUIElement.ElementType.button.rawValue),
+          "label": "Compose",
+          "frame": ["x": 300, "y": 700, "width": 60, "height": 60],
+          "children": [],
+        ],
+      ],
+    ]
+    var nodes: [SnapshotNode] = []
+    appendPrivateAXNode(
+      tree,
+      to: &nodes,
+      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      viewport: CGRect(x: 0, y: 0, width: 390, height: 844),
+      depth: 0,
+      parentIndex: nil,
+      insideMatchedScope: false
+    )
+
+    let card = nodes.first { $0.label == "feedItem-by-whiskers.test" }
+    XCTAssertEqual(card?.actions, ["Reply", "Repost", "Open post options menu"])
+    // A node the bridge did not annotate stays absent, not empty.
+    XCTAssertNil(nodes.first { $0.label == "Compose" }?.actions)
   }
 
   func testPrivateAXScopeSelectsSubtreeNotMatchingLabels() {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -61,7 +61,9 @@ extension RunnerTests {
     // than voiding the whole coverage.
     let truncated =
       (coverage[RunnerAXSnapshotCustomActionsTruncatedKey] as? NSNumber)?.intValue ?? 0
-    return SnapshotCustomActionCoverage(read: read, candidates: candidates, truncated: truncated)
+    let blocked = (coverage[RunnerAXSnapshotCustomActionsBlockedKey] as? NSNumber)?.boolValue ?? false
+    return SnapshotCustomActionCoverage(
+      read: read, candidates: candidates, truncated: truncated, blocked: blocked)
   }
 
   func rememberPrivateAXAcceptedDepth(bundleId: String?, processIdentifier: Int?, depth: Int) {
@@ -576,6 +578,86 @@ extension RunnerTests {
       Self.privateAXCustomActionCoverage([RunnerAXSnapshotCustomActionsReadKey: 12]))
   }
 
+  /// The AX call cannot be cancelled once issued, so the read deadline frees
+  /// only the caller — the call keeps running. Without containment, repeating
+  /// `snapshot --actions` against a wedged element would stack orphaned reads,
+  /// all sharing one XCAXClient. This pins the containment: one serial queue and
+  /// a single-flight refusal that adds no work while a read is outstanding.
+  func testHungCustomActionReadIsContainedAndRecovers() {
+    let hung = HungAXClientForTesting()
+    let element = NSObject()
+    let dispatchesBefore = RunnerAXSnapshotBridge.customActionReadDispatchCount()
+    defer { hung.release() }
+
+    // 1. First read wedges. The caller is freed by the deadline, but the call is
+    //    still out there, so it stays counted in flight.
+    var completed = ObjCBool(true)
+    let firstStarted = Date()
+    let first = RunnerAXSnapshotBridge.customActionNames(
+      forElement: element, axClient: hung, completed: &completed)
+    XCTAssertNil(first)
+    XCTAssertFalse(completed.boolValue)
+    XCTAssertGreaterThanOrEqual(-firstStarted.timeIntervalSinceNow, 0.9)
+    XCTAssertEqual(RunnerAXSnapshotBridge.customActionReadsInFlight(), 1)
+    XCTAssertEqual(
+      RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 1)
+
+    // 2. Repeats do NOT accumulate: no new dispatch, still exactly one in
+    //    flight, and they return immediately instead of paying the deadline.
+    for _ in 0..<5 {
+      let started = Date()
+      XCTAssertNil(
+        RunnerAXSnapshotBridge.customActionNames(
+          forElement: element, axClient: hung, completed: &completed))
+      XCTAssertFalse(completed.boolValue)
+      XCTAssertLessThan(-started.timeIntervalSinceNow, 0.2)
+    }
+    XCTAssertEqual(RunnerAXSnapshotBridge.customActionReadsInFlight(), 1)
+    XCTAssertEqual(
+      RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 1)
+
+    // 3. A capture in that state discloses the skip rather than presenting the
+    //    unread elements as action-free — and spends no read budget doing it.
+    let leaf = RunnerAXSnapshotFrontier()
+    leaf.snapshot = FrontierSnapshotWithElementForTesting()
+    leaf.node = NSMutableDictionary(dictionary: ["label": "feedItem", "children": []])
+    let coverage = RunnerAXSnapshotBridge.annotateCustomActions(
+      onMergedLeaves: [leaf], axClient: hung, limit: 12, rootFrame: .zero, deadline: nil)
+    XCTAssertEqual(coverage[RunnerAXSnapshotCustomActionsBlockedKey] as? Bool, true)
+    XCTAssertEqual(coverage[RunnerAXSnapshotCustomActionsReadKey] as? Int, 0)
+    XCTAssertEqual(coverage[RunnerAXSnapshotCustomActionsCandidatesKey] as? Int, 1)
+    XCTAssertEqual(
+      RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 1)
+
+    // And the rendered verdict names the hang, not the scroll remedy.
+    let blockedWarnings = Self.customActionCoverageWarnings(
+      Self.privateAXCustomActionCoverage(coverage)!)
+    XCTAssertEqual(blockedWarnings.count, 1)
+    XCTAssertTrue(blockedWarnings[0].contains("still hung"))
+    XCTAssertFalse(blockedWarnings[0].contains("Scroll"))
+
+    // 4. Recovery: once the wedged call returns, reads resume by themselves.
+    hung.release()
+    let recovered = expectation(description: "in-flight drains")
+    DispatchQueue.global().async {
+      while RunnerAXSnapshotBridge.customActionReadsInFlight() > 0 {
+        usleep(20_000)
+      }
+      recovered.fulfill()
+    }
+    wait(for: [recovered], timeout: 5)
+
+    completed = ObjCBool(false)
+    XCTAssertNil(
+      RunnerAXSnapshotBridge.customActionNames(
+        forElement: element, axClient: hung, completed: &completed))
+    // Completed (the fake answers nil actions), which is the point: the pass is
+    // live again rather than latched off.
+    XCTAssertTrue(completed.boolValue)
+    XCTAssertEqual(
+      RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 2)
+  }
+
   /// The element budget bounds how many elements we read; these caps bound what
   /// any ONE element can put in the response. Clipping must be reported, since
   /// a clipped list looks exactly like a complete one.
@@ -613,7 +695,7 @@ extension RunnerTests {
     let partial = SnapshotQuality(
       state: "recovered", backend: "private-ax", reason: nil, reasonCode: "requested-backend",
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0))
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0, blocked: false))
     let message = Self.legacyQualityMessage(partial)
     XCTAssertTrue(message?.contains("12 of 19 merged elements") == true)
     XCTAssertTrue(message?.contains("remaining 7") == true)
@@ -623,7 +705,7 @@ extension RunnerTests {
     let complete = SnapshotQuality(
       state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 19, candidates: 19, truncated: 0))
+      customActions: SnapshotCustomActionCoverage(read: 19, candidates: 19, truncated: 0, blocked: false))
     XCTAssertNil(Self.legacyQualityMessage(complete))
 
     // A healthy capture with an incomplete pass still discloses — the guard must
@@ -631,7 +713,7 @@ extension RunnerTests {
     let healthyButCapped = SnapshotQuality(
       state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0))
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0, blocked: false))
     XCTAssertTrue(
       Self.legacyQualityMessage(healthyButCapped)?.contains("12 of 19") == true)
   }
@@ -789,6 +871,37 @@ extension RunnerTests {
       ["Blue Sky", "Callstack", "Welcome back", "Email", "Password", "Sign in", "Forgot password?"]
     )
     XCTAssertFalse(labels.contains("Admin settings"))
+  }
+}
+
+/// Stands in for an AX client whose `attributesForElement:` never returns —
+/// the wedged-server case the containment exists for. `release()` lets the
+/// hung call finish so recovery is observable.
+private final class HungAXClientForTesting: NSObject {
+  private let gate = DispatchSemaphore(value: 0)
+  private let releasedOnce = NSLock()
+  private var released = false
+
+  @objc(attributesForElement:attributes:error:)
+  func attributes(forElement element: Any, attributes: Any, error: NSErrorPointer) -> Any? {
+    releasedOnce.lock()
+    let alreadyReleased = released
+    releasedOnce.unlock()
+    // Once the wedge clears, the server answers normally again — that is what
+    // makes the recovery leg a recovery rather than a second hang.
+    if alreadyReleased {
+      return nil
+    }
+    gate.wait()
+    return nil
+  }
+
+  func release() {
+    releasedOnce.lock()
+    defer { releasedOnce.unlock() }
+    guard !released else { return }
+    released = true
+    gate.signal()
   }
 }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -48,6 +48,17 @@ extension RunnerTests {
     return depths.filter { $0 <= remembered }
   }
 
+  /// The bridge omits the key entirely when the capture did not ask for custom
+  /// actions, which is the difference between "nothing to disclose" and "read
+  /// none of them" — so a missing key must stay nil, never (0, 0).
+  static func privateAXCustomActionCoverage(_ raw: Any?) -> SnapshotCustomActionCoverage? {
+    guard let coverage = raw as? [String: Any],
+      let read = (coverage[RunnerAXSnapshotCustomActionsReadKey] as? NSNumber)?.intValue,
+      let candidates = (coverage[RunnerAXSnapshotCustomActionsCandidatesKey] as? NSNumber)?.intValue
+    else { return nil }
+    return SnapshotCustomActionCoverage(read: read, candidates: candidates)
+  }
+
   func rememberPrivateAXAcceptedDepth(bundleId: String?, processIdentifier: Int?, depth: Int) {
     // No PID means no way to notice a relaunch later; record nothing rather than risk serving
     // a stale shallow rung to a fresh process.
@@ -191,7 +202,10 @@ extension RunnerTests {
       )
       return SnapshotBackendCapture(
         payload: DataPayload(nodes: nodes, truncated: (response["truncated"] as? Bool) == true),
-        effectiveDepth: depthLimited ? effectiveDepth : nil
+        effectiveDepth: depthLimited ? effectiveDepth : nil,
+        customActions: Self.privateAXCustomActionCoverage(
+          response[RunnerAXSnapshotCustomActionsKey]
+        )
       )
     #else
       return nil
@@ -537,6 +551,52 @@ extension RunnerTests {
       Self.xcTestChannelStateFirstFailure(.boundedXCTestProbe, requestPinnedBackend: true)?.code,
       "budget")
     XCTAssertNil(Self.xcTestChannelStateFirstFailure(.normal, requestPinnedBackend: true))
+  }
+
+  /// The disclosure only exists if the counts survive the bridge boundary, and
+  /// "did not ask" must stay distinguishable from "read none".
+  func testCustomActionCoverageParsesOnlyCompletePairs() {
+    let coverage = Self.privateAXCustomActionCoverage([
+      RunnerAXSnapshotCustomActionsReadKey: 12,
+      RunnerAXSnapshotCustomActionsCandidatesKey: 19,
+    ])
+    XCTAssertEqual(coverage?.read, 12)
+    XCTAssertEqual(coverage?.candidates, 19)
+
+    // Absent key = the capture never asked; it must not read as (0, 0), which
+    // would warn "0 of 0" on every default capture.
+    XCTAssertNil(Self.privateAXCustomActionCoverage(nil))
+    // A half-present pair cannot express a ratio, so it is dropped whole.
+    XCTAssertNil(
+      Self.privateAXCustomActionCoverage([RunnerAXSnapshotCustomActionsReadKey: 12]))
+  }
+
+  /// A capped pass must say so; a complete one must stay silent.
+  func testPartialCustomActionPassIsDisclosedAndCompleteOneIsNot() {
+    let partial = SnapshotQuality(
+      state: "recovered", backend: "private-ax", reason: nil, reasonCode: "requested-backend",
+      effectiveDepth: nil, collapsedLeafIndexes: nil,
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19))
+    let message = Self.legacyQualityMessage(partial)
+    XCTAssertTrue(message?.contains("12 of 19 merged elements") == true)
+    XCTAssertTrue(message?.contains("remaining 7") == true)
+    XCTAssertTrue(message?.contains("Scroll them into view") == true)
+
+    // Every candidate read: nothing to disclose, and a healthy capture stays silent.
+    let complete = SnapshotQuality(
+      state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
+      effectiveDepth: nil, collapsedLeafIndexes: nil,
+      customActions: SnapshotCustomActionCoverage(read: 19, candidates: 19))
+    XCTAssertNil(Self.legacyQualityMessage(complete))
+
+    // A healthy capture with an incomplete pass still discloses — the guard must
+    // not key the disclosure off degradation state.
+    let healthyButCapped = SnapshotQuality(
+      state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
+      effectiveDepth: nil, collapsedLeafIndexes: nil,
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19))
+    XCTAssertTrue(
+      Self.legacyQualityMessage(healthyButCapped)?.contains("12 of 19") == true)
   }
 
   /// Action names annotated by the bridge must survive into the emitted node —

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -56,7 +56,12 @@ extension RunnerTests {
       let read = (coverage[RunnerAXSnapshotCustomActionsReadKey] as? NSNumber)?.intValue,
       let candidates = (coverage[RunnerAXSnapshotCustomActionsCandidatesKey] as? NSNumber)?.intValue
     else { return nil }
-    return SnapshotCustomActionCoverage(read: read, candidates: candidates)
+    // read/candidates are the ratio and must both be present; the truncation
+    // count is additive, so an older bridge that omits it reads as zero rather
+    // than voiding the whole coverage.
+    let truncated =
+      (coverage[RunnerAXSnapshotCustomActionsTruncatedKey] as? NSNumber)?.intValue ?? 0
+    return SnapshotCustomActionCoverage(read: read, candidates: candidates, truncated: truncated)
   }
 
   func rememberPrivateAXAcceptedDepth(bundleId: String?, processIdentifier: Int?, depth: Int) {
@@ -571,12 +576,44 @@ extension RunnerTests {
       Self.privateAXCustomActionCoverage([RunnerAXSnapshotCustomActionsReadKey: 12]))
   }
 
+  /// The element budget bounds how many elements we read; these caps bound what
+  /// any ONE element can put in the response. Clipping must be reported, since
+  /// a clipped list looks exactly like a complete one.
+  func testActionNamesAreCappedPerElementAndReported() {
+    var truncated = ObjCBool(true)
+
+    // Under both caps: untouched, nothing to report.
+    let small = ["Reply", "Repost"]
+    XCTAssertEqual(
+      RunnerAXSnapshotBridge.cappedActionNames(small, truncated: &truncated), small)
+    XCTAssertFalse(truncated.boolValue)
+
+    // More actions than the per-element cap: clipped to the first 8, reported.
+    let many = (1...20).map { "Action \($0)" }
+    let cappedMany = RunnerAXSnapshotBridge.cappedActionNames(many, truncated: &truncated)
+    XCTAssertEqual(cappedMany.count, 8)
+    XCTAssertEqual(cappedMany.first, "Action 1")
+    XCTAssertTrue(truncated.boolValue)
+
+    // A single very long name is shortened, reported, and stays one string.
+    let long = String(repeating: "a", count: 500)
+    let cappedLong = RunnerAXSnapshotBridge.cappedActionNames([long], truncated: &truncated)
+    XCTAssertEqual(cappedLong.count, 1)
+    XCTAssertTrue(truncated.boolValue)
+    XCTAssertLessThan(cappedLong[0].count, long.count)
+    XCTAssertTrue(cappedLong[0].hasSuffix("…"))
+
+    // Empty input is not "truncated".
+    XCTAssertEqual(RunnerAXSnapshotBridge.cappedActionNames([], truncated: &truncated), [])
+    XCTAssertFalse(truncated.boolValue)
+  }
+
   /// A capped pass must say so; a complete one must stay silent.
   func testPartialCustomActionPassIsDisclosedAndCompleteOneIsNot() {
     let partial = SnapshotQuality(
       state: "recovered", backend: "private-ax", reason: nil, reasonCode: "requested-backend",
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19))
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0))
     let message = Self.legacyQualityMessage(partial)
     XCTAssertTrue(message?.contains("12 of 19 merged elements") == true)
     XCTAssertTrue(message?.contains("remaining 7") == true)
@@ -586,7 +623,7 @@ extension RunnerTests {
     let complete = SnapshotQuality(
       state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 19, candidates: 19))
+      customActions: SnapshotCustomActionCoverage(read: 19, candidates: 19, truncated: 0))
     XCTAssertNil(Self.legacyQualityMessage(complete))
 
     // A healthy capture with an incomplete pass still discloses — the guard must
@@ -594,7 +631,7 @@ extension RunnerTests {
     let healthyButCapped = SnapshotQuality(
       state: "healthy", backend: "private-ax", reason: nil, reasonCode: nil,
       effectiveDepth: nil, collapsedLeafIndexes: nil,
-      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19))
+      customActions: SnapshotCustomActionCoverage(read: 12, candidates: 19, truncated: 0))
     XCTAssertTrue(
       Self.legacyQualityMessage(healthyButCapped)?.contains("12 of 19") == true)
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1362,12 +1362,18 @@ extension RunnerTests {
   /// Pure command→options projection, extracted so the runner unit bundle can
   /// prove the decoded wire field actually reaches capture options (#1634 P2).
   static func snapshotOptions(from command: Command) -> SnapshotOptions {
-    SnapshotOptions(
+    let customActions = command.customActions ?? false
+    return SnapshotOptions(
       interactiveOnly: command.interactiveOnly ?? false,
       depth: command.depth,
       scope: command.scope,
       raw: command.raw ?? false,
+      // Custom actions are only readable through the private AX client, so
+      // asking for them pins that backend rather than silently returning a
+      // capture that structurally cannot carry them. An explicit pin wins.
       preferredBackend: command.preferredBackend
+        ?? (customActions ? SnapshotBackendKind.privateAX.rawValue : nil),
+      customActions: customActions
     )
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
@@ -138,6 +138,7 @@ struct Command: Codable {
   let fps: Int?
   let interactiveOnly: Bool?
   let preferredBackend: String?
+  let customActions: Bool?
   let depth: Int?
   let scope: String?
   let raw: Bool?
@@ -389,6 +390,9 @@ struct SnapshotNode: Codable {
   let parentIndex: Int?
   let hiddenContentAbove: Bool?
   let hiddenContentBelow: Bool?
+  /// Names of the element's UIAccessibilityCustomActions, present only when the
+  /// capture asked for them and the element carries some.
+  var actions: [String]? = nil
 }
 
 struct SnapshotOptions {
@@ -400,4 +404,7 @@ struct SnapshotOptions {
   /// health ("private-ax"). Same-backend evidence probes (tap-outcome
   /// corroboration) must be captured the way their baseline was.
   var preferredBackend: String? = nil
+  /// Read UIAccessibilityCustomActions for merged leaves. Opt-in: each element
+  /// costs its own AX round trip (see RunnerAXSnapshotBridge).
+  var customActions: Bool = false
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -498,7 +498,8 @@ extension RunnerTests {
         reason: failure.message,
         reasonCode: "ax-rejected",
         effectiveDepth: nil,
-        collapsedLeafIndexes: nil
+        collapsedLeafIndexes: nil,
+        customActions: nil
       ),
       runnerFatal: true,
       runnerFatalReason: Self.axSnapshotUnavailableReason

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -22,6 +22,16 @@ struct SnapshotQuality: Codable {
   let effectiveDepth: Int?
   /// Leaves that merge many labels — a container marked accessible hides its descendants.
   let collapsedLeafIndexes: [Int]?
+  /// Coverage of the bounded custom-action pass, when the capture asked for one.
+  let customActions: SnapshotCustomActionCoverage?
+}
+
+/// How much of the merged-element set the custom-action pass actually read. An
+/// unread element renders exactly like one with no actions, so a partial pass
+/// has to say so — otherwise absence reads as proof of absence.
+struct SnapshotCustomActionCoverage: Codable {
+  let read: Int
+  let candidates: Int
 }
 
 enum SnapshotBackendKind: String, CaseIterable {
@@ -78,6 +88,8 @@ struct SnapshotBackendCapture {
   let payload: DataPayload
   /// Set by the private AX backend when the ladder accepted a shallower depth than requested.
   let effectiveDepth: Int?
+  /// Set by the private AX backend when the capture asked for custom actions.
+  var customActions: SnapshotCustomActionCoverage? = nil
 }
 
 extension RunnerTests {
@@ -555,7 +567,8 @@ extension RunnerTests {
       reason: reason?.reason,
       reasonCode: reason?.code,
       effectiveDepth: capture.effectiveDepth,
-      collapsedLeafIndexes: Self.collapsedLeafIndexes(payload.nodes ?? [])
+      collapsedLeafIndexes: Self.collapsedLeafIndexes(payload.nodes ?? []),
+      customActions: capture.customActions
     )
     return DataPayload(
       // Legacy human text for older daemons that read message instead of snapshotQuality.
@@ -568,8 +581,19 @@ extension RunnerTests {
     )
   }
 
+  /// One line, response level. An unread merged element is byte-identical to
+  /// one with no actions, so a partial pass must name its own incompleteness.
+  static func customActionCoverageWarning(_ coverage: SnapshotCustomActionCoverage) -> String {
+    "Custom actions were read for \(coverage.read) of \(coverage.candidates) merged elements, "
+      + "on-screen ones first; the remaining \(coverage.candidates - coverage.read) were not read, "
+      + "so an absent actions list on those is not evidence that they have none. "
+      + "Scroll them into view and re-run to read them."
+  }
+
   static func legacyQualityMessage(_ quality: SnapshotQuality) -> String? {
-    guard quality.state != "healthy" || quality.collapsedLeafIndexes != nil else { return nil }
+    let partialCustomActions = quality.customActions.map { $0.read < $0.candidates } ?? false
+    guard quality.state != "healthy" || quality.collapsedLeafIndexes != nil || partialCustomActions
+    else { return nil }
     var parts: [String] = []
     if quality.state == "recovered" {
       let meaning = quality.reasonCode == "budget" || quality.reasonCode == "deferred"
@@ -587,6 +611,9 @@ extension RunnerTests {
           + (quality.reason.map { " (\($0))" } ?? "")
           + ". Use screenshot as visual truth and coordinate taps."
       )
+    }
+    if let coverage = quality.customActions, coverage.read < coverage.candidates {
+      parts.append(Self.customActionCoverageWarning(coverage))
     }
     if let depth = quality.effectiveDepth {
       // No --depth remedy here: an explicit --depth capture disables the
@@ -670,7 +697,8 @@ extension RunnerTests {
       reason: "snapshot returned only structural application/window nodes",
       reasonCode: "sparse-tree",
       effectiveDepth: nil,
-      collapsedLeafIndexes: nil
+      collapsedLeafIndexes: nil,
+      customActions: nil
     )
     let message = Self.legacyQualityMessage(recovered)
     XCTAssertTrue(message?.contains("queries snapshot backend") == true)
@@ -680,7 +708,7 @@ extension RunnerTests {
       Self.legacyQualityMessage(
         SnapshotQuality(
           state: "healthy", backend: "tree", reason: nil, reasonCode: nil, effectiveDepth: nil,
-          collapsedLeafIndexes: nil)
+          collapsedLeafIndexes: nil, customActions: nil)
       )
     )
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -36,6 +36,9 @@ struct SnapshotCustomActionCoverage: Codable {
   /// clipped list looks complete, so it is disclosed on the same principle as
   /// an unread element.
   let truncated: Int
+  /// The pass stopped early because an earlier read is still hung. Distinct from
+  /// a budget stop: the remedy is waiting, not scrolling.
+  let blocked: Bool
 }
 
 enum SnapshotBackendKind: String, CaseIterable {
@@ -590,7 +593,14 @@ extension RunnerTests {
   /// so both have to name themselves.
   static func customActionCoverageWarnings(_ coverage: SnapshotCustomActionCoverage) -> [String] {
     var lines: [String] = []
-    if coverage.read < coverage.candidates {
+    if coverage.blocked {
+      // Scrolling is the remedy for a budget stop, not for this one — saying it
+      // here would send the reader off doing something that cannot help.
+      lines.append(
+        "Custom actions were not read: an earlier accessibility read is still hung, so this "
+          + "capture skipped the read pass instead of queueing behind it. No element's actions "
+          + "list is authoritative here. Reads resume once that call returns.")
+    } else if coverage.read < coverage.candidates {
       lines.append(
         "Custom actions were read for \(coverage.read) of \(coverage.candidates) merged elements, "
           + "on-screen ones first; the remaining \(coverage.candidates - coverage.read) were not read, "

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -32,6 +32,10 @@ struct SnapshotQuality: Codable {
 struct SnapshotCustomActionCoverage: Codable {
   let read: Int
   let candidates: Int
+  /// Elements whose action list was clipped by the per-element output caps. A
+  /// clipped list looks complete, so it is disclosed on the same principle as
+  /// an unread element.
+  let truncated: Int
 }
 
 enum SnapshotBackendKind: String, CaseIterable {
@@ -581,18 +585,31 @@ extension RunnerTests {
     )
   }
 
-  /// One line, response level. An unread merged element is byte-identical to
-  /// one with no actions, so a partial pass must name its own incompleteness.
-  static func customActionCoverageWarning(_ coverage: SnapshotCustomActionCoverage) -> String {
-    "Custom actions were read for \(coverage.read) of \(coverage.candidates) merged elements, "
-      + "on-screen ones first; the remaining \(coverage.candidates - coverage.read) were not read, "
-      + "so an absent actions list on those is not evidence that they have none. "
-      + "Scroll them into view and re-run to read them."
+  /// Response level, one line per incompleteness. An unread merged element is
+  /// byte-identical to one with no actions, and a clipped list looks complete,
+  /// so both have to name themselves.
+  static func customActionCoverageWarnings(_ coverage: SnapshotCustomActionCoverage) -> [String] {
+    var lines: [String] = []
+    if coverage.read < coverage.candidates {
+      lines.append(
+        "Custom actions were read for \(coverage.read) of \(coverage.candidates) merged elements, "
+          + "on-screen ones first; the remaining \(coverage.candidates - coverage.read) were not read, "
+          + "so an absent actions list on those is not evidence that they have none. "
+          + "Scroll them into view and re-run to read them.")
+    }
+    if coverage.truncated > 0 {
+      lines.append(
+        "\(coverage.truncated) element(s) published more custom actions than are shown; those "
+          + "lists are clipped to the first 8 names, and long names are shortened.")
+    }
+    return lines
   }
 
   static func legacyQualityMessage(_ quality: SnapshotQuality) -> String? {
-    let partialCustomActions = quality.customActions.map { $0.read < $0.candidates } ?? false
-    guard quality.state != "healthy" || quality.collapsedLeafIndexes != nil || partialCustomActions
+    let customActionWarnings =
+      quality.customActions.map { Self.customActionCoverageWarnings($0) } ?? []
+    guard quality.state != "healthy" || quality.collapsedLeafIndexes != nil
+      || !customActionWarnings.isEmpty
     else { return nil }
     var parts: [String] = []
     if quality.state == "recovered" {
@@ -612,9 +629,7 @@ extension RunnerTests {
           + ". Use screenshot as visual truth and coordinate taps."
       )
     }
-    if let coverage = quality.customActions, coverage.read < coverage.candidates {
-      parts.append(Self.customActionCoverageWarning(coverage))
-    }
+    parts.append(contentsOf: customActionWarnings)
     if let depth = quality.effectiveDepth {
       // No --depth remedy here: an explicit --depth capture disables the
       // frontier extension, so following it would return strictly less than

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -149,13 +149,25 @@ extension RunnerTests {
   /// degraded on this capture, and the daemon keys warning suppression and the settle budget
   /// reset off exactly that distinction. The bounded probe keeps 'budget': its short XCTest
   /// slice genuinely constrains what this capture could read.
+  ///
+  /// `requestPinnedBackend` separates the two ways the plan can arrive at the same
+  /// deferred shape. A capture that ASKED for a private-AX-only reading (custom
+  /// actions) degraded nothing, so reporting slow accessibility work would name a
+  /// cause that does not exist.
   static func xcTestChannelStateFirstFailure(
-    _ state: SnapshotXCTestChannelPlanState
+    _ state: SnapshotXCTestChannelPlanState,
+    requestPinnedBackend: Bool = false
   ) -> (reason: String, code: String)? {
     switch state {
     case .normal:
       return nil
     case .deferredToIndependentBackend:
+      if requestPinnedBackend {
+        return (
+          "the private AX backend was selected because this capture asked for accessibility custom actions",
+          "requested-backend"
+        )
+      }
       return (
         "XCTest-backed snapshot tiers were deferred after recent slow accessibility work on this screen",
         "deferred"
@@ -237,9 +249,11 @@ extension RunnerTests {
     // penalized route: privateAX-first plan, 'deferred' verdict — the backend was pre-selected
     // deliberately, so no degradation warning should render for it.
     var xCTestChannelPenalized = false
+    var xCTestChannelPenalizedByBreaker = false
 #if os(iOS)
+    xCTestChannelPenalizedByBreaker = isSnapshotXCTestChannelPenalized(bundleId: currentBundleId)
     xCTestChannelPenalized = Self.snapshotXCTestChannelTreatedAsPenalized(
-      penalized: isSnapshotXCTestChannelPenalized(bundleId: currentBundleId),
+      penalized: xCTestChannelPenalizedByBreaker,
       preferredBackend: options.preferredBackend
     )
 #endif
@@ -249,7 +263,12 @@ extension RunnerTests {
       availableBackends: Set(SnapshotBackendKind.allCases.filter(\.isAvailableOnCurrentPlatform))
     )
     let effectivePlan = effective.plan
-    firstFailure = Self.xcTestChannelStateFirstFailure(effective.xCTestChannelState)
+    // Only a customActions-implied pin is request-pinned; the daemon's
+    // same-backend evidence probe pins for its own reasons and keeps 'deferred'.
+    firstFailure = Self.xcTestChannelStateFirstFailure(
+      effective.xCTestChannelState,
+      requestPinnedBackend: options.customActions && !xCTestChannelPenalizedByBreaker
+    )
     switch effective.xCTestChannelState {
     case .normal:
       break

--- a/apple/runner/RUNNER_PROTOCOL.md
+++ b/apple/runner/RUNNER_PROTOCOL.md
@@ -37,6 +37,17 @@ Examples:
 private-AX backend (no other backend can read them) and costs one accessibility
 round trip per merged element, so it is opt-in.
 
+The pass is bounded on three axes, and every bound is disclosed through
+`snapshotQuality.customActions` `{read, candidates, truncated}` rather than
+silently applied:
+
+- at most 12 elements per capture, on-screen first, stopping at the capture
+  deadline — `read < candidates` means the rest were not read;
+- 1s per element read, so one wedged element cannot consume the capture budget
+  (a timed-out element counts as unread, never as "read, has no actions");
+- at most 8 action names per element, each at most 80 characters —
+  `truncated` counts elements whose list was clipped.
+
 ```json
 { "command": "recordStart", "outPath": "/tmp/demo.mp4", "fps": 30 }
 ```

--- a/apple/runner/RUNNER_PROTOCOL.md
+++ b/apple/runner/RUNNER_PROTOCOL.md
@@ -37,16 +37,22 @@ Examples:
 private-AX backend (no other backend can read them) and costs one accessibility
 round trip per merged element, so it is opt-in.
 
-The pass is bounded on three axes, and every bound is disclosed through
-`snapshotQuality.customActions` `{read, candidates, truncated}` rather than
-silently applied:
+The pass is bounded on four axes, and every bound is disclosed through
+`snapshotQuality.customActions` `{read, candidates, truncated, blocked}` rather
+than silently applied:
 
 - at most 12 elements per capture, on-screen first, stopping at the capture
   deadline — `read < candidates` means the rest were not read;
 - 1s per element read, so one wedged element cannot consume the capture budget
   (a timed-out element counts as unread, never as "read, has no actions");
 - at most 8 action names per element, each at most 80 characters —
-  `truncated` counts elements whose list was clipped.
+  `truncated` counts elements whose list was clipped;
+- one read in flight at a time. The AX call cannot be cancelled once issued, so
+  the deadline frees only the caller; the call itself keeps running. All reads
+  therefore share one serial queue, and while an abandoned read is still
+  outstanding the pass is skipped outright (`blocked`) instead of queueing
+  behind it — repeating the capture adds no work. Reads resume on their own
+  once the hung call returns.
 
 ```json
 { "command": "recordStart", "outPath": "/tmp/demo.mp4", "fps": 30 }

--- a/apple/runner/RUNNER_PROTOCOL.md
+++ b/apple/runner/RUNNER_PROTOCOL.md
@@ -27,9 +27,15 @@ Examples:
   "interactiveOnly": true,
   "depth": 2,
   "scope": "app",
-  "raw": false
+  "raw": false,
+  "customActions": false
 }
 ```
+
+`customActions` asks the capture to name each merged element's
+`UIAccessibilityCustomAction`s in a node's `actions` array. It pins the
+private-AX backend (no other backend can read them) and costs one accessibility
+round trip per merged element, so it is opt-in.
 
 ```json
 { "command": "recordStart", "outPath": "/tmp/demo.mp4", "fps": 30 }

--- a/packages/contracts/src/cli-flags.ts
+++ b/packages/contracts/src/cli-flags.ts
@@ -77,6 +77,7 @@ export type CliFlags = CloudProviderProfileFields &
     snapshotDepth?: number;
     snapshotScope?: string;
     snapshotRaw?: boolean;
+    snapshotCustomActions?: boolean;
     snapshotForceFull?: boolean;
     artifact?: string;
     dsym?: string;

--- a/packages/contracts/src/client-capture.ts
+++ b/packages/contracts/src/client-capture.ts
@@ -22,6 +22,8 @@ export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
     depth?: number;
     scope?: string;
     raw?: boolean;
+    /** List accessibility custom actions on merged elements (iOS simulator). */
+    customActions?: boolean;
     forceFull?: boolean;
     timeoutMs?: number;
     /**

--- a/packages/contracts/src/client-request.ts
+++ b/packages/contracts/src/client-request.ts
@@ -28,6 +28,7 @@ export type CommandExecutionOptions = Partial<ScreenshotRequestFlags> & {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  customActions?: boolean;
   forceFull?: boolean;
   count?: number;
   fps?: number;

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -41,7 +41,7 @@ export type SnapshotQualityVerdict = {
    * unread element is indistinguishable from one with no actions, so a partial
    * pass has to be disclosed rather than left to look complete.
    */
-  customActions?: { read: number; candidates: number; truncated: number };
+  customActions?: { read: number; candidates: number; truncated: number; blocked: boolean };
 };
 
 export type Rect = {

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -21,13 +21,18 @@ export type SnapshotQualityVerdict = {
   reason?: string;
   // 'deferred' = the penalty circuit breaker pre-selected a non-XCTest backend; nothing new
   // degraded on THIS capture (no repeated warning, no settle budget reset).
+  // 'requested-backend' = the REQUEST pre-selected it (e.g. `snapshot --actions`,
+  // which only the private-AX backend can serve). Nothing degraded at all, so it
+  // must never surface as a degradation — not even through the one-shot latch
+  // that exists to catch internally-armed penalties.
   reasonCode?:
     | 'ax-rejected'
     | 'sparse-tree'
     | 'budget'
     | 'no-nodes'
     | 'capture-failed'
-    | 'deferred';
+    | 'deferred'
+    | 'requested-backend';
   effectiveDepth?: number;
   collapsedLeafIndexes?: number[];
 };
@@ -56,6 +61,12 @@ export type SnapshotOptions = {
    * captured the way its baseline was.
    */
   preferredBackend?: 'private-ax';
+  /**
+   * Read accessibility custom actions for elements that merge their children
+   * away. Opt-in because each such element costs its own accessibility round
+   * trip; see `RawSnapshotNode.actions`.
+   */
+  customActions?: boolean;
 };
 
 export type SnapshotPresentationFlagInput = {
@@ -63,6 +74,7 @@ export type SnapshotPresentationFlagInput = {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotCustomActions?: boolean;
 };
 
 export type RawSnapshotNode = {
@@ -90,6 +102,14 @@ export type RawSnapshotNode = {
   hiddenContentBelow?: boolean;
   interactionBlocked?: 'covered';
   presentationHints?: string[];
+  /**
+   * Accessibility custom actions the element exposes (iOS
+   * `UIAccessibilityCustomAction`, React Native `accessibilityActions`). Merged
+   * cards publish their real affordances here instead of as child elements, so
+   * this is often the only evidence that a collapsed node has any. Populated by
+   * opt-in captures only — see `snapshot --actions`.
+   */
+  actions?: string[];
 };
 
 export type HiddenContentHint = {

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -35,6 +35,13 @@ export type SnapshotQualityVerdict = {
     | 'requested-backend';
   effectiveDepth?: number;
   collapsedLeafIndexes?: number[];
+  /**
+   * Coverage of an opt-in custom-action pass (`snapshot --actions`): how many
+   * merged elements were eligible and how many the bounded pass reached. An
+   * unread element is indistinguishable from one with no actions, so a partial
+   * pass has to be disclosed rather than left to look complete.
+   */
+  customActions?: { read: number; candidates: number };
 };
 
 export type Rect = {

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -41,7 +41,7 @@ export type SnapshotQualityVerdict = {
    * unread element is indistinguishable from one with no actions, so a partial
    * pass has to be disclosed rather than left to look complete.
    */
-  customActions?: { read: number; candidates: number };
+  customActions?: { read: number; candidates: number; truncated: number };
 };
 
 export type Rect = {
@@ -253,6 +253,10 @@ export function buildSnapshotPresentationKey(flags: SnapshotOptions | undefined)
     depth: typeof flags?.depth === 'number' ? flags.depth : null,
     scope: flags?.scope?.trim() || null,
     raw: flags?.raw === true,
+    // A capture that asked for custom actions is not the same presentation as
+    // one that did not: without this, 'snapshot' then 'snapshot --actions' on a
+    // still screen reports 'unchanged' and never delivers what was asked for.
+    customActions: flags?.customActions === true,
   });
 }
 
@@ -265,6 +269,7 @@ export function snapshotPresentationOptionsFromFlags(
     interactiveOnly: flags.snapshotInteractiveOnly,
     raw: flags.snapshotRaw,
     scope: flags.snapshotScope,
+    customActions: flags.snapshotCustomActions,
   };
 }
 

--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -350,6 +350,17 @@ function summarizeProviderScenarioFlagExclusions() {
       owner: 'iOS platform and screenshot-diff runtime tests',
       keys: ['screenshotNormalizeStatusBar', 'screenshotPixelDensity'],
     },
+    {
+      // Reading accessibility custom actions has no provider-scenario surface:
+      // the values come from the private AX client inside the runner process,
+      // and the fake runner derives its behavior from fixture tables that
+      // cannot fabricate them. Covered instead by the runner's XCTest unit
+      // bundle (option→backend-pin projection, node carry, coverage counting
+      // and disclosure) plus TS presentation and quality-verdict tests.
+      name: 'Apple simulator private-AX capture options',
+      owner: 'runner XCTest unit, snapshot-lines, and snapshot-quality tests',
+      keys: ['snapshotCustomActions'],
+    },
   ];
 }
 

--- a/src/cli-schema/cli-config.ts
+++ b/src/cli-schema/cli-config.ts
@@ -66,6 +66,7 @@ const PROJECT_CONFIG_FLAG_KEYS = new Set<FlagKey>([
   'snapshotDepth',
   'snapshotScope',
   'snapshotRaw',
+  'snapshotCustomActions',
   'snapshotForceFull',
   'screenshotPixelDensity',
   'screenshotFullscreen',

--- a/src/commands/capture/index.test.ts
+++ b/src/commands/capture/index.test.ts
@@ -31,6 +31,7 @@ describe('capture command interface', () => {
           snapshotDepth: 3,
           snapshotScope: 'Login',
           snapshotRaw: true,
+          snapshotCustomActions: true,
           snapshotForceFull: true,
           timeoutMs: 10_000,
         }),
@@ -40,6 +41,7 @@ describe('capture command interface', () => {
       depth: 3,
       scope: 'Login',
       raw: true,
+      customActions: true,
       forceFull: true,
       timeoutMs: 10_000,
     });

--- a/src/commands/capture/runtime/snapshot-unchanged.ts
+++ b/src/commands/capture/runtime/snapshot-unchanged.ts
@@ -102,6 +102,7 @@ function buildComparableSnapshotPresentation(
     hiddenContentBelow: node.hiddenContentBelow,
     interactionBlocked: node.interactionBlocked,
     presentationHints: node.presentationHints,
+    actions: node.actions,
   }));
 }
 

--- a/src/commands/capture/runtime/snapshot.test.ts
+++ b/src/commands/capture/runtime/snapshot.test.ts
@@ -68,11 +68,16 @@ test('runtime snapshot forwards interactive capture options', async () => {
 
   assert.equal(observedOptions?.interactiveOnly, true);
   assert.deepEqual(observedOptions, {
+    customActions: undefined,
     depth: undefined,
     interactiveOnly: true,
     raw: undefined,
     scope: undefined,
   });
+
+  await device.capture.snapshot({ session: 'default', interactiveOnly: true, customActions: true });
+
+  assert.equal(observedOptions?.customActions, true);
 });
 
 test('runtime diff snapshot initializes and then compares against session baseline', async () => {

--- a/src/commands/capture/runtime/snapshot.ts
+++ b/src/commands/capture/runtime/snapshot.ts
@@ -151,6 +151,7 @@ async function captureRuntimeSnapshot(
       depth: options.depth,
       scope: options.scope,
       raw: options.raw,
+      customActions: options.customActions,
     },
   );
   const snapshot = ensureSnapshotPresentationKey(

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -25,6 +25,9 @@ const snapshotCommandMetadata = defineFieldCommandMetadata(
     depth: integerField(),
     scope: stringField(),
     raw: booleanField(),
+    customActions: booleanField(
+      'List accessibility custom actions (iOS UIAccessibilityCustomAction, React Native accessibilityActions) on elements that merge their children away. iOS simulator only; costs one accessibility round trip per merged element.',
+    ),
     forceFull: booleanField(),
     timeoutMs: integerField('Maximum wall-clock time for the snapshot command.'),
     // #1271 stage 2: `snapshot` is observation-only, so a repair-armed heal
@@ -45,8 +48,15 @@ const snapshotCommandDefinition = defineExecutableCommand(
 
 const snapshotCliSchema = {
   usageOverride:
-    'snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw] [--force-full] [--timeout <ms>]',
-  allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS, 'snapshotForceFull', 'timeoutMs', 'record'],
+    'snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw] [--actions] [--force-full] [--timeout <ms>]',
+  allowedFlags: [
+    'snapshotDiff',
+    ...SNAPSHOT_FLAGS,
+    'snapshotCustomActions',
+    'snapshotForceFull',
+    'timeoutMs',
+    'record',
+  ],
 } as const;
 
 export const snapshotCliReader: CliReader = (_positionals, flags) => ({
@@ -56,6 +66,7 @@ export const snapshotCliReader: CliReader = (_positionals, flags) => ({
   depth: flags.snapshotDepth,
   scope: flags.snapshotScope,
   raw: flags.snapshotRaw,
+  customActions: flags.snapshotCustomActions,
   forceFull: flags.snapshotForceFull,
   timeoutMs: flags.timeoutMs,
 });

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -26,7 +26,7 @@ const snapshotCommandMetadata = defineFieldCommandMetadata(
     scope: stringField(),
     raw: booleanField(),
     customActions: booleanField(
-      'List accessibility custom actions (iOS UIAccessibilityCustomAction, React Native accessibilityActions) on elements that merge their children away. iOS simulator only; costs one accessibility round trip per merged element.',
+      'Name the affordances an element merged away (iOS UIAccessibilityCustomAction, React Native accessibilityActions) — a card whose reply/options controls are not separate elements still lists them here. The names are for PLANNING, not invocation: there is no API to trigger them, so reach the affordance through the element detail screen, through the same control exposed as a labeled element elsewhere, or by coordinates from its rect. iOS simulator only; costs one accessibility round trip per merged element.',
     ),
     forceFull: booleanField(),
     timeoutMs: integerField('Maximum wall-clock time for the snapshot command.'),

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -204,7 +204,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     names: ['--actions'],
     type: 'boolean',
     usageLabel: '--actions',
-    usageDescription: 'Snapshot: list accessibility custom actions on merged elements (iOS sim)',
+    usageDescription:
+      'Snapshot: name the affordances merged inside an element (iOS sim); not directly invokable — reach them via the detail screen, labeled children, or coordinates',
   },
   {
     key: 'snapshotForceFull',

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -200,6 +200,13 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription: 'Snapshot: raw node output',
   },
   {
+    key: 'snapshotCustomActions',
+    names: ['--actions'],
+    type: 'boolean',
+    usageLabel: '--actions',
+    usageDescription: 'Snapshot: list accessibility custom actions on merged elements (iOS sim)',
+  },
+  {
     key: 'snapshotForceFull',
     names: ['--force-full'],
     type: 'boolean',

--- a/src/commands/command-flags.ts
+++ b/src/commands/command-flags.ts
@@ -70,6 +70,7 @@ function buildFlags(options: InternalRequestOptions): CommandFlags {
     snapshotDepth: options.depth,
     snapshotScope: options.scope,
     snapshotRaw: options.raw,
+    snapshotCustomActions: options.customActions,
     snapshotForceFull: options.forceFull,
     ...screenshotFlagsFromOptions(options),
     appsFilter: options.appsFilter,

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -62,6 +62,7 @@ export type SnapshotCommandOptions = CommandContext & {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  customActions?: boolean;
   forceFull?: boolean;
 };
 

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -36,6 +36,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotCustomActions?: boolean;
   snapshotIncludeRects?: boolean;
   snapshotIncludeHiddenContentHints?: boolean;
   skipIosSimulatorBootCheck?: boolean;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -657,6 +657,7 @@ async function handleSnapshotCommand(
     depth: snapshotContext.snapshotDepth,
     scope: snapshotContext.snapshotScope,
     raw: snapshotContext.snapshotRaw,
+    customActions: snapshotContext.snapshotCustomActions,
     includeRects: snapshotContext.snapshotIncludeRects,
     includeHiddenContentHints: snapshotContext.snapshotIncludeHiddenContentHints,
     surface: snapshotContext.surface,

--- a/src/daemon/__tests__/request-router-custom-action-flags.test.ts
+++ b/src/daemon/__tests__/request-router-custom-action-flags.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `--actions` reads custom actions through the private-AX snapshot path, which
+ * a raw capture does not use. Answering the pair with a capture that
+ * structurally cannot carry actions would silently no-op a requested
+ * capability, so it is rejected at the shared request seam — before any
+ * session or device work, which is why no device setup is needed here.
+ */
+import { test, expect } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import { createRequestHandler } from '../request-router.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+
+function createHandler() {
+  return createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore: makeSessionStore('agent-device-router-custom-action-flags-'),
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+test('--actions with --raw is rejected as INVALID_ARGS before any command runs', async () => {
+  const response = await createHandler()({
+    token: 'test-token',
+    session: 'default',
+    command: 'snapshot',
+    positionals: [],
+    flags: { snapshotCustomActions: true, snapshotRaw: true },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toMatch(/--actions and --raw are mutually exclusive/);
+});
+
+test('--actions alone is not rejected by the pairing check', async () => {
+  const response = await createHandler()({
+    token: 'test-token',
+    session: 'default',
+    command: 'get',
+    positionals: ['attrs', '@e1'],
+    flags: { snapshotCustomActions: true },
+  });
+
+  // Fails downstream on the missing session — but not on the pair. (The guard
+  // is flag-scoped, so any command exercises it; a ref get fails fast.)
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.message).not.toMatch(/mutually exclusive/);
+});
+
+test('--raw alone is untouched by the guard', async () => {
+  const response = await createHandler()({
+    token: 'test-token',
+    session: 'default',
+    command: 'get',
+    positionals: ['attrs', '@e1'],
+    flags: { snapshotRaw: true },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.message).not.toMatch(/mutually exclusive/);
+});

--- a/src/daemon/__tests__/snapshot-custom-actions-platform-guard.test.ts
+++ b/src/daemon/__tests__/snapshot-custom-actions-platform-guard.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Custom actions are read through the private-AX snapshot backend, which only
+ * the iOS simulator has. Every other target would accept `--actions`, take an
+ * ordinary capture, and return nodes with no `actions` — indistinguishable from
+ * "this screen has no custom actions". The guard runs after the session device
+ * is resolved but before any device work, so a seeded session exercises it
+ * without a real device.
+ */
+import { test, expect } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { createRequestHandler } from '../request-router.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import type { SessionState } from '../types.ts';
+
+function handlerForDevice(device: DeviceInfo) {
+  const sessionStore = makeSessionStore('agent-device-custom-actions-guard-');
+  sessionStore.set('default', {
+    name: 'default',
+    device,
+    appBundleId: 'com.example.app',
+  } as SessionState);
+  return createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+async function snapshotWithActions(device: DeviceInfo) {
+  return await handlerForDevice(device)({
+    token: 'test-token',
+    session: 'default',
+    command: 'snapshot',
+    positionals: [],
+    flags: { snapshotCustomActions: true, snapshotInteractiveOnly: true },
+  });
+}
+
+const nonSimulatorTargets: DeviceInfo[] = [
+  { platform: 'android', id: 'emulator-5554', name: 'Pixel', kind: 'emulator' },
+  { platform: 'android', id: 'ABC123', name: 'Pixel 9', kind: 'device' },
+  { platform: 'apple', id: 'mac', name: 'Mac', kind: 'device', appleOs: 'macos' },
+  // An iOS PHYSICAL device is the subtle one: iOS family, but no private-AX backend.
+  { platform: 'apple', id: 'udid', name: 'iPhone', kind: 'device', appleOs: 'ios' },
+  { platform: 'linux', id: 'local', name: 'Linux', kind: 'device' },
+  { platform: 'web', id: 'chrome', name: 'Chrome', kind: 'device' },
+];
+
+for (const device of nonSimulatorTargets) {
+  test(`--actions is refused on ${device.platform}/${device.kind}/${device.appleOs ?? '-'}`, async () => {
+    const response = await snapshotWithActions(device);
+
+    expect(response.ok).toBe(false);
+    if (response.ok) return;
+    expect(response.error.code).toBe('UNSUPPORTED_OPERATION');
+    expect(response.error.message).toMatch(/--actions requires an iOS simulator/);
+    // The message has to name the target, or the caller cannot tell which half
+    // of the request was impossible.
+    expect(response.error.message).toContain(device.platform);
+  });
+}
+
+test('--actions is not refused on an iOS simulator', async () => {
+  const response = await snapshotWithActions({
+    platform: 'apple',
+    id: 'sim-udid',
+    name: 'iPhone 17 Pro',
+    kind: 'simulator',
+    appleOs: 'ios',
+  });
+
+  // It fails later (no real runner behind this seeded session), but never on
+  // the platform guard.
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.message).not.toMatch(/requires an iOS simulator/);
+});

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -43,6 +43,7 @@ export function contextFromFlags(
     snapshotDepth: flags?.snapshotDepth,
     snapshotScope: flags?.snapshotScope,
     snapshotRaw: flags?.snapshotRaw,
+    snapshotCustomActions: flags?.snapshotCustomActions,
     snapshotIncludeHiddenContentHints: flags?.snapshotIncludeHiddenContentHints,
     ...screenshotFlagsFromOptions(flags),
     count: flags?.count,

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -149,6 +149,8 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
     registerParameterizedFillDiagnosticValue(req);
     const invalidRecordingFlags = recordingFlagsResponse(req);
     if (invalidRecordingFlags) return invalidRecordingFlags;
+    const invalidCustomActionFlags = customActionFlagsResponse(req);
+    if (invalidCustomActionFlags) return invalidCustomActionFlags;
     // #1478: raw `flags.saveScript` on a non-owner command never reaches
     // admission, device work, or a handler that could arm publication.
     const unsupportedSaveScript = unsupportedSaveScriptFlagResponse(req);
@@ -332,6 +334,25 @@ function recordingFlagsResponse(req: DaemonRequest): DaemonResponse | undefined 
   if (req.flags?.record && req.flags?.noRecord) return mutuallyExclusiveRecordFlagsResponse();
   if (req.flags?.recordAs !== undefined && req.command !== 'fill') {
     return errorResponse('INVALID_ARGS', '--record-as is supported only by fill.');
+  }
+  return undefined;
+}
+
+/**
+ * `--actions` reads custom actions through the private-AX snapshot path, which
+ * a raw capture deliberately does not take (ADR 0004: raw preserves the tree
+ * backend's own errors). Asking for both is a contradiction, and answering it
+ * with a capture that structurally cannot carry actions would be a requested
+ * capability silently no-opped. Rejected at the request seam so CLI, Node
+ * client, and MCP all get the same answer before any device work.
+ */
+function customActionFlagsResponse(req: DaemonRequest): DaemonResponse | undefined {
+  if (req.flags?.snapshotCustomActions !== true) return undefined;
+  if (req.flags?.snapshotRaw === true) {
+    return errorResponse(
+      'INVALID_ARGS',
+      '--actions and --raw are mutually exclusive: custom actions are only readable through the private-AX snapshot path, which a raw capture does not use.',
+    );
   }
   return undefined;
 }

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -199,6 +199,7 @@ const SANITIZED_FLAG_KEYS = [
   'snapshotDepth',
   'snapshotScope',
   'snapshotRaw',
+  'snapshotCustomActions',
   ...SCREENSHOT_ACTION_FLAG_KEYS,
   'relaunch',
   'saveScript',

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -318,6 +318,7 @@ const SAFE_ACTION_FLAG_SPECS: Record<string, SafeFlagSpec> = {
       { source: 'snapshotInteractiveOnly', output: 'interactiveOnly' },
       { source: 'snapshotDiff', output: 'diff' },
       { source: 'snapshotRaw', output: 'raw' },
+      { source: 'snapshotCustomActions', output: 'actions' },
       { source: 'snapshotForceFull', output: 'forceFull' },
     ],
     numbers: [{ source: 'snapshotDepth', output: 'depth' }],

--- a/src/daemon/snapshot-quality-latch.ts
+++ b/src/daemon/snapshot-quality-latch.ts
@@ -45,6 +45,9 @@ export function resolveRecoveredWarningLatch(params: {
   if (!verdict) return { latch };
   if (verdict.state === 'healthy') return { latch: undefined };
   if (verdict.state !== 'recovered') return { latch };
+  // A request-pinned backend never degraded anything, so it neither warns nor
+  // touches the penalty latch.
+  if (verdict.reasonCode === 'requested-backend') return { latch };
   if (verdict.reasonCode !== 'deferred') {
     return { latch: { appBundleId } };
   }

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -48,6 +48,7 @@ export async function dispatchSnapshotViaRuntime(params: {
         depth: req.flags?.snapshotDepth,
         scope: snapshotScope,
         raw: req.flags?.snapshotRaw,
+        customActions: req.flags?.snapshotCustomActions,
         forceFull: req.flags?.snapshotForceFull,
       });
       // #1076 versioned refs: the snapshot response is a ref-issuing response,

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -4,7 +4,7 @@ import {
   type SnapshotDiffSummary,
 } from '@agent-device/contracts/capture';
 import { stripAndroidSystemChromeProvenance } from '@agent-device/contracts/platform';
-import { isIosFamily, publicPlatformString } from '@agent-device/kernel/device';
+import { isIosFamily, publicPlatformString, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import type { CommandSessionRecord } from '../runtime.ts';
@@ -19,6 +19,7 @@ import {
   resolveSessionDevice,
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
+import { isIosSimulator } from './device-targets.ts';
 import { activateCompleteRefFrame } from './ref-frame.ts';
 import {
   applyRecoveredWarningLatch,
@@ -147,6 +148,11 @@ async function dispatchSnapshotRuntimeCommand(
   if (unsupported) return unsupported;
   const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
   if (!resolvedScope.ok) return resolvedScope;
+  // Pure flags+device, so it answers before the session precondition: otherwise
+  // --actions on an iOS physical device costs a round trip ("run open first")
+  // before reporting that the flag is unserviceable there at all.
+  const customActionsGuard = requireCustomActionsSupported(req, device);
+  if (customActionsGuard) return customActionsGuard;
   const iosAppSessionGuard = await requireIosAppSessionForSnapshot(params.command, session, device);
   if (iosAppSessionGuard) return iosAppSessionGuard;
 
@@ -197,6 +203,29 @@ async function dispatchSnapshotRuntimeCommand(
       }),
     };
   });
+}
+
+/**
+ * Custom actions come from the private-AX snapshot backend, which only exists
+ * on the iOS simulator. Every other target would accept the flag, take a normal
+ * capture, and return nodes with no `actions` — indistinguishable from "this
+ * screen has no custom actions". Refuse instead, naming the resolved target so
+ * the caller knows which half of the request was impossible.
+ */
+function requireCustomActionsSupported(
+  req: DaemonRequest,
+  device: DeviceInfo,
+): DaemonResponse | null {
+  if (req.flags?.snapshotCustomActions !== true || isIosSimulator(device)) {
+    return null;
+  }
+  return errorResponse(
+    'UNSUPPORTED_OPERATION',
+    `--actions requires an iOS simulator: custom actions are read through the private accessibility snapshot backend, which ${device.platform}/${device.kind} targets do not have.`,
+    {
+      hint: 'Re-run without --actions, or target an iOS simulator.',
+    },
+  );
 }
 
 /**

--- a/src/platforms/apple/core/runner/runner-contract.ts
+++ b/src/platforms/apple/core/runner/runner-contract.ts
@@ -93,6 +93,12 @@ export type RunnerCommand = {
   interactiveOnly?: boolean;
   /** Pin the snapshot capture backend (same-backend evidence probes). */
   preferredBackend?: 'private-ax';
+  /**
+   * Read accessibility custom actions for merged leaves. Opt-in: each element
+   * costs its own AX round trip, and the runner pins the private-AX backend
+   * because no other backend can carry them.
+   */
+  customActions?: boolean;
   depth?: number;
   scope?: string;
   raw?: boolean;

--- a/src/platforms/apple/interactor.ts
+++ b/src/platforms/apple/interactor.ts
@@ -73,6 +73,7 @@ export function createAppleInteractor(
                 appBundleId: options?.appBundleId,
                 interactiveOnly: options?.interactiveOnly,
                 preferredBackend: options?.preferredBackend,
+                customActions: options?.customActions,
                 depth: options?.depth,
                 scope: options?.scope,
                 raw: options?.raw,

--- a/src/snapshot/__tests__/snapshot-actions-identity.test.ts
+++ b/src/snapshot/__tests__/snapshot-actions-identity.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { buildSnapshotPresentationKey } from '@agent-device/kernel/snapshot';
+import type { SnapshotNode } from '@agent-device/kernel/snapshot';
+import { buildSnapshotDiff } from '../snapshot-diff.ts';
+
+function card(actions?: string[]): SnapshotNode {
+  return {
+    ref: 'e8',
+    index: 0,
+    depth: 0,
+    type: 'Link',
+    label: 'feedItem-by-whiskers.test',
+    enabled: true,
+    hittable: true,
+    ...(actions ? { actions } : {}),
+  };
+}
+
+test('an action-only change is a diff, not an unchanged line', () => {
+  const diff = buildSnapshotDiff([card(['Reply'])], [card(['Reply', 'Repost'])]);
+  const kinds = diff.lines.map((line) => line.kind);
+
+  // The rendered text already differs; the comparable key has to agree, or the
+  // line is reported unchanged while showing different content.
+  assert.equal(kinds.includes('unchanged'), false);
+  assert.equal(diff.summary.unchanged, 0);
+  assert.equal(diff.summary.additions + diff.summary.removals > 0, true);
+});
+
+test('gaining actions where there were none is a diff', () => {
+  const diff = buildSnapshotDiff([card()], [card(['Reply'])]);
+
+  assert.equal(
+    diff.lines.every((line) => line.kind !== 'unchanged'),
+    true,
+  );
+});
+
+test('identical actions still compare as unchanged', () => {
+  const diff = buildSnapshotDiff([card(['Reply', 'Repost'])], [card(['Reply', 'Repost'])]);
+
+  assert.equal(
+    diff.lines.every((line) => line.kind === 'unchanged'),
+    true,
+  );
+});
+
+test('asking for custom actions is a different presentation than not asking', () => {
+  // Otherwise `snapshot` then `snapshot --actions` on a still screen answers
+  // "unchanged" and never delivers the actions that were explicitly requested.
+  assert.notEqual(
+    buildSnapshotPresentationKey({ interactiveOnly: true }),
+    buildSnapshotPresentationKey({ interactiveOnly: true, customActions: true }),
+  );
+  assert.equal(
+    buildSnapshotPresentationKey({ interactiveOnly: true, customActions: false }),
+    buildSnapshotPresentationKey({ interactiveOnly: true }),
+  );
+});

--- a/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
+++ b/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { readSnapshotQualityVerdict, renderSnapshotQualityWarnings } from '../snapshot-quality.ts';
+
+const pinned = {
+  state: 'recovered',
+  backend: 'private-ax',
+  reasonCode: 'requested-backend',
+} as const;
+
+test('a capped custom-action pass discloses what it did not read', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    { ...pinned, customActions: { read: 12, candidates: 19 } },
+    [],
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /read for 12 of 19 merged elements/);
+  assert.match(warnings[0] ?? '', /remaining 7 were not read/);
+  // The point of the line: absence must not read as proof of absence.
+  assert.match(warnings[0] ?? '', /not evidence that they have none/);
+  assert.match(warnings[0] ?? '', /on-screen ones first/);
+  assert.match(warnings[0] ?? '', /Scroll them into view/);
+});
+
+test('a complete custom-action pass says nothing', () => {
+  assert.deepEqual(
+    renderSnapshotQualityWarnings({ ...pinned, customActions: { read: 19, candidates: 19 } }, []),
+    [],
+  );
+  // No merged elements at all is also complete.
+  assert.deepEqual(
+    renderSnapshotQualityWarnings({ ...pinned, customActions: { read: 0, candidates: 0 } }, []),
+    [],
+  );
+});
+
+test('a capture that never asked for actions has no coverage and no line', () => {
+  assert.deepEqual(renderSnapshotQualityWarnings(pinned, []), []);
+});
+
+test('the coverage pair survives verdict parsing, and half a pair does not', () => {
+  assert.deepEqual(
+    readSnapshotQualityVerdict({
+      state: 'recovered',
+      backend: 'private-ax',
+      customActions: { read: 12, candidates: 19 },
+    })?.customActions,
+    { read: 12, candidates: 19 },
+  );
+
+  // A ratio needs both sides; a partial object is dropped rather than half-read.
+  for (const customActions of [{ read: 12 }, { candidates: 19 }, { read: '12', candidates: 19 }]) {
+    assert.equal(
+      readSnapshotQualityVerdict({ state: 'recovered', backend: 'private-ax', customActions })
+        ?.customActions,
+      undefined,
+    );
+  }
+});
+
+test('the coverage line is independent of degradation state', () => {
+  // A healthy capture can still have hit the read cap.
+  const warnings = renderSnapshotQualityWarnings(
+    { state: 'healthy', backend: 'private-ax', customActions: { read: 3, candidates: 8 } },
+    [],
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /read for 3 of 8 merged elements/);
+});

--- a/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
+++ b/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
@@ -10,7 +10,7 @@ const pinned = {
 
 test('a capped custom-action pass discloses what it did not read', () => {
   const warnings = renderSnapshotQualityWarnings(
-    { ...pinned, customActions: { read: 12, candidates: 19 } },
+    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 0 } },
     [],
   );
 
@@ -25,12 +25,18 @@ test('a capped custom-action pass discloses what it did not read', () => {
 
 test('a complete custom-action pass says nothing', () => {
   assert.deepEqual(
-    renderSnapshotQualityWarnings({ ...pinned, customActions: { read: 19, candidates: 19 } }, []),
+    renderSnapshotQualityWarnings(
+      { ...pinned, customActions: { read: 19, candidates: 19, truncated: 0 } },
+      [],
+    ),
     [],
   );
   // No merged elements at all is also complete.
   assert.deepEqual(
-    renderSnapshotQualityWarnings({ ...pinned, customActions: { read: 0, candidates: 0 } }, []),
+    renderSnapshotQualityWarnings(
+      { ...pinned, customActions: { read: 0, candidates: 0, truncated: 0 } },
+      [],
+    ),
     [],
   );
 });
@@ -44,9 +50,9 @@ test('the coverage pair survives verdict parsing, and half a pair does not', () 
     readSnapshotQualityVerdict({
       state: 'recovered',
       backend: 'private-ax',
-      customActions: { read: 12, candidates: 19 },
+      customActions: { read: 12, candidates: 19, truncated: 0 },
     })?.customActions,
-    { read: 12, candidates: 19 },
+    { read: 12, candidates: 19, truncated: 0 },
   );
 
   // A ratio needs both sides; a partial object is dropped rather than half-read.
@@ -57,12 +63,48 @@ test('the coverage pair survives verdict parsing, and half a pair does not', () 
       undefined,
     );
   }
+
+  // The truncation count is additive, so an older runner that omits it keeps a
+  // usable ratio instead of voiding the whole coverage.
+  assert.deepEqual(
+    readSnapshotQualityVerdict({
+      state: 'recovered',
+      backend: 'private-ax',
+      customActions: { read: 12, candidates: 19 },
+    })?.customActions,
+    { read: 12, candidates: 19, truncated: 0 },
+  );
+});
+
+test('a clipped action list is disclosed even when every candidate was read', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    { ...pinned, customActions: { read: 19, candidates: 19, truncated: 2 } },
+    [],
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /2 element\(s\) published more custom actions than are shown/);
+});
+
+test('an incomplete pass that also clipped reports both, one line each', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 3 } },
+    [],
+  );
+
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0] ?? '', /read for 12 of 19 merged elements/);
+  assert.match(warnings[1] ?? '', /3 element\(s\) published more/);
 });
 
 test('the coverage line is independent of degradation state', () => {
   // A healthy capture can still have hit the read cap.
   const warnings = renderSnapshotQualityWarnings(
-    { state: 'healthy', backend: 'private-ax', customActions: { read: 3, candidates: 8 } },
+    {
+      state: 'healthy',
+      backend: 'private-ax',
+      customActions: { read: 3, candidates: 8, truncated: 0 },
+    },
     [],
   );
 

--- a/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
+++ b/src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts
@@ -10,7 +10,7 @@ const pinned = {
 
 test('a capped custom-action pass discloses what it did not read', () => {
   const warnings = renderSnapshotQualityWarnings(
-    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 0 } },
+    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 0, blocked: false } },
     [],
   );
 
@@ -26,7 +26,7 @@ test('a capped custom-action pass discloses what it did not read', () => {
 test('a complete custom-action pass says nothing', () => {
   assert.deepEqual(
     renderSnapshotQualityWarnings(
-      { ...pinned, customActions: { read: 19, candidates: 19, truncated: 0 } },
+      { ...pinned, customActions: { read: 19, candidates: 19, truncated: 0, blocked: false } },
       [],
     ),
     [],
@@ -34,10 +34,56 @@ test('a complete custom-action pass says nothing', () => {
   // No merged elements at all is also complete.
   assert.deepEqual(
     renderSnapshotQualityWarnings(
-      { ...pinned, customActions: { read: 0, candidates: 0, truncated: 0 } },
+      { ...pinned, customActions: { read: 0, candidates: 0, truncated: 0, blocked: false } },
       [],
     ),
     [],
+  );
+});
+
+test('a pass blocked by a hung read says so, and does not offer the scroll remedy', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    { ...pinned, customActions: { read: 0, candidates: 18, truncated: 0, blocked: true } },
+    [],
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /still hung/);
+  assert.match(warnings[0] ?? '', /skipped the read pass/);
+  // Scrolling cannot clear a hung read; borrowing the budget-stop remedy here
+  // would send the reader in circles.
+  assert.doesNotMatch(warnings[0] ?? '', /Scroll them into view/);
+  assert.doesNotMatch(warnings[0] ?? '', /0 of 18/);
+});
+
+test('blocked wins over the partial line rather than emitting both', () => {
+  // Both conditions are true when a hang stops the pass early, but the partial
+  // line's remedy is wrong here, so exactly one line is emitted.
+  const warnings = renderSnapshotQualityWarnings(
+    { ...pinned, customActions: { read: 3, candidates: 18, truncated: 0, blocked: true } },
+    [],
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /still hung/);
+});
+
+test('the blocked flag survives verdict parsing and defaults to false', () => {
+  assert.equal(
+    readSnapshotQualityVerdict({
+      state: 'recovered',
+      backend: 'private-ax',
+      customActions: { read: 0, candidates: 5, truncated: 0, blocked: true },
+    })?.customActions?.blocked,
+    true,
+  );
+  assert.equal(
+    readSnapshotQualityVerdict({
+      state: 'recovered',
+      backend: 'private-ax',
+      customActions: { read: 1, candidates: 5 },
+    })?.customActions?.blocked,
+    false,
   );
 });
 
@@ -50,9 +96,9 @@ test('the coverage pair survives verdict parsing, and half a pair does not', () 
     readSnapshotQualityVerdict({
       state: 'recovered',
       backend: 'private-ax',
-      customActions: { read: 12, candidates: 19, truncated: 0 },
+      customActions: { read: 12, candidates: 19, truncated: 0, blocked: false },
     })?.customActions,
-    { read: 12, candidates: 19, truncated: 0 },
+    { read: 12, candidates: 19, truncated: 0, blocked: false },
   );
 
   // A ratio needs both sides; a partial object is dropped rather than half-read.
@@ -72,13 +118,13 @@ test('the coverage pair survives verdict parsing, and half a pair does not', () 
       backend: 'private-ax',
       customActions: { read: 12, candidates: 19 },
     })?.customActions,
-    { read: 12, candidates: 19, truncated: 0 },
+    { read: 12, candidates: 19, truncated: 0, blocked: false },
   );
 });
 
 test('a clipped action list is disclosed even when every candidate was read', () => {
   const warnings = renderSnapshotQualityWarnings(
-    { ...pinned, customActions: { read: 19, candidates: 19, truncated: 2 } },
+    { ...pinned, customActions: { read: 19, candidates: 19, truncated: 2, blocked: false } },
     [],
   );
 
@@ -88,7 +134,7 @@ test('a clipped action list is disclosed even when every candidate was read', ()
 
 test('an incomplete pass that also clipped reports both, one line each', () => {
   const warnings = renderSnapshotQualityWarnings(
-    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 3 } },
+    { ...pinned, customActions: { read: 12, candidates: 19, truncated: 3, blocked: false } },
     [],
   );
 
@@ -103,7 +149,7 @@ test('the coverage line is independent of degradation state', () => {
     {
       state: 'healthy',
       backend: 'private-ax',
-      customActions: { read: 3, candidates: 8, truncated: 0 },
+      customActions: { read: 3, candidates: 8, truncated: 0, blocked: false },
     },
     [],
   );

--- a/src/snapshot/snapshot-diff.ts
+++ b/src/snapshot/snapshot-diff.ts
@@ -31,7 +31,14 @@ function snapshotNodeToComparableLine(node: SnapshotNode, depthOverride?: number
   const selectedPart = node.selected === true ? 'selected' : 'unselected';
   const hittablePart = node.hittable === true ? 'hittable' : 'not-hittable';
   const depthPart = String(depthOverride ?? node.depth ?? 0);
-  return [depthPart, role, textPart, enabledPart, selectedPart, hittablePart].join('|');
+  // The rendered line carries the actions list, so the comparable key has to as
+  // well: otherwise an action-only change diffs as 'unchanged' while its text
+  // silently differs from the baseline's. JSON-encoded because the names are
+  // app-authored and may contain the field separator.
+  const actionsPart = node.actions ? JSON.stringify(node.actions) : '';
+  return [depthPart, role, textPart, enabledPart, selectedPart, hittablePart, actionsPart].join(
+    '|',
+  );
 }
 
 export function buildSnapshotDiff(

--- a/src/snapshot/snapshot-lines.ts
+++ b/src/snapshot/snapshot-lines.ts
@@ -123,7 +123,24 @@ function formatCustomActions(node: SnapshotNode): string {
   if (!actions || actions.length === 0) {
     return '';
   }
-  return ` actions: [${actions.map((action) => `"${action}"`).join(', ')}]`;
+  // App-authored strings on a one-line-per-node surface: quotes and backslashes
+  // get the same escaping as text previews, and control characters collapse to
+  // spaces so a name containing a newline cannot split one node across lines.
+  return ` actions: [${actions
+    .map((action) => `"${escapePreviewText(collapseControlCharacters(action))}"`)
+    .join(', ')}]`;
+}
+
+function collapseControlCharacters(value: string): string {
+  return (
+    value
+      // Whitespace folds the way text previews already fold it (newlines, tabs).
+      .replace(/\s+/g, ' ')
+      // Remaining C0/C1 controls are zero-width but can still corrupt a terminal.
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\u0000-\u001f\u007f-\u009f]/g, '')
+      .trim()
+  );
 }
 
 export function displayLabel(node: SnapshotNode, type: string): string {

--- a/src/snapshot/snapshot-lines.ts
+++ b/src/snapshot/snapshot-lines.ts
@@ -105,10 +105,25 @@ export function formatSnapshotLine(
   }
   const metadataText = metadata.map((entry) => ` [${entry}]`).join('');
   const textPart = label ? ` "${label}"` : '';
+  const actionsText = formatCustomActions(node);
   if (hiddenGroup) {
-    return `${indent}${ref} [${type}]${metadataText}`.trimEnd();
+    return `${indent}${ref} [${type}]${metadataText}${actionsText}`.trimEnd();
   }
-  return `${indent}${ref} [${type}]${textPart}${metadataText}`.trimEnd();
+  return `${indent}${ref} [${type}]${textPart}${metadataText}${actionsText}`.trimEnd();
+}
+
+/**
+ * Accessibility custom actions render as a named list rather than bracketed
+ * metadata: they are the element's hidden affordances, and an agent reading the
+ * line needs the exact names it would have to match. Names only — activation
+ * points and identifiers are not actionable through any API we have.
+ */
+function formatCustomActions(node: SnapshotNode): string {
+  const actions = node.actions?.filter((action) => action.trim().length > 0);
+  if (!actions || actions.length === 0) {
+    return '';
+  }
+  return ` actions: [${actions.map((action) => `"${action}"`).join(', ')}]`;
 }
 
 export function displayLabel(node: SnapshotNode, type: string): string {

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -54,11 +54,25 @@ export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdi
       )
         ? (raw.reasonCode as SnapshotQualityVerdict['reasonCode'])
         : undefined,
+    customActions: readCustomActionCoverage(raw.customActions),
     effectiveDepth: typeof raw.effectiveDepth === 'number' ? raw.effectiveDepth : undefined,
     collapsedLeafIndexes: Array.isArray(raw.collapsedLeafIndexes)
       ? raw.collapsedLeafIndexes.filter((entry): entry is number => typeof entry === 'number')
       : undefined,
   };
+}
+
+/**
+ * A partial verdict is dropped rather than half-read: the whole point of the
+ * pair is the ratio, and a coverage object missing one side cannot express one.
+ */
+function readCustomActionCoverage(
+  value: unknown,
+): SnapshotQualityVerdict['customActions'] | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.read !== 'number' || typeof raw.candidates !== 'number') return undefined;
+  return { read: raw.read, candidates: raw.candidates };
 }
 
 export function isSparseSnapshotQualityVerdict(
@@ -74,8 +88,27 @@ export function renderSnapshotQualityWarnings(
 ): string[] {
   return [
     ...stateWarning(verdict),
+    ...customActionCoverageWarning(verdict),
     ...depthWarning(verdict),
     ...collapsedLeafWarnings(verdict, nodes),
+  ];
+}
+
+/**
+ * Disclosed at response level, once, and only when the pass was incomplete: a
+ * merged element the bounded pass never reached renders exactly like one with
+ * no custom actions, so staying silent would teach the reader that the rest of
+ * the list has no affordances — the mis-inference `--actions` exists to stop.
+ *
+ * The remedy is scrolling, not `--scope`: the runner reads on-screen elements
+ * first, and scope is applied after the read pass, so it cannot redirect the
+ * budget.
+ */
+function customActionCoverageWarning(verdict: SnapshotQualityVerdict): string[] {
+  const coverage = verdict.customActions;
+  if (!coverage || coverage.read >= coverage.candidates) return [];
+  return [
+    `Custom actions were read for ${coverage.read} of ${coverage.candidates} merged elements, on-screen ones first; the remaining ${coverage.candidates - coverage.read} were not read, so an absent actions list on those is not evidence that they have none. Scroll them into view and re-run to read them.`,
   ];
 }
 

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -20,6 +20,7 @@ const SNAPSHOT_QUALITY_REASON_CODES = new Set<NonNullable<SnapshotQualityVerdict
   'no-nodes',
   'capture-failed',
   'deferred',
+  'requested-backend',
 ]);
 
 export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdict | undefined {
@@ -95,7 +96,7 @@ function stateWarning(verdict: SnapshotQualityVerdict): string[] {
     // warning is suppressed here. When the capture that ARMED the penalty was internal
     // (selector resolution, settle observation, system-modal probe) and never rendered it,
     // the daemon's session latch re-renders the warning once at the response seam.
-    if (verdict.reasonCode === 'deferred') return [];
+    if (verdict.reasonCode === 'deferred' || verdict.reasonCode === 'requested-backend') return [];
     return [recoveredSnapshotQualityWarning(verdict.backend)];
   }
   if (verdict.state === 'sparse') {

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -72,7 +72,14 @@ function readCustomActionCoverage(
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
   if (typeof raw.read !== 'number' || typeof raw.candidates !== 'number') return undefined;
-  return { read: raw.read, candidates: raw.candidates };
+  // read/candidates are the ratio and must both be present; the truncation
+  // count is additive, so an older runner that omits it reads as zero rather
+  // than voiding the whole coverage.
+  return {
+    read: raw.read,
+    candidates: raw.candidates,
+    truncated: typeof raw.truncated === 'number' ? raw.truncated : 0,
+  };
 }
 
 export function isSparseSnapshotQualityVerdict(
@@ -106,10 +113,21 @@ export function renderSnapshotQualityWarnings(
  */
 function customActionCoverageWarning(verdict: SnapshotQualityVerdict): string[] {
   const coverage = verdict.customActions;
-  if (!coverage || coverage.read >= coverage.candidates) return [];
-  return [
-    `Custom actions were read for ${coverage.read} of ${coverage.candidates} merged elements, on-screen ones first; the remaining ${coverage.candidates - coverage.read} were not read, so an absent actions list on those is not evidence that they have none. Scroll them into view and re-run to read them.`,
-  ];
+  if (!coverage) return [];
+  const lines: string[] = [];
+  if (coverage.read < coverage.candidates) {
+    lines.push(
+      `Custom actions were read for ${coverage.read} of ${coverage.candidates} merged elements, on-screen ones first; the remaining ${coverage.candidates - coverage.read} were not read, so an absent actions list on those is not evidence that they have none. Scroll them into view and re-run to read them.`,
+    );
+  }
+  if (coverage.truncated > 0) {
+    // A clipped list looks complete, which is the same failure mode as an
+    // unread element, so it gets its own line rather than a silent cap.
+    lines.push(
+      `${coverage.truncated} element(s) published more custom actions than are shown; those lists are clipped to the first 8 names, and long names are shortened.`,
+    );
+  }
+  return lines;
 }
 
 /**

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -79,6 +79,7 @@ function readCustomActionCoverage(
     read: raw.read,
     candidates: raw.candidates,
     truncated: typeof raw.truncated === 'number' ? raw.truncated : 0,
+    blocked: raw.blocked === true,
   };
 }
 
@@ -115,7 +116,14 @@ function customActionCoverageWarning(verdict: SnapshotQualityVerdict): string[] 
   const coverage = verdict.customActions;
   if (!coverage) return [];
   const lines: string[] = [];
-  if (coverage.read < coverage.candidates) {
+  if (coverage.blocked) {
+    // Not a budget stop, so it must not borrow the budget stop's remedy:
+    // scrolling cannot clear a hung read, and telling the reader to try would
+    // send them in circles.
+    lines.push(
+      'Custom actions were not read: an earlier accessibility read is still hung, so this capture skipped the read pass instead of queueing behind it. No element’s actions list is authoritative here. Reads resume once that call returns.',
+    );
+  } else if (coverage.read < coverage.candidates) {
     lines.push(
       `Custom actions were read for ${coverage.read} of ${coverage.candidates} merged elements, on-screen ones first; the remaining ${coverage.candidates - coverage.read} were not read, so an absent actions list on those is not evidence that they have none. Scroll them into view and re-run to read them.`,
     );

--- a/src/utils/__tests__/snapshot-lines-custom-actions.test.ts
+++ b/src/utils/__tests__/snapshot-lines-custom-actions.test.ts
@@ -47,6 +47,24 @@ test('formatSnapshotLine omits the actions list when there is nothing to name', 
   }
 });
 
+test('formatSnapshotLine escapes app-authored names so they cannot corrupt the line', () => {
+  const line = formatSnapshotLine(
+    { ...mergedCard, actions: ['Say "hi"', 'C:\\path', 'Reply\nto post', 'Bell\u0007ring'] },
+    0,
+    false,
+    undefined,
+    { summarizeTextSurfaces: true },
+  );
+
+  // Quotes and backslashes escape; a newline folds to a space; a bare control
+  // character is dropped. The result stays exactly one line.
+  assert.equal(
+    line,
+    '@e72 [link] "feedItem-by-whiskers.test" actions: ["Say \\"hi\\"", "C:\\\\path", "Reply to post", "Bellring"]',
+  );
+  assert.equal(line.includes('\n'), false);
+});
+
 test('formatSnapshotLine still names actions on a hidden group, which has no label part', () => {
   const line = formatSnapshotLine({ ...mergedCard, actions: ['Reply'] }, 1, true, undefined, {
     summarizeTextSurfaces: true,

--- a/src/utils/__tests__/snapshot-lines-custom-actions.test.ts
+++ b/src/utils/__tests__/snapshot-lines-custom-actions.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
+
+const mergedCard = {
+  ref: 'e72',
+  index: 0,
+  depth: 0,
+  type: 'Link',
+  label: 'feedItem-by-whiskers.test',
+  enabled: true,
+};
+
+test('formatSnapshotLine names the custom actions a merged element hides', () => {
+  const line = formatSnapshotLine(
+    { ...mergedCard, actions: ['Reply', 'Repost', 'Open post options menu'] },
+    0,
+    false,
+    undefined,
+    { summarizeTextSurfaces: true },
+  );
+
+  assert.equal(
+    line,
+    '@e72 [link] "feedItem-by-whiskers.test" actions: ["Reply", "Repost", "Open post options menu"]',
+  );
+});
+
+test('formatSnapshotLine keeps actions after bracketed metadata', () => {
+  const line = formatSnapshotLine(
+    { ...mergedCard, enabled: false, actions: ['Reply'] },
+    0,
+    false,
+    undefined,
+    { summarizeTextSurfaces: true },
+  );
+
+  assert.equal(line, '@e72 [link] "feedItem-by-whiskers.test" [disabled] actions: ["Reply"]');
+});
+
+test('formatSnapshotLine omits the actions list when there is nothing to name', () => {
+  for (const actions of [undefined, [], ['', '   ']]) {
+    const line = formatSnapshotLine({ ...mergedCard, actions }, 0, false, undefined, {
+      summarizeTextSurfaces: true,
+    });
+    assert.equal(line, '@e72 [link] "feedItem-by-whiskers.test"');
+  }
+});
+
+test('formatSnapshotLine still names actions on a hidden group, which has no label part', () => {
+  const line = formatSnapshotLine({ ...mergedCard, actions: ['Reply'] }, 1, true, undefined, {
+    summarizeTextSurfaces: true,
+  });
+
+  assert.equal(line, '  @e72 [link] actions: ["Reply"]');
+});

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -14,7 +14,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
-    customActions: { read: 12, candidates: 19, truncated: 1 },
+    customActions: { read: 12, candidates: 19, truncated: 1, blocked: false },
   });
   assert.deepEqual(verdict, {
     state: 'recovered',
@@ -23,7 +23,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
-    customActions: { read: 12, candidates: 19, truncated: 1 },
+    customActions: { read: 12, candidates: 19, truncated: 1, blocked: false },
   });
 });
 

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -14,6 +14,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
+    customActions: { read: 12, candidates: 19 },
   });
   assert.deepEqual(verdict, {
     state: 'recovered',
@@ -22,6 +23,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
+    customActions: { read: 12, candidates: 19 },
   });
 });
 

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -14,7 +14,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
-    customActions: { read: 12, candidates: 19 },
+    customActions: { read: 12, candidates: 19, truncated: 1 },
   });
   assert.deepEqual(verdict, {
     state: 'recovered',
@@ -23,7 +23,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     reasonCode: 'budget',
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
-    customActions: { read: 12, candidates: 19 },
+    customActions: { read: 12, candidates: 19, truncated: 1 },
   });
 });
 


### PR DESCRIPTION
## The problem

SWM AppControlBench evidence: Bluesky's feed cards collapse into ONE accessibility element (`feedItem-by-whiskers.test`). The ellipsis/options button, reply button and inline hashtag links are not children in our snapshot, so models fall into coordinate-guessing loops — tap hits the image, media viewer opens, back, retry — and four tasks burned 330–720s each. A competing tool surfaced the options control on the same screen and finished in 3 calls / 19s.

The affordances are not missing, they are just not children. Apps that merge a card for VoiceOver publish its sub-actions as `UIAccessibilityCustomAction`s — which is exactly what React Native's `accessibilityActions` prop compiles to. Bluesky's post-DETAIL screen exposes "Open post options menu" as a real labeled button; the feed card merges it away.

## What ships

`snapshot --actions` names the actions a merged element hides:

```
@e8 [link] "feedItem-by-whiskers.test" actions: ["Reply", "Repost", "Open post options menu"]
```

Names only, one line, no extra nesting. An agent that reads this stops guessing that the card is a single opaque tap target.

## Phase 1 — feasibility findings

Probed live inside the runner process against `XCUIDevice.accessibilityInterface` (`XCAXClient_iOS`) on iOS 26.2 / Xcode 26.2.

**Reading: feasible.** The AX server does expose them. `XCTAutomationSupport` declares `XC_kAXXCAttributeCustomActions`, and `-[XCAXClient_iOS attributesForElement:attributes:error:]` returns, per merged element, an array of dictionaries:

```
CustomActionIdentifier = "Name:Reply\nTarget:0x0\nSelector:(null)";
CustomActionName = Reply;
CustomActionActivationPoint = { X = 0; Y = 0; };
CustomActionSortPriority = 0;
```

`CustomActionActivationPoint` is `(0,0)` for actions created the ordinary way, so there is no position to expose — the names are the actionable part.

**Reading in bulk: NOT feasible.** Adding the attribute to the bulk `requestSnapshotForElement:attributes:parameters:error:` request does not merely slow it down, it breaks the reply:

```
BULK pass=0 (without) ok=1 ms=111
BULK pass=1 (with)    ok=0 ms=65068  err=Timed out while fetching snapshot from testmanagerd..

[xpc.exceptions] Exception caught during decoding of reply to message
'_XCT_fetchSnapshotForElement:attributes:parameters:reply:', dropping incoming message
Exception: value for key 'NS.objects' was of unexpected class 'NSArray'
Allowed classes are: NSValue, NSDictionary, NSNumber, NSString
```

XCTest's reply decoder has an NSSecureCoding allowlist without `NSArray`, so a reply carrying custom actions is dropped and the request times out. This is why the implementation reads one element at a time (~100ms each, a different XPC message that decodes fine) rather than asking for the attribute in the tree request.

**Invocation: NOT feasible from the runner.** Five distinct routes, all closed:

| Route | Result |
| --- | --- |
| `XCUIElement` public/private API | no custom-action method exists |
| `-[XCAXClient_iOS performAction:onElement:value:error:]` | wants an `XCUIAccessibilityAction` (`initWithAXAction:` + `actionNumber`); every AX action number swept returned `kAXErrorCannotComplete`, with the action dict, its identifier string, and its name as `value:` |
| `-[XCAXClient_iOS setAttribute:value:element:outError:]` on the custom-actions attribute | returns success for every value shape and does nothing (status label unchanged) |
| `-[XCAXClient_iOS parameterizedAttribute:forElement:parameter:error:]` | `kAXErrorNoValue` ("copying parameterized attribute 2036") |
| raw `AXUIElementPerformAction` / `AXUIElementSetAttributeValue` | reachable via `dlsym`, but unusable: a snapshot's `XCAccessibilityElement` is token-based and answers `nil` for `AXUIElement`, and an element rebuilt with `_AXUIElementCreateWithPIDAndID(pid, elementID)` answers `kAXErrorInvalidUIElement` (-25202) |

So this PR ships the read half. `RunnerAXSnapshotBridge.h` records the table above next to the code so the next person does not re-derive it. If invocation becomes possible, `press @ref --action "<name>"` is the natural follow-up and the names shipped here are already the matching key.

**Fixture used.** A 120-line UIKit app compiled with `swiftc` and installed with `simctl` (`dev.agentdevice.axfixture`): two cards that set `isAccessibilityElement = true` on a container holding real Reply/Repost/••• buttons, each card carrying three `UIAccessibilityCustomAction`s, plus a status label that records the last invoked action. This is the same shape RN emits, it is deterministic, and it needs no Metro. The repo has no iOS fixture app with custom actions (the only Xcode project is the runner's own host app), and stock apps do not give a controllable oracle.

## Before / after (live, iOS 26.2 simulator, repo CLI)

Same app, same screen, one session.

```
$ node bin/agent-device.mjs snapshot -i
Snapshot: 6 nodes
@e1 [application] "AXFixture"
@e2 [window]
@e3 [other] "last action: none"
@e4 [link] "feedItem-by-whiskers.test"
@e5 [link] "feedItem-by-otter.test"
@e6 [button] "Plain button"
```

The merged card is a dead end — three real controls inside it, none reachable.

```
$ node bin/agent-device.mjs snapshot -i --actions
Snapshot: 10 nodes (truncated)
@e1 [application] "AXFixture"
@e2 [window]
@e3 [other]
@e4 [other]
@e5 [other]
@e6 [other]
@e7 [text] "last action: none"
@e8 [link] "feedItem-by-whiskers.test" actions: ["Reply", "Repost", "Open post options menu"]
@e9 [link] "feedItem-by-otter.test" actions: ["Reply", "Repost", "Open post options menu"]
@e10 [button] "Plain button"
```

Verdict on that capture, showing the pin does not read as a degradation:

```json
{"state":"recovered","backend":"private-ax",
 "reason":"the private AX backend was selected because this capture asked for accessibility custom actions",
 "reasonCode":"requested-backend"}
```

Runner log for the same capture — the bound is real and the read set is small:

```
AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=4 annotated=2 candidates=4
```

Cost, same screen, back to back: `snapshot -i` 0.24s / 0.66s, `snapshot -i --actions` 0.91s / 0.91s. The node-count and shape difference between the two outputs is the backend difference (private-AX presents the tree differently from the XCTest tree backend), not the actions read.

## Disclosing a capped pass

The read budget (12 elements) is smaller than a long feed's card count, and an element the pass never reached renders **byte-identically** to one with no custom actions. Silence there would teach a reader that the rest of the feed has no affordances — precisely the mis-inference this feature exists to prevent. So the runner carries `read`/`candidates` into the quality verdict and the response renders one line when the pass was incomplete:

```
$ node bin/agent-device.mjs snapshot -i --actions      # 16-card scrollable fixture
Snapshot: 13 nodes (truncated)
Custom actions were read for 12 of 18 merged elements, on-screen ones first; the remaining 6 were
not read, so an absent actions list on those is not evidence that they have none. Scroll them into
view and re-run to read them.
@e8  [link] "feedItem-by-whiskers.test" actions: ["Reply", "Repost", "Open post options menu"]
...
```

```
AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=12 annotated=11 candidates=18 onScreen=7
```

Response level, one line, no per-node bytes. A complete pass says nothing (`read >= candidates`), and "the capture never asked" stays distinguishable from "read none of them" — the bridge omits the key entirely rather than reporting `(0, 0)`, which would otherwise warn on every default capture.

### The scoped-re-run remedy does not work — measured, so it is not shipped

The obvious remedy for a capped pass is "re-run scoped". It does nothing: `--scope` is applied when the Swift walk builds nodes, long after the bridge's read pass, so it cannot redirect the budget. Measured on the 16-card fixture:

```
$ snapshot -i --actions                            → reads=12 candidates=18
$ snapshot -i --actions -s "feedItem-by-user9.test" → reads=12 candidates=18   (unchanged)
```

Making `--scope` narrow the read set would mean duplicating the scope predicate inside the ObjC bridge (scope inclusion is ancestry-dependent, decided during the Swift walk), which is exactly the kind of second, drifting implementation this repo keeps out.

Instead the read pass now **orders candidates on-screen first**. That does two things: the budget lands on the elements an agent can actually act on, and the disclosed remedy becomes true — scrolling changes the on-screen set, so a re-run reads elements the previous pass could not. Verified end to end on a scrollable fixture:

```
# top of feed: user12-14 are off-screen and unread
$ agent-device scroll down ; agent-device scroll down
$ agent-device snapshot -i --actions
@e11 [link] "feedItem-by-user12.test" actions: ["Reply", "Repost", "Open post options menu"]
@e12 [link] "feedItem-by-user13.test" actions: ["Reply", "Repost", "Open post options menu"]
@e13 [link] "feedItem-by-user14.test" actions: ["Reply", "Repost", "Open post options menu"]
```

An empty root frame (no viewport to judge against) treats every candidate as on-screen, so ordering degrades to document order rather than to "nothing is on screen".

## Telling the reader what the names are for

Invocation is impossible, so a model that sees `actions: ["Reply", …]` will plausibly invent `press @e8 --action "Reply"` — the exact shape this PR deliberately does not ship. Both places a model reads now say so:

- `--actions` flag help: *"name the affordances merged inside an element (iOS sim); not directly invokable — reach them via the detail screen, labeled children, or coordinates"*
- the MCP/SDK field description spells out the same three routes and says the names are for **planning**, not invocation.

**Follow-up, not in this PR:** one sentence belongs in the compact workflow help card's snapshot section, but that card is being rewritten by the in-flight help-diet PR #1663 (still open, not in this base — `cli-help.ts` line ~376 sits inside the `workflow` topic it rewrites). Touching it here would collide. Once #1663 lands, add: *"Merged element (one node where the UI shows several controls): `snapshot --actions` names the affordances it hides — planning only, nothing invokes them."* — into the card if it fits the <9000-byte budget, otherwise into `help debugging`.

## Refusals: the request either gets actions or an error

A requested capability that silently returns nothing is worse than an error, because a node with no `actions` is indistinguishable from an element that genuinely has none. Every unserviceable combination fails closed:

| Request | Answer |
| --- | --- |
| `snapshot --actions --raw` | `INVALID_ARGS` — raw does not use the private-AX path. Rejected at the shared request seam, so CLI, Node client and MCP answer alike before any device work |
| `diff --actions` | `INVALID_ARGS` — `snapshotCustomActions` is deliberately not in the shared `SNAPSHOT_FLAGS` group |
| `--actions` on android / macOS / linux / web / **iOS physical device** | `UNSUPPORTED_OPERATION` naming the resolved target. Checked before the session precondition, since it is pure flags+device — otherwise an iOS physical device costs a round trip ("run open first") before learning the flag is unserviceable there at all |

```
$ agent-device snapshot --actions --raw
Error (INVALID_ARGS): --actions and --raw are mutually exclusive: custom actions are only
readable through the private-AX snapshot path, which a raw capture does not use.

$ agent-device diff snapshot --actions
Error (INVALID_ARGS): Flag --actions is not supported for command diff.
```

## Bounds, all three disclosed

The pass is bounded on four axes, and each bound reports itself through `snapshotQuality.customActions` `{read, candidates, truncated, blocked}`:

- **12 elements per capture**, on-screen first, stopping at the capture deadline;
- **1s per element read** — the AX call is a synchronous XPC round trip with no timeout of its own, so it runs off-thread behind a bounded wait. *attempts* is what the budget buys, *reads* is what completed, so a timed-out element stays in the undisclosed remainder rather than being reported as "read, and it has no actions";
- **one read in flight at a time** — the AX call is a synchronous XPC round trip that cannot be cancelled, so the deadline frees only the caller while the call keeps running. All reads share one serial queue, and while an abandoned read is outstanding the pass is skipped outright (`blocked`) rather than queueing behind it, so a repeated capture adds no work. `blocked` gets its own disclosure line, deliberately not folded into the partial-pass line, because scrolling cannot clear a hang. Reads resume on their own once the hung call returns;
- **8 names × 80 characters per element** — the names are app-authored, so their count and length are the app's choice, and a long generated list is a plausible accident as well as a hostile case. Clipped elements are counted and disclosed on their own line, because a clipped list looks exactly as complete as a full one.

Live, against a fixture card publishing 12 actions including a 500-character name and a name containing a quote and a newline:

```
1 element(s) published more custom actions than are shown; those lists are clipped to the
first 8 names, and long names are shortened.
@e9 [link] "feedItem-by-whiskers.test" actions: ["long-long-…-long-…", "Say \"hi\" now", "Extra 3", … "Extra 8"]

AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS reads=12 attempts=12 annotated=11 candidates=18 onScreen=7 truncated=1
```

Names get the same escaping as text previews plus control-character folding — visible above, `Say "hi"\nnow` renders as `"Say \"hi\" now"`: quote escaped, newline folded, still exactly one line.

## Actions count as identity

Three enumerations decide "same node", and all three now read `actions`:

1. `snapshotNodeToComparableLine` — the rendered line already carried actions while the diff key did not, so an action-only change diffed as `unchanged` with silently different text;
2. `buildComparableSnapshotPresentation` — the unchanged-comparison projection;
3. `buildSnapshotPresentationKey` — the sharpest one: `snapshot` then `snapshot --actions` on a still screen produced an identical presentation key, answered `unchanged`, and never delivered the actions that were explicitly asked for.

## Design notes

- **Opt-in and bounded on three axes, every bound disclosed** — see above. Default captures pay nothing: `customActionLimit: 0` skips candidate collection entirely, the same way `deepExtensionCallLimit: 0` already does.
- **Candidate rule.** Labelled childless nodes only. That is the shape a merged card takes (container marked accessible, real controls invisible); unlabelled leaves are decoration and are not worth a round trip. Nodes that deep extension filled in since serialization are skipped — a node with real children is not merged.
- **Backend pin.** `--actions` implies `preferredBackend: private-ax`, because no other backend can read the attribute; returning a capture that structurally cannot carry actions would be a silent no-op. An explicit pin is never overwritten.
- **New `requested-backend` reason code.** The pin reuses the existing deferred-plan machinery, which reports `deferred` — "after recent slow accessibility work on this screen". For a user-requested pin nothing was slow, and the daemon's one-shot latch re-rendered that as a degradation warning on the first `--actions` capture of a session. A request-pinned capture now reports its own cause, and both `renderSnapshotQualityWarnings` and the latch treat it as the non-event it is.

## Scope / deferred

- **Invocation** (`press @ref --action`) — infeasible today, evidence above. No interaction dispatch path was added, so ADR 0011's matrix is untouched.
- **Error/hint integration** — a failed press inside a merged element does not yet mention available actions. It needs the runner to re-resolve one element from a ref on the failure path; worth doing as a follow-up now that the read primitive exists (`customActionNamesForElement:axClient:` is the seam).
- **Non-simulator and non-private-AX backends** — physical iOS devices have no private-AX backend, so `--actions` yields nothing there.
- **`diff`** does not take `--actions`; per-element reads on both sides of a comparison are not worth the cost.

## Validation

- Runner XCTest unit lane (isolated derived path, own simulator): `testCustomActionsRequestPinsPrivateAXBackend`, `testPrivateAXNodesCarryAnnotatedCustomActions`, `testRequestPinnedBackendReportsItsOwnReason`, `testCustomActionCoverageParsesOnlyCompletePairs`, `testPartialCustomActionPassIsDisclosedAndCompleteOneIsNot` pass, plus the pre-existing private-AX/deep-extension regressions (`testDeepExtensionCountsMissedFrontiers`, `testPreferredPrivateAXBackendPlansAsPenalized`, `testPrivateAXDepthLimitedRequiresEveryFrontierResolved`, `testPrivateAXInteractiveFiltersLoginLikeHiddenDrawer`) — 7/7.
- New `src/snapshot/__tests__/snapshot-quality-custom-actions.test.ts` (5 tests) covers the capped/complete/never-asked cases, half-a-pair parsing, and that the line is independent of degradation state. New `src/utils/__tests__/snapshot-lines-custom-actions.test.ts` (4 tests) pins the rendered shape, ordering against bracketed metadata, the empty/whitespace cases, and hidden groups.
- `src/commands/capture/runtime/snapshot.test.ts` forwarding assertion extended to prove the flag reaches the backend; `src/commands/capture/index.test.ts` extended for the CLI reader.
- `pnpm test:unit` fully green: 633 files / 5617 tests. Three new TS test files cover the raw-pairing guard, the platform guard across six non-simulator targets, and action-aware identity/diff/presentation-key.
- `pnpm typecheck`, `pnpm lint`, `pnpm check:layering`, `pnpm check:fallow`, `pnpm check:production-exports`, `pnpm check:command-docs`, `oxfmt --check .` all clean. No `SessionState` field added.
- CI's public-CLI-flag completeness gate (`integration-progress-model.ts`, the one ADR 0011 cites for catching the unclassified `--verify` on #1064) flagged `snapshotCustomActions`. It is classified in its own bucket rather than the provider-scenario table: the values come from the private AX client inside the runner process, and the fake runner derives its behavior from fixture tables that cannot fabricate custom actions, so there is no provider-backed scenario to claim. The owning coverage is named instead.
- Live validation ran on a purpose-created simulator with an isolated state dir; the simulator, its runner, the daemon and both derived-data trees were removed afterwards.
