### PR TITLE
perf: speed up device inventory and status

### DIFF
--- a/packages/platform-apple/src/inventory.test.ts
+++ b/packages/platform-apple/src/inventory.test.ts
@@ -121,3 +121,29 @@ test('simulator-set inventory remains scoped while retaining the host Mac', asyn
   );
   assert.deepEqual(calls, [['simctl', '--set', '/tmp/custom-set', 'list', 'devices', '-j']]);
 });
+
+test('unscoped Apple inventory starts simulator and physical discovery concurrently', async () => {
+  const calls: string[] = [];
+  let releaseSimulators!: () => void;
+  const simulatorsBlocked = new Promise<void>((resolve) => {
+    releaseSimulators = resolve;
+  });
+  const host = createInventoryHost({
+    run: async (request) => {
+      calls.push(request.tool);
+      if (request.tool === 'simctl') {
+        await simulatorsBlocked;
+        return commandResult(JSON.stringify({ devices: {} }));
+      }
+      return commandResult(request.tool === 'xctrace' ? '== Devices ==' : '');
+    },
+  });
+
+  const discovery = createAppleInventorySource(host).discover({}, inventoryScope);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.ok(calls.includes('simctl'));
+  assert.ok(calls.includes('xctrace'));
+  releaseSimulators();
+  await discovery;
+});

--- a/packages/platform-apple/src/inventory.ts
+++ b/packages/platform-apple/src/inventory.ts
@@ -32,18 +32,24 @@ async function discoverAppleDevices(
     throw new AppError('TOOL_MISSING', 'xcrun not found in PATH');
   }
 
-  const simulators = await listAppleSimulators(host, request, scope);
-  if (request.kind === 'simulator') return simulators;
+  const simulatorDiscovery = listAppleSimulators(host, request, scope);
+  if (request.kind === 'simulator') return await simulatorDiscovery;
 
-  const withHost = [...simulators, hostMacDevice(host)];
-  if (
-    request.iosSimulatorSetPath ||
-    (request.udid && simulators.some((device) => device.id === request.udid))
-  ) {
-    return sortAppleDevicesForSelection(withHost);
+  if (request.iosSimulatorSetPath || request.udid) {
+    const simulators = await simulatorDiscovery;
+    const withHost = [...simulators, hostMacDevice(host)];
+    if (request.iosSimulatorSetPath || simulators.some((device) => device.id === request.udid)) {
+      return sortAppleDevicesForSelection(withHost);
+    }
+    const physical = await listPhysicalAppleDevices(host, scope);
+    return sortAppleDevicesForSelection(mergeAppleDevices(withHost, physical));
   }
 
-  const physical = await listPhysicalAppleDevices(host, scope);
+  const [simulators, physical] = await Promise.all([
+    simulatorDiscovery,
+    listPhysicalAppleDevices(host, scope),
+  ]);
+  const withHost = [...simulators, hostMacDevice(host)];
   return sortAppleDevicesForSelection(mergeAppleDevices(withHost, physical));
 }
 

--- a/src/__tests__/test-utils/host-process-mock.ts
+++ b/src/__tests__/test-utils/host-process-mock.ts
@@ -1,4 +1,6 @@
 type HostProcessModule = typeof import('../../utils/host-process.ts');
