### PR TITLE
fix: validate macOS recording finalization

### DIFF
--- a/packages/platform-apple/src/recording/completion.ts
+++ b/packages/platform-apple/src/recording/completion.ts
@@ -1,3 +1,4 @@
+import { asAppError } from '@agent-device/kernel/errors';
 import type { ScreenRecordingLiveSnapshot } from '@agent-device/contracts/platform';
 import { createScreenRecordingCompletion } from '@agent-device/capture-kit';
 import type { AppleScreenRecordingOperationHost } from './recovery.ts';
@@ -10,22 +11,27 @@ export async function completeAppleRecording(
   if (snapshot.invalidatedReason && !snapshot.showTouches) {
     throw new Error(`recording invalidated: ${snapshot.invalidatedReason}`);
   }
-  const finalization = await host.screenRecording.finalize.complete({
-    outputPath: snapshot.outPath,
-    showTouches: snapshot.invalidatedReason ? false : snapshot.showTouches,
-    gestureEvents: snapshot.gestureEvents,
-    exportQuality: snapshot.exportQuality ?? 'medium',
-    ...(snapshot.runnerStartedAtUptimeMs !== undefined &&
-    snapshot.targetAppReadyUptimeMs !== undefined
-      ? {
-          trimStartMs: Math.max(
-            0,
-            snapshot.targetAppReadyUptimeMs - snapshot.runnerStartedAtUptimeMs,
-          ),
-        }
-      : {}),
-    targetLabel,
-  });
+  let finalization;
+  try {
+    finalization = await host.screenRecording.finalize.complete({
+      outputPath: snapshot.outPath,
+      showTouches: snapshot.invalidatedReason ? false : snapshot.showTouches,
+      gestureEvents: snapshot.gestureEvents,
+      exportQuality: snapshot.exportQuality ?? 'medium',
+      ...(snapshot.runnerStartedAtUptimeMs !== undefined &&
+      snapshot.targetAppReadyUptimeMs !== undefined
+        ? {
+            trimStartMs: Math.max(
+              0,
+              snapshot.targetAppReadyUptimeMs - snapshot.runnerStartedAtUptimeMs,
+            ),
+          }
+        : {}),
+      targetLabel,
+    });
+  } catch (error) {
+    throw asAppError(error, 'COMMAND_FAILED');
+  }
   return createScreenRecordingCompletion(snapshot, {
     ...finalization,
     ...(snapshot.invalidatedReason

--- a/packages/platform-apple/src/recording/runtime.ts
+++ b/packages/platform-apple/src/recording/runtime.ts
@@ -1,4 +1,5 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
+import { asAppError } from '@agent-device/kernel/errors';
 import type {
   CleanupOutcome,
   RuntimeOwnerRef,
@@ -138,13 +139,11 @@ async function startAppleRunnerRecording(params: AppleRecordingStartParams) {
   } as const;
   let runnerStop: Promise<void> | undefined;
   const stopRunner = () =>
-    (runnerStop ??= host.screenRecording.apple
-      .runRunner(device, {
-        kind: 'stop',
-        appBundleId,
-        ...runnerOwnership,
-      })
-      .then(() => undefined));
+    (runnerStop ??= runAppleRecordingOperation(() =>
+      host.screenRecording.apple
+        .runRunner(device, { kind: 'stop', appBundleId, ...runnerOwnership })
+        .then(() => undefined),
+    ));
   if (!runnerDescriptorMatchesDevice(device, result.remotePath)) {
     await stopRunner().catch(() => {});
     throw new Error('Apple runner recording did not expose coherent durable media ownership');
@@ -187,6 +186,14 @@ async function startAppleRunnerRecording(params: AppleRecordingStartParams) {
       return { status: 'cleaned' } as const;
     },
   });
+}
+
+async function runAppleRecordingOperation<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    throw asAppError(error, 'COMMAND_FAILED');
+  }
 }
 
 function runnerDescriptorMatchesDevice(

--- a/src/daemon/handlers/__tests__/session-close-shutdown.test.ts
+++ b/src/daemon/handlers/__tests__/session-close-shutdown.test.ts
@@ -543,6 +543,33 @@ test('close finalizes an active iOS simulator recording before deleting the sess
   );
 });
 
