### PR TITLE
[RFC] prototype: open --foreground collapses the snapshot->hint->open->snapshot dance into one call

### DIFF
--- a/packages/contracts/src/cli-flags.ts
+++ b/packages/contracts/src/cli-flags.ts
@@ -116,6 +116,13 @@ export type CliFlags = CloudProviderProfileFields &
     saveScript?: boolean | string;
     shutdown?: boolean;
     relaunch?: boolean;
+    /**
+     * RFC prototype (open --foreground, branch claude/observe-foreground): resolve the
+     * app target from the sole booted iOS simulator's sole running app instead of
+     * requiring an explicit app argument. Fails closed (AMBIGUOUS_MATCH) unless the
+     * environment is unambiguous.
+     */
+    foreground?: boolean;
     surface?: SessionSurface;
     headless?: boolean;
     restart?: boolean;

--- a/packages/contracts/src/client-app.ts
+++ b/packages/contracts/src/client-app.ts
@@ -45,6 +45,13 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
     launchConsole?: string;
     launchArgs?: string[];
     relaunch?: boolean;
+    /**
+     * RFC prototype (branch claude/observe-foreground): resolve the app target from the
+     * sole booted iOS simulator's sole running app instead of an explicit app
+     * argument, and return an initial interactive snapshot alongside the open result.
+     * Fails closed (AMBIGUOUS_MATCH) unless the environment is unambiguous.
+     */
+    foreground?: boolean;
     saveScript?: boolean | string;
     /** #1258: overwrite an existing --save-script target instead of refusing. Alias: --overwrite. */
     force?: boolean;
@@ -67,6 +74,16 @@ export type AppOpenResult = {
   startup?: StartupPerfSample;
   runtime?: SessionRuntimeHints;
   device?: AgentDeviceSessionDevice;
+  /**
+   * RFC prototype (open --foreground, branch claude/observe-foreground): the initial
+   * interactive snapshot captured immediately after open, composed from the same
+   * snapshot-runtime dispatch `agent-device snapshot -i` uses. Present only when
+   * `--foreground` triggered the auto-resolve path. Left loosely typed for this
+   * prototype rather than reusing `CaptureSnapshotResult` end to end (see PR
+   * follow-ups) since the daemon-side composition does not attach client-only
+   * fields like `identifiers`.
+   */
+  snapshot?: Record<string, unknown>;
   identifiers: AgentDeviceIdentifiers;
 };
 

