### PR TITLE
fix: complete request cancellation propagation

### DIFF
--- a/src/commands/interaction/runtime/selector-wait-cancellation.test.ts
+++ b/src/commands/interaction/runtime/selector-wait-cancellation.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { AgentDeviceBackend } from '../../../backend.ts';
+import { createLocalArtifactAdapter } from '../../../io.ts';
+import {
+  createAgentDevice,
+  createMemorySessionStore,
+  localCommandPolicy,
+} from '../../../runtime.ts';
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+for (const authority of ['runtime', 'command'] as const) {
+  test(`duration wait observes ${authority} cancellation`, async () => {
+    const controller = new AbortController();
+    const sleepStarted = deferred();
+    const releaseSleep = deferred();
+    const reason = new Error(`${authority} wait canceled`);
+    const device = createAgentDevice({
+      backend: { platform: 'ios' } satisfies AgentDeviceBackend,
+      artifacts: createLocalArtifactAdapter(),
+      sessions: createMemorySessionStore(),
+      policy: localCommandPolicy(),
+      clock: {
+        now: () => 0,
+        sleep: async () => {
+          sleepStarted.resolve();
+          await releaseSleep.promise;
+        },
+      },
+      ...(authority === 'runtime' ? { signal: controller.signal } : {}),
+    });
+
+    const waiting = device.selectors.wait({
+      target: { kind: 'sleep', durationMs: 1_000 },
+      ...(authority === 'command' ? { signal: controller.signal } : {}),
+    });
+    await sleepStarted.promise;
+    controller.abort(reason);
+    releaseSleep.resolve();
+
+    await assert.rejects(waiting, (error) => error === reason);
+  });
+}
+

--- a/src/commands/interaction/runtime/selector-wait-cancellation.test.ts
+++ b/src/commands/interaction/runtime/selector-wait-cancellation.test.ts
@@ -53,4 +53,3 @@ for (const authority of ['runtime', 'command'] as const) {
     await assert.rejects(waiting, (error) => error === reason);
   });
 }
-

--- a/src/commands/interaction/runtime/selector-wait.ts
+++ b/src/commands/interaction/runtime/selector-wait.ts
@@ -25,6 +25,7 @@ import { findNodeByLabel, resolveRefLabel } from './selector-read-utils.ts';
 import {
   createWaitPolling,
   DEFAULT_WAIT_TIMEOUT_MS,
+  sleepWithWaitCancellation,
   type WaitPollDeadline,
   waitTimeoutError,
 } from './wait-polling.ts';
@@ -178,7 +179,7 @@ export function createSelectorWaitCommands<Runtime extends SelectorWaitRuntime>(
     options: WaitCommandOptions,
   ): Promise<WaitCommandResult> => {
     if (options.target.kind === 'sleep') {
-      await sleep(runtime, options.target.durationMs);
+      await sleepWithWaitCancellation(runtime, options, options.target.durationMs);
       return { kind: 'sleep', waitedMs: options.target.durationMs };
     }
     if (options.target.kind === 'ref') {
@@ -446,9 +447,4 @@ function backendContext(
     signal: options.signal ?? runtime.signal,
     metadata: options.metadata,
   };
-}
-
-async function sleep(runtime: SelectorWaitRuntime, durationMs: number): Promise<void> {
-  if (runtime.clock) await runtime.clock.sleep(durationMs);
-  else await new Promise((resolve) => setTimeout(resolve, durationMs));
 }

--- a/src/commands/interaction/runtime/wait-polling.ts
+++ b/src/commands/interaction/runtime/wait-polling.ts
@@ -87,7 +87,11 @@ export function createWaitPolling(
     }),
     rethrowIfNeverReadable: unreadable.rethrowIfNeverReadable,
     sleepUntilNextPoll: async () =>