+test('close resolves a recording resource through the effective session key', async () => {
+  const sessionStore = makeSessionStore();
+  const effectiveSessionName = 'cwd:0123456789abcdef:default';
+  const session = makeIosSimulatorRecordingSession(sessionStore, effectiveSessionName);
+  session.name = 'default';
+  const finish = recordingFinishMock(session);
+  sessionStore.set(effectiveSessionName, session);
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'close',
+      positionals: [],
+      flags: {},
+    },
+    sessionName: effectiveSessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(finish).toHaveBeenCalledOnce();
+  expect(sessionStore.get(effectiveSessionName)).toBeUndefined();
+});
+
 test('close surfaces a recording finalization failure through the cleanup-failure channel', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-recording-close-failure-session';

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -107,7 +107,7 @@ async function runSessionCloseTeardown(params: {
     }
   };
   const retainAppleRunner = shouldRetainAppleRunnerAfterClose(req, session);
-  await stopBestEffortSessionResources(session, sessionStore, attemptCleanup);
+  await stopBestEffortSessionResources(session, sessionName, sessionStore, attemptCleanup);
   const platformCloseError = repairArmed
     ? undefined
     : await dispatchTargetedPlatformClose({ req, session, logPath });
@@ -126,21 +126,22 @@ type CleanupRunner = (step: string, run: () => Promise<void>) => Promise<void>;
 
 async function stopBestEffortSessionResources(
   session: SessionState,
+  sessionName: string,
   sessionStore: SessionStore,
   attemptCleanup: CleanupRunner,
 ): Promise<void> {
   // Recording overlay finalization needs the Apple runner.
-  const currentSession = sessionStore.get(session.name) ?? session;
+  const currentSession = sessionStore.get(sessionName) ?? session;
   if (currentSession.screenRecording) {
     await attemptCleanup('recording', () =>
       finishSessionScreenRecording({
         session: currentSession,
-        sessionName: session.name,
+        sessionName,
         sessionStore,
       }),
     );
   }
-  await attemptCleanup('app_log', () => stopSessionAppLog({ session, sessionStore }));
+  await attemptCleanup('app_log', () => stopSessionAppLog({ session, sessionName, sessionStore }));
   await attemptCleanup('audio_probe', async () => {
     await stopSessionAudioProbe(session, 'session-close');
   });

--- a/src/daemon/server/daemon-runtime-recording-teardown.test.ts
+++ b/src/daemon/server/daemon-runtime-recording-teardown.test.ts
@@ -127,3 +127,38 @@ test('daemon shutdown awaits durable recording finalization inside its extended 
   expect(stderrChunks.join('')).not.toMatch(/timed out/);
   expect(sessionStore.get(session.name)).toBeUndefined();
 });
+
+test('daemon shutdown resolves durable recording resources through the effective session key', async () => {
+  const root = mkdtempForTestSync('agent-device-shutdown-effective-session-');
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const effectiveSessionName = 'cwd:0123456789abcdef:default';
+  const session = makeRecordingSession({
+    name: effectiveSessionName,
+    sessionStore,
+    finish: async () => ({
+      status: 'completed' as const,
+      result: {
+        backend: 'simctl recordVideo',
+        outPath: path.join(root, 'recording.mp4'),
+        startedAt: 1,
+        completedAt: 2,
+        scope: 'app' as const,
+        showTouches: false,
+        recordOnlySession: false,
+      },
+    }),
+  });
+  session.name = 'default';
+  sessionStore.set(effectiveSessionName, session);
+  const stderrChunks: string[] = [];
+
+  await teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir: root,
+    stderr: { write: (chunk) => stderrChunks.push(chunk) },
+  });
+
+  expect(stderrChunks.join('')).not.toMatch(/resource record is missing/);
+  expect(sessionStore.get(effectiveSessionName)).toBeUndefined();
+});

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -107,11 +107,16 @@ export async function teardownDaemonSessionForShutdown(params: {
   afterSuccessfulTeardown?: (session: SessionState) => Promise<void>;
 }): Promise<void> {
   const { session, sessionStore, stateDir, stderr, beforeDelete, afterSuccessfulTeardown } = params;
+  const sessionName = sessionStore.resolveStoredSessionName(session);
   const timeoutMs = resolveDaemonSessionTeardownTimeoutMs(session);
   // The ownership-fenced app-log side effect must settle while this process
   // still owns the daemon lock. It is intentionally outside the generic
   // teardown race so lock release and runtime shutdown cannot overtake it.
-  const appLogTeardownSucceeded = await stopSessionAppLog({ session, sessionStore }).then(
+  const appLogTeardownSucceeded = await stopSessionAppLog({
+    session,
+    sessionName,
+    sessionStore,
+  }).then(
     () => true,
     (error) => {
       stderr.write(
@@ -122,11 +127,11 @@ export async function teardownDaemonSessionForShutdown(params: {
       return false;
     },
   );
-  const sessionAfterAppLog = sessionStore.get(session.name) ?? session;
+  const sessionAfterAppLog = sessionStore.get(sessionName) ?? session;
   const teardown = teardownSessionResources({
     appLog: 'already-settled',
     session: sessionAfterAppLog,
-    sessionName: session.name,
+    sessionName,
     sessionStore,
     stateDir,
   }).then(
@@ -154,7 +159,7 @@ export async function teardownDaemonSessionForShutdown(params: {
   sessionStore.finalizeRepairTeardown(session);
   await beforeDelete?.(session);
   if (teardownSucceeded) await afterSuccessfulTeardown?.(session);
-  sessionStore.delete(session.name);
+  sessionStore.delete(sessionName);
 }
 
 export type DaemonRuntimeOptions = {

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -309,7 +309,11 @@ export class SessionStore {
     return expandSessionPath(filePath, cwd);
   }
 
-  private resolveStoredSessionName(session: SessionState): string {
+  /**
+   * Resolve the map key for a live session object. SessionState.name is the
+   * public session name, while the map key may include cwd/tenant isolation.
+   */
+  resolveStoredSessionName(session: SessionState): string {
     for (const [name, value] of this.sessions) {
       if (value === session) return name;
     }

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -43,15 +43,16 @@ export async function stopAppleRunnerForClose(session: SessionState): Promise<vo
 
 export async function stopSessionAppLog(params: {
   session: SessionState;
+  sessionName: string;
   sessionStore: SessionStore;
 }): Promise<void> {
-  const { session, sessionStore } = params;
+  const { session, sessionName, sessionStore } = params;
   if (!session.appLog) return;
   await forceCleanupSessionAppLog({
     session,
-    sessionName: session.name,
+    sessionName,
     sessionStore,
-    resourcePath: appLogResourceStore.resolvePath(sessionStore.resolveSessionDir(session.name)),
+    resourcePath: appLogResourceStore.resolvePath(sessionStore.resolveSessionDir(sessionName)),
   });
 }
 
@@ -170,7 +171,7 @@ export async function teardownSessionResources(
       ? [
           {
             step: 'app_log',
-            run: () => stopSessionAppLog({ session, sessionStore }),
+            run: () => stopSessionAppLog({ session, sessionName, sessionStore }),
           },
         ]
       : [];

--- a/src/platform-runtime-screen-recording-apple-runner-transport.test.ts
+++ b/src/platform-runtime-screen-recording-apple-runner-transport.test.ts
@@ -28,6 +28,14 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const macosDevice = {
+  ...device,
+  appleOs: 'macos' as const,
+  id: 'host-macos-local',
+  name: 'Mac',
+  target: 'desktop' as const,
+};
+
 test('scopes an unavailable runner authority instead of falling back to a local lease', async () => {
   await withAppleRunnerScreenRecordingTransport(undefined, async () => {
     const transport = resolveAppleRunnerScreenRecordingTransport();
@@ -96,4 +104,28 @@ test('does not issue an unowned stop when runner acquisition exposes no session 
   ).rejects.toThrow('did not expose a durable runner session identity');
 
   expect(runner.run).toHaveBeenCalledOnce();
+});
+
+test('keeps macOS runner recording ownership local to the requested output path', async () => {
+  runner.snapshot.mockReturnValue({ sessionId: 'runner-session-1', alive: true });
+  runner.run.mockResolvedValue({ recorderStartUptimeMs: 42 });
+  const transport = resolveAppleRunnerScreenRecordingTransport();
+
+  await expect(
+    transport.start({
+      device: macosDevice,
+      appBundleId: 'com.apple.TextEdit',
+      outputPath: '/tmp/capture.mp4',
+    }),
+  ).resolves.toEqual({ runnerSessionId: 'runner-session-1', recorderStartUptimeMs: 42 });
+
+  expect(runner.run).toHaveBeenCalledWith(
+    macosDevice,
+    {
+      command: 'recordStart',
+      outPath: '/tmp/capture.mp4',
+      appBundleId: 'com.apple.TextEdit',
+    },
+    { signal: undefined },
+  );
 });

--- a/src/platform-runtime-screen-recording-apple-runner-transport.ts
+++ b/src/platform-runtime-screen-recording-apple-runner-transport.ts
@@ -62,7 +62,8 @@ async function startLocalAppleRunnerRecording({
   const { getRunnerSessionSnapshot, runAppleRunnerCommand } =
     await import('./platforms/apple/core/runner/runner-client.ts');
   const recordingFileName = `agent-device-recording-${Date.now()}.mp4`;
-  const remotePath = device.kind === 'device' ? `tmp/${recordingFileName}` : undefined;
+  const remotePath =
+    device.appleOs === 'macos' || device.kind !== 'device' ? undefined : `tmp/${recordingFileName}`;
   const result = await runAppleRunnerCommand(
     device,
     {

--- a/test/integration/provider-scenarios/macos-recording.test.ts
+++ b/test/integration/provider-scenarios/macos-recording.test.ts
@@ -2,14 +2,24 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from 'vitest';
-import { assertRecordingStarted, assertRecordingStopped, assertRpcOk } from './assertions.ts';
+import {
+  assertRecordingStarted,
+  assertRecordingStopped,
+  assertRpcError,
+  assertRpcOk,
+} from './assertions.ts';
 import { PROVIDER_SCENARIO_MACOS } from './fixtures.ts';
-import { createProviderScenarioTempPath, withProviderScenarioResource } from './harness.ts';
+import {
+  createProviderScenarioTempPath,
+  type ProviderScenarioHarness,
+  withProviderScenarioResource,
+} from './harness.ts';
 import { createMacOsDesktopWorld } from './macos-world.ts';
 import {
   createAppleRunnerProviderFromTranscript,
   createAppleRunnerScreenRecordingTransportFromTranscript,
 } from './providers.ts';
+import { screenRecordingResourceStore } from '../../../src/daemon/screen-recording-resource-store.ts';
 import { createProviderTranscript } from './transcript.ts';
 
 test('Provider-backed integration macOS recording uses focused exact runner authority', async () => {
@@ -17,40 +27,12 @@ test('Provider-backed integration macOS recording uses focused exact runner auth
     'agent-device-provider-scenario-macos-record',
     'mp4',
   );
-  const runnerTranscript = createProviderTranscript([
-    {
-      command: 'macos.runner.recordStart',
-      deviceId: PROVIDER_SCENARIO_MACOS.id,
-      platform: 'apple',
-      request: {
-        command: 'recordStart',
-        outPath: recordingPath,
-        fps: 30,
-        appBundleId: 'com.apple.systempreferences',
-      },
-      result: { runnerSessionId: 'macos-runner-recording-1' },
-    },
-    {
-      command: 'macos.runner.recordStop',
-      deviceId: PROVIDER_SCENARIO_MACOS.id,
-      platform: 'apple',
-      request: { command: 'recordStop', appBundleId: 'com.apple.systempreferences' },
-      result: {},
-    },
-  ]);
-  const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
-    runnerTranscript,
-    'macos.runner',
-  );
-  const appleRunnerScreenRecordingTransport =
-    createAppleRunnerScreenRecordingTransportFromTranscript(
-      runnerTranscript,
-      'macos.runner',
-      (outputPath) =>
-        fs.copyFileSync(
-          path.join(process.cwd(), 'website/docs/public/agent-device-contacts.mp4'),
-          outputPath,
-        ),
+  const { runnerTranscript, appleRunnerProvider, appleRunnerScreenRecordingTransport } =
+    createMacOsRecordingScenario(recordingPath, (outputPath) =>
+      fs.copyFileSync(
+        path.join(process.cwd(), 'website/docs/public/agent-device-contacts.mp4'),
+        outputPath,
+      ),
     );
   await withProviderScenarioResource(
     async () =>
@@ -75,3 +57,135 @@ test('Provider-backed integration macOS recording uses focused exact runner auth
     },
   );
 });
+
+test('Provider-backed integration macOS recording rejects runner-stop failure and retains cleanup state', async () => {
+  const recordingPath = createProviderScenarioTempPath(
+    'agent-device-provider-scenario-macos-stop-failure',
+    'mp4',
+  );
+  const stopError = 'macOS runner recordStop rejected';
+  const { runnerTranscript, appleRunnerProvider, appleRunnerScreenRecordingTransport } =
+    createMacOsRecordingScenario(recordingPath, undefined, stopError);
+
+  await withProviderScenarioResource(
+    async () =>
+      await createMacOsDesktopWorld({
+        appleRunnerProvider,
+        appleRunnerScreenRecordingTransport,
+      }),
+    async ({ daemon }) => {
+      await openMacOsSettings(daemon);
+
+      const recordStart = await daemon.callCommand('record', ['start', recordingPath], {
+        hideTouches: true,
+        fps: 30,
+      });
+      assertRecordingStarted(recordStart, { outPath: recordingPath, showTouches: false });
+
+      const recordStop = await daemon.callCommand('record', ['stop']);
+      assertRpcError(recordStop, 'COMMAND_FAILED', /recordStop rejected/);
+      assert.equal(recordStop.json?.result, undefined);
+
+      const session = daemon.session();
+      assert.ok(session?.screenRecording, 'failed stop must retain the live session resource');
+      const resource = screenRecordingResourceStore.read(
+        screenRecordingResourceStore.resolvePath(daemon.sessionDir()),
+      );
+      assert.equal(resource.status, 'decoded');
+      if (resource.status === 'decoded') {
+        assert.equal(resource.envelope.lifecycle, 'open');
+        assert.equal(resource.envelope.metadata?.phase, 'cleanup-pending');
+        assert.equal(resource.envelope.metadata?.cleanupStatus, 'cleanup-pending');
+      }
+      runnerTranscript.assertComplete();
+    },
+  );
+});
+
+test('Provider-backed integration macOS recording rejects an invalid MP4 before artifact publication', async () => {
+  const recordingPath = createProviderScenarioTempPath(
+    'agent-device-provider-scenario-macos-invalid-video',
+    'mp4',
+  );
+  const { runnerTranscript, appleRunnerProvider, appleRunnerScreenRecordingTransport } =
+    createMacOsRecordingScenario(recordingPath, (outputPath) =>
+      fs.writeFileSync(outputPath, Buffer.from('not an MP4')),
+    );
+
+  await withProviderScenarioResource(
+    async () =>
+      await createMacOsDesktopWorld({
+        appleRunnerProvider,
+        appleRunnerScreenRecordingTransport,
+      }),
+    async ({ daemon }) => {
+      await openMacOsSettings(daemon);
+
+      const recordStart = await daemon.callCommand('record', ['start', recordingPath], {
+        hideTouches: true,
+        fps: 30,
+      });
+      assertRecordingStarted(recordStart, { outPath: recordingPath, showTouches: false });
+
+      const recordStop = await daemon.callCommand('record', ['stop']);
+      assertRpcError(recordStop, 'COMMAND_FAILED', /was not finalized into a playable video/);
+      assert.equal(recordStop.json?.result, undefined);
+      assert.equal(daemon.session()?.screenRecording, undefined);
+
+      const resource = screenRecordingResourceStore.read(
+        screenRecordingResourceStore.resolvePath(daemon.sessionDir()),
+      );
+      assert.equal(resource.status, 'decoded');
+      if (resource.status === 'decoded') {
+        assert.equal(resource.envelope.lifecycle, 'completed');
+        assert.equal(resource.envelope.metadata?.phase, 'completed');
+        assert.equal(resource.envelope.metadata?.cleanupStatus, 'cleaned');
+      }
+      runnerTranscript.assertComplete();
+    },
+  );
+});
+
+function createMacOsRecordingScenario(
+  recordingPath: string,
+  onStopped?: (outputPath: string) => void,
+  stopError?: string,
+) {
+  const runnerTranscript = createProviderTranscript([
+    {
+      command: 'macos.runner.recordStart',
+      deviceId: PROVIDER_SCENARIO_MACOS.id,
+      platform: 'apple',
+      request: {
+        command: 'recordStart',
+        outPath: recordingPath,
+        fps: 30,
+        appBundleId: 'com.apple.systempreferences',
+      },
+      result: { runnerSessionId: 'macos-runner-recording-1' },
+    },
+    {
+      command: 'macos.runner.recordStop',
+      deviceId: PROVIDER_SCENARIO_MACOS.id,
+      platform: 'apple',
+      request: { command: 'recordStop', appBundleId: 'com.apple.systempreferences' },
+      ...(stopError === undefined ? { result: {} } : { error: stopError }),
+    },
+  ]);
+  return {
+    runnerTranscript,
+    appleRunnerProvider: createAppleRunnerProviderFromTranscript(runnerTranscript, 'macos.runner'),
+    appleRunnerScreenRecordingTransport: createAppleRunnerScreenRecordingTransportFromTranscript(
+      runnerTranscript,
+      'macos.runner',
+      onStopped,
+    ),
+  };
+}
+
+async function openMacOsSettings(
+  daemon: Pick<ProviderScenarioHarness, 'callCommand'>,
+): Promise<void> {
+  const open = await daemon.callCommand('open', ['settings'], { platform: 'macos' });
+  assert.equal(assertRpcOk(open).appBundleId, 'com.apple.systempreferences');
+}


### PR DESCRIPTION
## Summary

Closes #1249.

macOS Apple runner recordings now keep local media ownership coherent through start, stop, and finalization.

- Normalize Apple runner stop and finalizer failures as `COMMAND_FAILED` while preserving memoized cleanup ownership.
- Reject invalid or unstable MP4 output before artifact publication.
- Treat the local macOS host as a local-output runner target even though its device kind is `device`; this prevents a fabricated remote path from rejecting an otherwise valid recording.
- Add production-route provider coverage for successful macOS recording, stop rejection with cleanup-pending retention, invalid MP4 rejection, and the macOS transport ownership regression.
- No command-surface or documentation changes; the scope remains the Apple recording runtime.

## Validation

- `pnpm check:affected --run` passed with host networking: 92 test files, 393 tests, and 100% changed-line coverage (10/10).
- Focused transport, runtime, recovery, finalizer, and macOS provider scenarios passed.
- Live source-built TextEdit verification: `open TextEdit` and a healthy tree snapshot succeeded; `record start` returned the requested local output path.
- Live `record stop` repeatedly failed because the XCTest runner would not accept the reconnect. `ffprobe` correctly found the resulting file unfinalized (`moov atom not found`). The session was closed/deleted, but the recording manifest remains cleanup-pending because no runner process remained to accept exact-owner cleanup. The PR stays draft with this residual host-runner risk documented.