### PR TITLE
fix: preserve recording evidence across fault boundaries

### DIFF
--- a/packages/platform-android/src/recording/launch-boundary.test.ts
+++ b/packages/platform-android/src/recording/launch-boundary.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest';
+import { localRuntimeOwner } from '@agent-device/contracts/platform';
+import {
+  androidRecordingDevice,
+  recordingHost,
+  recordingInput,
+  recordingProcess,
+} from './fixtures.ts';
+import { bindAndroidScreenRecordingRuntime } from './runtime.ts';
+
+const start = async (overrides: Record<string, unknown>, signal = new AbortController().signal) =>
+  await bindAndroidScreenRecordingRuntime({
+    host: recordingHost(overrides),
+    device: androidRecordingDevice,
+    owner: localRuntimeOwner('android'),
+    signal,
+  });
+
+test('cancellation during active manifest publication retires evidence after confirmed rollback', async () => {
+  const controller = new AbortController();
+  const reason = new Error('recording canceled during active manifest publication');
+  const calls: string[] = [];
+  let manifest = '';
+  let writes = 0;
+  const runtime = await start(
+    {
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+        writes += 1;
+        if (writes === 2) {
+          controller.abort(reason);
+          throw reason;
+        }
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      removeManifest: async () => {
+        calls.push('remove-manifest');
+        manifest = '';
+        return true;
+      },
+      stop: async ({ pid }: { pid: string }) => {
+        calls.push(`signal:${pid}`);
+        return 'already-missing' as const;
+      },
+      remove: async () => {
+        calls.push('remove-artifact');
+        return true;
+      },
+    },
+    controller.signal,
+  );
+
+  await expect(runtime.screenRecordingStart(recordingInput())).rejects.toBe(reason);
+  expect(calls).toEqual(['signal:42', 'remove-artifact', 'remove-manifest']);
+  expect(manifest).toBe('');
+
+  const replacement = await start({
+    readManifest: async () =>
+      manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+    writeManifest: async ({ contents }: { contents: string }) => {
+      manifest = contents;
+    },
+  });
+  await expect(replacement.screenRecordingStart(recordingInput())).resolves.toMatchObject({
+    envelope: expect.any(Object),
+  });
+  expect(manifest).not.toBe('');
+});
+
+test('cancellation during active manifest publication retains evidence after uncertain rollback', async () => {
+  const controller = new AbortController();
+  const reason = new Error('recording canceled with uncertain active cleanup');
+  let manifest = '';
+  let writes = 0;
+  const runtime = await start(
+    {
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+        writes += 1;
+        if (writes === 2) {
+          controller.abort(reason);
+          throw reason;
+        }
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      stop: async () => 'ownership-lost' as const,
+      remove: async () => true,
+    },
+    controller.signal,
+  );
+
+  await expect(runtime.screenRecordingStart(recordingInput())).rejects.toBe(reason);
+  expect(manifest).not.toBe('');
+
+  const replacement = await start({
+    readManifest: async () => ({ status: 'read' as const, contents: manifest }),
+    start: async () => recordingProcess('43'),
+  });
+  await expect(replacement.screenRecordingStart(recordingInput())).rejects.toThrow(
+    'native recovery evidence already exists',
+  );
+});

--- a/packages/platform-android/src/recording/launch.test.ts
+++ b/packages/platform-android/src/recording/launch.test.ts
@@ -223,3 +223,77 @@ test('preserves cancellation before and after child acquisition without retries'
   expect(calls).toEqual(['start', 'signal:42:undefined', 'remove']);
   expect(disposals).toBe(0);
 });
