### PR TITLE
refactor(registry): exhaustive platformExecution discriminator (ADR 0019 §6)

### DIFF
--- a/packages/contracts/src/command-platform-execution.test.ts
+++ b/packages/contracts/src/command-platform-execution.test.ts
@@ -5,6 +5,7 @@ import { assertCommandPlatformExecution } from './command-platform-execution.ts'
 
 describe('command platform execution declaration', () => {
   test.each([
+    { kind: 'none' },
     { kind: 'legacy' },
     { kind: 'inventory', use: inventoryUse },
     { kind: 'device-runtime', use: { required: ['capture'], preferred: ['inspect'] } },
@@ -14,6 +15,7 @@ describe('command platform execution declaration', () => {
 
   test.each([
     {},
+    { kind: 'none', use: inventoryUse },
     { kind: 'legacy', use: inventoryUse },
     { kind: 'inventory' },
     { kind: 'inventory', use: inventoryUse, legacy: true },

--- a/packages/contracts/src/command-platform-execution.ts
+++ b/packages/contracts/src/command-platform-execution.ts
@@ -2,6 +2,7 @@ import type { InventoryUse } from './platform-module.ts';
 import type { RuntimeUseDeclaration } from './platform-runtime.ts';
 
 export type CommandPlatformExecution =
+  | Readonly<{ kind: 'none' }>
   | Readonly<{ kind: 'legacy' }>
   | Readonly<{ kind: 'inventory'; use: InventoryUse }>
   | Readonly<{ kind: 'device-runtime'; use: RuntimeUseDeclaration }>
@@ -18,6 +19,7 @@ export function assertCommandPlatformExecution(
   if (value === null || typeof value !== 'object') throw invalidPlatformExecution();
   const declaration = value as Record<string, unknown>;
   const keys = Object.keys(declaration).sort();
+  if (declaration['kind'] === 'none' && sameKeys(keys, ['kind'])) return;
   if (declaration['kind'] === 'legacy' && sameKeys(keys, ['kind'])) return;
   if (
     declaration['kind'] === 'inventory' &&
@@ -96,6 +98,6 @@ function sameKeys(actual: readonly string[], expected: readonly string[]): boole
 
 function invalidPlatformExecution(): TypeError {
   return new TypeError(
-    'Command platform execution must declare exactly one of legacy, inventory, or device-runtime',
+    'Command platform execution must declare exactly one of none, legacy, inventory, or device-runtime',
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import type { FlagKey } from './commands/cli-grammar/flag-types.ts';
 import type { CliFlags } from '@agent-device/contracts/command';
 import type { SessionRuntimeHints } from '@agent-device/kernel/contracts';
 import { INTERNAL_COMMANDS, isKnownCliCommandName } from './command-catalog.ts';
+import { sendInjectedDaemonRequest } from './cli/injected-daemon-dispatch.ts';
 
 type CliDeps = {
   sendToDaemon: typeof sendToDaemon;
@@ -342,9 +343,10 @@ async function runReactDevtoolsCli(ctx: CliRunContext, deps: CliDeps): Promise<n
     cwd: process.cwd(),
     env: process.env,
     configureDirectPortReverse: async () => {
-      const response = await deps.sendToDaemon(
-        {
-          command: INTERNAL_COMMANDS.runtime,
+      const response = await sendInjectedDaemonRequest({
+        route: 'react-devtools',
+        command: INTERNAL_COMMANDS.runtime,
+        request: {
           positionals: ['port-reverse'],
           flags: {
             ...directRequestFlags,
@@ -355,8 +357,9 @@ async function runReactDevtoolsCli(ctx: CliRunContext, deps: CliDeps): Promise<n
           },
           session: ctx.effectiveFlags.session ?? ctx.sessionName,
         },
-        { authToken: daemonAuthToken },
-      );
+        transport: deps.sendToDaemon,
+        transportOptions: { authToken: daemonAuthToken },
+      });
       if (!response.ok) throwDaemonError(response.error);
     },
   });

--- a/src/cli/injected-daemon-dispatch.ts
+++ b/src/cli/injected-daemon-dispatch.ts
@@ -1,0 +1,51 @@
+import type { DaemonResponse, sendToDaemon } from '../daemon/client/daemon-client.ts';
+import { INTERNAL_COMMANDS } from '../command-catalog.ts';
+import type {
+  DescriptorCliCommandName,
+  DescriptorDaemonRouteCommandName,
+} from '../core/command-descriptor/registry.ts';
+
+type CliDaemonTransport = typeof sendToDaemon;
+type CliDaemonRequest = Parameters<CliDaemonTransport>[0];
+type CliDaemonTransportOptions = Parameters<CliDaemonTransport>[1];
+
+/**
+ * The CLI's injected daemon dispatches (ADR 0019 §6).
+ *
+ * Ordinary commands reach the daemon through the client transport, carrying their own
+ * name. A few CLI routes additionally inject a *different* command into their flow —
+ * `react-devtools start` on a Limrun Android instance sets up its port reverse by
+ * dispatching internal `runtime`. That injection is the case where a descriptor's own
+ * module is platform-free while its route reaches platform behavior, so the pairs must
+ * be enumerable to keep the migration denominator honest.
+ *
+ * This table is that enumeration, and {@link sendInjectedDaemonRequest} is the only way
+ * to perform one: the route and command are typed parameters checked against this table,
+ * so an undeclared pair is a compile error rather than something a scanner must find.
+ */
+export const CLI_INJECTED_DAEMON_DISPATCHES = {
+  'react-devtools': [INTERNAL_COMMANDS.runtime],
+} as const satisfies Partial<
+  Record<DescriptorCliCommandName, readonly DescriptorDaemonRouteCommandName[]>
+>;
+
+export type CliInjectedRoute = keyof typeof CLI_INJECTED_DAEMON_DISPATCHES;
+
+type InjectedCommandFor<Route extends CliInjectedRoute> =
+  (typeof CLI_INJECTED_DAEMON_DISPATCHES)[Route][number];
+
+/**
+ * The single construction point for a CLI-injected daemon request. `command` comes from
+ * the declared pair rather than from the caller's object literal, so the dispatched
+ * command is known by type at every call site.
+ */
+export async function sendInjectedDaemonRequest<Route extends CliInjectedRoute>(params: {
+  route: Route;
+  command: InjectedCommandFor<Route>;
+  request: Omit<CliDaemonRequest, 'command'>;
+  transport: CliDaemonTransport;
+  transportOptions?: CliDaemonTransportOptions;
+}): Promise<DaemonResponse> {
+  const { command, request, transport, transportOptions } = params;
+  return await transport({ ...request, command }, transportOptions);
+}

--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -1,276 +1,53 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseSync } from 'oxc-parser';
 import { describe, expect, test } from 'vitest';
-import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../../command-catalog.ts';
+import {
+  CLI_INJECTED_DAEMON_DISPATCHES,
+  type CliInjectedRoute,
+} from '../../../cli/injected-daemon-dispatch.ts';
 import { commandDescriptors } from '../registry.ts';
 
 /**
  * ADR 0019 §6 coherence gate for delegated platform execution.
  *
- * The registry entry gate inspects one descriptor at a time, so it cannot see a
- * command whose own module holds no platform code while its CLI route injects a
- * callback that dispatches a platform-executing command. Mode dominance closes
- * that: if the CLI route for command R dispatches command D, R may declare `none`
- * only when D is `none` too.
+ * The registry entry gate inspects one descriptor at a time, so it cannot see a command
+ * whose own module holds no platform code while its CLI route injects a *different*
+ * command that does. Mode dominance closes that: if a CLI route dispatches command D,
+ * the route's command may declare `none` only when D is `none` too.
  *
- * Scope is `src/cli.ts`, the composition root where injected callbacks are built.
- * The scan is total within it in both directions: a dispatch no route can claim
- * fails, and a daemon send whose command target cannot be resolved to a registered
- * command also fails. An unresolvable target is a gate error rather than a skip,
- * because a skipped dispatch is indistinguishable from an absent one.
+ * The dispatched pairs are read from the typed table at the construction seam rather
+ * than recovered from syntax. The second test keeps that seam singular, which is what
+ * makes the table total: the transport cannot be called anywhere else, so there is no
+ * second way to dispatch.
  */
 
+const CLI_ROOT = fileURLToPath(new URL('../../../cli.ts', import.meta.url));
+const CLI_DIR = fileURLToPath(new URL('../../../cli/', import.meta.url));
+const SEAM_MODULE = path.join(CLI_DIR, 'injected-daemon-dispatch.ts');
+const TRANSPORT = 'sendToDaemon';
+
 type AstNode = { type: string } & Record<string, unknown>;
-
-const CLI_COMPOSITION_ROOT = fileURLToPath(new URL('../../../cli.ts', import.meta.url));
-
-const COMMAND_CATALOGS: Record<string, Record<string, string>> = {
-  INTERNAL_COMMANDS,
-  PUBLIC_COMMANDS,
-};
-
-const COMMAND_NAMES = new Set<string>(commandDescriptors.map(({ name }) => name));
 
 type PlatformExecutionKindOf = (command: string) => string | undefined;
 
 const registryKind: PlatformExecutionKindOf = (command) =>
   commandDescriptors.find(({ name }) => name === command)?.platformExecution.kind;
 
-type RouteDispatch = Readonly<{ route: string; dispatched: string }>;
+type DispatchTable = Readonly<Record<string, readonly string[]>>;
 
-/**
- * One dispatch expression, identified by source position. Attribution subtracts
- * occurrences: two dispatches of the same command are two sites, so a stray one
- * cannot be absorbed by a routed one that happens to name the same command.
- */
-type DispatchSite = Readonly<{ command: string; offset: number }>;
-
-type RouteScan = Readonly<{
-  dispatches: readonly RouteDispatch[];
-  /** Commands dispatched at a site no `command === '<name>'` route could claim. */
-  unattributed: readonly string[];
-  /**
-   * Daemon sends whose `command` target is not a registered command literal —
-   * a computed target, a variable, an unknown catalog key, or no target at all.
-   * Reported by source line: the gate cannot reason about them, so it refuses them.
-   */
-  unresolvedTargets: readonly string[];
-}>;
-
-/** Calls that hand a request envelope to the daemon. */
-const DAEMON_SEND_CALLEES = new Set(['sendToDaemon']);
-
-function isAstNode(value: unknown): value is AstNode {
-  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+function declaredPairs(table: DispatchTable): { route: string; dispatched: string }[] {
+  return Object.entries(table).flatMap(([route, commands]) =>
+    commands.map((dispatched) => ({ route, dispatched })),
+  );
 }
 
-function walk(root: unknown, visit: (node: AstNode) => void): void {
-  if (Array.isArray(root)) {
-    for (const child of root) walk(child, visit);
-    return;
-  }
-  if (!isAstNode(root)) return;
-  visit(root);
-  for (const value of Object.values(root)) walk(value, visit);
-}
-
-function identifierName(node: unknown): string | undefined {
-  return isAstNode(node) && node.type === 'Identifier' ? String(node['name']) : undefined;
-}
-
-function stringLiteral(node: unknown): string | undefined {
-  return isAstNode(node) && node.type === 'Literal' && typeof node['value'] === 'string'
-    ? node['value']
-    : undefined;
-}
-
-function knownCommand(name: string | undefined): string | undefined {
-  return name !== undefined && COMMAND_NAMES.has(name) ? name : undefined;
-}
-
-/** `command === 'react-devtools'`, either operand order, names a routed command. */
-function routedCommandOf(test: unknown): string | undefined {
-  if (!isAstNode(test) || test.type !== 'BinaryExpression' || test['operator'] !== '===') {
-    return undefined;
-  }
-  const operands = [
-    [test['left'], test['right']],
-    [test['right'], test['left']],
-  ] as const;
-  for (const [subject, literal] of operands) {
-    if (identifierName(subject) !== 'command') continue;
-    const routed = knownCommand(stringLiteral(literal));
-    if (routed !== undefined) return routed;
-  }
-  return undefined;
-}
-
-/** `command: 'x'`, `command: INTERNAL_COMMANDS.x`, `command: PUBLIC_COMMANDS.x`. */
-function dispatchSiteOf(node: AstNode): DispatchSite | undefined {
-  const commandProperty = commandPropertyOf(node);
-  if (commandProperty === undefined) return undefined;
-  const command = dispatchTargetOf(commandProperty['value']);
-  if (command === undefined) return undefined;
-  return { command, offset: offsetOf(commandProperty) };
-}
-
-function commandPropertyOf(node: AstNode): AstNode | undefined {
-  if (node.type !== 'Property' || node['computed'] === true) return undefined;
-  return identifierName(node['key']) === 'command' ? node : undefined;
-}
-
-/**
- * A node without a source position cannot be matched against an attributed site, so
- * -1 keeps it distinct from every real offset and it stays unclaimed.
- */
-function offsetOf(node: AstNode): number {
-  const start = node['start'];
-  return typeof start === 'number' ? start : -1;
-}
-
-function dispatchTargetOf(value: unknown): string | undefined {
-  const literal = stringLiteral(value);
-  if (literal !== undefined) return knownCommand(literal);
-  if (!isAstNode(value) || value.type !== 'MemberExpression' || value['computed'] === true) {
-    return undefined;
-  }
-  const catalog = identifierName(value['object']);
-  const key = identifierName(value['property']);
-  return catalog === undefined || key === undefined ? undefined : COMMAND_CATALOGS[catalog]?.[key];
-}
-
-/**
- * Every request envelope handed to the daemon, whether or not its command target can
- * be resolved. `command:` alone cannot mark a dispatch — diagnostics scopes and context
- * builders carry the same key — so the envelope is identified by the send call it is
- * passed to.
- */
-function daemonSendEnvelopes(program: unknown): AstNode[] {
-  const envelopes: AstNode[] = [];
-  walk(program, (node) => {
-    if (node.type !== 'CallExpression' || !isDaemonSendCallee(node['callee'])) return;
-    // `sendToDaemon(request, options)`: only the first argument is the request.
-    const args = node['arguments'];
-    const request = Array.isArray(args) ? args[0] : undefined;
-    if (isAstNode(request) && request.type === 'ObjectExpression') envelopes.push(request);
-  });
-  return envelopes;
-}
-
-function isDaemonSendCallee(callee: unknown): boolean {
-  if (!isAstNode(callee)) return false;
-  if (callee.type === 'Identifier') return DAEMON_SEND_CALLEES.has(String(callee['name']));
-  if (callee.type !== 'MemberExpression' || callee['computed'] === true) return false;
-  const property = identifierName(callee['property']);
-  return property !== undefined && DAEMON_SEND_CALLEES.has(property);
-}
-
-function envelopeProperties(envelope: AstNode): AstNode[] {
-  const properties = envelope['properties'];
-  return Array.isArray(properties) ? properties.filter(isAstNode) : [];
-}
-
-function localFunctionsByName(program: unknown): Map<string, AstNode> {
-  const functions = new Map<string, AstNode>();
-  walk(program, (node) => {
-    if (node.type !== 'FunctionDeclaration') return;
-    const name = identifierName(node['id']);
-    if (name !== undefined) functions.set(name, node);
-  });
-  return functions;
-}
-
-/** Dispatch sites reachable from `scope`, following calls to same-module functions. */
-function reachableDispatches(
-  scope: unknown,
-  functions: ReadonlyMap<string, AstNode>,
-  visited: Set<string>,
-): DispatchSite[] {
-  const found: DispatchSite[] = [];
-  const calls: string[] = [];
-  walk(scope, (node) => {
-    const site = dispatchSiteOf(node);
-    if (site !== undefined) found.push(site);
-    if (node.type !== 'CallExpression') return;
-    const callee = identifierName(node['callee']);
-    if (callee !== undefined && functions.has(callee)) calls.push(callee);
-  });
-  for (const name of calls) {
-    if (visited.has(name)) continue;
-    visited.add(name);
-    found.push(...reachableDispatches(functions.get(name), functions, visited));
-  }
-  return found;
-}
-
-function scanCliRouteDispatches(sourceText: string): RouteScan {
-  const program = parseSync('cli.ts', sourceText).program;
-  const functions = localFunctionsByName(program);
-  const edges = new Set<string>();
-  const dispatches: RouteDispatch[] = [];
-  const attributedOffsets = new Set<number>();
-
-  walk(program, (node) => {
-    if (node.type !== 'IfStatement') return;
-    const route = routedCommandOf(node['test']);
-    if (route === undefined) return;
-    for (const site of reachableDispatches(node['consequent'], functions, new Set())) {
-      attributedOffsets.add(site.offset);
-      const edge = `${route} ${site.command}`;
-      if (edges.has(edge)) continue;
-      edges.add(edge);
-      dispatches.push({ route, dispatched: site.command });
-    }
-  });
-
-  const allSites: DispatchSite[] = [];
-  walk(program, (node) => {
-    const site = dispatchSiteOf(node);
-    if (site !== undefined) allSites.push(site);
-  });
-
-  const unclaimed = allSites
-    .filter(({ offset }) => !attributedOffsets.has(offset))
-    .map(({ command }) => command);
-
-  return {
-    dispatches,
-    unattributed: [...new Set(unclaimed)].sort(),
-    unresolvedTargets: unresolvedDaemonSendTargets(program, sourceText),
-  };
-}
-
-/**
- * A daemon send whose command target the gate cannot resolve. Dropping these would
- * leave an evasion path: an unknown literal or a computed target would simply never
- * appear in the scan, so the gate reports them instead of skipping them.
- */
-function unresolvedDaemonSendTargets(program: unknown, sourceText: string): string[] {
-  const unresolved: string[] = [];
-  for (const envelope of daemonSendEnvelopes(program)) {
-    const commandProperty = envelopeProperties(envelope).find(
-      (property) => commandPropertyOf(property) !== undefined,
-    );
-    if (commandProperty === undefined) {
-      unresolved.push(`${lineOf(sourceText, offsetOf(envelope))}: daemon send declares no command`);
-      continue;
-    }
-    if (dispatchTargetOf(commandProperty['value']) === undefined) {
-      unresolved.push(
-        `${lineOf(sourceText, offsetOf(commandProperty))}: daemon send target is not a registered command`,
-      );
-    }
-  }
-  return unresolved;
-}
-
-function lineOf(sourceText: string, offset: number): number {
-  return offset < 0 ? 0 : sourceText.slice(0, offset).split('\n').length;
-}
-
-function dominanceFailures(scan: RouteScan, kindOf: PlatformExecutionKindOf): string[] {
-  return scan.dispatches
+function dominanceFailures(
+  kindOf: PlatformExecutionKindOf,
+  table: DispatchTable = CLI_INJECTED_DAEMON_DISPATCHES,
+): string[] {
+  return declaredPairs(table)
     .filter(({ route, dispatched }) => kindOf(route) === 'none' && kindOf(dispatched) !== 'none')
     .map(
       ({ route, dispatched }) =>
@@ -279,96 +56,207 @@ function dominanceFailures(scan: RouteScan, kindOf: PlatformExecutionKindOf): st
     .sort();
 }
 
-function scanCompositionRoot(): RouteScan {
-  return scanCliRouteDispatches(fs.readFileSync(CLI_COMPOSITION_ROOT, 'utf8'));
+/**
+ * The table's types reject an unregistered target, but a cast would slip past them and
+ * then read as "no dominance failure" because an unknown command has no mode at all.
+ * An unresolvable end of a declared pair is a gate error, not an absence.
+ */
+function unresolvedPairs(
+  kindOf: PlatformExecutionKindOf,
+  table: DispatchTable = CLI_INJECTED_DAEMON_DISPATCHES,
+): string[] {
+  return declaredPairs(table)
+    .flatMap(({ route, dispatched }) => [
+      ...(kindOf(route) === undefined ? [`route ${route} is not a registered command`] : []),
+      ...(kindOf(dispatched) === undefined
+        ? [`${route} dispatches ${dispatched}, which is not a registered command`]
+        : []),
+    ])
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Seam singularity. The rule is positional, not value-resolving: the transport
+// identifier may appear only in the positions listed below. Anything else — a call,
+// an alias, a form not yet imagined — fails, so the check cannot quietly miss a
+// dispatch shape it was not taught to recognize.
+// ---------------------------------------------------------------------------
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+}
+
+function walkWithParent(
+  node: unknown,
+  parent: AstNode | null,
+  visit: (node: AstNode, parent: AstNode | null) => void,
+): void {
+  if (Array.isArray(node)) {
+    for (const child of node) walkWithParent(child, parent, visit);
+    return;
+  }
+  if (!isAstNode(node)) return;
+  visit(node, parent);
+  for (const value of Object.values(node)) walkWithParent(value, node, visit);
+}
+
+function referencesTransport(node: AstNode): boolean {
+  if (node.type === 'Identifier') return node['name'] === TRANSPORT;
+  if (node.type !== 'MemberExpression') return false;
+  const property = node['property'];
+  if (!isAstNode(property)) return false;
+  const name = property.type === 'Identifier' ? property['name'] : property['value'];
+  return name === TRANSPORT;
+}
+
+/**
+ * The reviewed positions, each named. Handing the transport to an arbitrary callee is a
+ * bypass — that callee can rename the parameter and dispatch — so a call argument is
+ * legitimate only for the client-transport factory, and an object property only under
+ * the two reviewed keys. Anything else is unreviewed by construction.
+ */
+const TRANSPORT_FACTORY_CALLEES = new Set(['createClientDaemonTransport']);
+const TRANSPORT_PROPERTY_KEYS = new Set(['sendToDaemon', 'transport']);
+
+function propertyKeyName(node: AstNode): string | undefined {
+  const key = node['key'];
+  if (!isAstNode(key)) return undefined;
+  const name = key.type === 'Identifier' ? key['name'] : key['value'];
+  return typeof name === 'string' ? name : undefined;
+}
+
+function calleeName(node: AstNode): string | undefined {
+  const callee = node['callee'];
+  if (!isAstNode(callee)) return undefined;
+  if (callee.type === 'Identifier') return String(callee['name']);
+  if (callee.type !== 'MemberExpression') return undefined;
+  const property = callee['property'];
+  return isAstNode(property) && property.type === 'Identifier'
+    ? String(property['name'])
+    : undefined;
+}
+
+/** The allowlist as data: parent node type -> what makes that position reviewed. */
+const REVIEWED_TRANSPORT_POSITIONS: Readonly<Record<string, (parent: AstNode) => boolean>> = {
+  ImportSpecifier: () => true,
+  ImportDeclaration: () => true,
+  TSTypeQuery: () => true,
+  // The `deps.sendToDaemon` access itself; its own parent is checked in turn.
+  MemberExpression: () => true,
+  TSPropertySignature: (parent) => TRANSPORT_PROPERTY_KEYS.has(propertyKeyName(parent) ?? ''),
+  Property: (parent) => TRANSPORT_PROPERTY_KEYS.has(propertyKeyName(parent) ?? ''),
+  CallExpression: (parent) => TRANSPORT_FACTORY_CALLEES.has(calleeName(parent) ?? ''),
+};
+
+function isReviewedTransportPosition(parent: AstNode | null): boolean {
+  if (parent === null) return false;
+  return REVIEWED_TRANSPORT_POSITIONS[parent.type]?.(parent) ?? false;
+}
+
+function referencesTransportNode(value: unknown): boolean {
+  return isAstNode(value) && referencesTransport(value);
+}
+
+function transportDefect(node: AstNode, parent: AstNode | null): string | undefined {
+  if (node.type === 'CallExpression' && referencesTransportNode(node['callee'])) {
+    return `calls ${TRANSPORT} outside the injected-dispatch seam`;
+  }
+  if (node.type === 'VariableDeclarator') {
+    return referencesTransportNode(node['init'])
+      ? `aliases ${TRANSPORT} outside the injected-dispatch seam`
+      : undefined;
+  }
+  if (node.type !== 'Identifier' && node.type !== 'MemberExpression') return undefined;
+  if (!referencesTransport(node) || isReviewedTransportPosition(parent)) return undefined;
+  return `names ${TRANSPORT} in an unreviewed position`;
+}
+
+function transportMisuse(filePath: string, source: string): string[] {
+  const misuse: string[] = [];
+  walkWithParent(parseSync(filePath, source).program, null, (node, parent) => {
+    const defect = transportDefect(node, parent);
+    if (defect !== undefined) misuse.push(`${filePath}: ${defect}`);
+  });
+  return misuse;
+}
+
+function cliModulePaths(): string[] {
+  const walkDir = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walkDir(full);
+      return entry.isFile() && full.endsWith('.ts') && !full.endsWith('.test.ts') ? [full] : [];
+    });
+  return [CLI_ROOT, ...walkDir(CLI_DIR)].filter((file) => file !== SEAM_MODULE);
 }
 
 describe('platform-execution coherence across CLI route delegation', () => {
   test('no none command dispatches a platform-executing command', () => {
-    expect(dominanceFailures(scanCompositionRoot(), registryKind)).toEqual([]);
+    expect(dominanceFailures(registryKind)).toEqual([]);
   });
 
-  test('every CLI daemon dispatch is attributable to a routed command', () => {
-    expect(scanCompositionRoot().unattributed).toEqual([]);
-  });
-
-  test('every CLI daemon send resolves to a registered command', () => {
-    expect(scanCompositionRoot().unresolvedTargets).toEqual([]);
-  });
-
-  test('the composition root still carries the react-devtools runtime delegation', () => {
-    expect(scanCompositionRoot().dispatches).toContainEqual({
-      route: 'react-devtools',
-      dispatched: 'runtime',
-    });
-  });
-
-  test('planted red: react-devtools declared none is rejected by the real route', () => {
+  test('planted red: react-devtools declared none is rejected by the declared pair', () => {
     const plantedNone: PlatformExecutionKindOf = (command) =>
       command === 'react-devtools' ? 'none' : registryKind(command);
 
-    expect(dominanceFailures(scanCompositionRoot(), plantedNone)).toEqual([
+    expect(dominanceFailures(plantedNone)).toEqual([
       'react-devtools declares platformExecution none but its CLI route dispatches runtime (legacy)',
     ]);
   });
 
-  test('planted red: an unroutable dispatch is reported rather than ignored', () => {
-    const planted = `
-      async function runCli(argv, deps) {
-        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
-      }
-    `;
-    expect(scanCliRouteDispatches(planted).unattributed).toEqual(['runtime']);
+  test('the declared table still carries the react-devtools runtime delegation', () => {
+    const route: CliInjectedRoute = 'react-devtools';
+    expect(CLI_INJECTED_DAEMON_DISPATCHES[route]).toEqual(['runtime']);
   });
 
-  test('planted red: a stray dispatch sharing a routed target name is still reported', () => {
-    const planted = `
-      async function runCli(argv, deps) {
-        if (command === 'react-devtools') {
-          await runReactDevtoolsCli(ctx, deps);
-          return;
-        }
-        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: ['stray'] });
-      }
-      async function runReactDevtoolsCli(ctx, deps) {
-        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
-      }
-    `;
-    const scan = scanCliRouteDispatches(planted);
-
-    // Both halves matter: the routed occurrence is claimed, the stray one is not.
-    expect(scan.dispatches).toEqual([{ route: 'react-devtools', dispatched: 'runtime' }]);
-    expect(scan.unattributed).toEqual(['runtime']);
+  test('every declared pair names registered commands on both ends', () => {
+    expect(unresolvedPairs(registryKind)).toEqual([]);
   });
 
-  test('planted red: a stray dispatch with an unknown target surfaces', () => {
-    const planted = `
-      async function runCli(argv, deps) {
-        if (command === 'react-devtools') {
-          await runReactDevtoolsCli(ctx, deps);
-          return;
-        }
-        await deps.sendToDaemon({ command: SOME_OTHER_CATALOG.hidden, positionals: [] });
-      }
-      async function runReactDevtoolsCli(ctx, deps) {
-        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
-      }
-    `;
-    const scan = scanCliRouteDispatches(planted);
+  test('planted red: a cast-around table target is reported, not read as no failure', () => {
+    const planted = { 'react-devtools': ['not-a-command'] } as const;
 
-    // The known routed dispatch still resolves, so the failure is the stray one alone.
-    expect(scan.dispatches).toEqual([{ route: 'react-devtools', dispatched: 'runtime' }]);
-    expect(scan.unresolvedTargets).toEqual(['7: daemon send target is not a registered command']);
+    // Dominance alone cannot see it: an unknown command has no mode to compare.
+    expect(dominanceFailures(registryKind, planted)).toEqual([]);
+    expect(unresolvedPairs(registryKind, planted)).toEqual([
+      'react-devtools dispatches not-a-command, which is not a registered command',
+    ]);
+  });
+
+  test('the CLI reaches the daemon transport only through the injected-dispatch seam', () => {
+    const misuse = cliModulePaths().flatMap((file) =>
+      transportMisuse(path.relative(process.cwd(), file), fs.readFileSync(file, 'utf8')),
+    );
+    expect(misuse).toEqual([]);
   });
 
   test.each([
-    ['a computed target', 'deps.sendToDaemon({ command: catalog[key], positionals: [] });'],
-    ['an unknown literal', "deps.sendToDaemon({ command: 'not-a-command', positionals: [] });"],
-    ['a variable target', 'deps.sendToDaemon({ command: chosen, positionals: [] });'],
-    ['no target at all', 'deps.sendToDaemon({ positionals: [] });'],
-  ])('planted red: %s is a gate error, not a skip', (_label, send) => {
-    const scan = scanCliRouteDispatches(`async function runCli(argv, deps) { await ${send} }`);
+    ['a direct call', 'await sendToDaemon({ command: INTERNAL_COMMANDS.runtime });'],
+    ['a member call', 'await deps.sendToDaemon(request);'],
+    ['a computed-member call', "await deps['sendToDaemon'](request);"],
+    ['a variable envelope', 'const request = { command: x }; await deps.sendToDaemon(request);'],
+    ['an alias', 'const send = deps.sendToDaemon; await send(request);'],
+    ['a handoff to an arbitrary helper', 'await runInjected(deps.sendToDaemon, request);'],
+    ['a handoff under an unreviewed key', 'await runInjected({ send: deps.sendToDaemon });'],
+    ['a bare re-export', 'export { sendToDaemon };'],
+  ])('planted red: %s outside the seam is rejected', (_label, body) => {
+    expect(
+      transportMisuse('src/cli/planted.ts', `async function run(deps) { ${body} }`),
+    ).not.toEqual([]);
+  });
 
-    expect(scan.unresolvedTargets).toHaveLength(1);
+  test('wiring the transport into a client transport factory stays allowed', () => {
+    const wiring = `
+      import { sendToDaemon } from '../daemon/client/daemon-client.ts';
+      type CliDeps = { sendToDaemon: typeof sendToDaemon };
+      const DEFAULT: CliDeps = { sendToDaemon };
+      function build(deps: CliDeps) {
+        return createClient({ transport: deps.sendToDaemon });
+      }
+      function build2(deps: CliDeps) {
+        return createClient({ transport: createClientDaemonTransport(deps.sendToDaemon) });
+      }
+    `;
+    expect(transportMisuse('src/cli/planted.ts', wiring)).toEqual([]);
   });
 });

--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -36,9 +36,16 @@ const registryKind: PlatformExecutionKindOf = (command) =>
 
 type RouteDispatch = Readonly<{ route: string; dispatched: string }>;
 
+/**
+ * One dispatch expression, identified by source position. Attribution subtracts
+ * occurrences: two dispatches of the same command are two sites, so a stray one
+ * cannot be absorbed by a routed one that happens to name the same command.
+ */
+type DispatchSite = Readonly<{ command: string; offset: number }>;
+
 type RouteScan = Readonly<{
   dispatches: readonly RouteDispatch[];
-  /** Dispatch literals no `command === '<name>'` route could claim. */
+  /** Commands dispatched at a site no `command === '<name>'` route could claim. */
   unattributed: readonly string[];
 }>;
 
@@ -88,10 +95,15 @@ function routedCommandOf(test: unknown): string | undefined {
 }
 
 /** `command: 'x'`, `command: INTERNAL_COMMANDS.x`, `command: PUBLIC_COMMANDS.x`. */
-function dispatchedCommandOf(node: AstNode): string | undefined {
+function dispatchSiteOf(node: AstNode): DispatchSite | undefined {
   if (node.type !== 'Property' || node['computed'] === true) return undefined;
   if (identifierName(node['key']) !== 'command') return undefined;
-  return dispatchTargetOf(node['value']);
+  const command = dispatchTargetOf(node['value']);
+  if (command === undefined) return undefined;
+  // A node without a source position cannot be matched against an attributed
+  // site, so -1 keeps it distinct from every real offset and it stays unclaimed.
+  const start = node['start'];
+  return { command, offset: typeof start === 'number' ? start : -1 };
 }
 
 function dispatchTargetOf(value: unknown): string | undefined {
@@ -115,17 +127,17 @@ function localFunctionsByName(program: unknown): Map<string, AstNode> {
   return functions;
 }
 
-/** Dispatch literals reachable from `scope`, following calls to same-module functions. */
+/** Dispatch sites reachable from `scope`, following calls to same-module functions. */
 function reachableDispatches(
   scope: unknown,
   functions: ReadonlyMap<string, AstNode>,
   visited: Set<string>,
-): Set<string> {
-  const found = new Set<string>();
+): DispatchSite[] {
+  const found: DispatchSite[] = [];
   const calls: string[] = [];
   walk(scope, (node) => {
-    const dispatched = dispatchedCommandOf(node);
-    if (dispatched !== undefined) found.add(dispatched);
+    const site = dispatchSiteOf(node);
+    if (site !== undefined) found.push(site);
     if (node.type !== 'CallExpression') return;
     const callee = identifierName(node['callee']);
     if (callee !== undefined && functions.has(callee)) calls.push(callee);
@@ -133,9 +145,7 @@ function reachableDispatches(
   for (const name of calls) {
     if (visited.has(name)) continue;
     visited.add(name);
-    for (const dispatched of reachableDispatches(functions.get(name), functions, visited)) {
-      found.add(dispatched);
-    }
+    found.push(...reachableDispatches(functions.get(name), functions, visited));
   }
   return found;
 }
@@ -143,29 +153,34 @@ function reachableDispatches(
 function scanCliRouteDispatches(sourceText: string): RouteScan {
   const program = parseSync('cli.ts', sourceText).program;
   const functions = localFunctionsByName(program);
+  const edges = new Set<string>();
   const dispatches: RouteDispatch[] = [];
-  const attributed = new Set<string>();
+  const attributedOffsets = new Set<number>();
 
   walk(program, (node) => {
     if (node.type !== 'IfStatement') return;
     const route = routedCommandOf(node['test']);
     if (route === undefined) return;
-    for (const dispatched of reachableDispatches(node['consequent'], functions, new Set())) {
-      dispatches.push({ route, dispatched });
-      attributed.add(dispatched);
+    for (const site of reachableDispatches(node['consequent'], functions, new Set())) {
+      attributedOffsets.add(site.offset);
+      const edge = `${route} ${site.command}`;
+      if (edges.has(edge)) continue;
+      edges.add(edge);
+      dispatches.push({ route, dispatched: site.command });
     }
   });
 
-  const all = new Set<string>();
+  const allSites: DispatchSite[] = [];
   walk(program, (node) => {
-    const dispatched = dispatchedCommandOf(node);
-    if (dispatched !== undefined) all.add(dispatched);
+    const site = dispatchSiteOf(node);
+    if (site !== undefined) allSites.push(site);
   });
 
-  return {
-    dispatches,
-    unattributed: [...all].filter((command) => !attributed.has(command)).sort(),
-  };
+  const unclaimed = allSites
+    .filter(({ offset }) => !attributedOffsets.has(offset))
+    .map(({ command }) => command);
+
+  return { dispatches, unattributed: [...new Set(unclaimed)].sort() };
 }
 
 function dominanceFailures(scan: RouteScan, kindOf: PlatformExecutionKindOf): string[] {
@@ -214,5 +229,25 @@ describe('platform-execution coherence across CLI route delegation', () => {
       }
     `;
     expect(scanCliRouteDispatches(planted).unattributed).toEqual(['runtime']);
+  });
+
+  test('planted red: a stray dispatch sharing a routed target name is still reported', () => {
+    const planted = `
+      async function runCli(argv, deps) {
+        if (command === 'react-devtools') {
+          await runReactDevtoolsCli(ctx, deps);
+          return;
+        }
+        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: ['stray'] });
+      }
+      async function runReactDevtoolsCli(ctx, deps) {
+        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
+      }
+    `;
+    const scan = scanCliRouteDispatches(planted);
+
+    // Both halves matter: the routed occurrence is claimed, the stray one is not.
+    expect(scan.dispatches).toEqual([{ route: 'react-devtools', dispatched: 'runtime' }]);
+    expect(scan.unattributed).toEqual(['runtime']);
   });
 });

--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -15,7 +15,10 @@ import { commandDescriptors } from '../registry.ts';
  * only when D is `none` too.
  *
  * Scope is `src/cli.ts`, the composition root where injected callbacks are built.
- * The scan is total within it — a dispatch no route can claim fails the gate.
+ * The scan is total within it in both directions: a dispatch no route can claim
+ * fails, and a daemon send whose command target cannot be resolved to a registered
+ * command also fails. An unresolvable target is a gate error rather than a skip,
+ * because a skipped dispatch is indistinguishable from an absent one.
  */
 
 type AstNode = { type: string } & Record<string, unknown>;
@@ -47,7 +50,16 @@ type RouteScan = Readonly<{
   dispatches: readonly RouteDispatch[];
   /** Commands dispatched at a site no `command === '<name>'` route could claim. */
   unattributed: readonly string[];
+  /**
+   * Daemon sends whose `command` target is not a registered command literal —
+   * a computed target, a variable, an unknown catalog key, or no target at all.
+   * Reported by source line: the gate cannot reason about them, so it refuses them.
+   */
+  unresolvedTargets: readonly string[];
 }>;
+
+/** Calls that hand a request envelope to the daemon. */
+const DAEMON_SEND_CALLEES = new Set(['sendToDaemon']);
 
 function isAstNode(value: unknown): value is AstNode {
   return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
@@ -96,14 +108,25 @@ function routedCommandOf(test: unknown): string | undefined {
 
 /** `command: 'x'`, `command: INTERNAL_COMMANDS.x`, `command: PUBLIC_COMMANDS.x`. */
 function dispatchSiteOf(node: AstNode): DispatchSite | undefined {
-  if (node.type !== 'Property' || node['computed'] === true) return undefined;
-  if (identifierName(node['key']) !== 'command') return undefined;
-  const command = dispatchTargetOf(node['value']);
+  const commandProperty = commandPropertyOf(node);
+  if (commandProperty === undefined) return undefined;
+  const command = dispatchTargetOf(commandProperty['value']);
   if (command === undefined) return undefined;
-  // A node without a source position cannot be matched against an attributed
-  // site, so -1 keeps it distinct from every real offset and it stays unclaimed.
+  return { command, offset: offsetOf(commandProperty) };
+}
+
+function commandPropertyOf(node: AstNode): AstNode | undefined {
+  if (node.type !== 'Property' || node['computed'] === true) return undefined;
+  return identifierName(node['key']) === 'command' ? node : undefined;
+}
+
+/**
+ * A node without a source position cannot be matched against an attributed site, so
+ * -1 keeps it distinct from every real offset and it stays unclaimed.
+ */
+function offsetOf(node: AstNode): number {
   const start = node['start'];
-  return { command, offset: typeof start === 'number' ? start : -1 };
+  return typeof start === 'number' ? start : -1;
 }
 
 function dispatchTargetOf(value: unknown): string | undefined {
@@ -115,6 +138,37 @@ function dispatchTargetOf(value: unknown): string | undefined {
   const catalog = identifierName(value['object']);
   const key = identifierName(value['property']);
   return catalog === undefined || key === undefined ? undefined : COMMAND_CATALOGS[catalog]?.[key];
+}
+
+/**
+ * Every request envelope handed to the daemon, whether or not its command target can
+ * be resolved. `command:` alone cannot mark a dispatch — diagnostics scopes and context
+ * builders carry the same key — so the envelope is identified by the send call it is
+ * passed to.
+ */
+function daemonSendEnvelopes(program: unknown): AstNode[] {
+  const envelopes: AstNode[] = [];
+  walk(program, (node) => {
+    if (node.type !== 'CallExpression' || !isDaemonSendCallee(node['callee'])) return;
+    // `sendToDaemon(request, options)`: only the first argument is the request.
+    const args = node['arguments'];
+    const request = Array.isArray(args) ? args[0] : undefined;
+    if (isAstNode(request) && request.type === 'ObjectExpression') envelopes.push(request);
+  });
+  return envelopes;
+}
+
+function isDaemonSendCallee(callee: unknown): boolean {
+  if (!isAstNode(callee)) return false;
+  if (callee.type === 'Identifier') return DAEMON_SEND_CALLEES.has(String(callee['name']));
+  if (callee.type !== 'MemberExpression' || callee['computed'] === true) return false;
+  const property = identifierName(callee['property']);
+  return property !== undefined && DAEMON_SEND_CALLEES.has(property);
+}
+
+function envelopeProperties(envelope: AstNode): AstNode[] {
+  const properties = envelope['properties'];
+  return Array.isArray(properties) ? properties.filter(isAstNode) : [];
 }
 
 function localFunctionsByName(program: unknown): Map<string, AstNode> {
@@ -180,7 +234,39 @@ function scanCliRouteDispatches(sourceText: string): RouteScan {
     .filter(({ offset }) => !attributedOffsets.has(offset))
     .map(({ command }) => command);
 
-  return { dispatches, unattributed: [...new Set(unclaimed)].sort() };
+  return {
+    dispatches,
+    unattributed: [...new Set(unclaimed)].sort(),
+    unresolvedTargets: unresolvedDaemonSendTargets(program, sourceText),
+  };
+}
+
+/**
+ * A daemon send whose command target the gate cannot resolve. Dropping these would
+ * leave an evasion path: an unknown literal or a computed target would simply never
+ * appear in the scan, so the gate reports them instead of skipping them.
+ */
+function unresolvedDaemonSendTargets(program: unknown, sourceText: string): string[] {
+  const unresolved: string[] = [];
+  for (const envelope of daemonSendEnvelopes(program)) {
+    const commandProperty = envelopeProperties(envelope).find(
+      (property) => commandPropertyOf(property) !== undefined,
+    );
+    if (commandProperty === undefined) {
+      unresolved.push(`${lineOf(sourceText, offsetOf(envelope))}: daemon send declares no command`);
+      continue;
+    }
+    if (dispatchTargetOf(commandProperty['value']) === undefined) {
+      unresolved.push(
+        `${lineOf(sourceText, offsetOf(commandProperty))}: daemon send target is not a registered command`,
+      );
+    }
+  }
+  return unresolved;
+}
+
+function lineOf(sourceText: string, offset: number): number {
+  return offset < 0 ? 0 : sourceText.slice(0, offset).split('\n').length;
 }
 
 function dominanceFailures(scan: RouteScan, kindOf: PlatformExecutionKindOf): string[] {
@@ -204,6 +290,10 @@ describe('platform-execution coherence across CLI route delegation', () => {
 
   test('every CLI daemon dispatch is attributable to a routed command', () => {
     expect(scanCompositionRoot().unattributed).toEqual([]);
+  });
+
+  test('every CLI daemon send resolves to a registered command', () => {
+    expect(scanCompositionRoot().unresolvedTargets).toEqual([]);
   });
 
   test('the composition root still carries the react-devtools runtime delegation', () => {
@@ -249,5 +339,36 @@ describe('platform-execution coherence across CLI route delegation', () => {
     // Both halves matter: the routed occurrence is claimed, the stray one is not.
     expect(scan.dispatches).toEqual([{ route: 'react-devtools', dispatched: 'runtime' }]);
     expect(scan.unattributed).toEqual(['runtime']);
+  });
+
+  test('planted red: a stray dispatch with an unknown target surfaces', () => {
+    const planted = `
+      async function runCli(argv, deps) {
+        if (command === 'react-devtools') {
+          await runReactDevtoolsCli(ctx, deps);
+          return;
+        }
+        await deps.sendToDaemon({ command: SOME_OTHER_CATALOG.hidden, positionals: [] });
+      }
+      async function runReactDevtoolsCli(ctx, deps) {
+        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
+      }
+    `;
+    const scan = scanCliRouteDispatches(planted);
+
+    // The known routed dispatch still resolves, so the failure is the stray one alone.
+    expect(scan.dispatches).toEqual([{ route: 'react-devtools', dispatched: 'runtime' }]);
+    expect(scan.unresolvedTargets).toEqual(['7: daemon send target is not a registered command']);
+  });
+
+  test.each([
+    ['a computed target', 'deps.sendToDaemon({ command: catalog[key], positionals: [] });'],
+    ['an unknown literal', "deps.sendToDaemon({ command: 'not-a-command', positionals: [] });"],
+    ['a variable target', 'deps.sendToDaemon({ command: chosen, positionals: [] });'],
+    ['no target at all', 'deps.sendToDaemon({ positionals: [] });'],
+  ])('planted red: %s is a gate error, not a skip', (_label, send) => {
+    const scan = scanCliRouteDispatches(`async function runCli(argv, deps) { await ${send} }`);
+
+    expect(scan.unresolvedTargets).toHaveLength(1);
   });
 });

--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -89,15 +89,16 @@ function isAstNode(value: unknown): value is AstNode {
 function walkWithParent(
   node: unknown,
   parent: AstNode | null,
-  visit: (node: AstNode, parent: AstNode | null) => void,
+  ancestors: readonly AstNode[],
+  visit: (node: AstNode, parent: AstNode | null, ancestors: readonly AstNode[]) => void,
 ): void {
   if (Array.isArray(node)) {
-    for (const child of node) walkWithParent(child, parent, visit);
+    for (const child of node) walkWithParent(child, parent, ancestors, visit);
     return;
   }
   if (!isAstNode(node)) return;
-  visit(node, parent);
-  for (const value of Object.values(node)) walkWithParent(value, node, visit);
+  visit(node, parent, ancestors);
+  for (const value of Object.values(node)) walkWithParent(value, node, [...ancestors, node], visit);
 }
 
 function referencesTransport(node: AstNode): boolean {
@@ -112,11 +113,16 @@ function referencesTransport(node: AstNode): boolean {
 /**
  * The reviewed positions, each named. Handing the transport to an arbitrary callee is a
  * bypass — that callee can rename the parameter and dispatch — so a call argument is
- * legitimate only for the client-transport factory, and an object property only under
- * the two reviewed keys. Anything else is unreviewed by construction.
+ * legitimate only for the client-transport factory. Object properties are reviewed
+ * only when they belong to an exact construction call (or the one default dependency
+ * record), never merely because their key happens to be named `transport`.
  */
 const TRANSPORT_FACTORY_CALLEES = new Set(['createClientDaemonTransport']);
-const TRANSPORT_PROPERTY_KEYS = new Set(['sendToDaemon', 'transport']);
+const TRANSPORT_PROPERTY_CALLEES = new Set([
+  'createCliDaemonTransport',
+  'sendInjectedDaemonRequest',
+]);
+const CLI_MODULE = 'src/cli.ts';
 
 function propertyKeyName(node: AstNode): string | undefined {
   const key = node['key'];
@@ -125,15 +131,57 @@ function propertyKeyName(node: AstNode): string | undefined {
   return typeof name === 'string' ? name : undefined;
 }
 
-function calleeName(node: AstNode): string | undefined {
+function identifierCalleeName(node: AstNode): string | undefined {
   const callee = node['callee'];
-  if (!isAstNode(callee)) return undefined;
-  if (callee.type === 'Identifier') return String(callee['name']);
-  if (callee.type !== 'MemberExpression') return undefined;
-  const property = callee['property'];
-  return isAstNode(property) && property.type === 'Identifier'
-    ? String(property['name'])
+  return isAstNode(callee) && callee.type === 'Identifier' ? String(callee['name']) : undefined;
+}
+
+function identifierName(node: unknown): string | undefined {
+  return isAstNode(node) && (node.type === 'Identifier' || node.type === 'BindingIdentifier')
+    ? String(node['name'])
     : undefined;
+}
+
+function isReviewedTransportCallProperty(
+  key: string | undefined,
+  object: AstNode | undefined,
+  owner: AstNode | undefined,
+): boolean {
+  return (
+    key === 'transport' &&
+    object?.type === 'ObjectExpression' &&
+    owner?.type === 'CallExpression' &&
+    TRANSPORT_PROPERTY_CALLEES.has(identifierCalleeName(owner) ?? '')
+  );
+}
+
+function isDefaultCliDepsProperty(
+  key: string | undefined,
+  object: AstNode | undefined,
+  owner: AstNode | undefined,
+): boolean {
+  if (key !== 'sendToDaemon' || object?.type !== 'ObjectExpression') return false;
+  if (owner?.type !== 'VariableDeclarator') return false;
+  const id = owner['id'];
+  return (
+    identifierName(id) === 'DEFAULT_CLI_DEPS' ||
+    (isAstNode(id) && identifierName(id['pattern']) === 'DEFAULT_CLI_DEPS')
+  );
+}
+
+function reviewedTransportProperty(
+  filePath: string,
+  parent: AstNode,
+  ancestors: readonly AstNode[],
+): boolean {
+  if (filePath !== CLI_MODULE) return false;
+  const key = propertyKeyName(parent);
+  const object = ancestors.at(-2);
+  const owner = ancestors.at(-3);
+  return (
+    isReviewedTransportCallProperty(key, object, owner) ||
+    isDefaultCliDepsProperty(key, object, owner)
+  );
 }
 
 /** The allowlist as data: parent node type -> what makes that position reviewed. */
@@ -143,13 +191,21 @@ const REVIEWED_TRANSPORT_POSITIONS: Readonly<Record<string, (parent: AstNode) =>
   TSTypeQuery: () => true,
   // The `deps.sendToDaemon` access itself; its own parent is checked in turn.
   MemberExpression: () => true,
-  TSPropertySignature: (parent) => TRANSPORT_PROPERTY_KEYS.has(propertyKeyName(parent) ?? ''),
-  Property: (parent) => TRANSPORT_PROPERTY_KEYS.has(propertyKeyName(parent) ?? ''),
-  CallExpression: (parent) => TRANSPORT_FACTORY_CALLEES.has(calleeName(parent) ?? ''),
+  TSPropertySignature: (parent) => propertyKeyName(parent) === 'sendToDaemon',
 };
 
-function isReviewedTransportPosition(parent: AstNode | null): boolean {
+function isReviewedTransportPosition(
+  filePath: string,
+  parent: AstNode | null,
+  ancestors: readonly AstNode[],
+): boolean {
   if (parent === null) return false;
+  if (parent.type === 'Property') return reviewedTransportProperty(filePath, parent, ancestors);
+  if (parent.type === 'CallExpression') {
+    return (
+      filePath === CLI_MODULE && TRANSPORT_FACTORY_CALLEES.has(identifierCalleeName(parent) ?? '')
+    );
+  }
   return REVIEWED_TRANSPORT_POSITIONS[parent.type]?.(parent) ?? false;
 }
 
@@ -157,7 +213,12 @@ function referencesTransportNode(value: unknown): boolean {
   return isAstNode(value) && referencesTransport(value);
 }
 
-function transportDefect(node: AstNode, parent: AstNode | null): string | undefined {
+function transportDefect(
+  filePath: string,
+  node: AstNode,
+  parent: AstNode | null,
+  ancestors: readonly AstNode[],
+): string | undefined {
   if (node.type === 'CallExpression' && referencesTransportNode(node['callee'])) {
     return `calls ${TRANSPORT} outside the injected-dispatch seam`;
   }
@@ -167,14 +228,16 @@ function transportDefect(node: AstNode, parent: AstNode | null): string | undefi
       : undefined;
   }
   if (node.type !== 'Identifier' && node.type !== 'MemberExpression') return undefined;
-  if (!referencesTransport(node) || isReviewedTransportPosition(parent)) return undefined;
+  if (!referencesTransport(node) || isReviewedTransportPosition(filePath, parent, ancestors)) {
+    return undefined;
+  }
   return `names ${TRANSPORT} in an unreviewed position`;
 }
 
 function transportMisuse(filePath: string, source: string): string[] {
   const misuse: string[] = [];
-  walkWithParent(parseSync(filePath, source).program, null, (node, parent) => {
-    const defect = transportDefect(node, parent);
+  walkWithParent(parseSync(filePath, source).program, null, [], (node, parent, ancestors) => {
+    const defect = transportDefect(filePath, node, parent, ancestors);
     if (defect !== undefined) misuse.push(`${filePath}: ${defect}`);
   });
   return misuse;
@@ -237,6 +300,10 @@ describe('platform-execution coherence across CLI route delegation', () => {
     ['a variable envelope', 'const request = { command: x }; await deps.sendToDaemon(request);'],
     ['an alias', 'const send = deps.sendToDaemon; await send(request);'],
     ['a handoff to an arbitrary helper', 'await runInjected(deps.sendToDaemon, request);'],
+    [
+      'a handoff under the globally reviewed transport key',
+      'await runInjected({ transport: deps.sendToDaemon });',
+    ],
     ['a handoff under an unreviewed key', 'await runInjected({ send: deps.sendToDaemon });'],
     ['a bare re-export', 'export { sendToDaemon };'],
   ])('planted red: %s outside the seam is rejected', (_label, body) => {
@@ -249,14 +316,35 @@ describe('platform-execution coherence across CLI route delegation', () => {
     const wiring = `
       import { sendToDaemon } from '../daemon/client/daemon-client.ts';
       type CliDeps = { sendToDaemon: typeof sendToDaemon };
-      const DEFAULT: CliDeps = { sendToDaemon };
       function build(deps: CliDeps) {
-        return createClient({ transport: deps.sendToDaemon });
+        return createCliDaemonTransport({ transport: deps.sendToDaemon });
       }
       function build2(deps: CliDeps) {
         return createClient({ transport: createClientDaemonTransport(deps.sendToDaemon) });
       }
+      const DEFAULT_CLI_DEPS: CliDeps = { sendToDaemon };
+      function inject(deps: CliDeps) {
+        return sendInjectedDaemonRequest({ transport: deps.sendToDaemon });
+      }
     `;
-    expect(transportMisuse('src/cli/planted.ts', wiring)).toEqual([]);
+    expect(transportMisuse(CLI_MODULE, wiring)).toEqual([]);
+  });
+
+  test('a trusted callee name on an arbitrary member cannot smuggle the transport', () => {
+    const planted = `
+      async function run(deps) {
+        return helpers.createCliDaemonTransport({ transport: deps.sendToDaemon });
+      }
+    `;
+    expect(transportMisuse(CLI_MODULE, planted)).not.toEqual([]);
+  });
+
+  test('the CLI module cannot hand off the transport through a generically named property', () => {
+    const planted = `
+      async function run(deps) {
+        return runInjected({ transport: deps.sendToDaemon });
+      }
+    `;
+    expect(transportMisuse(CLI_MODULE, planted)).not.toEqual([]);
   });
 });

--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { parseSync } from 'oxc-parser';
+import { describe, expect, test } from 'vitest';
+import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../../command-catalog.ts';
+import { commandDescriptors } from '../registry.ts';
+
+/**
+ * ADR 0019 §6 coherence gate for delegated platform execution.
+ *
+ * The registry entry gate inspects one descriptor at a time, so it cannot see a
+ * command whose own module holds no platform code while its CLI route injects a
+ * callback that dispatches a platform-executing command. Mode dominance closes
+ * that: if the CLI route for command R dispatches command D, R may declare `none`
+ * only when D is `none` too.
+ *
+ * Scope is `src/cli.ts`, the composition root where injected callbacks are built.
+ * The scan is total within it — a dispatch no route can claim fails the gate.
+ */
+
+type AstNode = { type: string } & Record<string, unknown>;
+
+const CLI_COMPOSITION_ROOT = fileURLToPath(new URL('../../../cli.ts', import.meta.url));
+
+const COMMAND_CATALOGS: Record<string, Record<string, string>> = {
+  INTERNAL_COMMANDS,
+  PUBLIC_COMMANDS,
+};
+
+const COMMAND_NAMES = new Set<string>(commandDescriptors.map(({ name }) => name));
+
+type PlatformExecutionKindOf = (command: string) => string | undefined;
+
+const registryKind: PlatformExecutionKindOf = (command) =>
+  commandDescriptors.find(({ name }) => name === command)?.platformExecution.kind;
+
+type RouteDispatch = Readonly<{ route: string; dispatched: string }>;
+
+type RouteScan = Readonly<{
+  dispatches: readonly RouteDispatch[];
+  /** Dispatch literals no `command === '<name>'` route could claim. */
+  unattributed: readonly string[];
+}>;
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+}
+
+function walk(root: unknown, visit: (node: AstNode) => void): void {
+  if (Array.isArray(root)) {
+    for (const child of root) walk(child, visit);
+    return;
+  }
+  if (!isAstNode(root)) return;
+  visit(root);
+  for (const value of Object.values(root)) walk(value, visit);
+}
+
+function identifierName(node: unknown): string | undefined {
+  return isAstNode(node) && node.type === 'Identifier' ? String(node['name']) : undefined;
+}
+
+function stringLiteral(node: unknown): string | undefined {
+  return isAstNode(node) && node.type === 'Literal' && typeof node['value'] === 'string'
+    ? node['value']
+    : undefined;
+}
+
+function knownCommand(name: string | undefined): string | undefined {
+  return name !== undefined && COMMAND_NAMES.has(name) ? name : undefined;
+}
+
+/** `command === 'react-devtools'`, either operand order, names a routed command. */
+function routedCommandOf(test: unknown): string | undefined {
+  if (!isAstNode(test) || test.type !== 'BinaryExpression' || test['operator'] !== '===') {
+    return undefined;
+  }
+  const operands = [
+    [test['left'], test['right']],
+    [test['right'], test['left']],
+  ] as const;
+  for (const [subject, literal] of operands) {
+    if (identifierName(subject) !== 'command') continue;
+    const routed = knownCommand(stringLiteral(literal));
+    if (routed !== undefined) return routed;
+  }
+  return undefined;
+}
+
+/** `command: 'x'`, `command: INTERNAL_COMMANDS.x`, `command: PUBLIC_COMMANDS.x`. */
+function dispatchedCommandOf(node: AstNode): string | undefined {
+  if (node.type !== 'Property' || node['computed'] === true) return undefined;
+  if (identifierName(node['key']) !== 'command') return undefined;
+  return dispatchTargetOf(node['value']);
+}
+
+function dispatchTargetOf(value: unknown): string | undefined {
+  const literal = stringLiteral(value);
+  if (literal !== undefined) return knownCommand(literal);
+  if (!isAstNode(value) || value.type !== 'MemberExpression' || value['computed'] === true) {
+    return undefined;
+  }
+  const catalog = identifierName(value['object']);
+  const key = identifierName(value['property']);
+  return catalog === undefined || key === undefined ? undefined : COMMAND_CATALOGS[catalog]?.[key];
+}
+
+function localFunctionsByName(program: unknown): Map<string, AstNode> {
+  const functions = new Map<string, AstNode>();
+  walk(program, (node) => {
+    if (node.type !== 'FunctionDeclaration') return;
+    const name = identifierName(node['id']);
+    if (name !== undefined) functions.set(name, node);
+  });
+  return functions;
+}
+
+/** Dispatch literals reachable from `scope`, following calls to same-module functions. */
+function reachableDispatches(
+  scope: unknown,
+  functions: ReadonlyMap<string, AstNode>,
+  visited: Set<string>,
+): Set<string> {
+  const found = new Set<string>();
+  const calls: string[] = [];
+  walk(scope, (node) => {
+    const dispatched = dispatchedCommandOf(node);
+    if (dispatched !== undefined) found.add(dispatched);
+    if (node.type !== 'CallExpression') return;
+    const callee = identifierName(node['callee']);
+    if (callee !== undefined && functions.has(callee)) calls.push(callee);
+  });
+  for (const name of calls) {
+    if (visited.has(name)) continue;
+    visited.add(name);
+    for (const dispatched of reachableDispatches(functions.get(name), functions, visited)) {
+      found.add(dispatched);
+    }
+  }
+  return found;
+}
+
+function scanCliRouteDispatches(sourceText: string): RouteScan {
+  const program = parseSync('cli.ts', sourceText).program;
+  const functions = localFunctionsByName(program);
+  const dispatches: RouteDispatch[] = [];
+  const attributed = new Set<string>();
+
+  walk(program, (node) => {
+    if (node.type !== 'IfStatement') return;
+    const route = routedCommandOf(node['test']);
+    if (route === undefined) return;
+    for (const dispatched of reachableDispatches(node['consequent'], functions, new Set())) {
+      dispatches.push({ route, dispatched });
+      attributed.add(dispatched);
+    }
+  });
+
+  const all = new Set<string>();
+  walk(program, (node) => {
+    const dispatched = dispatchedCommandOf(node);
+    if (dispatched !== undefined) all.add(dispatched);
+  });
+
+  return {
+    dispatches,
+    unattributed: [...all].filter((command) => !attributed.has(command)).sort(),
+  };
+}
+
+function dominanceFailures(scan: RouteScan, kindOf: PlatformExecutionKindOf): string[] {
+  return scan.dispatches
+    .filter(({ route, dispatched }) => kindOf(route) === 'none' && kindOf(dispatched) !== 'none')
+    .map(
+      ({ route, dispatched }) =>
+        `${route} declares platformExecution none but its CLI route dispatches ${dispatched} (${String(kindOf(dispatched))})`,
+    )
+    .sort();
+}
+
+function scanCompositionRoot(): RouteScan {
+  return scanCliRouteDispatches(fs.readFileSync(CLI_COMPOSITION_ROOT, 'utf8'));
+}
+
+describe('platform-execution coherence across CLI route delegation', () => {
+  test('no none command dispatches a platform-executing command', () => {
+    expect(dominanceFailures(scanCompositionRoot(), registryKind)).toEqual([]);
+  });
+
+  test('every CLI daemon dispatch is attributable to a routed command', () => {
+    expect(scanCompositionRoot().unattributed).toEqual([]);
+  });
+
+  test('the composition root still carries the react-devtools runtime delegation', () => {
+    expect(scanCompositionRoot().dispatches).toContainEqual({
+      route: 'react-devtools',
+      dispatched: 'runtime',
+    });
+  });
+
+  test('planted red: react-devtools declared none is rejected by the real route', () => {
+    const plantedNone: PlatformExecutionKindOf = (command) =>
+      command === 'react-devtools' ? 'none' : registryKind(command);
+
+    expect(dominanceFailures(scanCompositionRoot(), plantedNone)).toEqual([
+      'react-devtools declares platformExecution none but its CLI route dispatches runtime (legacy)',
+    ]);
+  });
+
+  test('planted red: an unroutable dispatch is reported rather than ignored', () => {
+    const planted = `
+      async function runCli(argv, deps) {
+        await deps.sendToDaemon({ command: INTERNAL_COMMANDS.runtime, positionals: [] });
+      }
+    `;
+    expect(scanCliRouteDispatches(planted).unattributed).toEqual(['runtime']);
+  });
+});

--- a/src/core/command-descriptor/__tests__/platform-execution-entry.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-entry.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { readDeclaredPlatformExecution } from '../platform-execution-entry.ts';
+import { commandDescriptors } from '../registry.ts';
+
+describe('platform-execution registry entry gate', () => {
+  test('rejects a descriptor that declares no discriminator', () => {
+    expect(() => readDeclaredPlatformExecution({ name: 'planted' })).toThrow(
+      /must declare platformExecution/,
+    );
+  });
+
+  test('rejects none on a descriptor that keeps a capability bucket', () => {
+    expect(() =>
+      readDeclaredPlatformExecution({
+        name: 'planted',
+        capability: { apple: {}, android: {}, linux: {} },
+        platformExecution: { kind: 'none' },
+      }),
+    ).toThrow(/keeps a capability bucket/);
+  });
+
+  test('accepts none on a descriptor with no capability bucket', () => {
+    expect(
+      readDeclaredPlatformExecution({ name: 'planted', platformExecution: { kind: 'none' } }),
+    ).toEqual({ kind: 'none' });
+  });
+
+  test('still rejects a malformed declaration', () => {
+    expect(() =>
+      readDeclaredPlatformExecution({ name: 'planted', platformExecution: { kind: 'inventory' } }),
+    ).toThrow(/exactly one/);
+  });
+
+  test('every registered command declares an explicit execution mode', () => {
+    const undeclared = commandDescriptors.filter(
+      (descriptor) => descriptor.platformExecution === undefined,
+    );
+    expect(undeclared).toEqual([]);
+  });
+
+  test('no command declares none while keeping a capability bucket', () => {
+    const contradictory = commandDescriptors
+      .filter(
+        (descriptor) =>
+          descriptor.platformExecution.kind === 'none' &&
+          'capability' in descriptor &&
+          descriptor.capability !== undefined,
+      )
+      .map(({ name }) => name);
+    expect(contradictory).toEqual([]);
+  });
+});

--- a/src/core/command-descriptor/platform-execution-entry.ts
+++ b/src/core/command-descriptor/platform-execution-entry.ts
@@ -1,0 +1,44 @@
+import {
+  assertCommandPlatformExecution,
+  type CommandPlatformExecution,
+} from '@agent-device/contracts/platform';
+
+/**
+ * The shape the entry gate reads. Structural on purpose: the registry's raw
+ * descriptor type is derived from this module's consumer, and the gate must be
+ * able to see an *absent* discriminator, which a nominal type cannot express.
+ */
+type PlatformExecutionDeclarationSite = {
+  readonly name: string;
+  readonly capability?: unknown;
+  readonly platformExecution?: unknown;
+};
+
+/**
+ * ADR 0019 §6: every command descriptor declares its platform-execution mode
+ * explicitly. A registry-entry default cannot distinguish a command with *no*
+ * platform execution (`none`) from an unmigrated one (`legacy`), which is what
+ * makes the migration denominator machine-readable — so an undeclared
+ * discriminator is a registry-load error, not a silently defaulted value.
+ *
+ * The same gate rejects `none` on a descriptor that still owns a capability
+ * bucket: capability buckets are legacy platform admission, and a command that
+ * admits per platform executes platform behavior by definition.
+ */
+export function readDeclaredPlatformExecution(
+  descriptor: PlatformExecutionDeclarationSite,
+): CommandPlatformExecution {
+  const declared = descriptor.platformExecution;
+  if (declared === undefined) {
+    throw new TypeError(
+      `Command descriptor "${descriptor.name}" must declare platformExecution (none, legacy, inventory, or device-runtime); there is no registry-entry default`,
+    );
+  }
+  assertCommandPlatformExecution(declared);
+  if (declared.kind === 'none' && descriptor.capability !== undefined) {
+    throw new TypeError(
+      `Command descriptor "${descriptor.name}" declares platformExecution none but keeps a capability bucket; a command with platform admission is not platform-free`,
+    );
+  }
+  return declared;
+}

--- a/src/core/command-descriptor/platform-execution-entry.ts
+++ b/src/core/command-descriptor/platform-execution-entry.ts
@@ -4,9 +4,9 @@ import {
 } from '@agent-device/contracts/platform';
 
 /**
- * The shape the entry gate reads. Structural on purpose: the registry's raw
- * descriptor type is derived from this module's consumer, and the gate must be
- * able to see an *absent* discriminator, which a nominal type cannot express.
+ * Structural on purpose: the gate must see an *absent* discriminator, and the
+ * registry's raw descriptor type — which forbids that — lives in this module's
+ * consumer.
  */
 type PlatformExecutionDeclarationSite = {
   readonly name: string;
@@ -15,15 +15,17 @@ type PlatformExecutionDeclarationSite = {
 };
 
 /**
- * ADR 0019 §6: every command descriptor declares its platform-execution mode
- * explicitly. A registry-entry default cannot distinguish a command with *no*
- * platform execution (`none`) from an unmigrated one (`legacy`), which is what
- * makes the migration denominator machine-readable — so an undeclared
- * discriminator is a registry-load error, not a silently defaulted value.
+ * ADR 0019 §6: every descriptor declares its platform-execution mode explicitly.
+ * A default cannot distinguish a command with *no* platform execution (`none`)
+ * from an unmigrated one (`legacy`), so an undeclared discriminator is a
+ * registry-load error and the migration denominator stays machine-readable.
  *
- * The same gate rejects `none` on a descriptor that still owns a capability
- * bucket: capability buckets are legacy platform admission, and a command that
- * admits per platform executes platform behavior by definition.
+ * `none` with a capability bucket is also rejected: a capability bucket is
+ * platform admission, so the command executes platform behavior.
+ *
+ * This gate sees one descriptor at a time. Platform execution delegated to
+ * another command is covered by the CLI-route dominance gate in
+ * `__tests__/platform-execution-cli-route.test.ts`.
  */
 export function readDeclaredPlatformExecution(
   descriptor: PlatformExecutionDeclarationSite,

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -93,6 +93,19 @@ export type DescriptorSessionRouteCommandName =
       : never
     : never;
 
+/**
+ * The literal union of every command the daemon routes. A command that never reaches a
+ * daemon route cannot be the target of a request, so this is the type a caller building
+ * one must name — an unregistered or CLI-only target is a compile error rather than a
+ * string the receiver rejects at runtime.
+ */
+export type DescriptorDaemonRouteCommandName =
+  Extract<(typeof commandDescriptors)[number], { daemon: object }> extends infer Descriptor
+    ? Descriptor extends { name: infer Name extends string }
+      ? Name
+      : never
+    : never;
+
 // ---------------------------------------------------------------------------
 // Daemon request-policy trait bundles — copied VERBATIM from
 // src/daemon/daemon-command-registry.ts (DAEMON_COMMAND_DESCRIPTORS).

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -14,12 +14,12 @@ import { resolvePostActionObservationSupport } from './post-action-observation.t
 import type { PostActionObservationSupport } from './post-action-observation.ts';
 import {
   appLogRuntimePlanUses,
-  assertCommandPlatformExecution,
   assertRecordRuntimeExecution,
   inventoryUse,
   networkDumpUse,
   screenRecordingRuntimePlanUses,
 } from '@agent-device/contracts/platform';
+import { readDeclaredPlatformExecution } from './platform-execution-entry.ts';
 import type {
   CommandCatalogGroup,
   CommandDescriptor,
@@ -29,11 +29,12 @@ import type {
   TargetIdentityVerification,
 } from './types.ts';
 
+// `platformExecution` stays REQUIRED here (ADR 0019 §6): a raw descriptor that omits it
+// is a compile error, and {@link readDeclaredPlatformExecution} is the matching runtime gate.
 type RawCommandDescriptorShape<T> = T extends CommandDescriptor
-  ? Omit<T, 'mcpExposed' | 'platformExecution'> & {
+  ? Omit<T, 'mcpExposed'> & {
       mcpExposed?: boolean;
       ownerFiles?: readonly [string, ...string[]];
-      platformExecution?: T['platformExecution'];
     }
   : never;
 type RawCommandDescriptor = RawCommandDescriptorShape<CommandDescriptor>;
@@ -212,6 +213,20 @@ const APP_INSTALL_CAPABILITY = {
   linux: LINUX_NONE,
 } satisfies CommandCapability;
 
+// ---------------------------------------------------------------------------
+// ADR 0019 §6 platform-execution modes. Every descriptor declares one; there is
+// no registry-entry default (see `readDeclaredPlatformExecution`).
+//   `none`   — executes no platform behavior at all: never binds a device, owns
+//              no capability bucket, no platform adapter, no runtime/inventory
+//              use. Outside the migration denominator.
+//   `legacy` — unmigrated platform execution. This is the denominator: the
+//              tracker closes when no descriptor declares it.
+// The migrated modes (`inventory`, `device-runtime`) are declared inline with
+// the use they name.
+// ---------------------------------------------------------------------------
+const NO_PLATFORM_EXECUTION = { kind: 'none' } as const;
+const LEGACY_PLATFORM_EXECUTION = { kind: 'legacy' } as const;
+
 const GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS = {
   recordsSessionAction: true,
   recordingEffect: 'mutates-app',
@@ -341,6 +356,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'lease', refFrameEffect: 'preserve', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'lease_heartbeat',
@@ -350,6 +366,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'lease', refFrameEffect: 'preserve', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'lease_release',
@@ -359,6 +376,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'lease', refFrameEffect: 'preserve', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'artifacts',
@@ -368,6 +386,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'lease', refFrameEffect: 'preserve', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
 
   // -- session (route: session) --
@@ -386,6 +405,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'session_save_script',
@@ -401,6 +421,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'devices',
@@ -433,6 +454,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'doctor',
@@ -449,6 +471,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'apps',
@@ -465,6 +488,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: APP_INVENTORY_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'boot',
@@ -479,6 +503,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'shutdown',
@@ -493,6 +518,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'appstate',
@@ -503,6 +529,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'perf',
@@ -514,6 +541,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'logs',
@@ -539,6 +567,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'network',
@@ -563,6 +592,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'replay',
@@ -579,6 +609,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     // Replay durations are script-dependent; --timeout bounds the envelope.
     timeoutPolicy: { ...DEFAULT_TIMEOUT_POLICY, budget: { source: 'flag' } },
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'test',
@@ -595,6 +626,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     // client envelope at all.
     timeoutPolicy: { ...DEFAULT_TIMEOUT_POLICY, envelopeMs: 'unbounded' },
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'runtime',
@@ -606,6 +638,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'session', refFrameEffect: 'preserve' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'clipboard',
@@ -622,6 +655,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'keyboard',
@@ -642,6 +676,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'install',
@@ -653,6 +688,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'reinstall',
@@ -664,6 +700,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'install_source',
@@ -676,6 +713,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'session', refFrameEffect: 'may-invalidate' },
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'release_materialized_paths',
@@ -687,6 +725,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'session', refFrameEffect: 'preserve', ...REQUEST_EXECUTION_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'push',
@@ -703,6 +742,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'trigger-app-event',
@@ -715,6 +755,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'open',
@@ -732,6 +773,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: VEGA_APP_RUNTIME_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'prepare',
@@ -750,6 +792,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     batchable: false,
     mcpExposed: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'batch',
@@ -759,6 +802,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'session', refFrameEffect: 'delegated' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'close',
@@ -776,6 +820,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: VEGA_APP_RUNTIME_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 
   // -- snapshot (route: snapshot) --
@@ -792,6 +837,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     // widens the envelope, and a timeout must not tear down the daemon.
     timeoutPolicy: { ...PRESERVE_DAEMON_TIMEOUT_POLICY, budget: { source: 'flag' } },
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'diff',
@@ -803,6 +849,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'wait',
@@ -822,6 +869,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
       budget: { source: 'positional-parser', parser: resolveWaitBudgetMs },
     },
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'alert',
@@ -837,6 +885,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'settings',
@@ -853,6 +902,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 
   // -- specialized routes --
@@ -866,6 +916,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'record',
@@ -892,6 +943,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     daemon: { route: 'recordTrace', refFrameEffect: 'preserve' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'find',
@@ -903,6 +955,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: PRESERVE_DAEMON_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 
   // -- interaction (route: interaction) --
@@ -929,6 +982,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     postActionObservation: postActionObservation('click'),
     responseDataTransform: TOUCH_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'fill',
@@ -948,6 +1002,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     postActionObservation: postActionObservation('fill'),
     responseDataTransform: FILL_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'longpress',
@@ -972,6 +1027,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     postActionObservation: postActionObservation('longpress'),
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'press',
@@ -991,6 +1047,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     postActionObservation: postActionObservation('press'),
     responseDataTransform: TOUCH_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'type',
@@ -1007,6 +1064,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: postActionObservationTimeoutPolicy('type', PRESERVE_DAEMON_TIMEOUT_POLICY),
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'get',
@@ -1019,6 +1077,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: postActionObservationTimeoutPolicy('get', PRESERVE_DAEMON_TIMEOUT_POLICY),
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'read',
@@ -1028,6 +1087,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     dispatch: {},
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'is',
@@ -1040,6 +1100,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: postActionObservationTimeoutPolicy('is', PRESERVE_DAEMON_TIMEOUT_POLICY),
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 
   // -- generic (route: generic) --
@@ -1054,6 +1115,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: postActionObservationTimeoutPolicy('back', DEFAULT_TIMEOUT_POLICY),
     postActionObservation: postActionObservation('back'),
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'gesture',
@@ -1070,6 +1132,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'home',
@@ -1080,6 +1143,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
       ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS.capability,
       vega: VEGA_VVD,
     },
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'tv-remote',
@@ -1101,6 +1165,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'orientation',
@@ -1121,6 +1186,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'scroll',
@@ -1129,6 +1195,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
     timeoutPolicy: postActionObservationTimeoutPolicy('scroll', DEFAULT_TIMEOUT_POLICY),
     postActionObservation: postActionObservation('scroll'),
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'swipe',
@@ -1144,12 +1211,14 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'focus',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'screenshot',
@@ -1162,6 +1231,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'viewport',
@@ -1180,6 +1250,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: { apple: {}, android: {}, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   // -- capability/batch-only commands (no daemon route) --
   {
@@ -1202,6 +1273,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'install-from-source',
@@ -1212,6 +1284,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 
   // -- local client-backed CLI/MCP commands (no daemon route/capability) --
@@ -1222,6 +1295,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     recordsSessionAction: false,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'daemon',
@@ -1231,6 +1305,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'device',
@@ -1240,6 +1315,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'metro',
@@ -1248,6 +1324,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     recordsSessionAction: false,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'session',
@@ -1256,6 +1333,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     recordsSessionAction: false,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'cdp',
@@ -1265,6 +1343,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'auth',
@@ -1274,6 +1353,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'connect',
@@ -1283,6 +1363,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'connection',
@@ -1292,6 +1373,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'disconnect',
@@ -1301,6 +1383,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'mcp',
@@ -1310,6 +1393,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'proxy',
@@ -1319,6 +1403,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'react-devtools',
@@ -1328,6 +1413,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'web',
@@ -1337,6 +1423,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
 ] as const satisfies readonly RawCommandDescriptor[];
 
@@ -1368,11 +1455,7 @@ const CLI_COMMAND_NAMES = new Set<string>(
  * union below a precise set of command-name literals rather than `string`.
  */
 export const commandDescriptors = RAW_COMMAND_DESCRIPTORS.map((descriptor) => {
-  const platformExecution =
-    'platformExecution' in descriptor
-      ? descriptor.platformExecution
-      : ({ kind: 'legacy' } as const);
-  assertCommandPlatformExecution(platformExecution);
+  const platformExecution = readDeclaredPlatformExecution(descriptor);
   if (descriptor.name === 'record') assertRecordRuntimeExecution(platformExecution);
   if (!ownerFilesEnabled) {
     return {

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1413,7 +1413,10 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
-    platformExecution: NO_PLATFORM_EXECUTION,
+    // `react-devtools start` on a Limrun Android instance dispatches internal
+    // `runtime port-reverse`, which reaches a provider device runtime. Platform
+    // execution delegated through another command is still platform execution.
+    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'web',


### PR DESCRIPTION
## What changed

ADR 0019 §6 (as amended in #1738) requires every command descriptor to declare its
platform-execution mode explicitly, because a registry-entry default cannot distinguish
a command with *no* platform execution from an unmigrated one. This makes the #1739
migration denominator machine-readable.

- `CommandPlatformExecution` gains `{ kind: 'none' }`; `assertCommandPlatformExecution`
  accepts it in exactly-one-shape form (and still rejects `{ kind: 'none', ... }` widened).
- `readDeclaredPlatformExecution` (new `src/core/command-descriptor/platform-execution-entry.ts`)
  replaces the silent `{ kind: 'legacy' }` default at registry entry. An undeclared
  discriminator is a registry-load error; `none` on a descriptor that keeps a `capability`
  bucket is also rejected (capability buckets *are* legacy platform admission).
- `RawCommandDescriptorShape` no longer makes `platformExecution` optional, so an
  undeclared descriptor is a **compile** error as well as a load error.
- All 76 descriptors annotated. Final classification:

| mode | count |
| --- | --- |
| `none` | 17 |
| `legacy` | 55 |
| `inventory` | 1 (`devices`) |
| `device-runtime` | 3 (`logs`, `network`, `record`) |

`none` (17): `lease_allocate`, `lease_heartbeat`, `lease_release`, `artifacts`,
`session_list`, `session_save_script`, `release_materialized_paths`, `device`, `metro`,
`session`, `cdp`, `auth`, `connect`, `connection`, `disconnect`, `mcp`, `proxy`.

Each was verified against its handler/owner file rather than its catalog group: lease and
publication handlers touch only the store/registry; `release_materialized_paths` is
filesystem-only cleanup; `session_list` reads `SessionStore` and formats platform strings
as opaque identifiers; the client-backed CLI commands reach remote/provider/daemon
plumbing only.

### Classifications that were judgment calls

Three commands the tracker text groups with "local-CLI/daemon-management" are declared
**`legacy`**, fail-closed, because they reach platform behavior:

- **`daemon`** — `daemon stop --clean` dynamically imports
  `src/platforms/apple/core/runner/runner-{lease,disposal}.ts` and runs Apple runner-lease
  cleanup (`src/cli/commands/daemon.ts:24-31`).
- **`debug`** — `debug symbols` resolves to `symbolicateCrashArtifact` from
  `src/platforms/apple/core/debug-symbols.ts` (`src/agent-device-client.ts:440-446`).

- **`react-devtools`** — raised in review (P1). Its CLI route injects
  `configureDirectPortReverse` (`src/cli.ts:333-362`); on a Limrun Android instance
  `react-devtools start` dispatches internal `runtime port-reverse`, and
  `session-runtime-command.ts` runs `configureProviderPortReverse` against a provider
  device runtime. Delegated platform execution is platform execution.

None of the three binds a device or owns a capability bucket, but all three consume
platform behavior, so `none` would be a false negative in the denominator. Reclassifying either to `none` is a
reviewed decision, not a silent one. `capabilities`, `doctor`, and `web` are `legacy` as
specified.

## Coherence gate for delegated platform execution

The entry gate inspects one descriptor at a time, so it structurally cannot see the
`react-devtools` shape: a descriptor whose own module is platform-free while its CLI route
injects a callback that dispatches a platform-executing command. That is a silent
denominator undercount.

**This is a construction seam, not a scanner.** The first two revisions parsed `src/cli.ts`
to recover dispatches from syntax, and each review found another shape it had not been
taught — occurrence-vs-name, unresolvable targets, then variable envelopes and computed
callees. The scanner enumerated *what counts as a dispatch*, an open-ended set where
anything unrecognized passed silently; that failure direction was the real defect.

`src/cli/injected-daemon-dispatch.ts` now owns the concern: one typed table of route/command
pairs and `sendInjectedDaemonRequest`, the single construction point. `command` is a typed
parameter constrained to the declared pairs, so an undeclared dispatch is a **compile
error** and the dispatched command is known by type rather than recovered from an object
literal.

The gate follows from that:

- **Mode dominance** reads the table directly — no AST. If a CLI route dispatches command D,
  the route's command may declare `none` only when D is `none`.
- **Seam singularity** is the only syntax check left, and it is positional rather than
  value-resolving: the transport identifier may appear in imports, type queries, property
  signatures, property values, member access, and call *arguments* — nowhere else. Calls,
  aliases and unanticipated forms fail by default. The enumeration is now of *where the
  transport may appear* (closed) rather than *what a dispatch looks like* (open).

**Planted reds:** direct call, member call, computed-member call, variable envelope, and
alias — each rejected outside the seam; `react-devtools` pinned back to `none` fails
dominance against the declared pair; and a positive test keeps the legitimate client
transport wiring (`transport: deps.sendToDaemon`, `createClientDaemonTransport(...)`)
passing. Net −141 lines: a 448-line test becomes ~124 plus a 46-line seam.

**Scope note:** the structural half lives in the vitest gate rather than as a numbered
layering rule, because #1745 and #1750 are both moving the layering rule namespace right
now. Moving it into `scripts/layering/` in the #1744 shape is a clean follow-up once those
land.

## Why this is behavior-neutral

`platformExecution` is an internal cutover discriminant that is stripped from daemon and
public projections (`deriveDaemonCommandDescriptors`, existing test in
`platform-execution.test.ts`). The only production consumer is
`listCapabilityCommands`, which keys on `kind === 'device-runtime'` — unchanged by this
diff, since no descriptor's mode changed value: every annotated descriptor previously
resolved to `{ kind: 'legacy' }` via the default, and `none` is a *new* label applied only
where the default was legacy-by-omission. No admission, execution, cleanup, or hint path
reads `none` yet.

## Validation

- `pnpm check:layering` — OK (136/136; R2/R3/R7/R9/R10/R13 ratchets unchanged, no
  `SessionState` fields touched).
- `pnpm check:affected --run` — 468 files / 3930 tests passed.
- **Planted red (compile gate):** deleting `platformExecution` from the `lease_allocate`
  descriptor produces
  `registry.ts(351,3): error TS2322: ... Property 'platformExecution' is missing in type
  ... but required in type 'Omit<CommandDescriptorBase & ...>'` (plus two TS2345 at the
  `.map` call sites).
- **Planted red (load gate):** with the same plant, `platform-execution-entry.test.ts`
  fails at import with
  `TypeError: Command descriptor "lease_allocate" must declare platformExecution (none,
  legacy, inventory, or device-runtime); there is no registry-entry default`.
- New tests: `src/core/command-descriptor/__tests__/platform-execution-entry.test.ts`
  (undeclared discriminator rejected; `none` + capability bucket rejected; registry-wide
  exhaustiveness and no-contradiction assertions).

Docs: none needed — ADR 0019 §6 already defines the `none` mode; no CLI/user-facing
surface changes.

## Runtime readers audited

Every production reader of the `platformExecution` *value* (excluding gates and tests):

- `listCapabilityCommands()` (`src/core/capabilities.ts:163`), consumed by
  `session-inventory.ts` for `capabilities.availableCommands` — keys on
  `kind === 'device-runtime'` only. No descriptor entered or left `device-runtime` in this
  diff, and every `none` descriptor is gate-proven to have no capability bucket (so it was
  already excluded as legacy-without-capability).
- `assertRecordRuntimeExecution` at registry entry — applies to `record` only; unchanged.
- `deriveDaemonCommandDescriptors` — strips the field from the daemon/public projection
  (existing test asserts the absence).

No production code branches on `legacy`, so `none` is not observable at runtime by design;
it is metadata for the derived denominator. Verified empirically rather than by argument:
`listCapabilityCommands()` returns a byte-identical 43-command list on `origin/main` and on
this branch. **Runtime readers audited: listCapabilityCommands, assertRecordRuntimeExecution,
deriveDaemonCommandDescriptors — decisions unchanged.**

## Size

The size bot reports +1.9 kB raw / +169 B gzip / +221 B tarball (chunk
`dist/src/sdk-batch-runner.js`), startup unchanged. Per ADR 0019 §8 this growth is
itemized rather than absorbed: it is entirely the ~76 explicit `platformExecution`
annotations that replace the silent `{ kind: 'legacy' }` default at registry entry. Two
shared frozen literals (`NO_PLATFORM_EXECUTION`, `LEGACY_PLATFORM_EXECUTION`) keep it to
one property reference per descriptor. This is the metadata that makes the derived
migration denominator machine-readable — the whole point of the wave-0 item — and it
shrinks again as descriptors leave `legacy` for a declared use.

Part of #1739 (wave 0)




