### PR TITLE
perf: collapse app-driving startup turns

### DIFF
--- a/packages/contracts/src/cli-flags.ts
+++ b/packages/contracts/src/cli-flags.ts
@@ -118,10 +118,9 @@ export type CliFlags = CloudProviderProfileFields &
     shutdown?: boolean;
     relaunch?: boolean;
     /**
-     * RFC prototype (open --foreground, branch claude/observe-foreground): resolve the
-     * app target from the sole booted iOS simulator's sole running app instead of
-     * requiring an explicit app argument. Fails closed (AMBIGUOUS_MATCH) unless the
-     * environment is unambiguous.
+     * Include the initial interactive snapshot in a fresh open response. With
+     * no app argument, iOS can discover the sole running app on the sole booted
+     * simulator and fails closed when that environment is ambiguous.
      */
     foreground?: boolean;
     surface?: SessionSurface;

--- a/packages/contracts/src/client-app.ts
+++ b/packages/contracts/src/client-app.ts
@@ -47,10 +47,9 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
     launchArgs?: string[];
     relaunch?: boolean;
     /**
-     * RFC prototype (branch claude/observe-foreground): resolve the app target from the
-     * sole booted iOS simulator's sole running app instead of an explicit app
-     * argument, and return an initial interactive snapshot alongside the open result.
-     * Fails closed (AMBIGUOUS_MATCH) unless the environment is unambiguous.
+     * Include the initial interactive snapshot in a fresh open response. With
+     * no app argument, iOS can discover the sole running app on the sole booted
+     * simulator and fails closed when that environment is ambiguous.
      */
     foreground?: boolean;
     saveScript?: boolean | string;