+
+test('cancellation after child acquisition retires pending native evidence after rollback', async () => {
+  const controller = new AbortController();
+  const reason = new Error('recording canceled after native acquisition');
+  const calls: string[] = [];
+  let manifest = '';
+  const runtime = await start(
+    {
+      start: async () => {
+        calls.push('start');
+        controller.abort(reason);
+        return recordingProcess('42');
+      },
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      removeManifest: async () => {
+        calls.push('remove-manifest');
+        manifest = '';
+        return true;
+      },
+      stop: async ({ pid }: { pid: string }) => {
+        calls.push(`signal:${pid}`);
+        return 'already-missing' as const;
+      },
+      remove: async () => {
+        calls.push('remove-artifact');
+        return true;
+      },
+    },
+    controller.signal,
+  );
+
+  await expect(runtime.screenRecordingStart(recordingInput())).rejects.toBe(reason);
+  expect(calls).toEqual(['start', 'signal:42', 'remove-artifact', 'remove-manifest']);
+  expect(manifest).toBe('');
+});
+
+test('cancellation retains pending native evidence when rollback is unconfirmed', async () => {
+  const controller = new AbortController();
+  const reason = new Error('recording canceled with uncertain native cleanup');
+  const calls: string[] = [];
+  let manifest = '';
+  const runtime = await start(
+    {
+      start: async () => {
+        calls.push('start');
+        controller.abort(reason);
+        return recordingProcess('42');
+      },
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      removeManifest: async () => {
+        calls.push('remove-manifest');
+        manifest = '';
+        return true;
+      },
+      stop: async ({ pid }: { pid: string }) => {
+        calls.push(`signal:${pid}`);
+        return 'ownership-lost' as const;
+      },
+    },
+    controller.signal,
+  );
+
+  await expect(runtime.screenRecordingStart(recordingInput())).rejects.toBe(reason);
+  expect(calls).toEqual(['start', 'signal:42']);
+  expect(manifest).not.toBe('');
+});