+type HostProcessIdentityObservation =
+  import('../../utils/host-process.ts').HostProcessIdentityObservation;
 
 /**
  * `vi.mock` factory for `utils/host-process.ts` in tests that seed a "live"
@@ -8,8 +10,8 @@ type HostProcessModule = typeof import('../../utils/host-process.ts');
  * readProcessStartTime shells out to `ps` with a 1s timeout; under full-suite
  * CPU contention a re-read can miss that deadline and return null, mismatching
  * the seeded value and flipping a genuinely-live owner to 'owner-process-dead'.
- * This factory reads our own pid's start time once for real, then serves the
- * cached value so every read is self-consistent. Other pids read as null, same
+ * This factory assigns our own pid a stable synthetic start time, then serves
+ * that value so every read is self-consistent without a subprocess. Other pids read as null, same
  * as a real `ps` miss. isProcessAlive stays real (a plain `kill(pid, 0)`
  * syscall, not a subprocess), so fabricated dead-pid fixtures still classify
  * as dead through that non-flaky check.
@@ -25,15 +27,23 @@ export async function pinOwnProcessStartTime(
   importOriginal: () => Promise<HostProcessModule>,
 ): Promise<HostProcessModule> {
   const actual = await importOriginal();
-  let cachedOwnStartTime: string | null | undefined;
+  const ownStartTime = 'test-process-start-time';
   return {
     ...actual,
     readProcessStartTime: (pid: number) => {
       if (pid !== process.pid) return null;
-      if (cachedOwnStartTime === undefined) {
-        cachedOwnStartTime = actual.readProcessStartTime(process.pid);
+      return ownStartTime;
+    },
+    readHostProcessIdentityObservations: (pids: Iterable<number>) => {
+      const selected = [...pids];
+      const observations = new Map<number, HostProcessIdentityObservation>();
+      if (selected.includes(process.pid)) {
+        observations.set(process.pid, {
+          state: 'S',
+          startTime: ownStartTime,
+        });
       }
-      return cachedOwnStartTime;
+      return observations;
     },
   };
 }

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -5,7 +5,11 @@ import {
   matchesPlatformSelector,
   type PlatformSelector,
 } from '@agent-device/kernel/device';
-import { classifyOwnerLiveness, type OwnerLiveness } from '../utils/owner-identity.ts';
+import {
+  classifyOwnerLivenessFromObservation,
+  type OwnerLiveness,
+} from '../utils/owner-identity.ts';
+import { readHostProcessIdentityObservations } from '../utils/host-process.ts';
 import { resolveDeviceClaimRoot } from './device-claim-paths.ts';
 import type { DeviceClaim } from './device-claims.ts';
 
@@ -32,11 +36,20 @@ export function inspectDeviceClaims(selectors: DeviceClaimSelectors): InspectedD
   const root = resolveDeviceClaimRoot();
   const listed = readClaimEntries(root);
   if ('claims' in listed) return listed.claims;
-  return listed.entries
+  const parsed = listed.entries
     .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
-    .map((entry) => inspectDeviceClaimFile(path.join(root, entry.name)))
+    .map((entry) => readDeviceClaimFile(path.join(root, entry.name)))
     .filter((entry): entry is InspectedDeviceClaim => entry !== null)
     .filter((entry) => matchesClaimSelectors(entry.claim, selectors));
+  const observations = readHostProcessIdentityObservations(
+    parsed.flatMap((entry) => (entry.claim ? [entry.claim.ownerPid] : [])),
+  );
+  return parsed.map((entry) =>
+    classifyInspectedClaim(
+      entry,
+      entry.claim ? (observations.get(entry.claim.ownerPid) ?? null) : null,
+    ),
+  );
 }
 
 function readClaimEntries(
@@ -81,6 +94,13 @@ function matchesClaimPlatform(claim: DeviceClaim, platform: PlatformSelector | u
 }
 
 export function inspectDeviceClaimFile(filePath: string): InspectedDeviceClaim | null {
+  const entry = readDeviceClaimFile(filePath);
+  if (!entry?.claim) return entry;
+  const observations = readHostProcessIdentityObservations([entry.claim.ownerPid]);
+  return classifyInspectedClaim(entry, observations.get(entry.claim.ownerPid) ?? null);
+}
+
+function readDeviceClaimFile(filePath: string): InspectedDeviceClaim | null {
   const fileName = path.basename(filePath);
   try {
     return inspectClaimContents(fileName, fs.readFileSync(filePath, 'utf8'));
@@ -103,14 +123,28 @@ function inspectClaimContents(fileName: string, contents: string): InspectedDevi
       fileName,
       deviceKey: claim.deviceKey,
       claim,
-      classification: classifyOwnerLiveness({
-        owner: { pid: claim.ownerPid, startTime: claim.ownerStartTime },
-        stateDir: claim.stateDir,
-      }),
+      classification: 'unknown',
     };
   } catch (error) {
     return { fileName, classification: 'inconsistent', error: String(error) };
   }
+}
+
+function classifyInspectedClaim(
+  entry: InspectedDeviceClaim,
+  observation: Parameters<typeof classifyOwnerLivenessFromObservation>[1],
+): InspectedDeviceClaim {
+  if (!entry.claim) return entry;
+  return {
+    ...entry,
+    classification: classifyOwnerLivenessFromObservation(
+      {
+        owner: { pid: entry.claim.ownerPid, startTime: entry.claim.ownerStartTime },
+        stateDir: entry.claim.stateDir,
+      },
+      observation,
+    ),
+  };
 }
 
 function normalizeClaim(value: unknown): DeviceClaim | null {

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -21,10 +21,11 @@ vi.mock('../../../platforms/android/ime-lifecycle.ts', () => ({
   activateAndroidTestIme: vi.fn(async () => {}),
   restoreAndroidTestIme: vi.fn(async () => ({ restored: false, reason: 'no-record' })),
 }));
-vi.mock('../../../utils/host-process.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../utils/host-process.ts')>();
-  return { ...actual, readProcessStartTime: vi.fn(() => 'test-process-start') };
-});
+vi.mock('../../../utils/host-process.ts', async (importOriginal) =>
+  (await import('../../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
+    importOriginal,
+  ),
+);
 
 import { dispatchCommand, resolveTargetDevice } from '../../../core/dispatch.ts';
 import { ensureDeviceReady } from '../../device-ready.ts';

--- a/src/utils/__tests__/host-process-liveness.test.ts
+++ b/src/utils/__tests__/host-process-liveness.test.ts
@@ -8,7 +8,7 @@ vi.mock('../exec.ts', async () => {
   return { ...actual, runCmdSync: mockRunCmdSync };
 });
 
-import { isProcessZombie } from '../host-process.ts';
+import { isProcessZombie, readHostProcessIdentityObservations } from '../host-process.ts';
 
 function psReturns(stdout: string, exitCode = 0): void {
   mockRunCmdSync.mockReturnValue({ stdout, stderr: '', exitCode });
@@ -37,4 +37,28 @@ test('isProcessZombie treats running states and ps failures as not zombie', () =
 test('isProcessZombie returns false for an invalid pid without invoking ps', () => {
   assert.equal(isProcessZombie(-1), false);
   assert.equal(mockRunCmdSync.mock.calls.length, 0);
+});
+
+test('reads many process identities from one ps snapshot', () => {
+  psReturns(`4242 Ss   Mon Aug 10 20:00:00 2026
+4343 ZN   Mon Aug 10 20:01:00 2026
+`);
+
+  const observations = readHostProcessIdentityObservations([4242, 4343, 4242]);
+
+  assert.deepEqual(observations.get(4242), {
+    state: 'Ss',
+    startTime: 'Mon Aug 10 20:00:00 2026',
+  });
+  assert.deepEqual(observations.get(4343), {
+    state: 'ZN',
+    startTime: 'Mon Aug 10 20:01:00 2026',
+  });
+  assert.equal(mockRunCmdSync.mock.calls.length, 1);
+  assert.deepEqual(mockRunCmdSync.mock.calls[0]?.[1], [
+    '-p',
+    '4242,4343',
+    '-o',
+    'pid=,state=,lstart=',
+  ]);
 });

--- a/src/utils/__tests__/owner-identity-liveness.test.ts
+++ b/src/utils/__tests__/owner-identity-liveness.test.ts
@@ -13,7 +13,7 @@ vi.mock('../host-process.ts', () => ({
   readProcessStartTime: mockReadProcessStartTime,
 }));
 
-import { classifyOwnerLiveness } from '../owner-identity.ts';
+import { classifyOwnerLiveness, classifyOwnerLivenessFromObservation } from '../owner-identity.ts';
 
 const OWNER_PID = 4242;
 
@@ -49,4 +49,13 @@ test('a null-start-time owner stays fail-closed while its pid is alive', () => {
   // a clock step could make a live owner look like it started after the
   // resource was acquired, so an alive pid must never be condemned on age.
   assert.equal(classifyOwnerLiveness({ owner: { pid: OWNER_PID, startTime: null } }), 'live');
+});
+
+test('a missing entry in a completed process snapshot stays fail-closed without another ps read', () => {
+  assert.equal(
+    classifyOwnerLivenessFromObservation({ owner: { pid: OWNER_PID, startTime: 'start-a' } }, null),
+    'live',
+  );
+  assert.equal(mockIsProcessZombie.mock.calls.length, 0);
+  assert.equal(mockReadProcessStartTime.mock.calls.length, 0);
 });

--- a/src/utils/host-process.ts
+++ b/src/utils/host-process.ts
@@ -10,6 +10,11 @@ export type HostProcessInfo = {
   command: string;
 };
 
+export type HostProcessIdentityObservation = Readonly<{
+  state: string;
+  startTime: string;
+}>;
+
 type HostProcessRunCommand = (
   cmd: string,
   args: string[],
@@ -60,6 +65,31 @@ export function readProcessCommand(pid: number): string | null {
 // process state exposes that it already terminated.
 export function isProcessZombie(pid: number): boolean {
   return readProcessField(pid, 'state=')?.startsWith('Z') ?? false;
+}
+
+export function readHostProcessIdentityObservations(
+  pids: Iterable<number>,
+): ReadonlyMap<number, HostProcessIdentityObservation> {
+  const observations = new Map<number, HostProcessIdentityObservation>();
+  const selected = uniquePositivePids(pids);
+  if (selected.length === 0) return observations;
+  try {
+    const result = runCmdSync('ps', ['-p', selected.join(','), '-o', 'pid=,state=,lstart='], {
+      allowFailure: true,
+      timeoutMs: PS_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) return observations;
+    for (const line of result.stdout.split('\n')) {
+      const match = /^\s*(\d+)\s+(\S+)\s+(.+?)\s*$/.exec(line);
+      if (!match) continue;
+      const pid = Number.parseInt(match[1]!, 10);
+      if (!Number.isInteger(pid) || pid <= 0) continue;
+      observations.set(pid, { state: match[2]!, startTime: match[3]! });
+    }
+  } catch {
+    // A failed ps snapshot is unknown evidence; callers remain fail-closed.
+  }
+  return observations;
 }
 
 function readProcessField(pid: number, field: 'lstart=' | 'command=' | 'state='): string | null {

--- a/src/utils/owner-identity.ts
+++ b/src/utils/owner-identity.ts
@@ -1,5 +1,10 @@
 import fs from 'node:fs';
-import { isProcessAlive, isProcessZombie, readProcessStartTime } from './host-process.ts';
+import {
+  isProcessAlive,
+  isProcessZombie,
+  readProcessStartTime,
+  type HostProcessIdentityObservation,
+} from './host-process.ts';
 
 export type OwnerIdentity = {
   pid: number;
@@ -37,11 +42,26 @@ export function classifyOwnerLiveness(params: {
   owner: Pick<OwnerIdentity, 'pid' | 'startTime'>;
   stateDir?: string;
 }): OwnerLiveness {
+  return classifyOwnerLivenessFromObservation(params);
+}
+
+export function classifyOwnerLivenessFromObservation(
+  params: {
+    owner: Pick<OwnerIdentity, 'pid' | 'startTime'>;
+    stateDir?: string;
+  },
+  observation?: HostProcessIdentityObservation | null,
+): OwnerLiveness {
   const { owner, stateDir } = params;
   if (!isProcessAlive(owner.pid)) return 'owner-process-dead';
-  if (isProcessZombie(owner.pid)) return 'owner-process-dead';
+  if (observation !== undefined ? observation?.state.startsWith('Z') : isProcessZombie(owner.pid)) {
+    return 'owner-process-dead';
+  }
   if (owner.startTime) {
-    const currentStartTime = readProcessStartTime(owner.pid);
+    const currentStartTime =
+      observation !== undefined
+        ? (observation?.startTime ?? null)
+        : readProcessStartTime(owner.pid);
     if (currentStartTime !== null && currentStartTime !== owner.startTime) {
       return 'owner-process-dead';
     }


### PR DESCRIPTION
## Summary

- overlap Apple simulator and physical-device discovery for unscoped inventory, reducing the same-run Apple critical path from about 2.39s to 1.53s
- classify advisory device claims from one batched process snapshot instead of two synchronous ps launches per live claim; 159-claim status improved from 2.66s to 0.14s
- keep device results atomic for JSON, SDK, and MCP consumers; partial-result streaming was evaluated but would complicate agent merge semantics without reducing completion latency

The change touches 9 files and stays within the devices/device-status command family and their shared process-liveness seam. No docs or skills changed because command syntax, output shape, and workflow guidance are unchanged.

## Validation

`pnpm check:affected --run` passed immediately before push: 296 test files / 2,655 tests, 95% changed-line coverage, plus format, lint, typecheck, layering, Fallow, build, interaction contracts, and provider integration.

Regression evidence: the Apple concurrency test failed before the production change because only simctl started while simulator discovery was blocked; it passes with physical discovery starting concurrently. Batched process observation is covered by a one-ps-call test and fail-closed missing-observation coverage.

Manual host timing used the real Apple device services and 159 advisory claims. Cold CoreDevice startup remains externally variable and produced one ~11s outlier; the fix removes serialized simulator latency from that path rather than caching potentially stale inventory.