@@ -76,13 +75,11 @@ export type AppOpenResult = {
   runtime?: SessionRuntimeHints;
   device?: AgentDeviceSessionDevice;
   /**
-   * RFC prototype (open --foreground, branch claude/observe-foreground): the initial
-   * interactive snapshot captured immediately after open, composed from the same
-   * snapshot-runtime dispatch `agent-device snapshot -i` uses. Present only when
-   * `--foreground` triggered the auto-resolve path. Left loosely typed for this
-   * prototype rather than reusing `CaptureSnapshotResult` end to end (see PR
-   * follow-ups) since the daemon-side composition does not attach client-only
-   * fields like `identifiers`.
+   * Initial interactive snapshot captured immediately after an open that
+   * requested `foreground`, composed from the same snapshot-runtime dispatch
+   * `agent-device snapshot -i` uses. It stays loosely typed rather than reusing
+   * `CaptureSnapshotResult` because the daemon-side composition does not attach
+   * client-only fields like `identifiers`.
    */
   snapshot?: Record<string, unknown>;
   /**

--- a/scripts/__tests__/help-conformance-bench.test.ts
+++ b/scripts/__tests__/help-conformance-bench.test.ts
@@ -14,6 +14,14 @@ import { summarizeResults } from '../help-conformance-summary.mjs';
 
 const execFileAsync = promisify(execFile);
 const SCRIPT = join(import.meta.dirname, '..', 'help-conformance-bench.mjs');
+const AGENT_DEVICE_SKILL = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'skills',
+  'agent-device',
+  'SKILL.md',
+);
 
 // These tests spawn the real script in --dry-run mode with every required doc
 // overridden, so no LLM call and no built CLI is needed: the raw-first-screen
@@ -511,6 +519,22 @@ test('foreground attach grammar accepts both auto-discovery and an explicit know
   });
   assert.deepEqual(autoDiscovery.issues, []);
   assert.deepEqual(explicitTarget.issues, []);
+});
+
+test('compact skill starts a known-app task with foreground open and an initial snapshot', async () => {
+  const skill = await readFile(AGENT_DEVICE_SKILL, 'utf8');
+  const startIndex = skill.indexOf('For an ordinary app-driving task');
+  const endIndex = skill.indexOf('Default loop:');
+  assert.notEqual(startIndex, -1);
+  assert.ok(endIndex > startIndex);
+  const ordinaryStart = skill.slice(startIndex, endIndex);
+  const openingCommands = ordinaryStart
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('agent-device open <app>'));
+
+  assert.deepEqual(openingCommands, ['agent-device open <app> --foreground']);
+  assert.match(ordinaryStart, /returns the initial interactive snapshot in the same call/);
 });
 
 test('plan validator applies narrow grammar to permitted external commands', async () => {

--- a/scripts/__tests__/help-conformance-bench.test.ts
+++ b/scripts/__tests__/help-conformance-bench.test.ts
@@ -496,33 +496,21 @@ test('case matchers score parsed tokens so shell quoting does not change results
   });
 });
 
-test('foreground attach scoring rejects an explicit app positional after flags', async () => {
-  const validCommand = 'agent-device open --foreground --platform ios';
+test('foreground attach grammar accepts both auto-discovery and an explicit known app', async () => {
+  const autoDiscoveryCommand = 'agent-device open --foreground --platform ios';
   const explicitTargetCommand = 'agent-device open --foreground --platform ios com.example.app';
-  const [validAttach, explicitTarget] = await validatePlanCommands([
-    validCommand,
+  const [autoDiscovery, explicitTarget] = await validatePlanCommands([
+    autoDiscoveryCommand,
     explicitTargetCommand,
   ]);
 
+  assert.deepEqual(autoDiscovery.agentCommand, { command: 'open', positionals: [] });
   assert.deepEqual(explicitTarget.agentCommand, {
     command: 'open',
     positionals: ['com.example.app'],
   });
-  assert.equal(
-    scoreExpectations({ expectations: ['noExplicitForegroundTarget'] }, [validCommand], '', [
-      validAttach,
-    ]).noExplicitForegroundTarget,
-    true,
-  );
-  assert.equal(
-    scoreExpectations(
-      { expectations: ['noExplicitForegroundTarget'] },
-      [explicitTargetCommand],
-      '',
-      [explicitTarget],
-    ).noExplicitForegroundTarget,
-    false,
-  );
+  assert.deepEqual(autoDiscovery.issues, []);
+  assert.deepEqual(explicitTarget.issues, []);
 });
 
 test('plan validator applies narrow grammar to permitted external commands', async () => {

--- a/scripts/help-conformance-case-checks.mjs
+++ b/scripts/help-conformance-case-checks.mjs
@@ -16,13 +16,6 @@ const EXPECTATION_SCORERS = {
   // validator splits and validates each segment), so it is the only place
   // that can tell whether the model actually chained.
   usesConfidentChaining: ({ commands }) => commands.some((command) => /&&/.test(command)),
-  noExplicitForegroundTarget: ({ commandValidation }) =>
-    commandValidation
-      .filter(
-        ({ tokens, agentCommand }) =>
-          agentCommand?.command === 'open' && tokens.includes('--foreground'),
-      )
-      .every(({ agentCommand }) => agentCommand.positionals.length === 0),
   noWaitStable: ({ joined }) => !joined.includes('wait stable'),
   verifiesNamedExpectation: ({ joined }) => /\b(wait|is|get|find)\b/.test(joined),
   usesDogfoodEvidence: ({ joined }) =>

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -647,36 +647,22 @@ Use the output already shown to determine whether the feed-search UI is present,
   {
     id: 'foreground-attach-single-sim',
     docs: ['--help:first30', 'workflow'],
-    task: 'You are starting fresh with no active session. The environment guarantees exactly one booted iOS simulator with exactly one app running on it -- the app you want to keep testing. Plan the command to attach to it and get its initial interactive snapshot in a single call (this only resolves unambiguously because of that guarantee, and it rejects an explicit app or device selector), then press the visible Continue control and close the session.',
-    expectations: [
-      'validPlanCommands',
-      'fullPrefix',
-      'usesSettleOnMutations',
-      'opensAndCloses',
-      'noExplicitForegroundTarget',
-    ],
+    task: 'You are starting fresh with no active session. The configured iOS target already has com.example.demo in the foreground. Plan the command that keeps this deterministic app/device selection and gets its initial interactive snapshot in a single call, then press the visible Continue control and close the session.',
+    expectations: ['validPlanCommands', 'fullPrefix', 'usesSettleOnMutations', 'opensAndCloses'],
     matchers: [
       {
         id: 'startsWithForegroundOpen',
-        // Flag order is not semantically meaningful (`open --platform ios
-        // --foreground` is exactly as correct as `open --foreground
-        // --platform ios`); this only checks that --foreground is on the
-        // first command and there is no app positional before it. The
-        // no-positional guarantee comes from the forbidden checks below.
-        pattern: /^agent-device\s+open\b[^\n]*--foreground\b/i,
+        // Flag order is not semantically meaningful; require the known app
+        // and --foreground on the first command, in either order.
+        pattern:
+          /^agent-device\s+open\b(?=[^\n]*\bcom\.example\.demo\b)(?=[^\n]*--foreground\b)[^\n]*$/i,
       },
       {
         id: 'pressesContinueAfterAttach',
         pattern: /agent-device\s+press\s+[^\n]*continue[^\n]*--settle\b/i,
       },
     ],
-    forbidden: [
-      {
-        id: 'noDeviceSelectorWithForeground',
-        pattern: /--foreground\b[^\n]*--(?:udid|device)\b|--(?:udid|device)\b[^\n]*--foreground\b/i,
-      },
-      { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
-    ],
+    forbidden: [{ id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET }],
   },
   {
     id: 'merged-card-actions-not-directly-invokable',

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -5,7 +5,21 @@ description: Automates Apple-platform apps (iOS, tvOS, macOS), Android devices, 
 
 # agent-device
 
-Router only. Before your first agent-device command or plan, read the smallest version-matched CLI guide that fits the task — this single read also replaces a separate `agent-device --version` check:
+For an ordinary app-driving task, start directly. Do not run `--help`, `--version`, `appstate`, or `snapshot` first:
+
+```bash
+# The prompt says this app is already foreground and names its app/bundle id:
+agent-device open <app> --foreground
+
+# Otherwise:
+agent-device open <app>
+```
+
+`open <app> --foreground` keeps normal configured target selection and returns the initial interactive snapshot in the same call. Continue from its current refs. Prefer a concrete `@eN` ref from the current snapshot over a broad mutation selector. When a response prints a pinned ref such as `@e12~s42` — including an ambiguity candidate or settled diff — copy the whole pinned ref exactly; a bare ref from a partial result is intentionally rejected.
+
+Default loop: `open -> act with a current ref or specific selector -> verify -> close`. Use `--settle` on planned `press`, `click`, `fill`, `longpress`, `scroll`, or `back`; continue from the settled diff when it already proves the next state. If a mutation returns `AMBIGUOUS_MATCH`, retry one listed pinned candidate rather than adding `--first` or guessing by coordinates.
+
+Read the smallest version-matched CLI guide only when the task is specialized, you are planning rather than operating, or a command/hint does not answer the question. This single read also replaces a separate `agent-device --version` check:
 
 ```bash
 agent-device help manual-qa   # scripted/manual QA, acceptance checks, checklist execution
@@ -34,8 +48,6 @@ agent-device help tv
 agent-device help ios-system-ui  # iOS SpringBoard, widgets, and system-UI surfaces
 ```
 
-Default loop: `open -> snapshot/-i -> get/is/find or press/fill/scroll/wait -> verify -> close`. When target-specific help says capture or selectors are unsupported, use its control-only loop and the device display as visual truth.
-
-Use this skill only to route into version-matched CLI help. Let the selected help topic provide exact command shapes, platform limits, and current workflow guidance; use `help workflow` as the full reference when a task-specific topic is too narrow.
+When target-specific help says capture or selectors are unsupported, use its control-only loop and the device display as visual truth. Let help own advanced command shapes and platform limits; use `help workflow` as the fallback reference when the compact loop is insufficient.
 
 For precise location workflows, read the installed `settings` help before planning so coordinate support and platform limits come from the active CLI version.

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -5,14 +5,10 @@ description: Automates Apple-platform apps (iOS, tvOS, macOS), Android devices, 
 
 # agent-device
 
-For an ordinary app-driving task, start directly. Do not run `--help`, `--version`, `appstate`, or `snapshot` first:
+For an ordinary app-driving task with a known app or bundle id, start directly. Do not run `--help`, `--version`, `appstate`, or `snapshot` first:
 
 ```bash
-# The prompt says this app is already foreground and names its app/bundle id:
 agent-device open <app> --foreground
-
-# Otherwise:
-agent-device open <app>
 ```
 
 `open <app> --foreground` keeps normal configured target selection and returns the initial interactive snapshot in the same call. Continue from its current refs. Prefer a concrete `@eN` ref from the current snapshot over a broad mutation selector. When a response prints a pinned ref such as `@e12~s42` — including an ambiguity candidate or settled diff — copy the whole pinned ref exactly; a bare ref from a partial result is intentionally rejected.

--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -141,7 +141,7 @@ test('help workflow advertises open --foreground and snapshot -i --actions', asy
   assert.equal(result.calls.length, 0);
   assert.match(
     result.stdout,
-    /One iOS sim, app running, no session: open --foreground: attach \+ snapshot\. Capture fails; stays open: snapshot -i\. App\/device\/ambiguity fail/,
+    /Known app: open <app> --foreground -> snapshot\. Bare form needs one running app on one iOS sim; capture failure keeps session open/,
   );
   assert.match(
     result.stdout,

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -88,7 +88,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   );
   assert.match(usageText, /Agent Starting Point:/);
   assert.match(usageText, /Write full command lines starting with agent-device/);
-  assert.match(usageText, /Default app loop: agent-device open <app>/);
+  assert.match(usageText, /Default app loop: agent-device open <app> --foreground/);
   assert.match(
     usageText,
     /Use --settle only on planned press, click, fill, longpress, scroll, or back commands; never add it to open, snapshot, or close/,
@@ -255,7 +255,7 @@ test('usageForCommand resolves workflow help topic', async () => {
   assert.match(help, /Shapes and platform quirks: help gestures/);
   assert.match(
     help,
-    /One iOS sim, app running, no session: open --foreground: attach \+ snapshot\. Capture fails; stays open: snapshot -i\. App\/device\/ambiguity fail/,
+    /Known app: open <app> --foreground -> snapshot\. Bare form needs one running app on one iOS sim; capture failure keeps session open/,
   );
   assert.match(help, /Never open artifact paths or invent package ids/);
   assert.match(

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -79,7 +79,7 @@ const AGENT_START_LINES = [
   // loop explicit plus a closed target grammar made GPT-mini reliable and moved
   // Haiku from 0/2 baseline to 4/4; generic structured-hint recovery passed 8/8
   // uncoached output cases versus 7/8 with the longer special-case prose.
-  'Default app loop: agent-device open <app> -> agent-device snapshot -i -> mutate a current target with --settle -> continue from that settled diff -> agent-device close.',
+  'Default app loop: agent-device open <app> --foreground -> mutate a current target from its initial snapshot with --settle -> continue from that settled diff -> agent-device close.',
   'Use --settle only on planned press, click, fill, longpress, scroll, or back commands; never add it to open, snapshot, or close. type never accepts --settle: run agent-device type "text", then diff snapshot if verification is needed. Once the task\'s requested end state or an explicit success confirmation is visible, stop; do not tap transient follow-up controls or navigate away only to re-verify.',
   'Follow structured command hints before choosing a recovery action.',
   'Targets are concrete refs or selectors: @e12, label="Query", role=button label="Submit".',
@@ -226,7 +226,7 @@ Command shape:
 Bootstrap:
   agent-device devices --platform ios
   agent-device open MyApp --platform ios --device "iPhone 17 Pro"
-  One iOS sim, app running, no session: open --foreground: attach + snapshot. Capture fails; stays open: snapshot -i. App/device/ambiguity fail.
+  Known app: open <app> --foreground -> snapshot. Bare form needs one running app on one iOS sim; capture failure keeps session open.
   Install arguments are app/package id then artifact path: agent-device install com.example.app ./dist/app.apk --platform android, then open <id> --relaunch for fresh state. Use reinstall only when explicitly requested.
   Unknown app id: devices, then apps, then open <discovered-app-id>. Never open artifact paths or invent package ids; ask if lookup misses the target.
   Apple CI: prepare ios-runner after boot/install, before replay/test (help prepare). Remote/cloud: connect -> open -> commands -> close -> disconnect (help remote). Reusable scripts, secret-safe fills, replay repair: help scripting.

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -75,10 +75,9 @@ const AGENT_WORKFLOWS = [
 
 const AGENT_START_LINES = [
   'Write full command lines starting with agent-device; do not output pseudo commands, helper prose, pipes, grep, jq, or hidden stderr.',
-  // Benchmarked 2026-07-25 with scripts/help-conformance-bench.mjs: keeping the
-  // loop explicit plus a closed target grammar made GPT-mini reliable and moved
-  // Haiku from 0/2 baseline to 4/4; generic structured-hint recovery passed 8/8
-  // uncoached output cases versus 7/8 with the longer special-case prose.
+  // The explicit loop and closed target grammar are conformance-gated below;
+  // the foreground-open form was separately validated by the 2026-08-08
+  // controlled app-driving benchmark recorded in PR #1693.
   'Default app loop: agent-device open <app> --foreground -> mutate a current target from its initial snapshot with --settle -> continue from that settled diff -> agent-device close.',
   'Use --settle only on planned press, click, fill, longpress, scroll, or back commands; never add it to open, snapshot, or close. type never accepts --settle: run agent-device type "text", then diff snapshot if verification is needed. Once the task\'s requested end state or an explicit success confirmation is visible, stop; do not tap transient follow-up controls or navigate away only to re-verify.',
   'Follow structured command hints before choosing a recovery action.',

--- a/src/commands/cli-grammar/flag-definitions-action.ts
+++ b/src/commands/cli-grammar/flag-definitions-action.ts
@@ -279,7 +279,7 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--foreground',
     usageDescription:
-      "[RFC] open: resolve app + return an initial snapshot from the sole booted iOS simulator's sole running app",
+      'open: keep normal app/device selection and return an initial snapshot; without an app, resolve the sole running app on the sole booted iOS simulator',
   },
   {
     key: 'restart',

--- a/src/commands/management/app.ts
+++ b/src/commands/management/app.ts
@@ -51,7 +51,7 @@ const openCommandMetadata = defineFieldCommandMetadata(
     ),
     relaunch: booleanField('Force relaunch.'),
     foreground: booleanField(
-      "[RFC prototype] On a fresh session with no app argument, resolve the target from the sole booted iOS simulator's sole running app and include an initial interactive snapshot in the response. Fails with AMBIGUOUS_MATCH when the environment is not unambiguous (0 or 2+ booted simulators, or no confidently-detectable running app) — never guesses.",
+      'Include an initial interactive snapshot in a fresh open response. With no app argument, discover the sole running app on the sole booted iOS simulator; ambiguous environments fail closed.',
     ),
     saveScript: jsonSchemaField<boolean | string>({
       oneOf: [booleanSchema(), stringSchema()],

--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -388,11 +388,44 @@ test('corroborates a tap when the request carries no flags and the baseline used
   expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
 });
 
+test('a changed capture after ordinary agent turn latency still corroborates the tap', async () => {
+  const sessionName = 'ios-agent-turn-latency-corroboration';
+  const sessionStore = makeSessionStore();
+  const baseline = snapshot(profileNodes);
+  baseline.createdAt = Date.now() - 6_000;
+  sessionStore.set(
+    sessionName,
+    makeIosSession(sessionName, {
+      appBundleId: 'com.example.app',
+      snapshot: baseline,
+    }),
+  );
+  mockDispatch.mockImplementation(async (_device, command) => {
+    if (command === 'press') {
+      throw new AppError(
+        'XCTEST_RECORDED_FAILURE',
+        'XCTest recorded a failure while executing tap; the action may not have been performed.',
+      );
+    }
+    if (command === 'snapshot') return snapshotPayload(imageViewerNodes);
+    return {};
+  });
+
+  const response = await runClick(sessionStore, sessionName);
+
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toMatch(/post-action accessibility capture changed/);
+  }
+  expect(mockDispatch.mock.calls.filter((call) => call[1] === 'snapshot')).toHaveLength(1);
+  expect(sessionStore.get(sessionName)?.actions).toHaveLength(1);
+});
+
 test('a changed capture against a stale baseline keeps the tap failure', async () => {
   const sessionName = 'ios-stale-baseline-tap-corroboration';
   const sessionStore = makeSessionStore();
   const baseline = snapshot(profileNodes);
-  baseline.createdAt = Date.now() - 5_001;
+  baseline.createdAt = Date.now() - 15_001;
   sessionStore.set(
     sessionName,
     makeIosSession(sessionName, {

--- a/src/daemon/handlers/__tests__/session-open-foreground.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-foreground.test.ts
@@ -58,19 +58,22 @@ test('rejects --foreground against an existing session', async () => {
   expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
 });
 
-test('rejects --foreground combined with an explicit app argument', async () => {
+test('keeps an explicit app and its target constraints for foreground snapshot composition', async () => {
+  const req = baseRequest({
+    flags: {
+      foreground: true,
+      platform: 'ios',
+      udid: 'configured-udid',
+      iosSimulatorDeviceSet: '/custom/set',
+    },
+    positionals: ['com.example.demo'],
+  });
   const resolution = await resolveForegroundOpenRequest({
-    req: baseRequest({ flags: { foreground: true }, positionals: ['com.example.demo'] }),
+    req,
     hasExistingSession: false,
   });
 
-  expect(resolution.type).toBe('response');
-  if (resolution.type === 'response') {
-    expect(resolution.response.ok).toBe(false);
-    if (!resolution.response.ok) {
-      expect(resolution.response.error.code).toBe('INVALID_ARGS');
-    }
-  }
+  expect(resolution).toEqual({ type: 'resolved', req });
   expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
 });
 

--- a/src/daemon/handlers/__tests__/session-open-foreground.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-foreground.test.ts
@@ -58,7 +58,7 @@ test('rejects --foreground against an existing session', async () => {
   expect(resolveSoleForegroundIosApp).not.toHaveBeenCalled();
 });
 
-test('keeps an explicit app and its target constraints for foreground snapshot composition', async () => {
+test('keeps an explicit app and its target constraints for foreground composition on an existing session', async () => {
   const req = baseRequest({
     flags: {
       foreground: true,
@@ -70,7 +70,7 @@ test('keeps an explicit app and its target constraints for foreground snapshot c
   });
   const resolution = await resolveForegroundOpenRequest({
     req,
-    hasExistingSession: false,
+    hasExistingSession: true,
   });
 
   expect(resolution).toEqual({ type: 'resolved', req });

--- a/src/daemon/handlers/interaction-ios-tap-outcome.ts
+++ b/src/daemon/handlers/interaction-ios-tap-outcome.ts
@@ -13,7 +13,10 @@ import type { ContextFromFlags } from './interaction-common.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
 
 const XCTEST_RECORDED_FAILURE = 'XCTEST_RECORDED_FAILURE';
-const IOS_TAP_CORROBORATION_BASELINE_MAX_AGE_MS = 5_000;
+// A model commonly needs 5-10s to choose a target after receiving a snapshot.
+// Keep the window bounded, but long enough for that ordinary decision turn;
+// the same-backend/same-presentation checks below still fail closed.
+const IOS_TAP_CORROBORATION_BASELINE_MAX_AGE_MS = 15_000;
 
 const IOS_TAP_CORROBORATION_WARNING =
   'XCTest reported the tap as failed, but a same-scope post-action accessibility capture changed; treating the tap as landed. Observe the current screen before issuing another tap.';

--- a/src/daemon/handlers/session-open-foreground.ts
+++ b/src/daemon/handlers/session-open-foreground.ts
@@ -11,17 +11,22 @@ export type ForegroundOpenResolution =
   | { type: 'response'; response: DaemonResponse };
 
 /**
- * RFC prototype (branch claude/observe-foreground): `open --foreground` collapses the
+ * `open --foreground` collapses the
  * `snapshot -i` (fails) -> read hint -> `open <bundleId>` -> `snapshot -i` dance into one
  * call for the common case (one booted iOS simulator, one running app).
  *
- * When `--foreground` is set with no explicit app argument on a fresh session, this
- * auto-resolves the target via `resolveSoleForegroundIosApp` — the exact same
- * ambiguity-detection probe that enriches the SESSION_NOT_FOUND hint — and rewrites the
- * request's positionals/flags so the rest of `handleOpenCommand`'s existing new-session
- * flow (device resolution, surface validation, session creation) runs completely
- * unmodified against the resolved device + bundle id. Only iOS simulators are handled;
- * see the PR body for scoped-out platforms.
+ * When `--foreground` is set with an explicit app, normal open resolution remains the
+ * source of truth for app and device selection; this module only composes the initial
+ * snapshot after open succeeds. That makes the deterministic, configured-target form
+ * (`open <app> --foreground`) the cheap path for harnesses and other callers that already
+ * know the foreground bundle.
+ *
+ * Without an app argument, this auto-resolves the target via
+ * `resolveSoleForegroundIosApp` — the exact same ambiguity-detection probe that enriches
+ * the SESSION_NOT_FOUND hint — and rewrites the request's positionals/flags so the rest
+ * of `handleOpenCommand`'s existing new-session flow runs unmodified against the resolved
+ * device + bundle id. Only iOS simulators are handled; see the PR body for scoped-out
+ * platforms.
  *
  * Fails closed with AMBIGUOUS_MATCH — never guesses — when the environment is not
  * unambiguous: zero or multiple booted simulators, zero or multiple running apps, or a
@@ -45,15 +50,7 @@ export async function resolveForegroundOpenRequest(params: {
       ),
     };
   }
-  if (req.positionals?.[0]) {
-    return {
-      type: 'response',
-      response: errorResponse(
-        'INVALID_ARGS',
-        'open --foreground cannot be combined with an explicit app argument.',
-      ),
-    };
-  }
+  if (req.positionals?.[0]) return { type: 'resolved', req };
   // #1670 P1: the resolved-device rewrite below pins --udid/--platform, so an
   // explicit selector must fail fast instead of being silently overwritten
   // (open --foreground --udid B with sim A sole-booted must NOT open A).

--- a/src/daemon/handlers/session-open-foreground.ts
+++ b/src/daemon/handlers/session-open-foreground.ts
@@ -41,6 +41,12 @@ export async function resolveForegroundOpenRequest(params: {
   const { req, hasExistingSession } = params;
   if (req.flags?.foreground !== true) return { type: 'not-requested' };
 
+  // With an explicit app, foreground means "open through the normal target
+  // path, then compose the initial snapshot". That remains valid for an
+  // existing session: normal open owns switching/relaunching the app and the
+  // composition below observes the resulting session state.
+  if (req.positionals?.[0]) return { type: 'resolved', req };
+
   if (hasExistingSession) {
     return {
       type: 'response',
@@ -50,7 +56,6 @@ export async function resolveForegroundOpenRequest(params: {
       ),
     };
   }
-  if (req.positionals?.[0]) return { type: 'resolved', req };
   // #1670 P1: the resolved-device rewrite below pins --udid/--platform, so an
   // explicit selector must fail fast instead of being silently overwritten
   // (open --foreground --udid B with sim A sole-booted must NOT open A).

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -22,8 +22,8 @@ export type ResolvedForegroundIosApp = {
  * as inconclusive, never propagated — callers sit on error/decision paths
  * where a probe failure must not replace their deterministic outcome.
  *
- * `buildIosOpenCommandHint` (error-hint enrichment) and the `open --foreground`
- * convenience (RFC, #observe-foreground) both compose this single probe
+ * `buildIosOpenCommandHint` (error-hint enrichment) and the bare
+ * `open --foreground` auto-discovery form both compose this single probe
  * instead of re-deriving the ambiguity rules.
  */
 export async function resolveSoleForegroundIosApp(


### PR DESCRIPTION
## Summary

- make `open <app> --foreground` preserve normal app/device selection, work for both fresh and existing sessions, and return the initial interactive snapshot in one call; bare iOS auto-discovery remains fail-closed
- make the compact skill and canonical CLI guidance start ordinary app-driving tasks directly, without mandatory help/version/session probes, with a conformance test pinning the default recipe
- extend same-scope iOS tap corroboration from 5s to a bounded 15s so ordinary model turn latency can still prove a tap landed after XCTest reports failure

The wider corroboration window deliberately accepts some additional organic-label-drift exposure. It remains limited to `XCTEST_RECORDED_FAILURE`, requires the same backend and presentation, and returns an explicit re-observation warning; a false corroboration could still record a tap that did not land, so this is an accepted bounded tradeoff rather than a general success fallback.

## Validation

- `pnpm check:affected --run` — all runnable checks passed, including 2,559 affected Vitest tests, 100% changed-line coverage, Node integration, package, architecture/progress, and replay compatibility
- red-before: reverting the review fixes makes the existing-session explicit-app foreground test fail with `INVALID_ARGS` and the skill conformance test find both foreground and plain-open recipes; both pass on this head
- focused suite: 11 files / 245 tests passed; `pnpm build` passed
- live iOS at exact head: `open xyz.blueskyweb.app --foreground --platform ios --udid C4578E05-BB63-4A3D-AB53-B011EFA2D981 --session review-1693 --json` returned a healthy interactive snapshot on a fresh session, then the identical command succeeded again on the existing session with a new refs generation; the session was closed afterward
- controlled GPT-5.4 runs with isolated config/binary: Element-14 improved from 75.3s / 14 calls to 59.3s / 7 (Argent: 53.6s / 10); Element-03 improved from 174.8s / 30 to 85.4s / 12 (Argent: 122.8s / 18)
- Bluesky reproduced the XCTest recorded-failure path and the changed post-action capture correctly corroborated the landed tap; timing was excluded because local golden verification proved that benchmark fixture was logged out
