### PR TITLE
refactor(find): resolve a mutating find's target once, not twice (#1654)

### DIFF
--- a/packages/contracts/src/facades/interaction.ts
+++ b/packages/contracts/src/facades/interaction.ts
@@ -90,6 +90,7 @@ export type {
   LongPressCommandResponseData,
   LongPressCommandResult,
   PointTarget,
+  PreresolvedInteractionTarget,
   PressCommandResponseData,
   PressCommandResult,
   RecordingTargetOverride,

--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -204,7 +204,8 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
     },
   },
   'runtime-ref': {
-    description: 'Session snapshot ref lookup, guarded coordinate tap.',
+    description:
+      'Session snapshot ref lookup, guarded coordinate tap. #1654: when the caller already resolved the node (a mutating `find`), the lookup is replaced by that node and every guarantee below is enforced against it — the guards are unchanged, only the lookup is skipped.',
     commands: ['press', 'click', 'fill', 'longpress'],
     guarantees: {
       ...RUNTIME_TREE_SHARED_GUARANTEES,
@@ -219,6 +220,13 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       // ADR 0012 decision 2: tryResolveRefNode produces both outcomes — exact
       // for a resolved @ref, label-fallback for trailing-label recovery.
+      //
+      // #1654 second producer on this path: adoptPreresolvedRefTarget reports
+      // `exact` for a pre-resolved target. Truthful rather than borrowed — the
+      // producer mints the ref off the node it hands over, so the ref does name
+      // that node exactly. It cannot report label-fallback, which is correct:
+      // label recovery is a property of LOOKING a stale ref up, and a
+      // pre-resolved target never performs that lookup.
       resolutionDisclosure: {
         kind: 'runtime',
         via: 'src/commands/interaction/runtime/resolution.ts#tryResolveRefNode',

--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -218,18 +218,13 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'runtime',
         via: 'packages/selectors/src/internal/resolve.ts#STALE_REF_HINT',
       },
-      // ADR 0012 decision 2: tryResolveRefNode produces both outcomes — exact
-      // for a resolved @ref, label-fallback for trailing-label recovery.
-      //
-      // #1654 second producer on this path: adoptPreresolvedRefTarget reports
-      // `exact` for a pre-resolved target. Truthful rather than borrowed — the
-      // producer mints the ref off the node it hands over, so the ref does name
-      // that node exactly. It cannot report label-fallback, which is correct:
-      // label recovery is a property of LOOKING a stale ref up, and a
-      // pre-resolved target never performs that lookup.
+      // ADR 0012 decision 2: the shared builder produces both outcomes — exact
+      // for an ordinary or pre-resolved @ref, label-fallback only for trailing-
+      // label recovery. The pre-resolved path validates carried ref/node/tree
+      // provenance before it can claim exact.
       resolutionDisclosure: {
         kind: 'runtime',
-        via: 'src/commands/interaction/runtime/resolution.ts#tryResolveRefNode',
+        via: 'src/commands/interaction/runtime/resolution.ts#buildRefResolution',
       },
     },
   },

--- a/packages/contracts/src/interaction.ts
+++ b/packages/contracts/src/interaction.ts
@@ -86,6 +86,35 @@ export type RecordingTargetOverride = {
   refLabel?: string;
 };
 
