### PR TITLE
fix: enforce replay timeout envelope

### DIFF
--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -740,6 +740,22 @@ test('replay path falls through to the generic client command route', async () =
   assert.doesNotMatch(result.stderr, /Unknown command: replay/);
 });
 
+test('replay --timeout reaches the daemon request envelope through the public CLI', async () => {
+  const missingPath = '/tmp/does-not-exist.ad';
+  const result = await runCliCapture(['replay', missingPath, '--timeout', '1000'], async () => ({
+    ok: false,
+    error: {
+      code: 'UNKNOWN',
+      message: `ENOENT: no such file or directory, open '${missingPath}'`,
+    },
+  }));
+
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.command, 'replay');
+  assert.equal(result.calls[0]?.flags?.timeoutMs, 1000);
+});
+
 test('replay rejects extra plain replay paths before daemon dispatch', async () => {
   const client = createStubClient({
     installFromSource: async () => {

--- a/src/commands/replay/index.test.ts
+++ b/src/commands/replay/index.test.ts
@@ -147,6 +147,17 @@ describe('replay command interface', () => {
     expect(testRequest.options).not.toHaveProperty('reportJunit');
   });
 
+  test('projects replay --timeout into the daemon request envelope', () => {
+    const input = replayCliReader(['./probe-hang.ad'], flags({ timeoutMs: 1_000 }));
+
+    expect(input).toMatchObject({ path: './probe-hang.ad', timeoutMs: 1_000 });
+    expect(replayDaemonWriter(input)).toMatchObject({
+      command: 'replay',
+      positionals: ['./probe-hang.ad'],
+      options: { timeoutMs: 1_000 },
+    });
+  });
+
   test('folds replay and test Metro hints into the runtime request envelope', async () => {
     const runCalls: unknown[] = [];
     const testCalls: unknown[] = [];

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -53,6 +53,7 @@ export const replayCommandMetadata = defineFieldCommandMetadata(
     keepSession: booleanField(
       'Leave the session active by suppressing exactly an authored terminal close in native .ad.',
     ),
+    timeoutMs: integerField('Maximum wall-clock duration for the replay request.'),
     // ADR 0012 decision 6, R1/R6: arms agent-supervised re-record repair
     // from the first replay attempt; optional string value is the healed
     // script's output path.

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -154,6 +154,7 @@ export const replayCliReader: CliReader = (positionals, flags) => ({
   resumeFrom: flags.replayFrom,
   resumePlanDigest: flags.replayPlanDigest,
   keepSession: flags.replayKeepSession,
+  timeoutMs: flags.timeoutMs,
   saveScript: flags.saveScript,
   force: flags.force,
 });


### PR DESCRIPTION
## Summary

Forward `replay --timeout <ms>` through both replay projections that precede daemon dispatch: the CLI reader and the executable command metadata schema.

The reader previously dropped the value, and the metadata schema then filtered it from executable input before client request construction. The regression coverage now checks both the replay reader→writer path and the public CLI→daemon request boundary.

Closes #1668

## Validation

- Proved the public-CLI regression red before the metadata fix: expected `flags.timeoutMs` to be `1000`, received `undefined`.
- Exact pushed head `b9a0f8eaa` on iOS simulator: a 5-second impossible-selector replay with `--timeout 1000` returned `Daemon request timed out` in `real 1.40`; an immediate `open` on the same simulator and isolated state directory succeeded, confirming the request/device claim was released, and the follow-up session closed cleanly.
- `VITEST_MAX_WORKERS=1 pnpm check:affected --run`: 128 files and 1,085 tests passed, plus format, lint, typecheck, layering, Fallow, and build.

Docs and skills were not changed because the CLI flag and flag-bound timeout policy were already documented; this restores their declared behavior.