### PR TITLE
perf(cli): keep node:http and ICU off the CLI startup path (-54% warm call)

### DIFF
--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Every CLI invocation eagerly evaluates the static import closure of
+ * `src/cli.ts`. Importing `node:http` (or `node:https`) for a VALUE inside that
+ * closure initializes undici and, under `NODE_USE_SYSTEM_CA=1`, the platform
+ * trust store as well -- ~79ms added to every warm command on macOS, including
+ * ones that never speak HTTP (the default daemon transport is a `node:net`
+ * socket). The HTTP daemon transport, remote-artifact upload and download all
+ * load these modules on demand instead.
+ *
+ * Type-only imports are free and stay allowed; this only rejects value imports.
+ */
+
+const srcRoot = path.resolve(import.meta.dirname, '..');
+// `from './x.ts'` / `from "./x.ts"`, excluding `import type ... from`.
+const STATIC_IMPORT =
+  /(?:^|\n)\s*(?:import|export)\s+(?!type\s)([^;]*?)\s*from\s*['"]([^'"]+)['"]/g;
+
+function collectStaticImports(source: string): { clause: string; specifier: string }[] {
+  const found: { clause: string; specifier: string }[] = [];
+  STATIC_IMPORT.lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+  while ((match = STATIC_IMPORT.exec(source)) !== null) {
+    found.push({ clause: match[1] ?? '', specifier: match[2] ?? '' });
+  }
+  return found;
+}
+
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const candidate = path.resolve(path.dirname(fromFile), specifier);
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  for (const suffix of ['.ts', '.tsx', '/index.ts']) {
+    const withSuffix = `${candidate}${suffix}`;
+    if (fs.existsSync(withSuffix)) return withSuffix;
+  }
+  return null;
+}
+
+function eagerClosureOfCli(): string[] {
+  const queue = [path.join(srcRoot, 'cli.ts')];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current || visited.has(current)) continue;
+    visited.add(current);
+    for (const { specifier } of collectStaticImports(fs.readFileSync(current, 'utf8'))) {
+      if (!specifier.startsWith('.')) continue;
+      const resolved = resolveRelative(current, specifier);
+      if (resolved) queue.push(resolved);
+    }
+  }
+  return [...visited];
+}
+
+test('the CLI startup import closure never value-imports node:http or node:https', () => {
+  const offenders: string[] = [];
+  for (const file of eagerClosureOfCli()) {
+    for (const { clause, specifier } of collectStaticImports(fs.readFileSync(file, 'utf8'))) {
+      if (specifier !== 'node:http' && specifier !== 'node:https') continue;
+      // `import type http from` is caught by the regex's negative lookahead;
+      // `import { type IncomingMessage } from` is a value import of nothing.
+      const importsOnlyTypes = clause
+        .replace(/^\{|\}$/g, '')
+        .split(',')
+        .every((binding) => binding.trim() === '' || binding.trim().startsWith('type '));
+      if (importsOnlyTypes) continue;
+      offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
+    }
+  }
+
+  expect(
+    offenders,
+    'Load node:http / node:https on demand instead: a value import here costs every warm CLI ' +
+      'command ~79ms of undici + system-CA initialization.',
+  ).toEqual([]);
+});
+
+test('the CLI startup import closure is reachable and non-trivial', () => {
+  // Guards the test above from silently passing because the walk found nothing.
+  expect(eagerClosureOfCli().length).toBeGreaterThan(50);
+});

--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { parseSync } from 'oxc-parser';
 
 /**
  * Every CLI invocation eagerly evaluates the static import closure of
@@ -11,34 +12,49 @@ import path from 'node:path';
  * socket). The HTTP daemon transport, remote-artifact upload and download all
  * load these modules on demand instead.
  *
- * Type-only imports are free and stay allowed; this only rejects value imports.
+ * Classification comes from oxc-parser's ES module record rather than a regex,
+ * because the forms that matter are exactly the ones a regex tuned to
+ * `import ... from` misses: a bare side-effect `import 'node:http'` binds
+ * nothing yet still evaluates the module, so it reintroduces the whole cost
+ * while looking like nothing at all. Type-only imports are erased at build and
+ * stay allowed; dynamic `import()` is the fix and is deliberately not followed.
  */
 
 const srcRoot = path.resolve(import.meta.dirname, '..');
-// `from './x.ts'` / `from "./x.ts"`, excluding `import type ... from`.
-const STATIC_IMPORT =
-  /(?:^|\n)\s*(?:import|export)\s+(?!type\s)([^;]*?)\s*from\s*['"]([^'"]+)['"]/g;
+const LAZY_HTTP_MODULES = new Set(['node:http', 'node:https']);
 
