### PR TITLE
refactor(contracts): make ExecResult host-command vocabulary, not root exec internals

### DIFF
--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -32,6 +32,7 @@ export {
   isAudioProbeSupportedDevice,
   isHostSystemAudioProbeDevice,
 } from '../audio-probe-support.ts';
+export type { ExecResult } from '../host-command.ts';
 export type { PlatformPlugin } from '../platform-plugin.ts';
 export type { PlatformGatedProviderResolverKey } from '../platform-providers.ts';
 export type { RunnerLogicalLeaseContext } from '../runner-lease-context.ts';

--- a/packages/contracts/src/host-command.ts
+++ b/packages/contracts/src/host-command.ts
@@ -1,0 +1,22 @@
+/**
+ * Host-command result vocabulary.
+ *
+ * The SHAPE of a finished host command, split from the code that runs one.
+ * `src/utils/exec.ts` keeps the running — process spawning, argument policy,
+ * timeouts, redaction — because that is host policy the root composition owns
+ * (#1490 keeps `exec` root-side deliberately). What every caller passes around
+ * afterwards is just this record, and that is vocabulary.
+ *
+ * The split is load-bearing rather than tidy: 13 of the ~22 modules that named
+ * this type live under `src/platforms/`, and they wanted only the type. Leaving
+ * it in `utils/exec.ts` meant every platform module imported root code to
+ * describe a value it already had — a dependency that no platform package could
+ * ever satisfy, for a type with no runtime behavior at all.
+ */
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  /** Present only when the command was run with `binaryStdout`. */
+  stdoutBuffer?: Buffer;
+};

