### PR TITLE
fix(test): include workspace packages in changed-line coverage

### DIFF
--- a/scripts/coverage-changed/model.test.ts
+++ b/scripts/coverage-changed/model.test.ts
@@ -89,6 +89,14 @@ test('source/test classification matches the coverage include glob', () => {
   assert.equal(isIncludableSource('src/core/__tests__/x.ts'), false);
   assert.equal(isIncludableSource('scripts/y.ts'), false);
   assert.equal(isIncludableSource('src/core/x.tsx'), false);
+  // Workspace packages are the second coverage root.
+  assert.equal(isIncludableSource('packages/contracts/src/x.ts'), true);
+  assert.equal(isIncludableSource('packages/contracts/src/deep/x.ts'), true);
+  assert.equal(isIncludableSource('packages/contracts/src/x.test.ts'), false);
+  assert.equal(isIncludableSource('packages/contracts/src/__tests__/x.ts'), false);
+  assert.equal(isIncludableSource('packages/contracts/src/x.tsx'), false);
+  assert.equal(isIncludableSource('packages/contracts/test/x.ts'), false);
+  assert.equal(isIncludableSource('packages/contracts/x.ts'), false);
   assert.equal(isTestFile('src/a.test.ts'), true);
   assert.equal(isTestFile('src/__tests__/a.ts'), true);
   assert.equal(isTestFile('src/a.ts'), false);
@@ -145,6 +153,23 @@ test('gate fails when changed-line coverage is below threshold and lists offende
   // Branches on changed lines are reported, not gated.
   assert.equal(result.branch.total, 2);
   assert.equal(result.branch.covered, 1);
+});
+
+test('workspace package source counts toward the gate like root source', () => {
+  const packageCoverage = parseLcov(
+    ['SF:packages/contracts/src/feature.ts', 'DA:1,4', 'DA:2,0', 'end_of_record'].join('\n'),
+  );
+  const result = computeChangedCoverage({
+    diffs: [diff('packages/contracts/src/feature.ts', [1, 2])],
+    coverage: packageCoverage,
+    fileLines: () => null,
+  });
+  // 1/2 = 50% < 70: a package change can now fail the gate on its own.
+  assert.equal(result.totalLines, 2);
+  assert.equal(result.coveredLines, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.offenders[0]?.path, 'packages/contracts/src/feature.ts');
+  assert.deepEqual(result.offenders[0]?.uncoveredLines, [2]);
 });
 
 test('non-executable added lines (absent from DA) never enter the denominator', () => {

--- a/scripts/coverage-changed/model.ts
+++ b/scripts/coverage-changed/model.ts
@@ -4,10 +4,11 @@
 // the gate is deterministic against renames and deletes. run.ts owns all I/O.
 //
 // The coverable universe is the lcov report itself, not a second copy of
-// vitest's exclude globs: coverage runs with `all` on, so every includable
-// `src/**/*.ts` file appears in lcov even when untested. A changed includable
-// file ABSENT from lcov was dropped by an exclude glob — reported (non-gating)
-// so exclusions cannot silently absorb new logic.
+// vitest's exclude globs: coverage runs with `all` on, so every includable file
+// under either coverage root (`src/**/*.ts` and `packages/*/src/**/*.ts`)
+// appears in lcov even when untested. A changed includable file ABSENT from
+// lcov was dropped by an exclude glob — reported (non-gating) so exclusions
+// cannot silently absorb new logic.
 
 // Single source of truth for the gate. Changed-line coverage below this
 // percentage fails the Coverage CI job (unless waived).
@@ -149,15 +150,20 @@ export function parseUnifiedDiff(diff: string): ChangedFileDiff[] {
   return files;
 }
 
-// Vitest coverage `include` is `src/**/*.ts`. Test files are excluded there and
-// carry no product logic, so they never count toward the gate or the excluded
-// tally (which exists to surface hidden logic, not test code).
+// Vitest coverage `include` spans two roots: `src/**/*.ts` and
+// `packages/*/src/**/*.ts`. Test files are excluded there and carry no product
+// logic, so they never count toward the gate or the excluded tally (which
+// exists to surface hidden logic, not test code).
 export function isTestFile(path: string): boolean {
   return /\.test\.ts$/.test(path) || /(^|\/)__tests__\//.test(path);
 }
 
+// Both coverage roots, package-generic so a new workspace needs no edit here.
+// Anything outside them — scripts, package-level `test/`, `.tsx` — stays out.
+const SOURCE_ROOT = /^(?:packages\/[^/]+\/)?src\/.*\.ts$/;
+
 export function isIncludableSource(path: string): boolean {
-  return /^src\/.*\.ts$/.test(path) && !isTestFile(path);
+  return SOURCE_ROOT.test(path) && !isTestFile(path);
 }
 
 // A changed line looks like product code (not blank, not a comment-only line).

--- a/scripts/coverage-changed/run.test.ts
+++ b/scripts/coverage-changed/run.test.ts
@@ -83,6 +83,20 @@ test('fails when a changed source line is uncovered and names that line', () => 
   assert.match(out, /`src\/feature\.ts`: 2/);
 });
 
+test('fails when a changed workspace package line is uncovered and names that line', () => {
+  write(
+    'packages/contracts/src/feature.ts',
+    'export const covered = 1;\nexport const uncovered = 2;\n',
+  );
+  git('add', '-A');
+  git('commit', '-q', '-m', 'package feature');
+  writeLcov('SF:packages/contracts/src/feature.ts\nDA:1,3\nDA:2,0\nend_of_record\n');
+  const { code, out } = capture(() => run(['--base', 'main'], repo));
+  assert.equal(code, 1);
+  assert.match(out, /Changed-line coverage gate: FAIL/);
+  assert.match(out, /`packages\/contracts\/src\/feature\.ts`: 2/);
+});
+
 test('waiver env keeps the job green, still reporting numbers to the job summary', () => {
   write('src/feature.ts', 'export const covered = 1;\nexport const uncovered = 2;\n');
   git('add', '-A');


### PR DESCRIPTION
Closes #1684.

## Why

The full Vitest coverage run instruments both root `src/` and workspace package source (`vitest.config.ts` includes `['src/**/*.ts', 'packages/*/src/**/*.ts']`), but the changed-line gate rejected every `packages/*/src/**` path in `isIncludableSource` before consulting LCOV. A PR could therefore add uncovered lines to contracts, selectors, kernel, or provider packages while the 70% changed-line gate reported no package denominator at all.

## What changed

- `scripts/coverage-changed/model.ts`: `isIncludableSource` now matches both coverage roots via one package-generic source-root pattern (`/^(?:packages\/[^/]+\/)?src\/.*\.ts$/`) plus the existing `isTestFile` predicate — no enumerated package list to drift as workspaces are added. Package `.test.ts`, `__tests__/`, package-level `test/`, `.tsx`, and `scripts/**` stay excluded. Scoring, waiver behavior, the excluded-line tally, and branch reporting are untouched.
- Comments that claimed a root-only coverage universe now name both roots truthfully.

## Tests

Proven red before the fix — these three failed on the pre-fix model, the first two because the classifier rejected package paths, the third because the gate scored the package change `0/0` and exited 0:

- `source/test classification matches the coverage include glob`
- `workspace package source counts toward the gate like root source` (new)
- `fails when a changed workspace package line is uncovered and names that line` (new)

Detail:

- `scripts/coverage-changed/model.test.ts`: classification matrix extended with package source, package tests, `__tests__`, `.tsx`, and package-level `test/` cases; new pure-model regression proving a package diff contributes to the denominator (1/2 = 50%) and fails the gate, naming the offending path and uncovered line.
- `scripts/coverage-changed/run.test.ts`: new temporary-repository regression proving the executable gate returns `1`, prints `FAIL`, and renders `` `packages/contracts/src/feature.ts`: 2 ``. The existing root-source regression stays as a control.

## Verification

- `pnpm check:coverage-changed:test` → exit 0 (19/19)
- `pnpm check:quick` → exit 0
- `pnpm check:affected --run` → exit 0 (all runnable checks passed)
- `git status --short` lists only the three in-scope files

Note: `check:affected` needed `git fetch --unshallow --tags` first — the fresh clone was shallow, so `check:replay-compat` and the merge-base diff failed on missing history. That is an environment artifact, not a repository change.

No thresholds, waiver semantics, CI workflow order, Vitest configuration, docs, or product source were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgngjVMdk2eSKQ9d1gYLGo