-      await sleepWithinWait(runtime, options, Math.min(WAIT_POLL_INTERVAL_MS, remainingMs())),
+      await sleepWithWaitCancellation(
+        runtime,
+        options,
+        Math.min(WAIT_POLL_INTERVAL_MS, remainingMs()),
+      ),
     timeoutMs,
     waitedMs: () => now(runtime) - startedAtMs,
   };
@@ -162,7 +166,7 @@ function now(runtime: WaitPollingRuntime): number {
   return runtime.clock?.now() ?? Date.now();
 }
 
-async function sleepWithinWait(
+export async function sleepWithWaitCancellation(
   runtime: WaitPollingRuntime,
   options: WaitPollingOptions,
   durationMs: number,

--- a/src/daemon/__tests__/snapshot-runtime-cancellation.test.ts
+++ b/src/daemon/__tests__/snapshot-runtime-cancellation.test.ts
@@ -85,4 +85,3 @@ for (const command of ['snapshot', 'diff snapshot'] as const) {
     }
   });
 }
-

--- a/src/daemon/__tests__/snapshot-runtime-cancellation.test.ts
+++ b/src/daemon/__tests__/snapshot-runtime-cancellation.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { makeAndroidSession } from '../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import {
+  clearRequestAbortRegistration,
+  markRequestCanceled,
+  registerRequestAbort,
+} from '../../request/cancel.ts';
+import { dispatchSnapshotDiffViaRuntime, dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
+
+const dispatchCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: dispatchCommandMock,
+  };
+});
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  dispatchCommandMock.mockReset();
+});
+
+for (const command of ['snapshot', 'diff snapshot'] as const) {
+  test(`${command} forwards request cancellation into snapshot dispatch`, async () => {
+    const sessionName = 'default';
+    const sessionStore = makeSessionStore('agent-device-snapshot-cancellation-');
+    sessionStore.set(sessionName, makeAndroidSession(sessionName));
+    const requestId = `snapshot-cancellation-${command.replace(' ', '-')}`;
+    const registration = registerRequestAbort(requestId);
+    if (!registration) throw new Error('expected request abort registration');
+    const dispatchEntered = deferred();
+    const releaseDispatch = deferred();
+    let observedSignal: AbortSignal | undefined;
+
+    dispatchCommandMock.mockImplementation(async (...args: unknown[]) => {
+      const context = args[4] as { signal?: AbortSignal } | undefined;
+      observedSignal = context?.signal;
+      dispatchEntered.resolve();
+      await releaseDispatch.promise;
+      context?.signal?.throwIfAborted();
+      return { nodes: [], truncated: false, backend: 'uiautomator' };
+    });
+
+    try {
+      const input = {
+        req: {
+          command: command === 'snapshot' ? 'snapshot' : 'diff',
+          positionals: command === 'snapshot' ? [] : ['snapshot'],
+          token: 't',
+          session: sessionName,
+          meta: { requestId },
+        },
+        sessionName,
+        logPath: '/tmp/agent-device-snapshot-cancellation.log',
+        sessionStore,
+      };
+      const running =
+        command === 'snapshot'
+          ? dispatchSnapshotViaRuntime(input)
+          : dispatchSnapshotDiffViaRuntime(input);
+      await dispatchEntered.promise;
+      markRequestCanceled(requestId);
+      releaseDispatch.resolve();
+
+      expect(observedSignal).toBe(registration.controller.signal);
+      await expect(running).rejects.toBe(registration.controller.signal.reason);
+    } finally {
+      releaseDispatch.resolve();
+      clearRequestAbortRegistration(registration);
+    }
+  });
+}
+

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -27,6 +27,7 @@ import {
 } from './snapshot-quality-latch.ts';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
+import { getRequestSignal } from '../request/cancel.ts';
 import { isInteractiveObservation } from './session-action-recorder.ts';
 import { setSnapshotLineage } from './session-snapshot.ts';
 import { SessionStore } from './session-store.ts';
@@ -284,6 +285,7 @@ function createSnapshotRuntime(params: {
       capturedQuality: params.capturedQuality,
     }),
     ...createDaemonRuntimePolicy('snapshot'),
