### PR TITLE
docs: adopt request-bound platform runtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,7 +12,7 @@ task touches:
 - [Recording & replay](#recording--replay)
 - [Maestro compatibility](#maestro-compatibility)
 - [Providers, cloud, and the test harness](#providers-cloud-and-the-test-harness)
-- [Architecture](#architecture-perfect-shape-refactor-completed-2026-07) — the two-registry end state
+- [Architecture](#architecture) — the command-descriptor baseline and staged platform-runtime seam
 - [Selector capture reliability contract](#selector-capture-reliability-contract) — invariants any capture refactor must preserve
 - [Testing principles](#testing-principles)
 
@@ -20,8 +20,38 @@ task touches:
 
 ### Sessions, targets, devices
 
-- Interactor: semantic interface between command dispatch and platform behavior.
-- Platform module: platform-specific implementation behind the Interactor.
+- Interactor (legacy): monolithic semantic interface between dispatch and platform behavior, retained
+  only for commands not yet migrated under ADR 0019. Avoid for new or migrated command behavior.
+- Platform family: one internal ownership axis in the canonical registry (`apple`, `android`,
+  `harmonyos`, `vega`, `linux`, or `web`). Family ownership does not imply uniform support across its
+  leaves, device kinds, or providers.
+- Platform leaf: concrete OS/device shape within a family whose support is classified independently,
+  such as iOS simulator, physical iOS, tvOS, or macOS within Apple.
+- Platform module: private `@agent-device/platform-*` package that owns one family's device mechanics
+  behind a metadata-eager, implementation-lazy façade.
+- Implementation laziness: platform-module property where family metadata is cheap to compose while
+  discovery mechanics, runtime implementations, and helper managers load only when that family is
+  first discovered or bound.
+- Device inventory gateway: platform-neutral composition of canonical local-family and provider
+  inventory sources. It discovers and classifies devices before any selected-device binding exists.
+- Device runtime gateway: platform-neutral seam that reports runtime facts and binds one admitted
+  device to its selected runtime owner.
+- Runtime owner: exactly one local platform module or provider runtime selected to execute device
+  behavior for an ownership-qualified device.
+- Request binding: request-lived attachment of cancellation, diagnostics, progress, and admitted
+  context to a runtime owner. It never owns a helper manager, healthy helper generation, or adopted
+  durable resource.
+- Bound device runtime: behavior-bearing view returned by a request binding after the required
+  operations in a command's runtime use are proven.
+- Runtime facet: capability-cohesive interface on a bound device runtime, with normalized semantic
+  inputs and typed outcomes rather than command names or daemon payloads.
+- Runtime fact: typed claim about behavior available for one exact platform leaf, device/backend, and
+  provider mode.
+- Narrowed bound runtime: compile-time projection exposing required facets non-optionally, explicitly
+  preferred facets optionally, and no undeclared facets; handlers do not cast missing proof into
+  existence.
+- Host capability: narrow authority injected into a platform module for host process execution,
+  diagnostics, progress, or resolved native assets; it carries no daemon request or session policy.
 - Target: selected automation destination, such as mobile, tv, or desktop.
 - Modality: broad supported device family, such as mobile, tv, or desktop.
 - Session: daemon-owned state for a selected target and opened app or surface.
@@ -46,6 +76,10 @@ task touches:
 
 - Command surface: catalog of public command identity, interface exposure, adapter policy, and
   shared command metadata across CLI, Node.js, MCP, and batch entrypoints.
+- Runtime use: platform-neutral declaration on a command descriptor containing operations required
+  for admission and, separately, preferred fast paths whose absence does not reject the command.
+- Inventory use: platform-neutral declaration for an inventory command that composes canonical local
+  family and provider inventory sources without fabricating a selected-device binding.
 - Daemon command registry: daemon-side source of truth for command route ownership and
   request-policy traits, including admission exemptions, session locking, selector validation,
   replay-scoped actions, recording invalidation, Android dialog guards, and request provider device
@@ -202,9 +236,20 @@ task touches:
 - Destination guard: portable selector-targeted `wait` near the end of an open-to-destination script
   that confirms a landmark on the ready destination screen before replay hands the live session to
   its caller.
-- Recording backend: daemon-internal module interface selected per recording target that owns
-  platform recording validation, output path policy, start/stop execution, and record-only cleanup
-  below the daemon recording lifecycle.
+- Screen-recording facet: runtime facet that starts platform screen/video capture and returns a live
+  handle plus its durable descriptor. It is distinct from script recording.
+- Live resource handle: process-local authority to finish or forcibly dispose active app-log,
+  screen-recording, or profiler work through outcome-bearing `finish`/`forceCleanup` operations; its
+  `AsyncDisposable` adapter rejects when cleanup is unconfirmed. A neutral contract handle may live
+  in R7-owned `SessionState`; it is never serialized into persisted recovery state.
+- Durable resource descriptor: bounded, versioned, persistable identity and recovery state from
+  which the same runtime owner can deterministically reattach, recover completion, or report a typed
+  missing/unreattachable outcome.
+- Reattachment: fenced recovery attempt by the descriptor's exact runtime owner, returning a live
+  handle, completed result, missing state, or typed unreattachable reason without restarting the
+  resource or falling through to another owner.
+- Recording backend (legacy): daemon-selected tag-to-implementation interface retained only for
+  screen-recording commands not yet migrated under ADR 0019. Avoid for new behavior.
 
 ### Maestro compatibility
 
@@ -219,14 +264,14 @@ task touches:
 
 ### Providers, cloud, and the test harness
 
-- Provider: request-scoped adapter interface for external device, runner, or host tool execution.
+- Provider: external device/runtime adapter that may own a complete device runtime or contribute a
+  typed transport to a platform module; ownership is resolved and bound per request.
 - Provider-backed integration scenario: device-free integration test that runs the real daemon
   request path and replaces only external device or host tool execution.
-- Cloud WebDriver runtime: package-shaped `ProviderDeviceRuntime` implementation that maps a
-  cloud-owned Appium/WebDriver session into agent-device lease, inventory, install, interactor, and
-  release hooks without adding provider-specific branches to daemon routing. Cloud WebDriver adapters
-  must expose explicit command capabilities because snapshots come from Appium page source rather
-  than agent-device native iOS runner or Android helper backends.
+- Cloud WebDriver runtime: direct provider runtime owner that maps a cloud-owned Appium/WebDriver
+  session into agent-device leases, inventory, runtime facts/facets, durable resources, and release
+  without provider-specific daemon branches. Its exact facts differ from local Apple/Android
+  runtimes because snapshots come from Appium page source.
 - CloudArtifact: provider-hosted session output such as video, Appium logs, device logs, automation
   logs, or provider dashboard links. Cloud artifacts stay under the `cloudArtifacts` response field
   so they do not collide with daemon-managed local/downloadable `artifacts`.
@@ -245,7 +290,7 @@ task touches:
 - HTTP contract test: narrow test that verifies JSON-RPC transport, auth, and response finalization
   over the daemon HTTP boundary.
 
-## Architecture (perfect-shape refactor, completed 2026-07)
+## Architecture
 
 ADR 0011 (interaction guarantee contract) is the interaction-semantics counterpart of ADR 0008's
 registry thesis: the dispatch-path × guarantee matrix is declared once in
@@ -253,9 +298,10 @@ registry thesis: the dispatch-path × guarantee matrix is declared once in
 gate-enforced, and cross-language rules are pinned by golden parity tables. New dispatch paths and
 guarantees are whole-matrix decisions, not local edits.
 
-The perfect-shape refactor is complete and merged. Its end-state:
+The 2026 command/registry refactor is the enforced baseline. ADR 0019 keeps the command-descriptor
+axis and stages a deeper platform-runtime seam, one abandonment-safe command cutover at a time:
 
-- Two derivation registries. One `CommandDescriptor` per command
+- Command and platform axes. One `CommandDescriptor` per command
   (`src/core/command-descriptor/registry.ts`) is the single declaration site from which the
   public/internal/local command catalog, capability matrix, daemon command registry, batch allowlist,
   timeout policy, MCP exposure list, capability-checked CLI command list, post-action observation
@@ -265,13 +311,17 @@ The perfect-shape refactor is complete and merged. Its end-state:
   simple Node client command methods. Closed public Node-client result contracts are narrowed through
   `CommandResultMap`; action/backend-dependent methods remain explicitly broad until their public
   response projections are reconciled. See
-  [Node client result types](docs/node-client-result-types.md). One `PlatformPlugin` per platform
-  family (`src/core/platform-plugin/`) stops core/daemon from branching on platform, with the Apple
-  plugin the first instance. See [ADR 0008](docs/adr/0008-command-descriptor-registry.md).
+  [Node client result types](docs/node-client-result-types.md). The current shallow `PlatformPlugin`
+  registry remains the complete legacy adapter for unmigrated commands. ADR 0019 replaces that axis
+  command by command with an immutable, metadata-eager/implementation-lazy platform-module registry:
+  descriptors declare inventory or device runtime use, runtime owners report exact facts and
+  behavior-bearing facets, and only the root composition module imports concrete packages. See
+  [ADR 0008](docs/adr/0008-command-descriptor-registry.md) and
+  [ADR 0019](docs/adr/0019-request-bound-platform-runtime.md).
 - Typed result spine. Per-command typed results replaced the ad-hoc `Record`-typed returns across the
   daemon/dispatch path; errors gained machine-readable `retriable`/`supportedOn` signals on
   `DaemonError` (#939). Error-system conventions live in [ADR 0010](docs/adr/0010-error-system.md).
-- Apple platform model. Internally `Platform` is `apple` (plus `android`/`vega`/`linux`/`web`) with an
+- Apple platform model. Internally `Platform` is `apple` (plus `android`/`harmonyos`/`vega`/`linux`/`web`) with an
   `appleOs` discriminant (`ios | ipados | tvos | watchos | visionos | macos`); the shared Apple engine
   lives under `src/platforms/apple/core/` with per-OS leaves under `src/platforms/apple/os/<os>/`.
   The public wire stays non-breaking: `PUBLIC_PLATFORMS` (`packages/kernel/src/device.ts`) still emits
@@ -312,8 +362,9 @@ The perfect-shape refactor is complete and merged. Its end-state:
   daemon descriptor, whose route type is `keyof typeof DAEMON_ROUTE_HANDLERS` — derived from what
   the server actually implements. Both are explained at the baseline.
 - SessionState ownership (R7). `SessionStore.get()` returns the live record out of a private Map
-  and `set()` re-puts the same reference, so any `session.<field> = …` in the daemon is a durable
-  write to store-owned state — persistence depends on aliasing, not on an API call. That is
+  and `set()` re-puts the same reference, so any `session.<field> = …` in the daemon is an immediate
+  write to store-owned live state — visibility depends on aliasing, not on an API call, and the map
+  is not rehydrated across daemon restart. That is
   workable while each field has an owner that keeps its invariants, so
   `SESSION_STATE_FIELD_OWNERS` (`scripts/layering/session-state.ts`) records them and the gate
   stops the set from growing quietly: a new field must declare an owner, a foreign write fails
@@ -356,9 +407,10 @@ The perfect-shape refactor is complete and merged. Its end-state:
   ratchets: engines live behind the `packages/{maestro,replay-test,ad-replay,selectors}` façades, engines
   cannot import daemon/platform/provider implementations, and no logical module may deep-import
   another module's `internal/` tree. The P6 platform-modularity phases were measured and deferred
-  at the #1478 checkpoint (2026-08-04): the Apple perf edge no longer participates in any cycle,
-  so the remaining R9 work sits at the command-registration hubs, not the platform seam. These are
-  ratchets, not permission to scaffold façades before a real seam has two adapters.
+  at the #1478 checkpoint (2026-08-04); HarmonyOS then supplied the additional real adapter pressure
+  that earned ADR 0019's staged platform-runtime migration. Its substrate plus complete
+  `devices`/`logs`/`network` checkpoint must validate the seam before any further command migration.
+  These are ratchets, not permission to scaffold façades before a real seam has two adapters.
 - Zero-dep CI jobs (R8). Some jobs run scripts straight from a checkout with `install-deps: false`,
   so they have no `node_modules`. Nothing local can feel that constraint — every dev machine has
   `node_modules` sitting right there — so a script grows a package import, passes locally, and fails
@@ -388,9 +440,11 @@ when landing it, satisfy the gate where one exists.
   cycles are deliberately tolerated by the gate; a report surfacing them as data is proposed in
   #1410 (the analysis half of the graph tooling, kept after the #1409 viewer was rejected) and is
   not landed yet.
-- **Policy × detail boundaries on demonstrated axes of change.** The two registries are the two
-  demonstrated axes: `CommandDescriptor` (what the system does) × `PlatformPlugin` (how a device
-  does it), ADR 0008/0009. Boundary-crossing enforcement is narrower than the principle: the
+- **Policy × detail boundaries on demonstrated axes of change.** The two demonstrated axes are
+  `CommandDescriptor` inventory/runtime use (what the system needs) × inventory sources or
+  runtime-owner facts/facets (how a family or exact device can do it), ADR 0008/0009/0019. The shallow
+  `PlatformPlugin` remains only as the legacy command adapter during staged adoption.
+  Boundary-crossing enforcement is narrower than the principle: the
   apple-platform leak guard (`publicPlatformString`, provider-integration suite) gates one specific
   DTO class — internal `apple` never reaching serialized public output — and the injectable Apple
   runner transport (`runnerProvider`, #1389) is one adopted seam, not a rule covering every
@@ -408,11 +462,12 @@ when landing it, satisfy the gate where one exists.
   its port only when it has two real adapters, normally the daemon adapter and a deterministic
   adapter running the same contract suite. A pure shared kernel instead stays behind its direct
   package façade; the selector engine is the worked example. Calls go down through module façades
-  and back through ports; no inter-module event bus — ADR 0018's journal is an observation channel,
-  never a coordination mechanism. No engine receives `DaemonRequest`, `DaemonError`, `SessionStore`,
-  mutable `SessionState`, provider handles, or concrete platform implementations; the daemon
-  adapter closes each capability over one already-admitted request, so an engine cannot express a
-  session name, acquire a lock, or select a provider scope. Session state keeps three consistency
+  and back through ports; no inter-module event bus — current diagnostics/session events, and the
+  ADR 0018 journal if accepted, are observation channels rather than coordination mechanisms. No
+  engine receives `DaemonRequest`, `DaemonError`, `SessionStore`, mutable `SessionState`, provider
+  handles, or concrete platform implementations; the daemon adapter closes each capability over one
+  already-admitted request, so an engine cannot express a session name, acquire a lock, or select a
+  provider scope. Session state keeps three consistency
   disciplines distinct and never forces them through one generic transaction: immediate pessimistic
   transitions for ref/observation lineage (ADR 0014's mid-request expiry is why end-of-request
   commit/rollback is rejected), staged arm/complete/close-succeeded/commit-or-abort protocols with
@@ -429,7 +484,8 @@ when landing it, satisfy the gate where one exists.
 
 ### Deferred
 
-The refactor is substantively done; these follow-ups are intentionally deferred, not lost:
+The completed command/registry baseline retains these deferred follow-ups. ADR 0019's staged
+platform-runtime migration is an active accepted decision, not part of this list:
 
 - Dynamic Node-client results — interactions, observability, alert, React Native overlay, and
   settings remain broad until their action/backend-specific payloads have accurate public
@@ -494,8 +550,9 @@ Evidence: [ADR 0002](docs/adr/0002-persistent-platform-helper-sessions.md),
 - Provider-backed integration scenarios should exercise the public daemon path whenever practical.
 - Prefer the in-process provider scenario harness for broad scenarios; keep HTTP contract tests narrow
   and transport-specific.
-- Provider seams sit below platform modules so integration tests still cover platform command
-  translation.
+- Transport providers sit below a platform module; direct provider runtimes sit beside local family
+  owners. Both run the same runtime contract scenarios through the public daemon path so provider
+  coverage still exercises the appropriate device-command translation.
 - Provider transcripts are for exact external command contracts.
 - Scenario transcripts are for broad, user-rooted workflows that should replace mocked handler unit
   tests.

--- a/docs/adr/0001-provider-first-integration-scenarios.md
+++ b/docs/adr/0001-provider-first-integration-scenarios.md
@@ -4,6 +4,11 @@
 
 Accepted
 
+> **Amended by [ADR 0019](0019-request-bound-platform-runtime.md).** Provider-first scenario
+> coverage and semantic provider operations remain accepted. The monolithic `Interactor` and the
+> request callback-stack topology are superseded one command at a time by request-bound runtime
+> facets and explicit provider ownership.
+
 ## Context
 
 The test suite had many mocked daemon handler and dispatch unit tests. Those tests were expensive to maintain and skipped important behavior across request admission, locking, session state, handler routing, dispatch, Interactor resolution, and platform module command translation.
@@ -12,9 +17,11 @@ Android already had an ADB provider seam. Apple-family and Linux platform module
 
 ## Decision
 
-Keep `Interactor` as the semantic interface between dispatch and platform behavior.
+For commands not yet migrated under ADR 0019, keep `Interactor` as the legacy semantic interface
+between dispatch and platform behavior. New command cutovers use ADR 0019's bound runtime facets.
 
-Add request-scoped provider seams below platform modules:
+For commands still on the legacy adapter, use these request-scoped provider seams below platform
+modules:
 
 - Android ADB provider
 - Apple tool provider with semantic `simctl`, `devicectl`, macOS helper, and macOS host subproviders

--- a/docs/adr/0002-persistent-platform-helper-sessions.md
+++ b/docs/adr/0002-persistent-platform-helper-sessions.md
@@ -4,6 +4,11 @@
 
 Accepted
 
+> **Amended by [ADR 0019](0019-request-bound-platform-runtime.md).** Persistent protocols,
+> invalidation, and explicitly safe one-shot fallback remain accepted. "Daemon-owned" means the
+> daemon owns helper lifetime policy; platform modules own process-lived helper managers and helper
+> mechanics, and request bindings attach to but never own or stop healthy helper generations.
+
 ## Context
 
 Some platform automation backends are expensive to start but cheap to reuse. iOS already uses a
@@ -29,10 +34,11 @@ startup, cheap repeated commands, and a need for strict invalidation.
 Use persistent platform helper sessions when a backend has high startup cost and a reusable
 automation context.
 
-A helper session is an optimization layer owned by the daemon, not a replacement for command
-correctness. It may keep processes, sockets, runner state, accessibility service flags, or device
-forwards warm. It must still execute each command against fresh platform state unless a separate
-cache contract has explicit invalidation.
+A helper session is an optimization layer governed by daemon-owned lifetime policy, not a
+replacement for command correctness. Platform modules own helper-manager mechanics. A helper may
+keep processes, sockets, runner state, accessibility service flags, or device forwards warm. It must
+still execute each command against fresh platform state unless a separate cache contract has explicit
+invalidation.
 
 The session pattern is:
 
@@ -67,7 +73,7 @@ process ownership into cross-command interference.
 
 For iOS, keep the XCTest runner session as the reference implementation for lifecycle and
 invalidation behavior. Android does not need to copy iOS internals, but it should reuse the same
-daemon-side ideas: per-device session manager, readiness checks, structured protocol errors,
+lifetime-policy ideas: per-device session management, readiness checks, structured protocol errors,
 fallback/invalidation, and request-scoped observability.
 
 For future platforms such as HarmonyOS, prefer designing adapters around this same helper-session
@@ -106,9 +112,9 @@ Persistent sessions should not make direct interactive commands unexpectedly slo
 connect/request timeouts for the persistent path, then fall back to the existing one-shot timeout
 budget.
 
-The daemon remains the owner of session lifecycle. Platform modules may expose helper-session
-operations, but command handlers should not directly manage long-lived helper processes or raw host
-tool state.
+The daemon remains the owner of helper lifetime policy. Platform modules own helper-manager mechanics
+and may expose helper-session operations, but request bindings and command handlers must not directly
+own or stop long-lived helper processes or raw host tool state.
 
 This ADR does not require every backend to implement a persistent session. It defines the preferred
 shape when the backend has the same startup/reuse economics that iOS and Android snapshots now

--- a/docs/adr/0008-command-descriptor-registry.md
+++ b/docs/adr/0008-command-descriptor-registry.md
@@ -4,6 +4,12 @@
 
 Accepted
 
+> **Amended by [ADR 0019](0019-request-bound-platform-runtime.md).** `CommandDescriptor` remains
+> the command declaration root. Device-command capability buckets evolve into typed required and
+> preferred runtime use joined with leaf/device/provider-specific runtime facts; inventory commands
+> declare inventory use instead of fabricating a device binding. The descriptor's other derived
+> projections remain accepted.
+
 ## Context
 
 A command's identity is restated, by hand, across roughly ten tables that must stay aligned by

--- a/docs/adr/0009-apple-platform-consolidation.md
+++ b/docs/adr/0009-apple-platform-consolidation.md
@@ -4,6 +4,12 @@
 
 Accepted
 
+> **Amended by [ADR 0019](0019-request-bound-platform-runtime.md).** The Apple family and explicit
+> `AppleOS` leaf axis remain accepted. The shallow `PlatformPlugin` shape and root
+> `src/platforms/**` location are superseded by the lazy platform-module registry and private
+> `@agent-device/platform-*` packages. Execution cuts over command-atomically; shared physical
+> mechanics move only through ADR 0019's legal injected transition or after their last legacy user.
+
 ## Context
 
 Apple support is modeled asymmetrically and is physically smeared across an `ios` directory that is really
@@ -47,23 +53,26 @@ net-new work (XCUITest supports it — a profile row, a build case, `#if os(visi
 filter, plus real spatial-input QA); watchOS is an explicit **unsupported sentinel** because XCUITest cannot
 drive watchOS UI. macOS stays a distinct AppKit leaf (its helper binary and menubar/desktop surface model are
 preserved). The tvOS focus-only interaction contract (no coordinate `tap`) must not be flattened across OSes,
-and snapshot fidelity is uneven (the deep-RN AX-server fallback is iOS-simulator-only). The final
-`Platform` collapse of `ios`+`macos` into `apple` is the last, highest-diff step.
+and snapshot fidelity is uneven (the deep-RN AX-server fallback is iOS-simulator-only). The internal
+`Platform` collapse of `ios`+`macos` into `apple` was the last, highest-diff step; public leaf output
+remains a separate compatibility projection.
 
 This composes with ADR 0008 (the descriptor's capability facet) and ADR 0003.
 
-Implementation status as of 2026-07:
+Implementation status as of 2026-08:
 
-- Shipped: additive `appleOs` groundwork; the shared Apple engine under `src/platforms/apple/core`; macOS
-  leaf files under `src/platforms/apple/os/macos`; a dedicated tvOS leaf under `src/platforms/apple/os/tvos`;
+- Shipped: the internal `Platform` collapse to `apple`; additive `appleOs` groundwork; the shared
+  Apple engine under `src/platforms/apple/core`; macOS leaf files under
+  `src/platforms/apple/os/macos`; a dedicated tvOS leaf under `src/platforms/apple/os/tvos`;
   direct internal imports to the Apple modules; the per-`AppleOS` capability table
   (`APPLE_OS_CAPABILITIES`, `src/platforms/apple/capabilities.ts`, parity-pinned against the pre-table
   predicates); the watchOS **unsupported sentinel** (reserved in the `AppleOS` type and interactor-rejected —
   XCUITest cannot drive watchOS UI — never produced by discovery); and visionOS profile/build/discovery
   groundwork.
-- Deferred: the public `Platform` collapse from `ios`/`macos` to `apple` (the last, highest-diff step; the
-  public wire still emits `ios`/`macos` leaves via `PUBLIC_PLATFORMS`) and net-new visionOS spatial-input QA.
+- Retained compatibility: the public wire still emits `ios`/`macos` leaves through
+  `PUBLIC_PLATFORMS`; internal family ownership must not leak into that projection.
+- Deferred: net-new visionOS spatial-input QA.
 
-This ADR owns the architectural decision. The Phase 3 platform-plugin umbrella (#972) is closed; within
-this consolidation the public `Platform` collapse above is the last deferred step (net-new visionOS
-spatial-input QA is separate follow-up, outside the consolidation).
+This ADR owns the Apple family/leaf decision. The Phase 3 platform-plugin umbrella (#972) is closed;
+ADR 0019 now owns the staged package/runtime seam. Net-new visionOS spatial-input QA remains a
+separate follow-up outside the consolidation.

--- a/docs/adr/0010-error-system.md
+++ b/docs/adr/0010-error-system.md
@@ -3,6 +3,11 @@
 - Status: accepted
 - Date: 2026-07-03
 
+> **Amended by [ADR 0019](0019-request-bound-platform-runtime.md).** Existing normalization and
+> cause-preservation rules remain accepted. When an operation and binding/resource cleanup both
+> fail, the operation remains primary and cleanup is structured secondary diagnostic evidence;
+> cleanup-only failure surfaces normally.
+
 ## Context
 
 The error system is centralized in `src/kernel/errors.ts` (`AppError`, `normalizeError`,

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -518,6 +518,11 @@ boundaries, and the early adoption checkpoint keep that coexistence shippable an
 - **Use session events or a future event journal as the durable-resource store:** rejected. It would
   make correctness depend on observability; current events are projections, and proposed ADR 0018
   explicitly preserves the same no-state-from-events rule.
+- **A separate process-local resource ledger beside `SessionState` for live handles:** rejected. The
+  session store is in-memory, so live `SessionState` already is the process-local home; a parallel
+  ledger keyed by the same session/resource identity would duplicate the ownership its R7 transition
+  owner already governs. The live/persisted boundary, not a second live store, is the protection:
+  only the descriptor and neutral metadata enter the persisted recovery record.
 - **Rely only on performance thresholds for lazy loading:** rejected. Thresholds catch regressions
   late and can pass while unrelated implementation graphs load; the import/evaluation shape is also
   contract-tested.

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -1,0 +1,523 @@
+# ADR 0019: Request-Bound Platform Runtime
+
+## Status
+
+Accepted for staged adoption (2026-08-09). Checkpoint outcome: **pending**. Only the
+platform-module substrate and complete `devices`, `logs`, and `network` command cutovers are
+authorized before the checkpoint. Daemon-owned generic session teardown may invoke the neutral
+app-log disposal contract without changing `close`'s legacy platform-execution owner. If another
+command's platform adapter must change, this Status must name its complete unit before substrate work
+begins. Broader migration requires this Status to record **continue**.
+
+## Rules at a glance
+
+- Daemon device-execution code depends on platform-neutral contracts. Concrete device mechanics
+  live in private `@agent-device/platform-*` packages and are value-imported only by the root
+  composition module.
+- The platform registry is **metadata-eager and implementation-lazy**. Cheap family identity,
+  inventory entrypoints, and static fact declarations may load at composition time; platform
+  mechanics and process-lived helper managers load only when discovery or the first binding for that
+  family needs them.
+- The registry selects one local runtime owner per canonical platform family. Support is claimed and
+  tested for the exact platform leaf, device kind/backend, and provider mode; family ownership never
+  implies uniform leaf support.
+- Command descriptors declare one typed execution shape: inventory use, or platform-neutral required
+  device operations with separately declared preferred fast paths. Runtime owners report
+  device-specific facts and expose behavior-bearing facets; platform and provider implementations
+  never name commands.
+- `RequestExecutionScope.bindDevice(device, use)` resolves provider ownership, validates the facts
+  and concrete facets, and returns a runtime type narrowed to the proven runtime use. Handlers cannot
+  use undeclared facets or repair missing proof with casts or non-null assertions.
+- Provider ownership is first-class and fail-closed. An owning provider may supply transport to a
+  platform runtime or implement facets directly; missing required behavior never falls through to a
+  local owner.
+- Process-lived helper managers, request-lived device bindings, and daemon-session durable resources
+  have distinct lifetimes. Helper instances remain lazy, identity-bound, invalidatable, and
+  idle-stoppable. Disposing a request binding never stops a healthy helper or adopted resource.
+- Durable work has two representations: a process-local live handle and a versioned, persistable
+  descriptor through which the same runtime owner can recover. Live session state may own a neutral
+  facet handle under R7; only the descriptor and neutral metadata enter persisted recovery state.
+  Concrete platform process objects never cross the seam.
+- The migration unit is one command descriptor across its full existing denominator: every inventory
+  source or every supported device-runtime cell. A descriptor has exactly one legacy,
+  inventory-backed, or device-runtime-backed platform-execution shape at every committed state, and a
+  migrated command has no legacy execution fallback.
+- Broader adoption pauses after the first real slices. Evidence records one decision: continue,
+  revise the seam and rerun the checkpoint, or stop with every landed command still coherent.
+
+## Context
+
+ADR 0009 deliberately introduced a shallow `PlatformPlugin`: it wrapped the existing platform
+branches, preserved their lazy imports byte-for-byte, and moved each daemon column only after a
+parity gate proved equivalence. That was the right migration shape. It stopped platform conditionals
+from spreading, but its app-log, recording, performance, and provider facets still return tags or
+predicates that the daemon maps back to concrete implementations.
+
+The canonical registry now has six families: `apple`, `android`, `harmonyos`, `vega`, `linux`, and
+`web`. HarmonyOS supplied the additional real adapter pressure that the earlier platform-package
+checkpoint deliberately deferred. With this many families, a tag-to-implementation map leaves the
+daemon owning every platform variation even when the platform conditional has moved behind a
+plugin.
+
+The replacement must preserve the properties paid for by the existing architecture: daemon-owned
+request policy, provider-first integration scenarios, Apple-family leaf modeling, kept-hot helper
+performance, interaction guarantee honesty, pre-mutation ref-frame expiry, normalized errors,
+package direction, and CLI cold-start laziness.
+
+## Decision
+
+### 1. Platform modules provide behavior through one composition seam
+
+Each canonical family has one private `packages/platform-<family>` workspace package named
+`@agent-device/platform-<family>`. Its façade exposes cheap metadata plus lazy implementations of a
+`DeviceInventorySource` and `DeviceRuntimeGateway`; the implementations behind those entrypoints own
+platform tool invocation, helper protocols, runtime facts, output parsing, recovery mechanics, and
+other native details. A platform package contains only that family's implementations and mechanics,
+never daemon orchestration, command policy, or cross-family defaults.
+
+The root composition module, `src/platform-runtime.ts`, constructs immutable
+inventory/runtime registries and injects a composed inventory gateway plus provider-first runtime
+gateway into daemon request execution. Daemon device-execution modules import runtime contracts only.
+Shared runtime interfaces and neutral data types live in `@agent-device/contracts`. In production,
+only that composition module may import a concrete platform package; reusable types do not leak
+through type-only platform imports. Platform packages may import contracts, kernel/domain packages,
+and explicitly injected host capabilities; they may not import daemon requests or responses, mutable
+session state, command catalogs/grammar, root implementation files, sibling platform packages, or raw
+process primitives outside the shared host-command port. R11 applies these rules to static, type-only,
+dynamic, and re-export edges; package-owned tests may import their own public façade. Contracts may
+depend on kernel vocabulary but never on concrete platform packages or daemon implementation types.
+
+Canonical family, `AppleOS`, public-leaf, and selector identity remain declared in
+`@agent-device/kernel/device`. Platform-module metadata references one canonical family; during
+coexistence the legacy plugin registry derives its family identity from the same declaration rather
+than becoming a second root.
+
+Host command execution, diagnostics, progress, and resolved native assets enter through focused host
+capabilities. A platform package receives only the capabilities its implementation needs. Shared
+logic moves to an honest domain package only after more than one implementation needs it; there is
+no `platform-common`, generic host-utilities package, universal command dispatcher, or generic
+platform-resource union.
+
+#### Implementation-laziness
+
+Static composition must not make every daemon or CLI startup evaluate every platform implementation.
+The registry eagerly loads only metadata-only package façades. A façade keeps heavy leaf imports and
+helper-manager construction behind lazy entrypoints:
+
+- discovery loads mechanics only for a family whose inventory is requested;
+- binding loads mechanics only for the selected runtime owner;
+- process-lived helper managers are created on first use, not while composing the registry; and
+- loading one family does not load an unrelated family's implementation graph.
+
+Composition may capture inert configured paths eagerly. Filesystem/tool probing, asset preparation or
+building, helper construction, and facts requiring a selected-owner probe remain lazy. The structural
+suite must prove that unrelated implementations are not evaluated before selected discovery/binding,
+and the built artifact retains its startup measurement. Passing a startup threshold alone is not a
+substitute for preserving the loading shape; the tracking issue owns the exact probe and planted-red
+procedure.
+
+### 2. Runtime use joins facts and narrows the bound runtime
+
+`CommandDescriptor` remains the command declaration root. Its runtime-use declaration has a typed set
+of required platform-neutral operations and may separately name preferred optimizations. Commands
+whose use depends on normalized input first produce a discriminated execution plan that retains
+literal required/preferred types. Required and preferred operation keys are disjoint, and the
+required-only path is semantically complete; preferred operations may improve execution but are
+never necessary for command correctness.
+
+Inventory commands have a separate `inventoryUse` declaration. `devices` calls the composed
+`DeviceInventoryGateway`, which selects canonical family sources and provider-owned inventory sources
+from the request selectors; it neither invents a synthetic device nor calls `bindDevice`. Its
+coverage denominator is all six local family inventory sources, every provider inventory source, and
+selector/public-device projection parity. Inventory results become ordinary `DeviceInfo` values only
+after their source has classified the canonical family and required leaf identity.
+
+A runtime owner reports exhaustive facts for the exact device shape and returns capability-cohesive
+facets with normalized semantic inputs and typed outcomes. Facet inputs never contain a command name,
+`DaemonRequest`, `DaemonResponse`, `SessionState`, CLI flags, or an opaque command payload. A missing
+facet plus a typed unavailability fact represents unsupported behavior; implementations do not ship
+stubs that throw `unsupported` after binding. Runtime-use keys identify individual semantic
+operations, not whole facet namespaces, so selecting one operation does not expose undeclared sibling
+operations from the same facet.
+
+`RequestExecutionScope.bindDevice(device, use)` is the trust choke point. It:
+
+1. resolves the exact local or provider runtime owner;
+2. checks every required operation and classifies each preferred operation against facts for the
+   platform leaf, device kind/backend, and provider mode;
+3. creates or reuses one request binding for that ownership-qualified device;
+4. verifies that every required operation and every preferred operation advertised as available has
+   a concrete facet implementation; an advertised operation with no implementation is a
+   runtime-contract error; and
+5. returns a selected operation projection: required operations are non-optional, declared preferred
+   operations are optional and present only when available, and undeclared operations are inaccessible.
+
+The cached broad runtime remains private to `RequestExecutionScope`; narrowing does not intersect a
+wide optional aggregate that would still expose undeclared facets. The descriptor and its specialized
+handler share one non-widened declaration, and a widened generic descriptor carries no static proof.
+A compile-time contract test proves the selected projection. A structural
+**runtime-facet-narrowing gate** covers every runtime-migrated handler owner and rejects attempts to
+manufacture required-operation proof with assertions or optional admission. Optional access is
+permitted only for descriptor-declared preferred operations. The tracking issue owns the gate
+implementation and its required planted violation.
+
+Absence or failure of a preferred path may change optimization/path disclosure, not whether the
+semantic command can execute. Failure falls back to the complete required path only through a typed
+reason and an explicit descriptor/ADR 0011 path classification; it is never a generic `catch`
+fallback. Helper/session reuse hidden inside one required operation remains that facet's implementation
+detail and follows ADR 0002 rather than becoming a daemon-visible preferred operation.
+
+Family registration and support coverage are separate gates. The immutable registry owns each of the
+six canonical families exactly once. Before a command cuts over, an independent parity artifact
+freezes its legacy supported/unsupported cells and hints. Runtime-fact scenarios expand canonical
+kernel-owned family/leaf fixtures over device kinds/backends and provider modes; a new runtime may
+not make a difficult legacy-supported cell disappear. Behavior changes require a separate decision.
+
+Apple coverage uses an exhaustive `AppleOS` fixture table and explicitly exercises iOS simulator and
+physical backends where they differ, iPadOS, tvOS focus-only/no-coordinate behavior, macOS desktop,
+visionOS deferred or supported cells, and the watchOS unsupported/discovery-absence sentinel. Every
+fixture matches exactly one family. A loop over six families with one generic `platform: 'apple'`
+device is not leaf coverage.
+
+### 3. Provider ownership is exact and fail-closed
+
+For one device, provider resolution has three outcomes:
+
+1. exactly one provider owns it: bind that provider-owned runtime;
+2. no provider owns it: bind the local family runtime; or
+3. more than one provider owns it: fail with an ownership-contract error.
+
+Only providers that declare device-runtime ownership participate in this arbitration. A narrow tool,
+transport, app-log, or recording provider is an injected dependency of the selected local/provider
+runtime; it does not become a second runtime owner or compete in the owner count.
+
+Provider ownership is authoritative. If the owning provider lacks a required fact or facet, admission
+returns the typed unsupported result; it never tries the local family implementation. A provider may
+implement a complete runtime directly, as Cloud WebDriver can, or contribute a narrow transport used
+inside the owning family module, as an Android transport can. Provider callback stacks threaded
+through daemon handlers are not part of the new seam.
+
+Ordinary binding performs the arbitration above. Every `DeviceBinding` also exposes a unique,
+restart-stable runtime-owner reference identifying the local family owner or the configured provider
+runtime instance, not merely a provider kind. Composition rejects duplicate owner references. Durable
+descriptors embed that reference; exact-owner binding resolves it directly, validates descriptor
+device/fence identity, and never reruns ordinary ownership arbitration or `ownsDevice`. An unavailable
+expected provider is `unreattachable: owner-unavailable`; it never becomes a local bind.
+
+### 4. Bindings attach to process-lived helper managers; they do not own helpers
+
+Platform gateways and their helper managers are process-lived. Individual helper generations remain
+lazy, identity-bound, invalidatable, restartable, and idle-stoppable under ADR 0002. A request binding
+attaches cancellation, diagnostics, progress, and admitted device/session context. Disposing it
+releases only those request attachments and request-local acquisitions.
+
+The underlying `DeviceBinding` implements `AsyncDisposable` and remains private to
+`RequestExecutionScope`; handlers receive only a non-disposable `BoundDeviceRuntime<Use>` projection.
+Each gateway bind owns a private rollback stack and publishes a binding only after every request-local
+acquisition succeeds. Failure after any internal acquisition releases that partial state before the
+bind rejects. On publication, ownership transfers exactly once to a repository-owned, reverse-order
+scope disposal stack; caching another projection never registers or disposes the binding twice.
+
+Request execution invokes that stack from `finally`. Source-executed TypeScript does not use
+`await using` while the supported minimum Node 22 runtime cannot parse that syntax, type stripping
+cannot lower it, and Node 22 has no `AsyncDisposableStack`; the contract keeps a later syntax migration
+mechanical. A binding itself is never adopted beyond the request; only a durable resource handle
+returned by one of its facets may transfer to session ownership.
+
+Persistent helper shutdown happens only through explicit device lifecycle policy, helper-manager
+invalidation, platform idle policy, or platform-module shutdown after daemon-session resources have
+been finalized. After adoption, a durable handle may retain its own helper attachment beyond the
+originating request; that attachment belongs to the handle and is no longer registered for
+request-scope disposal. Adoption detaches every originating request diagnostic/event/progress port.
+Later `finish` or forced disposal executes inside the current request observability scope or an
+explicit daemon session-teardown observability scope; a durable handle never retains an old request
+async context.
+
+A shared lifecycle contract scenario is required for every helper-backed runtime. With idle expiry
+disabled and no invalidation, process exit, identity change, or ownership transfer, it proves that
+disposing request bindings never terminates or restarts the healthy helper and an immediate later
+binding reuses that generation. Module shutdown terminates each still-live, still-owned generation at
+most once. Every durable-resource facet separately proves that its adopted resource survives
+originating-binding disposal. Each platform supplies honest evidence appropriate to its helper rather
+than relying on wall-clock behavior alone. Bind contract scenarios also fail after each successive
+internal acquisition and prove that the unpublished partial binding leaves no request attachment.
+
+Published bindings are disposed on success, failure, cancellation, and early return, in reverse
+acquisition order; unpublished partial binds roll themselves back before rejecting. Disposal runs
+inside the active request diagnostics/event context before `request.finished`, diagnostics flush,
+final response construction, and device/session lock release, so cleanup-only failure cannot follow a
+recorded success. If the operation and cleanup both fail, the operation error remains primary and
+cleanup is structured secondary diagnostic evidence; a cleanup-only failure surfaces normally.
+
+### 5. Durable resources are reattachable by the same owner
+
+App-log streams, screen recordings, and native profiler captures may outlive one request. Starting
+durable work returns:
+
+- a **live resource handle**, which is process-local authority to finish or forcibly dispose the
+  active resource; and
+- a **durable resource descriptor**, which is bounded, JSON-safe, versioned state sufficient for the
+  exact runtime owner to make a deterministic recovery attempt.
+
+Facet-specific handles expose `finish(): Promise<FinishOutcome>` for idempotent normal completion,
+`forceCleanup(): Promise<CleanupOutcome>` for outcome-bearing forced cleanup, and idempotent
+`[Symbol.asyncDispose](): Promise<void>` as the scope-cleanup adapter. The adapter resolves only for
+confirmed cleanup/already-missing outcomes and rejects with a normalized ownership-lost or
+cleanup-pending error otherwise; it does not pretend `Promise<void>` carries a typed result.
+
+Every destructive finish/cleanup operation holds the authoritative ownership lease from fence
+validation through the native side effect and persisted lifecycle transition, or passes a fencing
+token to a native/provider operation that atomically rejects stale owners. A check immediately before
+the side effect is not sufficient. A transport that can provide neither mechanism cannot claim
+transferable reattachment; cleanup-only recovery requires proof that the prior owner is gone, and
+otherwise remains manual recovery.
+
+A facet start internally rolls back if it cannot publish a complete handle/descriptor pair, and the
+start promise is invoked through the request scope's pending-transfer guard. The scope registers the
+guarded handle for forced cleanup before resolving the result to command orchestration, then releases
+that guard only after the authoritative active record and the live `SessionState` handle/descriptor
+adoption both succeed. Cancellation or failure anywhere in that gap disposes the unadopted handle and
+terminalizes the record only after confirmed cleanup; uncertain cleanup leaves the record
+cleanup-pending. Contract scenarios inject cancellation and failure between partial start,
+publication, persistence, live adoption, and transfer.
+
+There is no generic `PlatformResource`. Live `SessionState` may retain a neutral facet-specific
+contract handle beside its descriptor and metadata; the field has one R7 transition owner. Only the
+descriptor and neutral metadata enter the authoritative persisted recovery record. Concrete platform
+classes, provider clients, child handles, timers, transports, and wait promises enter neither store.
+
+Persisted JSON re-enters as `unknown`. Contracts first validate a neutral envelope containing resource
+kind/envelope version, session/device identity, exact owner reference, fence, and lifecycle state.
+Only after exact-owner selection does that facet's total codec decode its descriptor body. Invalid or
+unknown envelopes/bodies remain retained recovery evidence with a typed
+`descriptor-invalid`/`descriptor-version-unsupported` outcome; they are never cast to a descriptor,
+deleted, or offered to another facet.
+
+When no live handle is available, the daemon completes lease/admission and takeover fencing, binds
+the descriptor's exact owner, and calls that facet's typed `reattach`. Reattachment returns a closed
+outcome: `active` with a handle, `completed` with its result, `missing`, or `unreattachable` with a
+typed reason. Unsupported descriptor schema/version returns
+`unreattachable: descriptor-version-unsupported`: the facet does not guess a migration, discard the
+descriptor, fall through to another owner, or start a replacement. Other closed reasons include
+`owner-unavailable`, `transport-not-reattachable`, and `ownership-fence-lost`. A descriptor may
+explicitly declare cleanup-only recovery when its native transport cannot reconstruct equivalent live
+control; that limitation is a runtime fact, not a best-effort guess during takeover.
+
+Reattachment does not rehydrate `SessionState` or change `SESSION_NOT_FOUND` policy. With no admitted
+live session, a reconstructed handle is recovery-scope-owned and may only complete or clean up the
+resource; adopting it for continued session use requires an independently admitted live session.
+
+Every durable facet also exposes a typed, idempotent
+`cleanup(descriptor, fence, scope): Promise<CleanupOutcome>` for descriptor-only forced cleanup.
+Cleanup-only recovery uses this operation instead of pretending to reconstruct a full handle, and its
+closed outcome records cleaned, already missing, or still cleanup-pending state. Finish, dispose, and
+descriptor cleanup all use the same serialized/atomically enforced fence. If the exact owner or
+descriptor schema is unavailable, cleanup cannot be guessed: the authoritative record remains
+cleanup-pending with a manual-recovery reason.
+
+The descriptor must have an authoritative persisted home before command start success is returned.
+Prefer the platform/resource-owned recovery manifest when that resource already owns one. If a
+resource has no honest manifest, introduce a daemon-owned persisted resource record only for that
+demonstrated need, and extract a shared resource index only after multiple resource types earn it.
+Current diagnostics/session events—and any future journal from proposed ADR 0018—are
+observability-only and never a recovery source of truth. They may mirror descriptor lifecycle events,
+but reattachment never scans telemetry to rebuild state.
+
+Every authoritative home exposes a deterministic facet-owned lookup or enumeration path after
+process loss. Its neutral record carries session/device identity, the exact runtime-owner reference,
+descriptor and metadata, an ownership/fence token, and a lifecycle state sufficient to distinguish
+starting, active, completing, completed, and cleanup-pending recovery. A new handle is not exposed
+until the persisted ownership fence is acquired. Every finish/cleanup attempt holds that ownership
+guard through destructive work and the persisted transition, or delegates to an operation that
+atomically enforces the token, so a prior owner cannot later terminate a transferred resource.
+
+Persisting a descriptor does not make external-resource start and descriptor write atomic. A
+platform whose native tool cannot close that crash window retains a platform-owned orphan marker or
+equivalent recovery protocol. Descriptors contain stable reconstruction coordinates, not promises,
+timers, child handles, buffers, credentials, or a dump of live implementation state.
+
+Ownership transfer is explicit. Start persists active recovery evidence before returning command
+success, and the pending guard transfers only after live session adoption. Completion preserves a
+terminal result or stable result coordinates before active recovery evidence is removed. Once
+adopted, request-binding disposal cannot stop the resource. Normal session teardown preserves
+facet-specific ordering; adopted durable handles are not placed in the request binding's generic
+disposable transaction.
+
+### 6. Command cutover is the abandonment-safe migration unit
+
+The command descriptor is the sole migration discriminant, but it does not own a daemon handler
+value. It declares command identity and an internal-only execution mode excluded from public
+projections. The mode selects one neutral declaration shape: legacy platform admission, device
+`runtimeUse`, or `inventoryUse`. ADR 0003's daemon-owned total route table continues to own specialized
+handler implementations and request-policy traits; that route/policy projection remains present and
+unchanged in every mode. A derived coherence gate joins the declarations without importing daemon
+handlers into the descriptor registry.
+
+The descriptor-derived **runtime-command-cutover gate** covers the command's whole platform-execution
+projection: either legacy admission/hints plus its complete legacy platform adapter; device runtime
+use plus fact-derived admission and its complete runtime-backed adapter; or inventory use plus the
+composed inventory gateway. Never more than one and never none. A migrated device unit deletes its old
+capability closures/hints and legacy platform adapter. A migrated inventory unit deletes its old
+inventory branches/adapter. Neither cutover deletes, duplicates, or changes the ADR 0003 daemon route.
+No handler selects old versus new platform behavior by family, provider, failure, environment
+variable, or feature flag.
+
+One device-command migration unit is one command across every runtime cell where it is currently
+supported: all applicable platform leaves, device kinds/backends, transport-composed providers, and
+direct provider runtimes. Unsupported cells are classified through new runtime facts; they do not
+remain on the old adapter. An inventory-command unit covers every local family and provider inventory
+source plus selector/public projection parity. The unit also deletes that command's superseded daemon
+platform branches, backend tags and tag-to-implementation maps, capability closures/hints, legacy
+imports, parity scaffolding, and old platform adapter. The independent pre-cutover parity artifact
+proves available-command and unsupported-hint equivalence before those legacy sources are deleted; a
+deliberate behavior change is a separate decision rather than a migration gap.
+
+Facets organize contracts and implementation locality; a whole facet is not a required PR boundary.
+A repository may indefinitely contain migrated and unmigrated commands, but no command has two
+platform-execution paths and no merged state depends on a later PR for correctness. Rollback is a
+revert of the complete command unit, not a retained execution fallback.
+
+A behavior-neutral package/registry substrate may land before the first command only when it routes
+no production descriptor, is dead-code clean, independently revertible, and preserves lazy loading.
+Otherwise it lands with the `devices` command unit. Shared Apple-runner or Android-helper mechanics
+used by migrated and legacy commands are not duplicated or connected through a package-to-root
+back-import. They either remain physically in place until their last consumer can move, or move
+behind a neutral lower-level capability injected by composition into both the package facet and the
+complete legacy adapter while command execution ownership remains singular.
+
+The substrate and every command unit are reviewed from a clean committed tree with all production
+files present in `HEAD`; a green layering run while new production files are untracked is not
+evidence. Platform packages receive no migration allowlist or root back-import exception.
+`check:affected` must select platform contract, provider, and coverage scenarios for a
+`packages/platform-*` change. Every new structural gate is accepted only after a planted violation
+demonstrates the intended red result.
+
+Any unit touching `SessionState` classifies each changed field once under R7, keeps request bindings,
+concrete platform/provider types, and raw process/transport mechanics out, and gives each mutable
+resource field one transition owner. The permitted live value is the opaque implementation behind a
+neutral facet-specific handle contract. The unit proves partial-start cleanup, transfer, finish,
+forced disposal, and error precedence. Equality-pinned R10 writer/owner counts and external
+`daemon/types.ts` importer membership are lowered in the same unit when they shrink. R9 total-cycle
+and R10 cycle-zone pressure may not grow; shrink reporting follows their existing growth-only policy.
+
+### 7. Adoption checkpoint
+
+No command migration beyond the metadata/package substrate and complete `devices`, `logs`, and
+`network` command cutovers begins until this ADR's Status records **continue**. `network` is included
+because it consumes the app-log resource. Daemon-owned generic session teardown may invoke the
+neutral app-log handle's forced-disposal contract without changing `close`'s legacy platform adapter;
+the `logs` unit proves that path through `close`. If `close`, `open`, or another command instead must
+bind a runtime or select app-log platform behavior, its full unit must be named in Status before the
+substrate lands. `logs` is the deliberate first descriptor/reattachment pilot, not merely a
+request-lifetime handle exercise.
+
+Before the substrate lands, the tracking issue records and reviews the exact commands, thresholds,
+scenario denominator, and scoped counts used below. The same measures are reported from the clean
+committed checkpoint tree.
+
+The checkpoint records exactly one outcome:
+
+- **continue**: every hard evidence item passes and broader command migration may proceed;
+- **revise**: amend the contracts/ADR, rerun the checkpoint, and begin no further command migration; or
+- **stop**: abandon broader migration; already-landed command units remain coherent or are retired by
+  a separate explicit decision.
+
+Any failed hard item requires **revise** or **stop**; recording evidence of the failure is not
+evidence for **continue**.
+
+Evidence must cover:
+
+- one platform-execution path, an unchanged ADR 0003 route/policy projection, and zero old capability
+  closures, tags/maps, or concrete daemon platform imports for each migrated command;
+- package direction and the absence of daemon request/session/command types in platform packages;
+- independent package builds/declarations, metadata-eager/implementation-lazy loading, and reviewed
+  startup/build/package thresholds;
+- typed runtime-use narrowing and a planted-red narrowing-gate violation;
+- six-family runtime ownership, six local inventory sources, provider inventory sources, and
+  independently enumerated leaf/device/provider support parity and scenario counts;
+- provider-first fail-closed behavior plus unique restart-stable exact-owner references;
+- rollback after every partial bind acquisition and published-binding disposal without
+  persistent-helper shutdown;
+- descriptor persistence and exact-owner recovery after loss of a process-local handle, including
+  validated decoding, resumed control for reattachable cells, executable descriptor-only cleanup,
+  and explicit cleanup-only/version-unreattachable behavior;
+- pending-handle cleanup across every start/persist/adopt/transfer gap, durable-handle transfer,
+  serialized or native-atomic fencing, idempotent teardown, and operation/cleanup error precedence;
+- semantic/provider/device parity for `devices`, `logs`, and `network`;
+- unchanged-or-lower R7/R10, type-cycle, and external-daemon-type ratchets; and
+- numeric before/after daemon platform import, branch, and tag counts with a strict net decrease.
+
+The seam is revised or stopped before broader migration if a platform package needs root/daemon or
+sibling-platform imports; a command needs old/new or provider/local execution fallback; runtime
+facets degenerate into tags, command switches, or opaque execution payloads; leaf/provider facts
+require default fallthrough; `SessionState` names/exposes concrete platform/provider types or raw
+mechanics rather than the permitted neutral live handle; a persisted record bypasses the validated
+neutral envelope or facet-owned descriptor codec, or contains raw live mechanics; implementation
+laziness cannot be preserved; R7/R10/type-cycle pressure grows; or the landed slices add more daemon
+platform ownership than they remove.
+
+The tracking issue owns command order, PR/file lists, test-only compatibility fixtures, exact
+benchmark commands and thresholds, raw evidence, and reviewers. Temporary fixtures never authorize
+a production bridge, duplicate route, or recorded package back-import. After the checkpoint, this
+ADR's status records its outcome; it does not retain a migration diary.
+
+## Relationship to prior decisions
+
+- [ADR 0001](0001-provider-first-integration-scenarios.md): provider-first scenario coverage and
+  semantic provider operations remain. The monolithic `Interactor` and request callback-stack
+  topology are superseded as commands migrate.
+- [ADR 0002](0002-persistent-platform-helper-sessions.md): persistent-helper protocols,
+  invalidation, and explicitly safe one-shot fallback remain. Daemon ownership means lifetime
+  policy; platform modules own helper managers/mechanics, and request bindings never own helpers.
+- [ADR 0003](0003-daemon-command-registry.md) and
+  [ADR 0007](0007-remote-device-leases.md): daemon request-policy traits, lease admission, and lock
+  ordering remain daemon-owned. Binding happens only after their admission requirements are met.
+- [ADR 0008](0008-command-descriptor-registry.md): the descriptor registry remains the command root.
+  Device-command capability buckets evolve into typed required/preferred runtime use joined with
+  exact runtime facts; inventory commands declare inventory use.
+- [ADR 0009](0009-apple-platform-consolidation.md): the Apple family and `AppleOS` leaf axis remain.
+  The shallow `PlatformPlugin` shape is superseded as command units migrate; physical shared
+  mechanics move only through the legal injected substrate transition or after their last legacy
+  consumer.
+- [ADR 0010](0010-error-system.md): normalized errors remain; this ADR adds operation/cleanup
+  precedence and typed reattachment outcomes.
+- [ADR 0011](0011-interaction-guarantee-contract.md),
+  [ADR 0013](0013-unified-gesture-plans.md), and
+  [ADR 0014](0014-session-ref-frame-lifetime.md): interaction paths stay distinct, normalized gesture
+  plans cross the seam, and daemon authorization expires immediately before any possibly mutating
+  facet call. Platform implementations may not hide UI mutation inside an observational facet.
+- [ADR 0018](0018-unified-event-journal.md) is proposed, not a dependency of this decision. If
+  accepted, its journal and teardown scopes may implement this ADR's observability contexts, while
+  remaining observation rather than coordination or persisted recovery state.
+
+## Consequences
+
+The daemon keeps policy, command semantics, response construction, session/lease ownership,
+selector/ref authority, interaction guarantees, and artifact orchestration. Platform packages gain
+locality for native mechanics, provider transport composition, persistent helpers, and resource
+recovery. Adding a platform implements existing runtime contracts and facts instead of adding daemon
+tags, maps, callbacks, and branches.
+
+The cost is a staged cross-repository migration with temporarily coexisting legacy,
+inventory-backed, and device-runtime-backed commands. Command-atomic cutover, explicit deletion
+boundaries, and the early adoption checkpoint keep that coexistence shippable and abandonment-safe.
+
+## Alternatives considered
+
+- **Move all platform source into packages first:** rejected. It changes physical ownership before
+  proving the behavior seam, creates large root-import tunnels, and cannot be reviewed or abandoned
+  command by command.
+- **Keep extending `PlatformPlugin` with tags and predicates:** rejected. It relocates selection data
+  but leaves the daemon mapping every platform tag back to behavior.
+- **One replacement `Interactor`, universal dispatcher, or `SystemFacet`:** rejected. Platform leaf
+  support differs by operation, and a wide optional interface recreates unsupported stubs and
+  command-aware platform code.
+- **Provider/local or old/new execution fallback:** rejected. Provider ownership and command cutover
+  must be exact; success-path fallback hides semantic divergence. Explicitly accepted internal helper
+  fallbacks remain governed by ADR 0002.
+- **Use session events or a future event journal as the durable-resource store:** rejected. It would
+  make correctness depend on observability; current events are projections, and proposed ADR 0018
+  explicitly preserves the same no-state-from-events rule.
+- **Rely only on performance thresholds for lazy loading:** rejected. Thresholds catch regressions
+  late and can pass while unrelated implementation graphs load; the import/evaluation shape is also
+  contract-tested.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,8 @@
 | [0015 Direct Maestro Compatibility Engine](0015-direct-maestro-engine.md) | Maestro YAML parsing/execution, compatibility observation policy, conformance, performance gates, gesture integration |
 | [0016 Active-Session Script Publication](0016-active-session-script-publication.md) | publishing an armed open-to-destination `.ad` script without closing its live session |
 | [0017 Parameterized Recorded Inputs](0017-parameterized-recorded-inputs.md) | safely authoring sensitive fill inputs as `${VAR}` placeholders across recording, replay, and repair |
+| [0018 Unified Request Event Journal (Proposed)](0018-unified-event-journal.md) | event/diagnostic vocabulary, journal scopes and sinks, progress-channel separation, observability-only state |
+| [0019 Request-Bound Platform Runtime](0019-request-bound-platform-runtime.md) | platform-package boundaries/composition, device discovery, runtime facts/facets, request binding, provider ownership, platform-shaped session resources, durable reattachment, daemon-handler migration |
 
 ADRs record *why*; the registries and gates they describe are the living source of truth — when
 prose and a registry disagree, the registry wins and the ADR needs a follow-up.


### PR DESCRIPTION
## Summary

Adopt ADR 0019 as the canonical direction for moving platform-specific daemon mechanics behind contracts-owned, request-bound runtimes implemented by private `@agent-device/platform-*` packages.

The decision keeps registration metadata-eager and implementation-lazy, makes admission and execution command-atomic across all six platform families and providers, defines request/process/session resource lifetimes, and requires a measured `devices`/`logs`/`network` checkpoint before broader migration. It also aligns `CONTEXT.md` and amends ADRs 0001, 0002, 0008, 0009, and 0010 where the new decision narrows or supersedes their seams.

Scope is eight architecture-document files; no runtime or command behavior changes in this PR. Implementation is tracked in #1696.

## Validation

Documentation-only change. The affected gate classified all eight files as docs-only and selected no runtime checks; whitespace and relative Markdown-link validation also pass. Runtime and device verification do not apply.