--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -341,6 +341,11 @@ function summarizeProviderScenarioFlagExclusions() {
       keys: ['headless', 'testIme'],
     },
     {
+      name: 'open foreground auto-resolution (RFC prototype)',
+      owner: 'daemon session-open-foreground handler unit tests',
+      keys: ['foreground'],
+    },
+    {
       name: 'Apple simulator screenshot rendering options',
       owner: 'iOS platform and screenshot-diff runtime tests',
       keys: ['screenshotNormalizeStatusBar', 'screenshotPixelDensity'],

--- a/src/agent-device-client.ts
+++ b/src/agent-device-client.ts
@@ -279,6 +279,11 @@ export function createAgentDeviceClient(
           startup: normalizeStartupSample(data.startup),
           runtime: normalizeRuntimeHints(data.runtime),
           device,
+          // RFC prototype (open --foreground): only present when the daemon's
+          // foreground-attach composition captured an initial snapshot.
+          ...(data.snapshot && typeof data.snapshot === 'object'
+            ? { snapshot: data.snapshot as Record<string, unknown> }
+            : {}),
           identifiers: {
             session,
             deviceId: device?.id,

--- a/src/commands/cli-grammar/flag-definitions-action.ts
+++ b/src/commands/cli-grammar/flag-definitions-action.ts
@@ -274,6 +274,14 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription: 'open: terminate app process before launching it',
   },
   {
+    key: 'foreground',
+    names: ['--foreground'],
+    type: 'boolean',
+    usageLabel: '--foreground',
+    usageDescription:
+      "[RFC] open: resolve app + return an initial snapshot from the sole booted iOS simulator's sole running app",
+  },
+  {
     key: 'restart',
     names: ['--restart'],
     type: 'boolean',

--- a/src/commands/management/app.ts
+++ b/src/commands/management/app.ts
@@ -50,6 +50,9 @@ const openCommandMetadata = defineFieldCommandMetadata(
       'Launch arguments forwarded verbatim to the platform launch command.',
     ),
     relaunch: booleanField('Force relaunch.'),
+    foreground: booleanField(
+      "[RFC prototype] On a fresh session with no app argument, resolve the target from the sole booted iOS simulator's sole running app and include an initial interactive snapshot in the response. Fails with AMBIGUOUS_MATCH when the environment is not unambiguous (0 or 2+ booted simulators, or no confidently-detectable running app) — never guesses.",
+    ),
     saveScript: jsonSchemaField<boolean | string>({
       oneOf: [booleanSchema(), stringSchema()],
     }),
@@ -130,6 +133,7 @@ const openCliSchema = {
     'force',
     'noRecord',
     'relaunch',
+    'foreground',
     'surface',
     ...METRO_RELOAD_FLAGS,
     'launchUrl',
@@ -155,6 +159,7 @@ const openCliReader: CliReader = (positionals, flags) => ({
   launchConsole: flags.launchConsole,
   launchArgs: flags.launchArgs,
   relaunch: flags.relaunch,
+  foreground: flags.foreground,
   saveScript: flags.saveScript,
   force: flags.force,
   deviceHub: flags.deviceHub,

--- a/src/daemon/handlers/__tests__/session-open-foreground.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-foreground.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const resolveSoleForegroundIosApp = vi.hoisted(() => vi.fn());
+const dispatchSnapshotViaRuntime = vi.hoisted(() => vi.fn());
+
+vi.mock('../../ios-app-session-hint.ts', () => ({ resolveSoleForegroundIosApp }));
+vi.mock('../../snapshot-runtime.ts', () => ({ dispatchSnapshotViaRuntime }));
+
+import { IOS_SIMULATOR } from '../../../__tests__/test-utils/index.ts';
+import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import {
+  composeOpenWithInitialSnapshot,
+  resolveForegroundOpenRequest,
+} from '../session-open-foreground.ts';
+
+function baseRequest(overrides: Partial<DaemonRequest> = {}): DaemonRequest {
+  return {
+    token: 't',
+    session: 'default',
+    command: 'open',
+    positionals: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resolveSoleForegroundIosApp.mockReset();
+  dispatchSnapshotViaRuntime.mockReset();
+});
+
+// --- resolveForegroundOpenRequest ---
+
+test('leaves the request untouched when --foreground was not requested', async () => {
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest(),
+    hasExistingSession: false,
+  });
+
+  expect(resolution).toEqual({ type: 'not-requested' });
+  expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
+});
+
+test('rejects --foreground against an existing session', async () => {
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest({ flags: { foreground: true } }),
+    hasExistingSession: true,
+  });
+
+  expect(resolution.type).toBe('response');
+  if (resolution.type === 'response') {
+    expect(resolution.response.ok).toBe(false);
+    if (!resolution.response.ok) {
+      expect(resolution.response.error.code).toBe('INVALID_ARGS');
+    }
+  }
+  expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
+});
+
+test('rejects --foreground combined with an explicit app argument', async () => {
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest({ flags: { foreground: true }, positionals: ['com.example.demo'] }),
+    hasExistingSession: false,
+  });
+
+  expect(resolution.type).toBe('response');
+  if (resolution.type === 'response') {
+    expect(resolution.response.ok).toBe(false);
+    if (!resolution.response.ok) {
+      expect(resolution.response.error.code).toBe('INVALID_ARGS');
+    }
+  }
+  expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
+});
+
+test('an unambiguous environment rewrites positionals and pins the resolved device', async () => {
+  const soleBootedDevice = { ...IOS_SIMULATOR, id: 'booted-1', name: 'iPhone 16' };
+  resolveSoleForegroundIosApp.mockResolvedValue({
+    device: soleBootedDevice,
+    app: { bundleId: 'xyz.blueskyweb.app', name: 'Bluesky' },
+  });
+
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest({ flags: { foreground: true, iosSimulatorDeviceSet: '/custom/set' } }),
+    hasExistingSession: false,
+  });
+
+  expect(resolution).toEqual({
+    type: 'resolved',
+    req: baseRequest({
+      flags: {
+        foreground: true,
+        iosSimulatorDeviceSet: '/custom/set',
+        udid: 'booted-1',
+        platform: 'ios',
+      },
+      positionals: ['xyz.blueskyweb.app'],
+    }),
+  });
+  expect(resolveSoleForegroundIosApp).toHaveBeenCalledWith({ simulatorSetPath: '/custom/set' });
+});
+
+test('an ambiguous environment fails closed with AMBIGUOUS_MATCH instead of guessing', async () => {
+  resolveSoleForegroundIosApp.mockResolvedValue(undefined);
+
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest({ flags: { foreground: true } }),
+    hasExistingSession: false,
+  });
+
+  expect(resolution.type).toBe('response');
+  if (resolution.type === 'response') {
+    expect(resolution.response.ok).toBe(false);
+    if (!resolution.response.ok) {
+      expect(resolution.response.error.code).toBe('AMBIGUOUS_MATCH');
+      expect(resolution.response.error.details?.reason).toBe('foreground_app_ambiguous');
+      expect(resolution.response.error.details?.hint).toMatch(/agent-device open <app>/);
+    }
+  }
+});
+
+test('a probe failure fails closed like ambiguity, never silently succeeds', async () => {
+  // The resolver owns the catch-all (see resolveSoleForegroundIosApp): a
+  // rejecting simctl/launchctl probe surfaces as `undefined`, which this
+  // handler must treat exactly like ambiguity — a hard AMBIGUOUS_MATCH, not
+  // a guessed target.
+  resolveSoleForegroundIosApp.mockResolvedValue(undefined);
+
+  const resolution = await resolveForegroundOpenRequest({
+    req: baseRequest({ flags: { foreground: true } }),
+    hasExistingSession: false,
+  });
+
+  expect(resolution.type).toBe('response');
+  if (resolution.type === 'response') {
+    expect(resolution.response.ok).toBe(false);
+    if (!resolution.response.ok) {
+      expect(resolution.response.error.code).toBe('AMBIGUOUS_MATCH');
+    }
+  }
+});
+
+// --- composeOpenWithInitialSnapshot ---
+
+const okOpenResponse: DaemonResponse = { ok: true, data: { session: 'default' } };
+const failedOpenResponse: DaemonResponse = {
+  ok: false,
+  error: { code: 'AMBIGUOUS_MATCH', message: 'nope' },
+};
+
+test('passes a failed open response through untouched', async () => {
+  const result = await composeOpenWithInitialSnapshot({
+    req: baseRequest({ flags: { foreground: true } }),
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: {} as never,
+    openResponse: failedOpenResponse,
+  });
+
+  expect(result).toBe(failedOpenResponse);
+  expect(dispatchSnapshotViaRuntime).not.toHaveBeenCalled();
+});
+
+test('leaves a successful open response untouched when --foreground was not requested', async () => {
+  const result = await composeOpenWithInitialSnapshot({
+    req: baseRequest(),
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: {} as never,
+    openResponse: okOpenResponse,
+  });
+
+  expect(result).toBe(okOpenResponse);
+  expect(dispatchSnapshotViaRuntime).not.toHaveBeenCalled();
+});
+
+test('attaches the initial snapshot by delegating to the existing snapshot runtime dispatch', async () => {
+  dispatchSnapshotViaRuntime.mockResolvedValue({ ok: true, data: { nodes: [], truncated: false } });
+
+  const req = baseRequest({ flags: { foreground: true }, positionals: ['xyz.blueskyweb.app'] });
+  const result = await composeOpenWithInitialSnapshot({
+    req,
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: {} as never,
+    openResponse: okOpenResponse,
+  });
+
+  expect(dispatchSnapshotViaRuntime).toHaveBeenCalledWith({
+    req: { ...req, command: 'snapshot', positionals: [] },
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: {},
+  });
+  expect(result).toEqual({
+    ok: true,
+    data: { session: 'default', snapshot: { nodes: [], truncated: false } },
+  });
+});
+
+test('surfaces a snapshot-capture failure instead of the open success', async () => {
+  const snapshotFailure: DaemonResponse = {
+    ok: false,
+    error: { code: 'COMMAND_FAILED', message: 'capture failed' },
+  };
+  dispatchSnapshotViaRuntime.mockResolvedValue(snapshotFailure);
+
+  const result = await composeOpenWithInitialSnapshot({
+    req: baseRequest({ flags: { foreground: true } }),
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: {} as never,
+    openResponse: okOpenResponse,
+  });
+
+  expect(result).toBe(snapshotFailure);
+});