+/**
+ * #1654: a target its CALLER already resolved, against a tree the caller
+ * captured itself, handed to the interaction leaf so the leaf does not resolve
+ * the same `@ref` a second time.
+ *
+ * The sole producer is a mutating `find` (`src/daemon/handlers/find.ts`): it
+ * captures, matches by locator, promotes to a hittable ancestor, and mints
+ * `@eN` off the node it chose — then re-enters the interaction leaf. Without
+ * this channel the leaf looked `@eN` up again in the session frame tree, so a
+ * tree that had since advanced could hand the action a DIFFERENT node than the
+ * one find matched, or refuse a ref find had just observed.
+ *
+ * What this does NOT skip: the shared guards. Occlusion, hittable-ancestor
+ * promotion, and the off-screen check still run, on this node, at the same
+ * symbols the ADR 0011 `runtime-ref` cells name — the pre-resolution replaces
+ * the LOOKUP, not the guarantees.
+ *
+ * In-process only, like `RecordingTargetOverride` above: it travels on the
+ * daemon-only `internal` request channel (`toDaemonRequest` never copies that
+ * off the wire), carries live node references, and is never serialized into a
+ * response.
+ */
+export type PreresolvedInteractionTarget = {
+  /** The node the caller resolved, after the caller's own promotion. */
+  node: SnapshotNode;
+  /** The tree `node` came from — the guards read its siblings for occlusion/viewport. */
+  nodes: SnapshotNode[];
+};
+
 export type ResolvedInteractionTarget =
   | {
       kind: 'point';

--- a/packages/contracts/src/interaction.ts
+++ b/packages/contracts/src/interaction.ts
@@ -94,9 +94,10 @@ export type RecordingTargetOverride = {
  * The sole producer is a mutating `find` (`src/daemon/handlers/find.ts`): it
  * captures, matches by locator, promotes to a hittable ancestor, and mints
  * `@eN` off the node it chose — then re-enters the interaction leaf. Without
- * this channel the leaf looked `@eN` up again in the session frame tree, so a
- * tree that had since advanced could hand the action a DIFFERENT node than the
- * one find matched, or refuse a ref find had just observed.
+ * this channel the leaf repeated an in-memory `@eN` lookup after find had
+ * already selected the node. No reachable production path is currently known
+ * to advance the tree in that interval; this type removes the duplicate lookup
+ * structurally and keeps the selected ref/node/tree provenance together.
  *
  * What this does NOT skip: the shared guards. Occlusion, hittable-ancestor
  * promotion, and the off-screen check still run, on this node, at the same
@@ -109,6 +110,8 @@ export type RecordingTargetOverride = {
  * response.
  */
 export type PreresolvedInteractionTarget = {
+  /** The ref minted for `node`; the consumer validates it against the positional target. */
+  ref: string;
   /** The node the caller resolved, after the caller's own promotion. */
   node: SnapshotNode;
   /** The tree `node` came from — the guards read its siblings for occlusion/viewport. */

--- a/src/commands/interaction/runtime/interactions.ts
+++ b/src/commands/interaction/runtime/interactions.ts
@@ -1,6 +1,7 @@
 import type {
   ClickButton,
   FillCommandResult,
+  PreresolvedInteractionTarget,
   PressCommandResult,
   RepeatedInput,
   ResolvedTarget,
@@ -49,6 +50,8 @@ export type PressCommandOptions = CommandContext &
     button?: ClickButton;
     /** ADR 0012 step 4: replay-only post-resolution guard; see resolution.ts. */
     expectedResolvedTarget?: ExpectedResolvedTarget;
+    /** #1654: a mutating `find`'s already-resolved node; see resolution.ts. */
+    preresolvedTarget?: PreresolvedInteractionTarget;
   } & PostActionObservationOptions;
 
 export type ClickCommandOptions = PressCommandOptions;
@@ -63,6 +66,8 @@ export type FillCommandOptions = CommandContext & {
   allowNonHittableCoordinateFallback?: boolean;
   /** ADR 0012 step 4: replay-only post-resolution guard; see resolution.ts. */
   expectedResolvedTarget?: ExpectedResolvedTarget;
+  /** #1654: a mutating `find`'s already-resolved node; see resolution.ts. */
+  preresolvedTarget?: PreresolvedInteractionTarget;
 } & PostActionObservationOptions;
 
 export type TypeTextCommandOptions = CommandContext & {
@@ -103,6 +108,7 @@ export const fillCommand: RuntimeCommand<FillCommandOptions, FillCommandResult> 
     promoteToHittableAncestor: false,
     captureEvidenceBaseline: observation.needsPreActionBaseline,
     expectedResolvedTarget: options.expectedResolvedTarget,
+    preresolvedTarget: options.preresolvedTarget,
   });
   if (!runtime.backend.fill) {
     throw new AppError('UNSUPPORTED_OPERATION', 'fill is not supported by this backend');
@@ -192,6 +198,7 @@ async function tapCommand(
     promoteToHittableAncestor: true,
     captureEvidenceBaseline: observation.needsPreActionBaseline,
     expectedResolvedTarget: options.expectedResolvedTarget,
+    preresolvedTarget: options.preresolvedTarget,
   });
   if (!runtime.backend.tap) {
     throw new AppError('UNSUPPORTED_OPERATION', 'tap is not supported by this backend');
@@ -246,6 +253,13 @@ async function maybeTapRefTarget(
   // ADR 0012 step 4: a guarded replay action needs the runtime resolution
   // path so the post-resolution identity guard actually runs.
   if (options.expectedResolvedTarget) return null;
+  // #1654 scope note: `preresolvedTarget` deliberately does NOT divert this
+  // path. It is the separate ADR 0011 `native-ref` dispatch path, wired only
+  // to the web provider's clickRef/fillRef (no mobile backend implements
+  // tapTarget/fillTarget), where the ref IS the provider's own element handle.
+  // Forcing a coordinate tap there to save a resolution would trade a working
+  // provider-native dispatch for a worse one. The double-hop #1654 removes is
+  // the runtime tree path below.
   // ADR 0011 native-ref preflight: the shared occlusion/offscreen guards run
   // against the stored session snapshot node before the backend call (a
   // backend fast path can silently "succeed", so errors must be raised here).

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { BackendSnapshotOptions } from '../../../backend.ts';
 import { ref, selector } from './selector-read-utils.ts';
-import { throwIfOffscreenInteractionTarget, tryResolveRefNode } from './resolution.ts';
+import {
+  buildRefResolution,
+  throwIfOffscreenInteractionTarget,
+  tryResolveRefNode,
+} from './resolution.ts';
 import { resolveSelectorChain } from '@agent-device/selectors';
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
 import type { Point } from '@agent-device/kernel/snapshot';
@@ -514,6 +518,21 @@ test('tryResolveRefNode discloses exact for a resolved ref and label-fallback fo
   });
 
   assert.equal(tryResolveRefNode(nodes, '@e9', { fallbackLabel: '' }), null);
+});
+
+test('buildRefResolution is the shared exact and label-fallback disclosure constructor', () => {
+  const node = selectorSnapshot().nodes[0]!;
+
+  assert.deepEqual(buildRefResolution('e1', node, 'exact').resolution, {
+    source: 'ref',
+    phase: 'pre-action',
+    kind: 'exact',
+  });
+  assert.deepEqual(buildRefResolution('e1', node, 'label-fallback').resolution, {
+    source: 'ref',
+    phase: 'pre-action',
+    kind: 'label-fallback',
+  });
 });
 
 // #1542: throwIfOffscreenInteractionTarget is exported for ADR 0011 registry

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -36,6 +36,7 @@ import { truncateUtf8 } from '../../../utils/truncate-utf8.ts';
 import type {
   InteractionTarget,
   PointTarget,
+  PreresolvedInteractionTarget,
   RecordingTargetOverride,
   ResolutionDiagnosticEntry,
   ResolutionDisclosure,
@@ -147,6 +148,12 @@ type ResolveInteractionTargetParams = {
   expectedResolvedTarget?: ExpectedResolvedTarget;
   /** Identifies one endpoint when a multi-target replay guard refuses. */
   replayTargetRole?: 'source' | 'destination';
+  /**
+   * #1654: the caller already resolved this `@ref` against its own capture, so
+   * the ref branch adopts that node instead of looking the ref up again. Ref
+   * targets only — a selector target has nothing pre-resolved to adopt.
+   */
+  preresolvedTarget?: PreresolvedInteractionTarget;
 };
 
 export async function resolveInteractionTarget(
@@ -225,17 +232,53 @@ async function tryCaptureEvidenceBaseline(
   }
 }
 
+/** The node a ref target acts on, plus the tree the shared guards read it against. */
+type RefResolution = { nodes: SnapshotState['nodes']; resolved: ResolvedRefNode };
+
+/**
+ * #1654: adopt the node the caller already resolved instead of resolving the
+ * same `@ref` a second time. This replaces the LOOKUP only — every guard below
+ * still runs, against the caller's tree, at the symbols the ADR 0011
+ * `runtime-ref` cells name.
+ *
+ * `exact` is the truthful disclosure here rather than a borrowed default: the
+ * producer mints `@eN` off the very node it hands over, so the ref does name
+ * that node exactly — the same provenance `tryResolveRefNode` reports when a
+ * ref resolves without label recovery.
+ */
+function adoptPreresolvedRefTarget(
+  target: Extract<InteractionTarget, { kind: 'ref' }>,
+  preresolved: PreresolvedInteractionTarget,
+): RefResolution {
+  const ref = normalizeRef(target.ref);
+  if (!ref) throw new AppError('INVALID_ARGS', `Invalid ref: ${target.ref}`);
+  return {
+    nodes: preresolved.nodes,
+    resolved: { ref, node: preresolved.node, resolution: EXACT_REF_RESOLUTION },
+  };
+}
+
+async function readRefResolution(
+  runtime: AgentDeviceRuntime,
+  options: CommandContext,
+  target: Extract<InteractionTarget, { kind: 'ref' }>,
+): Promise<RefResolution> {
+  const capture = await resolveSnapshotForRef(runtime, options, target);
+  return { nodes: capture.snapshot.nodes, resolved: capture.resolved };
+}
+
 async function resolveRefInteractionTarget(
   runtime: AgentDeviceRuntime,
   options: CommandContext,
   target: Extract<InteractionTarget, { kind: 'ref' }>,
   params: ResolveInteractionTargetParams,
 ): Promise<ResolvedInteractionTarget> {
-  const capture = await resolveSnapshotForRef(runtime, options, target);
-  const resolved = capture.resolved;
-  assertReplayTargetResolution(resolved.node, capture.snapshot.nodes, params);
+  const { nodes, resolved } = params.preresolvedTarget
+    ? adoptPreresolvedRefTarget(target, params.preresolvedTarget)
+    : await readRefResolution(runtime, options, target);
+  assertReplayTargetResolution(resolved.node, nodes, params);
   const node = params.promoteToHittableAncestor
-    ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
+    ? resolveActionableNodeOrThrow(nodes, resolved.node, {
         action: params.action,
         label: `Ref ${target.ref}`,
       })
@@ -246,7 +289,7 @@ async function resolveRefInteractionTarget(
     runtime,
     options,
     node,
-    capture.snapshot.nodes,
+    nodes,
     target.ref,
     params.action,
   );
@@ -258,7 +301,7 @@ async function resolveRefInteractionTarget(
     ...describeResolvedInteractionNode(
       runtime,
       visibleNode,
-      capture.snapshot.nodes,
+      nodes,
       params.action,
       resolved.resolution,
     ),

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -241,10 +241,9 @@ type RefResolution = { nodes: SnapshotState['nodes']; resolved: ResolvedRefNode 
  * still runs, against the caller's tree, at the symbols the ADR 0011
  * `runtime-ref` cells name.
  *
- * `exact` is the truthful disclosure here rather than a borrowed default: the
- * producer mints `@eN` off the very node it hands over, so the ref does name
- * that node exactly — the same provenance `tryResolveRefNode` reports when a
- * ref resolves without label recovery.
+ * `exact` is truthful only when all three pieces of carried provenance agree:
+ * the positional ref, the payload ref, and the node's own ref. Fail closed if
+ * future internal plumbing lets them drift.
  */
 function adoptPreresolvedRefTarget(
   target: Extract<InteractionTarget, { kind: 'ref' }>,
@@ -252,9 +251,17 @@ function adoptPreresolvedRefTarget(
 ): RefResolution {
   const ref = normalizeRef(target.ref);
   if (!ref) throw new AppError('INVALID_ARGS', `Invalid ref: ${target.ref}`);
+  const carriedRef = normalizeRef(preresolved.ref);
+  const nodeRef = preresolved.node.ref ? normalizeRef(preresolved.node.ref) : null;
+  if (carriedRef !== ref || nodeRef !== ref || !preresolved.nodes.includes(preresolved.node)) {
+    throw new AppError(
+      'COMMAND_FAILED',
+      'Internal find target provenance does not match the interaction ref',
+    );
+  }
   return {
     nodes: preresolved.nodes,
-    resolved: { ref, node: preresolved.node, resolution: EXACT_REF_RESOLUTION },
+    resolved: buildRefResolution(ref, preresolved.node, 'exact'),
   };
 }
 
@@ -420,6 +427,19 @@ const LABEL_FALLBACK_REF_RESOLUTION: ResolutionDisclosure = {
   phase: 'pre-action',
   kind: 'label-fallback',
 };
+
+/** Shared construction site for every runtime-ref resolution disclosure. */
+export function buildRefResolution(
+  ref: string,
+  node: SnapshotNode,
+  kind: 'exact' | 'label-fallback',
+): ResolvedRefNode {
+  return {
+    ref,
+    node,
+    resolution: kind === 'exact' ? EXACT_REF_RESOLUTION : LABEL_FALLBACK_REF_RESOLUTION,
+  };
+}
 
 const UNIQUE_RUNTIME_RESOLUTION: ResolutionDisclosure = {
   source: 'runtime',
@@ -733,12 +753,12 @@ export function tryResolveRefNode(
   if (!ref) throw new AppError('INVALID_ARGS', `Invalid ref: ${refInput}`);
   const refNode = findNodeByRef(nodes, ref);
   if (isUsableResolvedNode(refNode)) {
-    return { ref, node: refNode, resolution: EXACT_REF_RESOLUTION };
+    return buildRefResolution(ref, refNode, 'exact');
   }
   const fallbackNode =
     options.fallbackLabel.length > 0 ? findNodeByLabel(nodes, options.fallbackLabel) : null;
   if (isUsableResolvedNode(fallbackNode)) {
-    return { ref, node: fallbackNode, resolution: LABEL_FALLBACK_REF_RESOLUTION };
+    return buildRefResolution(ref, fallbackNode, 'label-fallback');
   }
   return null;
 }

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -1,5 +1,7 @@
 import { test, expect, vi, beforeEach } from 'vitest';
 import { handleFindCommands } from '../find.ts';
+import { handleInteractionCommands } from '../interaction.ts';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
 import { buildSnapshotSignatures } from '../../android-snapshot-freshness.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
@@ -1067,4 +1069,163 @@ test('read-only find while recording is intentionally deferred from target-v1 ev
   // replay verification, so read-only find records NO annotation in v1 —
   // an explicit deferral, not an accident.
   expect(recordedAction?.targetEvidence).toBeUndefined();
+});
+
+// --- #1654: the production route, find handler through the real interaction leaf ---
+//
+// The tests above stub `invoke`, so they prove what find SENDS. These drive the
+// real `handleInteractionCommands` on the other end, so they prove what the
+// action actually acts on — and they fail if either producer (click or fill)
+// stops attaching the channel, which a hand-built request cannot catch.
+
+const findRouteContextFromFlags = (flags: CommandFlags | undefined) => ({
+  count: flags?.count,
+  intervalMs: flags?.intervalMs,
+  delayMs: flags?.delayMs,
+  holdMs: flags?.holdMs,
+  jitterPx: flags?.jitterPx,
+  doubleTap: flags?.doubleTap,
+  clickButton: flags?.clickButton,
+});
+
+/** The tree find's capture returns: "Save" sits at a distinctive point. */
+function freshFindTree() {
+  return [
+    { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Save',
+      rect: { x: 300, y: 500, width: 20, height: 20 },
+      enabled: true,
+      hittable: true,
+    },
+  ];
+}
+
+/**
+ * A tree in which the SAME ref body names a different element. Modelled on the
+ * real window this closes: `refreshAndroidRefSnapshotIfFreshnessActive` can
+ * re-capture between find's match and the leaf's resolution, so `session.snapshot`
+ * advances underneath the `@ref` find just minted.
+ */
+function divergedSessionTree() {
+  return {
+    nodes: [
+      { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 }, ref: 'e1' },
+      {
+        index: 1,
+        parentIndex: 0,
+        type: 'XCUIElementTypeButton',
+        label: 'Delete',
+        rect: { x: 10, y: 700, width: 100, height: 40 },
+        enabled: true,
+        hittable: true,
+        ref: 'e2',
+      },
+    ],
+    createdAt: Date.now(),
+    backend: 'xctest' as const,
+  };
+}
+
+async function runFindThroughLeaf(options: {
+  positionals: string[];
+  divergeBeforeDispatch: boolean;
+}): Promise<{ response: DaemonResponse | null; invokeCalls: DaemonRequest[] }> {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'default';
+  const session = makeSession(sessionName);
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockImplementation(async (_device, command) =>
+    command === 'snapshot' ? { nodes: freshFindTree(), backend: 'xctest' } : {},
+  );
+
+  const invokeCalls: DaemonRequest[] = [];
+  const response = await handleFindCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'find',
+      positionals: options.positionals,
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/test.log',
+    sessionStore,
+    invoke: async (req) => {
+      invokeCalls.push(req);
+      if (options.divergeBeforeDispatch) {
+        const current = sessionStore.get(sessionName);
+        if (current) {
+          current.snapshot = divergedSessionTree();
+          sessionStore.set(sessionName, current);
+        }
+      }
+      // The real leaf, not a stub.
+      return (
+        (await handleInteractionCommands({
+          req,
+          sessionName,
+          sessionStore,
+          contextFromFlags: findRouteContextFromFlags,
+        })) ?? { ok: false, error: { code: 'COMMAND_FAILED', message: 'no interaction handler' } }
+      );
+    },
+  });
+  return { response, invokeCalls };
+}
+
+function dispatchedPoint(command: 'press' | 'fill'): string[] | undefined {
+  const call = mockDispatch.mock.calls.find((entry) => entry[1] === command);
+  return call?.[2] as string[] | undefined;
+}
+
+test('#1654 production route: find click carries its resolved node into the real interaction leaf', async () => {
+  const { response, invokeCalls } = await runFindThroughLeaf({
+    positionals: ['text', 'Save', 'click'],
+    divergeBeforeDispatch: false,
+  });
+
+  expect(response?.ok).toBe(true);
+  // The producer attaches the channel — fails if handleFindClick stops doing so.
+  expect(invokeCalls[0]?.internal?.findPreresolvedTarget?.node?.label).toBe('Save');
+  expect(dispatchedPoint('press')).toEqual(['310', '510']);
+});
+
+test('#1654 production route: find fill carries its resolved node into the real interaction leaf', async () => {
+  const { response, invokeCalls } = await runFindThroughLeaf({
+    positionals: ['text', 'Save', 'fill', 'hello'],
+    divergeBeforeDispatch: false,
+  });
+
+  expect(response?.ok).toBe(true);
+  // Fill has its own producer and its own forwarding hop; assert it separately.
+  expect(invokeCalls[0]?.internal?.findPreresolvedTarget?.node?.label).toBe('Save');
+  expect(dispatchedPoint('fill')).toEqual(['310', '510', 'hello']);
+});
+
+test('#1654 production route: a tree that advances mid-dispatch cannot retarget find click', async () => {
+  // The regression this closes. With the session tree advanced between find's
+  // match and the leaf's resolution, a second lookup of `@e2` finds "Delete" at
+  // (60, 720). Acting on find's node means (310, 510) regardless.
+  const { response } = await runFindThroughLeaf({
+    positionals: ['text', 'Save', 'click'],
+    divergeBeforeDispatch: true,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(dispatchedPoint('press')).toEqual(['310', '510']);
+});
+
+test('#1654 production route: a tree that advances mid-dispatch cannot retarget find fill', async () => {
+  const { response } = await runFindThroughLeaf({
+    positionals: ['text', 'Save', 'fill', 'hello'],
+    divergeBeforeDispatch: true,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(dispatchedPoint('fill')).toEqual(['310', '510', 'hello']);
 });

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -1105,10 +1105,9 @@ function freshFindTree() {
 }
 
 /**
- * A tree in which the SAME ref body names a different element. Modelled on the
- * real window this closes: `refreshAndroidRefSnapshotIfFreshnessActive` can
- * re-capture between find's match and the leaf's resolution, so `session.snapshot`
- * advances underneath the `@ref` find just minted.
+ * A defensive tree in which the same ref body names a different element. No
+ * reachable production path is currently known to advance `session.snapshot`
+ * in this interval; forcing it here pins the one-resolution contract itself.
  */
 function divergedSessionTree() {
   return {
@@ -1191,7 +1190,8 @@ test('#1654 production route: find click carries its resolved node into the real
 
   expect(response?.ok).toBe(true);
   // The producer attaches the channel — fails if handleFindClick stops doing so.
-  expect(invokeCalls[0]?.internal?.findPreresolvedTarget?.node?.label).toBe('Save');
+  expect(invokeCalls[0]?.internal?.findResolvedTarget?.node?.label).toBe('Save');
+  expect(invokeCalls[0]?.internal?.findResolvedTarget?.ref).toBe('@e2');
   expect(dispatchedPoint('press')).toEqual(['310', '510']);
 });
 
@@ -1203,14 +1203,15 @@ test('#1654 production route: find fill carries its resolved node into the real 
 
   expect(response?.ok).toBe(true);
   // Fill has its own producer and its own forwarding hop; assert it separately.
-  expect(invokeCalls[0]?.internal?.findPreresolvedTarget?.node?.label).toBe('Save');
+  expect(invokeCalls[0]?.internal?.findResolvedTarget?.node?.label).toBe('Save');
+  expect(invokeCalls[0]?.internal?.findResolvedTarget?.ref).toBe('@e2');
   expect(dispatchedPoint('fill')).toEqual(['310', '510', 'hello']);
 });
 
-test('#1654 production route: a tree that advances mid-dispatch cannot retarget find click', async () => {
-  // The regression this closes. With the session tree advanced between find's
-  // match and the leaf's resolution, a second lookup of `@e2` finds "Delete" at
-  // (60, 720). Acting on find's node means (310, 510) regardless.
+test('#1654 defensive invariant: a tree that advances mid-dispatch cannot retarget find click', async () => {
+  // This deliberately forces an otherwise-unreached state: a second lookup of
+  // `@e2` would find "Delete" at (60, 720), while the resolved handoff must keep
+  // find's selected "Save" node at (310, 510).
   const { response } = await runFindThroughLeaf({
     positionals: ['text', 'Save', 'click'],
     divergeBeforeDispatch: true,
@@ -1220,7 +1221,7 @@ test('#1654 production route: a tree that advances mid-dispatch cannot retarget 
   expect(dispatchedPoint('press')).toEqual(['310', '510']);
 });
 
-test('#1654 production route: a tree that advances mid-dispatch cannot retarget find fill', async () => {
+test('#1654 defensive invariant: a tree that advances mid-dispatch cannot retarget find fill', async () => {
   const { response } = await runFindThroughLeaf({
     positionals: ['text', 'Save', 'fill', 'hello'],
     divergeBeforeDispatch: true,

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -3737,6 +3737,138 @@ test("ADR 0014 blocker-2: a mutating find's internal fill from an expired frame 
   }
 });
 
+// #1654: the tree a mutating `find` matched against, deliberately NOT the tree
+// stored on the session. `@e2` names the "Continue" button in both trees, but
+// at a distinctive point here and at (60, 40) in the session frame tree — so
+// the tap coordinates say which tree the leaf actually resolved against.
+function makeFindPreresolvedTree() {
+  const nodes = attachRefs([
+    { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Continue',
+      rect: { x: 300, y: 500, width: 20, height: 20 },
+      enabled: true,
+      hittable: true,
+    },
+  ] as never);
+  return { nodes, node: nodes[1] as NonNullable<(typeof nodes)[number]> };
+}
+
+async function runFindInternalClick(
+  sessionStore: SessionStore,
+  sessionName: string,
+  internal: Record<string, unknown>,
+) {
+  return await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'click',
+      positionals: ['@e2'],
+      flags: { noRecord: true },
+      internal,
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+}
+
+function readPressPoint(): string[] | undefined {
+  const call = mockDispatch.mock.calls.find((entry) => entry[1] === 'press');
+  return call?.[2] as string[] | undefined;
+}
+
+test('#1654: a mutating find click acts on the node find resolved, not a re-resolved @ref', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'find-preresolved-click';
+  sessionStore.set(sessionName, makeStaleRefSession(sessionName));
+  mockDispatch.mockResolvedValue({});
+  const preresolved = makeFindPreresolvedTree();
+
+  const response = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: true,
+    findPreresolvedTarget: { node: preresolved.node, nodes: preresolved.nodes },
+  });
+
+  expect(response?.ok).toBe(true);
+  // find's node — (300,500,20,20) → (310, 510). A second resolution would read
+  // @e2 out of the SESSION frame tree instead and tap (60, 40).
+  expect(readPressPoint()).toEqual(['310', '510']);
+});
+
+test('#1654 control: without the pre-resolved node the same click still resolves @ref from the session tree', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'find-preresolved-control';
+  sessionStore.set(sessionName, makeStaleRefSession(sessionName));
+  mockDispatch.mockResolvedValue({});
+
+  const response = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: true,
+  });
+
+  // The ordinary ref path is untouched: @e1 is "Continue" at (10,20,100,40).
+  expect(response?.ok).toBe(true);
+  expect(readPressPoint()).toEqual(['60', '40']);
+});
+
+test('#1654: the leaf performs no ref lookup at all — a session that could not resolve @e2 still acts', async () => {
+  // The decisive shape: this session has NO stored snapshot, so any second
+  // resolution necessarily fails ("Ref @e2 not found or has no bounds"). The
+  // action succeeding proves the lookup did not run, rather than merely
+  // agreeing with it. It is also the real-world win — find captured this node
+  // a moment ago, so refusing it as unresolvable was never right.
+  const sessionStore = makeSessionStore();
+  const sessionName = 'find-preresolved-no-session-tree';
+  const session = makeSession(sessionName);
+  session.snapshot = undefined;
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockResolvedValue({});
+  const preresolved = makeFindPreresolvedTree();
+
+  const withoutPreresolution = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: true,
+  });
+  expect(withoutPreresolution?.ok).toBe(false);
+
+  const response = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: true,
+    findPreresolvedTarget: { node: preresolved.node, nodes: preresolved.nodes },
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(readPressPoint()).toEqual(['310', '510']);
+});
+
+test('#1654: the shared guards still run on the pre-resolved node', async () => {
+  // The pre-resolution replaces the lookup, not the guarantees: an occluded
+  // node is still refused, at the same ADR 0011 `runtime-ref` occlusion cell.
+  const sessionStore = makeSessionStore();
+  const sessionName = 'find-preresolved-occluded';
+  sessionStore.set(sessionName, makeStaleRefSession(sessionName));
+  mockDispatch.mockResolvedValue({});
+  const preresolved = makeFindPreresolvedTree();
+  const blocked = {
+    ...preresolved.node,
+    interactionBlocked: { by: 'overlay', reason: 'covered' as const },
+  };
+
+  const response = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: true,
+    findPreresolvedTarget: { node: blocked, nodes: [preresolved.nodes[0], blocked] },
+  });
+
+  expect(response?.ok).toBe(false);
+  if (response && !response.ok) {
+    expect(response.error.code).toBe('COMMAND_FAILED');
+    expect(response.error.message).toContain('covered by another visible element');
+  }
+  expect(readPressPoint()).toBeUndefined();
+});
+
 test('get text with a pinned stale ref gets the precise warning', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'pinned-get-text';

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -3718,6 +3718,8 @@ test("ADR 0014 blocker-2: a mutating find's internal fill from an expired frame 
 
   // The mutating find's internal dispatch (the exact request find.ts hands the
   // leaf) bypasses admission AND attaches no stale-ref warning.
+  const findNodes = session.snapshot.nodes;
+  const findNode = findNodes[0]!;
   const internal = await handleInteractionCommands({
     req: {
       token: 't',
@@ -3725,7 +3727,9 @@ test("ADR 0014 blocker-2: a mutating find's internal fill from an expired frame 
       command: 'fill',
       positionals: ['@e1', 'hello'],
       flags: {},
-      internal: { findResolvedTarget: true },
+      internal: {
+        findResolvedTarget: { ref: '@e1', node: findNode, nodes: findNodes },
+      },
     },
     sessionName,
     sessionStore,
@@ -3755,6 +3759,10 @@ function makeFindPreresolvedTree() {
     },
   ] as never);
   return { nodes, node: nodes[1] as NonNullable<(typeof nodes)[number]> };
+}
+
+function findResolvedTarget(preresolved: ReturnType<typeof makeFindPreresolvedTree>, ref = '@e2') {
+  return { ref, node: preresolved.node, nodes: preresolved.nodes };
 }
 
 async function runFindInternalClick(
@@ -3790,8 +3798,7 @@ test('#1654: a mutating find click acts on the node find resolved, not a re-reso
   const preresolved = makeFindPreresolvedTree();
 
   const response = await runFindInternalClick(sessionStore, sessionName, {
-    findResolvedTarget: true,
-    findPreresolvedTarget: { node: preresolved.node, nodes: preresolved.nodes },
+    findResolvedTarget: findResolvedTarget(preresolved),
   });
 
   expect(response?.ok).toBe(true);
@@ -3800,15 +3807,13 @@ test('#1654: a mutating find click acts on the node find resolved, not a re-reso
   expect(readPressPoint()).toEqual(['310', '510']);
 });
 
-test('#1654 control: without the pre-resolved node the same click still resolves @ref from the session tree', async () => {
+test('#1654 control: without the resolved-target payload the same click still resolves @ref from the session tree', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'find-preresolved-control';
   sessionStore.set(sessionName, makeStaleRefSession(sessionName));
   mockDispatch.mockResolvedValue({});
 
-  const response = await runFindInternalClick(sessionStore, sessionName, {
-    findResolvedTarget: true,
-  });
+  const response = await runFindInternalClick(sessionStore, sessionName, {});
 
   // The ordinary ref path is untouched: @e1 is "Continue" at (10,20,100,40).
   expect(response?.ok).toBe(true);
@@ -3816,11 +3821,10 @@ test('#1654 control: without the pre-resolved node the same click still resolves
 });
 
 test('#1654: the leaf performs no ref lookup at all — a session that could not resolve @e2 still acts', async () => {
-  // The decisive shape: this session has NO stored snapshot, so any second
-  // resolution necessarily fails ("Ref @e2 not found or has no bounds"). The
-  // action succeeding proves the lookup did not run, rather than merely
-  // agreeing with it. It is also the real-world win — find captured this node
-  // a moment ago, so refusing it as unresolvable was never right.
+  // Defensive proof of the structural contract: this synthetic session has no
+  // stored snapshot, so any second resolution necessarily fails ("Ref @e2 not
+  // found or has no bounds"). Production find normally stores its capture;
+  // this test proves lookup absence without claiming that missing state occurs.
   const sessionStore = makeSessionStore();
   const sessionName = 'find-preresolved-no-session-tree';
   const session = makeSession(sessionName);
@@ -3829,14 +3833,11 @@ test('#1654: the leaf performs no ref lookup at all — a session that could not
   mockDispatch.mockResolvedValue({});
   const preresolved = makeFindPreresolvedTree();
 
-  const withoutPreresolution = await runFindInternalClick(sessionStore, sessionName, {
-    findResolvedTarget: true,
-  });
+  const withoutPreresolution = await runFindInternalClick(sessionStore, sessionName, {});
   expect(withoutPreresolution?.ok).toBe(false);
 
   const response = await runFindInternalClick(sessionStore, sessionName, {
-    findResolvedTarget: true,
-    findPreresolvedTarget: { node: preresolved.node, nodes: preresolved.nodes },
+    findResolvedTarget: findResolvedTarget(preresolved),
   });
 
   expect(response?.ok).toBe(true);
@@ -3857,14 +3858,32 @@ test('#1654: the shared guards still run on the pre-resolved node', async () => 
   };
 
   const response = await runFindInternalClick(sessionStore, sessionName, {
-    findResolvedTarget: true,
-    findPreresolvedTarget: { node: blocked, nodes: [preresolved.nodes[0], blocked] },
+    findResolvedTarget: { ref: '@e2', node: blocked, nodes: [preresolved.nodes[0]!, blocked] },
   });
 
   expect(response?.ok).toBe(false);
   if (response && !response.ok) {
     expect(response.error.code).toBe('COMMAND_FAILED');
     expect(response.error.message).toContain('covered by another visible element');
+  }
+  expect(readPressPoint()).toBeUndefined();
+});
+
+test('#1654: the resolved-target payload fails closed when its ref provenance disagrees', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'find-preresolved-mismatched-ref';
+  sessionStore.set(sessionName, makeStaleRefSession(sessionName));
+  mockDispatch.mockResolvedValue({});
+  const preresolved = makeFindPreresolvedTree();
+
+  const response = await runFindInternalClick(sessionStore, sessionName, {
+    findResolvedTarget: findResolvedTarget(preresolved, '@e9'),
+  });
+
+  expect(response?.ok).toBe(false);
+  if (response && !response.ok) {
+    expect(response.error.code).toBe('COMMAND_FAILED');
+    expect(response.error.message).toContain('provenance does not match');
   }
   expect(readPressPoint()).toBeUndefined();
 });

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -1,5 +1,6 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
 import { isViewportRootNode } from '@agent-device/contracts/snapshot';
+import type { PreresolvedInteractionTarget } from '@agent-device/contracts/interaction';
 import {
   findBestMatchesByLocator,
   isReadOnlyFindAction,
@@ -418,6 +419,22 @@ function rectsMatch(
   );
 }
 
+/**
+ * #1654: hand the interaction leaf the node this find already resolved, so the
+ * leaf stops resolving `match.ref` a second time.
+ *
+ * `match.resolvedNode` is the end of find's own pipeline — locator match under
+ * the `findAct` policy, then `resolveInteractiveMatchNode` promotion — and
+ * `match.ref` is minted off it. Re-entering by bare `@ref` made the leaf look
+ * that ref up again in the SESSION frame tree, a different tree from the fresh
+ * capture find matched against: it could hand the action a different node, or
+ * refuse a ref find had observed a moment earlier. The leaf's guards
+ * (occlusion, promotion, off-screen) still run on this node.
+ */
+function preresolvedTarget(match: ResolvedMatch): PreresolvedInteractionTarget {
+  return { node: match.resolvedNode, nodes: match.nodes };
+}
+
 async function handleFindClick(ctx: FindContext, match: ResolvedMatch): Promise<DaemonResponse> {
   const { req, sessionName, sessionStore, session, invoke, command, locator, query, publicFlags } =
     ctx;
@@ -427,7 +444,7 @@ async function handleFindClick(ctx: FindContext, match: ResolvedMatch): Promise<
     command: 'click',
     positionals: [match.ref],
     flags: match.actionFlags,
-    internal: { findResolvedTarget: true },
+    internal: { findResolvedTarget: true, findPreresolvedTarget: preresolvedTarget(match) },
   });
   if (!response.ok) return response;
   const matchCoords = match.resolvedNode.rect
@@ -470,7 +487,7 @@ async function handleFindFill(
     command: 'fill',
     positionals: [match.ref, value],
     flags: match.actionFlags,
-    internal: { findResolvedTarget: true },
+    internal: { findResolvedTarget: true, findPreresolvedTarget: preresolvedTarget(match) },
   });
   if (!response.ok) return response;
   recordSessionAction(

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -425,14 +425,13 @@ function rectsMatch(
  *
  * `match.resolvedNode` is the end of find's own pipeline — locator match under
  * the `findAct` policy, then `resolveInteractiveMatchNode` promotion — and
- * `match.ref` is minted off it. Re-entering by bare `@ref` made the leaf look
- * that ref up again in the SESSION frame tree, a different tree from the fresh
- * capture find matched against: it could hand the action a different node, or
- * refuse a ref find had observed a moment earlier. The leaf's guards
+ * `match.ref` is minted off it. Re-entering by bare `@ref` made the leaf repeat
+ * that lookup. The handoff keeps ref, node, and source tree as one value so
+ * admission policy and lookup cannot drift independently. The leaf's guards
  * (occlusion, promotion, off-screen) still run on this node.
  */
 function preresolvedTarget(match: ResolvedMatch): PreresolvedInteractionTarget {
-  return { node: match.resolvedNode, nodes: match.nodes };
+  return { ref: match.ref, node: match.resolvedNode, nodes: match.nodes };
 }
 
 async function handleFindClick(ctx: FindContext, match: ResolvedMatch): Promise<DaemonResponse> {
@@ -444,7 +443,7 @@ async function handleFindClick(ctx: FindContext, match: ResolvedMatch): Promise<
     command: 'click',
     positionals: [match.ref],
     flags: match.actionFlags,
-    internal: { findResolvedTarget: true, findPreresolvedTarget: preresolvedTarget(match) },
+    internal: { findResolvedTarget: preresolvedTarget(match) },
   });
   if (!response.ok) return response;
   const matchCoords = match.resolvedNode.rect
@@ -487,7 +486,7 @@ async function handleFindFill(
     command: 'fill',
     positionals: [match.ref, value],
     flags: match.actionFlags,
-    internal: { findResolvedTarget: true, findPreresolvedTarget: preresolvedTarget(match) },
+    internal: { findResolvedTarget: preresolvedTarget(match) },
   });
   if (!response.ok) return response;
   recordSessionAction(

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -43,10 +43,10 @@ export function createInteractionRuntime(params: InteractionRuntimeParams) {
       getSession: () => session,
       recordOptions: {
         includeSnapshot: true,
-        // ADR 0014: a mutating find's internal dispatch already re-resolved its
-        // target by locator against the fresh capture, so it resolves against the
-        // observation, not the authorized frame tree.
-        omitRefFrameSnapshot: params.req.internal?.findResolvedTarget === true,
+        // ADR 0014: a mutating find's target came from the fresh operational
+        // observation, not the authorized frame tree. Resolution adopts the
+        // carried target; other runtime consumers still see that observation.
+        omitRefFrameSnapshot: params.req.internal?.findResolvedTarget !== undefined,
       },
       setRecord: (record) => {
         if (!record.snapshot) return;

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -4,6 +4,7 @@ import type {
   GestureReferenceFrame,
   InteractionTarget,
   LongPressCommandResult,
+  PreresolvedInteractionTarget,
   PressCommandResult,
   ResolvedInteractionTarget,
 } from '@agent-device/contracts/interaction';
@@ -222,6 +223,7 @@ async function dispatchTargetedTouchViaRuntime(
         flags: req.flags,
         durationMs,
         expectedResolvedTarget: replayTargetGuard,
+        preresolvedTarget: req.internal?.findPreresolvedTarget,
       }),
     afterRun: async (result) => {
       if (session.lease?.leaseProvider) return undefined;
@@ -268,6 +270,8 @@ async function runTargetedTouchInteraction(params: {
   flags: CommandFlags | undefined;
   durationMs?: number;
   expectedResolvedTarget?: ReplayTargetGuardDenotation;
+  /** #1654: a mutating `find`'s already-resolved node; see daemon/types.ts. */
+  preresolvedTarget?: PreresolvedInteractionTarget;
 }): Promise<TargetedTouchResult> {
   const { runtime, command, target, sessionName, requestId, flags, expectedResolvedTarget } =
     params;
@@ -294,6 +298,10 @@ async function runTargetedTouchInteraction(params: {
     verify: flags?.verify,
     settle,
     expectedResolvedTarget,
+    // Only click/press take it: `find` dispatches click and fill, never
+    // longpress, so declaring it on the longPress options above would be an
+    // unconsumed claim (#1649 review).
+    preresolvedTarget: params.preresolvedTarget,
   };
   return command === 'click'
     ? await runtime.interactions.click(target, options)
@@ -674,6 +682,7 @@ async function dispatchFillViaRuntime(
         verify: req.flags?.verify,
         settle: readSettleRequest(req.flags),
         expectedResolvedTarget: replayTargetGuard,
+        preresolvedTarget: req.internal?.findPreresolvedTarget,
       }),
     buildPayloads: (result) =>
       buildFillResponsePayloads({

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -149,7 +149,7 @@ async function dispatchTargetedTouchViaRuntime(
   // locator-minted ref (`internal.findResolvedTarget`), so it carries no
   // user-facing staleness — the caller never consumed a `@ref` (ADR 0014).
   const staleRefsWarning =
-    parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget !== true
+    parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget === undefined
       ? resolveRefStalenessWarning({
           session,
           ref: parsedTarget.target.ref,
@@ -195,7 +195,7 @@ async function dispatchTargetedTouchViaRuntime(
   return await dispatchRuntimeInteraction(params, {
     androidFreshnessBaseline,
     refContext:
-      parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget !== true
+      parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget === undefined
         ? {
             ref: parsedTarget.target.ref,
             mintedGeneration: parsedTarget.refGeneration,
@@ -223,7 +223,7 @@ async function dispatchTargetedTouchViaRuntime(
         flags: req.flags,
         durationMs,
         expectedResolvedTarget: replayTargetGuard,
-        preresolvedTarget: req.internal?.findPreresolvedTarget,
+        preresolvedTarget: req.internal?.findResolvedTarget,
       }),
     afterRun: async (result) => {
       if (session.lease?.leaseProvider) return undefined;
@@ -666,7 +666,7 @@ async function dispatchFillViaRuntime(
 
   return await dispatchRuntimeInteraction(params, {
     refContext:
-      parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget !== true
+      parsedTarget.target.kind === 'ref' && req.internal?.findResolvedTarget === undefined
         ? {
             ref: parsedTarget.target.ref,
             mintedGeneration: parsedTarget.refGeneration,
@@ -682,7 +682,7 @@ async function dispatchFillViaRuntime(
         verify: req.flags?.verify,
         settle: readSettleRequest(req.flags),
         expectedResolvedTarget: replayTargetGuard,
-        preresolvedTarget: req.internal?.findPreresolvedTarget,
+        preresolvedTarget: req.internal?.findResolvedTarget,
       }),
     buildPayloads: (result) =>
       buildFillResponsePayloads({
@@ -712,7 +712,7 @@ async function prepareFillRefTarget(
   // A mutating `find`'s internal dispatch supplies a locator-minted ref, so the
   // public response must not claim the caller consumed a stale `@ref` (ADR 0014).
   const staleRefsWarning =
-    params.req.internal?.findResolvedTarget === true
+    params.req.internal?.findResolvedTarget !== undefined
       ? undefined
       : resolveRefStalenessWarning({
           session,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -108,28 +108,14 @@ type DaemonRequestInternal = {
    */
   replayLandmarkGuard?: TargetAnnotationV1;
   /**
-   * ADR 0014: set when a mutating `find` re-enters the interaction leaf with the
-   * ref it just resolved by locator against a fresh capture. That ref is find's
-   * own diagnostic identity, not a client-supplied ref subject to frame
-   * lifetime, so the leaf skips ref-frame admission (it still crosses the
-   * side-effect seam and expires the frame).
+   * ADR 0014 / #1654: the complete ref/node/tree target a mutating `find`
+   * resolved against its fresh capture. Its presence both marks the ref as
+   * find-owned (so admission/staleness policy is skipped) and supplies the node
+   * adopted by the interaction leaf. One payload keeps those decisions from
+   * becoming independently representable. The leaf still crosses the
+   * side-effect seam and expires the frame.
    */
-  findResolvedTarget?: boolean;
-  /**
-   * #1654: the node that same mutating `find` resolved, carried alongside the
-   * ref so the leaf adopts it instead of resolving `@eN` a second time.
-   *
-   * `findResolvedTarget` above says "this ref is find's own"; this says "and
-   * here is what it resolved to". They stay separate fields because the first
-   * governs ref-frame admission and staleness (a policy question) while this
-   * one governs resolution (a lookup question), and the focus/type actions set
-   * neither — they dispatch coordinates directly.
-   *
-   * Set only by the in-process `invoke` hop. Like every `internal` field it is
-   * daemon-only (`toDaemonRequest` never copies it off the wire), which is what
-   * makes carrying live node references here sound.
-   */
-  findPreresolvedTarget?: PreresolvedInteractionTarget;
+  findResolvedTarget?: PreresolvedInteractionTarget;
   /**
    * #1271 stage 2 (ADR 0012 decision 6 amendment): PROVENANCE — set by the
    * replay runtime (`invokeResolvedReplayAction`,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -2,6 +2,7 @@ import type { CommandFlags } from '@agent-device/contracts/command';
 import type {
   GestureExecutionProfile,
   GestureReferenceFrame,
+  PreresolvedInteractionTarget,
   ScrollDirection,
 } from '@agent-device/contracts/interaction';
 import type { LogBackend } from '@agent-device/contracts/observability';
@@ -114,6 +115,21 @@ type DaemonRequestInternal = {
    * side-effect seam and expires the frame).
    */
   findResolvedTarget?: boolean;
+  /**
+   * #1654: the node that same mutating `find` resolved, carried alongside the
+   * ref so the leaf adopts it instead of resolving `@eN` a second time.
+   *
+   * `findResolvedTarget` above says "this ref is find's own"; this says "and
+   * here is what it resolved to". They stay separate fields because the first
+   * governs ref-frame admission and staleness (a policy question) while this
+   * one governs resolution (a lookup question), and the focus/type actions set
+   * neither — they dispatch coordinates directly.
+   *
+   * Set only by the in-process `invoke` hop. Like every `internal` field it is
+   * daemon-only (`toDaemonRequest` never copies it off the wire), which is what
+   * makes carrying live node references here sound.
+   */
+  findPreresolvedTarget?: PreresolvedInteractionTarget;
   /**
    * #1271 stage 2 (ADR 0012 decision 6 amendment): PROVENANCE — set by the
    * replay runtime (`invokeResolvedReplayAction`,


### PR DESCRIPTION
Closes #1654. Completes the remaining target-resolution item from #1630.

## Summary

A mutating `find click` / `find fill` used to select a node, mint a ref, then make the interaction runtime look that ref up again. This removes that redundant lookup: find now passes one typed internal target payload containing the ref, selected node, and source tree.

The interaction runtime adopts that payload only when the positional ref, payload ref, node ref, and node membership all agree. Mismatches fail closed. Occlusion, hittable-ancestor promotion, off-screen refusal, recording, ref-frame effects, settle/observation, and deferred-outcome handling still run through the existing interaction wrapper.

The resolution-disclosure guarantee now names a shared `buildRefResolution` producer used by both ordinary ref lookup and the adopted find target. The previous two-field workaround and its misleading “second producer” explanation are gone.

This is a structural robustness change, not a demonstrated user-facing bug. The earlier Android freshness-race claim was disproved; the divergent-tree tests are explicitly defensive invariants.

## Validation

- `VITEST_MAX_WORKERS=4 pnpm check:affected --run` — 405 files / 3,922 tests passed on `856be1097`
- The three timeout-only failures from the first host-loaded run passed together in isolation (36/36) before the bounded-concurrency full rerun
- Exact production-route tests cover both find click and find fill forwarding through the real interaction handler
- Provenance mismatch tests fail closed; ordinary `@ref` behavior and runtime-ref guarantees remain covered
- Device no-regression evidence on iPhone 17 Pro simulator at behavior-equivalent pre-tightening head `0a467d8`: [full transcript](https://github.com/callstack/agent-device/pull/1669#issuecomment-5218536804)

No docs or skills changed: the public command surface and behavior are unchanged; this tightens an internal dispatch contract and corrects its source/test claims.
