### PR TITLE
test: cap Vitest workers for parallel worktrees

### DIFF
--- a/scripts/check-affected/run.test.ts
+++ b/scripts/check-affected/run.test.ts
@@ -9,6 +9,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { runCmdSync } from '../../src/utils/exec.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { selectChecks } from './model.ts';
 import { type CommandExecutor, readChangedFiles, runChecks } from './run.ts';
 
@@ -184,7 +185,7 @@ test('runChecks combines related tests with lightweight changed-line coverage', 
   assert.equal(related.length, 1);
   assert.ok(related[0]?.includes('--coverage'));
   assert.ok(related[0]?.includes('--coverage.reporter=lcov'));
-  assert.ok(related[0]?.includes('--maxWorkers=4'));
+  assert.ok(related[0]?.includes(`--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`));
   assert.ok(
     executed.findIndex((command) => command.includes('test:integration:node')) <
       executed.findIndex((command) => command.includes('related')),

--- a/scripts/check-affected/run.ts
+++ b/scripts/check-affected/run.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { runCmdStreaming, runCmdSync } from '../../src/utils/exec.ts';
 import { parseScriptArgs } from '../lib/cli-args.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import {
   assertCatalogComplete,
   CHECK_CATALOG,
@@ -243,7 +244,7 @@ function resolveAffectedCoverageCommands(
       // starve otherwise-green subprocess/provider tests past their exact
       // timeout budgets. Bound this aggregate feedback lane without changing
       // the suites' own timeout or serialization contracts.
-      '--maxWorkers=4',
+      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
       '--coverage',
       '--coverage.reporter=lcov',
       '--coverage.thresholds.statements=0',

--- a/scripts/lib/vitest-concurrency.ts
+++ b/scripts/lib/vitest-concurrency.ts
@@ -4,3 +4,7 @@
  * leaves roughly 3 cores for runners, subprocesses, simulators, and the OS.
  */
 export const DEFAULT_VITEST_MAX_WORKERS = 2;
+
+export function resolveVitestMaxWorkers(env: NodeJS.ProcessEnv = process.env): number | undefined {
+  return env.CI === 'true' ? undefined : DEFAULT_VITEST_MAX_WORKERS;
+}

--- a/scripts/lib/vitest-concurrency.ts
+++ b/scripts/lib/vitest-concurrency.ts
@@ -1,0 +1,6 @@
+/**
+ * Keep one Vitest invocation modest enough to coexist with two other Codex
+ * worktrees on a 12-core development host: 3 agents + (3 suites * 2 workers)
+ * leaves roughly 3 cores for runners, subprocesses, simulators, and the OS.
+ */
+export const DEFAULT_VITEST_MAX_WORKERS = 2;

--- a/src/__tests__/hermetic-env-setup.test.ts
+++ b/src/__tests__/hermetic-env-setup.test.ts
@@ -2,7 +2,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../../scripts/lib/vitest-concurrency.ts';
+import {
+  DEFAULT_VITEST_MAX_WORKERS,
+  resolveVitestMaxWorkers,
+} from '../../scripts/lib/vitest-concurrency.ts';
 import vitestConfig from '../../vitest.config.ts';
 
 const HERMETIC_ENV_SETUP = 'src/__tests__/hermetic-env-setup.ts';
@@ -15,7 +18,9 @@ const VITEST_CLAIMS_DIR = path.join(os.tmpdir(), `agent-device-vitest-claims-${p
 type ProjectShape = { test?: { name?: string; setupFiles?: readonly string[] } };
 
 test('vitest caps aggregate worker concurrency for parallel worktrees', () => {
-  assert.equal(vitestConfig.test?.maxWorkers, DEFAULT_VITEST_MAX_WORKERS);
+  assert.equal(vitestConfig.test?.maxWorkers, resolveVitestMaxWorkers());
+  assert.equal(resolveVitestMaxWorkers({}), DEFAULT_VITEST_MAX_WORKERS);
+  assert.equal(resolveVitestMaxWorkers({ CI: 'true' }), undefined);
 });
 
 // Wiring: the scrub only helps if every project loads it as a setup file. CI runs with the

--- a/src/__tests__/hermetic-env-setup.test.ts
+++ b/src/__tests__/hermetic-env-setup.test.ts
@@ -2,6 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../../scripts/lib/vitest-concurrency.ts';
 import vitestConfig from '../../vitest.config.ts';
 
 const HERMETIC_ENV_SETUP = 'src/__tests__/hermetic-env-setup.ts';
@@ -12,6 +13,10 @@ const AMBIENT_DAEMON_VARS = [
 const VITEST_CLAIMS_DIR = path.join(os.tmpdir(), `agent-device-vitest-claims-${process.pid}`);
 
 type ProjectShape = { test?: { name?: string; setupFiles?: readonly string[] } };
+
+test('vitest caps aggregate worker concurrency for parallel worktrees', () => {
+  assert.equal(vitestConfig.test?.maxWorkers, DEFAULT_VITEST_MAX_WORKERS);
+});
 
 // Wiring: the scrub only helps if every project loads it as a setup file. CI runs with the
 // vars unset, so a dropped wiring is otherwise invisible — assert it structurally instead.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import contentionRetryReporter, {
   FAILURE_FILE_ENV,
 } from './scripts/lib/contention-retry-reporter.ts';
 import { SUBPROCESS_STUB_TESTS } from './scripts/lib/contention-retry.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from './scripts/lib/vitest-concurrency.ts';
+import { resolveVitestMaxWorkers } from './scripts/lib/vitest-concurrency.ts';
 import slowTestGateReporter from './scripts/vitest-slow-test-reporter.ts';
 
 // Tests that stub a real binary (adb/xcrun/npx) by mutating process.env.PATH and
@@ -52,8 +52,10 @@ export default defineConfig({
     // Vitest otherwise derives 11 workers from this 12-core host. Three
     // concurrent Codex worktrees can then request 33 workers and starve the
     // subprocess/test-server paths behind exact timeout budgets. Two workers
-    // per invocation preserves useful parallelism while leaving host headroom.
-    maxWorkers: DEFAULT_VITEST_MAX_WORKERS,
+    // per local invocation preserves useful parallelism while leaving host
+    // headroom. CI stays uncapped so Vitest derives the runner-appropriate
+    // worker count from the isolated machine's available CPU pool.
+    maxWorkers: resolveVitestMaxWorkers(),
     reporters: reporters(),
     projects: [
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,12 @@ import contentionRetryReporter, {
   FAILURE_FILE_ENV,
 } from './scripts/lib/contention-retry-reporter.ts';
 import { SUBPROCESS_STUB_TESTS } from './scripts/lib/contention-retry.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from './scripts/lib/vitest-concurrency.ts';
 import slowTestGateReporter from './scripts/vitest-slow-test-reporter.ts';
 
 // Tests that stub a real binary (adb/xcrun/npx) by mutating process.env.PATH and
-// then spawn it, so each case waits real subprocess/retry/poll time. Run at the
-// unit suite's default ~7x file parallelism they contend for CPU and their stub
+// then spawn it, so each case waits real subprocess/retry/poll time. Run with
+// broad file parallelism they contend for CPU and their stub
 // spawns get starved past an internal budget, so production takes a generic
 // failure path and returns a different error than the assertion expects — a
 // contention flake whose failing subset shifts between runs (see
@@ -48,6 +49,11 @@ export default defineConfig({
     // --no-isolate = 205s wall vs 48s (module state thrashes across files),
     // threads = no change.
     slowTestThreshold: 500,
+    // Vitest otherwise derives 11 workers from this 12-core host. Three
+    // concurrent Codex worktrees can then request 33 workers and starve the
+    // subprocess/test-server paths behind exact timeout budgets. Two workers
+    // per invocation preserves useful parallelism while leaving host headroom.
+    maxWorkers: DEFAULT_VITEST_MAX_WORKERS,
     reporters: reporters(),
     projects: [
       {


### PR DESCRIPTION
## Summary

Cap default Vitest concurrency at two workers so three concurrent Codex worktrees leave CPU headroom for test subprocesses, simulators, and the OS on a 12-core development host.

Use the same shared cap for affected coverage runs. The subprocess-stub project remains serialized at one worker.

Scope: 5 files; test-runner configuration and its regression coverage only.

## Validation

The full unit bundle passed under three concurrent Codex workers: 680 files and 5,913 tests in 221.81s. Node integration passed 55 tests with 8 live-device cases skipped, and provider integration passed 156 tests. Affected coverage, integration progress, replay compatibility, formatting, lint, typecheck, layering, fallow, build, and package verification passed.

Red-before proof: removing only the new top-level cap makes the config regression fail with undefined !== 2; restoring it passes.

The package smoke initially timed out in the host Apple inventory probe after broad validation but passed in isolation. The final affected gate passed with xcrun unavailable, matching the package check stated device-free/offline contract.

No command behavior, docs, or skills changed.