--- a/src/daemon/handlers/session-open-foreground.ts
+++ b/src/daemon/handlers/session-open-foreground.ts
@@ -1,0 +1,118 @@
+import { resolveSoleForegroundIosApp } from '../ios-app-session-hint.ts';
+import { dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
+import type { SessionStore } from '../session-store.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import { errorResponse } from './response.ts';
+
+export type ForegroundOpenResolution =
+  | { type: 'not-requested' }
+  | { type: 'resolved'; req: DaemonRequest }
+  | { type: 'response'; response: DaemonResponse };
+
+/**
+ * RFC prototype (branch claude/observe-foreground): `open --foreground` collapses the
+ * `snapshot -i` (fails) -> read hint -> `open <bundleId>` -> `snapshot -i` dance into one
+ * call for the common case (one booted iOS simulator, one running app).
+ *
+ * When `--foreground` is set with no explicit app argument on a fresh session, this
+ * auto-resolves the target via `resolveSoleForegroundIosApp` — the exact same
+ * ambiguity-detection probe that enriches the SESSION_NOT_FOUND hint — and rewrites the
+ * request's positionals/flags so the rest of `handleOpenCommand`'s existing new-session
+ * flow (device resolution, surface validation, session creation) runs completely
+ * unmodified against the resolved device + bundle id. Only iOS simulators are handled;
+ * see the PR body for scoped-out platforms.
+ *
+ * Fails closed with AMBIGUOUS_MATCH — never guesses — when the environment is not
+ * unambiguous: zero or multiple booted simulators, zero or multiple running apps, or a
+ * probe failure (the resolver owns the catch-all and reports failure as `undefined`,
+ * never a rejection). This mirrors `buildIosOpenCommandHint`'s no-guessing contract
+ * exactly, because it is built from the same underlying probe.
+ */
+export async function resolveForegroundOpenRequest(params: {
+  req: DaemonRequest;
+  hasExistingSession: boolean;
+}): Promise<ForegroundOpenResolution> {
+  const { req, hasExistingSession } = params;
+  if (req.flags?.foreground !== true) return { type: 'not-requested' };
+
+  if (hasExistingSession) {
+    return {
+      type: 'response',
+      response: errorResponse(
+        'INVALID_ARGS',
+        'open --foreground only applies to a fresh session. Close the current session first, or omit --foreground.',
+      ),
+    };
+  }
+  if (req.positionals?.[0]) {
+    return {
+      type: 'response',
+      response: errorResponse(
+        'INVALID_ARGS',
+        'open --foreground cannot be combined with an explicit app argument.',
+      ),
+    };
+  }
+
+  const resolved = await resolveSoleForegroundIosApp({
+    simulatorSetPath: req.flags?.iosSimulatorDeviceSet,
+  });
+  if (!resolved) {
+    return {
+      type: 'response',
+      response: errorResponse(
+        'AMBIGUOUS_MATCH',
+        'open --foreground requires an unambiguous environment: exactly one booted iOS simulator with exactly one app running.',
+        {
+          reason: 'foreground_app_ambiguous',
+          hint: 'Pass an explicit app instead: agent-device open <app> --platform ios.',
+        },
+      ),
+    };
+  }
+
+  return {
+    type: 'resolved',
+    req: {
+      ...req,
+      positionals: [resolved.app.bundleId],
+      flags: { ...req.flags, udid: resolved.device.id, platform: 'ios' },
+    },
+  };
+}
+
+/**
+ * The other half of the `open --foreground` composition: once `handleOpenCommand` has
+ * created the session (with `session.appBundleId` now set), attach an initial
+ * interactive snapshot by delegating to the EXISTING `snapshot` runtime dispatch
+ * (`dispatchSnapshotViaRuntime`) — the same ref-issuing, session-store-updating path
+ * `agent-device snapshot -i` uses. This is deliberately composition, not a new capture
+ * pipeline: refs, snapshot lineage, and ref-frame activation all come from the one
+ * capture path already trusted for `snapshot`.
+ *
+ * A no-op when `--foreground` was not requested, or when open itself failed (nothing to
+ * attach a snapshot to).
+ */
+export async function composeOpenWithInitialSnapshot(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  openResponse: DaemonResponse;
+}): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore, openResponse } = params;
+  if (!openResponse.ok || req.flags?.foreground !== true) return openResponse;
+
+  const snapshotResponse = await dispatchSnapshotViaRuntime({
+    req: { ...req, command: 'snapshot', positionals: [] },
+    sessionName,
+    logPath,
+    sessionStore,
+  });
+  if (!snapshotResponse.ok) return snapshotResponse;
+
+  return {
+    ok: true,
+    data: { ...openResponse.data, snapshot: snapshotResponse.data },
+  };
+}

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -54,6 +54,7 @@ import {
   validatePreResolvedOpenRequest,
   validateResolvedOpenRequest,
 } from './session-open-prepare.ts';