--- a/packages/platform-android/src/recording/launch.ts
+++ b/packages/platform-android/src/recording/launch.ts
@@ -49,12 +49,7 @@ export async function startInitialTransaction(params: {
       chunk = await startChunkAt(transport, remotePath, input, signal);
     } catch (error) {
       if (signal.aborted) {
-        // `startChunkAt` has already rolled back the child and its artifact. Retire the
-        // pre-launch marker as well when that cleanup is confirmed; if the manifest removal
-        // itself is unavailable, leave the marker for fenced recovery instead of authorizing a
-        // replacement from an unproven state. The cancellation remains the primary outcome.
-        if (!(error instanceof AndroidScreenRecordingStartRollbackUnconfirmed))
-          await removeNativeManifest(transport, manifestPath).catch(() => {});
+        await retireCanceledLaunchMarker(transport, manifestPath, error);
         throw signal.reason;
       }
       await removeFailedCandidateManifest(transport, manifestPath, error);
@@ -69,12 +64,38 @@ export async function startInitialTransaction(params: {
         signal,
       );
     } catch (error) {
-      await rollbackChunks(transport, [chunk]).catch(() => {});
+      await rollbackPublishedChunk(transport, manifestPath, chunk);
       throw error;
     }
     return { chunk, manifestPath };
   }
   throw last ?? new Error('Android screenrecord did not begin producing frames');
+}
+
+async function retireCanceledLaunchMarker(
+  transport: Transport,
+  manifestPath: string,
+  launchError: unknown,
+): Promise<void> {
+  // `startChunkAt` has already rolled back the child and its artifact. Retire the pre-launch
+  // marker only when that cleanup is confirmed; otherwise leave it for fenced recovery.
+  if (launchError instanceof AndroidScreenRecordingStartRollbackUnconfirmed) return;
+  await removeNativeManifest(transport, manifestPath).catch(() => {});
+}
+
+async function rollbackPublishedChunk(
+  transport: Transport,
+  manifestPath: string,
+  chunk: NativeChunk,
+): Promise<void> {
+  try {
+    await rollbackChunks(transport, [chunk]);
+  } catch {
+    // Retain the pending marker when native cleanup is uncertain so a fenced recovery can prove
+    // ownership before a later start is admitted.
+    return;
+  }
+  await removeNativeManifest(transport, manifestPath).catch(() => {});
 }
 
 /**

--- a/packages/platform-android/src/recording/launch.ts
+++ b/packages/platform-android/src/recording/launch.ts
@@ -48,7 +48,15 @@ export async function startInitialTransaction(params: {
     try {
       chunk = await startChunkAt(transport, remotePath, input, signal);
     } catch (error) {
-      if (signal.aborted) throw signal.reason;
+      if (signal.aborted) {
+        // `startChunkAt` has already rolled back the child and its artifact. Retire the
+        // pre-launch marker as well when that cleanup is confirmed; if the manifest removal
+        // itself is unavailable, leave the marker for fenced recovery instead of authorizing a
+        // replacement from an unproven state. The cancellation remains the primary outcome.
+        if (!(error instanceof AndroidScreenRecordingStartRollbackUnconfirmed))
+          await removeNativeManifest(transport, manifestPath).catch(() => {});
+        throw signal.reason;
+      }
       await removeFailedCandidateManifest(transport, manifestPath, error);
       last = error;
       continue;

--- a/packages/platform-android/src/recording/recovery-cleanup.test.ts
+++ b/packages/platform-android/src/recording/recovery-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
 import { androidRecordingDevice, recordingHost, recordingInput } from './fixtures.ts';
 import { bindAndroidScreenRecordingRuntime } from './runtime.ts';
@@ -129,6 +129,36 @@ test('cleans verified dead evidence so a later start is admitted', async () => {
     envelope: expect.any(Object),
   });
   expect(starts).toBe(2);
+});
+
+test('retains evidence when the recorder presence probe is uncertain', async () => {
+  vi.useFakeTimers();
+  try {
+    let manifest = '';
+    const runtime = await start({
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      inspect: async () => 'uncertain' as const,
+      stop: async () => 'uncertain' as const,
+    });
+    const started = await runtime.screenRecordingStart(recordingInput());
+    const cleanup = runtime.screenRecordingCleanup({ envelope: started.envelope });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(cleanup).resolves.toMatchObject({
+      status: 'cleanup-pending',
+      reason: 'transport-failed',
+    });
+    expect(manifest).not.toBe('');
+    await expect(runtime.screenRecordingStart(recordingInput())).rejects.toThrow(
+      'native recovery evidence already exists',
+    );
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('rejects a tampered output path before native recovery side effects', async () => {

--- a/src/daemon/__tests__/screen-recording-boundary-faults.test.ts
+++ b/src/daemon/__tests__/screen-recording-boundary-faults.test.ts
@@ -1,0 +1,298 @@
+import path from 'node:path';
+import { expect, test, vi } from 'vitest';
+import {
+  createDurableResourceEnvelope,
+  createScreenRecordingLiveHandle,
+} from '@agent-device/capture-kit';
+import {
+  localRuntimeOwner,
+  PendingTransferGuard,
+  type CleanupOutcome,
+  type ReattachOutcome,
+  type ScreenRecordingCompletion,
+  type ScreenRecordingLiveHandle,
+} from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { countDiagnosticEventsByPhase, withDiagnosticsScope } from '../../utils/diagnostics.ts';
+import { createDurableCaptureAdmissionLedger } from '../durable-capture-admission-ledger.ts';
+import { createDurableCaptureResource } from '../durable-capture-resource.ts';
+import type { DurableCaptureResourceStore } from '../durable-capture-resource-store.ts';
+import { screenRecordingResourceStore } from '../screen-recording-resource-store.ts';
+import type { SessionState } from '../types.ts';
+
+type ScreenRecordingStore = DurableCaptureResourceStore<'screen-recording'>;
+
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+};
+
+test('cancellation after native acquisition cleans the pending handle and permits replacement', async () => {
+  const resource = createScreenRecordingTestResource();
+  const context = makeContext(resource);
+  const start = makeStart(context, { status: 'cleaned' });
+  const cancellation = new AppError('CANCELED', 'recording request canceled');
+
+  await expect(
+    resource.adoptStarted({
+      ...context,
+      ...start,
+      throwIfCanceled: () => {
+        throw cancellation;
+      },
+    }),
+  ).rejects.toBe(cancellation);
+
+  expect(start.forceCleanup).toHaveBeenCalledOnce();
+  expect(resource.store.read(context.resourcePath)).toMatchObject({
+    status: 'decoded',
+    envelope: { lifecycle: 'completed', metadata: { phase: 'completed' } },
+  });
+  expect(context.sessionStore.get(context.sessionName)?.screenRecording).toBeUndefined();
+  expect(() => resource.createNextFence(replacementFenceParams(context, resource))).not.toThrow();
+});
+
+test('durable manifest persistence failure preserves the primary error and blocks uncertain replacement', async () => {
+  const persistenceError = new Error('durable recording manifest write failed');
+  const resource = createScreenRecordingTestResource(failFirstWrite(persistenceError));
+  const context = makeContext(resource);
+  const start = makeStart(context, {
+    status: 'cleanup-pending',
+    reason: 'transport-failed',
+    message: 'native cleanup could not confirm recorder presence',
+  });
+
+  await withDiagnosticsScope({ command: 'record' }, async () => {
+    await expect(
+      resource.adoptStarted({ ...context, ...start, throwIfCanceled: () => {} }),
+    ).rejects.toBe(persistenceError);
+    expect(countDiagnosticEventsByPhase(['screen_recording_pending_adoption_cleanup_failed'])).toBe(
+      1,
+    );
+  });
+
+  expect(start.forceCleanup).toHaveBeenCalledOnce();
+  expect(resource.store.read(context.resourcePath)).toMatchObject({
+    status: 'decoded',
+    envelope: {
+      lifecycle: 'open',
+      metadata: { phase: 'cleanup-pending', cleanupStatus: 'cleanup-pending' },
+    },
+  });
+  expect(() => resource.createNextFence(replacementFenceParams(context, resource))).toThrow(
+    /terminal state/,
+  );
+});
+
+test('durable manifest persistence failure permits replacement after confirmed cleanup', async () => {
+  const persistenceError = new Error('durable recording manifest write failed');
+  const resource = createScreenRecordingTestResource(failFirstWrite(persistenceError));
+  const context = makeContext(resource);
+  const start = makeStart(context, { status: 'cleaned' });
+
+  await expect(
+    resource.adoptStarted({ ...context, ...start, throwIfCanceled: () => {} }),
+  ).rejects.toBe(persistenceError);
+
+  expect(start.forceCleanup).toHaveBeenCalledOnce();
+  expect(resource.store.read(context.resourcePath)).toMatchObject({
+    status: 'decoded',
+    envelope: { lifecycle: 'completed', metadata: { phase: 'completed' } },
+  });
+  expect(() => resource.createNextFence(replacementFenceParams(context, resource))).not.toThrow();
+});
+
+test('retains recording evidence when exact-owner recovery resolves after its deadline', async () => {
+  vi.useFakeTimers();
+  try {
+    const resource = createScreenRecordingTestResource();
+    const context = makeContext(resource);
+    const start = makeStart(context, {
+      status: 'cleanup-pending',
+      reason: 'transport-failed',
+      message: 'late recorder cleanup could not confirm presence',
+    });
+    resource.store.write(context.resourcePath, start.envelope);
+
+    type Reattach = ReattachOutcome<ScreenRecordingLiveHandle, ScreenRecordingCompletion>;
+    let resolveReattach!: (outcome: Reattach) => void;
+    const reattach = new Promise<Reattach>((resolve) => {
+      resolveReattach = resolve;
+    });
+    const disposeControl = vi.fn(async () => {});
+    const diagnostics: Array<{
+      phase: string;
+      data: Readonly<Record<string, unknown>>;
+    }> = [];
+    const scope = {
+      signal: new AbortController().signal,
+      diagnostics: { emit: vi.fn() },
+      progress: { report: vi.fn() },
+    };
+
+    const recovery = resource.recoverAll({
+      sessionsDir: path.dirname(context.sessionStore.resolveSessionDir(context.sessionName)),
+      scope,
+      perRecordDeadlineMs: 25,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      acquireControl: async (_envelope, recoveryScope) => {
+        expect(recoveryScope.signal.aborted).toBe(false);
+        return {
+          reattach: async () => await reattach,
+          cleanup: async () => ({ status: 'already-missing' as const }),
+          [Symbol.asyncDispose]: disposeControl,
+        };
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(recovery).resolves.toEqual({ scanned: 1, recovered: 0, retained: 1 });
+
+    resolveReattach({ status: 'active', handle: start.handle });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(start.forceCleanup).toHaveBeenCalledOnce();
+    expect(disposeControl).toHaveBeenCalledOnce();
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: 'screen_recording_recovery_timed_out' }),
+        expect.objectContaining({
+          phase: 'screen_recording_recovery_late_handle_cleanup_failed',
+          data: expect.objectContaining({
+            error: 'late recorder cleanup could not confirm presence',
+            primaryError: 'Screen recording recovery exceeded its 25ms deadline',
+          }),
+        }),
+      ]),
+    );
+    expect(resource.store.read(context.resourcePath)).toMatchObject({
+      status: 'decoded',
+      envelope: { lifecycle: 'open' },
+    });
+    expect(() => resource.createNextFence(replacementFenceParams(context, resource))).toThrow(
+      /terminal state/,
+    );
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+function createScreenRecordingTestResource(
+  store: ScreenRecordingStore = screenRecordingResourceStore,
+) {
+  return createDurableCaptureResource<
+    'screen-recording',
+    ScreenRecordingLiveHandle,
+    ScreenRecordingCompletion
+  >({
+    resourceKind: 'screen-recording',
+    displayName: 'screen recording',
+    store,
+    sessionSlot: {
+      read: (session) => session.screenRecording,
+      replace: (session, screenRecording) => ({ ...session, screenRecording }),
+    },
+    completionMetadata: (completion) => ({
+      backend: completion.backend,
+      outputPath: completion.outPath,
+      completedAt: completion.completedAt,
+    }),
+    messages: {
+      noActive: 'no active recording',
+      cleanupPendingHint: 'Keep the screen-recording recovery record for exact-owner cleanup.',
+    },
+  });
+}
+
+function makeContext(resource: ReturnType<typeof createScreenRecordingTestResource>) {
+  const sessionStore = makeSessionStore('screen-recording-boundary-fault-');
+  const sessionName = 'recording';
+  const session: SessionState = {
+    name: sessionName,
+    device,
+    createdAt: 1,
+    actions: [],
+  };
+  sessionStore.set(sessionName, session);
+  return {
+    admissionLedger: createDurableCaptureAdmissionLedger({ displayName: 'screen recording' }),
+    session,
+    sessionName,
+    sessionStore,
+    device,
+    owner: localRuntimeOwner('android'),
+    fence: { token: 'recording-fence', generation: 1 } as const,
+    resourcePath: resource.store.resolvePath(sessionStore.resolveSessionDir(sessionName)),
+  };
+}
+
+function makeStart(context: ReturnType<typeof makeContext>, cleanup: CleanupOutcome) {
+  const forceCleanup = vi.fn(async () => cleanup);
+  const completion: ScreenRecordingCompletion = {
+    backend: 'android',
+    outPath: '/tmp/capture.mp4',
+    startedAt: 1,
+    completedAt: 2,
+    scope: 'device',
+    showTouches: false,
+    recordOnlySession: false,
+  };
+  const handle = createScreenRecordingLiveHandle(
+    {
+      backend: 'android',
+      outPath: completion.outPath,
+      startedAt: completion.startedAt,
+      scope: completion.scope,
+      showTouches: completion.showTouches,
+      recordOnlySession: completion.recordOnlySession,
+      gestureEvents: [],
+    },
+    {
+      finish: async () => ({ status: 'completed' as const, result: completion }),
+      forceCleanup,
+    },
+  );
+  const envelope = createDurableResourceEnvelope({
+    resourceKind: 'screen-recording',
+    sessionId: context.sessionName,
+    device: {
+      id: context.device.id,
+      family: context.device.platform,
+      kind: context.device.kind,
+    },
+    owner: context.owner,
+    fence: context.fence,
+    lifecycle: 'open',
+    descriptor: { version: 1, body: { nativeRecordingId: 'recording-1' } },
+  });
+  return { handle, forceCleanup, pendingHandle: new PendingTransferGuard(handle), envelope };
+}
+
+function failFirstWrite(error: Error): ScreenRecordingStore {
+  let failed = false;
+  return {
+    ...screenRecordingResourceStore,
+    write(resourcePath, envelope) {
+      if (!failed) {
+        failed = true;
+        throw error;
+      }
+      screenRecordingResourceStore.write(resourcePath, envelope);
+    },
+  };
+}
+
+function replacementFenceParams(
+  context: ReturnType<typeof makeContext>,
+  resource: ReturnType<typeof createScreenRecordingTestResource>,
+) {
+  return {
+    admissionLedger: context.admissionLedger,
+    resourcePath: resource.store.resolvePath(context.sessionStore.resolveSessionDir('replacement')),
+    device: context.device,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the first deterministic recording boundary-fault slice for #1431:

- covers cancellation after native acquisition, durable manifest persistence failure, exact-owner recovery deadlines, and uncertain Android presence probes
- preserves primary cancellation/errors, recovery evidence, cleanup diagnostics, and replacement-start admission
- fixes Android launch cancellation to retire the pending manifest only after confirmed native rollback

This follows the issue’s current first-slice scope; the complete command/fault matrix remains future work.

## Validation

`pnpm check:affected --run` passed, including 68 related test files and 261 tests.