-function collectStaticImports(source: string): { clause: string; specifier: string }[] {
-  const found: { clause: string; specifier: string }[] = [];
-  STATIC_IMPORT.lastIndex = 0;
-  let match: RegExpExecArray | null = null;
-  while ((match = STATIC_IMPORT.exec(source)) !== null) {
-    found.push({ clause: match[1] ?? '', specifier: match[2] ?? '' });
+/**
+ * Specifiers whose module this file causes to be EVALUATED at load time.
+ * Excludes type-only imports/re-exports (erased) and dynamic imports (lazy).
+ */
+function evaluatedModuleRefs(fileName: string, source: string): string[] {
+  const { module } = parseSync(fileName, source);
+  const refs: string[] = [];
+  for (const staticImport of module.staticImports) {
+    // No entries at all is a side-effect import (`import 'x'`), which always
+    // evaluates. Otherwise it evaluates unless every binding is type-only.
+    const evaluates =
+      staticImport.entries.length === 0 || staticImport.entries.some((entry) => !entry.isType);
+    if (evaluates) refs.push(staticImport.moduleRequest.value);
   }
-  return found;
+  for (const staticExport of module.staticExports) {
+    for (const entry of staticExport.entries) {
+      if (entry.moduleRequest && !entry.isType) refs.push(entry.moduleRequest.value);
+    }
+  }
+  return refs;
 }
 
 function resolveRelative(fromFile: string, specifier: string): string | null {
   const candidate = path.resolve(path.dirname(fromFile), specifier);
   if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   for (const suffix of ['.ts', '.tsx', '/index.ts']) {
-    const withSuffix = `${candidate}${suffix}`;
-    if (fs.existsSync(withSuffix)) return withSuffix;
+    if (fs.existsSync(`${candidate}${suffix}`)) return `${candidate}${suffix}`;
   }
   return null;
 }
 
+/** Every repo file evaluated as a consequence of importing `src/cli.ts`. */
 function eagerClosureOfCli(): string[] {
   const queue = [path.join(srcRoot, 'cli.ts')];
   const visited = new Set<string>();
@@ -46,7 +62,7 @@ function eagerClosureOfCli(): string[] {
     const current = queue.pop();
     if (!current || visited.has(current)) continue;
     visited.add(current);
-    for (const { specifier } of collectStaticImports(fs.readFileSync(current, 'utf8'))) {
+    for (const specifier of evaluatedModuleRefs(current, fs.readFileSync(current, 'utf8'))) {
       if (!specifier.startsWith('.')) continue;
       const resolved = resolveRelative(current, specifier);
       if (resolved) queue.push(resolved);
@@ -55,26 +71,52 @@ function eagerClosureOfCli(): string[] {
   return [...visited];
 }
 
-test('the CLI startup import closure never value-imports node:http or node:https', () => {
+test.for([
+  { form: 'side-effect import', code: `import 'node:http';`, evaluates: true },
+  { form: 'default value import', code: `import http from 'node:http';`, evaluates: true },
+  { form: 'namespace import', code: `import * as http from 'node:http';`, evaluates: true },
+  { form: 'named value import', code: `import { request } from 'node:http';`, evaluates: true },
+  { form: 'value re-export', code: `export { request } from 'node:http';`, evaluates: true },
+  { form: 'star re-export', code: `export * from 'node:http';`, evaluates: true },
+  {
+    form: 'mixed value + type import',
+    code: `import http, { type IncomingMessage } from 'node:http';`,
+    evaluates: true,
+  },
+  {
+    form: 'type-only default import',
+    code: `import type http from 'node:http';`,
+    evaluates: false,
+  },
+  {
+    form: 'type-only named import',
+    code: `import { type IncomingMessage } from 'node:http';`,
+    evaluates: false,
+  },
+  {
+    form: 'type-only re-export',
+    code: `export type { IncomingMessage } from 'node:http';`,
+    evaluates: false,
+  },
+  { form: 'dynamic import', code: `const m = await import('node:http');`, evaluates: false },
+])('$form is classified as evaluates=$evaluates', ({ code, evaluates }) => {
+  expect(evaluatedModuleRefs('fixture.ts', code)).toEqual(evaluates ? ['node:http'] : []);
+});
+
+test('the CLI startup import closure never evaluates node:http or node:https', () => {
   const offenders: string[] = [];
   for (const file of eagerClosureOfCli()) {
-    for (const { clause, specifier } of collectStaticImports(fs.readFileSync(file, 'utf8'))) {
-      if (specifier !== 'node:http' && specifier !== 'node:https') continue;
-      // `import type http from` is caught by the regex's negative lookahead;
-      // `import { type IncomingMessage } from` is a value import of nothing.
-      const importsOnlyTypes = clause
-        .replace(/^\{|\}$/g, '')
-        .split(',')
-        .every((binding) => binding.trim() === '' || binding.trim().startsWith('type '));
-      if (importsOnlyTypes) continue;
-      offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
+    for (const specifier of evaluatedModuleRefs(file, fs.readFileSync(file, 'utf8'))) {
+      if (LAZY_HTTP_MODULES.has(specifier)) {
+        offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
+      }
     }
   }
 
   expect(
     offenders,
-    'Load node:http / node:https on demand instead: a value import here costs every warm CLI ' +
-      'command ~79ms of undici + system-CA initialization.',
+    'Load node:http / node:https on demand instead: evaluating either one here costs every warm ' +
+      'CLI command ~79ms of undici + system-CA initialization.',
   ).toEqual([]);
 });
 

--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -79,7 +79,7 @@ function resolveWorkspace(specifier: string, packageDirs: Map<string, string>): 
   const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
     exports?: Record<string, { default?: string; types?: string } | string>;
   };
-  const target = manifest.exports?.[`.${match?.[2] ?? ''}` as string];
+  const target = manifest.exports?.[`.${match?.[2] ?? ''}`];
   const relativeTarget = typeof target === 'string' ? target : (target?.default ?? target?.types);
   if (!relativeTarget) return null;
   const resolved = path.resolve(packageDir, relativeTarget);

--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -54,8 +54,41 @@ function resolveRelative(fromFile: string, specifier: string): string | null {
   return null;
 }
 
+/** `@agent-device/<pkg>` -> that package's directory, keyed by its declared name. */
+function readWorkspacePackageDirs(): Map<string, string> {
+  const packagesRoot = path.resolve(srcRoot, '..', 'packages');
+  const dirs = new Map<string, string>();
+  for (const entry of fs.readdirSync(packagesRoot)) {
+    const manifestPath = path.join(packagesRoot, entry, 'package.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { name?: string };
+    if (manifest.name) dirs.set(manifest.name, path.join(packagesRoot, entry));
+  }
+  return dirs;
+}
+
+/**
+ * Workspace subpath imports are followed too: a package the CLI evaluates can
+ * pull `node:http` in just as effectively as a file under src/, and stopping the
+ * walk at the package boundary would be the same blind spot in a new place.
+ */
+function resolveWorkspace(specifier: string, packageDirs: Map<string, string>): string | null {
+  const match = /^(@agent-device\/[^/]+)(\/.*)?$/.exec(specifier);
+  const packageDir = match?.[1] ? packageDirs.get(match[1]) : undefined;
+  if (!packageDir) return null;
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
+    exports?: Record<string, { default?: string; types?: string } | string>;
+  };
+  const target = manifest.exports?.[`.${match?.[2] ?? ''}` as string];
+  const relativeTarget = typeof target === 'string' ? target : (target?.default ?? target?.types);
+  if (!relativeTarget) return null;
+  const resolved = path.resolve(packageDir, relativeTarget);
+  return fs.existsSync(resolved) ? resolved : null;
+}
+
 /** Every repo file evaluated as a consequence of importing `src/cli.ts`. */
 function eagerClosureOfCli(): string[] {
+  const packageDirs = readWorkspacePackageDirs();
   const queue = [path.join(srcRoot, 'cli.ts')];
   const visited = new Set<string>();
   while (queue.length > 0) {
@@ -63,8 +96,9 @@ function eagerClosureOfCli(): string[] {
     if (!current || visited.has(current)) continue;
     visited.add(current);
     for (const specifier of evaluatedModuleRefs(current, fs.readFileSync(current, 'utf8'))) {
-      if (!specifier.startsWith('.')) continue;
-      const resolved = resolveRelative(current, specifier);
+      const resolved = specifier.startsWith('.')
+        ? resolveRelative(current, specifier)
+        : resolveWorkspace(specifier, packageDirs);
       if (resolved) queue.push(resolved);
     }
   }
@@ -120,7 +154,13 @@ test('the CLI startup import closure never evaluates node:http or node:https', (
   ).toEqual([]);
 });
 
-test('the CLI startup import closure is reachable and non-trivial', () => {
-  // Guards the test above from silently passing because the walk found nothing.
-  expect(eagerClosureOfCli().length).toBeGreaterThan(50);
+test('the CLI startup import closure is reachable and crosses the package boundary', () => {
+  // Guards the test above from silently passing because the walk found nothing:
+  // a resolver that returns null for everything would leave both the src side
+  // and the workspace side of the closure empty while the guard stayed green.
+  const closure = eagerClosureOfCli();
+  expect(closure.length).toBeGreaterThan(50);
+  expect(
+    closure.filter((file) => file.includes(`${path.sep}packages${path.sep}`)).length,
+  ).toBeGreaterThan(0);
 });

--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -12,23 +12,36 @@ import { parseSync } from 'oxc-parser';
  * socket). The HTTP daemon transport, remote-artifact upload and download all
  * load these modules on demand instead.
  *
- * Classification comes from oxc-parser's ES module record rather than a regex,
- * because the forms that matter are exactly the ones a regex tuned to
- * `import ... from` misses: a bare side-effect `import 'node:http'` binds
- * nothing yet still evaluates the module, so it reintroduces the whole cost
- * while looking like nothing at all. Type-only imports are erased at build and
- * stay allowed; dynamic `import()` is the fix and is deliberately not followed.
+ * "On demand" is a claim about SCOPE, not about syntax, which is why this reads
+ * the AST rather than matching import forms. Two shapes evaluate the module
+ * during module evaluation while looking lazy or looking like nothing at all:
+ * a bare side-effect `import 'node:http'` (binds no names, still evaluates),
+ * and a dynamic `import('node:http')` sitting at module top level rather than
+ * inside a function -- including `.then(...)` and an immediately-invoked
+ * top-level function. A dynamic import is lazy only when its nearest enclosing
+ * function scope is not the module itself. Type-only imports and re-exports are
+ * erased at build and stay allowed.
+ *
+ * Known limitation: a top-level function that is invoked indirectly at load
+ * time (stored, then called by another top-level statement) reads as lazy here.
+ * Direct top-level invocation -- `(() => { ... })()` -- is detected.
  */
 
 const srcRoot = path.resolve(import.meta.dirname, '..');
 const LAZY_HTTP_MODULES = new Set(['node:http', 'node:https']);
+const FUNCTION_NODES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
+const WORKSPACE_SPECIFIER = /^(@agent-device\/[^/]+)(\/.*)?$/;
 
-/**
- * Specifiers whose module this file causes to be EVALUATED at load time.
- * Excludes type-only imports/re-exports (erased) and dynamic imports (lazy).
- */
-function evaluatedModuleRefs(fileName: string, source: string): string[] {
-  const { module } = parseSync(fileName, source);
+type AstNode = { type?: string; [key: string]: unknown };
+
+type ParsedModuleRecord = ReturnType<typeof parseSync>['module'];
+
+/** Static specifiers this file causes to be EVALUATED (not type-only). */
+function staticEvaluatedRefs(module: ParsedModuleRecord): string[] {
   const refs: string[] = [];
   for (const staticImport of module.staticImports) {
     // No entries at all is a side-effect import (`import 'x'`), which always
@@ -43,6 +56,63 @@ function evaluatedModuleRefs(fileName: string, source: string): string[] {
     }
   }
   return refs;
+}
+
+function unwrapParentheses(node: unknown): AstNode | null {
+  let current = node as AstNode | null;
+  while (current?.type === 'ParenthesizedExpression')
+    current = current.expression as AstNode | null;
+  return current;
+}
+
+/** The body of a function invoked right where it is defined, if this is that call. */
+function immediatelyInvokedBody(node: AstNode): unknown {
+  if (node.type !== 'CallExpression') return null;
+  const callee = unwrapParentheses(node.callee);
+  return callee && FUNCTION_NODES.has(String(callee.type)) ? callee.body : null;
+}
+
+function dynamicImportSpecifier(node: AstNode): string | null {
+  if (node.type !== 'ImportExpression') return null;
+  const source = node.source as { type?: string; value?: unknown } | undefined;
+  return source?.type === 'Literal' && typeof source.value === 'string' ? source.value : null;
+}
+
+function recordDynamicImport(record: AstNode, eager: boolean, found: string[]): void {
+  if (!eager) return;
+  const specifier = dynamicImportSpecifier(record);
+  if (specifier !== null) found.push(specifier);
+}
+
+/** Descends into a node's children, dropping `eager` on the way into a function body. */
+function visitChildren(record: AstNode, eager: boolean, found: string[]): void {
+  const childEager = eager && !FUNCTION_NODES.has(String(record.type));
+  for (const [key, value] of Object.entries(record)) {
+    if (key !== 'type') collectEagerDynamicImports(value, childEager, found);
+  }
+}
+
+/** Walks the AST, collecting only `import()` calls reached without entering a function. */
+function collectEagerDynamicImports(node: unknown, eager: boolean, found: string[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectEagerDynamicImports(child, eager, found);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const record = node as AstNode;
+  recordDynamicImport(record, eager, found);
+  // An immediately-invoked function runs now, so its body inherits `eager`.
+  const invokedBody = immediatelyInvokedBody(record);
+  if (invokedBody) collectEagerDynamicImports(invokedBody, eager, found);
+  visitChildren(record, eager, found);
+}
+
+/** Every specifier this file evaluates at load time, static or dynamic. */
+function eagerlyEvaluatedModules(fileName: string, source: string): string[] {
+  const parsed = parseSync(fileName, source);
+  const dynamic: string[] = [];
+  collectEagerDynamicImports(parsed.program, true, dynamic);
+  return [...new Set([...staticEvaluatedRefs(parsed.module), ...dynamic])];
 }
 
 function resolveRelative(fromFile: string, specifier: string): string | null {
@@ -67,22 +137,30 @@ function readWorkspacePackageDirs(): Map<string, string> {
   return dirs;
 }
 
+type ExportTarget = { default?: string; types?: string } | string;
+
+function readExportTarget(packageDir: string, subpath: string): string | undefined {
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
+    exports?: Record<string, ExportTarget>;
+  };
+  const target = manifest.exports?.[subpath];
+  if (typeof target === 'string') return target;
+  return target?.default ?? target?.types;
+}
+
 /**
  * Workspace subpath imports are followed too: a package the CLI evaluates can
  * pull `node:http` in just as effectively as a file under src/, and stopping the
  * walk at the package boundary would be the same blind spot in a new place.
  */
 function resolveWorkspace(specifier: string, packageDirs: Map<string, string>): string | null {
-  const match = /^(@agent-device\/[^/]+)(\/.*)?$/.exec(specifier);
-  const packageDir = match?.[1] ? packageDirs.get(match[1]) : undefined;
+  const match = WORKSPACE_SPECIFIER.exec(specifier);
+  const packageName = match?.[1];
+  const packageDir = packageName ? packageDirs.get(packageName) : undefined;
   if (!packageDir) return null;
-  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
-    exports?: Record<string, { default?: string; types?: string } | string>;
-  };
-  const target = manifest.exports?.[`.${match?.[2] ?? ''}`];
-  const relativeTarget = typeof target === 'string' ? target : (target?.default ?? target?.types);
-  if (!relativeTarget) return null;
-  const resolved = path.resolve(packageDir, relativeTarget);
+  const target = readExportTarget(packageDir, `.${match?.[2] ?? ''}`);
+  if (!target) return null;
+  const resolved = path.resolve(packageDir, target);
   return fs.existsSync(resolved) ? resolved : null;
 }
 
@@ -95,7 +173,7 @@ function eagerClosureOfCli(): string[] {
     const current = queue.pop();
     if (!current || visited.has(current)) continue;
     visited.add(current);
-    for (const specifier of evaluatedModuleRefs(current, fs.readFileSync(current, 'utf8'))) {
+    for (const specifier of eagerlyEvaluatedModules(current, fs.readFileSync(current, 'utf8'))) {
       const resolved = specifier.startsWith('.')
         ? resolveRelative(current, specifier)
         : resolveWorkspace(specifier, packageDirs);
@@ -106,41 +184,68 @@ function eagerClosureOfCli(): string[] {
 }
 
 test.for([
-  { form: 'side-effect import', code: `import 'node:http';`, evaluates: true },
-  { form: 'default value import', code: `import http from 'node:http';`, evaluates: true },
-  { form: 'namespace import', code: `import * as http from 'node:http';`, evaluates: true },
-  { form: 'named value import', code: `import { request } from 'node:http';`, evaluates: true },
-  { form: 'value re-export', code: `export { request } from 'node:http';`, evaluates: true },
-  { form: 'star re-export', code: `export * from 'node:http';`, evaluates: true },
+  // --- static forms ---
+  { form: 'side-effect import', code: `import 'node:http';`, eager: true },
+  { form: 'default value import', code: `import http from 'node:http';`, eager: true },
+  { form: 'namespace import', code: `import * as http from 'node:http';`, eager: true },
+  { form: 'named value import', code: `import { request } from 'node:http';`, eager: true },
+  { form: 'value re-export', code: `export { request } from 'node:http';`, eager: true },
+  { form: 'star re-export', code: `export * from 'node:http';`, eager: true },
   {
     form: 'mixed value + type import',
     code: `import http, { type IncomingMessage } from 'node:http';`,
-    evaluates: true,
+    eager: true,
   },
-  {
-    form: 'type-only default import',
-    code: `import type http from 'node:http';`,
-    evaluates: false,
-  },
+  { form: 'type-only default import', code: `import type http from 'node:http';`, eager: false },
   {
     form: 'type-only named import',
     code: `import { type IncomingMessage } from 'node:http';`,
-    evaluates: false,
+    eager: false,
   },
   {
     form: 'type-only re-export',
     code: `export type { IncomingMessage } from 'node:http';`,
-    evaluates: false,
+    eager: false,
   },
-  { form: 'dynamic import', code: `const m = await import('node:http');`, evaluates: false },
-])('$form is classified as evaluates=$evaluates', ({ code, evaluates }) => {
-  expect(evaluatedModuleRefs('fixture.ts', code)).toEqual(evaluates ? ['node:http'] : []);
+  // --- dynamic import: scope decides, not syntax ---
+  { form: 'top-level await import', code: `const m = await import('node:http');`, eager: true },
+  { form: 'top-level import().then', code: `import('node:http').then((m) => m);`, eager: true },
+  {
+    form: 'top-level immediately-invoked arrow',
+    code: `(async () => { await import('node:http'); })();`,
+    eager: true,
+  },
+  {
+    form: 'function-declaration-local import',
+    code: `async function load() { return await import('node:http'); }`,
+    eager: false,
+  },
+  {
+    form: 'arrow-local import',
+    code: `const load = async () => await import('node:http');`,
+    eager: false,
+  },
+  {
+    form: 'method-local import',
+    code: `class K { async load() { await import('node:http'); } }`,
+    eager: false,
+  },
+  {
+    form: 'ternary inside a function (the shipped lazy-load shape)',
+    code: `async function load(s: boolean) {
+      return s ? (await import('node:https')).default : (await import('node:http')).default;
+    }`,
+    eager: false,
+  },
+])('$form is eager=$eager', ({ code, eager }) => {
+  const refs = eagerlyEvaluatedModules('fixture.ts', code);
+  expect(refs.includes('node:http') || refs.includes('node:https')).toBe(eager);
 });
 
 test('the CLI startup import closure never evaluates node:http or node:https', () => {
   const offenders: string[] = [];
   for (const file of eagerClosureOfCli()) {
-    for (const specifier of evaluatedModuleRefs(file, fs.readFileSync(file, 'utf8'))) {
+    for (const specifier of eagerlyEvaluatedModules(file, fs.readFileSync(file, 'utf8'))) {
       if (LAZY_HTTP_MODULES.has(specifier)) {
         offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
       }
@@ -156,7 +261,7 @@ test('the CLI startup import closure never evaluates node:http or node:https', (
 
 test('the CLI startup import closure is reachable and crosses the package boundary', () => {
   // Guards the test above from silently passing because the walk found nothing:
-  // a resolver that returns null for everything would leave both the src side
+  // a resolver that returned null for everything would leave both the src side
   // and the workspace side of the closure empty while the guard stayed green.
   const closure = eagerClosureOfCli();
   expect(closure.length).toBeGreaterThan(50);

--- a/src/cli-schema/option-schema.ts
+++ b/src/cli-schema/option-schema.ts
@@ -91,7 +91,20 @@ function buildOptionSpecs(): OptionSpec[] {
         return supported.has(command);
       },
     }))
-    .sort((left, right) => left.key.localeCompare(right.key));
+    .sort((left, right) => compareOptionKeys(left.key, right.key));
+}
+
+/**
+ * Case-insensitive-then-codepoint ordering, matching what `localeCompare`
+ * produces for the ASCII flag-key vocabulary. This runs at module load on
+ * every CLI invocation, and the FIRST `localeCompare` in a process pays ~5ms
+ * of ICU collator initialization — a cost the CLI otherwise never incurs.
+ */
+function compareOptionKeys(left: string, right: string): number {
+  const leftLower = left.toLowerCase();
+  const rightLower = right.toLowerCase();
+  if (leftLower !== rightLower) return leftLower < rightLower ? -1 : 1;
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function primaryFlagDefinition(spec: OptionSpec): FlagDefinition {

--- a/src/daemon/client/daemon-client-progress.ts
+++ b/src/daemon/client/daemon-client-progress.ts
@@ -1,5 +1,7 @@
 import type { RequestProgressEvent, RequestProgressSink } from '@agent-device/contracts/progress';
-import http from 'node:http';
+// Type-only: importing `node:http` for a value eagerly initializes undici
+// (~9ms in a fresh process), which the default socket transport never needs.
+import type http from 'node:http';
 import type { Socket } from 'node:net';
 import { AppError } from '@agent-device/kernel/errors';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';

--- a/src/daemon/client/daemon-client-transport.ts
+++ b/src/daemon/client/daemon-client-transport.ts
@@ -1,7 +1,5 @@
 import type { RequestProgressSink } from '@agent-device/contracts/progress';
 import net from 'node:net';
-import http from 'node:http';
-import https from 'node:https';
 import { AppError } from '@agent-device/kernel/errors';
 import { readNodeHttpResponseBody } from '../../utils/node-http.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
@@ -20,6 +18,22 @@ import { DAEMON_RPC_PROTOCOL_VERSION } from '../http-health.ts';
 import { readVersion } from '../../utils/version.ts';
 
 type ResolvedDaemonTransport = 'socket' | 'http';
+type NodeHttpRequester = Pick<typeof import('node:http'), 'request'>;
+
+/**
+ * `node:http` eagerly initializes undici, which costs ~9ms of startup in a
+ * fresh process. The default local transport is a plain `node:net` socket and
+ * never issues an HTTP request, so both HTTP modules are loaded on demand —
+ * only the HTTP transport, remote daemons, and HTTP health checks pay for them.
+ */
+async function loadHttpRequester(protocol: string): Promise<NodeHttpRequester> {
+  // `.default` (not the namespace) so this stays the very same module object a
+  // static `import http from 'node:http'` yields — its `request` property is
+  // mutable, which the transport's tests rely on to stub outbound requests.
+  return protocol === 'https:'
+    ? (await import('node:https')).default
+    : (await import('node:http')).default;
+}
 type SendRequestOptions = {
   onProgress?: RequestProgressSink;
 };
@@ -102,19 +116,19 @@ export async function readRemoteDaemonHealth(info: DaemonInfo): Promise<RemoteDa
   return health;
 }
 
-function readDaemonHttpHealth(info: DaemonInfo): Promise<RemoteDaemonHealth> {
+async function readDaemonHttpHealth(info: DaemonInfo): Promise<RemoteDaemonHealth> {
   const endpoint = info.baseUrl
     ? buildDaemonHttpUrl(info.baseUrl, 'health')
     : info.httpPort
       ? `http://127.0.0.1:${info.httpPort}/health`
       : null;
-  if (!endpoint) return Promise.resolve({ reachable: false });
+  if (!endpoint) return { reachable: false };
   const url = new URL(endpoint);
-  const transport = url.protocol === 'https:' ? https : http;
+  const transport = await loadHttpRequester(url.protocol);
   const timeoutMs = info.baseUrl
     ? REMOTE_DAEMON_HEALTHCHECK_TIMEOUT_MS
     : LOCAL_DAEMON_HEALTHCHECK_TIMEOUT_MS;
-  return new Promise((resolve) => {
+  return await new Promise((resolve) => {
     const headers = info.baseUrl ? buildDaemonHttpAuthHeaders(info.token) : {};
     const req = transport.request(
       {
@@ -380,9 +394,9 @@ async function sendHttpRequest(
   if (info.baseUrl) {
     Object.assign(headers, buildDaemonHttpAuthHeaders(info.token));
   }
+  const transport = await loadHttpRequester(rpcUrl.protocol);
 
   return await new Promise((resolve, reject) => {
-    const transport = rpcUrl.protocol === 'https:' ? https : http;
     const request = transport.request(
       {
         protocol: rpcUrl.protocol,

--- a/src/daemon/client/daemon-client-transport.ts
+++ b/src/daemon/client/daemon-client-transport.ts
@@ -1,7 +1,7 @@
 import type { RequestProgressSink } from '@agent-device/contracts/progress';
 import net from 'node:net';
 import { AppError } from '@agent-device/kernel/errors';
-import { readNodeHttpResponseBody } from '../../utils/node-http.ts';
+import { loadNodeHttpRequester, readNodeHttpResponseBody } from '../../utils/node-http.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import type { DaemonPaths, DaemonTransportPreference } from '../config.ts';
@@ -18,22 +18,6 @@ import { DAEMON_RPC_PROTOCOL_VERSION } from '../http-health.ts';
 import { readVersion } from '../../utils/version.ts';
 
 type ResolvedDaemonTransport = 'socket' | 'http';
-type NodeHttpRequester = Pick<typeof import('node:http'), 'request'>;
-
-/**
- * `node:http` eagerly initializes undici, which costs ~9ms of startup in a
- * fresh process. The default local transport is a plain `node:net` socket and
- * never issues an HTTP request, so both HTTP modules are loaded on demand —
- * only the HTTP transport, remote daemons, and HTTP health checks pay for them.
- */
-async function loadHttpRequester(protocol: string): Promise<NodeHttpRequester> {
-  // `.default` (not the namespace) so this stays the very same module object a
-  // static `import http from 'node:http'` yields — its `request` property is
-  // mutable, which the transport's tests rely on to stub outbound requests.
-  return protocol === 'https:'
-    ? (await import('node:https')).default
-    : (await import('node:http')).default;
-}
 type SendRequestOptions = {
   onProgress?: RequestProgressSink;
 };
@@ -124,7 +108,7 @@ async function readDaemonHttpHealth(info: DaemonInfo): Promise<RemoteDaemonHealt
       : null;
   if (!endpoint) return { reachable: false };
   const url = new URL(endpoint);
-  const transport = await loadHttpRequester(url.protocol);
+  const transport = await loadNodeHttpRequester(url.protocol);
   const timeoutMs = info.baseUrl
     ? REMOTE_DAEMON_HEALTHCHECK_TIMEOUT_MS
     : LOCAL_DAEMON_HEALTHCHECK_TIMEOUT_MS;
@@ -394,7 +378,7 @@ async function sendHttpRequest(
   if (info.baseUrl) {
     Object.assign(headers, buildDaemonHttpAuthHeaders(info.token));
   }
-  const transport = await loadHttpRequester(rpcUrl.protocol);
+  const transport = await loadNodeHttpRequester(rpcUrl.protocol);
 
   return await new Promise((resolve, reject) => {
     const request = transport.request(

--- a/src/remote/daemon-artifacts.ts
+++ b/src/remote/daemon-artifacts.ts
@@ -1,6 +1,4 @@
 import fs from 'node:fs';
-import http from 'node:http';
-import https from 'node:https';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '@agent-device/kernel/errors';
@@ -349,7 +347,13 @@ type DownloadRemoteArtifactParams = {
 
 export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParams): Promise<void> {
   const artifactUrl = new URL(buildDaemonArtifactUrl(params.baseUrl, params.artifactId));
-  const transport = artifactUrl.protocol === 'https:' ? https : http;
+  // Loaded on demand: `prepareRemoteRequestArtifacts` runs on every CLI
+  // request, but only a remote daemon ever downloads an artifact, and
+  // importing `node:http` for a value costs ~9ms of undici init.
+  const transport =
+    artifactUrl.protocol === 'https:'
+      ? (await import('node:https')).default
+      : (await import('node:http')).default;
   await fs.promises.mkdir(path.dirname(params.destinationPath), { recursive: true });
   await new Promise<void>((resolve, reject) => {
     let settled = false;

--- a/src/remote/daemon-artifacts.ts
+++ b/src/remote/daemon-artifacts.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '@agent-device/kernel/errors';
+import { loadNodeHttpRequester } from '../utils/node-http.ts';
 import type { DaemonArtifact, DaemonRequest, DaemonResponse } from '../daemon/types.ts';
 import {
   buildDaemonHttpAuthHeaders,
@@ -347,13 +348,9 @@ type DownloadRemoteArtifactParams = {
 
 export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParams): Promise<void> {
   const artifactUrl = new URL(buildDaemonArtifactUrl(params.baseUrl, params.artifactId));
-  // Loaded on demand: `prepareRemoteRequestArtifacts` runs on every CLI
-  // request, but only a remote daemon ever downloads an artifact, and
-  // importing `node:http` for a value costs ~9ms of undici init.
-  const transport =
-    artifactUrl.protocol === 'https:'
-      ? (await import('node:https')).default
-      : (await import('node:http')).default;
+  // `prepareRemoteRequestArtifacts` runs on every CLI request, but only a
+  // remote daemon ever downloads an artifact, so the HTTP stack loads here.
+  const transport = await loadNodeHttpRequester(artifactUrl.protocol);
   await fs.promises.mkdir(path.dirname(params.destinationPath), { recursive: true });
   await new Promise<void>((resolve, reject) => {
     let settled = false;

--- a/src/remote/upload-stream.ts
+++ b/src/remote/upload-stream.ts
@@ -3,7 +3,7 @@ import type { IncomingHttpHeaders } from 'node:http';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '@agent-device/kernel/errors';
-import { readNodeHttpResponseBody } from '../utils/node-http.ts';
+import { loadNodeHttpRequester, readNodeHttpResponseBody } from '../utils/node-http.ts';
 import {
   createUploadProgressTransform,
   type UploadProgressSink,
@@ -64,13 +64,10 @@ async function streamFileToHttpRequestAttempt(options: {
   startOffset: number;
   progress?: UploadStreamProgressOptions;
 }): Promise<UploadStreamResponse> {
-  // Loaded on demand: this module sits in the CLI's eager import closure via
-  // the remote-artifact upload client, but only a remote daemon ever uploads.
-  // Importing `node:http` for a value costs ~9ms of undici init per process.
-  const transport =
-    options.url.protocol === 'https:'
-      ? (await import('node:https')).default
-      : (await import('node:http')).default;
+  // This module sits in the CLI's eager import closure via the remote-artifact
+  // upload client, but only a remote daemon ever uploads, so the HTTP stack
+  // loads here rather than at import time.
+  const transport = await loadNodeHttpRequester(options.url.protocol);
   const payloadSize = fs.statSync(options.payloadPath).size;
   const headers = buildUploadRequestHeaders(options.headers, options.startOffset, payloadSize);
   emitUploadAttemptStarted(options.progress, options.startOffset, payloadSize);

--- a/src/remote/upload-stream.ts
+++ b/src/remote/upload-stream.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
-import http, { type IncomingHttpHeaders } from 'node:http';
-import https from 'node:https';
+import type { IncomingHttpHeaders } from 'node:http';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '@agent-device/kernel/errors';
@@ -65,7 +64,13 @@ async function streamFileToHttpRequestAttempt(options: {
   startOffset: number;
   progress?: UploadStreamProgressOptions;
 }): Promise<UploadStreamResponse> {
-  const transport = options.url.protocol === 'https:' ? https : http;
+  // Loaded on demand: this module sits in the CLI's eager import closure via
+  // the remote-artifact upload client, but only a remote daemon ever uploads.
+  // Importing `node:http` for a value costs ~9ms of undici init per process.
+  const transport =
+    options.url.protocol === 'https:'
+      ? (await import('node:https')).default
+      : (await import('node:http')).default;
   const payloadSize = fs.statSync(options.payloadPath).size;
   const headers = buildUploadRequestHeaders(options.headers, options.startOffset, payloadSize);
   emitUploadAttemptStarted(options.progress, options.startOffset, payloadSize);

--- a/src/utils/node-http.ts
+++ b/src/utils/node-http.ts
@@ -1,6 +1,31 @@
 import type { IncomingMessage } from 'node:http';
 import { AppError } from '@agent-device/kernel/errors';
 
+/** The slice of `node:http` / `node:https` an outbound request needs. */
+export type NodeHttpRequester = Pick<typeof import('node:http'), 'request'>;
+
+/**
+ * Loads `node:http` / `node:https` on demand, at the call site that actually
+ * issues a request.
+ *
+ * Importing either for a VALUE initializes undici and, under
+ * `NODE_USE_SYSTEM_CA=1`, the platform trust store -- ~79ms per process. Several
+ * modules that only *might* speak HTTP (the daemon transport, remote artifact
+ * upload/download) sit in the CLI's eager import closure, where the default
+ * daemon transport is a plain `node:net` socket and no HTTP request is ever
+ * made. `src/__tests__/cli-startup-import-closure.test.ts` fails the build if a
+ * static import of either module reappears in that closure.
+ *
+ * Resolves `.default`, not the namespace, so callers get the very same module
+ * object a static `import http from 'node:http'` yields -- its `request`
+ * property is mutable, which the transport tests rely on to stub requests.
+ */
+export async function loadNodeHttpRequester(protocol: string): Promise<NodeHttpRequester> {
+  return protocol === 'https:'
+    ? (await import('node:https')).default
+    : (await import('node:http')).default;
+}
+
 export function readNodeHttpResponseBody(res: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     let body = '';


### PR DESCRIPTION
## Summary

Decomposing the per-invocation floor of a warm CLI call turned up **79ms of startup work that no local command needs**. Removing it cuts a warm `appstate` from **146.4ms to 67.6ms (-53.8%)**.

Two independent causes, both outside the leads that were expected to matter:

1. **`node:http` in the eager import closure.** Four modules reachable from `src/cli.ts` value-imported `node:http`/`node:https`, so every invocation initialized undici — and, under `NODE_USE_SYSTEM_CA=1`, the macOS system trust store behind it. That is ~70ms, mostly *off-CPU* (a blocking `trustd` lookup, invisible to `--cpu-prof`: the profile showed only 65ms of CPU in a 140ms call). The default daemon transport is a plain `node:net` socket and never issues an HTTP request. Both modules now load on demand.

2. **ICU initialization for an internal sort.** `option-schema.ts` sorted its specs with `localeCompare` at module scope. The *first* `localeCompare` in a fresh Node process costs ~5.4ms of collator init; every later one is ~0.002ms. A case-insensitive-then-codepoint comparator reproduces the identical order for the ASCII flag-key vocabulary (verified against all 159 keys).

## Warm-call floor decomposition

Warm `appstate` on a live iOS simulator session, n=10, 5-min load avg < 10, client-side `hrtime` marks correlated against the daemon's own request log:

| Phase | median |
|---|---|
| node boot → bin entry | 13.8 ms |
| `import('./cli.ts')` (eager closure: 34 files / 643 kB) | 32.6 ms |
| **ensureDaemon total** | **3.0 ms** |
|   · read daemon info (fs) | 0.1 ms |
|   · `canConnect` TCP probe (a second connect, discarded) | 1.2 ms |
|   · version + daemon code signature | 1.5 ms |
| **sendRequest total** | **2.0 ms** |
|   · RPC socket connect | 0.5 ms |
|   · request `JSON.stringify` (481 B) | 0.003 ms |
|   · connect → first response byte | 1.2 ms |
|   · response `JSON.parse` (230 B) | 0.2 ms |
| daemon-side `request_start` → `request_success` | 0–1 ms |

**The "daemon connect + RPC" bucket is ~5ms, not 118ms.** The 118ms figure was device work plus host-load artifacts. There is no meaningful daemon-transport overhead left to remove: the redundant `canConnect` probe and the code-signature read together are ~2.7ms. The real cost sat in the import bucket, and it was not closure *size* — it was two accidental initializations.

## Before / after

Interleaved A/B, alternating two prebuilt dists in one loop (both kept inside the repo tree), re-opening the session per block and discarding the first call after each swap. n=30 per arm, 5-min load avg < 10.

| command | before | after | delta |
|---|---|---|---|
| `appstate` | 146.4 ms | 67.6 ms | **-53.8%** |
| `session list` | 137.9 ms | 57.7 ms | **-58.2%** |
| `snapshot -i` | 195.5 ms | 188.8 ms | -3.4% (device-work bound) |

Per-command system-CA penalty, before → after: `appstate` +69.6ms → +0.0ms, `session list` +64.4ms → +0.4ms.

Without `NODE_USE_SYSTEM_CA` set at all, `appstate` still goes 73.9ms → 57.9ms (**-22%**) — so this is not purely an artifact of that setting. Long device-bound commands (`snapshot`, `devices`) never paid the trust-store cost, because they are slow enough to absorb it; the commands that paid it in full are exactly the cheap ones agents issue in bulk.

## Measured and rejected

The facet restructure deferred by #1660 — splitting command metadata from runtime handlers — was estimated before attempting, against a 20ms bar:

- `registry.js` is 142.5 kB of the 643 kB eager closure but only **~1.6ms** of module evaluation.
- **All** module compilation (`compileSourceTextModule`) across every chunk is ~9.5ms.

Eliminating the entire closure could not reach 20ms, so the refactor was not attempted. Closure *size* is a poor proxy for startup cost here.

## Behavior

Unchanged. The HTTP daemon transport, remote daemons, and remote artifact upload/download all still work — verified live over `--daemon-transport http` with a dual-mode daemon. The lazy imports resolve `.default` rather than the namespace, so they stay the same mutable module object a static import yields (the transport tests stub `http.request` on it).

## Tests

- New unit test walks the eager import closure of `src/cli.ts` and fails if any file in it value-imports `node:http`/`node:https` again, naming the offender; type-only imports stay allowed. Verified it fails on a reintroduced regression rather than passing vacuously, and it carries a second assertion so the walk can't silently find nothing.
- Full `pnpm test:unit`: 639 files / 5729 tests pass.
- `oxfmt --check`, `pnpm lint`, `pnpm typecheck`, `pnpm check:layering` all clean.

Live validation used a dedicated `claude-rpcfloor-test` simulator and an isolated state dir, both torn down afterward.
