### PR TITLE
docs(cli): advertise open --foreground and snapshot --actions in the workflow card

### DIFF
--- a/scripts/__tests__/help-conformance-bench.test.ts
+++ b/scripts/__tests__/help-conformance-bench.test.ts
@@ -496,6 +496,35 @@ test('case matchers score parsed tokens so shell quoting does not change results
   });
 });
 
+test('foreground attach scoring rejects an explicit app positional after flags', async () => {
+  const validCommand = 'agent-device open --foreground --platform ios';
+  const explicitTargetCommand = 'agent-device open --foreground --platform ios com.example.app';
+  const [validAttach, explicitTarget] = await validatePlanCommands([
+    validCommand,
+    explicitTargetCommand,
+  ]);
+
+  assert.deepEqual(explicitTarget.agentCommand, {
+    command: 'open',
+    positionals: ['com.example.app'],
+  });
+  assert.equal(
+    scoreExpectations({ expectations: ['noExplicitForegroundTarget'] }, [validCommand], '', [
+      validAttach,
+    ]).noExplicitForegroundTarget,
+    true,
+  );
+  assert.equal(
+    scoreExpectations(
+      { expectations: ['noExplicitForegroundTarget'] },
+      [explicitTargetCommand],
+      '',
+      [explicitTarget],
+    ).noExplicitForegroundTarget,
+    false,
+  );
+});
+
 test('plan validator applies narrow grammar to permitted external commands', async () => {
   const results = await validatePlanCommands(
     [

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -4,6 +4,7 @@ import {
   APP_NOT_INSTALLED_SAMPLE,
   BROWSERSTACK_CONNECT_SAMPLE,
   DEVICE_IN_USE_SAMPLE,
+  FOREGROUND_SNAPSHOT_FAILURE_SAMPLE,
   MERGED_CARD_ACTIONS_SAMPLE,
   NOT_SETTLED_SAMPLE,
   OFFSCREEN_TARGET_SNAPSHOT_SAMPLE,
@@ -14,6 +15,8 @@ import {
   STALE_REF_SAMPLE,
 } from '../help-conformance-sample-outputs.mjs';
 import { interactionCliOutputFormatters } from '../../src/commands/interaction/output.ts';
+import { snapshotCliOutput } from '../../src/commands/capture/output.ts';
+import { openCliOutput } from '../../src/commands/management/output.ts';
 import { NEVER_SETTLED_HINT } from '../../src/commands/interaction/runtime/settle.ts';
 import { buildAmbiguousMatchError } from '../../src/daemon/handlers/find.ts';
 import { refMutationAdmissionResponse } from '../../src/daemon/handlers/interaction-ref-policy.ts';
@@ -269,6 +272,26 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
     },
   },
   {
+    name: 'FOREGROUND_SNAPSHOT_FAILURE_SAMPLE',
+    producer: 'the open success renderer with a failed composed snapshot',
+    sample: FOREGROUND_SNAPSHOT_FAILURE_SAMPLE,
+    render: () => {
+      const warning =
+        'The session is open, but the initial interactive snapshot failed (COMMAND_FAILED: capture failed). Run: agent-device snapshot -i';
+      return (
+        openCliOutput({
+          session: 'default',
+          warnings: [warning],
+          initialSnapshotError: {
+            code: 'COMMAND_FAILED',
+            message: 'capture failed',
+          },
+          identifiers: { session: 'default' },
+        }).text ?? ''
+      );
+    },
+  },
+  {
     name: 'MERGED_CARD_ACTIONS_SAMPLE',
     producer: "the snapshot renderer with --actions naming a merged element's custom actions",
     sample: MERGED_CARD_ACTIONS_SAMPLE,
@@ -280,6 +303,7 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
         {
           index: 0,
           ref: 'e1',
+          depth: 0,
           type: 'Application',
           label: 'Bluesky',
           rect: { x: 0, y: 0, width: 390, height: 844 },
@@ -288,6 +312,7 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
           index: 1,
           ref: 'e2',
           parentIndex: 0,
+          depth: 1,
           type: 'Window',
           rect: { x: 0, y: 0, width: 390, height: 844 },
         },
@@ -295,6 +320,7 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
           index: 2,
           ref: 'e3',
           parentIndex: 1,
+          depth: 2,
           type: 'CollectionView',
           interactive: true,
           rect: { x: 0, y: 60, width: 390, height: 700 },
@@ -303,6 +329,7 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
           index: 3,
           ref: 'e72',
           parentIndex: 2,
+          depth: 3,
           type: 'Link',
           label: 'feedItem-by-whiskers.test',
           interactive: true,
@@ -310,9 +337,11 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
           actions: ['Reply', 'Repost', 'Open post options menu'],
         },
       ];
-      return formatSnapshotText(
-        { nodes, backend: 'xctest', truncated: false },
-        { interactiveOnly: true },
+      return (
+        snapshotCliOutput({
+          result: { nodes, backend: 'xctest', truncated: false },
+          interactiveOnly: true,
+        }).text ?? ''
       ).trimEnd();
     },
   },

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -4,6 +4,7 @@ import {
   APP_NOT_INSTALLED_SAMPLE,
   BROWSERSTACK_CONNECT_SAMPLE,
   DEVICE_IN_USE_SAMPLE,
+  MERGED_CARD_ACTIONS_SAMPLE,
   NOT_SETTLED_SAMPLE,
   OFFSCREEN_TARGET_SNAPSHOT_SAMPLE,
   PRIVATE_AX_RECOVERY_SAMPLE,
@@ -260,6 +261,54 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
         row(9, 'e10', 'Notifications', 1030),
         row(10, 'e11', 'Wallpaper', 1160),
         row(11, 'e12', 'Developer', 1290),
+      ];
+      return formatSnapshotText(
+        { nodes, backend: 'xctest', truncated: false },
+        { interactiveOnly: true },
+      ).trimEnd();
+    },
+  },
+  {
+    name: 'MERGED_CARD_ACTIONS_SAMPLE',
+    producer: "the snapshot renderer with --actions naming a merged element's custom actions",
+    sample: MERGED_CARD_ACTIONS_SAMPLE,
+    render: () => {
+      // A Bluesky-style feed item merged into one Link node: its Reply/Repost/
+      // menu controls are AX custom actions, not child nodes, so they only
+      // surface when --actions is passed through to the renderer.
+      const nodes = [
+        {
+          index: 0,
+          ref: 'e1',
+          type: 'Application',
+          label: 'Bluesky',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 1,
+          ref: 'e2',
+          parentIndex: 0,
+          type: 'Window',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 2,
+          ref: 'e3',
+          parentIndex: 1,
+          type: 'CollectionView',
+          interactive: true,
+          rect: { x: 0, y: 60, width: 390, height: 700 },
+        },
+        {
+          index: 3,
+          ref: 'e72',
+          parentIndex: 2,
+          type: 'Link',
+          label: 'feedItem-by-whiskers.test',
+          interactive: true,
+          rect: { x: 0, y: 60, width: 390, height: 140 },
+          actions: ['Reply', 'Repost', 'Open post options menu'],
+        },
       ];
       return formatSnapshotText(
         { nodes, backend: 'xctest', truncated: false },

--- a/scripts/help-conformance-case-checks.mjs
+++ b/scripts/help-conformance-case-checks.mjs
@@ -16,6 +16,13 @@ const EXPECTATION_SCORERS = {
   // validator splits and validates each segment), so it is the only place
   // that can tell whether the model actually chained.
   usesConfidentChaining: ({ commands }) => commands.some((command) => /&&/.test(command)),
+  noExplicitForegroundTarget: ({ commandValidation }) =>
+    commandValidation
+      .filter(
+        ({ tokens, agentCommand }) =>
+          agentCommand?.command === 'open' && tokens.includes('--foreground'),
+      )
+      .every(({ agentCommand }) => agentCommand.positionals.length === 0),
   noWaitStable: ({ joined }) => !joined.includes('wait stable'),
   verifiesNamedExpectation: ({ joined }) => /\b(wait|is|get|find)\b/.test(joined),
   usesDogfoodEvidence: ({ joined }) =>

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -651,7 +651,12 @@ Use the output already shown to determine whether the feed-search UI is present,
     matchers: [
       {
         id: 'startsWithForegroundOpen',
-        pattern: /^agent-device\s+open\s+--foreground\b/i,
+        // Flag order is not semantically meaningful (`open --platform ios
+        // --foreground` is exactly as correct as `open --foreground
+        // --platform ios`); this only checks that --foreground is on the
+        // first command and there is no app positional before it. The
+        // no-positional guarantee comes from the forbidden checks below.
+        pattern: /^agent-device\s+open\b[^\n]*--foreground\b/i,
       },
       {
         id: 'pressesContinueAfterAttach',

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -3,6 +3,7 @@ import {
   APP_NOT_INSTALLED_SAMPLE,
   BROWSERSTACK_CONNECT_SAMPLE,
   DEVICE_IN_USE_SAMPLE,
+  FOREGROUND_SNAPSHOT_FAILURE_SAMPLE,
   MERGED_CARD_ACTIONS_SAMPLE,
   NOT_SETTLED_SAMPLE,
   OFFSCREEN_TARGET_SNAPSHOT_SAMPLE,
@@ -647,7 +648,13 @@ Use the output already shown to determine whether the feed-search UI is present,
     id: 'foreground-attach-single-sim',
     docs: ['--help:first30', 'workflow'],
     task: 'You are starting fresh with no active session. The environment guarantees exactly one booted iOS simulator with exactly one app running on it -- the app you want to keep testing. Plan the command to attach to it and get its initial interactive snapshot in a single call (this only resolves unambiguously because of that guarantee, and it rejects an explicit app or device selector), then press the visible Continue control and close the session.',
-    expectations: ['validPlanCommands', 'fullPrefix', 'usesSettleOnMutations', 'opensAndCloses'],
+    expectations: [
+      'validPlanCommands',
+      'fullPrefix',
+      'usesSettleOnMutations',
+      'opensAndCloses',
+      'noExplicitForegroundTarget',
+    ],
     matchers: [
       {
         id: 'startsWithForegroundOpen',
@@ -664,10 +671,6 @@ Use the output already shown to determine whether the feed-search UI is present,
       },
     ],
     forbidden: [
-      {
-        id: 'noAppPositionalWithForeground',
-        pattern: /open[ \t]+(?!--)\S+[^\n]*--foreground\b|open[ \t]+--foreground[ \t]+(?!--)\S+/i,
-      },
       {
         id: 'noDeviceSelectorWithForeground',
         pattern: /--foreground\b[^\n]*--(?:udid|device)\b|--(?:udid|device)\b[^\n]*--foreground\b/i,
@@ -695,6 +698,25 @@ Use the output already shown to determine whether the feed-search UI is present,
         pattern: /(?:^|\n)agent-device\s+(?:press|click|find)\b[^\n]*(?:label|text)="?reply"?/i,
       },
       { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
+    ],
+  },
+  {
+    id: 'foreground-attach-snapshot-recovery',
+    docs: ['--help:first30', 'workflow'],
+    task: quiz(
+      FOREGROUND_SNAPSHOT_FAILURE_SAMPLE,
+      'The foreground attach succeeded and the session is still open, but its initial snapshot failed. What command should run next to get interactive refs?',
+    ),
+    expectations: ['validPlanCommands', 'fullPrefix', 'usesSnapshotI'],
+    matchers: [
+      {
+        id: 'retriesSnapshotInOpenSession',
+        pattern: /(?:^|\n)agent-device\s+snapshot\s+-i\b/i,
+      },
+    ],
+    forbidden: [
+      { id: 'noSecondOpen', pattern: /(?:^|\n)agent-device\s+open\b/i },
+      { id: 'noPrematureClose', pattern: /(?:^|\n)agent-device\s+close\b/i },
     ],
   },
 ];

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -3,6 +3,7 @@ import {
   APP_NOT_INSTALLED_SAMPLE,
   BROWSERSTACK_CONNECT_SAMPLE,
   DEVICE_IN_USE_SAMPLE,
+  MERGED_CARD_ACTIONS_SAMPLE,
   NOT_SETTLED_SAMPLE,
   OFFSCREEN_TARGET_SNAPSHOT_SAMPLE,
   SETTLE_DIFF_SAMPLE,
@@ -640,6 +641,55 @@ Use the output already shown to determine whether the feed-search UI is present,
         pattern: /(?:^|\n)agent-device\s+open\s+(?:sample\.apk|bs:\/\/app-id)\b/i,
       },
       { id: 'noRedundantInstall', pattern: /(?:^|\n)agent-device\s+install\b/i },
+    ],
+  },
+  {
+    id: 'foreground-attach-single-sim',
+    docs: ['--help:first30', 'workflow'],
+    task: 'You are starting fresh with no active session. The environment guarantees exactly one booted iOS simulator with exactly one app running on it -- the app you want to keep testing. Plan the command to attach to it and get its initial interactive snapshot in a single call (this only resolves unambiguously because of that guarantee, and it rejects an explicit app or device selector), then press the visible Continue control and close the session.',
+    expectations: ['validPlanCommands', 'fullPrefix', 'usesSettleOnMutations', 'opensAndCloses'],
+    matchers: [
+      {
+        id: 'startsWithForegroundOpen',
+        pattern: /^agent-device\s+open\s+--foreground\b/i,
+      },
+      {
+        id: 'pressesContinueAfterAttach',
+        pattern: /agent-device\s+press\s+[^\n]*continue[^\n]*--settle\b/i,
+      },
+    ],
+    forbidden: [
+      {
+        id: 'noAppPositionalWithForeground',
+        pattern: /open[ \t]+(?!--)\S+[^\n]*--foreground\b|open[ \t]+--foreground[ \t]+(?!--)\S+/i,
+      },
+      {
+        id: 'noDeviceSelectorWithForeground',
+        pattern: /--foreground\b[^\n]*--(?:udid|device)\b|--(?:udid|device)\b[^\n]*--foreground\b/i,
+      },
+      { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
+    ],
+  },
+  {
+    id: 'merged-card-actions-not-directly-invokable',
+    docs: ['--help:first30', 'workflow'],
+    task: quiz(
+      MERGED_CARD_ACTIONS_SAMPLE,
+      'The goal is to reply to this post. The actions list names "Reply" as a hidden affordance on @e72, but that name is not a pressable selector. What command should run next?',
+    ),
+    expectations: ['validPlanCommands', 'fullPrefix'],
+    matchers: [
+      {
+        id: 'opensCardToReachReply',
+        pattern: /(?:^|\n)agent-device\s+(?:press|click)\s+@e72\b[^\n]*--settle\b/i,
+      },
+    ],
+    forbidden: [
+      {
+        id: 'noPressingActionNameAsSelector',
+        pattern: /(?:^|\n)agent-device\s+(?:press|click|find)\b[^\n]*(?:label|text)="?reply"?/i,
+      },
+      { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
     ],
   },
 ];

--- a/scripts/help-conformance-command-validator.ts
+++ b/scripts/help-conformance-command-validator.ts
@@ -5,7 +5,13 @@ import { isCommandName } from '../src/commands/command-metadata.ts';
 
 type ValidationKind = 'agent-device-grammar' | 'pseudo-ref';
 
+type ParsedAgentCommand = {
+  command: string;
+  positionals: string[];
+};
+
 type ValidationResult = { valid: true } | { valid: false; kind: ValidationKind; error: string };
+type PlanValidationResult = ValidationResult & { agentCommand?: ParsedAgentCommand };
 
 const TARGET_POSITION_BY_COMMAND = new Map<string, number>([
   ['click', 0],
@@ -71,10 +77,23 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
 }
 
-function validateInput(value: unknown): ValidationResult | ValidationResult[] {
-  if (Array.isArray(value) && value.every(isStringArray))
-    return value.map(validateAgentDeviceCommand);
-  return validateAgentDeviceCommand(value);
+function validateInput(value: unknown): PlanValidationResult | PlanValidationResult[] {
+  if (Array.isArray(value) && value.every(isStringArray)) return value.map(validatePlanCommand);
+  return validatePlanCommand(value);
+}
+
+function validatePlanCommand(value: unknown): PlanValidationResult {
+  const validation = validateAgentDeviceCommand(value);
+  if (!validation.valid || !isStringArray(value)) return validation;
+  const parsed = parseArgs(value, { strictFlags: true });
+  if (!parsed.command) return validation;
+  return {
+    ...validation,
+    agentCommand: {
+      command: parsed.command,
+      positionals: [...parsed.positionals],
+    },
+  };
 }
 
 function runCli(): void {

--- a/scripts/help-conformance-plan-validator.mjs
+++ b/scripts/help-conformance-plan-validator.mjs
@@ -30,12 +30,16 @@ function applyCommandPolicy(parsed, agentResultState, allowedExternalCommands) {
   }
   const result = agentResultState.results[agentResultState.index++];
   return result?.valid
-    ? parsed
+    ? attachAgentCommand(parsed, result.agentCommand)
     : withIssue(
         parsed,
         result?.kind ?? 'agent-device-grammar',
         result?.error ?? 'Command validation returned no result.',
       );
+}
+
+function attachAgentCommand(parsed, agentCommand) {
+  return agentCommand ? { ...parsed, agentCommand } : parsed;
 }
 
 // The compact workflow card teaches chaining confident consecutive steps with

--- a/scripts/help-conformance-sample-outputs.mjs
+++ b/scripts/help-conformance-sample-outputs.mjs
@@ -147,3 +147,19 @@ Next:
 Use the installed package or bundle identifier in open, not the app artifact name.
 After close, run agent-device artifacts --json --session adc-browserstack for provider video and logs.`,
 };
+
+// Merged feed-item card on iOS (#1665): the row itself is the only ref — its
+// Reply/Repost/menu controls have no separate child nodes in the tree, so
+// snapshot -i alone would show a plain link with no way to act on it.
+// snapshot -i --actions names the hidden affordances instead of hiding them
+// silently; the names are evidence only, never directly invokable (help
+// workflow: "reach via its detail screen, labeled children elsewhere, or
+// coordinates").
+export const MERGED_CARD_ACTIONS_SAMPLE = {
+  command: 'agent-device snapshot -i --actions',
+  output: `Snapshot: 4 nodes
+@e1 [application] "Bluesky"
+@e2 [window]
+@e3 [collection]
+@e72 [link] "feedItem-by-whiskers.test" actions: ["Reply", "Repost", "Open post options menu"]`,
+};

--- a/scripts/help-conformance-sample-outputs.mjs
+++ b/scripts/help-conformance-sample-outputs.mjs
@@ -148,6 +148,14 @@ Use the installed package or bundle identifier in open, not the app artifact nam
 After close, run agent-device artifacts --json --session adc-browserstack for provider video and logs.`,
 };
 
+// open --foreground succeeded, but its composed snapshot failed. The session
+// remains usable, so recovery is snapshot -i rather than a second open.
+export const FOREGROUND_SNAPSHOT_FAILURE_SAMPLE = {
+  command: 'agent-device open --foreground',
+  output: `Opened: default
+Warning: The session is open, but the initial interactive snapshot failed (COMMAND_FAILED: capture failed). Run: agent-device snapshot -i`,
+};
+
 // Merged feed-item card on iOS (#1665): the row itself is the only ref — its
 // Reply/Repost/menu controls have no separate child nodes in the tree, so
 // snapshot -i alone would show a plain link with no way to act on it.

--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -141,11 +141,11 @@ test('help workflow advertises open --foreground and snapshot -i --actions', asy
   assert.equal(result.calls.length, 0);
   assert.match(
     result.stdout,
-    /No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed \(AMBIGUOUS_MATCH\) otherwise; rejects an explicit app\/--udid\/--device/,
+    /One iOS sim, app running, no session: open --foreground: attach \+ snapshot\. Capture fails; stays open: snapshot -i\. App\/device\/ambiguity fail/,
   );
   assert.match(
     result.stdout,
-    /snapshot -i --actions names custom-action affordances hidden inside a merged element \(iOS sim only\); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates/,
+    /iOS sim: snapshot -i --actions shows merged actions; use detail\/coords, not names/,
   );
 });
 

--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -135,6 +135,20 @@ test('help workflow documents open/close/relaunch runner guarantees as lifecycle
   assert.match(result.stdout, /Env vars: help physical-device/);
 });
 
+test('help workflow advertises open --foreground and snapshot -i --actions', async () => {
+  const result = await runCliCapture(['help', 'workflow']);
+  assert.equal(result.code, 0);
+  assert.equal(result.calls.length, 0);
+  assert.match(
+    result.stdout,
+    /No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed \(AMBIGUOUS_MATCH\) otherwise; rejects an explicit app\/--udid\/--device/,
+  );
+  assert.match(
+    result.stdout,
+    /snapshot -i --actions names custom-action affordances hidden inside a merged element \(iOS sim only\); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates/,
+  );
+});
+
 test('help physical-device documents the runner/daemon lifecycle detail moved out of workflow (#1051)', async () => {
   const result = await runCliCapture(['help', 'physical-device']);
   assert.equal(result.code, 0);

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -253,6 +253,10 @@ test('usageForCommand resolves workflow help topic', async () => {
   );
   assert.match(help, /Known flow: batch \.\/steps\.json \(help scripting\)/);
   assert.match(help, /Shapes and platform quirks: help gestures/);
+  assert.match(
+    help,
+    /No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed \(AMBIGUOUS_MATCH\) otherwise; rejects an explicit app\/--udid\/--device/,
+  );
   assert.match(help, /Never open artifact paths or invent package ids/);
   assert.match(
     help,
@@ -302,6 +306,10 @@ test('usageForCommand resolves workflow help topic', async () => {
     /confirm the requested end state is actually visible on the current screen, scrolling it into view if needed/,
   );
   assert.match(help, /get text alone, or stopping one screen early, is not enough/);
+  assert.match(
+    help,
+    /snapshot -i --actions names custom-action affordances hidden inside a merged element \(iOS sim only\); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates/,
+  );
   assert.match(help, /Perf\/memory\/log\/network\/trace\/crash: help debugging/);
   assert.match(help, /Recording, save-script, batch, replay repair: help scripting/);
   assert.match(help, /help react-native for Metro\/Re\.Pack reload/);

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -255,7 +255,7 @@ test('usageForCommand resolves workflow help topic', async () => {
   assert.match(help, /Shapes and platform quirks: help gestures/);
   assert.match(
     help,
-    /No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed \(AMBIGUOUS_MATCH\) otherwise; rejects an explicit app\/--udid\/--device/,
+    /One iOS sim, app running, no session: open --foreground: attach \+ snapshot\. Capture fails; stays open: snapshot -i\. App\/device\/ambiguity fail/,
   );
   assert.match(help, /Never open artifact paths or invent package ids/);
   assert.match(
@@ -308,7 +308,7 @@ test('usageForCommand resolves workflow help topic', async () => {
   assert.match(help, /get text alone, or stopping one screen early, is not enough/);
   assert.match(
     help,
-    /snapshot -i --actions names custom-action affordances hidden inside a merged element \(iOS sim only\); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates/,
+    /iOS sim: snapshot -i --actions shows merged actions; use detail\/coords, not names/,
   );
   assert.match(help, /Perf\/memory\/log\/network\/trace\/crash: help debugging/);
   assert.match(help, /Recording, save-script, batch, replay repair: help scripting/);

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -226,7 +226,7 @@ Command shape:
 Bootstrap:
   agent-device devices --platform ios
   agent-device open MyApp --platform ios --device "iPhone 17 Pro"
-  No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed (AMBIGUOUS_MATCH) otherwise; rejects an explicit app/--udid/--device.
+  One iOS sim, app running, no session: open --foreground: attach + snapshot. Capture fails; stays open: snapshot -i. App/device/ambiguity fail.
   Install arguments are app/package id then artifact path: agent-device install com.example.app ./dist/app.apk --platform android, then open <id> --relaunch for fresh state. Use reinstall only when explicitly requested.
   Unknown app id: devices, then apps, then open <discovered-app-id>. Never open artifact paths or invent package ids; ask if lookup misses the target.
   Apple CI: prepare ios-runner after boot/install, before replay/test (help prepare). Remote/cloud: connect -> open -> commands -> close -> disconnect (help remote). Reusable scripts, secret-safe fills, replay repair: help scripting.
@@ -265,7 +265,7 @@ Validation and evidence:
   Nearby mutation diff: diff snapshot -i; with no prior snapshot it initializes the baseline (zero changes) instead of failing.
   Named expectations need the exact text/selector via wait/is/get/find -- a bare screenshot/snapshot is not verification. Before declaring a task done, confirm the requested end state is actually visible on the current screen, scrolling it into view if needed; get text alone, or stopping one screen early, is not enough.
   When an action only reveals or reaches a target, verify the exact target named, not just the action. Prefer testIDs/ids/selectors over visible text. Icon/tappable proof: screenshot --overlay-refs; if snapshot is sparse/AX-unavailable, use plain screenshot and coordinates, then retry snapshot -i on another screen.
-  snapshot -i --actions names custom-action affordances hidden inside a merged element (iOS sim only); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates.
+  iOS sim: snapshot -i --actions shows merged actions; use detail/coords, not names.
   Perf/memory/log/network/trace/crash: help debugging. Recording, save-script, batch, replay repair: help scripting.
 
 React Native: help react-native for Metro/Re.Pack reload, DevTools, RN overlays. JS-only change: metro reload, find "Home"; open --relaunch for native reset.

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -226,6 +226,7 @@ Command shape:
 Bootstrap:
   agent-device devices --platform ios
   agent-device open MyApp --platform ios --device "iPhone 17 Pro"
+  No session, one booted iOS simulator, one running app: open --foreground attaches and returns the initial snapshot in one call; fails closed (AMBIGUOUS_MATCH) otherwise; rejects an explicit app/--udid/--device.
   Install arguments are app/package id then artifact path: agent-device install com.example.app ./dist/app.apk --platform android, then open <id> --relaunch for fresh state. Use reinstall only when explicitly requested.
   Unknown app id: devices, then apps, then open <discovered-app-id>. Never open artifact paths or invent package ids; ask if lookup misses the target.
   Apple CI: prepare ios-runner after boot/install, before replay/test (help prepare). Remote/cloud: connect -> open -> commands -> close -> disconnect (help remote). Reusable scripts, secret-safe fills, replay repair: help scripting.
@@ -264,6 +265,7 @@ Validation and evidence:
   Nearby mutation diff: diff snapshot -i; with no prior snapshot it initializes the baseline (zero changes) instead of failing.
   Named expectations need the exact text/selector via wait/is/get/find -- a bare screenshot/snapshot is not verification. Before declaring a task done, confirm the requested end state is actually visible on the current screen, scrolling it into view if needed; get text alone, or stopping one screen early, is not enough.
   When an action only reveals or reaches a target, verify the exact target named, not just the action. Prefer testIDs/ids/selectors over visible text. Icon/tappable proof: screenshot --overlay-refs; if snapshot is sparse/AX-unavailable, use plain screenshot and coordinates, then retry snapshot -i on another screen.
+  snapshot -i --actions names custom-action affordances hidden inside a merged element (iOS sim only); not directly invokable -- reach via its detail screen, labeled children elsewhere, or coordinates.
   Perf/memory/log/network/trace/crash: help debugging. Recording, save-script, batch, replay repair: help scripting.
 
 React Native: help react-native for Metro/Re.Pack reload, DevTools, RN overlays. JS-only change: metro reload, find "Home"; open --relaunch for native reset.


### PR DESCRIPTION
## Summary

Advertise two shipped iOS simulator workflows in the compact `agent-device help workflow` card:

- `open --foreground` attaches to the sole running app and returns its initial interactive snapshot; if capture fails, the session remains open and recovery is `snapshot -i`.
- `snapshot -i --actions` exposes custom-action names hidden in merged elements while making clear those names are evidence, not direct targets.

The conformance harness now rejects explicit foreground app targets from parsed positionals regardless of flag order, pins degraded-open recovery, and builds the merged-actions sample through the real `snapshot -i` output route. Scope is 10 help/conformance files; runtime behavior is unchanged.

## Validation

- Workflow card: 8,992 bytes (under the 9,000-byte compact-card gate).
- Deterministic help/conformance suite: 276 tests passed.
- Red-before proof: the old scorer accepted `open --foreground --platform ios com.example.app`; the new parsed-positionals check rejects it.
- Red-before proof: realistic node depths made the old sample producer render an indented tree; `snapshotCliOutput({ interactiveOnly: true })` restores the production flattened output.
- `pnpm check:affected --run`: every runnable local check passed, including format, lint, typecheck, layering, Fallow, build/package, affected coverage, provider integration, Node integration, progress, and replay compatibility.

No device run is required: this changes help text and its planning/conformance fixtures, not device-facing runtime behavior.
