### PR TITLE
docs: align snapshot fallback and actions guidance

### DIFF
--- a/src/__tests__/command-doc-coverage.test.ts
+++ b/src/__tests__/command-doc-coverage.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'vitest';
 import { PUBLIC_COMMANDS, isKnownCliCommandName } from '../command-catalog.ts';
 import { cliCommandAlias } from '../commands/cli-command-aliases.ts';
+import { getCliCommandSchema } from '../cli-schema/command-schema.ts';
+import { buildCommandUsage } from '../cli-schema/usage.ts';
 
 // Enumerates the public command surface (`PUBLIC_COMMANDS`, derived from the
 // command descriptor registry) against the human-facing command reference at
@@ -29,29 +31,52 @@ const UNDOCUMENTED_PUBLIC_COMMAND_WAIVERS: readonly CommandDocWaiver[] = [];
 // companion binary). Empty today.
 const UNKNOWN_DOCUMENTED_COMMAND_WAIVERS: readonly CommandDocWaiver[] = [];
 
-// Extracts the set of `agent-device <token>` command tokens documented inside
-// fenced code blocks, mapped to the 1-based line where each first appears. Prose
-// mentions outside code fences are ignored on purpose: only executable usage
-// lines count as "documenting" a command, so a passing reference like
-// "the effective agent-device state dir" is not read as an `agent-device state`
-// command.
-function extractDocumentedCommandTokens(markdown: string): Map<string, number> {
-  const documented = new Map<string, number>();
+// Yields the lines inside fenced code blocks with their 1-based line numbers.
+// Prose outside code fences is skipped on purpose: only executable usage lines
+// count as "documenting" a command, so a passing reference like "the effective
+// agent-device state dir" is not read as an `agent-device state` command.
+function* fencedLines(markdown: string): Generator<{ text: string; lineNumber: number }> {
   let insideFence = false;
   const lines = markdown.split('\n');
   for (let index = 0; index < lines.length; index++) {
-    const line = lines[index] ?? '';
-    if (/^\s*(?:```|~~~)/.test(line)) {
+    const text = lines[index] ?? '';
+    if (/^\s*(?:```|~~~)/.test(text)) {
       insideFence = !insideFence;
       continue;
     }
-    if (!insideFence) continue;
-    const token = /^\s*agent-device\s+([a-z0-9-]+)/.exec(line)?.[1];
+    if (insideFence) yield { text, lineNumber: index + 1 };
+  }
+}
+
+// Extracts the set of `agent-device <token>` command tokens documented inside
+// fenced code blocks, mapped to the 1-based line where each first appears.
+function extractDocumentedCommandTokens(markdown: string): Map<string, number> {
+  const documented = new Map<string, number>();
+  for (const { text, lineNumber } of fencedLines(markdown)) {
+    const token = /^\s*agent-device\s+([a-z0-9-]+)/.exec(text)?.[1];
     if (token !== undefined && !documented.has(token)) {
-      documented.set(token, index + 1);
+      documented.set(token, lineNumber);
     }
   }
   return documented;
+}
+
+// Locates a verbatim executable usage line inside a code block. Command names
+// are covered by the token checks above; this is the stricter per-command gate
+// that keeps a published invocation identical to the schema that produces it.
+function findUsageLine(markdown: string, usageLine: string): number | undefined {
+  for (const { text, lineNumber } of fencedLines(markdown)) {
+    if (text.trim() === usageLine) return lineNumber;
+  }
+  return undefined;
+}
+
+// The canonical `snapshot` invocation, derived from the command schema rather
+// than restated here: `snapshot` grew `--actions`, `--force-full`, and
+// `--timeout` while the command reference still published a three-flag usage
+// line, so the flag list must stay owned by the schema.
+function canonicalSnapshotUsageLine(): string {
+  return `agent-device ${buildCommandUsage('snapshot', getCliCommandSchema('snapshot'))}`;
 }
 
 function isRegistryCommandToken(token: string): boolean {
@@ -111,6 +136,14 @@ function undocumentedMessage(missing: readonly string[]): string {
   );
 }
 
+function canonicalUsageMessage(usageLine: string): string {
+  return (
+    `${COMMANDS_DOC_PATH} does not publish the canonical usage line \`${usageLine}\`. ` +
+    'The command schema owns CLI syntax: update the documented code block to match it rather ' +
+    'than editing this expectation.'
+  );
+}
+
 function unknownMessage(unknown: readonly string[]): string {
   return (
     `${COMMANDS_DOC_PATH} documents command token(s) absent from the command registry: ` +
@@ -140,6 +173,15 @@ describe('command reference doc coverage', () => {
       UNKNOWN_DOCUMENTED_COMMAND_WAIVERS,
     );
     assert.deepEqual(unknown, [], unknownMessage(unknown));
+  });
+
+  test('commands.md publishes the canonical snapshot CLI usage', () => {
+    const usageLine = canonicalSnapshotUsageLine();
+    assert.notEqual(
+      findUsageLine(markdown, usageLine),
+      undefined,
+      canonicalUsageMessage(usageLine),
+    );
   });
 
   test('no stale waivers', () => {
@@ -214,6 +256,15 @@ describe('command reference doc coverage gate behavior', () => {
     const message = unknownMessage(unknown);
     assert.match(message, /website\/docs\/docs\/commands\.md/);
     assert.match(message, /retired-command/);
+  });
+
+  test('a drifted snapshot usage line fails, naming file and canonical usage', () => {
+    const usageLine = canonicalSnapshotUsageLine();
+    const driftedDocs = markdown.replaceAll(usageLine, 'agent-device snapshot [-i]');
+    assert.equal(findUsageLine(driftedDocs, usageLine), undefined);
+    const message = canonicalUsageMessage(usageLine);
+    assert.match(message, /website\/docs\/docs\/commands\.md/);
+    assert.ok(message.includes(usageLine), 'the failure names the usage line the schema produces');
   });
 
   test('a waiver suppresses an intentional forward omission', () => {

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -338,7 +338,9 @@ agent-device get attrs @e1
   controls are not separate elements still lists them. It is iOS-simulator-only and exists for
   planning, not invocation: there is no API to trigger a named action, so reach the affordance
   through the element's detail screen, the same control exposed as a labeled element elsewhere, or
-  coordinates from its rect. See [Snapshots](/docs/snapshots) for the full constraints.
+  coordinates from its rect. It is mutually exclusive with `--raw`, which takes a capture path that
+  cannot carry custom actions: the pair is rejected as `INVALID_ARGS` before any device work. See
+  [Snapshots](/docs/snapshots) for the full constraints.
 - `diff snapshot` compares the current snapshot with the previous session baseline and then updates baseline.
 - `snapshot --diff` is an alias for `diff snapshot`.
 - Default snapshot text is an agent-facing, token-efficient view for planning and targeting actions. It may collapse helper/accessibility noise; use `--raw` or `--json` when you need the full provider tree.

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -316,7 +316,7 @@ agent-device close
 ## Snapshot and inspect
 
 ```bash
-agent-device snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw]
+agent-device snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw] [--actions] [--force-full] [--timeout <ms>]
 agent-device diff snapshot [-i] [-d <depth>] [-s <scope>] [--raw]
 agent-device get text @e1
 agent-device get attrs @e1
@@ -333,6 +333,12 @@ agent-device get attrs @e1
   Android interactive window roots when available, so keyboard and system-overlay nodes can appear
   alongside the app root; `androidSnapshot.captureMode` and `androidSnapshot.windowCount` describe
   the capture.
+- `--actions` names the custom accessibility affordances an element merged away (iOS
+  `UIAccessibilityCustomAction`, React Native `accessibilityActions`), so a card whose reply/options
+  controls are not separate elements still lists them. It is iOS-simulator-only and exists for
+  planning, not invocation: there is no API to trigger a named action, so reach the affordance
+  through the element's detail screen, the same control exposed as a labeled element elsewhere, or
+  coordinates from its rect. See [Snapshots](/docs/snapshots) for the full constraints.
 - `diff snapshot` compares the current snapshot with the previous session baseline and then updates baseline.
 - `snapshot --diff` is an alias for `diff snapshot`.
 - Default snapshot text is an agent-facing, token-efficient view for planning and targeting actions. It may collapse helper/accessibility noise; use `--raw` or `--json` when you need the full provider tree.

--- a/website/docs/docs/snapshots.md
+++ b/website/docs/docs/snapshots.md
@@ -40,9 +40,9 @@ agent-device snapshot --diff             # Alias for the same diff operation
 - Each merged element costs one accessibility round trip, so the pass is opt-in and bounded. When it
   cannot read every candidate, the response says how many it read — an absent list on an unread
   element is not evidence that it has none.
-- Do not combine it with `--raw`. The raw diagnostic strategy stays tree-first, and only the private
-  accessibility backend can read custom actions, so `--raw --actions` returns a raw tree without
-  them.
+- Mutually exclusive with `--raw`. Custom actions are only readable through the private-AX capture
+  path, which the raw diagnostic strategy does not take, so the pair is rejected as `INVALID_ARGS`
+  before any device work — on the CLI, the Node client, and MCP alike. Choose one or the other.
 
 ## Efficient snapshot usage
 

--- a/website/docs/docs/snapshots.md
+++ b/website/docs/docs/snapshots.md
@@ -12,18 +12,37 @@ agent-device snapshot -i                 # Interactive elements only (recommende
 agent-device snapshot -d 3               # Limit depth to 3 levels
 agent-device snapshot -s "Contacts"      # Scope to label/identifier
 agent-device snapshot -i -d 5            # Combine options
+agent-device snapshot --actions          # Name custom actions merged into elements (iOS simulator)
 agent-device diff snapshot               # Preferred structural diff vs previous session baseline
 agent-device snapshot --diff             # Alias for the same diff operation
 ```
 
-| Option       | Description                  |
-| ------------ | ---------------------------- |
-| `-i`         | Interactive-only output      |
-| `-d <depth>` | Limit tree depth             |
-| `-s <scope>` | Scope to label or identifier |
+| Option           | Description                                                                     |
+| ---------------- | ------------------------------------------------------------------------------- |
+| `--diff`         | Structural diff against the previous session baseline (alias for `diff snapshot`) |
+| `-i`             | Interactive-only output                                                          |
+| `-d <depth>`     | Limit tree depth                                                                 |
+| `-s <scope>`     | Scope to label or identifier                                                     |
+| `--raw`          | Full provider tree instead of the visible-first agent view                       |
+| `--actions`      | Name the custom accessibility actions merged inside an element (iOS simulator)   |
+| `--force-full`   | Re-emit the full tree even when it is unchanged since the previous snapshot      |
+| `--timeout <ms>` | Maximum wall-clock time for the snapshot command                                 |
 
-Note: If XCTest returns 0 nodes (foreground app changed), agent-device fails explicitly.
-It does not automatically switch to AX.
+`--actions` constraints:
+
+- iOS simulators only. Physical iOS devices, macOS, and Android targets reject the flag.
+- It names the affordances an element merged away (iOS `UIAccessibilityCustomAction`, React Native
+  `accessibilityActions`), so a card whose reply/options controls are not separate elements still
+  lists them.
+- The names are for planning and discovery, not invocation. There is no API to trigger one: reach
+  the affordance through the element's detail screen, through the same control exposed as a labeled
+  element elsewhere, or by coordinates from its rect.
+- Each merged element costs one accessibility round trip, so the pass is opt-in and bounded. When it
+  cannot read every candidate, the response says how many it read — an absent list on an unread
+  element is not evidence that it has none.
+- Do not combine it with `--raw`. The raw diagnostic strategy stays tree-first, and only the private
+  accessibility backend can read custom actions, so `--raw --actions` returns a raw tree without
+  them.
 
 ## Efficient snapshot usage
 
@@ -66,7 +85,23 @@ agent-device snapshot -i
 # [off-screen below] 2 interactive items: "All Contacts", "New List"
 ```
 
-## Backends (iOS):
+## iOS capture behavior
 
-- `xctest` (default): full fidelity, fast, no Accessibility permission required.
-- `ax`: fast accessibility tree, may miss details, requires Accessibility permission; simulator-only.
+Capture tiers are internal. There is no flag that selects a backend; `--raw` chooses a strategy, and
+the strategy owns which tiers it may use.
+
+- Regular (non-`--raw`) capture uses the **regular visible strategy**: it starts with the recursive
+  XCTest tree, and when that returns **sparse** output for a screen XCTest cannot serialize, it can
+  recover through a query sweep and then, on simulators, a private accessibility backend.
+- The ladder is bounded by the capture budget rather than retried indefinitely; when the budget is
+  spent, the best payload captured so far is returned.
+- Recovery and degradation stay observable instead of being presented as an empty UI. A
+  **recovered** capture warns that it fell back to another backend and is safe to continue from; a
+  **sparse** capture reports that no backend could read the screen and points you at `screenshot`
+  as visual truth plus coordinate taps. Use `--json` and read `snapshotQuality` when you need the
+  state, backend, and reason behind **degraded** output.
+- `--raw` uses the **raw diagnostic strategy**: it stays tree-first and preserves strict capture
+  failures, so a real XCTest accessibility serialization error surfaces as an error rather than as
+  an empty tree.
+- Private-accessibility recovery and `--actions` reads are simulator-specific. Physical iOS devices
+  have no equivalent independent semantic backend; they bound the XCTest work with a probe instead.


### PR DESCRIPTION
## Summary

Two website pages described `snapshot` in ways that no longer match the shipped command, so an agent reading them would misdiagnose a recovered capture and never discover `--actions`.

**Snapshot guide** claimed regular iOS capture never falls back:

> Note: If XCTest returns 0 nodes (foreground app changed), agent-device fails explicitly. It does not automatically switch to AX.

Regular capture actually runs a bounded `recursiveTree → querySweep → privateAX` recovery ladder (`regularVisiblePlan` in `RunnerTests+SnapshotCapturePlan.swift`, per ADR 0004). The page now has an **iOS capture behavior** section written from the accepted decision and the live plan: the regular visible strategy recovers through the ladder when XCTest returns **sparse** output; the ladder is bounded by the capture budget; **recovered**/**sparse** results stay observable through quality warnings and `--json` `snapshotQuality` rather than being presented as an empty UI; `--raw` selects the raw diagnostic strategy, which stays tree-first and preserves strict capture failures. Private-AX recovery and custom-action reads are documented as simulator-specific — physical devices bound the XCTest work with a probe instead. Capture tiers are described as internal, not as user-selectable backends (the old `xctest` / `ax` "Backends (iOS)" list read like a choice; it isn't one).

**Command reference** published a three-flag usage line while the CLI has grown three more flags:

```diff
-agent-device snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw]
+agent-device snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw] [--actions] [--force-full] [--timeout <ms>]
```

`--actions` is now documented on both pages as iOS-simulator-only and **planning-only**. It names the affordances an element merged away (`UIAccessibilityCustomAction`, React Native `accessibilityActions`) so a card whose reply/options controls are not separate elements still lists them — but there is no API to trigger one, so the docs route readers to the detail screen, an equivalent labeled element, or coordinates from the rect. The guide also records the per-element accessibility round trip, the partial-coverage disclosure, and that `--actions` is **mutually exclusive with `--raw`**: `customActionFlagsResponse` in `src/daemon/request-router.ts` rejects the pair as `INVALID_ARGS` at the shared request seam, before any session or device work, so CLI, Node client, and MCP all give the same answer.

To stop the usage line drifting a third time, `src/__tests__/command-doc-coverage.test.ts` gains a schema-derived gate: `commands.md` must publish exactly what `buildCommandUsage('snapshot', getCliCommandSchema('snapshot'))` returns. The flag list is never restated in the test — the schema stays the single source of truth, so adding a `snapshot` flag fails the gate until the reference is updated. The fence walker the existing token checks already used is extracted so both checks parse code blocks one way.

Closes #1689

## Validation

Docs-only for behavior — no runtime, CLI, grammar, ADR, or runner code changed, so there is no device-facing path to verify on a simulator; the two prose pages are checked against ADR 0004, the live `regularVisiblePlan`/`rawDiagnosticPlan`, the request-router flag guard, and the `--actions` field description rather than against a device.

The new gate was proven red before the docs edit, failing as `command reference doc coverage > commands.md publishes the canonical snapshot CLI usage` and naming the missing line verbatim; it passes after. A companion test plants a drifted usage line to prove the gate can still fail. `check:affected` selected format, lint, typecheck, fallow, and the related-vitest run — all green — and the Rspress site builds clean.

Two notes for the reviewer:

- The plan's drift check flagged `commands.md` as changed since `13bc70f24`, but the drift is confined to the HarmonyOS, install, and cloud sections; every in-scope excerpt still matched live code, so this was not treated as a stop.
- `website/doc_build/` is **not** gitignored, so `pnpm --dir website build` leaves ~2,300 untracked generated files in the worktree. `check:affected` folds untracked files into its change set, so the build output fails `format:check` on a clean tree and makes the gate unrunnable until the directory is deleted by hand. I removed the output rather than adding an ignore rule, since `.gitignore` is outside this change's scope — but the missing entry looks worth a follow-up.

3 files changed; scope stayed within the two website pages and their gate.