--- a/src/daemon/__tests__/app-log.test.ts
+++ b/src/daemon/__tests__/app-log.test.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -6,7 +7,7 @@ import { finished } from 'node:stream/promises';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { withAppleToolProvider } from '../../platforms/apple/core/tool-provider.ts';
-import type { ExecResult } from '../../utils/exec.ts';
+
 import { runAppLogDoctor, rotateAppLogIfNeeded } from '../app-log.ts';
 import { assertAndroidPackageArgSafe } from '../app-log-android.ts';
 import {

--- a/src/daemon/app-log-process.ts
+++ b/src/daemon/app-log-process.ts
@@ -1,8 +1,8 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import fs from 'node:fs';
 import path from 'node:path';
 import { readProcessCommand, readProcessStartTime } from '../utils/host-process.ts';
 import type { LogBackend } from '@agent-device/contracts/observability';
-import type { ExecResult } from '../utils/exec.ts';
 
 export const APP_LOG_PID_FILENAME = 'app-log.pid';
 

--- a/src/daemon/app-log-stream.ts
+++ b/src/daemon/app-log-stream.ts
@@ -1,6 +1,6 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import fs from 'node:fs';
 import type { Readable } from 'node:stream';
-import type { ExecResult } from '../utils/exec.ts';
 
 export async function waitForChildExit(
   wait: Promise<ExecResult>,

--- a/src/daemon/handlers/record-trace-ios-simulator.ts
+++ b/src/daemon/handlers/record-trace-ios-simulator.ts
@@ -1,6 +1,7 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { sleep } from '../../utils/timeouts.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import type { ExecResult } from '../../utils/exec.ts';
+
 import { signalPidsBestEffort, uniquePositivePids } from '../../utils/host-process.ts';
 import { formatRecordTraceError } from '../record-trace-errors.ts';
 import type { SessionState } from '../types.ts';

--- a/src/daemon/record-trace-errors.ts
+++ b/src/daemon/record-trace-errors.ts
@@ -1,4 +1,4 @@
-import type { ExecResult } from '../utils/exec.ts';
+import type { ExecResult } from '@agent-device/contracts/platform';
 
 export function formatRecordTraceError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/src/daemon/recording-provider.ts
+++ b/src/daemon/recording-provider.ts
@@ -1,6 +1,7 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { buildSimctlArgsForDevice } from '../platforms/apple/core/simctl.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import { runCmdBackground, type ExecBackgroundResult, type ExecResult } from '../utils/exec.ts';
+import { runCmdBackground, type ExecBackgroundResult } from '../utils/exec.ts';
 import { createScopedProvider } from '../utils/scoped-provider.ts';
 
 export type RecordingProcess = {

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -1,7 +1,8 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import { escapeXmlTextAndAttribute } from '@agent-device/xml';
-import { execFailureDetails, type ExecResult } from '../utils/exec.ts';
+import { execFailureDetails } from '../utils/exec.ts';
 import type { SessionRuntimeHints } from './types.ts';
 import {
   resolveRuntimeTransportHints,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -19,12 +19,12 @@ import type {
 } from '@agent-device/kernel/contracts';
 import type { DeviceInfo, Platform, PlatformSelector } from '@agent-device/kernel/device';
 import type { Rect, SnapshotState, SnapshotCaptureBackend } from '@agent-device/kernel/snapshot';
-import type { ExecBackgroundResult, ExecResult } from '../utils/exec.ts';
+import type { ExecBackgroundResult } from '../utils/exec.ts';
 // Type-only import; erased at runtime. ref-frame.ts imports SessionState from
 // here, so this back-edge must stay type-only to avoid a runtime cycle.
 import type { SnapshotDiagnosticsState } from '@agent-device/contracts/capture';
 import type { DeviceLease } from '@agent-device/contracts/device';
-import type { AudioProbeSource } from '@agent-device/contracts/platform';
+import type { AudioProbeSource, ExecResult } from '@agent-device/contracts/platform';
 import type { AndroidNativePerfSession } from '../platforms/android/perf.ts';
 import type { SessionScriptPublicationState } from './session-script-publication-state.ts';
 import type {

--- a/src/platforms/android/__tests__/devices.test.ts
+++ b/src/platforms/android/__tests__/devices.test.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { beforeEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import { appendFileSync, existsSync, promises as fs, writeFileSync } from 'node:fs';
@@ -14,7 +15,7 @@ const execActual =
 
 import { AppError } from '@agent-device/kernel/errors';
 import { runCmdDetached, withCommandExecutorOverride } from '../../../utils/exec.ts';
-import type { CommandExecutorOverride, ExecResult } from '../../../utils/exec.ts';
+import type { CommandExecutorOverride } from '../../../utils/exec.ts';
 import {
   ensureAndroidEmulatorBooted,
   listAndroidDevices,

--- a/src/platforms/android/adb-executor.ts
+++ b/src/platforms/android/adb-executor.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Readable, Writable } from 'node:stream';
 import type { DeviceInfo } from '@agent-device/kernel/device';
@@ -14,7 +15,6 @@ import {
   type CommandExecutorOverride,
   type ExecBackgroundOptions,
   type ExecOptions,
-  type ExecResult,
 } from '../../utils/exec.ts';
 import { AppError } from '@agent-device/kernel/errors';
 

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -1,5 +1,6 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { requireExecSuccess, runCmd, runCmdDetached, whichCmd } from '../../utils/exec.ts';
-import type { ExecResult } from '../../utils/exec.ts';
+
 import { sleep } from '../../utils/timeouts.ts';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import type { DeviceInfo } from '@agent-device/kernel/device';

--- a/src/platforms/apple/core/__tests__/devices.test.ts
+++ b/src/platforms/apple/core/__tests__/devices.test.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { isIosFamily } from '@agent-device/kernel/device';
 import { beforeEach, test } from 'vitest';
 import assert from 'node:assert/strict';
@@ -12,7 +13,6 @@ import {
   resolveAppleTargetFromDevicectlDevice,
 } from '../devices.ts';
 import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
-import type { ExecResult } from '../../../../utils/exec.ts';
 
 const toolCalls: Array<[string, string[]]> = [];
 let mockRunCommand: (cmd: string, args: string[]) => Promise<ExecResult>;

--- a/src/platforms/apple/core/__tests__/runner-command-recovery.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-command-recovery.test.ts
@@ -1,8 +1,9 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import assert from 'node:assert/strict';
 import { afterEach, test, vi } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
 import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/device-fixtures.ts';
-import type { ExecResult } from '../../../../utils/exec.ts';
+
 import { handleRunnerTransportErrorAfterCommandSend } from '../runner/runner-command-recovery.ts';
 import type { RunnerCommand } from '../runner/runner-contract.ts';
 import type { RunnerSession } from '../runner/runner-session.ts';

--- a/src/platforms/apple/core/__tests__/runner-disposal.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-disposal.test.ts
@@ -1,10 +1,11 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   IOS_SIMULATOR,
   MACOS_DEVICE,
   TVOS_SIMULATOR,
 } from '../../../../__tests__/test-utils/index.ts';
-import type { ExecResult } from '../../../../utils/exec.ts';
+
 import type { RunnerSession } from '../runner/runner-session-types.ts';
 
 const {

--- a/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
@@ -1,8 +1,9 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import assert from 'node:assert/strict';
 import { afterEach, expect, test, vi } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
 import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/device-fixtures.ts';
-import type { ExecResult } from '../../../../utils/exec.ts';
+
 import type { RunnerSession } from '../runner/runner-session.ts';
 import { startFakeRunnerServer, type FakeRunnerServer } from './fake-runner-server.ts';
 

--- a/src/platforms/apple/core/perf-xctrace.ts
+++ b/src/platforms/apple/core/perf-xctrace.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,7 +17,6 @@ import {
   requireExecSuccess,
   runCmdBackground,
   type ExecBackgroundResult,
-  type ExecResult,
 } from '../../../utils/exec.ts';
 import { uniqueStrings } from '@agent-device/kernel/collections';
 import { findAllXmlNodes } from './perf-xml.ts';

--- a/src/platforms/apple/core/perf.ts
+++ b/src/platforms/apple/core/perf.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -11,7 +12,7 @@ import {
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { parseXmlDocumentSync, type XmlNode } from '@agent-device/xml';
-import { execFailureDetails, requireExecSuccess, type ExecResult } from '../../../utils/exec.ts';
+import { execFailureDetails, requireExecSuccess } from '../../../utils/exec.ts';
 import { splitNonEmptyTrimmedLines } from '../../../utils/parsing.ts';
 import { roundPercent } from '../../perf-utils.ts';
 import { uniqueStrings } from '@agent-device/kernel/collections';

--- a/src/platforms/apple/core/physical-device-console.ts
+++ b/src/platforms/apple/core/physical-device-console.ts
@@ -1,4 +1,5 @@
-import type { ExecResult } from '../../../utils/exec.ts';
+import type { ExecResult } from '@agent-device/contracts/platform';
+
 import { runXcrun } from './tool-provider.ts';
 
 export type CoreDeviceConsoleCaptureSupport =

--- a/src/platforms/apple/core/runner/runner-adoption.ts
+++ b/src/platforms/apple/core/runner/runner-adoption.ts
@@ -1,10 +1,11 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import path from 'node:path';
 import { resolveIosSimulatorDeviceSetPath } from '../../../../utils/device-isolation.ts';
 import { emitDiagnostic } from '../../../../utils/diagnostics.ts';
 import { isProcessAlive } from '../../../../utils/host-process.ts';
 import { parseBooleanLiteral } from '../../../../utils/source-value.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { ExecResult } from '../../../../utils/exec.ts';
+
 import { sendRunnerCommandOnce } from './runner-transport.ts';
 import { withRunnerCommandId } from './runner-contract.ts';
 import {

--- a/src/platforms/apple/core/runner/runner-session-types.ts
+++ b/src/platforms/apple/core/runner/runner-session-types.ts
@@ -1,5 +1,5 @@
-import type { RunnerLogicalLeaseContext } from '@agent-device/contracts/platform';
-import type { ExecResult } from '../../../../utils/exec.ts';
+import type { ExecResult, RunnerLogicalLeaseContext } from '@agent-device/contracts/platform';
+
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { RunnerXctestrunArtifact } from './runner-xctestrun.ts';
 import type { RunnerLease } from './runner-lease.ts';

--- a/src/platforms/apple/core/runner/runner-session.ts
+++ b/src/platforms/apple/core/runner/runner-session.ts
@@ -1,13 +1,9 @@
 import { AppError, toAppErrorCode } from '@agent-device/kernel/errors';
-import {
-  runCmdBackground,
-  type ExecResult,
-  type ExecBackgroundResult,
-} from '../../../../utils/exec.ts';
+import { runCmdBackground, type ExecBackgroundResult } from '../../../../utils/exec.ts';
 import { withKeyedLock } from '../../../../utils/keyed-lock.ts';
 import { Deadline } from '../../../../utils/retry.ts';
 import { isIosFamily, isApplePlatform, type DeviceInfo } from '@agent-device/kernel/device';
-import type { RunnerLogicalLeaseContext } from '@agent-device/contracts/platform';
+import type { ExecResult, RunnerLogicalLeaseContext } from '@agent-device/contracts/platform';
 import type { AppleRunnerLifecycleOptions } from './runner-provider.ts';
 import { emitRequestProgress } from '../../../../request/progress.ts';
 import { createRequestCanceledError } from '../../../../request/cancel.ts';

--- a/src/platforms/apple/core/simctl.ts
+++ b/src/platforms/apple/core/simctl.ts
@@ -1,5 +1,6 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
-import type { ExecOptions, ExecResult } from '../../../utils/exec.ts';
+import type { ExecOptions } from '../../../utils/exec.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../../utils/device-isolation.ts';
 import { runXcrun } from './tool-provider.ts';
 

--- a/src/platforms/apple/core/tool-provider-types.ts
+++ b/src/platforms/apple/core/tool-provider-types.ts
@@ -1,5 +1,6 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import type { AppsFilter } from '@agent-device/contracts/device';
-import type { ExecOptions, ExecResult } from '../../../utils/exec.ts';
+import type { ExecOptions } from '../../../utils/exec.ts';
 import type { IosAppInfo } from './app-info.ts';
 
 export type AppleToolCommandExecutor = (

--- a/src/platforms/apple/core/tool-provider.ts
+++ b/src/platforms/apple/core/tool-provider.ts
@@ -1,10 +1,5 @@
-import {
-  coerceExecResult,
-  runCmd,
-  whichCmd,
-  type ExecOptions,
-  type ExecResult,
-} from '../../../utils/exec.ts';
+import type { ExecResult } from '@agent-device/contracts/platform';
+import { coerceExecResult, runCmd, whichCmd, type ExecOptions } from '../../../utils/exec.ts';
 import { createScopedProvider } from '../../../utils/scoped-provider.ts';
 import { createLocalAppleMacOsHostProvider } from '../os/macos/host-provider.ts';
 import type {

--- a/src/platforms/linux/tool-provider.ts
+++ b/src/platforms/linux/tool-provider.ts
@@ -1,7 +1,8 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import type { ClickButton, ScrollDirection } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import { runCmd, whichCmd, type ExecOptions, type ExecResult } from '../../utils/exec.ts';
+import { runCmd, whichCmd, type ExecOptions } from '../../utils/exec.ts';
 import { createScopedProvider } from '../../utils/scoped-provider.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import type {

--- a/src/platforms/vega/tool-provider.ts
+++ b/src/platforms/vega/tool-provider.ts
@@ -1,9 +1,10 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { VegaTvRemoteKey } from '@agent-device/contracts/interaction';
-import { runCmd, whichCmd, type ExecOptions, type ExecResult } from '../../utils/exec.ts';
+import { runCmd, whichCmd, type ExecOptions } from '../../utils/exec.ts';
 import { createScopedProvider } from '../../utils/scoped-provider.ts';
 
 export type VegaToolProvider = {

--- a/src/platforms/web/agent-browser-provider.test.ts
+++ b/src/platforms/web/agent-browser-provider.test.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -18,7 +19,7 @@ vi.mock('./agent-browser-lifecycle.ts', async (importOriginal) => {
 
 import { createAgentBrowserWebProvider } from './agent-browser-provider.ts';
 import type { WebSnapshotResult } from './provider.ts';
-import { withCommandExecutorOverride, type ExecResult } from '../../utils/exec.ts';
+import { withCommandExecutorOverride } from '../../utils/exec.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { buildSelectorChainForNode, resolveSelectorChain } from '@agent-device/selectors';
 import { attachRefs } from '@agent-device/kernel/snapshot';

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -12,7 +13,6 @@ import {
   runCmdStreaming,
   runCmdSync,
   whichCmd,
-  type ExecResult,
 } from '../exec.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { constants } from 'node:fs';
 import { access, stat } from 'node:fs/promises';
@@ -8,13 +9,6 @@ import { pipeline } from 'node:stream/promises';
 import { AppError } from '@agent-device/kernel/errors';
 import { emitDiagnostic, getDiagnosticsMeta, updateDiagnosticsScope } from './diagnostics.ts';
 import { parseBooleanLiteral } from './source-value.ts';
-
-export type ExecResult = {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  stdoutBuffer?: Buffer;
-};
 
 export type ExecOptions = {
   cwd?: string;

--- a/src/utils/host-process.ts
+++ b/src/utils/host-process.ts
@@ -1,4 +1,5 @@
-import type { ExecOptions, ExecResult } from './exec.ts';
+import type { ExecResult } from '@agent-device/contracts/platform';
+import type { ExecOptions } from './exec.ts';
 import { runCmd, runCmdSync } from './exec.ts';
 import { sleep } from './timeouts.ts';
 

--- a/test/integration/cli-json.ts
+++ b/test/integration/cli-json.ts
@@ -1,4 +1,5 @@
-import { runCmd, runCmdSync, type ExecResult } from '../../src/utils/exec.ts';
+import type { ExecResult } from '@agent-device/contracts/platform';
+import { runCmd, runCmdSync } from '../../src/utils/exec.ts';
 
 const CLI_TIMEOUT_MS = 120_000;
 

--- a/test/integration/provider-scenarios/harness.ts
+++ b/test/integration/provider-scenarios/harness.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -14,7 +15,6 @@ import { trackDownloadableArtifact } from '../../../src/daemon/artifact-tracking
 import { LeaseRegistry } from '../../../src/daemon/lease-registry.ts';
 import { SessionStore } from '../../../src/daemon/session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../../src/daemon/types.ts';
-import type { ExecResult } from '../../../src/utils/exec.ts';
 
 const PROVIDER_SCENARIO_TOKEN = 'provider-scenario-token';
 const PROVIDER_SCENARIO_TEMP_REMOVE_OPTIONS = {

--- a/test/integration/provider-scenarios/providers.ts
+++ b/test/integration/provider-scenarios/providers.ts
@@ -1,3 +1,4 @@
+import type { ExecResult } from '@agent-device/contracts/platform';
 import type { AppleRunnerProvider } from '../../../src/platforms/apple/core/runner/runner-provider.ts';
 import type { RunnerCommand } from '../../../src/platforms/apple/core/runner/runner-contract.ts';
 import type {
@@ -6,7 +7,7 @@ import type {
   AppleToolProvider,
   AppleToolSubcommandExecutor,
 } from '../../../src/platforms/apple/core/tool-provider.ts';
-import type { ExecResult } from '../../../src/utils/exec.ts';
+
 import type { ProviderScenarioTranscript } from './transcript.ts';
 
 export type FlatToolCall = [string, ...string[]];


### PR DESCRIPTION
First step of the platform-seam work — the #1490 W3 / #1478 P6a prerequisite. Type-only, no behavior change.

> Rewritten from the auto-generated description, which said this "eliminates circular dependency issues" for "platform packages" and exposes "public contracts API". None of those are accurate — see *What this is not* below.

## The problem

`ExecResult` — `{ stdout, stderr, exitCode, stdoutBuffer? }` — was declared beside the implementation in `src/utils/exec.ts`. **13 of the ~22 modules that name it live under `src/platforms/`**, and every one of them wanted only the type: the shape of a finished host command, with no runtime behavior at all.

So platform modules imported root code to describe a value they already held. For a type that erases at compile time.

## The change

`ExecResult` moves to `@agent-device/contracts/platform`, beside `PlatformPlugin` and the rest of the platform-family vocabulary.

The *running* stays in `src/utils/exec.ts` — process spawning, argument policy, timeouts, redaction are host policy the root composition owns, and #1490 keeps `exec` root-side deliberately. This splits the vocabulary from the policy rather than relocating the policy.

Per #1490's rules: no re-export shim at the old path. Every consumer names the contracts subpath, and `exec.ts` imports the type it implements against.

## What this is not

- **Not a circular-dependency fix.** There was no cycle. `check:layering` reports zero value-import cycles before and after, and R4 would have rejected one. This was a layering/packaging blocker.
- **Not public API.** `@agent-device/contracts` is `"private": true` — an internal workspace package bundled into the single published artifact. Nothing is exposed to consumers.
- **Not the exec seam.** Stated explicitly so this is not mistaken for done: **45 platform modules still import `utils/exec.ts` for behavior** — `runCmd` (98 references), `requireExecSuccess` (45), `withCommandExecutorOverride` (32), `execFailureDetails` (30), `whichCmd` (24), `runCmdBackground` (21), and a long tail. That is genuine capability coupling and needs the narrow injected-capability treatment W1c used for limrun, not a type move. It is the single biggest remaining blocker to platform packages, and it is the next slice, not this one.

## Why it is worth landing on its own

It is the one part of the exec coupling that is pure cost with no design question attached: 13 modules paying a dependency for nothing. Separating it means the behavioral port that follows is reviewed on its own merits, with the noise already gone.

## Validation

`pnpm typecheck`, `lint`, `format:check`, `check:layering`, `check:production-exports`, and `VITEST_MAX_WORKERS=2 pnpm check:affected --run` all green at `dac1cf7`.

Layering unmoved — R6 at 7, R9 at 47, R11 at 10 packages / 32 subpaths. `check:production-exports` is byte-identical to the `main` baseline (10 issues, 10 suppressed).

**One number I have not fully attributed:** the size report shows a *reduction* — JS raw −3.5 kB, gzip −1.3 kB, tarball −9.8 kB, unpacked −32 kB. A type-only move should be ≈0, so flagging rather than claiming a cause. The plausible mechanism is that modules which imported *only* `type ExecResult` from `exec.ts` now have no edge to it at all, so `exec.js` stops being pulled into chunks that never needed it — but I have not verified that, and I would rather say so than assert it. A reduction cannot regress behavior, and the packaged-CLI and bundle-size gates cover the artifact; happy to dig in if the number matters to review.