### PR TITLE
refactor(daemon): absorb androidAdbExecutor DI slot into the generic provider scope

### DIFF
--- a/src/daemon/__tests__/request-handler-catalog.test.ts
+++ b/src/daemon/__tests__/request-handler-catalog.test.ts
@@ -258,7 +258,9 @@ async function runCatalogCommandThroughHandlerChain(
           sessionStore,
           leaseRegistry,
           invoke: async () => ({ ok: true, data: {} }),
-          androidAdbExecutor: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+          providerScope: {
+            androidAdbExecutor: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+          },
           bindDevice: unavailableBindDevice,
           bindExactDevice: unavailableBindExactDevice,
           reconcileOrphanedDeviceClaim: async () => ({

--- a/src/daemon/__tests__/request-handler-chain-provider-scope.test.ts
+++ b/src/daemon/__tests__/request-handler-chain-provider-scope.test.ts
@@ -1,11 +1,5 @@
-// Wiring-equivalence coverage for the androidAdbExecutor DI slot absorbed into
-// the generic per-request provider-injection mechanism (ADR 0019 §9, issue
-// #1739 wave 0). `RequestHandlerChainParams` used to carry a platform-named
-// `androidAdbExecutor` slot threaded by hand from `request-router.ts`; it now
-// carries only the neutral `providerScope: RequestPlatformProviderScope`
-// already produced by `withRequestPlatformProviderScope`, and the session
-// route picks its own field back out of that scope. These tests prove the
-// exact executor reference still reaches the session handler unchanged.
+// Proves the exact androidAdbExecutor reference reaches the session handler
+// through the neutral providerScope, and that an empty scope forwards none.
 import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 

--- a/src/daemon/__tests__/request-handler-chain-provider-scope.test.ts
+++ b/src/daemon/__tests__/request-handler-chain-provider-scope.test.ts
@@ -1,0 +1,102 @@
+// Wiring-equivalence coverage for the androidAdbExecutor DI slot absorbed into
+// the generic per-request provider-injection mechanism (ADR 0019 §9, issue
+// #1739 wave 0). `RequestHandlerChainParams` used to carry a platform-named
+// `androidAdbExecutor` slot threaded by hand from `request-router.ts`; it now
+// carries only the neutral `providerScope: RequestPlatformProviderScope`
+// already produced by `withRequestPlatformProviderScope`, and the session
+// route picks its own field back out of that scope. These tests prove the
+// exact executor reference still reaches the session handler unchanged.
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+
+const handleSessionCommandsMock = vi.fn(async (_params: unknown) => ({ ok: true, data: {} }));
+vi.mock('../handlers/session.ts', () => ({
+  handleSessionCommands: handleSessionCommandsMock,
+}));
+
+import { INTERNAL_COMMANDS } from '../../command-catalog.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { runRequestHandlerChain } from '../request-handler-chain.ts';
+import { makeIosSession } from '../../__tests__/test-utils/index.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import {
+  unavailableBindDevice,
+  unavailableBindExactDevice,
+} from './test-device-runtime-gateway.ts';
+import { createScreenRecordingAdmissionLedger } from '../screen-recording-admission-ledger.ts';
+import type { DaemonRequest } from '../types.ts';
+import type { AndroidAdbExecutor } from '../../platforms/android/adb-executor.ts';
+
+function makeRequest(command: string, sessionName: string): DaemonRequest {
+  return {
+    command,
+    token: 'test-token',
+    session: sessionName,
+    positionals: [],
+    flags: {},
+    meta: { requestId: `req-${command}` },
+  };
+}
+
+function baseChainParams(sessionName: string) {
+  const sessionStore = makeSessionStore('agent-device-provider-scope-');
+  sessionStore.set(sessionName, makeIosSession(sessionName));
+  return {
+    req: makeRequest(INTERNAL_COMMANDS.runtime, sessionName),
+    sessionName,
+    logPath: '/tmp/agent-device-provider-scope.log',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    invoke: async () => ({ ok: true, data: {} }) as const,
+    bindDevice: unavailableBindDevice,
+    bindExactDevice: unavailableBindExactDevice,
+    reconcileOrphanedDeviceClaim: async () => ({
+      status: 'retained' as const,
+      reason: 'test-no-recovery',
+    }),
+    screenRecordingAdmissionLedger: createScreenRecordingAdmissionLedger(),
+    requestScope: {
+      signal: new AbortController().signal,
+      diagnostics: { emit: () => {} },
+      progress: { report: () => {} },
+    },
+    retainDeviceExecutionLock: async () => {},
+    throwIfCanceled: () => {},
+    contextFromFlags: () => ({ logPath: '/tmp/agent-device-provider-scope.log' }),
+  };
+}
+
+test('the android adb executor from the generic provider scope reaches the session handler by the exact same reference', async () => {
+  handleSessionCommandsMock.mockClear();
+  const androidAdbExecutor: AndroidAdbExecutor = async () => ({
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  });
+
+  await runRequestHandlerChain({
+    ...baseChainParams('provider-scope-test'),
+    providerScope: { androidAdbExecutor },
+  });
+
+  assert.equal(handleSessionCommandsMock.mock.calls.length, 1);
+  const forwardedParams = handleSessionCommandsMock.mock.calls[0]?.[0] as {
+    androidAdbExecutor?: AndroidAdbExecutor;
+  };
+  assert.equal(forwardedParams.androidAdbExecutor, androidAdbExecutor);
+});
+
+test('an empty provider scope forwards no android adb executor to the session handler', async () => {
+  handleSessionCommandsMock.mockClear();
+
+  await runRequestHandlerChain({
+    ...baseChainParams('provider-scope-empty'),
+    providerScope: {},
+  });
+
+  assert.equal(handleSessionCommandsMock.mock.calls.length, 1);
+  const forwardedParams = handleSessionCommandsMock.mock.calls[0]?.[0] as {
+    androidAdbExecutor?: AndroidAdbExecutor;
+  };
+  assert.equal(forwardedParams.androidAdbExecutor, undefined);
+});

--- a/src/daemon/__tests__/request-handler-chain.test.ts
+++ b/src/daemon/__tests__/request-handler-chain.test.ts
@@ -45,6 +45,7 @@ function makeChainParams(req: DaemonRequest) {
     sessionStore,
     leaseRegistry: new LeaseRegistry(),
     invoke: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+    providerScope: {},
     bindDevice: unavailableBindDevice,
     bindExactDevice: unavailableBindExactDevice,
     reconcileOrphanedDeviceClaim: async () => ({

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -1,6 +1,5 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import type { CloudArtifactProvider } from '@agent-device/contracts/observability';
-import type { AndroidAdbExecutor } from '../platforms/android/adb-executor.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { getDaemonCommandRoute } from './daemon-command-registry.ts';
 import * as genericRequestHandlerModule from './request-generic-dispatch.ts';
@@ -14,6 +13,7 @@ import type { DeviceClaimReconciler } from './device-claims.ts';
 import type { AppLogAdmissionLedger } from './app-log-admission-ledger.ts';
 import type { ScreenRecordingAdmissionLedger } from './screen-recording-admission-ledger.ts';
 import type { PlatformRequestScope } from '@agent-device/contracts/platform';
+import type { RequestPlatformProviderScope } from './request-platform-providers.ts';
 
 type RequestHandlerChainParams = {
   req: DaemonRequest;
@@ -27,7 +27,13 @@ type RequestHandlerChainParams = {
   cloudArtifactProvider?: CloudArtifactProvider;
   invoke: DaemonInvokeFn;
   invokeReplayAction?: DaemonInvokeFn;
-  androidAdbExecutor?: AndroidAdbExecutor;
+  /**
+   * Per-request platform-provider injections resolved by the generic
+   * `withRequestPlatformProviderScope` mechanism. Route handlers pick their own
+   * platform-specific field back out of this neutral scope instead of the chain
+   * carrying one named slot per platform (e.g. `androidAdbExecutor`).
+   */
+  providerScope: RequestPlatformProviderScope;
   bindDevice: BindDeviceRuntime;
   bindExactDevice: BindExactDeviceRuntime;
   reconcileOrphanedDeviceClaim: DeviceClaimReconciler;
@@ -129,7 +135,7 @@ async function runSessionHandler(
       leaseLifecycleProvider: params.leaseLifecycleProvider,
       invoke: params.invoke,
       invokeReplayAction: params.invokeReplayAction,
-      androidAdbExecutor: params.androidAdbExecutor,
+      androidAdbExecutor: params.providerScope.androidAdbExecutor,
       bindDevice: params.bindDevice,
       bindExactDevice: params.bindExactDevice,
       reconcileOrphanedDeviceClaim: params.reconcileOrphanedDeviceClaim,

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -275,7 +275,7 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
       invokeReplayAction: allowReplayActions
         ? createReplayScopedActionInvoker(lockedScope, providerScope)
         : undefined,
-      androidAdbExecutor: providerScope.androidAdbExecutor,
+      providerScope,
       bindDevice: lockedScope.bindDevice,
       bindExactDevice: lockedScope.bindExactDevice,
       reconcileOrphanedDeviceClaim: createDeviceClaimReconciler({


### PR DESCRIPTION
## What changed

`src/daemon/request-handler-chain.ts` threaded a platform-concrete
`androidAdbExecutor?: AndroidAdbExecutor` parameter through the generic
`RequestHandlerChainParams`. That value was already produced by the daemon's
existing generic per-request provider-injection mechanism —
`RequestPlatformProviderScope`, built by `withRequestPlatformProviderScope` in
`request-platform-providers.ts` — but `request-router.ts` flattened it out
(`androidAdbExecutor: providerScope.androidAdbExecutor`) into a separately
named chain-level slot before calling `runRequestHandlerChain`.

This PR:
- Replaces `RequestHandlerChainParams.androidAdbExecutor` with
  `providerScope: RequestPlatformProviderScope`.
- Updates the session route (`runSessionHandler`, the sole in-chain consumer)
  to read `params.providerScope.androidAdbExecutor` when building
  `handleSessionCommands`' own params — which is otherwise unchanged.
- Updates `request-router.ts` to pass the whole resolved `providerScope`
  through instead of extracting `androidAdbExecutor` out of it first.

The generic chain signature no longer names any platform.

## Why this is behavior-neutral

- The exact same `RequestPlatformProviderScope` object — and its
  `androidAdbExecutor` field, resolved the same way by
  `withRequestPlatformProviderScope` — now reaches the session handler; only
  the path it travels through `RequestHandlerChainParams` changed, not its
  value or how it's resolved.
- Everything downstream of `handleSessionCommands` (`session.ts`,
  `session-doctor.ts`, `session-doctor-android.ts`, `session-native-perf.ts`,
  `session-observability.ts`) is untouched.
- Full provider-integration coverage that exercises the real ADB executor
  end-to-end through the daemon route (`android-lifecycle.test.ts`'s "Android
  Settings flow uses scripted ADB provider", `doctor.test.ts`,
  `android-recording.test.ts`, etc.) passes unchanged.

I did not find a case where this DI slot could not be absorbed without
changing production behavior — the value flowing through
`RequestHandlerChainParams` was always exactly `providerScope.androidAdbExecutor`,
so this stayed pure wiring.

## Validation

- New wiring-equivalence test (`request-handler-chain-provider-scope.test.ts`):
  mocks `handleSessionCommands` and proves (a) the exact `androidAdbExecutor`
  function reference passed into `providerScope` reaches it unchanged for a
  session-routed request, and (b) an empty provider scope still forwards
  `undefined` (as before).
- `pnpm exec tsc -p tsconfig.json` — clean
- `pnpm check:layering` — 136/136 structural tests pass
- `pnpm check:affected --run` — 80 test files / 337 tests passed (including
  the full provider-integration suite: `android-lifecycle`, `doctor`,
  `android-recording`, `record-trace-android-liveness`, etc.), plus format,
  lint, layering, and build/declarations checks

Part of #1739 (wave 0).