### PR TITLE
test: fail closed on unknown recording provider commands

### DIFF
--- a/test/integration/provider-scenarios/android-recording-fixtures.ts
+++ b/test/integration/provider-scenarios/android-recording-fixtures.ts
@@ -75,7 +75,9 @@ export function seedAndroidRecordingResource(
           scope: manifest.scope,
           showTouches: manifest.showTouches,
           recordOnlySession: manifest.recordOnlySession,
-          exportQuality: manifest.exportQuality,
+          ...(manifest.exportQuality === undefined
+            ? {}
+            : { exportQuality: manifest.exportQuality }),
           transportMode: manifest.transportMode,
         },
       },

--- a/test/integration/provider-scenarios/android-recording-manifest-fixtures.ts
+++ b/test/integration/provider-scenarios/android-recording-manifest-fixtures.ts
@@ -21,7 +21,7 @@ export type AndroidRecordingManifestFixture = {
   scope: 'device';
   showTouches: boolean;
   recordOnlySession: boolean;
-  exportQuality: 'medium' | 'high';
+  exportQuality?: 'medium' | 'high';
   transportMode: 'transport-composed';
   chunks: NativeChunk[];
   pendingRemotePath?: string;
@@ -126,7 +126,7 @@ function hasCaptureSettings(value: JsonObject): boolean {
     value.scope === 'device' &&
     isBooleanProperty(value, 'showTouches') &&
     isBooleanProperty(value, 'recordOnlySession') &&
-    isExportQuality(value.exportQuality) &&
+    isOptionalExportQuality(value.exportQuality) &&
     value.transportMode === 'transport-composed' &&
     hasChunkList(value.chunks) &&
     hasOptionalString(value, 'pendingRemotePath') &&
@@ -172,6 +172,10 @@ function isBooleanProperty(value: JsonObject, key: string): boolean {
 
 function isExportQuality(value: JsonValue | undefined): boolean {
   return value === 'medium' || value === 'high';
+}
+
+function isOptionalExportQuality(value: JsonValue | undefined): boolean {
+  return value === undefined || isExportQuality(value);
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/test/integration/provider-scenarios/android-recording-provider-fixtures.test.ts
+++ b/test/integration/provider-scenarios/android-recording-provider-fixtures.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { createAndroidRecordingProvider } from './android-recording-provider-fixtures.ts';
+
+test('Android recording provider fixtures reject unmodeled executable commands', async () => {
+  const provider = createAndroidRecordingProvider({ calls: [] });
+
+  await assert.rejects(
+    provider.exec(['shell', 'echo unmodeled-provider-command']),
+    /Unhandled Android recording provider command: shell echo unmodeled-provider-command/,
+  );
+});

--- a/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
+++ b/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
@@ -50,7 +50,9 @@ function respondToCommand(
   const pull = respondToPull(args, params, state);
   if (pull) return pull;
   if (args.join(' ') === 'shell getprop sys.boot_completed') return ok('1\n');
-  return respondToShellCommand(args[1] ?? '', state);
+  const response = args[0] === 'shell' ? respondToShellCommand(args[1] ?? '', state) : undefined;
+  if (response) return response;
+  throw new Error(`Unhandled Android recording provider command: ${args.join(' ')}`);
 }
 
 function respondToPull(
@@ -108,10 +110,19 @@ function respondToManifestTarget(
 
 function respondToProcessCommand(command: string, processes: Map<string, NativeProcess>) {
   return (
+    respondToProcessList(command, processes) ??
     respondToProcessDirectory(command, processes) ??
     respondToProcessMetadata(command, processes) ??
     respondToProcessSignal(command, processes)
   );
+}
+
+function respondToProcessList(command: string, processes: Map<string, NativeProcess>) {
+  if (command !== 'ps -A -o pid=') return undefined;
+  const alivePids = [...processes.entries()]
+    .filter(([, nativeProcess]) => nativeProcess.alive)
+    .map(([pid]) => pid);
+  return ok(alivePids.length > 0 ? `${alivePids.join('\n')}\n` : '');
 }
 
 function respondToProcessDirectory(command: string, processes: Map<string, NativeProcess>) {
@@ -148,8 +159,16 @@ function respondToScreenrecordCommand(command: string, processes: Map<string, Na
 }
 
 function respondToArtifactCommand(command: string) {
-  if (command.startsWith('test -e ')) return ok();
-  return command.startsWith('stat -c %s ') ? ok('2048\n') : ok();
+  for (const prefix of ['test -e ', 'rm -f ']) {
+    const target = shellPath(command, prefix);
+    if (target && isRecordingArtifactPath(target)) return ok();
+  }
+  const target = shellPath(command, 'stat -c %s ');
+  return target && isRecordingArtifactPath(target) ? ok('2048\n') : undefined;
+}
+
+function isRecordingArtifactPath(path: string): boolean {
+  return /^\/(?:sdcard|data\/local\/tmp)\/agent-device-recording-\d+\.mp4$/.test(path);
 }
 
 function addManifestProcesses(


### PR DESCRIPTION
## Summary

Make the Android recording provider fixture fail closed when production executes an unmodeled command. Explicitly model process enumeration and recording-artifact commands, and align the native-manifest fixture with the production contract where export quality is optional.

This makes provider transcript drift fail loudly instead of returning a fabricated successful result. It is the first bounded Tier A hardening step from #1680; it does not introduce a generic virtual-device framework.

## Validation

The new tracer was first observed red with `Missing expected rejection` against the previous catch-all response. Tightening then exposed and replaced two hidden fixture assumptions: unmodeled process enumeration and a falsely required export-quality field.

`pnpm check:affected --run` passes, including formatting, lint, full typecheck, Fallow, and four related provider-integration files with 8/8 tests.
