### PR TITLE
fix(ios): wait for hidden-keyboard synthesized text to commit before responding

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -159,6 +159,106 @@ extension RunnerTests {
     repairMode == .none && fromTapWitness && !softwareKeyboardVisible
   }
 
+  enum SynthesizedTextCommitProgress: Equatable {
+    case committed
+    case pending
+    case diverged
+  }
+
+  // The private synthesize call returns once the event record is posted, not once the target
+  // app has committed the characters, so intermediate reads walk prefix-by-prefix toward the
+  // expected value. Anything off that prefix path means the app transformed the input
+  // (formatter, mid-text caret, autocomplete) and the runner must not second-guess it.
+  static func synthesizedTextCommitProgress(
+    observedText: String?,
+    expectedText: String
+  ) -> SynthesizedTextCommitProgress {
+    guard let observedText else {
+      return .diverged
+    }
+    if observedText == expectedText {
+      return .committed
+    }
+    return expectedText.hasPrefix(observedText) ? .pending : .diverged
+  }
+
+  static func synthesizedTextCommitRepairTail(
+    observedText: String,
+    expectedText: String
+  ) -> String? {
+    guard expectedText.hasPrefix(observedText), observedText.count < expectedText.count else {
+      return nil
+    }
+    let tail = String(expectedText.dropFirst(observedText.count))
+    guard !tail.contains("\n"), !tail.contains("\r") else {
+      return nil
+    }
+    return tail
+  }
+
+  /// Blocks until the synthesized bare-type text is observable in the target field, so `type`
+  /// cannot report ok while trailing characters are still uncommitted (or dropped) on a slow
+  /// simulator. Exits fast when the app transforms the input; re-synthesizes the missing tail
+  /// once if commit progress stalls as a strict prefix of the expected value.
+  func awaitSynthesizedFirstResponderCommit(
+    app: XCUIApplication,
+    target: TextEntryTarget,
+    textBefore: String?,
+    typedText: String,
+    synthesizer: any TextEntrySynthesizing
+  ) {
+    guard let textBefore, !typedText.contains("\n"), !typedText.contains("\r") else {
+      return
+    }
+    let expectedText = textBefore + typedText
+    var repaired = false
+    var lastObservedText: String?
+    var lastChangeAt = Date()
+    let deadline = Date().addingTimeInterval(TextEntryTiming.synthesizedCommitTimeout)
+    while Date() < deadline {
+      guard let observedText = editableTextValue(
+        for: resolveTextEntryElement(app: app, target: target),
+        treatingPlaceholderAsEmpty: true
+      ) else {
+        return
+      }
+      switch Self.synthesizedTextCommitProgress(observedText: observedText, expectedText: expectedText) {
+      case .committed, .diverged:
+        return
+      case .pending:
+        break
+      }
+      if lastObservedText != observedText {
+        lastObservedText = observedText
+        lastChangeAt = Date()
+      } else if Date().timeIntervalSince(lastChangeAt) >= TextEntryTiming.synthesizedCommitQuietWindow {
+        guard !repaired,
+          let tail = Self.synthesizedTextCommitRepairTail(
+            observedText: observedText,
+            expectedText: expectedText
+          )
+        else {
+          return
+        }
+        NSLog(
+          "AGENT_DEVICE_RUNNER_REPAIR_TEXT_ENTRY route=synthesized-first-responder expectedLength=%d observedLength=%d",
+          expectedText.count,
+          observedText.count
+        )
+        guard case .continueTyping = synthesizer.enterText(
+          app: app,
+          text: tail,
+          replacingExistingText: false
+        ) else {
+          return
+        }
+        repaired = true
+        lastChangeAt = Date()
+      }
+      sleepFor(TextEntryTiming.pollInterval)
+    }
+  }
+
   static func shouldUseResolvedCoordinateTextEntryRoute(
     repairMode: TextTypingRepairMode,
     hasX: Bool,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
@@ -40,6 +40,8 @@ extension RunnerTests {
     static let pollInterval: TimeInterval = 0.02
     static let warmupValueTimeout: TimeInterval = 0.4
     static let verificationStabilityWindow: TimeInterval = 0.2
+    static let synthesizedCommitTimeout: TimeInterval = 3.0
+    static let synthesizedCommitQuietWindow: TimeInterval = 0.6
   }
 
   struct TextEntryResult {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
@@ -61,6 +61,56 @@ extension RunnerTests {
     }
   }
 
+  func testSynthesizedTextCommitProgressWalksExpectedPrefixOnly() {
+    let expected = "hardware-keyboard"
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboard", expectedText: expected),
+      .committed
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "", expectedText: expected),
+      .pending
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboa", expectedText: expected),
+      .pending
+    )
+    // Transformed input (formatter, mid-text caret, autocomplete) must stop the wait.
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardwarX", expectedText: expected),
+      .diverged
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboards", expectedText: expected),
+      .diverged
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: nil, expectedText: expected),
+      .diverged
+    )
+  }
+
+  func testSynthesizedTextCommitRepairTailOnlyForStrictPrefixWithoutSubmitKeys() {
+    XCTAssertEqual(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboa", expectedText: "hardware-keyboard"),
+      "rd"
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitRepairTail(observedText: "", expectedText: "abc"),
+      "abc"
+    )
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboard", expectedText: "hardware-keyboard")
+    )
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardwarX", expectedText: "hardware-keyboard")
+    )
+    // Never re-synthesize a tail that would submit.
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "ab", expectedText: "abc\n")
+    )
+  }
+
 #if os(iOS)
   func testSynthesizedTextEntryFallsBackOnlyWhenPrivateSynthesisIsUnavailable() {
     XCTAssertEqual(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -111,8 +111,23 @@ extension RunnerTests {
       {
         textEntryRoute = "synthesized-first-responder"
         NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=synthesized-first-responder")
+        let textBefore = editableTextValue(for: currentTarget, treatingPlaceholderAsEmpty: true)
         switch synthesizer.enterText(app: app, text: value, replacingExistingText: false) {
         case .continueTyping:
+          // No refresh point: like the tap-witness target itself, the commit wait must observe
+          // only the element the tap selected, never rediscover a different field.
+          awaitSynthesizedFirstResponderCommit(
+            app: app,
+            target: TextEntryTarget(
+              element: currentTarget,
+              refreshPoint: nil,
+              prefersFocusedElement: false,
+              fromTapWitness: true
+            ),
+            textBefore: textBefore,
+            typedText: value,
+            synthesizer: synthesizer
+          )
           return (currentTarget, true, nil)
         case .fallback:
           return (nil, false, .synthesisUnavailable)


### PR DESCRIPTION
## What

The `synthesized-first-responder` bare-`type` route (added in #1657) returned `ok` as soon as the private XCTest event record was posted, while the target app was still committing characters. On slow CI simulators the trailing characters land after the response, so anything reading the field right after — the smoke-lane assert, or a real agent doing `type` → submit — observes a truncated value through the public `type` path. This is the root cause of the `testBareTypeUsesTappedInputWhenSoftwareKeyboardIsHidden` flake (`"hardware-keyboa" != "hardware-keyboard"`) that hit #1670, #1671, and `claude/agent-device-issue-1658` on TypeScript-only diffs.

Fix is in the production route, not the test: after a successful dispatch, `awaitSynthesizedFirstResponderCommit` polls the tapped element until its value reaches `textBefore + typedText` (3s ceiling), and:

- exits immediately when the observed value leaves the expected prefix path — a formatter, mid-text caret, or autocomplete transformed the input, and the runner must not second-guess the app;
- if progress stalls as a strict prefix for 0.6s, re-synthesizes the missing tail exactly once (defense against true drops);
- skips entirely for newline/CR-suffixed text so a repair can never double-submit, and for secure fields (unreadable value);
- carries no refresh point, so like the tap witness itself it can never rediscover a different field.

Prefix/tail decisions are pure policy functions with unit tests. Bare `type` keeps its `verified: nil` contract — no new failure modes, the response just can't outrun the field anymore.

## Validation

On a booted iPhone 17 Pro simulator (iOS 26.2):

- Baseline: the flaky test + both sibling type regressions + the two new policy tests, 5/5 pass.
- 5 runs of the flaky test under full-core CPU load (`yes` burner per core): all pass. `type-all` phase ran 563–884ms vs a uniform ~494ms dispatch-only on unpatched code — the commit wait absorbed up to ~390ms of real post-dispatch lag per run.
- A/B: unpatched code also passes 5/5 locally under load (an M-series host can't get slow enough to reproduce the CI failure), but the absorbed-lag timings plus the CI failures pin the mechanism.
- The tail repair never fired in any local run — consistent with commit lag rather than true keystroke drops. If it ever fires in CI it logs `AGENT_DEVICE_RUNNER_REPAIR_TEXT_ENTRY route=synthesized-first-responder`.

## Reviewer notes

- Common-case overhead is one pre-dispatch value read plus 1–2 polls (~tens of ms); divergent fields (formatters) exit on the first poll.
- The delayed-typing path (`--delay-ms`) now commit-waits per character, which doubles as per-char drop detection; the inter-char delay usually absorbs the wait.
- Evidence: failing job https://github.com/callstack/agent-device/actions/runs/31175138786/job/92857172185 (plus run 31171859329 on #1670), passing on byte-identical runner sources on main.