### PR TITLE
refactor(contracts): consolidate per-domain defineUse wrappers into one neutral defineUse

### DIFF
--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -37,7 +37,6 @@ export { assertCommandPlatformExecution } from '../command-platform-execution.ts
 export type { CommandPlatformExecution } from '../command-platform-execution.ts';
 export { AsyncCleanupStack, PendingTransferGuard } from '../async-lifecycle.ts';
 export {
-  defineUse,
   localRuntimeOwner,
   narrowDeviceBinding,
   providerRuntimeOwner,
@@ -170,6 +169,7 @@ export type {
   NetworkRuntimePlan,
   NetworkRuntimePlanInput,
 } from '../network-runtime-plan.ts';
+export { defineUse } from '../platform-runtime-operations.ts';
 export type {
   PlatformRuntimeHost,
   PlatformRuntimeModule,

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -37,6 +37,7 @@ export { assertCommandPlatformExecution } from '../command-platform-execution.ts
 export type { CommandPlatformExecution } from '../command-platform-execution.ts';
 export { AsyncCleanupStack, PendingTransferGuard } from '../async-lifecycle.ts';
 export {
+  defineUse,
   localRuntimeOwner,
   narrowDeviceBinding,
   providerRuntimeOwner,

--- a/packages/contracts/src/logs-runtime-plan.ts
+++ b/packages/contracts/src/logs-runtime-plan.ts
@@ -1,15 +1,12 @@
 import { AppError } from '@agent-device/kernel/errors';
-import { runtimeUse } from './platform-runtime.ts';
-import type { PlatformRuntimeOperations } from './platform-runtime-operations.ts';
+import { defineUse } from './platform-runtime.ts';
 
-const appLogUse = runtimeUse<PlatformRuntimeOperations>();
-
-const appLogInspectUse = appLogUse({ required: ['appLogInspect'] });
-const appLogDoctorUse = appLogUse({ required: ['appLogInspect', 'appLogDoctor'] });
-const appLogStartUse = appLogUse({ required: ['appLogInspect', 'appLogStart'] });
+const appLogInspectUse = defineUse({ required: ['appLogInspect'] });
+const appLogDoctorUse = defineUse({ required: ['appLogInspect', 'appLogDoctor'] });
+const appLogStartUse = defineUse({ required: ['appLogInspect', 'appLogStart'] });
 
 /** Fact-only admission probe; it is deliberately not an execution-plan variant. */
-export const appLogAdmissionUse = appLogUse({
+export const appLogAdmissionUse = defineUse({
   required: [],
   preferred: ['appLogInspect'],
 });

--- a/packages/contracts/src/logs-runtime-plan.ts
+++ b/packages/contracts/src/logs-runtime-plan.ts
@@ -1,5 +1,5 @@
 import { AppError } from '@agent-device/kernel/errors';
-import { defineUse } from './platform-runtime.ts';
+import { defineUse } from './platform-runtime-operations.ts';
 
 const appLogInspectUse = defineUse({ required: ['appLogInspect'] });
 const appLogDoctorUse = defineUse({ required: ['appLogInspect', 'appLogDoctor'] });

--- a/packages/contracts/src/network-runtime-plan.ts
+++ b/packages/contracts/src/network-runtime-plan.ts
@@ -1,6 +1,6 @@
 import type { NetworkIncludeMode } from '@agent-device/kernel/contracts';
 import { AppError } from '@agent-device/kernel/errors';
-import { defineUse } from './platform-runtime.ts';
+import { defineUse } from './platform-runtime-operations.ts';
 
 export const networkDumpUse = defineUse({ required: ['networkDump'] });
 

--- a/packages/contracts/src/network-runtime-plan.ts
+++ b/packages/contracts/src/network-runtime-plan.ts
@@ -1,14 +1,11 @@
 import type { NetworkIncludeMode } from '@agent-device/kernel/contracts';
 import { AppError } from '@agent-device/kernel/errors';
-import { runtimeUse } from './platform-runtime.ts';
-import type { PlatformRuntimeOperations } from './platform-runtime-operations.ts';
+import { defineUse } from './platform-runtime.ts';
 
-const defineNetworkUse = runtimeUse<PlatformRuntimeOperations>();
-
-export const networkDumpUse = defineNetworkUse({ required: ['networkDump'] });
+export const networkDumpUse = defineUse({ required: ['networkDump'] });
 
 /** Fact-only capability projection; it is not an execution-plan variant. */
-export const networkAdmissionUse = defineNetworkUse({
+export const networkAdmissionUse = defineUse({
   required: [],
   preferred: ['networkDump'],
 });

--- a/packages/contracts/src/platform-runtime-operations.ts
+++ b/packages/contracts/src/platform-runtime-operations.ts
@@ -2,15 +2,24 @@ import type { AppLogRuntimeHost, AppLogRuntimeOperations } from './app-log-runti
 import type { NetworkRuntimeHost, NetworkRuntimeOperations } from './network-runtime.ts';
 import type { ScreenRecordingRuntimeHost } from './screen-recording-runtime-host.ts';
 import type { ScreenRecordingRuntimeOperations } from './screen-recording-runtime.ts';
-import type {
-  DeviceRuntimeOwner,
-  RuntimeOwnerRef,
-  RuntimePlatformModule,
+import {
+  runtimeUse,
+  type DeviceRuntimeOwner,
+  type RuntimeOwnerRef,
+  type RuntimePlatformModule,
 } from './platform-runtime.ts';
 
 export type PlatformRuntimeOperations = AppLogRuntimeOperations &
   NetworkRuntimeOperations &
   ScreenRecordingRuntimeOperations;
+
+/**
+ * The one neutral runtime-use declaration every command domain shares (ADR 0019 §9): no
+ * per-domain currying wrappers. Lives here, next to the concrete `PlatformRuntimeOperations`
+ * catalog it closes over, so the generic `runtimeUse` primitive in `platform-runtime.ts`
+ * never depends on it.
+ */
+export const defineUse = runtimeUse<PlatformRuntimeOperations>();
 
 export type PlatformRuntimeHost = AppLogRuntimeHost &
   NetworkRuntimeHost &

--- a/packages/contracts/src/platform-runtime.ts
+++ b/packages/contracts/src/platform-runtime.ts
@@ -9,6 +9,7 @@ import {
 import { AppError } from '@agent-device/kernel/errors';
 import type { PlatformModuleMetadata } from './platform-module.ts';
 import type { PlatformRequestScope } from './platform-runtime-host.ts';
+import type { PlatformRuntimeOperations } from './platform-runtime-operations.ts';
 
 type RuntimeOperation = (...args: never[]) => unknown;
 
@@ -72,6 +73,14 @@ export function runtimeUse<Operations extends object>() {
     return Object.freeze({ required, preferred }) as RuntimeUse<Operations, Required, Preferred>;
   };
 }
+
+/**
+ * The one neutral runtime-use declaration every command domain shares. Per-domain currying
+ * wrappers around `runtimeUse<PlatformRuntimeOperations>()` add a module per domain for no
+ * information (ADR 0019 §9); every device runtime-use declaration is built through this
+ * single export instead.
+ */
+export const defineUse = runtimeUse<PlatformRuntimeOperations>();
 
 function freezeUniqueKeys<Keys extends readonly string[]>(keys: Keys, label: string): Keys {
   const copy = [...keys];

--- a/packages/contracts/src/platform-runtime.ts
+++ b/packages/contracts/src/platform-runtime.ts
@@ -9,7 +9,6 @@ import {
 import { AppError } from '@agent-device/kernel/errors';
 import type { PlatformModuleMetadata } from './platform-module.ts';
 import type { PlatformRequestScope } from './platform-runtime-host.ts';
-import type { PlatformRuntimeOperations } from './platform-runtime-operations.ts';
 
 type RuntimeOperation = (...args: never[]) => unknown;
 
@@ -73,14 +72,6 @@ export function runtimeUse<Operations extends object>() {
     return Object.freeze({ required, preferred }) as RuntimeUse<Operations, Required, Preferred>;
   };
 }
-
-/**
- * The one neutral runtime-use declaration every command domain shares. Per-domain currying
- * wrappers around `runtimeUse<PlatformRuntimeOperations>()` add a module per domain for no
- * information (ADR 0019 §9); every device runtime-use declaration is built through this
- * single export instead.
- */
-export const defineUse = runtimeUse<PlatformRuntimeOperations>();
 
 function freezeUniqueKeys<Keys extends readonly string[]>(keys: Keys, label: string): Keys {
   const copy = [...keys];

--- a/packages/contracts/src/screen-recording-runtime-plan.ts
+++ b/packages/contracts/src/screen-recording-runtime-plan.ts
@@ -1,20 +1,17 @@
 import { AppError } from '@agent-device/kernel/errors';
-import { runtimeUse } from './platform-runtime.ts';
-import type { PlatformRuntimeOperations } from './platform-runtime-operations.ts';
+import { defineUse } from './platform-runtime.ts';
 import type { RecordingScope } from './recording-scope.ts';
 
-const defineScreenRecordingUse = runtimeUse<PlatformRuntimeOperations>();
-
-export const screenRecordingStartUse = defineScreenRecordingUse({
+export const screenRecordingStartUse = defineUse({
   required: ['screenRecordingStart'],
 });
-export const screenRecordingRecoveryUse = defineScreenRecordingUse({
+export const screenRecordingRecoveryUse = defineUse({
   required: ['screenRecordingReattach', 'screenRecordingCleanup'],
 });
-const screenRecordingNoRuntimeUse = defineScreenRecordingUse({ required: [] });
+const screenRecordingNoRuntimeUse = defineUse({ required: [] });
 
 /** Fact-only admission preserves start's preferred-fast-path semantics. */
-export const screenRecordingAdmissionUse = defineScreenRecordingUse({
+export const screenRecordingAdmissionUse = defineUse({
   required: [],
   preferred: ['screenRecordingStart'],
 });

--- a/packages/contracts/src/screen-recording-runtime-plan.ts
+++ b/packages/contracts/src/screen-recording-runtime-plan.ts
@@ -1,5 +1,5 @@
 import { AppError } from '@agent-device/kernel/errors';
-import { defineUse } from './platform-runtime.ts';
+import { defineUse } from './platform-runtime-operations.ts';
 import type { RecordingScope } from './recording-scope.ts';
 
 export const screenRecordingStartUse = defineUse({

--- a/src/daemon/app-log-resource-recovery.ts
+++ b/src/daemon/app-log-resource-recovery.ts
@@ -1,6 +1,6 @@
 import {
+  defineUse,
   narrowDeviceBinding,
-  runtimeUse,
   type AppLogCompletion,
   type AppLogLiveHandle,
   type DeviceRuntimeGateway,
@@ -16,7 +16,7 @@ import type {
   DurableCaptureRecoverySummary,
 } from './durable-capture-resource-recovery.ts';
 
-const appLogRecoveryUse = runtimeUse<PlatformRuntimeOperations>()({
+const appLogRecoveryUse = defineUse({
   required: ['appLogReattach', 'appLogCleanup'],
 });
 


### PR DESCRIPTION
## What changed

`packages/contracts` had four separate call sites re-deriving their own curried
alias of `runtimeUse<PlatformRuntimeOperations>()` with no distinguishing
information between them:

- `network-runtime-plan.ts`: `defineNetworkUse`
- `logs-runtime-plan.ts`: `appLogUse`
- `screen-recording-runtime-plan.ts`: `defineScreenRecordingUse`
- `src/daemon/app-log-resource-recovery.ts`: an inline
  `runtimeUse<PlatformRuntimeOperations>()({...})` instantiation

Per ADR 0019 §9: "Use declarations share one neutral `defineUse`; per-domain
currying wrappers add a module per domain for no information."

This PR exports one neutral `defineUse = runtimeUse<PlatformRuntimeOperations>()`
from `packages/contracts/src/platform-runtime.ts` (the module where `runtimeUse`
already lives) and re-exports it from the `@agent-device/contracts/platform`
facade. Every runtime-use declaration in the four call sites above
(`networkDumpUse`, `networkAdmissionUse`, the app-log uses
`appLogInspectUse`/`appLogDoctorUse`/`appLogStartUse`/`appLogAdmissionUse`, the
screen-recording uses `screenRecordingStartUse`/`screenRecordingRecoveryUse`/
`screenRecordingAdmissionUse`, and `appLogRecoveryUse`) now builds through that
single `defineUse` export. The per-domain wrapper consts are deleted.

`runtimeUse` itself is untouched and stays exported — it's still the generic
primitive exercised directly by `platform-runtime.test.ts` against an
unrelated test `Operations` type.

## Why this is behavior-neutral

This is a type-level refactor only:

- `defineUse` is exactly `runtimeUse<PlatformRuntimeOperations>()` — the same
  function the deleted wrappers each produced, with the same `Operations` type
  parameter. Every call site keeps its exact `required`/`preferred` argument
  list unchanged, so every produced `RuntimeUse` object is identical.
- No use declaration was added, removed, or had its required/preferred keys
  changed.
- Existing `deepEqual` assertions in `network-runtime-plan.test.ts`,
  `logs-runtime-plan.test.ts`, and `screen-recording-runtime-plan.test.ts`
  already pin every produced use object's exact `{required, preferred}` shape
  (e.g. `assert.deepEqual(networkDumpUse, { required: ['networkDump'], preferred: [] })`).
  These pass unchanged after the refactor, so they double as the before/after
  regression proof that the produced objects didn't change.

## Validation

- `pnpm exec tsc -b packages/kernel packages/contracts` — clean
- `pnpm typecheck` (full workspace + examples/sdk) — clean
- `pnpm check:layering` — 136/136 structural tests pass; type-cycle count
  unchanged at 46 (under the 47 baseline), confirming the new type-only
  `platform-runtime.ts` → `platform-runtime-operations.ts` import edge
  introduces no regression
- `pnpm check:affected --run` — 473 test files / 3939 tests passed, plus
  format, lint, layering, build/declarations, coverage-changed,
  integration-progress, replay-compat, and daemon-wire-compat checks

Part of #1739 (wave 0).