+    signal: getRequestSignal(req.meta?.requestId),
     sessions: createDaemonRuntimeSessionStore({
       sessionName,
       getSession: () => sessionStore.get(sessionName),
@@ -394,7 +396,7 @@ function createDaemonSnapshotBackend(params: {
   const { req, logPath, session, device, snapshotScope } = params;
   return {
     platform: publicPlatformString(device),
-    captureSnapshot: async (_context, options): Promise<BackendSnapshotResult> => {
+    captureSnapshot: async (context, options): Promise<BackendSnapshotResult> => {
       const capture = await captureSnapshot({
         device,
         session,
@@ -402,6 +404,7 @@ function createDaemonSnapshotBackend(params: {
         outPath: options?.outPath ?? req.flags?.out,
         logPath,
         snapshotScope,
+        signal: context.signal,
       });
       const annotations = snapshotCaptureAnnotationsFrom(capture);
       // Feed the latch seam the capture's own verdict: the stored session


### PR DESCRIPTION
## Summary

- Duration-only waits now reject when either the runtime or command AbortSignal cancels, reusing the existing cancellation-aware sleep path without changing successful output or timeout accounting.
- `snapshot` and `diff snapshot` now carry the request-scoped signal through `CommandContext` into the existing capture seam, so canceled requests no longer continue device work.
- This restores an internal request-lifecycle guarantee without changing the public CLI, API, schema, or error contract. Docs and skills are intentionally unchanged.
- Closes #1686

Scope: 5 files (3 implementation, 2 regression tests), with no expansion beyond wait/snapshot cancellation.

## Validation

Red-before-fix evidence:

- `duration wait observes runtime cancellation` and `duration wait observes command cancellation` failed with `Missing expected rejection`.
- `snapshot forwards request cancellation into snapshot dispatch` and `diff snapshot forwards request cancellation into snapshot dispatch` failed because the observed signal was `undefined` instead of the registered aborted `AbortSignal`.
- These were assertion failures, not timeout-based red evidence.

After the fix:

- Focused cancellation/regression suite: 24/24 tests passed.
- `pnpm check:quick` passed.
- Final pre-push `pnpm check:affected --run`: formatting, lint, typecheck, layering, Fallow, build, 159 test files, and 1,284 tests passed.
- Final `pnpm check`: 662 test files and 5,874 tests passed; local smoke tests had 38 passes and 3 expected live-environment skips.

Exact-head practical iOS Simulator evidence at `d7305e17651578d6b897911c7ce881bf5df21e34`:

- Freshness: ran `pnpm build`, then `pnpm clean:daemon` before opening Settings on the booted iPhone 17 Pro Simulator (`6044A251-23C2-4584-B7DB-87A16B787757`) in dedicated session `pr1709-cancel`.
- Duration wait: started `wait 30000`, disconnected the client while the request was active, and the request ended after 3,992 ms with `This operation was aborted` instead of running for 30 seconds (`requestId=9e67cbbcbeb16eed`). A same-session interactive snapshot then succeeded in 120 ms and returned the Settings tree.
- Snapshot: ran an in-flight snapshot with `--timeout 10`; diagnostics recorded `request canceled` through `snapshot_capture`, terminated one timed-out runner PID, and preserved the daemon (`requestId=ed03e6eda2127dd0`). The command returned in 112 ms. A same-session snapshot then restarted the runner and succeeded in 8,998 ms, again returning the Settings tree (`requestId=21a96de4d6649834`).
- Cleanup: closed `pr1709-cancel` successfully and released the simulator lease.

An earlier affected run hit six unrelated recording-harness contention timeouts; the one allowed rerun passed all 159 files / 1,284 tests, and the final pre-push run passed cleanly. The first full check only tripped the slow-test gate on cold Swift typechecking (14.2s / 6.87s); after cache warm-up, the final full check passed.

AI-assisted. The contributor reviewed the code, red/green evidence, final test output, and conclusions before submission.
