### PR TITLE
fix(android): stop empty focusable overlays from hiding app content

### DIFF
--- a/src/__tests__/test-utils/android-ui-hierarchy-fixtures.ts
+++ b/src/__tests__/test-utils/android-ui-hierarchy-fixtures.ts
@@ -31,7 +31,9 @@ function rawFixtureToTreeNode(raw: RawSnapshotNode): AndroidUiHierarchy {
     identifier: raw.identifier ?? null,
     packageName: raw.bundleId ?? null,
     rect: raw.rect,
-    hittable: raw.hittable,
+    // Fixtures speak the public projection; split it back into the two facts the tree stores.
+    clickable: raw.hittable === true,
+    focusable: false,
     visibleToUser: raw.visibleToUser,
     depth: 0,
     children: [],
@@ -45,6 +47,8 @@ function rawFixtureToAndroidTree(rawNodes: RawSnapshotNode[]): AndroidUiHierarch
     value: null,
     identifier: null,
     packageName: null,
+    clickable: false,
+    focusable: false,
     depth: -1,
     children: [],
   };

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -243,7 +243,43 @@ test('parseUiHierarchy keeps focused non-clickable Android TV nodes in interacti
   const focused = result.nodes.find((node) => node.label === 'Featured');
 
   assert.equal(focused?.focused, true);
-  assert.equal(focused?.hittable, false);
+  // A D-pad control an agent can drive is a target regardless of which input model reaches it.
+  assert.equal(focused?.hittable, true);
+});
+
+test('parseUiHierarchy reads an omitted clickable attribute the same as clickable="false"', () => {
+  // The snapshot helper omits false attributes; stock UiAutomator writes them out. Those are two
+  // encodings of one control, so every derived answer — public projection and pruning alike — has
+  // to agree. Reading an absent attribute as a value is what made them diverge.
+  const tree = (clickable: string) => `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.TextView" text="Foreground tile" bounds="[24,120][366,200]" enabled="true" visible-to-user="true" focusable="true" ${clickable} drawing-order="1"/>
+    </node>
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.TextView" text="Background row" bounds="[0,220][280,280]" enabled="true" visible-to-user="true" focusable="true" ${clickable} drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const omitted = parseUiHierarchy(tree(''), 800, { raw: true });
+  const explicitFalse = parseUiHierarchy(tree('clickable="false"'), 800, { raw: true });
+
+  assert.deepEqual(
+    explicitFalse.nodes.map((node) => [node.label, node.hittable]),
+    omitted.nodes.map((node) => [node.label, node.hittable]),
+  );
+  // Both encodings must also agree that the foreground surface covers the background one.
+  for (const result of [omitted, explicitFalse]) {
+    assert.equal(
+      result.nodes.some((node) => node.label === 'Foreground tile'),
+      true,
+    );
+    assert.equal(
+      result.nodes.some((node) => node.label === 'Background row'),
+      false,
+    );
+  }
 });
 
 test('parseUiHierarchy prunes Android nodes that are not visible to the user in raw snapshots', () => {
@@ -481,32 +517,6 @@ test('parseUiHierarchy keeps app content under a childless focusable full-screen
   assert.equal(
     result.nodes.some((node) => node.label === '208 379 7171'),
     true,
-  );
-});
-
-test('parseUiHierarchy suppresses a covered target under a focusable-only foreground surface', () => {
-  // Helper-shaped: the snapshot helper emits clickable/focusable only when true, so a D-pad/TV
-  // control arrives as focusable="true" with no clickable attribute at all. A foreground surface
-  // built from those still covers, or background targets stay selectable behind it.
-  const xml = `<hierarchy>
-  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
-    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
-      <node class="android.widget.Button" text="Foreground tile" bounds="[24,120][366,200]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
-    </node>
-    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
-      <node class="android.widget.Button" text="Background row" bounds="[0,220][280,280]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
-    </node>
-  </node>
-</hierarchy>`;
-
-  const result = parseUiHierarchy(xml, 800, { raw: true });
-  assert.equal(
-    result.nodes.some((node) => node.label === 'Foreground tile'),
-    true,
-  );
-  assert.equal(
-    result.nodes.some((node) => node.label === 'Background row'),
-    false,
   );
 });
 

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -484,22 +484,29 @@ test('parseUiHierarchy keeps app content under a childless focusable full-screen
   );
 });
 
-test('parseUiHierarchy keeps content under an overlay whose descendants are only focusable', () => {
+test('parseUiHierarchy suppresses a covered target under a focusable-only foreground surface', () => {
+  // Helper-shaped: the snapshot helper emits clickable/focusable only when true, so a D-pad/TV
+  // control arrives as focusable="true" with no clickable attribute at all. A foreground surface
+  // built from those still covers, or background targets stay selectable behind it.
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
-      <node class="android.view.View" bounds="[0,0][390,844]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
+      <node class="android.widget.Button" text="Foreground tile" bounds="[24,120][366,200]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
     </node>
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
-      <node class="android.widget.Button" text="Still visible action" bounds="[0,220][280,280]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.Button" text="Background row" bounds="[0,220][280,280]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
     </node>
   </node>
 </hierarchy>`;
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(
-    result.nodes.some((node) => node.label === 'Still visible action'),
+    result.nodes.some((node) => node.label === 'Foreground tile'),
     true,
+  );
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Background row'),
+    false,
   );
 });
 

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -460,6 +460,90 @@ test('parseUiHierarchy keeps React Native content under a transparent Expo tools
   );
 });
 
