### PR TITLE
fix(ios): wait for hidden-keyboard synthesized text to commit before responding

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -95,6 +95,7 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTypeWithoutResolvedInputReturnsTypedFailureBeforeDispatchingText \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBareTypeUsesTappedInputWhenSoftwareKeyboardIsHidden \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBareDelayedTypeFailsWhenTappedInputDisappearsMidCommand \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSynthesizedTextCommitProgressWalksExpectedPrefixOnly \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextEntryTapWitnessIsBoundToTargetIdentity \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testActivateTargetSkipsForegroundAndActivatesNonForegroundApplication \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testMissingBundleCommandInvalidatesCompleteCachedTargetState \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -393,7 +393,10 @@ extension RunnerTests {
     XCTAssertTrue(typeResponse.ok, String(describing: typeResponse.error))
     XCTAssertFalse(didRecordXCTestFailure(since: failureCountBefore))
     XCTAssertEqual(typeResponse.data?.textEntryRoute, "synthesized-first-responder")
-    XCTAssertEqual(String(describing: textField.value ?? ""), "hardware-keyboard")
+    XCTAssertEqual(
+      textFieldValue(of: textField, settlingAt: "hardware-keyboard"),
+      "hardware-keyboard"
+    )
 
     let secondFailureCountBefore = currentXCTestFailureCount()
     let secondTypeCommand = try runnerCommandFixture(
@@ -404,7 +407,10 @@ extension RunnerTests {
     XCTAssertFalse(secondTypeResponse.ok)
     XCTAssertEqual(secondTypeResponse.error?.code, "TEXT_INPUT_NOT_FOCUSED")
     XCTAssertFalse(didRecordXCTestFailure(since: secondFailureCountBefore))
-    XCTAssertEqual(String(describing: textField.value ?? ""), "hardware-keyboard")
+    XCTAssertEqual(
+      textFieldValue(of: textField, settlingAt: "hardware-keyboard"),
+      "hardware-keyboard"
+    )
   }
 
   func testBareDelayedTypeFailsWhenTappedInputDisappearsMidCommand() throws {
@@ -437,6 +443,24 @@ extension RunnerTests {
     XCTAssertFalse(typeResponse.ok)
     XCTAssertEqual(typeResponse.error?.code, "TEXT_INPUT_NOT_FOCUSED")
     XCTAssertFalse(textField.exists)
+  }
+
+  // The simulator commits synthesized keystrokes after the type command returns, so a one-shot
+  // read of `value` can land mid-word ("h", "hardware-ke") on a loaded machine. Poll until the
+  // field holds the expected text, then hand the caller the last value read so a real mismatch
+  // still fails with what the field actually held.
+  private func textFieldValue(
+    of element: XCUIElement,
+    settlingAt expected: String,
+    timeout: TimeInterval = 10
+  ) -> String {
+    let deadline = Date().addingTimeInterval(timeout)
+    var observed = String(describing: element.value ?? "")
+    while observed != expected, Date() < deadline {
+      sleepFor(0.05)
+      observed = String(describing: element.value ?? "")
+    }
+    return observed
   }
 #endif
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -393,10 +393,7 @@ extension RunnerTests {
     XCTAssertTrue(typeResponse.ok, String(describing: typeResponse.error))
     XCTAssertFalse(didRecordXCTestFailure(since: failureCountBefore))
     XCTAssertEqual(typeResponse.data?.textEntryRoute, "synthesized-first-responder")
-    XCTAssertEqual(
-      textFieldValue(of: textField, settlingAt: "hardware-keyboard"),
-      "hardware-keyboard"
-    )
+    XCTAssertEqual(String(describing: textField.value ?? ""), "hardware-keyboard")
 
     let secondFailureCountBefore = currentXCTestFailureCount()
     let secondTypeCommand = try runnerCommandFixture(
@@ -407,10 +404,7 @@ extension RunnerTests {
     XCTAssertFalse(secondTypeResponse.ok)
     XCTAssertEqual(secondTypeResponse.error?.code, "TEXT_INPUT_NOT_FOCUSED")
     XCTAssertFalse(didRecordXCTestFailure(since: secondFailureCountBefore))
-    XCTAssertEqual(
-      textFieldValue(of: textField, settlingAt: "hardware-keyboard"),
-      "hardware-keyboard"
-    )
+    XCTAssertEqual(String(describing: textField.value ?? ""), "hardware-keyboard")
   }
 
   func testBareDelayedTypeFailsWhenTappedInputDisappearsMidCommand() throws {
@@ -443,24 +437,6 @@ extension RunnerTests {
     XCTAssertFalse(typeResponse.ok)
     XCTAssertEqual(typeResponse.error?.code, "TEXT_INPUT_NOT_FOCUSED")
     XCTAssertFalse(textField.exists)
-  }
-
-  // The simulator commits synthesized keystrokes after the type command returns, so a one-shot
-  // read of `value` can land mid-word ("h", "hardware-ke") on a loaded machine. Poll until the
-  // field holds the expected text, then hand the caller the last value read so a real mismatch
-  // still fails with what the field actually held.
-  private func textFieldValue(
-    of element: XCUIElement,
-    settlingAt expected: String,
-    timeout: TimeInterval = 10
-  ) -> String {
-    let deadline = Date().addingTimeInterval(timeout)
-    var observed = String(describing: element.value ?? "")
-    while observed != expected, Date() < deadline {
-      sleepFor(0.05)
-      observed = String(describing: element.value ?? "")
-    }
-    return observed
   }
 #endif
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -159,6 +159,106 @@ extension RunnerTests {
     repairMode == .none && fromTapWitness && !softwareKeyboardVisible
   }
 
+  enum SynthesizedTextCommitProgress: Equatable {
+    case committed
+    case pending
+    case diverged
+  }
+
+  // The private synthesize call returns once the event record is posted, not once the target
+  // app has committed the characters, so intermediate reads walk prefix-by-prefix toward the
+  // expected value. Anything off that prefix path means the app transformed the input
+  // (formatter, mid-text caret, autocomplete) and the runner must not second-guess it.
+  static func synthesizedTextCommitProgress(
+    observedText: String?,
+    expectedText: String
+  ) -> SynthesizedTextCommitProgress {
+    guard let observedText else {
+      return .diverged
+    }
+    if observedText == expectedText {
+      return .committed
+    }
+    return expectedText.hasPrefix(observedText) ? .pending : .diverged
+  }
+
+  static func synthesizedTextCommitRepairTail(
+    observedText: String,
+    expectedText: String
+  ) -> String? {
+    guard expectedText.hasPrefix(observedText), observedText.count < expectedText.count else {
+      return nil
+    }
+    let tail = String(expectedText.dropFirst(observedText.count))
+    guard !tail.contains("\n"), !tail.contains("\r") else {
+      return nil
+    }
+    return tail
+  }
+
+  /// Blocks until the synthesized bare-type text is observable in the target field, so `type`
+  /// cannot report ok while trailing characters are still uncommitted (or dropped) on a slow
+  /// simulator. Exits fast when the app transforms the input; re-synthesizes the missing tail
+  /// once if commit progress stalls as a strict prefix of the expected value.
+  func awaitSynthesizedFirstResponderCommit(
+    app: XCUIApplication,
+    target: TextEntryTarget,
+    textBefore: String?,
+    typedText: String,
+    synthesizer: any TextEntrySynthesizing
+  ) {
+    guard let textBefore, !typedText.contains("\n"), !typedText.contains("\r") else {
+      return
+    }
+    let expectedText = textBefore + typedText
+    var repaired = false
+    var lastObservedText: String?
+    var lastChangeAt = Date()
+    let deadline = Date().addingTimeInterval(TextEntryTiming.synthesizedCommitTimeout)
+    while Date() < deadline {
+      guard let observedText = editableTextValue(
+        for: resolveTextEntryElement(app: app, target: target),
+        treatingPlaceholderAsEmpty: true
+      ) else {
+        return
+      }
+      switch Self.synthesizedTextCommitProgress(observedText: observedText, expectedText: expectedText) {
+      case .committed, .diverged:
+        return
+      case .pending:
+        break
+      }
+      if lastObservedText != observedText {
+        lastObservedText = observedText
+        lastChangeAt = Date()
+      } else if Date().timeIntervalSince(lastChangeAt) >= TextEntryTiming.synthesizedCommitQuietWindow {
+        guard !repaired,
+          let tail = Self.synthesizedTextCommitRepairTail(
+            observedText: observedText,
+            expectedText: expectedText
+          )
+        else {
+          return
+        }
+        NSLog(
+          "AGENT_DEVICE_RUNNER_REPAIR_TEXT_ENTRY route=synthesized-first-responder expectedLength=%d observedLength=%d",
+          expectedText.count,
+          observedText.count
+        )
+        guard case .continueTyping = synthesizer.enterText(
+          app: app,
+          text: tail,
+          replacingExistingText: false
+        ) else {
+          return
+        }
+        repaired = true
+        lastChangeAt = Date()
+      }
+      sleepFor(TextEntryTiming.pollInterval)
+    }
+  }
+
   static func shouldUseResolvedCoordinateTextEntryRoute(
     repairMode: TextTypingRepairMode,
     hasX: Bool,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -168,7 +168,9 @@ extension RunnerTests {
   // The private synthesize call returns once the event record is posted, not once the target
   // app has committed the characters, so intermediate reads walk prefix-by-prefix toward the
   // expected value. Anything off that prefix path means the app transformed the input
-  // (formatter, mid-text caret, autocomplete) and the runner must not second-guess it.
+  // (formatter, mid-text caret, autocomplete) and the runner must not second-guess it. An
+  // unreadable value — secure field, or the element stopped resolving — ends the wait the
+  // same way.
   static func synthesizedTextCommitProgress(
     observedText: String?,
     expectedText: String
@@ -182,80 +184,35 @@ extension RunnerTests {
     return expectedText.hasPrefix(observedText) ? .pending : .diverged
   }
 
-  static func synthesizedTextCommitRepairTail(
-    observedText: String,
-    expectedText: String
-  ) -> String? {
-    guard expectedText.hasPrefix(observedText), observedText.count < expectedText.count else {
-      return nil
-    }
-    let tail = String(expectedText.dropFirst(observedText.count))
-    guard !tail.contains("\n"), !tail.contains("\r") else {
-      return nil
-    }
-    return tail
-  }
-
   /// Blocks until the synthesized bare-type text is observable in the target field, so `type`
-  /// cannot report ok while trailing characters are still uncommitted (or dropped) on a slow
-  /// simulator. Exits fast when the app transforms the input; re-synthesizes the missing tail
-  /// once if commit progress stalls as a strict prefix of the expected value.
+  /// cannot report ok while trailing characters are still uncommitted on a slow simulator.
+  ///
+  /// Observation only. A stalled prefix cannot be told apart from a suffix still queued in the
+  /// event stream, so re-synthesizing the difference risks committing it twice after the command
+  /// already reported success. Text carrying a submit key is skipped outright: the app may clear
+  /// or rewrite the field on submit, so `textBefore + typedText` is not the value to wait for.
   func awaitSynthesizedFirstResponderCommit(
     app: XCUIApplication,
     target: TextEntryTarget,
     textBefore: String?,
-    typedText: String,
-    synthesizer: any TextEntrySynthesizing
+    typedText: String
   ) {
     guard let textBefore, !typedText.contains("\n"), !typedText.contains("\r") else {
       return
     }
     let expectedText = textBefore + typedText
-    var repaired = false
-    var lastObservedText: String?
-    var lastChangeAt = Date()
     let deadline = Date().addingTimeInterval(TextEntryTiming.synthesizedCommitTimeout)
     while Date() < deadline {
-      guard let observedText = editableTextValue(
+      let observedText = editableTextValue(
         for: resolveTextEntryElement(app: app, target: target),
         treatingPlaceholderAsEmpty: true
-      ) else {
-        return
-      }
+      )
       switch Self.synthesizedTextCommitProgress(observedText: observedText, expectedText: expectedText) {
       case .committed, .diverged:
         return
       case .pending:
-        break
+        sleepFor(TextEntryTiming.pollInterval)
       }
-      if lastObservedText != observedText {
-        lastObservedText = observedText
-        lastChangeAt = Date()
-      } else if Date().timeIntervalSince(lastChangeAt) >= TextEntryTiming.synthesizedCommitQuietWindow {
-        guard !repaired,
-          let tail = Self.synthesizedTextCommitRepairTail(
-            observedText: observedText,
-            expectedText: expectedText
-          )
-        else {
-          return
-        }
-        NSLog(
-          "AGENT_DEVICE_RUNNER_REPAIR_TEXT_ENTRY route=synthesized-first-responder expectedLength=%d observedLength=%d",
-          expectedText.count,
-          observedText.count
-        )
-        guard case .continueTyping = synthesizer.enterText(
-          app: app,
-          text: tail,
-          replacingExistingText: false
-        ) else {
-          return
-        }
-        repaired = true
-        lastChangeAt = Date()
-      }
-      sleepFor(TextEntryTiming.pollInterval)
     }
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
@@ -40,6 +40,8 @@ extension RunnerTests {
     static let pollInterval: TimeInterval = 0.02
     static let warmupValueTimeout: TimeInterval = 0.4
     static let verificationStabilityWindow: TimeInterval = 0.2
+    static let synthesizedCommitTimeout: TimeInterval = 3.0
+    static let synthesizedCommitQuietWindow: TimeInterval = 0.6
   }
 
   struct TextEntryResult {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
@@ -41,7 +41,6 @@ extension RunnerTests {
     static let warmupValueTimeout: TimeInterval = 0.4
     static let verificationStabilityWindow: TimeInterval = 0.2
     static let synthesizedCommitTimeout: TimeInterval = 3.0
-    static let synthesizedCommitQuietWindow: TimeInterval = 0.6
   }
 
   struct TextEntryResult {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
@@ -61,6 +61,56 @@ extension RunnerTests {
     }
   }
 
+  func testSynthesizedTextCommitProgressWalksExpectedPrefixOnly() {
+    let expected = "hardware-keyboard"
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboard", expectedText: expected),
+      .committed
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "", expectedText: expected),
+      .pending
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboa", expectedText: expected),
+      .pending
+    )
+    // Transformed input (formatter, mid-text caret, autocomplete) must stop the wait.
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardwarX", expectedText: expected),
+      .diverged
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: "hardware-keyboards", expectedText: expected),
+      .diverged
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitProgress(observedText: nil, expectedText: expected),
+      .diverged
+    )
+  }
+
+  func testSynthesizedTextCommitRepairTailOnlyForStrictPrefixWithoutSubmitKeys() {
+    XCTAssertEqual(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboa", expectedText: "hardware-keyboard"),
+      "rd"
+    )
+    XCTAssertEqual(
+      Self.synthesizedTextCommitRepairTail(observedText: "", expectedText: "abc"),
+      "abc"
+    )
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboard", expectedText: "hardware-keyboard")
+    )
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "hardwarX", expectedText: "hardware-keyboard")
+    )
+    // Never re-synthesize a tail that would submit.
+    XCTAssertNil(
+      Self.synthesizedTextCommitRepairTail(observedText: "ab", expectedText: "abc\n")
+    )
+  }
+
 #if os(iOS)
   func testSynthesizedTextEntryFallsBackOnlyWhenPrivateSynthesisIsUnavailable() {
     XCTAssertEqual(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntryPolicyTests.swift
@@ -90,27 +90,6 @@ extension RunnerTests {
     )
   }
 
-  func testSynthesizedTextCommitRepairTailOnlyForStrictPrefixWithoutSubmitKeys() {
-    XCTAssertEqual(
-      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboa", expectedText: "hardware-keyboard"),
-      "rd"
-    )
-    XCTAssertEqual(
-      Self.synthesizedTextCommitRepairTail(observedText: "", expectedText: "abc"),
-      "abc"
-    )
-    XCTAssertNil(
-      Self.synthesizedTextCommitRepairTail(observedText: "hardware-keyboard", expectedText: "hardware-keyboard")
-    )
-    XCTAssertNil(
-      Self.synthesizedTextCommitRepairTail(observedText: "hardwarX", expectedText: "hardware-keyboard")
-    )
-    // Never re-synthesize a tail that would submit.
-    XCTAssertNil(
-      Self.synthesizedTextCommitRepairTail(observedText: "ab", expectedText: "abc\n")
-    )
-  }
-
 #if os(iOS)
   func testSynthesizedTextEntryFallsBackOnlyWhenPrivateSynthesisIsUnavailable() {
     XCTAssertEqual(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -111,8 +111,23 @@ extension RunnerTests {
       {
         textEntryRoute = "synthesized-first-responder"
         NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=synthesized-first-responder")
+        let textBefore = editableTextValue(for: currentTarget, treatingPlaceholderAsEmpty: true)
         switch synthesizer.enterText(app: app, text: value, replacingExistingText: false) {
         case .continueTyping:
+          // No refresh point: like the tap-witness target itself, the commit wait must observe
+          // only the element the tap selected, never rediscover a different field.
+          awaitSynthesizedFirstResponderCommit(
+            app: app,
+            target: TextEntryTarget(
+              element: currentTarget,
+              refreshPoint: nil,
+              prefersFocusedElement: false,
+              fromTapWitness: true
+            ),
+            textBefore: textBefore,
+            typedText: value,
+            synthesizer: synthesizer
+          )
           return (currentTarget, true, nil)
         case .fallback:
           return (nil, false, .synthesisUnavailable)

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -125,8 +125,7 @@ extension RunnerTests {
               fromTapWitness: true
             ),
             textBefore: textBefore,
-            typedText: value,
-            synthesizer: synthesizer
+            typedText: value
           )
           return (currentTarget, true, nil)
         case .fallback:


### PR DESCRIPTION
Consolidates the hidden-keyboard text-entry flake into one PR. It started as a test-side fix; that approach was withdrawn — see below.

## The defect

The `synthesized-first-responder` bare-type route returned ok as soon as the private XCTest event record was *posted*, while the target app was still committing characters. Agents calling `type` then `snapshot` could observe a truncated field, and the smoke test observed it as a flake: `("h")` and `("hardware-ke")` instead of `("hardware-keyboard")` on 3 of 5 runs of a branch with zero Swift changes ([example job](https://github.com/callstack/agent-device/actions/runs/31180281315)).

The fix polls the tapped element after dispatch until the value commits, then responds. Originated in #1673 (commit c9575ade8, authored there); folded here after that PR was closed.

## What changed relative to #1673

The [P1 on #1673](https://github.com/callstack/agent-device/pull/1673#issuecomment-5217332113) is addressed by removing the repair path, not by defending it. A 600 ms quiet prefix cannot distinguish delayed commit from a dropped suffix — re-synthesizing the difference could post it while the original was still queued and commit the text twice, after the command had already reported ok. So the wait is now **observation only**:

- deleted `synthesizedTextCommitRepairTail`, the quiet-window constant, the stall tracking, and its unit test;
- deleted the `synthesizer` parameter — with no repair, the wait has no reason to hold a `TextEntrySynthesizing` at all, so it is a pure observer of the field it was given.

What remains is one bounded loop with a single decision point: poll until the value commits, the app transforms it (formatter, mid-caret, autocomplete), the value becomes unreadable (secure field, element stopped resolving), or the 3s ceiling expires. Every stop reason funnels through the pure `synthesizedTextCommitProgress` policy function, which is unit-tested without a simulator.

**Known limit, unchanged by this PR:** a genuinely dropped suffix still reports ok. Bare `type` is no-verification by design (`repairMode == .none`); this only removes the false truncation caused by commit lag, at a worst case of 3s.

## The withdrawn test-side fix

This branch first made the test poll `textField.value` until it settled. That was wrong to ship on its own: the flake was a true positive about the product, and a polling assertion would have made the test tolerate a runner that responds before the text commits — deleting the guard that proves this fix works. It is reverted here (commits `caecdc6d5` + `f91c0e8b1` kept for the trail). The one-shot read stays as the assertion, because with the commit wait in place the value *is* committed by the time `type` responds.

## CI gap found while folding

`ios.yml` enumerates its runner tests by hand with 25 `-only-testing:` flags, so #1673's new unit tests would never have executed in CI. `testSynthesizedTextCommitProgressWalksExpectedPrefixOnly` is now wired into that list.

## Verification

Built with `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1`, run on a dedicated iPhone 17 Pro Max sim (iOS 26.2) to keep a parallel session's simulator work out of the results:

- 4 tests × `-test-iterations 3` → **12/12 passed**, twice (before and after the simplification).
- `testBareTypeUsesTappedInputWhenSoftwareKeyboardIsHidden`: 12.66–12.75s with the commit wait vs 12.5–13.7s without — it exits as soon as the value commits, so it costs nothing in the normal case.

Local machines cannot reproduce the CI truncation even under saturation, so this is non-regression evidence plus the mechanism; the 5/5-under-load A/B that showed the wait absorbing ~390ms of post-dispatch lag is in #1673.