+import { resolveForegroundOpenRequest } from './session-open-foreground.ts';
 import { errorResponse } from './response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import { buildSessionRecoveryHint } from '../session-recovery-hints.ts';
@@ -652,9 +653,16 @@ export async function handleOpenCommand(params: {
   logPath: string;
   sessionStore: SessionStore;
 }): Promise<DaemonResponse> {
-  const { req, sessionName, logPath, sessionStore } = params;
+  const { sessionName, logPath, sessionStore } = params;
 
   const session = sessionStore.get(sessionName);
+  const foregroundResolution = await resolveForegroundOpenRequest({
+    req: params.req,
+    hasExistingSession: Boolean(session),
+  });
+  if (foregroundResolution.type === 'response') return foregroundResolution.response;
+  const req = foregroundResolution.type === 'resolved' ? foregroundResolution.req : params.req;
+
   if (session) {
     if (req.flags?.saveScript) {
       return errorResponse(

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -21,6 +21,7 @@ import { errorResponse, requireCommandSupported } from './response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { handleRuntimeCommand } from './session-runtime-command.ts';
 import { handleOpenCommand } from './session-open.ts';
+import { composeOpenWithInitialSnapshot } from './session-open-foreground.ts';
 import {
   resolveAndroidPackageForOpen,
   resolveSessionAppBundleIdForTarget,
@@ -450,7 +451,13 @@ const SESSION_COMMAND_HANDLER_IMPLS = {
   push: handlePushCommand,
   'trigger-app-event': handleTriggerAppEventCommand,
   open: async ({ req, sessionName, logPath, sessionStore }) =>
-    await handleOpenCommand({ req, sessionName, logPath, sessionStore }),
+    await composeOpenWithInitialSnapshot({
+      req,
+      sessionName,
+      logPath,
+      sessionStore,
+      openResponse: await handleOpenCommand({ req, sessionName, logPath, sessionStore }),
+    }),
   replay: handleSessionReplayCommandGroup,
   test: handleSessionReplayCommandGroup,
   batch: async ({ req, sessionName, invoke }) => await runBatchCommands(req, sessionName, invoke),

--- a/src/daemon/ios-app-session-hint.test.ts
+++ b/src/daemon/ios-app-session-hint.test.ts
@@ -7,7 +7,7 @@ vi.mock('../platforms/apple/core/devices.ts', () => ({ listBootedIosSimulators }
 vi.mock('../platforms/apple/core/app-resolution.ts', () => ({ detectSoleRunningIosSimulatorApp }));
 
 import { IOS_DEVICE, IOS_SIMULATOR } from '../__tests__/test-utils/index.ts';
-import { buildIosOpenCommandHint } from './ios-app-session-hint.ts';
+import { buildIosOpenCommandHint, resolveSoleForegroundIosApp } from './ios-app-session-hint.ts';
 
 beforeEach(() => {
   listBootedIosSimulators.mockReset();
@@ -121,4 +121,54 @@ test('a physical iOS device never probes for a hint', async () => {
 
   expect(hint).toBeUndefined();
   expect(listBootedIosSimulators).not.toHaveBeenCalled();
+});
+
+test('resolveSoleForegroundIosApp resolves the device and app when unambiguous', async () => {
+  const soleBootedDevice = { ...IOS_SIMULATOR, id: 'booted-1', name: 'iPhone 16' };
+  const app = { bundleId: 'xyz.blueskyweb.app', name: 'Bluesky' };
+  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue(app);
+
+  const resolved = await resolveSoleForegroundIosApp({ simulatorSetPath: '/custom/set' });
+
+  expect(resolved).toEqual({ device: soleBootedDevice, app });
+  expect(listBootedIosSimulators).toHaveBeenCalledWith({ simulatorSetPath: '/custom/set' });
+  expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
+});
+
+test('resolveSoleForegroundIosApp returns undefined for zero booted simulators', async () => {
+  listBootedIosSimulators.mockResolvedValue([]);
+
+  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
+  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
+});
+
+test('resolveSoleForegroundIosApp returns undefined for more than one booted simulator', async () => {
+  listBootedIosSimulators.mockResolvedValue([
+    { ...IOS_SIMULATOR, id: 'booted-1' },
+    { ...IOS_SIMULATOR, id: 'booted-2' },
+  ]);
+
+  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
+  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
+});
+
+test('resolveSoleForegroundIosApp returns undefined when the running-app probe is inconclusive', async () => {
+  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
+  detectSoleRunningIosSimulatorApp.mockResolvedValue(undefined);
+
+  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
+});
+
+test('resolveSoleForegroundIosApp catches a rejecting probe instead of propagating it', async () => {
+  // The catch-all lives in the resolver, so both consumers (the hint and
+  // open --foreground) inherit the never-propagate contract from one place.
+  listBootedIosSimulators.mockRejectedValue(new Error('simctl timed out'));
+
+  await expect(resolveSoleForegroundIosApp()).resolves.toBeUndefined();
+
+  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
+  detectSoleRunningIosSimulatorApp.mockRejectedValue(new Error('launchctl timed out'));
+
+  await expect(resolveSoleForegroundIosApp()).resolves.toBeUndefined();
 });

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -1,22 +1,55 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { detectSoleRunningIosSimulatorApp } from '../platforms/apple/core/app-resolution.ts';
+import type { IosAppInfo } from '../platforms/apple/core/app-info.ts';
 import { listBootedIosSimulators } from '../platforms/apple/core/devices.ts';
 import { shellQuoteIfNeeded } from '../utils/shell-quote.ts';
 
+export type ResolvedForegroundIosApp = {
+  device: DeviceInfo;
+  app: IosAppInfo;
+};
+
 /**
- * Enriches the generic "Run open first" SESSION_NOT_FOUND hint with the exact
- * runnable command, but only when the environment is unambiguous: exactly one
- * booted iOS simulator with exactly one app running on it.
+ * The shared ambiguity-detection probe: exactly one booted iOS simulator with
+ * exactly one app running on it, or `undefined`.
  *
  * Any ambiguity — no booted simulator, more than one, no running app, more
- * than one running app, or a probe failure — returns `undefined` so the
- * caller keeps the generic hint. This must never guess: a wrong-but-confident
- * command is worse than the default guidance.
+ * than one running app, or a probe failure — returns `undefined`. This must
+ * never guess: a wrong-but-confident answer is worse than failing closed.
  *
- * The whole probe is strictly best-effort: it runs on an error path, so a
- * throw here (a bounded probe still rejects on timeout or a spawn failure —
- * see app-resolution.ts) must fall back to `undefined`, never replace the
- * caller's deterministic error with a probe failure.
+ * Strictly best-effort: a throw here (a bounded probe still rejects on
+ * timeout or a spawn failure — see app-resolution.ts) is caught and treated
+ * as inconclusive, never propagated — callers sit on error/decision paths
+ * where a probe failure must not replace their deterministic outcome.
+ *
+ * `buildIosOpenCommandHint` (error-hint enrichment) and the `open --foreground`
+ * convenience (RFC, #observe-foreground) both compose this single probe
+ * instead of re-deriving the ambiguity rules.
+ */
+export async function resolveSoleForegroundIosApp(
+  options: { simulatorSetPath?: string } = {},
+): Promise<ResolvedForegroundIosApp | undefined> {
+  try {
+    const booted = await listBootedIosSimulators({ simulatorSetPath: options.simulatorSetPath });
+    if (booted.length !== 1) return undefined;
+    const [soleBootedDevice] = booted;
+    if (!soleBootedDevice) return undefined;
+
+    const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
+    if (!app) return undefined;
+
+    return { device: soleBootedDevice, app };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Enriches the generic "Run open first" SESSION_NOT_FOUND hint with the exact
+ * runnable command, but only when the environment is unambiguous (see
+ * `resolveSoleForegroundIosApp`, which also owns the never-guess and
+ * never-propagate contract). Ambiguity or a probe failure returns `undefined`
+ * so the caller keeps the generic hint.
  */
 // Wire-level details are redacted before send (packages/kernel/src/redaction.ts),
 // which silently truncates any string field over 400 chars — a truncated
@@ -29,23 +62,14 @@ const MAX_HINT_LENGTH = 350;
 export async function buildIosOpenCommandHint(device: DeviceInfo): Promise<string | undefined> {
   if (!isIosFamily(device) || device.kind !== 'simulator') return undefined;
 
-  try {
-    const booted = await listBootedIosSimulators({ simulatorSetPath: device.simulatorSetPath });
-    if (booted.length !== 1) return undefined;
-    const [soleBootedDevice] = booted;
-    if (!soleBootedDevice) return undefined;
+  const resolved = await resolveSoleForegroundIosApp({ simulatorSetPath: device.simulatorSetPath });
+  if (!resolved) return undefined;
 
-    const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
-    if (!app) return undefined;
-
-    const command = buildOpenCommand(soleBootedDevice, app.bundleId);
-    const hint =
-      `One booted device found ("${soleBootedDevice.name}", udid ${soleBootedDevice.id}) with ` +
-      `${app.bundleId} running. Run: ${command}`;
-    return hint.length <= MAX_HINT_LENGTH ? hint : undefined;
-  } catch {
-    return undefined;
-  }
+  const command = buildOpenCommand(resolved.device, resolved.app.bundleId);
+  const hint =
+    `One booted device found ("${resolved.device.name}", udid ${resolved.device.id}) with ` +
+    `${resolved.app.bundleId} running. Run: ${command}`;
+  return hint.length <= MAX_HINT_LENGTH ? hint : undefined;
 }
 
 // Always pins --udid: the sole-booted-device check only proves there is one

--- a/src/utils/result-serialization.ts
+++ b/src/utils/result-serialization.ts
@@ -164,6 +164,7 @@ export function serializeOpenResult(result: AppOpenResult): Record<string, unkno
       ...(result.startup ? { startup: result.startup } : {}),
       ...(result.runtime ? { runtime: result.runtime } : {}),
       ...(result.device ? serializeSessionDevice(result.device) : {}),
+      ...(result.snapshot ? { snapshot: result.snapshot } : {}),
     },
     target ? `Opened: ${target}` : 'Opened',
   );


### PR DESCRIPTION
**This is a first-pass RFC prototype — nobody has reviewed this design. It exists to give the maintainer something concrete to react to, not a finished feature.** Command spelling, error code, and scope are all up for debate.

> Rebased onto current main after #1662 merged: the `resolveSoleForegroundIosApp` extraction was re-done from the merged hint (carrying its catch-all, bounded-probe, `--udid`/device-set pinning, `MAX_HINT_LENGTH`, and "running" wording), and this PR's own error message now says "exactly one app running" — the probe verifies a sole running app process, not frontmost-scene status.

## Motivation

`agent-device snapshot -i` already emits an enriched hint (#1662) when it fails with `SESSION_NOT_FOUND` and the environment is unambiguous (one booted iOS simulator, one running app): it names the exact `open <bundleId>` command to run. Benchmark evidence: an agent still has to spend 2-3 turns on this — `snapshot -i` (fails) -> read hint -> `open <bundleId>` -> `snapshot -i` (succeeds) — in 27 of 30 benchmark tasks, costing ~20s and multiple model turns each time, even though the environment was completely unambiguous.

This PR prototypes `open --foreground`: on a fresh session with no app argument, it auto-resolves the target the same way the hint does, opens it, and returns the initial interactive snapshot in the same response — collapsing the 3-call dance into 1 call for the common case, with the exact same fail-closed, no-guessing semantics otherwise.

## Design: why `open --foreground`, not `observe` or `snapshot --attach-foreground`

Three spellings were considered:

1. **A new top-level `observe` command.** Cleanest single-purpose semantics, but the most new wiring: a new CLI grammar (metadata/schema/reader/writer), and — while `src/core/command-descriptor/registry.ts`'s single-declaration model means a *plain* new command is only ~1-2 files — this command isn't plain: it would need its own session-creation logic re-invoked or duplicated from `open`'s existing path (device resolution, advisory device claims, runtime-hint plumbing, session-store persistence), since `src/daemon/handlers/session-open.ts`'s `handleOpenCommand` is the sole owner of that machinery today.
2. **`snapshot --attach-foreground`.** `snapshot`'s daemon handler (`src/daemon/snapshot-runtime.ts`) is architecturally read-only: it *requires* an existing session and explicitly rejects a missing one (`requireIosAppSessionForSnapshot`). Teaching it to also create a session on demand would change a correctness-relevant invariant of that command, not just add wiring.
3. **`open --foreground`.** `open` already owns 100% of the session-creation machinery this needs. Traced end-to-end: adding a flag-only capability to an existing command touches only `src/commands/management/app.ts` (metadata field + `allowedFlags` + CLI reader) and a `FlagDefinition` entry in `src/commands/cli-grammar/flag-definitions-action.ts` — confirmed **zero** changes needed to `src/core/capabilities.ts`, `src/batch-policy.ts`, `src/client-types.ts`, `src/client.ts`, or the daemon command registry (`open`'s route/policy traits are unchanged). The daemon-side composition (resolve -> open -> attach snapshot) lives in one new file, `src/daemon/handlers/session-open-foreground.ts`, composing the *existing* `handleOpenCommand` and the *existing* `dispatchSnapshotViaRuntime` snapshot-runtime dispatch — no new capture pipeline.

Given this is explicitly a cheap RFC demonstration and not a production surface, minimizing new wiring was the deciding factor. Option 3 reuses the most existing plumbing by a wide margin.

## What changed

- **`src/daemon/ios-app-session-hint.ts`**: extracted the existing ambiguity-detection logic (previously inline in `buildIosOpenCommandHint`) into a new `resolveSoleForegroundIosApp()` that returns structured `{ device, app } | undefined` instead of a formatted string. The extraction was re-done from the **merged** #1662 version after rebase, so its review-fix semantics carry into the structured resolver: the catch-all now lives in the resolver (any probe rejection — timeout, spawn failure — yields `undefined`, never propagates, for both consumers), and the hint builder keeps its `--udid` + `--ios-simulator-device-set` command pinning, `MAX_HINT_LENGTH` fallback, and "running" wording unchanged. Same behavior, same tests (plus a resolver-level caught-rejection test), zero duplication.
- **`src/daemon/handlers/session-open-foreground.ts`** (new): `resolveForegroundOpenRequest()` intercepts `open --foreground` on a fresh session with no app argument, resolves via `resolveSoleForegroundIosApp`, and rewrites the request's `positionals`/`flags` (pinning `udid` + `platform: ios`) so the rest of `handleOpenCommand`'s existing new-session flow runs completely unmodified. Fails closed with `AMBIGUOUS_MATCH` (not a new/wrong code — this is the existing code used elsewhere for the same kind of ambiguity, e.g. `resolveAppleDevice`'s multi-simulator-match case) when 0 or 2+ booted simulators, or 0 or 2+ running apps, are found — a probe failure surfaces as the same fail-closed error, since the resolver reports it as `undefined`. `composeOpenWithInitialSnapshot()` then delegates to the existing `dispatchSnapshotViaRuntime` (the same path `snapshot -i` uses — ref issuance, session-store snapshot lineage, ref-frame activation all come for free) and merges the result under `data.snapshot`.
- **`src/daemon/handlers/session-open.ts` / `session.ts`**: `handleOpenCommand` now resolves the foreground request before doing anything else; the `open` router entry composes it with the snapshot attach step.
- **`src/commands/management/app.ts`, `src/commands/cli-grammar/flag-definitions-action.ts`, `packages/contracts/src/cli-flags.ts`, `packages/contracts/src/client-app.ts`, `src/agent-device-client.ts`, `src/utils/result-serialization.ts`**: thread the new `--foreground` boolean flag through the CLI grammar and (loosely-typed, see follow-ups) the typed Node client's `AppOpenResult.snapshot`.

## Live validation

Isolated simulators only (never `bench-golden*`, never the pinned UDID, never simulators I didn't create), repo CLI only, deleted at the end.

### Correctness: direct probe verification

```
$ node --experimental-strip-types -e "import('./src/daemon/ios-app-session-hint.ts').then(async (m) => {
  console.log(JSON.stringify(await m.resolveSoleForegroundIosApp({ simulatorSetPath: '<isolated set>' })));
})"
{
  "device": { "id": "...", "name": "claude-observe-test", "kind": "simulator", ... },
  "app": { "bundleId": "com.apple.Preferences", "name": "Settings" }
}
```

### Before: the 3-call dance (real transcript, isolated simulator, `com.apple.Preferences` launched via `simctl launch`, no agent-device session)

> Transcript captured on the pre-rebase build (which carried a port of the hint predating #1662's review fixes) — on current main the hint says "running" and pins `--udid`/`--ios-simulator-device-set`; the flow and timings are unaffected.

```
=== call1: snapshot -i ===
{
  "success": false,
  "error": {
    "code": "SESSION_NOT_FOUND",
    "message": "iOS snapshot requires an active app session on the target device. Run open first ...",
    "hint": "One booted device found (\"claude-observe-final\", udid A1D15DDB-...) with com.apple.Preferences in the foreground. Run: agent-device open com.apple.Preferences --platform ios",
    "details": { "reason": "ios_app_session_required" }
  }
}
=== call2: open com.apple.Preferences ===
{
  "success": true,
  "data": { "session": "default", "appBundleId": "com.apple.Preferences", "startup": { "durationMs": 700 }, ... }
}
=== call3: snapshot -i ===
{
  "success": false,
  "error": { "code": "COMMAND_FAILED", "message": "Timed out waiting for XCTest device set lock", ... }
}
TIMINGS(seconds): call1=4.216 call2=2.146 call3=30.275(timed out) TOTAL=36.637
```

Call 3 (the final, previously-manual `snapshot -i`) reliably lost a race against `open`'s background XCTest-runner prewarm on this run — see "Environmental notes" below; this is a pre-existing infra characteristic shared by both the old dance and the new command, not something this PR introduces or fixes.

### Fail-fast: ambiguous environment (real transcript, default device set with multiple genuinely-booted simulators from concurrent sessions — no construction needed)

```
$ agent-device open --foreground --platform ios --json
{
  "success": false,
  "error": {
    "code": "AMBIGUOUS_MATCH",
    "message": "open --foreground requires an unambiguous environment: exactly one booted iOS simulator with exactly one app running.",
    "hint": "Pass an explicit app instead: agent-device open <app> --platform ios.",
    "details": { "reason": "foreground_app_ambiguous" }
  }
}
```

3.9s, no guessing, no session created — confirmed via `xcrun simctl list devices booted` that 3+ simulators from other concurrent sessions were genuinely booted at the time. (Message shown with the post-rebase wording — "exactly one app running", not "in its foreground": the probe verifies a sole running `UIKitApplication` process, not frontmost-scene status, matching #1662's wording fix. The captured run differed only in that trailing phrase.)

### After: the 1-call flow

`resolveForegroundOpenRequest` was exercised live and worked correctly end-to-end through the resolve step every time I reached it (multiple runs): it correctly resolved `{device, bundleId}` and rewrote the request, or correctly failed closed with `AMBIGUOUS_MATCH` when ambiguous (see above). I was **not** able to capture a single fully-unbroken `open --foreground` run all the way through to a returned snapshot on this occasion — every attempt (~15+ fresh isolated simulators across roughly two hours) had its simulator crash/vanish (`Invalid device`, `exitCode: 148`) at some point between boot and the runner's XCTest launch, including attempts where the simulator survived long enough for my own manual `simctl launch` to succeed just before the daemon's own dispatch failed. This reproduced identically for the *old* 3-call dance's final step and is a property of the shared machine at the time (see below), not of this PR's code — the composed `open --foreground` reaches and exercises the exact same `dispatchSnapshotViaRuntime` path `snapshot -i` uses, with no new capture logic to fail differently.

### Environmental notes (found during validation, not fixed here — filed separately)

This machine was under extreme, sustained multi-tenant load for most of this validation session (`uptime` load averages up to 865; ~30 concurrent `agent-device` daemon processes and multiple concurrent `xcodebuild` processes observed from unrelated worktrees/sessions; free memory briefly dropped to ~500MB). Two concrete, precisely-diagnosed pre-existing bugs were found and reported as separate follow-ups (not fixed in this PR — out of scope, unrelated files):

1. `src/platforms/apple/core/runner/runner-device-set.ts`, `reconcileXcodebuildSimulatorSetRedirect`: `const xctestIsSymlink = xctestExists && fs.lstatSync(...).isSymbolicLink()` short-circuits to `false` for a **dangling** symlink at `~/Library/Developer/XCTestDevices` (since `fs.existsSync` follows symlinks), skipping the cleanup step and causing every subsequent XCTest-backed command **system-wide** to fail with `ENOTDIR` until someone manually repairs the path by hand. Reproducible: delete a `--ios-simulator-device-set` directory while it's still the live `XCTestDevices` symlink target.
2. The global `~/.agent-device/xctest-device-set.lock` (same file) has no stale-owner/liveness reclaim, unlike the device-claim mechanism fixed in #1647 — a killed daemon (or, observed once, a leaked lock from an automated test run whose `owner.json` literally recorded the mocked value `"startTime":"test-process-start"`) can leave it held indefinitely, blocking every future XCTest command until the lock directory is removed by hand.

Also noted, not filed: a freshly booted iOS 18.6 simulator can have `com.apple.mobilecal` (Calendar) respawn as a `UIKitApplication` launchd job with nothing explicitly launched by the user, occasionally making `resolveSoleForegroundIosApp` correctly-but-inconveniently report ambiguous even when only one app was deliberately launched — this is existing `detectSoleRunningIosSimulatorApp` behavior from the companion hint PR, not something this PR changes or should change (the no-guessing contract is doing exactly its job here).

## Not yet handled (explicitly scoped out)

- **Android, macOS, physical iOS devices**: `resolveSoleForegroundIosApp` only probes iOS simulators; `--foreground` on any other target fails closed (`AMBIGUOUS_MATCH` / no resolution), never guesses.
- **Typed Node SDK / MCP surface**: `--foreground` is wired through the CLI-direct-to-daemon path and the raw JSON `AppOpenResult.snapshot`, but `snapshot` is loosely typed (`Record<string, unknown>`, not the full `CaptureSnapshotResult`) since the daemon-side composition doesn't attach client-only fields like `identifiers`. No MCP tool schema smoke test added.
- **`--foreground` combined with an existing session or an explicit app argument**: rejected with `INVALID_ARGS` rather than silently ignored or auto-relaunching.
- **Test coverage**: unit tests cover `resolveForegroundOpenRequest` and `composeOpenWithInitialSnapshot` in isolation (10 new tests, hermetic, mocked probes/dispatch) plus the extracted `resolveSoleForegroundIosApp` probe (5 new tests in `ios-app-session-hint.test.ts`, including the caught-rejection contract). A full router-level integration test mirroring `request-router-open.test.ts`'s heavier mocking (`ensureDeviceReady`/`resolveTargetDevice`/`dispatchCommand`) was not added — left as a follow-up.

## Testing

- `npm run typecheck`, `npm run check:layering`, `npx oxlint <changed files> --deny-warnings`, `node ./node_modules/oxfmt/bin/oxfmt --check .` — all clean.
- `npx vitest run` across all touched/added test files plus the existing `open`-adjacent suites (`request-router-open`, `session-open-*`, `snapshot-handler`) — 169/169 passing after the rebase onto #1662.
- `npm run build` — succeeds; `bin/agent-device.mjs open --help` shows the new `--foreground` flag with its `[RFC]` description.

Not merging this myself — it needs your read on the command spelling above everything else.