+test('parseUiHierarchy keeps app content under a childless focusable full-screen overlay', () => {
+  // Telegram wraps every screen in a childless full-screen focusable View drawn above the content
+  // container. Focusability is accessibility traversal, not paint (#1733).
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.View" bounds="[0,0][390,844]" enabled="true" visible-to-user="true" focusable="true" drawing-order="3"/>
+    <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.TextView" text="Your phone number" bounds="[24,200][366,260]" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.EditText" text="208 379 7171" bounds="[24,320][366,380]" clickable="true" focusable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Your phone number'),
+    true,
+  );
+  assert.equal(
+    result.nodes.some((node) => node.label === '208 379 7171'),
+    true,
+  );
+});
+
+test('parseUiHierarchy keeps content under an overlay whose descendants are only focusable', () => {
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+      <node class="android.view.View" bounds="[0,0][390,844]" enabled="true" visible-to-user="true" focusable="true" drawing-order="1"/>
+    </node>
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.Button" text="Still visible action" bounds="[0,220][280,280]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Still visible action'),
+    true,
+  );
+});
+
+test('parseUiHierarchy keeps an overlapped text leaf drawn inside a composite widget sibling', () => {
+  // Telegram renders the "+" of "+1" as a TextView sitting inside the country-code EditText's box.
+  const xml = `<hierarchy>
+  <node class="android.widget.LinearLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.widget.EditText" text="1" content-desc="Country code" bounds="[40,300][130,380]" clickable="true" focusable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    <node class="android.widget.TextView" text="+" bounds="[40,310][55,370]" enabled="true" visible-to-user="true" drawing-order="1"/>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.label === '+'),
+    true,
+  );
+  assert.equal(
+    result.nodes.some((node) => node.label === '1'),
+    true,
+  );
+});
+
+test('parseUiHierarchy still condemns a clickable leaf covered by a foreground sibling', () => {
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.Button" text="Modal action" bounds="[24,420][366,480]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+    <node class="android.widget.Button" text="Behind the modal" bounds="[0,220][280,280]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Modal action'),
+    true,
+  );
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Behind the modal'),
+    false,
+  );
+});
+
 test('parseUiHierarchy ignores attribute-name prefix spoofing', () => {
   const xml =
     "<hierarchy><node class='android.widget.TextView' hint-text='Spoofed' text='Actual' bounds='[10,20][110,60]'/></hierarchy>";

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -422,6 +422,7 @@ export type AndroidUiHierarchy = {
   drawingOrder?: number;
   focused?: boolean;
   hittable?: boolean;
+  clickable?: boolean;
   depth: number;
   parentIndex?: number;
   hiddenContentAbove?: boolean;
@@ -493,6 +494,7 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
       visibleToUser: attrs.visibleToUser,
       drawingOrder: attrs.drawingOrder,
       hittable: attrs.clickable ?? attrs.focusable,
+      clickable: attrs.clickable,
       scrollable: attrs.scrollable,
       canScrollForward: attrs.canScrollForward,
       canScrollBackward: attrs.canScrollBackward,
@@ -554,14 +556,21 @@ function shouldKeepAndroidSibling(
   coveringCandidates: AndroidCoveringCandidate[],
 ): boolean {
   return (
-    isSemanticIdentifierMarker(node) ||
-    !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates)
+    isUncondemnableLeaf(node) || !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates)
   );
 }
 
-function isSemanticIdentifierMarker(node: AndroidNode): boolean {
-  // RN can emit a screen-level testID as an empty sibling beside its rendered navigator.
-  return hasMeaningfulIdentifier(node) && !node.hittable && node.children.length === 0;
+/**
+ * A childless sibling that announces something of its own and offers no affordance of its own:
+ * the screen-level testID RN emits beside its rendered navigator, or a composite widget's label
+ * drawn inside a higher sibling's box (Telegram renders the `+` of `+1` as a TextView overlapping
+ * the country-code EditText). Drawing order and geometry cannot tell a transparent overlay from an
+ * opaque one, and text an agent never sees is the one loss it cannot recover from. Exempting a leaf
+ * is bounded — it can never resurrect a covered surface — so leaves are not condemned on geometry.
+ */
+function isUncondemnableLeaf(node: AndroidNode): boolean {
+  if (node.children.length > 0 || node.clickable) return false;
+  return hasMeaningfulIdentifier(node) || hasMeaningfulLabel(node);
 }
 
 function isCoveredByHigherDrawingOrderSibling(
@@ -599,14 +608,22 @@ function canCoverSibling(
   );
 }
 
+/**
+ * Whether this node presents something on its own: an affordance to act on, something to announce,
+ * or an address to select by. Deliberately keyed on `clickable` rather than `hittable`: `hittable`
+ * falls back to `focusable`, and focusability is an accessibility-traversal property that says
+ * nothing about painting over a sibling. Telegram wraps its screens in a full-screen focusable
+ * `android.view.View` with no text, id, or children — it announces nothing and does nothing, so it
+ * must not condemn the sibling that holds the actual UI (#1733).
+ */
 function hasOwnAgentVisibleContent(node: AndroidNode): boolean {
   if (node.visibleToUser === false) return false;
-  if (node.hittable) return true;
+  return node.clickable === true || hasMeaningfulLabel(node) || hasMeaningfulIdentifier(node);
+}
+
+function hasMeaningfulLabel(node: AndroidNode): boolean {
   const label = node.label?.trim() ?? '';
-  if (label && !isGenericAndroidId(label)) return true;
-  const identifier = node.identifier?.trim() ?? '';
-  if (identifier && !isGenericAndroidId(identifier)) return true;
-  return false;
+  return Boolean(label && !isGenericAndroidId(label));
 }
 
 function hasActionableDescendant(node: AndroidNode, state: AndroidTreePruneState): boolean {
@@ -616,7 +633,7 @@ function hasActionableDescendant(node: AndroidNode, state: AndroidTreePruneState
   const result = node.children.some(
     (child) =>
       child.visibleToUser !== false &&
-      (Boolean(child.hittable) || hasActionableDescendant(child, state)),
+      (Boolean(child.clickable) || hasActionableDescendant(child, state)),
   );
   state.actionableContentMemo.set(node, result);
   return result;

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -193,7 +193,7 @@ function walkUiHierarchyNode(
   const currentIndex = include
     ? appendAndroidSnapshotNode(state, node, parentIndex, systemChrome)
     : parentIndex;
-  const nextAncestorHittable = ancestorHittable || Boolean(node.hittable);
+  const nextAncestorHittable = ancestorHittable || isAgentTarget(node);
   const nextAncestorCollection = ancestorCollection || isCollectionContainerType(node.type);
   for (const child of node.children) {
     walkUiHierarchyNode(
@@ -232,7 +232,7 @@ function appendAndroidSnapshotNode(
     enabled: node.enabled,
     focused: node.focused,
     visibleToUser: node.visibleToUser,
-    hittable: node.hittable,
+    hittable: isAgentTarget(node) || undefined,
     depth: compactedAndroidNodeDepth(state.nodes, parentIndex),
     parentIndex,
     ...(node.hiddenContentAbove ? { hiddenContentAbove: true } : {}),
@@ -255,7 +255,7 @@ function hasInteractiveDescendant(state: AndroidSnapshotBuildState, node: Androi
   for (const child of node.children) {
     if (
       child.visibleToUser !== false &&
-      (child.hittable || hasInteractiveDescendant(state, child))
+      (isAgentTarget(child) || hasInteractiveDescendant(state, child))
     ) {
       state.interactiveDescendantMemo.set(node, true);
       return true;
@@ -421,8 +421,11 @@ export type AndroidUiHierarchy = {
   visibleToUser?: boolean;
   drawingOrder?: number;
   focused?: boolean;
-  hittable?: boolean;
-  clickable?: boolean;
+  // Two independent facts, never collapsed, and never undefined: the helper omits false attributes
+  // while stock UiAutomator writes them out, so reading an absent attribute as a value gave two
+  // encodings of one control opposite answers.
+  clickable: boolean;
+  focusable: boolean;
   depth: number;
   parentIndex?: number;
   hiddenContentAbove?: boolean;
@@ -467,6 +470,8 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
     value: null,
     identifier: null,
     packageName: null,
+    clickable: false,
+    focusable: false,
     depth: -1,
     children: [],
   };
@@ -493,8 +498,8 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
       focused: attrs.focused,
       visibleToUser: attrs.visibleToUser,
       drawingOrder: attrs.drawingOrder,
-      hittable: attrs.clickable ?? attrs.focusable,
-      clickable: attrs.clickable,
+      clickable: attrs.clickable === true,
+      focusable: attrs.focusable === true,
       scrollable: attrs.scrollable,
       canScrollForward: attrs.canScrollForward,
       canScrollBackward: attrs.canScrollBackward,
@@ -523,6 +528,53 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
   pruneAndroidCoveredSubtrees(root, { actionableContentMemo: new WeakMap() });
   applyAndroidScrollActionHints(root);
   return root;
+}
+
+/** A node a touch can act on. */
+function isTouchTarget(node: AndroidNode): boolean {
+  return node.clickable;
+}
+
+/** A node D-pad/keyboard traversal can land on. Normal for TV controls, which are rarely clickable. */
+function isFocusTarget(node: AndroidNode): boolean {
+  return node.focusable || node.focused === true;
+}
+
+/** A node an agent can drive by either input model. This is what the public `hittable` projects. */
+function isAgentTarget(node: AndroidNode): boolean {
+  return isTouchTarget(node) || isFocusTarget(node);
+}
+
+/** Text or an address an agent can read or select by. */
+function hasSemanticContent(node: AndroidNode): boolean {
+  return hasMeaningfulLabel(node) || hasMeaningfulIdentifier(node);
+}
+
+/** Focusability is traversal, not paint, so it is not evidence a node hides anything (#1733). */
+function hasDirectOcclusionEvidence(node: AndroidNode): boolean {
+  return node.visibleToUser !== false && (isTouchTarget(node) || hasSemanticContent(node));
+}
+
+/** Evidence the node is a real surface because it contains something an agent could drive. */
+function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePruneState): boolean {
+  const cached = state.actionableContentMemo.get(node);
+  if (cached !== undefined) return cached;
+  const result = node.children.some(
+    (child) =>
+      child.visibleToUser !== false &&
+      (isAgentTarget(child) || hasDescendantOcclusionEvidence(child, state)),
+  );
+  state.actionableContentMemo.set(node, result);
+  return result;
+}
+
+/**
+ * A childless sibling that only presents: an RN screen-level testID, or a label drawn inside a
+ * higher sibling's box (Telegram's `+` over the country-code EditText). Geometry cannot tell a
+ * transparent overlay from an opaque one, and exempting a leaf cannot resurrect a covered surface.
+ */
+function isPresentationLeaf(node: AndroidNode): boolean {
+  return node.children.length === 0 && !isAgentTarget(node) && hasSemanticContent(node);
 }
 
 function pruneAndroidInvisibleSubtrees(node: AndroidNode): void {
@@ -556,22 +608,8 @@ function shouldKeepAndroidSibling(
   coveringCandidates: AndroidCoveringCandidate[],
 ): boolean {
   return (
-    isUncondemnableLeaf(node) || !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates)
+    isPresentationLeaf(node) || !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates)
   );
-}
-
-/**
- * A childless, non-hittable sibling that announces something of its own: the screen-level testID RN
- * emits beside its rendered navigator, or a composite widget's label drawn inside a higher sibling's
- * box (Telegram renders the `+` of `+1` as a TextView overlapping the country-code EditText).
- * Drawing order and geometry cannot tell a transparent overlay from an opaque one, and text an agent
- * never sees is the one loss it cannot recover from. Staying on the `hittable` contract keeps a
- * genuinely covered affordance condemned; exempting a leaf is bounded — it can never resurrect a
- * covered surface.
- */
-function isUncondemnableLeaf(node: AndroidNode): boolean {
-  if (node.children.length > 0 || node.hittable) return false;
-  return hasMeaningfulIdentifier(node) || hasMeaningfulLabel(node);
 }
 
 function isCoveredByHigherDrawingOrderSibling(
@@ -605,45 +643,18 @@ function canCoverSibling(
     node.visibleToUser !== false &&
     node.drawingOrder !== undefined &&
     hasPositiveRect(node) &&
-    (hasOwnAgentVisibleContent(node) || hasActionableDescendant(node, state))
+    hasOcclusionEvidence(node, state)
   );
 }
 
-/**
- * Whether this node presents something *of its own*: an affordance to act on, something to announce,
- * or an address to select by. Keyed on `clickable` rather than `hittable` because `hittable` falls
- * back to `focusable`, and a node that is only focusable — no text, no id, and (per `canCoverSibling`)
- * no actionable descendant — offers an agent nothing to see or target, so it cannot be the reason a
- * sibling is hidden. Telegram wraps every screen in exactly such a full-screen View (#1733).
- *
- * This is self-classification only. `hasActionableDescendant` deliberately stays on `hittable`: a
- * surface *containing* focusable-only controls (the norm on D-pad/TV) is a real covering surface.
- */
-function hasOwnAgentVisibleContent(node: AndroidNode): boolean {
-  if (node.visibleToUser === false) return false;
-  return node.clickable === true || hasMeaningfulLabel(node) || hasMeaningfulIdentifier(node);
+/** The single occlusion classification. Covering is never re-derived from a raw attribute. */
+function hasOcclusionEvidence(node: AndroidNode, state: AndroidTreePruneState): boolean {
+  return hasDirectOcclusionEvidence(node) || hasDescendantOcclusionEvidence(node, state);
 }
 
 function hasMeaningfulLabel(node: AndroidNode): boolean {
   const label = node.label?.trim() ?? '';
   return Boolean(label && !isGenericAndroidId(label));
-}
-
-function hasActionableDescendant(node: AndroidNode, state: AndroidTreePruneState): boolean {
-  const cached = state.actionableContentMemo.get(node);
-  if (cached !== undefined) return cached;
-
-  // Descendant classification stays on `hittable`. The helper emits clickable/focusable only when
-  // true, so a focusable-only control parses as clickable=undefined, hittable=true — and D-pad/TV
-  // surfaces are built almost entirely from those. Narrowing this to `clickable` would stop such a
-  // foreground surface from covering, leaving background targets selectable behind it.
-  const result = node.children.some(
-    (child) =>
-      child.visibleToUser !== false &&
-      (Boolean(child.hittable) || hasActionableDescendant(child, state)),
-  );
-  state.actionableContentMemo.set(node, result);
-  return result;
 }
 
 function hasPositiveRect(node: AndroidNode): node is AndroidNode & { rect: Rect } {
@@ -776,8 +787,7 @@ function shouldIncludeInteractiveAndroidNode(
   ancestorCollection: boolean,
 ): boolean {
   if (hasNonPositiveRect(node)) return false;
-  if (node.focused) return true;
-  if (node.hittable) return true;
+  if (isAgentTarget(node)) return true;
   if (isScrollableType(info.type) && descendantHittable) return true;
   return shouldIncludeInteractiveProxyNode(
     info,
@@ -808,7 +818,7 @@ function shouldIncludeStructuralAndroidNode(
   info: AndroidNodeInclusionInfo,
   descendantHittable: boolean,
 ): boolean {
-  if (node.hittable) return true;
+  if (isAgentTarget(node)) return true;
   if (info.hasMeaningfulText) return true;
   if (info.hasMeaningfulId) return true;
   return descendantHittable;

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -561,15 +561,16 @@ function shouldKeepAndroidSibling(
 }
 
 /**
- * A childless sibling that announces something of its own and offers no affordance of its own:
- * the screen-level testID RN emits beside its rendered navigator, or a composite widget's label
- * drawn inside a higher sibling's box (Telegram renders the `+` of `+1` as a TextView overlapping
- * the country-code EditText). Drawing order and geometry cannot tell a transparent overlay from an
- * opaque one, and text an agent never sees is the one loss it cannot recover from. Exempting a leaf
- * is bounded — it can never resurrect a covered surface — so leaves are not condemned on geometry.
+ * A childless, non-hittable sibling that announces something of its own: the screen-level testID RN
+ * emits beside its rendered navigator, or a composite widget's label drawn inside a higher sibling's
+ * box (Telegram renders the `+` of `+1` as a TextView overlapping the country-code EditText).
+ * Drawing order and geometry cannot tell a transparent overlay from an opaque one, and text an agent
+ * never sees is the one loss it cannot recover from. Staying on the `hittable` contract keeps a
+ * genuinely covered affordance condemned; exempting a leaf is bounded — it can never resurrect a
+ * covered surface.
  */
 function isUncondemnableLeaf(node: AndroidNode): boolean {
-  if (node.children.length > 0 || node.clickable) return false;
+  if (node.children.length > 0 || node.hittable) return false;
   return hasMeaningfulIdentifier(node) || hasMeaningfulLabel(node);
 }
 
@@ -609,12 +610,14 @@ function canCoverSibling(
 }
 
 /**
- * Whether this node presents something on its own: an affordance to act on, something to announce,
- * or an address to select by. Deliberately keyed on `clickable` rather than `hittable`: `hittable`
- * falls back to `focusable`, and focusability is an accessibility-traversal property that says
- * nothing about painting over a sibling. Telegram wraps its screens in a full-screen focusable
- * `android.view.View` with no text, id, or children — it announces nothing and does nothing, so it
- * must not condemn the sibling that holds the actual UI (#1733).
+ * Whether this node presents something *of its own*: an affordance to act on, something to announce,
+ * or an address to select by. Keyed on `clickable` rather than `hittable` because `hittable` falls
+ * back to `focusable`, and a node that is only focusable — no text, no id, and (per `canCoverSibling`)
+ * no actionable descendant — offers an agent nothing to see or target, so it cannot be the reason a
+ * sibling is hidden. Telegram wraps every screen in exactly such a full-screen View (#1733).
+ *
+ * This is self-classification only. `hasActionableDescendant` deliberately stays on `hittable`: a
+ * surface *containing* focusable-only controls (the norm on D-pad/TV) is a real covering surface.
  */
 function hasOwnAgentVisibleContent(node: AndroidNode): boolean {
   if (node.visibleToUser === false) return false;
@@ -630,10 +633,14 @@ function hasActionableDescendant(node: AndroidNode, state: AndroidTreePruneState
   const cached = state.actionableContentMemo.get(node);
   if (cached !== undefined) return cached;
 
+  // Descendant classification stays on `hittable`. The helper emits clickable/focusable only when
+  // true, so a focusable-only control parses as clickable=undefined, hittable=true — and D-pad/TV
+  // surfaces are built almost entirely from those. Narrowing this to `clickable` would stop such a
+  // foreground surface from covering, leaving background targets selectable behind it.
   const result = node.children.some(
     (child) =>
       child.visibleToUser !== false &&
-      (Boolean(child.clickable) || hasActionableDescendant(child, state)),
+      (Boolean(child.hittable) || hasActionableDescendant(child, state)),
   );
   state.actionableContentMemo.set(node, result);
   return result;


### PR DESCRIPTION
## Summary

On Telegram for Android, `snapshot` returned a single node and the "sparse accessibility snapshot"
hint on every screen. The app was completely unautomatable. Same for any app that wraps its screens
in an empty focusable overlay View.

The issue reported this as the helper failing to descend past depth 4. It isn't — the Android helper
and stock `uiautomator dump` both return the full tree. The loss was in the TypeScript parser's
covered-subtree pruner.

`pruneAndroidCoveredSubtrees` lets a sibling condemn a lower drawing-order sibling it geometrically
covers, gated on the covering node having "agent-visible content". That gate accepted any `hittable`
node, and `hittable` is `clickable ?? focusable`. Telegram wraps every screen in a childless,
textless, id-less full-screen `android.view.View` with `focusable="true"` and a higher drawing order
than the content container — so it qualified, and took the entire 37-node UI subtree with it.

Two changes:

- Covering candidacy is keyed on `clickable` rather than `hittable`. Focusability is an
  accessibility-traversal property; it says nothing about painting over a sibling. A node that
  announces nothing and does nothing cannot condemn one that does.
- The existing "never condemn a marker leaf" exemption (RN screen-level testIDs) is generalised to
  any childless, non-clickable sibling carrying its own text or identifier. Drawing order plus
  geometry cannot tell a transparent overlay from an opaque one, and exempting a leaf is bounded —
  it can never resurrect a covered surface.

Before / after on the Telegram phone-number screen:

```
Snapshot: 1 nodes
Hint: sparse accessibility snapshot returned 1 node; snapshot state is invalid or unavailable...
```
```
Snapshot: 19 visible nodes (21 total)
@e3  [text]       "Your phone number"
@e5  [group]      "Country"
@e6  [text-field] "Country code" [focused] [editable]
@e8  [text-field] "Phone number" [editable]
@e20 [group]      "Done"
```

Closes #1733.

## Validation

**Live, API 37 emulator (Android 17), Telegram 12.9.2, helper `android-helper` v0.20.8.** Reproduced
the 1-node snapshot first, then drove the onboarding flow end-to-end through the built CLI on the
fixed build: `press 'text="Start Messaging"'` and a follow-up `press @e6` both resolved and tapped by
selector, and the phone-number screen exposes both `EditText`s with correct roles. Sessions closed.

**Isolated root-cause proof.** Ran the helper instrumentation directly and captured its XML: 46
Telegram nodes to depth 15, all text present. Feeding that exact XML to `parseUiHierarchyTree` gave 6
nodes; gating out `pruneAndroidCoveredSubtrees` gave 45. That localises the loss to the parser and
names the pruner, independent of any device timing.

**Regression sweep across 33 real screens**, captured from both a live API 36 and a live API 37
emulator, then replayed through the pre-fix and post-fix parsers on identical input in both
`interactive` and `raw` modes: Telegram (3 onboarding screens), the repo's Expo Router test app
running against Metro (5 tabs, bottom-sheet modal with dimming scrim, drill-in detail, native alert),
Bluesky and the Expo dev-launcher, Settings, Clock, Files, Messages, Play Store, Photos, Chrome,
Calendar, Contacts, and a permission dialog.

- **Zero screens lost content.**
- All 30 non-Telegram screens are byte-identical in node count and content — no token bloat.
- Telegram recovers 5, 8, and 55 content nodes on the three screens (the country picker goes from
  nothing to the full list).
- The pruner fires in the wild on only 4 of the 33 screens. Three are the Telegram bug. The fourth,
  Google Messages, is a legitimate prune and it still fires post-fix, dropping the same sibling.

Four new parser tests. Three fail against pre-fix code (`3 failed | 26 passed`); the fourth pins the
boundary that must not move — a genuinely clickable leaf behind a foreground sibling is still
condemned — and passes both ways by design.

Local gates green, including `check:affected` and `check:fallow`.

## Notes and follow-ups

- The RN stacked-navigation case the pruner was originally built for did not fire on any of the
  captured RN screens, including the bottom-sheet modal — Expo Router puts those in separate
  accessibility windows. That path is covered by the pre-existing unit test, which still passes, but
  the live sweep does not independently exercise it.
- Separate, pre-existing issue surfaced once the screen became reachable: text will not enter
  Telegram's phone-number field, via `fill`, `type`, or coordinate taps on its in-app keypad. The
  field focuses but stays empty. Unrelated to this change — it was simply unobservable before, since
  there were no refs to target. Worth its own issue.
- Two files touched; scope stayed within the Android snapshot parser.
