### PR TITLE
refactor: route selector-resolution structural stages into typed policy

### DIFF
--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -150,9 +150,12 @@ const SHARED_RESPONSE_CONSTRUCTION: GuaranteeEnforcement = {
 // guard/observation implementations; only how the target is found
 // (disambiguation) and how failures are described (errorTaxonomy) differ.
 const RUNTIME_TREE_SHARED_GUARANTEES = {
+  // #1656: the decision point is the pipeline runner, which reads the acting
+  // row's occlusion stage; isSnapshotNodeInteractionBlocked stays the
+  // predicate it applies (and the annotation contract it reads).
   occlusion: {
     kind: 'runtime',
-    via: 'src/snapshot/snapshot-occlusion.ts#isSnapshotNodeInteractionBlocked',
+    via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
   },
   parentOwnedTouchPoint: {
     kind: 'runtime',
@@ -171,9 +174,11 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
     kind: 'runtime',
     via: 'src/commands/interaction/runtime/resolution.ts#throwIfOffscreenInteractionTarget',
   },
+  // Promotion runs only for rows that declare it (#1656); the retarget itself
+  // is still resolveActionableTouchResolution.
   nonHittable: {
     kind: 'runtime',
-    via: 'src/core/interaction-targeting.ts#resolveActionableTouchResolution',
+    via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
   },
   responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
   responseIdentity: {
@@ -249,7 +254,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       occlusion: {
         kind: 'runtime',
-        via: 'src/snapshot/snapshot-occlusion.ts#isSnapshotNodeInteractionBlocked',
+        via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
       },
       parentOwnedTouchPoint: {
         kind: 'runtime',
@@ -370,7 +375,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       occlusion: {
         kind: 'runtime',
-        via: 'src/snapshot/snapshot-occlusion.ts#isSnapshotNodeInteractionBlocked',
+        via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
       },
       parentOwnedTouchPoint: {
         kind: 'inapplicable',

--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -155,7 +155,7 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
   // predicate it applies (and the annotation contract it reads).
   occlusion: {
     kind: 'runtime',
-    via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
+    via: 'src/core/selector-pipeline.ts#runNodePipelineStages',
   },
   parentOwnedTouchPoint: {
     kind: 'runtime',
@@ -178,7 +178,7 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
   // is still resolveActionableTouchResolution.
   nonHittable: {
     kind: 'runtime',
-    via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
+    via: 'src/core/selector-pipeline.ts#runNodePipelineStages',
   },
   responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
   responseIdentity: {
@@ -254,7 +254,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       occlusion: {
         kind: 'runtime',
-        via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
+        via: 'src/core/selector-pipeline.ts#runNodePipelineStages',
       },
       parentOwnedTouchPoint: {
         kind: 'runtime',
@@ -375,7 +375,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       occlusion: {
         kind: 'runtime',
-        via: 'src/core/selector-pipeline-policy.ts#resolveSelectorPipelineTarget',
+        via: 'src/core/selector-pipeline.ts#runNodePipelineStages',
       },
       parentOwnedTouchPoint: {
         kind: 'inapplicable',

--- a/packages/selectors/package.json
+++ b/packages/selectors/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "sideEffects": false,
   "type": "module",
-  "description": "Shared selector matching, argument, and replay semantics for agent-device. `.` is string-only; `./ast` is the published parser surface behind `agent-device/selectors`.",
+  "description": "Shared selector matching, argument, and replay semantics for agent-device. `.` is string-only; `./ast` is the published parser surface behind `agent-device/selectors`; `./engine` is the resolve/list surface reserved for the selector-pipeline owner (R19).",
   "dependencies": {
     "@agent-device/ad-script": "workspace:*",
     "@agent-device/contracts": "workspace:*",
@@ -18,6 +18,10 @@
     "./ast": {
       "types": "./src/ast.ts",
       "default": "./src/ast.ts"
+    },
+    "./engine": {
+      "types": "./src/engine.ts",
+      "default": "./src/engine.ts"
     }
   },
   "devDependencies": {

--- a/packages/selectors/src/engine.ts
+++ b/packages/selectors/src/engine.ts
@@ -1,0 +1,24 @@
+/**
+ * The matching engine's own door (#1656).
+ *
+ * "Resolve a selector against a screen" and "list what it matched" are the two
+ * decisions a pipeline policy row exists to qualify: which nodes may be
+ * candidates, whether several matches refuse or collapse, and which structural
+ * stages run around the answer. A caller that reaches these directly gets the
+ * ambiguity contract and silently skips every structural stage — the failure
+ * #1649 caught in the first policy matrix and #1656's review caught in the
+ * second.
+ *
+ * So they live behind a subpath of their own rather than on the root façade,
+ * and R19 selector-pipeline-ownership admits exactly one importer:
+ * `src/core/selector-pipeline.ts`. A specifier is what the import graph
+ * resolves, so namespace imports, dynamic imports, and re-exports are all the
+ * same edge and all equally refused — which a name-shaped check could not say.
+ *
+ * Everything else selectors publishes (parsing, matching, formatting, replay)
+ * stays on the root façade: none of it decides what a row decides.
+ */
+export {
+  listSelectorChainMatches,
+  resolveSelectorChainWithPolicy,
+} from './internal/facade-engine.ts';

--- a/packages/selectors/src/index.test.ts
+++ b/packages/selectors/src/index.test.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert/strict';
+import { resolveSelectorChainWithPolicy } from './engine.ts';
 import { test } from 'vitest';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import * as selectorsFacade from './index.ts';
+import * as selectorsEngine from './engine.ts';
 import {
   buildSelectorCandidates,
   readReplaySelectorDisplayValue,
   readSelectorExpression,
   resolveRecordedTarget,
   resolveReplaySuggestionCandidate,
-  resolveSelectorChainWithPolicy,
   SELECTOR_RESOLUTION_POLICIES,
 } from './index.ts';
 
@@ -201,16 +202,36 @@ test('replay suggestion resolution and display values stay string-only at the fa
  * preserved semantics — so no fixture-tree assertion can catch a revert
  * (#1715 review). The absence of the symbol is the only observable.
  */
-test('the façade exposes no resolver that bypasses the policy matrix', () => {
+test('the façade exposes no resolver at all, and the engine door exposes only the two entries', () => {
   const exported = Object.keys(selectorsFacade);
-  assert.ok(exported.includes('resolveSelectorChainWithPolicy'));
-  assert.ok(!exported.includes('resolveSelectorChain'), 'knob-taking resolver must stay private');
+  // #1656 moved both engine entries behind `./engine`, which R19 reserves for
+  // the selector-pipeline owner: a route that could reach a resolver from the
+  // root façade would get an ambiguity contract while skipping every
+  // structural stage its policy row declares.
   assert.ok(
-    !exported.includes('findSelectorChainMatch'),
-    'count-only existence lookup must stay private; `is exists` names the readAny row',
+    !exported.includes('resolveSelectorChainWithPolicy'),
+    'resolution belongs to the engine subpath, behind the pipeline owner',
   );
   assert.ok(
-    !exported.includes('selectorResolutionKnobs'),
-    'knob derivation must stay private so a call site cannot rebuild a contract from knobs',
+    !exported.includes('listSelectorChainMatches'),
+    'enumeration belongs to the engine subpath, behind the pipeline owner',
   );
+  assert.deepEqual(Object.keys(selectorsEngine).sort(), [
+    'listSelectorChainMatches',
+    'resolveSelectorChainWithPolicy',
+  ]);
+
+  // Unchanged since #1630, on both surfaces: neither door hands out a knob
+  // resolver a call site could rebuild its contract from.
+  for (const [surface, names] of [
+    ['facade', exported],
+    ['engine', Object.keys(selectorsEngine)],
+  ] as const) {
+    assert.ok(!names.includes('resolveSelectorChain'), `${surface}: knob-taking resolver`);
+    assert.ok(
+      !names.includes('findSelectorChainMatch'),
+      `${surface}: count-only existence lookup; \`is exists\` names the readAny row`,
+    );
+    assert.ok(!names.includes('selectorResolutionKnobs'), `${surface}: knob derivation`);
+  }
 });

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -59,6 +59,7 @@ export type { IsPredicate } from './internal/predicates.ts';
 export type {
   PolicyResolutionOutcome,
   SelectorChainMatchList,
+  SelectorMatchOptions,
   SelectorResolution,
 } from './internal/public-resolution-types.ts';
 export { formatSelectorFailure } from './internal/resolve.ts';

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -1,11 +1,4 @@
-import type { SnapshotState } from '@agent-device/kernel/snapshot';
 import type { Selector } from './internal/parse.ts';
-import type {
-  PolicyResolutionOutcome,
-  SelectorChainMatchList,
-  SelectorMatchOptions,
-} from './internal/public-resolution-types.ts';
-import { resolveSelectorChainWithPolicy as resolveSelectorChainWithPolicyAst } from './internal/resolve-with-policy.ts';
 import {
   checkElementTargetArgs,
   checkGetFormat,
@@ -30,11 +23,7 @@ import {
   IS_PREDICATE_USAGE_HINT,
   normalizeIsPositionals,
 } from './internal/predicates.ts';
-import {
-  listSelectorChainMatches as listSelectorChainMatchesAst,
-  selectorFailureHint,
-  STALE_REF_HINT,
-} from './internal/resolve.ts';
+import { selectorFailureHint, STALE_REF_HINT } from './internal/resolve.ts';
 import {
   findBestMatchesByLocator,
   checkFindArgs,
@@ -81,7 +70,6 @@ export {
   isRoleHintWord,
   isSelectorToken,
   isValidSelectorExpression,
-  listSelectorChainMatches,
   normalizeIsPositionals,
   normalizeSelectorText,
   parseFindArgs,
@@ -226,52 +214,5 @@ function validateSelectorExpression(expression: string): void {
   parseSelectorChain(expression);
 }
 
-/** Public façade wrapper that accepts/returns selector text, never an AST. */
-function listSelectorChainMatches(
-  nodes: SnapshotState['nodes'],
-  expression: string,
-  options: SelectorMatchOptions,
-): SelectorChainMatchList | null {
-  const result = listSelectorChainMatchesAst(nodes, parseSelectorChain(expression), options);
-  return result ? { ...result, selector: result.selector.raw } : null;
-}
-
 export { SELECTOR_RESOLUTION_POLICIES } from './internal/resolution-policy.ts';
 export type { SelectorResolutionPolicy } from './internal/resolution-policy.ts';
-import type { SelectorResolutionPolicy } from './internal/resolution-policy.ts';
-
-/**
- * The façade's ONLY selector-resolution entry (#1630): every native consumer
- * of "resolve a selector against the screen" states its contract by naming a
- * `SELECTOR_RESOLUTION_POLICIES` row, because there is no knob-taking resolver
- * here to state it inline with instead. Accepts selector text and returns
- * selector text — never an AST, in either direction.
- *
- * The return leg is the half that is easy to miss: the parser-side outcome
- * carries the winning `Selector` node inside `resolution`, and returning it
- * unchanged would put a package-private parser object back in every caller's
- * hands through a nested field. The façade's own boundary gate reads exported
- * *names*, so it cannot see that; `selector-wait.ts` reading
- * `outcome.resolution.selector.raw` was the runtime proof it had happened.
- * Flattening here is the same treatment `listSelectorChainMatches` above gives
- * its own selector node (#1589).
- */
-function resolveSelectorChainWithPolicy(
-  nodes: SnapshotState['nodes'],
-  expression: string,
-  policy: SelectorResolutionPolicy,
-  options: SelectorMatchOptions,
-): PolicyResolutionOutcome {
-  const outcome = resolveSelectorChainWithPolicyAst(
-    nodes,
-    parseSelectorChain(expression),
-    policy,
-    options,
-  );
-  if (outcome.kind !== 'resolved') return outcome;
-  return {
-    ...outcome,
-    resolution: { ...outcome.resolution, selector: outcome.resolution.selector.raw },
-  };
-}
-export { resolveSelectorChainWithPolicy };

--- a/packages/selectors/src/internal/facade-engine.ts
+++ b/packages/selectors/src/internal/facade-engine.ts
@@ -1,0 +1,62 @@
+import type { SnapshotState } from '@agent-device/kernel/snapshot';
+import { parseSelectorChain } from './parse.ts';
+import { listSelectorChainMatches as listSelectorChainMatchesAst } from './resolve.ts';
+import { resolveSelectorChainWithPolicy as resolveSelectorChainWithPolicyAst } from './resolve-with-policy.ts';
+import type { SelectorResolutionPolicy } from './resolution-policy.ts';
+import type {
+  PolicyResolutionOutcome,
+  SelectorChainMatchList,
+  SelectorMatchOptions,
+} from './public-resolution-types.ts';
+
+/**
+ * The two engine entries, behind `@agent-device/selectors/engine` (#1656).
+ * Both are string-in/string-out façade wrappers (#1589): a nested parser node
+ * would reopen the AST boundary invisibly, since the package-boundary gate
+ * reads exported *names* and cannot see into a returned shape.
+ */
+
+/** Public façade wrapper that accepts/returns selector text, never an AST. */
+export function listSelectorChainMatches(
+  nodes: SnapshotState['nodes'],
+  expression: string,
+  options: SelectorMatchOptions,
+): SelectorChainMatchList | null {
+  const result = listSelectorChainMatchesAst(nodes, parseSelectorChain(expression), options);
+  return result ? { ...result, selector: result.selector.raw } : null;
+}
+
+/**
+ * The façade's ONLY selector-resolution entry (#1630): every native consumer
+ * of "resolve a selector against the screen" states its contract by naming a
+ * `SELECTOR_RESOLUTION_POLICIES` row, because there is no knob-taking resolver
+ * here to state it inline with instead. Accepts selector text and returns
+ * selector text — never an AST, in either direction.
+ *
+ * The return leg is the half that is easy to miss: the parser-side outcome
+ * carries the winning `Selector` node inside `resolution`, and returning it
+ * unchanged would put a package-private parser object back in every caller's
+ * hands through a nested field. The façade's own boundary gate reads exported
+ * *names*, so it cannot see that; `selector-wait.ts` reading
+ * `outcome.resolution.selector.raw` was the runtime proof it had happened.
+ * Flattening here is the same treatment `listSelectorChainMatches` above gives
+ * its own selector node (#1589).
+ */
+export function resolveSelectorChainWithPolicy(
+  nodes: SnapshotState['nodes'],
+  expression: string,
+  policy: SelectorResolutionPolicy,
+  options: SelectorMatchOptions,
+): PolicyResolutionOutcome {
+  const outcome = resolveSelectorChainWithPolicyAst(
+    nodes,
+    parseSelectorChain(expression),
+    policy,
+    options,
+  );
+  if (outcome.kind !== 'resolved') return outcome;
+  return {
+    ...outcome,
+    resolution: { ...outcome.resolution, selector: outcome.resolution.selector.raw },
+  };
+}

--- a/packages/selectors/src/internal/resolution-policy.ts
+++ b/packages/selectors/src/internal/resolution-policy.ts
@@ -81,6 +81,14 @@ export const SELECTOR_RESOLUTION_POLICIES = {
     ambiguity: 'reject-candidates',
     requireRect: true,
   },
+  /**
+   * `find <q> list` — the inspection surface: every match is the ANSWER, so the
+   * candidate set stays whole and nothing needs a tap point.
+   */
+  readList: {
+    ambiguity: 'reject-candidates',
+    requireRect: false,
+  },
 } as const satisfies Record<string, SelectorResolutionPolicy>;
 
 /**

--- a/packages/selectors/src/internal/resolution-policy.ts
+++ b/packages/selectors/src/internal/resolution-policy.ts
@@ -28,11 +28,13 @@ import type { SelectorResolutionOptions } from './public-resolution-types.ts';
  * documented semantics fails a test.
  *
  * The surrounding pipeline stages — occlusion, the off-screen guard,
- * hittable-ancestor promotion, and the wait poll budget — still live in the
- * callers and are NOT declared here. An earlier revision listed them as
- * columns; nothing consumed them, so they were unverifiable claims that read
- * as truth while being free to drift (#1649 review). Routing them into typed
- * behavior is tracked in #1656.
+ * hittable-ancestor promotion, and the wait poll budget — are declared in the
+ * companion structural table, `src/core/selector-pipeline-policy.ts` (#1656),
+ * whose rows each name one row of this matrix. They live there rather than
+ * here because this package is deliberately blind to snapshot occlusion
+ * annotations, backend visibility probes, and the wait clock; a column here
+ * would be a claim nothing in this package could enforce, which is exactly the
+ * unverifiable-column failure the #1649 review caught.
  */
 
 export type KnobBackedSelectorAmbiguity = 'disambiguate' | 'fail-closed' | 'first-match';

--- a/packages/selectors/src/internal/resolution-policy.ts
+++ b/packages/selectors/src/internal/resolution-policy.ts
@@ -32,9 +32,8 @@ import type { SelectorResolutionOptions } from './public-resolution-types.ts';
  * companion structural table, `src/core/selector-pipeline-policy.ts` (#1656),
  * whose rows each name one row of this matrix. They live there rather than
  * here because this package is deliberately blind to snapshot occlusion
- * annotations, backend visibility probes, and the wait clock; a column here
- * would be a claim nothing in this package could enforce, which is exactly the
- * unverifiable-column failure the #1649 review caught.
+ * annotations, backend visibility probes, and the wait clock: a column here
+ * would be a claim nothing in this package could enforce (#1649 review).
  */
 
 export type KnobBackedSelectorAmbiguity = 'disambiguate' | 'fail-closed' | 'first-match';

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -102,6 +102,7 @@ import {
   sourceExecutedUsingDeclarationViolations,
 } from './logs-runtime-cutover-policy.ts';
 import { contractsImplementationAuthorityViolations } from './contracts-implementation-policy.ts';
+import { selectorPipelineOwnershipViolations } from './selector-pipeline-ownership.ts';
 import {
   networkLegacyRouteViolations,
   networkRuntimeNarrowingViolations,
@@ -670,6 +671,7 @@ export const LAYERING_RULE_IDS = [
   'value-import-cycles',
   'logs-runtime-cutover',
   'contracts-implementation-authority',
+  'selector-pipeline-ownership',
   'network-runtime-cutover',
   'record-runtime-cutover',
   'back-edges',
@@ -691,6 +693,8 @@ export const LAYERING_RULES: Readonly<Record<LayeringRuleId, LayeringRule>> = {
   'logs-runtime-cutover': (context) => checkLogsRuntimeCutover(context.sources),
   'contracts-implementation-authority': (context) =>
     checkContractsImplementationAuthority(context.sources),
+  'selector-pipeline-ownership': (context) =>
+    selectorPipelineOwnershipViolations(context.edges, workspaceSpecifierTargets(repoRoot)),
   'network-runtime-cutover': (context) => checkNetworkRuntimeCutover(context.sources),
   'record-runtime-cutover': (context) => checkRecordRuntimeCutover(context.sources),
   'back-edges': (context) => checkBackEdges(context.edges),

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -387,13 +387,17 @@ test('the real tree parses, declares, and passes R11', () => {
   );
   const selectorsPackage = packages.find((pkg) => pkg.name === '@agent-device/selectors');
   assert.ok(selectorsPackage, 'selectors package must exist');
-  // Two subpaths, and the split is the point: `.` is the string-only façade
+  // Three subpaths, and each split is the point: `.` is the string-only façade
   // every in-repo consumer uses, `./ast` is the published parser surface that
   // `agent-device/selectors` has shipped since before the engine moved into
-  // this package. A third subpath, or the AST leaking into `.`, fails here.
+  // this package, and `./engine` is the resolve/list surface reserved for the
+  // selector-pipeline owner (R19, #1656) — a route reaching it skips the
+  // structural stages its policy row declares. A fourth subpath, or the AST
+  // leaking into `.`, fails here.
   assert.deepEqual([...selectorsPackage.exportTargets.keys()].sort(), [
     '@agent-device/selectors',
     '@agent-device/selectors/ast',
+    '@agent-device/selectors/engine',
   ]);
   assert.deepEqual([...selectorsPackage.workspaceDependencies].sort(), [
     '@agent-device/ad-script',

--- a/scripts/layering/rule-ids.test.ts
+++ b/scripts/layering/rule-ids.test.ts
@@ -7,40 +7,72 @@ import {
   duplicateRuleIds,
   KNOWN_RULE_ID_COLLISIONS,
   readLayeringSources,
+  ruleIdCollisionFailures,
 } from './rule-ids.ts';
 
 const layeringDirectory = path.dirname(fileURLToPath(import.meta.url));
 
-test('no rule id names two rules beyond the collisions #1750 is renaming away', () => {
+/** The exact collision #1750 is renaming away — the string the allowance names. */
+const TRANSITIONAL_COLLISION =
+  'R11 names contracts-implementation-authority and package-boundaries';
+
+function failuresFor(sources: string[], allowed: readonly string[] = []): string[] {
+  const declarations = collectRuleDeclarations(
+    sources.map((source, index) => ({ path: `${index}.ts`, source })),
+  );
+  return ruleIdCollisionFailures({ declarations, allowed });
+}
+
+test('the layering rules currently in tree carry no unallowed collision', () => {
   const declarations = collectRuleDeclarations(readLayeringSources(layeringDirectory));
   assert.ok(declarations.length > 10, 'expected the layering rules to be discovered');
-  const unexpected = duplicateRuleIds(declarations).filter(
-    (collision) => !KNOWN_RULE_ID_COLLISIONS.includes(collision),
+  assert.deepEqual(
+    ruleIdCollisionFailures({ declarations, allowed: KNOWN_RULE_ID_COLLISIONS }),
+    [],
   );
-  assert.deepEqual(unexpected, [], 'two rules answer to one id; allocate the next free number');
 });
 
-test('a collision is reported with both names, whichever order it lands in', () => {
-  // The failure this gate exists for: two branches both take a free number.
+test('a collision nobody allowed fails, whichever order it lands in', () => {
   // Synthetic ids: a fixture naming real rules would read as an allocation to
   // anyone grepping for the next free number, which is how the collision this
   // gate exists for happened.
-  const collision = [
-    { path: 'a.ts', source: "rule: 'R99 first-claimant'" },
-    { path: 'b.ts', source: "const RULE = 'R99 second-claimant';" },
+  const collision = ["rule: 'R99 first-claimant'", "const RULE = 'R99 second-claimant';"];
+  const expected = [
+    'two rules answer to one id: R99 names first-claimant and second-claimant. Allocate the next free number.',
   ];
-  assert.deepEqual(duplicateRuleIds(collectRuleDeclarations(collision)), [
-    'R99 names first-claimant and second-claimant',
+  assert.deepEqual(failuresFor(collision), expected);
+  assert.deepEqual(failuresFor([...collision].reverse()), expected, 'order must not matter');
+});
+
+test('an allowance expires with the collision it allows', () => {
+  // The failure mode this replaces: after #1750 renames R11 apart, an allowance
+  // still naming that collision would wave it back through if it returned.
+  const cleanTree = [
+    "rule: 'R11 package-boundaries'",
+    "rule: 'R18 contracts-implementation-authority'",
+  ];
+  assert.deepEqual(failuresFor(cleanTree, [TRANSITIONAL_COLLISION]), [
+    `stale allowance: "${TRANSITIONAL_COLLISION}" no longer occurs, so the entry admits a collision ` +
+      'nobody is fixing. Delete it from KNOWN_RULE_ID_COLLISIONS.',
   ]);
-  assert.deepEqual(
-    duplicateRuleIds(collectRuleDeclarations([...collision].reverse())),
-    ['R99 names first-claimant and second-claimant'],
-    'order of arrival must not change the verdict',
-  );
+});
+
+test('reintroducing the transitional collision is rejected once the allowance is gone', () => {
+  // The post-#1750 world: the list is empty, and the exact string it used to
+  // carry buys nothing.
+  const reintroduced = [
+    "rule: 'R11 contracts-implementation-authority'",
+    "rule: 'R11 package-boundaries'",
+  ];
+  assert.deepEqual(failuresFor(reintroduced, []), [
+    `two rules answer to one id: ${TRANSITIONAL_COLLISION}. Allocate the next free number.`,
+  ]);
+  // And while the transition is live, the same collision is allowed exactly
+  // because it is present — the allowance is never a blanket exemption.
+  assert.deepEqual(failuresFor(reintroduced, [TRANSITIONAL_COLLISION]), []);
 });
 
 test('one rule declaring its id from several call sites is not a collision', () => {
-  // R7 and R12 legitimately emit from many places.
   assert.deepEqual(
     duplicateRuleIds(
       collectRuleDeclarations([

--- a/scripts/layering/rule-ids.test.ts
+++ b/scripts/layering/rule-ids.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  collectRuleDeclarations,
+  duplicateRuleIds,
+  KNOWN_RULE_ID_COLLISIONS,
+  readLayeringSources,
+} from './rule-ids.ts';
+
+const layeringDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+test('no rule id names two rules beyond the collisions #1750 is renaming away', () => {
+  const declarations = collectRuleDeclarations(readLayeringSources(layeringDirectory));
+  assert.ok(declarations.length > 10, 'expected the layering rules to be discovered');
+  const unexpected = duplicateRuleIds(declarations).filter(
+    (collision) => !KNOWN_RULE_ID_COLLISIONS.includes(collision),
+  );
+  assert.deepEqual(unexpected, [], 'two rules answer to one id; allocate the next free number');
+});
+
+test('a collision is reported with both names, whichever order it lands in', () => {
+  // The failure this gate exists for: two branches both take a free number.
+  // Synthetic ids: a fixture naming real rules would read as an allocation to
+  // anyone grepping for the next free number, which is how the collision this
+  // gate exists for happened.
+  const collision = [
+    { path: 'a.ts', source: "rule: 'R99 first-claimant'" },
+    { path: 'b.ts', source: "const RULE = 'R99 second-claimant';" },
+  ];
+  assert.deepEqual(duplicateRuleIds(collectRuleDeclarations(collision)), [
+    'R99 names first-claimant and second-claimant',
+  ]);
+  assert.deepEqual(
+    duplicateRuleIds(collectRuleDeclarations([...collision].reverse())),
+    ['R99 names first-claimant and second-claimant'],
+    'order of arrival must not change the verdict',
+  );
+});
+
+test('one rule declaring its id from several call sites is not a collision', () => {
+  // R7 and R12 legitimately emit from many places.
+  assert.deepEqual(
+    duplicateRuleIds(
+      collectRuleDeclarations([
+        { path: 'a.ts', source: "rule: 'R98 many-emitters'" },
+        { path: 'a.ts', source: "rule: 'R98 many-emitters'" },
+      ]),
+    ),
+    [],
+  );
+});

--- a/scripts/layering/rule-ids.ts
+++ b/scripts/layering/rule-ids.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Rule-ID uniqueness.
+ *
+ * Layering rules are addressed by number in review, in CI annotations, and in
+ * the code comments that point at them, so a number must name exactly one rule.
+ * Two branches allocating the same free number do not conflict in git — the
+ * files differ — and land as two rules answering to one id, after which every
+ * reference to it is ambiguous. #1656 and #1750 both reached for R17.
+ *
+ * The claim being checked is about source text (which id a rule declares), so
+ * reading the declarations IS the check rather than a proxy for one. It is a
+ * naming registry, not a behavioural claim.
+ */
+
+export type RuleDeclaration = {
+  id: string;
+  name: string;
+  file: string;
+};
+
+/**
+ * A rule id is declared as a WHOLE string literal — `rule: 'R7 …'` at an
+ * emitter, `const RULE = 'R17 …'` at the top of a policy module. Matching the
+ * complete literal is what separates a declaration from the prose that also
+ * names rules ("R17 holds the devices command to…"): a sentence keeps going
+ * where a declaration closes its quote.
+ */
+const RULE_LITERAL = /'(R\d+) ([a-z0-9-]+)'/g;
+
+export function collectRuleDeclarations(files: readonly { path: string; source: string }[]) {
+  const declarations: RuleDeclaration[] = [];
+  for (const file of files) {
+    for (const match of file.source.matchAll(RULE_LITERAL)) {
+      declarations.push({ id: match[1]!, name: match[2]!, file: file.path });
+    }
+  }
+  return declarations;
+}
+
+export function duplicateRuleIds(declarations: readonly RuleDeclaration[]): string[] {
+  const byId = new Map<string, Set<string>>();
+  for (const declaration of declarations) {
+    const names = byId.get(declaration.id) ?? new Set<string>();
+    names.add(declaration.name);
+    byId.set(declaration.id, names);
+  }
+  return [...byId]
+    .filter(([, names]) => names.size > 1)
+    .map(([id, names]) => `${id} names ${[...names].sort().join(' and ')}`)
+    .sort();
+}
+
+/**
+ * Collisions that predate this gate: `main` reuses R11 and R13 for two rules
+ * each, which #1750 is renaming to R17/R18. Listed rather than pinned by
+ * equality so that PR can land in either order without breaking this one —
+ * the gate refuses NEW collisions today and these entries fall away with the
+ * rename. A stale entry is inert; a missing one is a failure.
+ */
+export const KNOWN_RULE_ID_COLLISIONS: readonly string[] = [
+  'R11 names contracts-implementation-authority and package-boundaries',
+  'R13 names device-inventory-cutover and platform-package-substrate',
+];
+
+/** The layering policy modules, which is where rule ids are declared. */
+export function readLayeringSources(directory: string): { path: string; source: string }[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
+    .map((entry) => ({
+      path: `scripts/layering/${entry}`,
+      source: readFileSync(path.join(directory, entry), 'utf8'),
+    }));
+}

--- a/scripts/layering/rule-ids.ts
+++ b/scripts/layering/rule-ids.ts
@@ -55,15 +55,47 @@ export function duplicateRuleIds(declarations: readonly RuleDeclaration[]): stri
 
 /**
  * Collisions that predate this gate: `main` reuses R11 and R13 for two rules
- * each, which #1750 is renaming to R17/R18. Listed rather than pinned by
- * equality so that PR can land in either order without breaking this one —
- * the gate refuses NEW collisions today and these entries fall away with the
- * rename. A stale entry is inert; a missing one is a failure.
+ * each, which #1750 is renaming to R17/R18. Transitional, and each entry
+ * expires on contact — see `ruleIdCollisionFailures`. Empty is the end state,
+ * and the gate gets there on its own.
  */
 export const KNOWN_RULE_ID_COLLISIONS: readonly string[] = [
   'R11 names contracts-implementation-authority and package-boundaries',
   'R13 names device-inventory-cutover and platform-package-substrate',
 ];
+
+/**
+ * Both halves of the transition, because an allowance that outlives the thing
+ * it allows fails OPEN: once #1750 renames R11/R13 apart, a list still naming
+ * those exact collisions would wave them straight back through if anyone
+ * reintroduced them.
+ *
+ * So an allowance is only valid while its collision is actually present. A
+ * collision nobody allowed fails, and an allowance whose collision is gone
+ * fails too — which forces the entry to be deleted in the same change that
+ * removes the collision, and leaves an empty list that admits nothing.
+ */
+export function ruleIdCollisionFailures(params: {
+  declarations: readonly RuleDeclaration[];
+  allowed: readonly string[];
+}): string[] {
+  const present = new Set(duplicateRuleIds(params.declarations));
+  const allowed = new Set(params.allowed);
+  return [
+    ...[...present]
+      .filter((collision) => !allowed.has(collision))
+      .map(
+        (collision) => `two rules answer to one id: ${collision}. Allocate the next free number.`,
+      ),
+    ...[...allowed]
+      .filter((collision) => !present.has(collision))
+      .map(
+        (collision) =>
+          `stale allowance: "${collision}" no longer occurs, so the entry admits a collision ` +
+          'nobody is fixing. Delete it from KNOWN_RULE_ID_COLLISIONS.',
+      ),
+  ].sort();
+}
 
 /** The layering policy modules, which is where rule ids are declared. */
 export function readLayeringSources(directory: string): { path: string; source: string }[] {

--- a/scripts/layering/selector-pipeline-ownership.test.ts
+++ b/scripts/layering/selector-pipeline-ownership.test.ts
@@ -1,62 +1,87 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { parseImports, type ResolvedImportEdge } from './model.ts';
 import {
   SELECTOR_ENGINE_OWNER,
+  SELECTOR_ENGINE_SPECIFIER,
   selectorPipelineOwnershipViolations,
 } from './selector-pipeline-ownership.ts';
 
-function violations(source: string, path = 'src/daemon/handlers/planted.ts'): string[] {
-  return selectorPipelineOwnershipViolations([{ path, source }]).map(
-    (violation) => `${violation.file}: ${violation.message}`,
-  );
+/**
+ * The rule reads resolved edges, so these drive real source through the same
+ * `parseImports` the gate uses. That is the point of the shape: a bypass is
+ * only refused in every import FORM if the check never looks at symbol names.
+ */
+function violations(source: string, file = 'src/daemon/handlers/planted.ts'): string[] {
+  const edges: ResolvedImportEdge[] = parseImports(source).map((edge) => ({
+    ...edge,
+    file,
+    target: edge.spec,
+    fromZone: 'daemon-server',
+    toZone: 'selectors',
+  }));
+  return selectorPipelineOwnershipViolations(edges).map((violation) => violation.message);
 }
 
-test('a route that reaches the selector engine directly is rejected', () => {
+test('every import form that reaches the engine is refused', () => {
   for (const source of [
-    "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
-    "import { listSelectorChainMatches } from '@agent-device/selectors';",
-    "import { formatSelectorFailure, resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
-    "import { listSelectorChainMatches as listMatches } from '@agent-device/selectors';",
+    // Named — the shape a symbol-matching check would also have caught.
+    `import { resolveSelectorChainWithPolicy } from '${SELECTOR_ENGINE_SPECIFIER}';`,
+    // Namespace: no symbol name appears anywhere in the statement.
+    `import * as engine from '${SELECTOR_ENGINE_SPECIFIER}';`,
+    // Deferred: the call site is a promise, and the specifier is the only trace.
+    `const engine = await import('${SELECTOR_ENGINE_SPECIFIER}');`,
+    // Re-export: launders the engine through a module the routes may import.
+    `export { listSelectorChainMatches } from '${SELECTOR_ENGINE_SPECIFIER}';`,
+    `export * from '${SELECTOR_ENGINE_SPECIFIER}';`,
+    // Side-effect import, for completeness of the edge kinds the model emits.
+    `import '${SELECTOR_ENGINE_SPECIFIER}';`,
+    // Type position still names the module the row exists to qualify.
+    `import type { SelectorChainMatchList } from '${SELECTOR_ENGINE_SPECIFIER}';`,
   ]) {
     assert.equal(violations(source).length, 1, source);
   }
 });
 
-test('the owner may hold the engine, and everyone may hold the vocabulary around it', () => {
+test('the owner holds the engine, and the root façade stays open to everyone', () => {
   assert.deepEqual(
     violations(
-      "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+      `import { resolveSelectorChainWithPolicy } from '${SELECTOR_ENGINE_SPECIFIER}';`,
       SELECTOR_ENGINE_OWNER,
     ),
-    [],
-  );
-  assert.deepEqual(
-    violations("import type { SelectorChainMatchList } from '@agent-device/selectors';"),
     [],
   );
   assert.deepEqual(
     violations(
       [
         "import { buildSelectorChainForNode, formatSelectorFailure } from '@agent-device/selectors';",
+        "import type { SelectorChainMatchList } from '@agent-device/selectors';",
         "import { resolveSelectorPipeline } from '../../core/selector-pipeline.ts';",
       ].join('\n'),
     ),
     [],
   );
-  // The engine's own package describes the engine rather than routing around it.
+  // A neighbouring subpath is a different door; only the engine is reserved.
   assert.deepEqual(
-    violations(
-      "import { listSelectorChainMatches } from '@agent-device/selectors';",
-      'packages/selectors/src/index.test.ts',
-    ),
+    violations("import { parseSelectorChain } from '@agent-device/selectors/ast';"),
     [],
   );
 });
 
-test('the refusal names the owner and the entry points that replace the bypass', () => {
-  const [message] = violations(
-    "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+test('a missing engine door fails the gate instead of silencing it', () => {
+  // The specifier is the whole enforcement, and `resolveImportEdges` drops an
+  // edge that resolves to nothing: without this, retiring the subpath would
+  // turn the rule green forever.
+  const [message] = selectorPipelineOwnershipViolations([], new Map()).map((v) => v.message);
+  assert.ok(message?.includes('not a workspace export'), message);
+  assert.deepEqual(
+    selectorPipelineOwnershipViolations([], new Map([[SELECTOR_ENGINE_SPECIFIER, 'x.ts']])),
+    [],
   );
+});
+
+test('the refusal names the owner and the entries that replace the bypass', () => {
+  const [message] = violations(`import * as engine from '${SELECTOR_ENGINE_SPECIFIER}';`);
   assert.ok(message?.includes(SELECTOR_ENGINE_OWNER), message);
   assert.ok(message?.includes('resolveSelectorPipeline'), message);
   assert.ok(message?.includes('SELECTOR_PIPELINE_POLICIES'), message);

--- a/scripts/layering/selector-pipeline-ownership.test.ts
+++ b/scripts/layering/selector-pipeline-ownership.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  SELECTOR_ENGINE_OWNER,
+  selectorPipelineOwnershipViolations,
+} from './selector-pipeline-ownership.ts';
+
+function violations(source: string, path = 'src/daemon/handlers/planted.ts'): string[] {
+  return selectorPipelineOwnershipViolations([{ path, source }]).map(
+    (violation) => `${violation.file}: ${violation.message}`,
+  );
+}
+
+test('a route that reaches the selector engine directly is rejected', () => {
+  for (const source of [
+    "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+    "import { listSelectorChainMatches } from '@agent-device/selectors';",
+    "import { formatSelectorFailure, resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+    "import { listSelectorChainMatches as listMatches } from '@agent-device/selectors';",
+  ]) {
+    assert.equal(violations(source).length, 1, source);
+  }
+});
+
+test('the owner may hold the engine, and everyone may hold the vocabulary around it', () => {
+  assert.deepEqual(
+    violations(
+      "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+      SELECTOR_ENGINE_OWNER,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    violations("import type { SelectorChainMatchList } from '@agent-device/selectors';"),
+    [],
+  );
+  assert.deepEqual(
+    violations(
+      [
+        "import { buildSelectorChainForNode, formatSelectorFailure } from '@agent-device/selectors';",
+        "import { resolveSelectorPipeline } from '../../core/selector-pipeline.ts';",
+      ].join('\n'),
+    ),
+    [],
+  );
+  // The engine's own package describes the engine rather than routing around it.
+  assert.deepEqual(
+    violations(
+      "import { listSelectorChainMatches } from '@agent-device/selectors';",
+      'packages/selectors/src/index.test.ts',
+    ),
+    [],
+  );
+});
+
+test('the refusal names the owner and the entry points that replace the bypass', () => {
+  const [message] = violations(
+    "import { resolveSelectorChainWithPolicy } from '@agent-device/selectors';",
+  );
+  assert.ok(message?.includes(SELECTOR_ENGINE_OWNER), message);
+  assert.ok(message?.includes('resolveSelectorPipeline'), message);
+  assert.ok(message?.includes('SELECTOR_PIPELINE_POLICIES'), message);
+});

--- a/scripts/layering/selector-pipeline-ownership.ts
+++ b/scripts/layering/selector-pipeline-ownership.ts
@@ -1,86 +1,66 @@
+import type { LayeringViolation, ResolvedImportEdge } from './model.ts';
+
 /**
- * R17 selector-pipeline ownership (#1656).
+ * R19 selector-pipeline-ownership (#1656).
  *
  * The structural stages of selector resolution — occlusion, off-screen,
  * hittable-ancestor promotion, the poll budget — are declared per caller in
  * `src/core/selector-pipeline-policy.ts` and executed by
  * `src/core/selector-pipeline.ts`. That only means something while the owner is
- * the ONLY way in: a route that calls the matching engine directly still gets a
+ * the ONLY way in: a route that reaches the matching engine itself still gets a
  * row's ambiguity contract while silently skipping every structural stage,
  * which is how a declared cell turns back into an unverifiable claim (the
  * failure #1649 caught in the first matrix and #1656's review caught in the
  * second).
  *
- * So the engine entry points are owner-only. A structural gate rather than a
- * convention, because the failure is invisible at the call site: code that
- * skips the stages looks exactly like code that runs them.
+ * The engine therefore lives behind its own package subpath, and this rule
+ * admits one importer. Enforcing on the SPECIFIER, over the resolved import
+ * graph, is what makes the boundary hold in every import form: a namespace
+ * import, a re-export, and a deferred `import()` are all the same edge, and
+ * none of them mentions the symbol a name-shaped check would look for.
  */
 
-export type SourceFile = { path: string; source: string };
+export const SELECTOR_ENGINE_SPECIFIER = '@agent-device/selectors/engine';
 
-export type LayeringViolation = {
-  rule: string;
-  file: string;
-  line: number;
-  message: string;
-};
-
-/**
- * The engine surface that resolves or enumerates a selector against a tree —
- * the decision a policy row exists to qualify. `@agent-device/selectors` also
- * exports parsing, matching and formatting helpers, which carry no row
- * semantics and stay freely importable.
- */
-export const OWNED_SELECTOR_ENGINE_SYMBOLS = [
-  'resolveSelectorChainWithPolicy',
-  'listSelectorChainMatches',
-] as const;
-
-/** The pipeline owner. The selectors package implements the engine it wraps. */
+/** The pipeline owner: the one module that may hold the engine. */
 export const SELECTOR_ENGINE_OWNER = 'src/core/selector-pipeline.ts';
 
-const IMPORT_BLOCK =
-  /import\s+(type\s+)?\{([^}]*)\}\s*from\s*['"](@agent-device\/selectors[^'"]*)['"]/g;
-
+/**
+ * `resolveImportEdges` DROPS an edge whose specifier resolves to nothing, so a
+ * rule keyed on a specifier goes quiet — not red — if that subpath ever stops
+ * being an export. The gate says so out loud instead: no resolvable engine
+ * door means this rule is not watching anything, which is a failure of the
+ * gate rather than a clean scan.
+ */
 export function selectorPipelineOwnershipViolations(
-  files: readonly SourceFile[],
+  edges: readonly ResolvedImportEdge[],
+  workspaceTargets?: ReadonlyMap<string, string>,
 ): LayeringViolation[] {
-  const violations: LayeringViolation[] = [];
-  for (const file of files) {
-    if (file.path === SELECTOR_ENGINE_OWNER) continue;
-    // The engine's own package and its tests describe the engine rather than
-    // route around it; the gate governs consumers.
-    if (file.path.startsWith('packages/selectors/')) continue;
-    for (const match of file.source.matchAll(IMPORT_BLOCK)) {
-      // A type-only import cannot call anything, and routes legitimately name
-      // the result types the owner hands back.
-      if (match[1]) continue;
-      for (const symbol of importedValueSymbols(match[2] ?? '')) {
-        if (!(OWNED_SELECTOR_ENGINE_SYMBOLS as readonly string[]).includes(symbol)) continue;
-        violations.push({
-          rule: 'R17 selector-pipeline-ownership',
-          file: file.path,
-          line: lineOf(file.source, match.index ?? 0),
-          message:
-            `imports ${symbol} from @agent-device/selectors. The selector engine is owned by ` +
-            `${SELECTOR_ENGINE_OWNER}: call resolveSelectorPipeline / listSelectorPipelineMatches / ` +
-            'runNodePipelineStages with a SELECTOR_PIPELINE_POLICIES row instead, so this route runs ' +
-            'the occlusion, off-screen and promotion stages the row declares rather than skipping them.',
-        });
-      }
-    }
+  if (workspaceTargets && !workspaceTargets.has(SELECTOR_ENGINE_SPECIFIER)) {
+    return [
+      {
+        rule: 'R19 selector-pipeline-ownership',
+        file: SELECTOR_ENGINE_OWNER,
+        line: 1,
+        message:
+          `${SELECTOR_ENGINE_SPECIFIER} is not a workspace export, so no import of it resolves ` +
+          'and this rule can no longer see a bypass. Restore the subpath export, or retire the ' +
+          'rule deliberately — do not leave it watching a door that does not exist.',
+      },
+    ];
   }
-  return violations;
-}
-
-function importedValueSymbols(names: string): string[] {
-  return names
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && !entry.startsWith('type '))
-    .map((entry) => entry.split(/\s+as\s+/)[0]?.trim() ?? '');
-}
-
-function lineOf(source: string, index: number): number {
-  return source.slice(0, index).split('\n').length;
+  return edges
+    .filter(
+      (edge) => edge.spec === SELECTOR_ENGINE_SPECIFIER && edge.file !== SELECTOR_ENGINE_OWNER,
+    )
+    .map((edge) => ({
+      rule: 'R19 selector-pipeline-ownership',
+      file: edge.file,
+      line: edge.line,
+      message:
+        `imports ${SELECTOR_ENGINE_SPECIFIER}. The selector engine is owned by ` +
+        `${SELECTOR_ENGINE_OWNER}: call resolveSelectorPipeline / listSelectorPipelineMatches / ` +
+        'runNodePipelineStages with a SELECTOR_PIPELINE_POLICIES row instead, so this route runs the ' +
+        'occlusion, off-screen and promotion stages the row declares rather than skipping them.',
+    }));
 }

--- a/scripts/layering/selector-pipeline-ownership.ts
+++ b/scripts/layering/selector-pipeline-ownership.ts
@@ -1,0 +1,86 @@
+/**
+ * R17 selector-pipeline ownership (#1656).
+ *
+ * The structural stages of selector resolution — occlusion, off-screen,
+ * hittable-ancestor promotion, the poll budget — are declared per caller in
+ * `src/core/selector-pipeline-policy.ts` and executed by
+ * `src/core/selector-pipeline.ts`. That only means something while the owner is
+ * the ONLY way in: a route that calls the matching engine directly still gets a
+ * row's ambiguity contract while silently skipping every structural stage,
+ * which is how a declared cell turns back into an unverifiable claim (the
+ * failure #1649 caught in the first matrix and #1656's review caught in the
+ * second).
+ *
+ * So the engine entry points are owner-only. A structural gate rather than a
+ * convention, because the failure is invisible at the call site: code that
+ * skips the stages looks exactly like code that runs them.
+ */
+
+export type SourceFile = { path: string; source: string };
+
+export type LayeringViolation = {
+  rule: string;
+  file: string;
+  line: number;
+  message: string;
+};
+
+/**
+ * The engine surface that resolves or enumerates a selector against a tree —
+ * the decision a policy row exists to qualify. `@agent-device/selectors` also
+ * exports parsing, matching and formatting helpers, which carry no row
+ * semantics and stay freely importable.
+ */
+export const OWNED_SELECTOR_ENGINE_SYMBOLS = [
+  'resolveSelectorChainWithPolicy',
+  'listSelectorChainMatches',
+] as const;
+
+/** The pipeline owner. The selectors package implements the engine it wraps. */
+export const SELECTOR_ENGINE_OWNER = 'src/core/selector-pipeline.ts';
+
+const IMPORT_BLOCK =
+  /import\s+(type\s+)?\{([^}]*)\}\s*from\s*['"](@agent-device\/selectors[^'"]*)['"]/g;
+
+export function selectorPipelineOwnershipViolations(
+  files: readonly SourceFile[],
+): LayeringViolation[] {
+  const violations: LayeringViolation[] = [];
+  for (const file of files) {
+    if (file.path === SELECTOR_ENGINE_OWNER) continue;
+    // The engine's own package and its tests describe the engine rather than
+    // route around it; the gate governs consumers.
+    if (file.path.startsWith('packages/selectors/')) continue;
+    for (const match of file.source.matchAll(IMPORT_BLOCK)) {
+      // A type-only import cannot call anything, and routes legitimately name
+      // the result types the owner hands back.
+      if (match[1]) continue;
+      for (const symbol of importedValueSymbols(match[2] ?? '')) {
+        if (!(OWNED_SELECTOR_ENGINE_SYMBOLS as readonly string[]).includes(symbol)) continue;
+        violations.push({
+          rule: 'R17 selector-pipeline-ownership',
+          file: file.path,
+          line: lineOf(file.source, match.index ?? 0),
+          message:
+            `imports ${symbol} from @agent-device/selectors. The selector engine is owned by ` +
+            `${SELECTOR_ENGINE_OWNER}: call resolveSelectorPipeline / listSelectorPipelineMatches / ` +
+            'runNodePipelineStages with a SELECTOR_PIPELINE_POLICIES row instead, so this route runs ' +
+            'the occlusion, off-screen and promotion stages the row declares rather than skipping them.',
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+function importedValueSymbols(names: string): string[] {
+  return names
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && !entry.startsWith('type '))
+    .map((entry) => entry.split(/\s+as\s+/)[0]?.trim() ?? '');
+}
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split('\n').length;
+}

--- a/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
+++ b/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
@@ -166,9 +166,9 @@ test('rect-requiring rows skip rectless nodes; read and wait rows accept them', 
  * The matrix may only declare what it can enforce (#1649 review). An earlier
  * revision carried occlusion / off-screen / promotion / poll columns that no
  * code consumed, so changing them left both behavior and the suite green —
- * an unverifiable claim reading as truth. Those four stages now live in the
+ * an unverifiable claim reading as truth. Those four stages belong to the
  * structural table (`src/core/selector-pipeline-policy.ts`, #1656), where
- * runners consume them; this still fails if such a field reappears HERE, where
+ * runners consume them; this still fails if such a field appears HERE, where
  * the selectors package has nothing to enforce it with.
  */
 test('policy rows declare only the fields this matrix actually enforces', () => {

--- a/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
+++ b/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
-import {
-  SELECTOR_RESOLUTION_POLICIES,
-  resolveSelectorChainWithPolicy,
-} from '@agent-device/selectors';
+import { SELECTOR_RESOLUTION_POLICIES } from '@agent-device/selectors';
+// The engine's own subpath (#1656): this file pins what a ROW means to the
+// engine, so it is the one consumer that legitimately holds it directly. R19
+// governs shipped routes — the layering scan reads production sources only.
+import { resolveSelectorChainWithPolicy } from '@agent-device/selectors/engine';
 
 /**
  * The matrix is exercised through the interface callers actually use

--- a/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
+++ b/src/commands/interaction/runtime/__tests__/resolution-policy-parity.test.ts
@@ -166,8 +166,10 @@ test('rect-requiring rows skip rectless nodes; read and wait rows accept them', 
  * The matrix may only declare what it can enforce (#1649 review). An earlier
  * revision carried occlusion / off-screen / promotion / poll columns that no
  * code consumed, so changing them left both behavior and the suite green —
- * an unverifiable claim reading as truth. This fails if such a field returns
- * without behavioral coverage.
+ * an unverifiable claim reading as truth. Those four stages now live in the
+ * structural table (`src/core/selector-pipeline-policy.ts`, #1656), where
+ * runners consume them; this still fails if such a field reappears HERE, where
+ * the selectors package has nothing to enforce it with.
  */
 test('policy rows declare only the fields this matrix actually enforces', () => {
   for (const [name, policy] of Object.entries(SELECTOR_RESOLUTION_POLICIES)) {

--- a/src/commands/interaction/runtime/__tests__/selector-read-policy.test.ts
+++ b/src/commands/interaction/runtime/__tests__/selector-read-policy.test.ts
@@ -4,7 +4,9 @@ import { AppError } from '@agent-device/kernel/errors';
 import { selector } from '../selector-read-utils.ts';
 import {
   ambiguousSelectorReadSnapshot,
+  createFakeClock,
   createSelectorDevice,
+  observationStagesSnapshot,
   skippedAlternativeSelectorSnapshot,
 } from './test-utils/index.ts';
 
@@ -128,4 +130,96 @@ test('find takes the document-order head on the same tree (readAny row)', async 
     action: 'exists',
   });
   assert.deepEqual(exists, { kind: 'found', found: true });
+});
+
+/**
+ * #1656: the same question for the STRUCTURAL stages. These drive the real
+ * command routes — `get`, `is`, `wait`, `find` — because that is the only
+ * place a stage claim can be falsified: a row that declares `promotion: none`
+ * and is never executed is a claim about a table, not about the product.
+ * Flipping any observation row's occlusion, off-screen, or promotion cell
+ * fails one of these.
+ */
+
+const COVERED_SELECTOR = 'label="Covered action"';
+const OFFSCREEN_SELECTOR = 'label="Scrolled away"';
+const NESTED_TEXT_SELECTOR = 'label="Account"';
+
+test('get attrs answers about a covered element (readUnique ignores occlusion)', async () => {
+  const device = createSelectorDevice(observationStagesSnapshot());
+
+  const attrs = await device.selectors.getAttrs(selector(COVERED_SELECTOR), {
+    session: 'default',
+  });
+
+  // A covered element still exists and still has attributes. The acting rows
+  // refuse it; a read that refused would leave an agent unable to inspect the
+  // very element it needs to clear.
+  assert.equal(attrs.kind, 'attrs');
+  assert.equal(attrs.node.label, 'Covered action');
+});
+
+test('is visible answers about an off-screen element (readUnique ignores off-screen)', async () => {
+  const device = createSelectorDevice(observationStagesSnapshot());
+
+  const result = await device.selectors.is({
+    session: 'default',
+    predicate: 'exists',
+    selector: OFFSCREEN_SELECTOR,
+  });
+
+  assert.equal(result.pass, true);
+});
+
+test('get attrs answers about the node it matched, never its hittable ancestor (readText/readUnique promote nothing)', async () => {
+  const device = createSelectorDevice(observationStagesSnapshot());
+
+  const attrs = await device.selectors.getAttrs(selector(NESTED_TEXT_SELECTOR), {
+    session: 'default',
+  });
+
+  // The acting rows promote this static text to the hittable cell that owns
+  // it. A read must not: the caller asked about `Account`, and answering with
+  // `Account row` would describe an element it never selected.
+  assert.equal(attrs.kind, 'attrs');
+  assert.equal(attrs.node.label, 'Account');
+  assert.equal(attrs.node.type, 'XCUIElementTypeStaticText');
+});
+
+test('wait is satisfied by covered and off-screen matches (wait row ignores both stages)', async () => {
+  for (const target of [COVERED_SELECTOR, OFFSCREEN_SELECTOR]) {
+    // An advancing clock, so a row that stopped being satisfied here reaches
+    // its deadline and FAILS rather than polling forever.
+    const device = createSelectorDevice(observationStagesSnapshot(), {
+      clock: createFakeClock(),
+    });
+
+    const result = await device.selectors.wait({
+      session: 'default',
+      target: { kind: 'selector', selector: target, timeoutMs: 1_000 },
+    });
+
+    assert.equal(result.kind, 'selector', target);
+  }
+});
+
+test('find reads answer about covered and off-screen matches (readAny ignores both stages)', async () => {
+  const device = createSelectorDevice(observationStagesSnapshot());
+
+  for (const query of [COVERED_SELECTOR, OFFSCREEN_SELECTOR]) {
+    const exists = await device.selectors.find({ session: 'default', query, action: 'exists' });
+    assert.deepEqual(exists, { kind: 'found', found: true }, query);
+  }
+
+  // `find list` enumerates through the same owner (`readList`), so its
+  // candidate set is the row's, not a private call into the engine.
+  const listed = await device.selectors.find({
+    session: 'default',
+    query: COVERED_SELECTOR,
+    action: 'list',
+  });
+  assert.equal(listed.kind, 'list');
+  assert.deepEqual(listed.kind === 'list' ? listed.matches.map((entry) => entry.node.label) : [], [
+    'Covered action',
+  ]);
 });

--- a/src/commands/interaction/runtime/__tests__/test-utils/index.ts
+++ b/src/commands/interaction/runtime/__tests__/test-utils/index.ts
@@ -443,6 +443,68 @@ export function ambiguousSelectorReadSnapshot(): SnapshotState {
 }
 
 /**
+ * The tree the OBSERVATION rows' structural stages are visible on (#1656). One
+ * screen, three shapes a read must answer about rather than refuse or retarget:
+ *
+ * - `Covered action` is annotated covered, so a row whose occlusion stage
+ *   refused would fail instead of reporting it.
+ * - `Scrolled away` sits below the viewport, so a row whose off-screen stage
+ *   refused would fail instead of reporting it.
+ * - `Account` is static text inside a hittable cell, so a row that promoted
+ *   would answer about the CELL instead of the text.
+ *
+ * Every label is unique, so the ambiguity contract is silent here and only the
+ * structural stages can move an answer.
+ */
+export function observationStagesSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 400, height: 800 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Covered action',
+      rect: { x: 20, y: 700, width: 200, height: 40 },
+      hittable: false,
+      interactionBlocked: 'covered',
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Scrolled away',
+      rect: { x: 20, y: 2000, width: 200, height: 40 },
+      hittable: true,
+    },
+    {
+      index: 3,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeCell',
+      label: 'Account row',
+      rect: { x: 20, y: 100, width: 300, height: 60 },
+      hittable: true,
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 3,
+      type: 'XCUIElementTypeStaticText',
+      label: 'Account',
+      rect: { x: 30, y: 110, width: 80, height: 20 },
+      hittable: false,
+    },
+  ]);
+}
+
+/**
  * The tree that separates first-match from uniqueness rows (#1715 review).
  * Alternative one (`label="Save"`) matches two nodes that are genuinely
  * indistinguishable — same depth, same area, both on screen — so the engine's
@@ -500,6 +562,13 @@ export function createSelectorDevice(
     findText?: boolean;
     now?: number;
     captureSnapshot?: () => BackendSnapshotResult | Promise<BackendSnapshotResult>;
+    /**
+     * An advancing clock, for routes that poll: with the default frozen clock a
+     * wait that is never satisfied spins instead of reaching its deadline, so a
+     * test asserting what `wait` RESOLVES would hang rather than fail if the
+     * answer ever changed.
+     */
+    clock?: { now: () => number; sleep: (ms: number) => Promise<void> };
   } = {},
 ) {
   const session = { name: 'default', snapshot };
@@ -520,7 +589,7 @@ export function createSelectorDevice(
     artifacts: createLocalArtifactAdapter(),
     sessions,
     policy: localCommandPolicy(),
-    clock: {
+    clock: options.clock ?? {
       now: () => options.now ?? 0,
       sleep: async () => {},
     },

--- a/src/commands/interaction/runtime/gestures.ts
+++ b/src/commands/interaction/runtime/gestures.ts
@@ -13,6 +13,7 @@ import {
   singlePointerPlanEndpoints,
 } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import type { Point, Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import {
@@ -164,7 +165,7 @@ export const focusCommand: RuntimeCommand<FocusCommandOptions, FocusCommandResul
   const resolved = await resolveInteractionTarget(runtime, options, {
     action: 'focus',
     requireInteractive: true,
-    promoteToHittableAncestor: false,
+    pipeline: SELECTOR_PIPELINE_POLICIES.resolvedTarget,
   });
   if (!runtime.backend.focus) {
     throw new AppError('UNSUPPORTED_OPERATION', 'focus is not supported by this backend');
@@ -187,7 +188,7 @@ export const longPressCommand: RuntimeCommand<
   const resolved = await resolveInteractionTarget(runtime, options, {
     action: 'longPress',
     requireInteractive: true,
-    promoteToHittableAncestor: true,
+    pipeline: SELECTOR_PIPELINE_POLICIES.promotedTarget,
     captureEvidenceBaseline: observation.needsPreActionBaseline,
     expectedResolvedTarget: options.expectedResolvedTarget,
   });
@@ -277,7 +278,7 @@ async function resolveDragTarget(
     {
       action: 'drag',
       requireInteractive: false,
-      promoteToHittableAncestor: false,
+      pipeline: SELECTOR_PIPELINE_POLICIES.resolvedTarget,
       expectedResolvedTarget: options.expectedResolvedTargets?.[endpoint],
       replayTargetRole: endpoint,
     },
@@ -410,7 +411,7 @@ async function resolveScrollTarget(
     {
       action: 'scroll',
       requireInteractive: false,
-      promoteToHittableAncestor: false,
+      pipeline: SELECTOR_PIPELINE_POLICIES.resolvedTarget,
     },
   );
 }

--- a/src/commands/interaction/runtime/interactions.ts
+++ b/src/commands/interaction/runtime/interactions.ts
@@ -7,6 +7,7 @@ import type {
   ResolvedTarget,
 } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import type { Point } from '@agent-device/kernel/snapshot';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { isFillableType } from '@agent-device/contracts/snapshot';
@@ -105,7 +106,7 @@ export const fillCommand: RuntimeCommand<FillCommandOptions, FillCommandResult> 
   const resolved = await resolveInteractionTarget(runtime, options, {
     action: 'fill',
     requireInteractive: true,
-    promoteToHittableAncestor: false,
+    pipeline: SELECTOR_PIPELINE_POLICIES.resolvedTarget,
     captureEvidenceBaseline: observation.needsPreActionBaseline,
     expectedResolvedTarget: options.expectedResolvedTarget,
     preresolvedTarget: options.preresolvedTarget,
@@ -195,7 +196,7 @@ async function tapCommand(
   const resolved = await resolveInteractionTarget(runtime, options, {
     action,
     requireInteractive: true,
-    promoteToHittableAncestor: true,
+    pipeline: SELECTOR_PIPELINE_POLICIES.promotedTarget,
     captureEvidenceBaseline: observation.needsPreActionBaseline,
     expectedResolvedTarget: options.expectedResolvedTarget,
     preresolvedTarget: options.preresolvedTarget,

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -9,6 +9,7 @@ import {
 } from './resolution.ts';
 import { resolveRecordedTarget } from '@agent-device/selectors';
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import type { Point } from '@agent-device/kernel/snapshot';
 import {
   clickRefE2,
@@ -566,6 +567,7 @@ test('throwIfOffscreenInteractionTarget: an on-screen node passes through unchan
     { session: 'default' },
     nodes[1]!,
     nodes,
+    SELECTOR_PIPELINE_POLICIES.promotedTarget,
     fakeOffscreenFailure(),
   );
 
@@ -592,11 +594,44 @@ test('throwIfOffscreenInteractionTarget: off-screen + backend confirms -> return
     { session: 'default' },
     nodes[1]!,
     nodes,
+    SELECTOR_PIPELINE_POLICIES.promotedTarget,
     fakeOffscreenFailure(),
   );
 
   assert.deepEqual(result.rect, { x: 30, y: 30, width: 40, height: 40 });
   assert.equal(result.index, nodes[1]!.index);
+});
+
+test('throwIfOffscreenInteractionTarget: a row whose off-screen stage is ignore returns the node untouched', async () => {
+  // #1656: reads and waits answer about the tree as captured, so the same
+  // node the acting rows refuse below passes through here — and the iOS
+  // rescue hook is never consulted, which is why it would throw if it were.
+  const device = createInteractionDevice(makeSnapshotState([]), {
+    confirmOffscreenTargetVisible: async () => {
+      throw new Error('an observation row must not spend the rescue round trip');
+    },
+  });
+  const nodes = makeSnapshotState([
+    { index: 0, depth: 0, type: 'Application', rect: { x: 0, y: 0, width: 400, height: 800 } },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      rect: { x: 20, y: 2000, width: 40, height: 40 },
+    },
+  ]).nodes;
+
+  const result = await throwIfOffscreenInteractionTarget(
+    device,
+    { session: 'default' },
+    nodes[1]!,
+    nodes,
+    SELECTOR_PIPELINE_POLICIES.readUnique,
+    fakeOffscreenFailure(),
+  );
+
+  assert.equal(result, nodes[1]);
 });
 
 test('throwIfOffscreenInteractionTarget: off-screen + no rescue -> throws with the supplied failure shape', async () => {
@@ -619,6 +654,7 @@ test('throwIfOffscreenInteractionTarget: off-screen + no rescue -> throws with t
         { session: 'default' },
         nodes[1]!,
         nodes,
+        SELECTOR_PIPELINE_POLICIES.promotedTarget,
         fakeOffscreenFailure(),
       ),
     /off-screen/,

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -603,9 +603,10 @@ test('throwIfOffscreenInteractionTarget: off-screen + backend confirms -> return
 });
 
 test('throwIfOffscreenInteractionTarget: a row whose off-screen stage is ignore returns the node untouched', async () => {
-  // #1656: reads and waits answer about the tree as captured, so the same
-  // node the acting rows refuse below passes through here — and the iOS
-  // rescue hook is never consulted, which is why it would throw if it were.
+  // #1656: reads and waits answer about the tree as captured, so the node the
+  // acting rows refuse below passes through here. The rescue hook throws on
+  // contact, so a row that started refusing would fail loudly rather than
+  // quietly spending an iOS round trip.
   const device = createInteractionDevice(makeSnapshotState([]), {
     confirmOffscreenTargetVisible: async () => {
       throw new Error('an observation row must not spend the rescue round trip');

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -9,7 +9,6 @@ import {
 } from './resolution.ts';
 import { resolveRecordedTarget } from '@agent-device/selectors';
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
-import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import type { Point } from '@agent-device/kernel/snapshot';
 import {
   clickRefE2,
@@ -567,7 +566,6 @@ test('throwIfOffscreenInteractionTarget: an on-screen node passes through unchan
     { session: 'default' },
     nodes[1]!,
     nodes,
-    SELECTOR_PIPELINE_POLICIES.promotedTarget,
     fakeOffscreenFailure(),
   );
 
@@ -594,45 +592,11 @@ test('throwIfOffscreenInteractionTarget: off-screen + backend confirms -> return
     { session: 'default' },
     nodes[1]!,
     nodes,
-    SELECTOR_PIPELINE_POLICIES.promotedTarget,
     fakeOffscreenFailure(),
   );
 
   assert.deepEqual(result.rect, { x: 30, y: 30, width: 40, height: 40 });
   assert.equal(result.index, nodes[1]!.index);
-});
-
-test('throwIfOffscreenInteractionTarget: a row whose off-screen stage is ignore returns the node untouched', async () => {
-  // #1656: reads and waits answer about the tree as captured, so the node the
-  // acting rows refuse below passes through here. The rescue hook throws on
-  // contact, so a row that started refusing would fail loudly rather than
-  // quietly spending an iOS round trip.
-  const device = createInteractionDevice(makeSnapshotState([]), {
-    confirmOffscreenTargetVisible: async () => {
-      throw new Error('an observation row must not spend the rescue round trip');
-    },
-  });
-  const nodes = makeSnapshotState([
-    { index: 0, depth: 0, type: 'Application', rect: { x: 0, y: 0, width: 400, height: 800 } },
-    {
-      index: 1,
-      depth: 1,
-      parentIndex: 0,
-      type: 'Button',
-      rect: { x: 20, y: 2000, width: 40, height: 40 },
-    },
-  ]).nodes;
-
-  const result = await throwIfOffscreenInteractionTarget(
-    device,
-    { session: 'default' },
-    nodes[1]!,
-    nodes,
-    SELECTOR_PIPELINE_POLICIES.readUnique,
-    fakeOffscreenFailure(),
-  );
-
-  assert.equal(result, nodes[1]);
 });
 
 test('throwIfOffscreenInteractionTarget: off-screen + no rescue -> throws with the supplied failure shape', async () => {
@@ -655,7 +619,6 @@ test('throwIfOffscreenInteractionTarget: off-screen + no rescue -> throws with t
         { session: 'default' },
         nodes[1]!,
         nodes,
-        SELECTOR_PIPELINE_POLICIES.promotedTarget,
         fakeOffscreenFailure(),
       ),
     /off-screen/,

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -9,16 +9,17 @@ import type {
 } from '../../../runtime-contract.ts';
 import {
   formatSelectorFailure,
-  resolveSelectorChainWithPolicy,
   selectorFailureHint,
   STALE_REF_HINT,
   type SelectorResolution,
   buildSelectorChainForNode,
 } from '@agent-device/selectors';
 import {
-  resolveSelectorPipelineTarget,
-  selectorPipelineCandidates,
-  selectorPipelineRefusesOffscreen,
+  resolveSelectorPipeline,
+  runNodePipelineStages,
+  type SelectorPipelineHooks,
+} from '../../../core/selector-pipeline.ts';
+import {
   SELECTOR_PIPELINE_POLICIES,
   type ActingPipelinePolicy,
   type SelectorPipelinePolicy,
@@ -295,20 +296,19 @@ async function resolveRefInteractionTarget(
   const { nodes, resolved } = params.preresolvedTarget
     ? adoptPreresolvedRefTarget(target, params.preresolvedTarget)
     : await readRefResolution(runtime, options, target);
-  assertReplayTargetResolution(resolved.node, nodes, params);
-  const node = resolveInteractionPipelineTarget(params.pipeline, nodes, resolved.node, {
+  // #1542: point/response read from the returned (possibly rescue-patched) node.
+  const visibleNode = await runInteractionPipelineStages({
+    policy: params.pipeline,
+    nodes,
+    node: resolved.node,
     action: params.action,
     label: `Ref ${target.ref}`,
+    hooks: {
+      onResolved: (node, tree) => assertReplayTargetResolution(node, tree, params),
+      offscreen: async (node, tree) =>
+        await assertVisibleRefTarget(runtime, options, node, tree, target.ref, params),
+    },
   });
-  // #1542: point/response read from the returned (possibly rescue-patched) node.
-  const visibleNode = await assertVisibleRefTarget(
-    runtime,
-    options,
-    node,
-    nodes,
-    target.ref,
-    params,
-  );
   const point = resolveNodeTouchPoint(visibleNode, nodes, {
     invalidMessage: `Ref ${target.ref} not found or has invalid bounds`,
     blockedTargetLabel: `Ref ${target.ref}`,
@@ -352,7 +352,7 @@ async function resolveSelectorInteractionTarget(
     );
   }
   if (!resolved || !resolved.node.rect) {
-    throw selectorInteractionFailure({
+    throw await selectorInteractionFailure({
       runtime,
       nodes: capture.snapshot.nodes,
       selectorExpression,
@@ -360,22 +360,20 @@ async function resolveSelectorInteractionTarget(
       resolved,
     });
   }
-  assertReplayTargetResolution(resolved.node, capture.snapshot.nodes, params);
-  const node = resolveInteractionPipelineTarget(
-    params.pipeline,
-    capture.snapshot.nodes,
-    resolved.node,
-    { action: params.action, label: `Selector ${resolved.selector}` },
-  );
   // #1542: see the ref-target twin above.
-  const visibleNode = await assertVisibleSelectorTarget(
-    runtime,
-    options,
-    node,
-    capture.snapshot.nodes,
-    resolved.selector,
-    params,
-  );
+  const selected = resolved;
+  const visibleNode = await runInteractionPipelineStages({
+    policy: params.pipeline,
+    nodes: capture.snapshot.nodes,
+    node: selected.node,
+    action: params.action,
+    label: `Selector ${selected.selector}`,
+    hooks: {
+      onResolved: (node, tree) => assertReplayTargetResolution(node, tree, params),
+      offscreen: async (node, tree) =>
+        await assertVisibleSelectorTarget(runtime, options, node, tree, selected.selector, params),
+    },
+  });
   const point = resolveNodeTouchPoint(visibleNode, capture.snapshot.nodes, {
     invalidMessage: `Selector ${resolved.selector} resolved to invalid bounds`,
     blockedTargetLabel: `Selector ${selectorExpression}`,
@@ -403,34 +401,30 @@ async function resolveSelectorInteractionTarget(
  * that. Both probes name a policy row, so the two contracts stay visible side
  * by side instead of as two sets of engine knobs (#1630).
  */
-function selectorInteractionFailure(params: {
+async function selectorInteractionFailure(params: {
   runtime: AgentDeviceRuntime;
   nodes: SnapshotState['nodes'];
   selectorExpression: string;
   action: InteractionAction;
   resolved: SelectorResolution | null;
-}): AppError {
+}): Promise<AppError> {
   const { runtime, nodes, selectorExpression, action, resolved } = params;
-  const pipeline = SELECTOR_PIPELINE_POLICIES.coveredDiagnosis;
-  const covered = resolveSelectorChainWithPolicy(
-    selectorPipelineCandidates(pipeline, nodes),
+  // The diagnosis row keeps covered nodes as candidates precisely so its
+  // occlusion stage can report them: "matched but covered" is a different
+  // failure with a different recovery than "did not match".
+  const covered = await resolveSelectorPipeline(
+    SELECTOR_PIPELINE_POLICIES.coveredDiagnosis,
+    nodes,
     selectorExpression,
-    pipeline.resolution,
     { platform: runtime.backend.platform },
   );
-  if (covered.kind === 'resolved') {
-    // The diagnosis row keeps covered nodes as candidates precisely so this
-    // stage can report them: "matched but covered" is a different failure with
-    // a different recovery than "did not match".
-    const target = resolveSelectorPipelineTarget(pipeline, nodes, covered.resolution.node);
-    if (target.kind === 'occluded') {
-      return buildCoveredInteractionError({
-        label: `Selector ${covered.resolution.selector}`,
-        node: target.node,
-        action,
-        selector: covered.resolution.selector,
-      });
-    }
+  if (covered.kind === 'occluded') {
+    return buildCoveredInteractionError({
+      label: `Selector ${covered.selector}`,
+      node: covered.node,
+      action,
+      selector: covered.selector,
+    });
   }
   const diagnostics = resolved?.diagnostics ?? [];
   return new AppError(
@@ -609,23 +603,29 @@ function describeNonHittableTarget(
 }
 
 /**
- * The promotion and occlusion stages of this action's row (#1656), plus the
- * refusal shape the interaction runtime owns. Which stages run is the row's
- * decision; every acting path — selector, ref, and the native-ref preflight —
- * enters them here.
+ * Every node stage this action's row declares, plus the covered refusal the
+ * interaction runtime owns. Which stages run is the row's decision; every
+ * acting path — selector, ref, and the native-ref preflight — enters them here.
  */
-function resolveInteractionPipelineTarget(
-  policy: SelectorPipelinePolicy,
-  nodes: SnapshotState['nodes'],
-  node: SnapshotNode,
-  options: { action: InteractionAction; label: string },
-): SnapshotNode {
-  const target = resolveSelectorPipelineTarget(policy, nodes, node);
+async function runInteractionPipelineStages(params: {
+  policy: SelectorPipelinePolicy;
+  nodes: SnapshotState['nodes'];
+  node: SnapshotNode;
+  action: InteractionAction;
+  label: string;
+  hooks: SelectorPipelineHooks;
+}): Promise<SnapshotNode> {
+  const target = await runNodePipelineStages(
+    params.policy,
+    params.nodes,
+    params.node,
+    params.hooks,
+  );
   if (target.kind === 'occluded') {
     throw buildCoveredInteractionError({
-      label: options.label,
+      label: params.label,
       node: target.node,
-      action: options.action,
+      action: params.action,
     });
   }
   return target.node;
@@ -842,7 +842,11 @@ function isUsableResolvedNode(node: SnapshotNode | null | undefined): node is Sn
   return resolveRectCenter(node.rect) !== null;
 }
 
-/** The two inputs every off-screen stage call needs: the row, and the verb it names. */
+/**
+ * The off-screen stage's refusal shape. Reached only through the pipeline
+ * owner, and only for rows whose off-screen stage refuses — the row's decision
+ * is made there, so this builds the message and never re-decides.
+ */
 type OffscreenStageParams = { action: InteractionAction; pipeline: SelectorPipelinePolicy };
 
 // Selector parity for the @ref off-screen guard: without it, a selector
@@ -855,9 +859,9 @@ async function assertVisibleSelectorTarget(
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
   selector: string,
-  { action, pipeline }: OffscreenStageParams,
+  { action }: OffscreenStageParams,
 ): Promise<SnapshotNode> {
-  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, pipeline, {
+  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, {
     message: `Selector ${selector} resolved to an off-screen element and is not safe to ${action}`,
     details: { reason: 'offscreen_selector', selector },
     // A selector re-resolves against a fresh snapshot on every attempt, so the
@@ -877,9 +881,9 @@ async function assertVisibleRefTarget(
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
   refInput: string,
-  { action, pipeline }: OffscreenStageParams,
+  { action }: OffscreenStageParams,
 ): Promise<SnapshotNode> {
-  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, pipeline, {
+  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, {
     message: `Ref ${refInput} is off-screen and not safe to ${action}`,
     details: { reason: 'offscreen_ref', ref: normalizeRef(refInput) },
     // The scroll that reveals the target expires the ref frame (#1366, ADR
@@ -940,15 +944,21 @@ export async function preflightNativeRefInteraction(
   // `resolvedTarget` whatever the command: its `none` promotion is what holds
   // ADR 0011's "the preflight never changes which element the backend acts on".
   const pipeline = SELECTOR_PIPELINE_POLICIES.resolvedTarget;
-  const node = resolveInteractionPipelineTarget(pipeline, nodes, resolved.node, {
-    action,
-    label: `Ref ${target.ref}`,
-  });
   // #1542: dispatches by REF, not coordinate, so no point to re-derive — but
   // evidence/annotation below still describes the returned (visible) node.
-  const visibleNode = await assertVisibleRefTarget(runtime, options, node, nodes, target.ref, {
+  const visibleNode = await runInteractionPipelineStages({
+    policy: pipeline,
+    nodes,
+    node: resolved.node,
     action,
-    pipeline,
+    label: `Ref ${target.ref}`,
+    hooks: {
+      offscreen: async (node, tree) =>
+        await assertVisibleRefTarget(runtime, options, node, tree, target.ref, {
+          action,
+          pipeline,
+        }),
+    },
   });
   return {
     ...describeNonHittableTarget(visibleNode, action),
@@ -983,18 +993,12 @@ export async function throwIfOffscreenInteractionTarget(
   options: CommandContext,
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
-  policy: SelectorPipelinePolicy,
   failure: {
     message: string;
     details: Record<string, unknown>;
     hint: (direction: OffscreenScrollDirection | null) => string;
   },
 ): Promise<SnapshotNode> {
-  // The off-screen stage of the caller's row (#1656). Rows that observe rather
-  // than act declare `ignore`: an element scrolled out of view still exists,
-  // still has text, and still satisfies a presence wait, so a read must not
-  // refuse it — and must not spend the iOS rescue round trip asking.
-  if (!selectorPipelineRefusesOffscreen(policy)) return node;
   const viewport = node.rect ? resolveEffectiveViewportRect(node, nodes) : null;
   if (!node.rect || !viewport || isNodeVisibleOnScreen(node, nodes)) return node;
   const rootViewport = resolveViewportRect(nodes, node.rect);

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -14,8 +14,15 @@ import {
   STALE_REF_HINT,
   type SelectorResolution,
   buildSelectorChainForNode,
-  SELECTOR_RESOLUTION_POLICIES,
 } from '@agent-device/selectors';
+import {
+  resolveSelectorPipelineTarget,
+  selectorPipelineCandidates,
+  selectorPipelineRefusesOffscreen,
+  SELECTOR_PIPELINE_POLICIES,
+  type ActingPipelinePolicy,
+  type SelectorPipelinePolicy,
+} from '../../../core/selector-pipeline-policy.ts';
 import { resolvePressRecordingTarget } from '../../../core/press-retarget.ts';
 import { requireSnapshotSession } from './selector-read-shared.ts';
 import { findNodeByLabel, resolveRefLabel } from '../../../snapshot/snapshot-processing.ts';
@@ -30,7 +37,6 @@ import {
   classifyOffscreenScrollDirection,
   type OffscreenScrollDirection,
 } from '../../../snapshot/mobile-snapshot-semantics.ts';
-import { isSnapshotNodeInteractionBlocked } from '../../../snapshot/snapshot-occlusion.ts';
 import { truncateUtf8 } from '../../../utils/truncate-utf8.ts';
 import type {
   InteractionTarget,
@@ -42,7 +48,6 @@ import type {
   ResolvedInteractionTarget,
 } from '@agent-device/contracts/interaction';
 import { now, toBackendContext } from '../../runtime-common.ts';
-import { resolveActionableTouchResolution } from '../../../core/interaction-targeting.ts';
 import { resolveInteractionTouchPoint } from '../../../core/interaction-touch-point.ts';
 import {
   localIdentitiesEqual,
@@ -135,7 +140,13 @@ export type InteractionSnapshot = {
 type ResolveInteractionTargetParams = {
   action: InteractionAction;
   requireInteractive: boolean;
-  promoteToHittableAncestor: boolean;
+  /**
+   * The structural pipeline this action runs (#1656): occlusion, off-screen,
+   * and hittable-ancestor promotion are the row's decisions, not per-call-site
+   * booleans. `promotedTarget` for tap-shaped actions, `resolvedTarget` for the
+   * actions that must keep the element they resolved.
+   */
+  pipeline: ActingPipelinePolicy;
   /**
    * `--verify` (#1047): also capture the pre-action node set for a `point` target
    * so `changedFromBefore` evidence has a baseline. Ref/selector targets already
@@ -285,13 +296,10 @@ async function resolveRefInteractionTarget(
     ? adoptPreresolvedRefTarget(target, params.preresolvedTarget)
     : await readRefResolution(runtime, options, target);
   assertReplayTargetResolution(resolved.node, nodes, params);
-  const node = params.promoteToHittableAncestor
-    ? resolveActionableNodeOrThrow(nodes, resolved.node, {
-        action: params.action,
-        label: `Ref ${target.ref}`,
-      })
-    : resolved.node;
-  assertInteractionNotBlocked(node, `Ref ${target.ref}`, params.action);
+  const node = resolveInteractionPipelineTarget(params.pipeline, nodes, resolved.node, {
+    action: params.action,
+    label: `Ref ${target.ref}`,
+  });
   // #1542: point/response read from the returned (possibly rescue-patched) node.
   const visibleNode = await assertVisibleRefTarget(
     runtime,
@@ -299,7 +307,7 @@ async function resolveRefInteractionTarget(
     node,
     nodes,
     target.ref,
-    params.action,
+    params,
   );
   const point = resolveNodeTouchPoint(visibleNode, nodes, {
     invalidMessage: `Ref ${target.ref} not found or has invalid bounds`,
@@ -329,16 +337,18 @@ async function resolveSelectorInteractionTarget(
   const selectorExpression = target.selector;
   let capture = await captureInteractionSnapshot(runtime, options, params.requireInteractive);
   let resolved = resolveActionSelector(
-    interactableSelectorNodes(capture.snapshot.nodes),
+    capture.snapshot.nodes,
     selectorExpression,
     runtime.backend.platform,
+    params.pipeline,
   );
   if ((!resolved || !resolved.node.rect) && params.requireInteractive) {
     capture = await captureInteractionSnapshot(runtime, options, false);
     resolved = resolveActionSelector(
-      interactableSelectorNodes(capture.snapshot.nodes),
+      capture.snapshot.nodes,
       selectorExpression,
       runtime.backend.platform,
+      params.pipeline,
     );
   }
   if (!resolved || !resolved.node.rect) {
@@ -351,13 +361,12 @@ async function resolveSelectorInteractionTarget(
     });
   }
   assertReplayTargetResolution(resolved.node, capture.snapshot.nodes, params);
-  const node = params.promoteToHittableAncestor
-    ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
-        action: params.action,
-        label: `Selector ${resolved.selector}`,
-      })
-    : resolved.node;
-  assertInteractionNotBlocked(node, `Selector ${resolved.selector}`, params.action);
+  const node = resolveInteractionPipelineTarget(
+    params.pipeline,
+    capture.snapshot.nodes,
+    resolved.node,
+    { action: params.action, label: `Selector ${resolved.selector}` },
+  );
   // #1542: see the ref-target twin above.
   const visibleNode = await assertVisibleSelectorTarget(
     runtime,
@@ -365,7 +374,7 @@ async function resolveSelectorInteractionTarget(
     node,
     capture.snapshot.nodes,
     resolved.selector,
-    params.action,
+    params,
   );
   const point = resolveNodeTouchPoint(visibleNode, capture.snapshot.nodes, {
     invalidMessage: `Selector ${resolved.selector} resolved to invalid bounds`,
@@ -402,19 +411,26 @@ function selectorInteractionFailure(params: {
   resolved: SelectorResolution | null;
 }): AppError {
   const { runtime, nodes, selectorExpression, action, resolved } = params;
+  const pipeline = SELECTOR_PIPELINE_POLICIES.coveredDiagnosis;
   const covered = resolveSelectorChainWithPolicy(
-    nodes,
+    selectorPipelineCandidates(pipeline, nodes),
     selectorExpression,
-    SELECTOR_RESOLUTION_POLICIES.actCoveredDiagnosis,
+    pipeline.resolution,
     { platform: runtime.backend.platform },
   );
-  if (covered.kind === 'resolved' && isSnapshotNodeInteractionBlocked(covered.resolution.node)) {
-    return buildCoveredInteractionError({
-      label: `Selector ${covered.resolution.selector}`,
-      node: covered.resolution.node,
-      action,
-      selector: covered.resolution.selector,
-    });
+  if (covered.kind === 'resolved') {
+    // The diagnosis row keeps covered nodes as candidates precisely so this
+    // stage can report them: "matched but covered" is a different failure with
+    // a different recovery than "did not match".
+    const target = resolveSelectorPipelineTarget(pipeline, nodes, covered.resolution.node);
+    if (target.kind === 'occluded') {
+      return buildCoveredInteractionError({
+        label: `Selector ${covered.resolution.selector}`,
+        node: target.node,
+        action,
+        selector: covered.resolution.selector,
+      });
+    }
   }
   const diagnostics = resolved?.diagnostics ?? [];
   return new AppError(
@@ -592,33 +608,27 @@ function describeNonHittableTarget(
   };
 }
 
-function interactableSelectorNodes(nodes: SnapshotState['nodes']): SnapshotState['nodes'] {
-  return nodes.filter((node) => !isSnapshotNodeInteractionBlocked(node));
-}
-
-function resolveActionableNodeOrThrow(
+/**
+ * The promotion and occlusion stages of this action's row (#1656), plus the
+ * refusal shape the interaction runtime owns. Which stages run is the row's
+ * decision; every acting path — selector, ref, and the native-ref preflight —
+ * enters them here.
+ */
+function resolveInteractionPipelineTarget(
+  policy: SelectorPipelinePolicy,
   nodes: SnapshotState['nodes'],
   node: SnapshotNode,
   options: { action: InteractionAction; label: string },
 ): SnapshotNode {
-  const resolution = resolveActionableTouchResolution(nodes, node);
-  if (resolution.reason === 'covered') {
+  const target = resolveSelectorPipelineTarget(policy, nodes, node);
+  if (target.kind === 'occluded') {
     throw buildCoveredInteractionError({
       label: options.label,
-      node,
+      node: target.node,
       action: options.action,
     });
   }
-  return resolution.node;
-}
-
-function assertInteractionNotBlocked(
-  node: SnapshotNode,
-  label: string,
-  action: InteractionAction,
-): void {
-  if (!isSnapshotNodeInteractionBlocked(node)) return;
-  throw buildCoveredInteractionError({ label, node, action });
+  return target.node;
 }
 
 function buildCoveredInteractionError(params: {
@@ -832,6 +842,9 @@ function isUsableResolvedNode(node: SnapshotNode | null | undefined): node is Sn
   return resolveRectCenter(node.rect) !== null;
 }
 
+/** The two inputs every off-screen stage call needs: the row, and the verb it names. */
+type OffscreenStageParams = { action: InteractionAction; pipeline: SelectorPipelinePolicy };
+
 // Selector parity for the @ref off-screen guard: without it, a selector
 // resolving to a closed drawer/carousel item "succeeds" by tapping coordinates
 // outside the viewport (observed as `Tapped (-161, 265)` against Bluesky's
@@ -842,9 +855,9 @@ async function assertVisibleSelectorTarget(
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
   selector: string,
-  action: InteractionAction,
+  { action, pipeline }: OffscreenStageParams,
 ): Promise<SnapshotNode> {
-  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, {
+  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, pipeline, {
     message: `Selector ${selector} resolved to an off-screen element and is not safe to ${action}`,
     details: { reason: 'offscreen_selector', selector },
     // A selector re-resolves against a fresh snapshot on every attempt, so the
@@ -864,9 +877,9 @@ async function assertVisibleRefTarget(
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
   refInput: string,
-  action: InteractionAction,
+  { action, pipeline }: OffscreenStageParams,
 ): Promise<SnapshotNode> {
-  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, {
+  return await throwIfOffscreenInteractionTarget(runtime, options, node, nodes, pipeline, {
     message: `Ref ${refInput} is off-screen and not safe to ${action}`,
     details: { reason: 'offscreen_ref', ref: normalizeRef(refInput) },
     // The scroll that reveals the target expires the ref frame (#1366, ADR
@@ -924,17 +937,20 @@ export async function preflightNativeRefInteraction(
     fallbackLabel: target.fallbackLabel ?? '',
   });
   if (!resolved) return {};
-  assertInteractionNotBlocked(resolved.node, `Ref ${target.ref}`, action);
+  // `resolvedTarget`, whatever the command: this row's `none` promotion is what
+  // makes "the preflight never changes which element the backend acts on" a
+  // declared property rather than an omission at this call site.
+  const pipeline = SELECTOR_PIPELINE_POLICIES.resolvedTarget;
+  const node = resolveInteractionPipelineTarget(pipeline, nodes, resolved.node, {
+    action,
+    label: `Ref ${target.ref}`,
+  });
   // #1542: dispatches by REF, not coordinate, so no point to re-derive — but
   // evidence/annotation below still describes the returned (visible) node.
-  const visibleNode = await assertVisibleRefTarget(
-    runtime,
-    options,
-    resolved.node,
-    nodes,
-    target.ref,
+  const visibleNode = await assertVisibleRefTarget(runtime, options, node, nodes, target.ref, {
     action,
-  );
+    pipeline,
+  });
   return {
     ...describeNonHittableTarget(visibleNode, action),
     // ADR 0012 decision 3: the guard lookup above doubles as the record-time
@@ -968,12 +984,18 @@ export async function throwIfOffscreenInteractionTarget(
   options: CommandContext,
   node: SnapshotNode,
   nodes: SnapshotState['nodes'],
+  policy: SelectorPipelinePolicy,
   failure: {
     message: string;
     details: Record<string, unknown>;
     hint: (direction: OffscreenScrollDirection | null) => string;
   },
 ): Promise<SnapshotNode> {
+  // The off-screen stage of the caller's row (#1656). Rows that observe rather
+  // than act declare `ignore`: an element scrolled out of view still exists,
+  // still has text, and still satisfies a presence wait, so a read must not
+  // refuse it — and must not spend the iOS rescue round trip asking.
+  if (!selectorPipelineRefusesOffscreen(policy)) return node;
   const viewport = node.rect ? resolveEffectiveViewportRect(node, nodes) : null;
   if (!node.rect || !viewport || isNodeVisibleOnScreen(node, nodes)) return node;
   const rootViewport = resolveViewportRect(nodes, node.rect);

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -142,9 +142,9 @@ type ResolveInteractionTargetParams = {
   requireInteractive: boolean;
   /**
    * The structural pipeline this action runs (#1656): occlusion, off-screen,
-   * and hittable-ancestor promotion are the row's decisions, not per-call-site
-   * booleans. `promotedTarget` for tap-shaped actions, `resolvedTarget` for the
-   * actions that must keep the element they resolved.
+   * and hittable-ancestor promotion are the row's decisions. `promotedTarget`
+   * for tap-shaped actions, `resolvedTarget` for the actions that must keep
+   * the element they resolved.
    */
   pipeline: ActingPipelinePolicy;
   /**
@@ -937,9 +937,8 @@ export async function preflightNativeRefInteraction(
     fallbackLabel: target.fallbackLabel ?? '',
   });
   if (!resolved) return {};
-  // `resolvedTarget`, whatever the command: this row's `none` promotion is what
-  // makes "the preflight never changes which element the backend acts on" a
-  // declared property rather than an omission at this call site.
+  // `resolvedTarget` whatever the command: its `none` promotion is what holds
+  // ADR 0011's "the preflight never changes which element the backend acts on".
   const pipeline = SELECTOR_PIPELINE_POLICIES.resolvedTarget;
   const node = resolveInteractionPipelineTarget(pipeline, nodes, resolved.node, {
     action,

--- a/src/commands/interaction/runtime/selector-action-resolution.test.ts
+++ b/src/commands/interaction/runtime/selector-action-resolution.test.ts
@@ -5,12 +5,18 @@ import {
   ELEMENT14_DISTINCT_SUBTREE_NODES,
   EQUIVALENT_WRAPPER_CHAIN_NODES,
 } from '../../../core/interaction-targeting.fixtures.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import { resolveActionSelector } from './selector-action-resolution.ts';
 
 test('mutating selector collapses a wrapper chain that resolves to one actionable node', () => {
   const snapshot = makeSnapshotState(EQUIVALENT_WRAPPER_CHAIN_NODES);
 
-  const result = resolveActionSelector(snapshot.nodes, 'label="Chat"', 'ios');
+  const result = resolveActionSelector(
+    snapshot.nodes,
+    'label="Chat"',
+    'ios',
+    SELECTOR_PIPELINE_POLICIES.promotedTarget,
+  );
 
   assert.equal(result?.node.index, 1);
   assert.equal(result?.matches, 3);
@@ -21,7 +27,13 @@ test('mutating selector rejects element-14-shaped matches in distinct subtrees w
   const snapshot = makeSnapshotState(ELEMENT14_DISTINCT_SUBTREE_NODES);
 
   assert.throws(
-    () => resolveActionSelector(snapshot.nodes, 'label="Team Standup"', 'ios'),
+    () =>
+      resolveActionSelector(
+        snapshot.nodes,
+        'label="Team Standup"',
+        'ios',
+        SELECTOR_PIPELINE_POLICIES.promotedTarget,
+      ),
     (error: unknown) => {
       assert.equal((error as { code?: unknown }).code, 'AMBIGUOUS_MATCH');
       const details = (error as { details?: Record<string, unknown> }).details;

--- a/src/commands/interaction/runtime/selector-action-resolution.ts
+++ b/src/commands/interaction/runtime/selector-action-resolution.ts
@@ -1,25 +1,23 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { Platform, PublicPlatform } from '@agent-device/kernel/device';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
-import { resolveSelectorChainWithPolicy, type SelectorResolution } from '@agent-device/selectors';
+import type { SelectorResolution } from '@agent-device/selectors';
 import { classifyActionableTouchCandidates } from '../../../core/interaction-targeting.ts';
-import {
-  selectorPipelineCandidates,
-  type ActingPipelinePolicy,
-} from '../../../core/selector-pipeline-policy.ts';
+import { listSelectorPipelineMatches } from '../../../core/selector-pipeline.ts';
+import type { ActingPipelinePolicy } from '../../../core/selector-pipeline-policy.ts';
 import { formatSnapshotLine } from '../../../snapshot/snapshot-lines.ts';
 
 const AMBIGUOUS_ACTION_CANDIDATE_LIMIT = 5;
 
 /**
- * Fail-fast resolution for mutating selectors. Wrapper duplicates may collapse
+ * How an acting row narrows its candidate set: wrapper duplicates may collapse
  * through structural/actionable equivalence; matches in distinct branches are
- * returned as actionable candidates instead of being ranked by geometry.
+ * refused with actionable candidates instead of being ranked by geometry.
  *
- * The acting row's occlusion stage runs first and is what `nodes` means from
- * there on: a covered node is not a candidate, and it is not a competitor in
- * the equivalence classification either — an overlay must not turn one control
- * into an ambiguous pair.
+ * Both the candidate set and the tree it is judged against come from the
+ * pipeline owner, so the row's occlusion stage has already run on both: a
+ * covered node is neither a candidate nor a competitor, and an overlay cannot
+ * turn one control into an ambiguous pair.
  */
 export function resolveActionSelector(
   nodes: SnapshotNode[],
@@ -27,23 +25,30 @@ export function resolveActionSelector(
   platform: Platform | PublicPlatform,
   policy: ActingPipelinePolicy,
 ): SelectorResolution | null {
-  const candidates = selectorPipelineCandidates(policy, nodes);
-  const outcome = resolveSelectorChainWithPolicy(
-    candidates,
-    selectorExpression,
-    policy.resolution,
-    { platform },
-  );
-  if (outcome.kind === 'none') return null;
-  if (outcome.kind === 'resolved') return outcome.resolution;
+  const { candidates, list } = listSelectorPipelineMatches(policy, nodes, selectorExpression, {
+    platform,
+  });
+  const matched = list?.matchedNodes ?? [];
+  if (!list || matched.length === 0) return null;
 
-  const classification = classifyActionableTouchCandidates(candidates, outcome.matchedNodes);
+  const diagnostics = [{ selector: list.selector, matches: matched.length }];
+  if (matched.length === 1) {
+    return {
+      node: matched[0]!,
+      selector: list.selector,
+      selectorIndex: list.selectorIndex,
+      matches: 1,
+      diagnostics,
+    };
+  }
+
+  const classification = classifyActionableTouchCandidates(candidates, matched);
   if (classification.kind === 'ambiguous') {
     throw new AppError(
       'AMBIGUOUS_MATCH',
-      `Selector matched ${classification.candidates.length} distinct actionable elements: ${outcome.selector}`,
+      `Selector matched ${classification.candidates.length} distinct actionable elements: ${list.selector}`,
       {
-        selector: outcome.selector,
+        selector: list.selector,
         matches: classification.candidates.length,
         candidates: classification.candidates
           .slice(0, AMBIGUOUS_ACTION_CANDIDATE_LIMIT)
@@ -54,16 +59,14 @@ export function resolveActionSelector(
 
   return {
     node: classification.node,
-    selector: outcome.selector,
-    selectorIndex: outcome.selectorIndex,
-    matches: outcome.matchedNodes.length,
-    diagnostics: [{ selector: outcome.selector, matches: outcome.matchedNodes.length }],
+    selector: list.selector,
+    selectorIndex: list.selectorIndex,
+    matches: matched.length,
+    diagnostics,
     disambiguation: {
-      matchCount: outcome.matchedNodes.length,
+      matchCount: matched.length,
       tiebreak: 'structural-equivalence',
-      alternatives: outcome.matchedNodes.filter(
-        (candidate) => candidate.index !== classification.node.index,
-      ),
+      alternatives: matched.filter((candidate) => candidate.index !== classification.node.index),
     },
   };
 }

--- a/src/commands/interaction/runtime/selector-action-resolution.ts
+++ b/src/commands/interaction/runtime/selector-action-resolution.ts
@@ -1,12 +1,12 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { Platform, PublicPlatform } from '@agent-device/kernel/device';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
-import {
-  resolveSelectorChainWithPolicy,
-  SELECTOR_RESOLUTION_POLICIES,
-  type SelectorResolution,
-} from '@agent-device/selectors';
+import { resolveSelectorChainWithPolicy, type SelectorResolution } from '@agent-device/selectors';
 import { classifyActionableTouchCandidates } from '../../../core/interaction-targeting.ts';
+import {
+  selectorPipelineCandidates,
+  type ActingPipelinePolicy,
+} from '../../../core/selector-pipeline-policy.ts';
 import { formatSnapshotLine } from '../../../snapshot/snapshot-lines.ts';
 
 const AMBIGUOUS_ACTION_CANDIDATE_LIMIT = 5;
@@ -15,22 +15,29 @@ const AMBIGUOUS_ACTION_CANDIDATE_LIMIT = 5;
  * Fail-fast resolution for mutating selectors. Wrapper duplicates may collapse
  * through structural/actionable equivalence; matches in distinct branches are
  * returned as actionable candidates instead of being ranked by geometry.
+ *
+ * The acting row's occlusion stage runs first and is what `nodes` means from
+ * there on: a covered node is not a candidate, and it is not a competitor in
+ * the equivalence classification either — an overlay must not turn one control
+ * into an ambiguous pair.
  */
 export function resolveActionSelector(
   nodes: SnapshotNode[],
   selectorExpression: string,
   platform: Platform | PublicPlatform,
+  policy: ActingPipelinePolicy,
 ): SelectorResolution | null {
+  const candidates = selectorPipelineCandidates(policy, nodes);
   const outcome = resolveSelectorChainWithPolicy(
-    nodes,
+    candidates,
     selectorExpression,
-    SELECTOR_RESOLUTION_POLICIES.act,
+    policy.resolution,
     { platform },
   );
   if (outcome.kind === 'none') return null;
   if (outcome.kind === 'resolved') return outcome.resolution;
 
-  const classification = classifyActionableTouchCandidates(nodes, outcome.matchedNodes);
+  const classification = classifyActionableTouchCandidates(candidates, outcome.matchedNodes);
   if (classification.kind === 'ambiguous') {
     throw new AppError(
       'AMBIGUOUS_MATCH',

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -13,8 +13,11 @@ import {
   parseFindSelectorExpression,
   type FindAction,
   type FindLocator,
-  SELECTOR_RESOLUTION_POLICIES,
 } from '@agent-device/selectors';
+import {
+  SELECTOR_PIPELINE_POLICIES,
+  selectorPipelineCandidates,
+} from '../../../core/selector-pipeline-policy.ts';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { isSparseSnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
@@ -211,8 +214,8 @@ export const getCommand: RuntimeCommand<GetCommandOptions, GetCommandResult> = a
     selector: options.target.selector,
     policy:
       options.property === 'text'
-        ? SELECTOR_RESOLUTION_POLICIES.readText
-        : SELECTOR_RESOLUTION_POLICIES.readUnique,
+        ? SELECTOR_PIPELINE_POLICIES.readText
+        : SELECTOR_PIPELINE_POLICIES.readUnique,
   });
   assertExpectedResolvedTarget(
     resolved.node,
@@ -303,9 +306,9 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
     // reach the engine directly — the claim was true of the docs and not of
     // the code (#1630).
     const matched = resolveSelectorChainWithPolicy(
-      capture.snapshot.nodes,
+      selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readAny, capture.snapshot.nodes),
       selectorExpression,
-      SELECTOR_RESOLUTION_POLICIES.readAny,
+      SELECTOR_PIPELINE_POLICIES.readAny.resolution,
       { platform: runtime.backend.platform },
     );
     if (matched.kind !== 'resolved') {
@@ -330,9 +333,9 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
   // refusal as no match at all, because `is` must never guess which duplicate
   // it answered about.
   const outcome = resolveSelectorChainWithPolicy(
-    capture.snapshot.nodes,
+    selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readUnique, capture.snapshot.nodes),
     selectorExpression,
-    SELECTOR_RESOLUTION_POLICIES.readUnique,
+    SELECTOR_PIPELINE_POLICIES.readUnique.resolution,
     { platform: runtime.backend.platform },
   );
   if (outcome.kind !== 'resolved') {
@@ -411,7 +414,12 @@ async function waitForFindMatch(
   options: FindReadCommandOptions,
   locator: FindLocator,
 ): Promise<FindReadCommandResult> {
-  const polling = createWaitPolling(runtime, options, options.timeoutMs);
+  const polling = createWaitPolling(
+    runtime,
+    options,
+    options.timeoutMs,
+    SELECTOR_PIPELINE_POLICIES.findWait,
+  );
   let deadline: WaitPollDeadline | undefined;
   while (polling.hasTimeRemaining()) {
     // A presence check never consumes scroll hints, so every poll skips deriving them —
@@ -486,9 +494,9 @@ async function findFirstLocatorMatch(
   }
   if (selectorExpression) {
     const outcome = resolveSelectorChainWithPolicy(
-      capture.snapshot.nodes,
+      selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readAny, capture.snapshot.nodes),
       selectorExpression,
-      SELECTOR_RESOLUTION_POLICIES.readAny,
+      SELECTOR_PIPELINE_POLICIES.readAny.resolution,
       { platform: runtime.backend.platform },
     );
     return { capture, match: outcome.kind === 'resolved' ? outcome.resolution.node : undefined };
@@ -500,18 +508,19 @@ async function findFirstLocatorMatch(
 }
 
 /**
- * `get` names the two rows it may consume by type: `readText` disambiguates
- * through the same tiebreak acting uses, `readUnique` fails closed. A row with
- * any other ambiguity contract is a compile error here rather than a silent
- * change to what `get` will bind to.
+ * `get` names the two pipeline rows it may consume by type: `readText`
+ * disambiguates through the same tiebreak acting uses, `readUnique` fails
+ * closed, and both observe rather than act. Any other row is a compile error
+ * here rather than a silent change to what `get` binds to — or, since #1656,
+ * to which structural stages a read would start running.
  */
-type GetResolutionPolicy = (typeof SELECTOR_RESOLUTION_POLICIES)['readText' | 'readUnique'];
+type GetPipelinePolicy = (typeof SELECTOR_PIPELINE_POLICIES)['readText' | 'readUnique'];
 
 async function resolveSelectorNode(
   runtime: AgentDeviceRuntime,
   options: GetCommandOptions,
   sessionName: string,
-  params: { selector: string; policy: GetResolutionPolicy },
+  params: { selector: string; policy: GetPipelinePolicy },
 ): Promise<{ capture: CapturedSnapshot; node: SnapshotNode; selector: string; ref: string }> {
   const capture = await captureSelectorSnapshot(
     runtime,
@@ -522,9 +531,9 @@ async function resolveSelectorNode(
     },
   );
   const outcome = resolveSelectorChainWithPolicy(
-    capture.snapshot.nodes,
+    selectorPipelineCandidates(params.policy, capture.snapshot.nodes),
     params.selector,
-    params.policy,
+    params.policy.resolution,
     { platform: runtime.backend.platform },
   );
   if (outcome.kind !== 'resolved') {

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -2,22 +2,22 @@ import {
   FIND_VALUE_REQUIRED_MESSAGE,
   findBestMatchesByLocator,
   formatSelectorFailure,
-  resolveSelectorChainWithPolicy,
   selectorFailureHint,
   buildSelectorChainForNode,
   checkIsPredicate,
   evaluateIsPredicate,
   IS_TEXT_VALUE_REQUIRED_MESSAGE,
-  listSelectorChainMatches,
   readSelectorAlternatives,
   parseFindSelectorExpression,
   type FindAction,
   type FindLocator,
 } from '@agent-device/selectors';
 import {
-  SELECTOR_PIPELINE_POLICIES,
-  selectorPipelineCandidates,
-} from '../../../core/selector-pipeline-policy.ts';
+  listSelectorPipelineMatches,
+  resolveSelectorPipeline,
+  type SelectorPipelineHooks,
+} from '../../../core/selector-pipeline.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { isSparseSnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
@@ -216,13 +216,11 @@ export const getCommand: RuntimeCommand<GetCommandOptions, GetCommandResult> = a
       options.property === 'text'
         ? SELECTOR_PIPELINE_POLICIES.readText
         : SELECTOR_PIPELINE_POLICIES.readUnique,
+    hooks: {
+      onResolved: (node, nodes) =>
+        assertExpectedResolvedTarget(node, nodes, options.expectedResolvedTarget, 'get'),
+    },
   });
-  assertExpectedResolvedTarget(
-    resolved.node,
-    resolved.capture.snapshot.nodes,
-    options.expectedResolvedTarget,
-    'get',
-  );
 
   const selectorChain = buildSelectorChainForNode(resolved.node, runtime.backend.platform, {
     action: 'get',
@@ -305,13 +303,13 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
     // already documented itself as serving `exists`, but this branch used to
     // reach the engine directly — the claim was true of the docs and not of
     // the code (#1630).
-    const matched = resolveSelectorChainWithPolicy(
-      selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readAny, capture.snapshot.nodes),
+    const matched = await resolveSelectorPipeline(
+      SELECTOR_PIPELINE_POLICIES.readAny,
+      capture.snapshot.nodes,
       selectorExpression,
-      SELECTOR_PIPELINE_POLICIES.readAny.resolution,
       { platform: runtime.backend.platform },
     );
-    if (matched.kind !== 'resolved') {
+    if (matched.kind !== 'target') {
       throw new AppError(
         'COMMAND_FAILED',
         formatSelectorFailure(selectorExpression, [], { unique: false }),
@@ -323,8 +321,8 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
     return {
       predicate: predicate,
       pass: true,
-      selector: matched.resolution.selector,
-      matches: matched.resolution.matches,
+      selector: matched.selector,
+      matches: matched.matches,
       selectorChain: readSelectorAlternatives(selectorExpression),
     };
   }
@@ -332,13 +330,17 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
   // `readUnique` is the fail-closed row: an ambiguous screen reports the same
   // refusal as no match at all, because `is` must never guess which duplicate
   // it answered about.
-  const outcome = resolveSelectorChainWithPolicy(
-    selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readUnique, capture.snapshot.nodes),
+  const outcome = await resolveSelectorPipeline(
+    SELECTOR_PIPELINE_POLICIES.readUnique,
+    capture.snapshot.nodes,
     selectorExpression,
-    SELECTOR_PIPELINE_POLICIES.readUnique.resolution,
     { platform: runtime.backend.platform },
+    {
+      onResolved: (node, nodes) =>
+        assertExpectedResolvedTarget(node, nodes, options.expectedResolvedTarget, 'is'),
+    },
   );
-  if (outcome.kind !== 'resolved') {
+  if (outcome.kind !== 'target') {
     throw new AppError(
       'COMMAND_FAILED',
       formatSelectorFailure(selectorExpression, [], { unique: true }),
@@ -351,13 +353,7 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
       },
     );
   }
-  const resolved = outcome.resolution;
-  assertExpectedResolvedTarget(
-    resolved.node,
-    capture.snapshot.nodes,
-    options.expectedResolvedTarget,
-    'is',
-  );
+  const resolved = outcome;
   const result = evaluateIsPredicate({
     predicate: predicate,
     node: resolved.node,
@@ -466,9 +462,12 @@ async function listFindMatches(
     throw sparseSelectorSnapshotError(capture.snapshot.snapshotQuality);
   }
   const matched = selectorExpression
-    ? (listSelectorChainMatches(capture.snapshot.nodes, selectorExpression, {
-        platform: runtime.backend.platform,
-      })?.matchedNodes ?? [])
+    ? (listSelectorPipelineMatches(
+        SELECTOR_PIPELINE_POLICIES.readList,
+        capture.snapshot.nodes,
+        selectorExpression,
+        { platform: runtime.backend.platform },
+      ).list?.matchedNodes ?? [])
     : findBestMatchesByLocator(capture.snapshot.nodes, locator, options.query, {}).matches;
   return {
     kind: 'list',
@@ -493,13 +492,13 @@ async function findFirstLocatorMatch(
     throw sparseSelectorSnapshotError(capture.snapshot.snapshotQuality);
   }
   if (selectorExpression) {
-    const outcome = resolveSelectorChainWithPolicy(
-      selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.readAny, capture.snapshot.nodes),
+    const outcome = await resolveSelectorPipeline(
+      SELECTOR_PIPELINE_POLICIES.readAny,
+      capture.snapshot.nodes,
       selectorExpression,
-      SELECTOR_PIPELINE_POLICIES.readAny.resolution,
       { platform: runtime.backend.platform },
     );
-    return { capture, match: outcome.kind === 'resolved' ? outcome.resolution.node : undefined };
+    return { capture, match: outcome.kind === 'target' ? outcome.node : undefined };
   }
   const match = findBestMatchesByLocator(capture.snapshot.nodes, locator, options.query, {
     requireRect: false,
@@ -520,7 +519,7 @@ async function resolveSelectorNode(
   runtime: AgentDeviceRuntime,
   options: GetCommandOptions,
   sessionName: string,
-  params: { selector: string; policy: GetPipelinePolicy },
+  params: { selector: string; policy: GetPipelinePolicy; hooks?: SelectorPipelineHooks },
 ): Promise<{ capture: CapturedSnapshot; node: SnapshotNode; selector: string; ref: string }> {
   const capture = await captureSelectorSnapshot(
     runtime,
@@ -530,13 +529,14 @@ async function resolveSelectorNode(
       ...deriveSelectorCapturePolicy(),
     },
   );
-  const outcome = resolveSelectorChainWithPolicy(
-    selectorPipelineCandidates(params.policy, capture.snapshot.nodes),
+  const outcome = await resolveSelectorPipeline(
+    params.policy,
+    capture.snapshot.nodes,
     params.selector,
-    params.policy.resolution,
     { platform: runtime.backend.platform },
+    params.hooks,
   );
-  if (outcome.kind !== 'resolved') {
+  if (outcome.kind !== 'target') {
     throw new AppError(
       'COMMAND_FAILED',
       formatSelectorFailure(params.selector, [], { unique: true }),
@@ -547,8 +547,8 @@ async function resolveSelectorNode(
   }
   return {
     capture,
-    node: outcome.resolution.node,
-    selector: outcome.resolution.selector,
-    ref: `@${outcome.resolution.node.ref}`,
+    node: outcome.node,
+    selector: outcome.selector,
+    ref: `@${outcome.node.ref}`,
   };
 }

--- a/src/commands/interaction/runtime/selector-wait.ts
+++ b/src/commands/interaction/runtime/selector-wait.ts
@@ -13,16 +13,12 @@ import {
   filterIdentitySet,
 } from '../../../replay/target-evidence-tree.ts';
 import type { PublicPlatform } from '@agent-device/kernel/device';
+import { checkWaitText, type SelectorChainMatchList } from '@agent-device/selectors';
 import {
-  checkWaitText,
-  type SelectorChainMatchList,
-  resolveSelectorChainWithPolicy,
-  type PolicyResolutionOutcome,
-} from '@agent-device/selectors';
-import {
-  SELECTOR_PIPELINE_POLICIES,
-  selectorPipelineCandidates,
-} from '../../../core/selector-pipeline-policy.ts';
+  resolveSelectorPipeline,
+  type SelectorPipelineOutcome,
+} from '../../../core/selector-pipeline.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import { deriveSelectorCapturePolicy } from './selector-capture-policy.ts';
 import { findNodeByLabel, resolveRefLabel } from './selector-read-utils.ts';
 import {
@@ -34,12 +30,11 @@ import {
 } from './wait-polling.ts';
 
 /**
- * The landmark check (#1349) needs the full candidate set, which the policy
- * outcome carries in either shape: a `first-match` resolution exposes the
- * winner, and the ambiguous branch exposes all candidates. Wait's row never
- * refuses, so this only ever adapts — it does not re-decide anything.
+ * The landmark check (#1349) needs the full candidate set, which the pipeline
+ * outcome carries in either shape. Wait's row never refuses, so this only ever
+ * adapts — it does not re-decide anything.
  */
-function policyMatchList(outcome: PolicyResolutionOutcome): SelectorChainMatchList | undefined {
+function policyMatchList(outcome: SelectorPipelineOutcome): SelectorChainMatchList | undefined {
   if (outcome.kind === 'ambiguous') {
     return {
       selector: outcome.selector,
@@ -47,10 +42,10 @@ function policyMatchList(outcome: PolicyResolutionOutcome): SelectorChainMatchLi
       matchedNodes: outcome.matchedNodes,
     };
   }
-  if (outcome.kind === 'resolved') {
+  if (outcome.kind === 'target') {
     return {
-      selector: outcome.resolution.selector,
-      selectorIndex: outcome.resolution.selectorIndex,
+      selector: outcome.selector,
+      selectorIndex: outcome.selectorIndex,
       // Every candidate, not just the winner: the landmark check is satisfied
       // when SOME match carries the recorded identity, so a first impostor
       // must not hide a later genuine landmark (#1349).
@@ -281,12 +276,12 @@ async function waitForSelector<Runtime extends SelectorWaitRuntime>(
     const capture = poll.value;
     if (capture) {
       const nodes = capture.snapshot.nodes;
-      const outcome = resolveSelectorChainWithPolicy(
-        // The wait row ignores occlusion: a covered element is present, and
-        // presence is the question this loop asks.
-        selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.wait, nodes),
+      // The wait row ignores occlusion and off-screen: a covered or scrolled-out
+      // element is present, and presence is the question this loop asks.
+      const outcome = await resolveSelectorPipeline(
+        SELECTOR_PIPELINE_POLICIES.wait,
+        nodes,
         selectorExpression,
-        SELECTOR_PIPELINE_POLICIES.wait.resolution,
         { platform: runtime.backend.platform },
       );
       // The wait row is `first-match`, so a multi-match screen resolves rather

--- a/src/commands/interaction/runtime/selector-wait.ts
+++ b/src/commands/interaction/runtime/selector-wait.ts
@@ -16,10 +16,13 @@ import type { PublicPlatform } from '@agent-device/kernel/device';
 import {
   checkWaitText,
   type SelectorChainMatchList,
-  SELECTOR_RESOLUTION_POLICIES,
   resolveSelectorChainWithPolicy,
   type PolicyResolutionOutcome,
 } from '@agent-device/selectors';
+import {
+  SELECTOR_PIPELINE_POLICIES,
+  selectorPipelineCandidates,
+} from '../../../core/selector-pipeline-policy.ts';
 import { deriveSelectorCapturePolicy } from './selector-capture-policy.ts';
 import { findNodeByLabel, resolveRefLabel } from './selector-read-utils.ts';
 import {
@@ -248,7 +251,7 @@ async function waitForSelector<Runtime extends SelectorWaitRuntime>(
   timeoutMs: number | null | undefined,
   recordedLandmark: TargetAnnotationV1 | undefined,
 ): Promise<WaitCommandResult> {
-  const polling = createWaitPolling(runtime, options, timeoutMs);
+  const polling = createWaitPolling(runtime, options, timeoutMs, SELECTOR_PIPELINE_POLICIES.wait);
   const capturePolicy = deriveSelectorCapturePolicy();
   // ADR 0012 / #1349: the LAST poll whose capture matched the recorded
   // selector without any match carrying the recorded landmark identity. A
@@ -279,9 +282,11 @@ async function waitForSelector<Runtime extends SelectorWaitRuntime>(
     if (capture) {
       const nodes = capture.snapshot.nodes;
       const outcome = resolveSelectorChainWithPolicy(
-        nodes,
+        // The wait row ignores occlusion: a covered element is present, and
+        // presence is the question this loop asks.
+        selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES.wait, nodes),
         selectorExpression,
-        SELECTOR_RESOLUTION_POLICIES.wait,
+        SELECTOR_PIPELINE_POLICIES.wait.resolution,
         { platform: runtime.backend.platform },
       );
       // The wait row is `first-match`, so a multi-match screen resolves rather
@@ -361,7 +366,7 @@ async function waitForText<Runtime extends SelectorWaitRuntime>(
   text: string,
   timeoutMs: number | null | undefined,
 ): Promise<WaitCommandResult> {
-  const polling = createWaitPolling(runtime, options, timeoutMs);
+  const polling = createWaitPolling(runtime, options, timeoutMs, SELECTOR_PIPELINE_POLICIES.wait);
   let deadline: WaitPollDeadline | undefined;
   while (polling.hasTimeRemaining()) {
     const poll = await polling.capture(async (signal) =>

--- a/src/commands/interaction/runtime/wait-polling.test.ts
+++ b/src/commands/interaction/runtime/wait-polling.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { AgentDeviceRuntime } from '../../../runtime-contract.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../../core/selector-pipeline-policy.ts';
 import { createWaitPolling } from './wait-polling.ts';
 
 test('poll delay is bounded by the remaining wait budget', async () => {
@@ -15,7 +16,7 @@ test('poll delay is bounded by the remaining wait budget', async () => {
       },
     },
   } as AgentDeviceRuntime;
-  const polling = createWaitPolling(runtime, {}, 125);
+  const polling = createWaitPolling(runtime, {}, 125, SELECTOR_PIPELINE_POLICIES.wait);
 
   assert.equal(await polling.sleepUntilNextPoll(), true);
   assert.deepEqual(sleeps, [125]);
@@ -30,6 +31,7 @@ test('poll delay observes both runtime and command cancellation', async () => {
       { signal: runtimeController.signal } as AgentDeviceRuntime,
       { signal: commandController.signal },
       10_000,
+      SELECTOR_PIPELINE_POLICIES.wait,
     );
     const sleeping = polling.sleepUntilNextPoll();
 

--- a/src/commands/interaction/runtime/wait-polling.ts
+++ b/src/commands/interaction/runtime/wait-polling.ts
@@ -1,9 +1,9 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { WAIT_REASONS } from '@agent-device/contracts/interaction';
 import { isUnreadableCaptureContentError } from '../../../snapshot/snapshot-quality.ts';
+import { selectorPollBudget } from '../../../core/selector-pipeline.ts';
 import {
   SELECTOR_PIPELINE_POLICIES,
-  selectorPollBudget,
   type SelectorPipelinePolicy,
 } from '../../../core/selector-pipeline-policy.ts';
 import { runWithinWaitDeadline } from './wait-deadline.ts';

--- a/src/commands/interaction/runtime/wait-polling.ts
+++ b/src/commands/interaction/runtime/wait-polling.ts
@@ -1,10 +1,19 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { WAIT_REASONS } from '@agent-device/contracts/interaction';
 import { isUnreadableCaptureContentError } from '../../../snapshot/snapshot-quality.ts';
+import {
+  SELECTOR_PIPELINE_POLICIES,
+  selectorPollBudget,
+  type SelectorPipelinePolicy,
+} from '../../../core/selector-pipeline-policy.ts';
 import { runWithinWaitDeadline } from './wait-deadline.ts';
 
-export const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
-const WAIT_POLL_INTERVAL_MS = 300;
+/**
+ * The default `wait` budget, read from the row that owns it (#1656) so the
+ * number has one home. `wait --stable` shares it: the quiet-window loop is a
+ * different observation, run under the same wait deadline.
+ */
+export const DEFAULT_WAIT_TIMEOUT_MS = SELECTOR_PIPELINE_POLICIES.wait.poll.defaultTimeoutMs;
 
 export type WaitPollDeadline = 'capture-stalled' | 'capture-truncated';
 
@@ -38,12 +47,20 @@ type WaitFailurePolling = {
   rethrowIfNeverReadable: () => void;
 };
 
+/**
+ * The poll stage of the caller's selector-pipeline row (#1656): the deadline
+ * and the inter-poll delay come from the row, not from module constants, so a
+ * caller cannot invent a budget and a row that resolves against a single
+ * capture cannot be polled at all.
+ */
 export function createWaitPolling(
   runtime: WaitPollingRuntime,
   options: WaitPollingOptions,
   requestedTimeoutMs: number | null | undefined,
+  policy: SelectorPipelinePolicy,
 ) {
-  const timeoutMs = requestedTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+  const budget = selectorPollBudget(policy);
+  const timeoutMs = requestedTimeoutMs ?? budget.defaultTimeoutMs;
   const startedAtMs = now(runtime);
   const unreadable = createUnreadablePollTracker();
   const remainingMs = () => Math.max(0, timeoutMs - (now(runtime) - startedAtMs));
@@ -87,11 +104,7 @@ export function createWaitPolling(
     }),
     rethrowIfNeverReadable: unreadable.rethrowIfNeverReadable,
     sleepUntilNextPoll: async () =>
-      await sleepWithWaitCancellation(
-        runtime,
-        options,
-        Math.min(WAIT_POLL_INTERVAL_MS, remainingMs()),
-      ),
+      await sleepWithWaitCancellation(runtime, options, Math.min(budget.intervalMs, remainingMs())),
     timeoutMs,
     waitedMs: () => now(runtime) - startedAtMs,
   };

--- a/src/commands/interaction/runtime/wait-polling.ts
+++ b/src/commands/interaction/runtime/wait-polling.ts
@@ -49,9 +49,8 @@ type WaitFailurePolling = {
 
 /**
  * The poll stage of the caller's selector-pipeline row (#1656): the deadline
- * and the inter-poll delay come from the row, not from module constants, so a
- * caller cannot invent a budget and a row that resolves against a single
- * capture cannot be polled at all.
+ * and the inter-poll delay come from the row, so a caller cannot invent a
+ * budget and a row that resolves against a single capture cannot be polled.
  */
 export function createWaitPolling(
   runtime: WaitPollingRuntime,

--- a/src/core/interaction-targeting.ts
+++ b/src/core/interaction-targeting.ts
@@ -98,14 +98,34 @@ function isAncestorOf(
   return false;
 }
 
-export function resolveActionableTouchNode(
-  nodes: SnapshotNode[],
+/**
+ * The tree's viewport root as an interaction target: a viewport root node whose
+ * rect is exactly the tree root's. Promotion that lands here has retargeted to
+ * "the screen" rather than to the thing that matched, which is why the
+ * `hittable-ancestor-below-root` promotion stage declines it and `find`
+ * excludes it from candidacy and ranking.
+ */
+export function isRootInteractionContainer(
   node: SnapshotNode,
-): SnapshotNode {
-  return resolveActionableTouchResolution(nodes, node).node;
+  root: SnapshotNode | undefined,
+): boolean {
+  if (!root?.rect || !node.rect) return false;
+  if (!isViewportRootNode(node)) return false;
+  const left = node.rect;
+  const right = root.rect;
+  return (
+    left.x === right.x &&
+    left.y === right.y &&
+    left.width === right.width &&
+    left.height === right.height
+  );
 }
 
-/** @internal Exposed for focused policy tests; runtime callers should use resolveActionableTouchNode. */
+/**
+ * The retarget itself. Runtime callers reach it through the promotion stage of
+ * `selector-pipeline-policy.ts`, which is what decides whether a given caller
+ * promotes at all; this stays exported for that runner and for focused tests.
+ */
 export function resolveActionableTouchResolution(
   nodes: SnapshotNode[],
   node: SnapshotNode,

--- a/src/core/selector-pipeline-policy.test.ts
+++ b/src/core/selector-pipeline-policy.test.ts
@@ -13,12 +13,9 @@ import {
 } from './selector-pipeline-policy.ts';
 
 /**
- * #1656: the structural stages are routed through the runners below, so this
- * file is what makes the table's cells load-bearing. Every row is driven
- * through every runner — including the rows whose answer is "skip this stage",
- * which is the half that used to be invisible: `is` not consulting occlusion
- * was an absence of code, and an absence cannot fail. Flip any cell in the
- * table and an assertion here changes.
+ * #1656: every row is driven through every runner — including the rows whose
+ * answer is "skip this stage", since a skip nothing exercises is a claim that
+ * cannot fail. Flip any cell in the table and an assertion here changes.
  *
  * Which stages a given CALLER runs is a separate question, pinned by the
  * caller-level suites (resolution.test.ts, find handler tests, selector-read

--- a/src/core/selector-pipeline-policy.test.ts
+++ b/src/core/selector-pipeline-policy.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import { SELECTOR_RESOLUTION_POLICIES } from '@agent-device/selectors';
+import { makeSnapshotState } from '../__tests__/test-utils/index.ts';
+import {
+  SELECTOR_PIPELINE_POLICIES,
+  resolveSelectorPipelineTarget,
+  selectorPipelineCandidates,
+  selectorPipelineRefusesOffscreen,
+  selectorPollBudget,
+  type SelectorPipelinePolicyName,
+} from './selector-pipeline-policy.ts';
+
+/**
+ * #1656: the structural stages are routed through the runners below, so this
+ * file is what makes the table's cells load-bearing. Every row is driven
+ * through every runner — including the rows whose answer is "skip this stage",
+ * which is the half that used to be invisible: `is` not consulting occlusion
+ * was an absence of code, and an absence cannot fail. Flip any cell in the
+ * table and an assertion here changes.
+ *
+ * Which stages a given CALLER runs is a separate question, pinned by the
+ * caller-level suites (resolution.test.ts, find handler tests, selector-read
+ * policy tests).
+ */
+
+const ROWS = Object.keys(SELECTOR_PIPELINE_POLICIES) as SelectorPipelinePolicyName[];
+
+/** A covered button beside an uncovered twin, under a full-screen root. */
+const COVERED_TREE: RawSnapshotNode[] = [
+  {
+    index: 0,
+    depth: 0,
+    type: 'XCUIElementTypeApplication',
+    rect: { x: 0, y: 0, width: 390, height: 844 },
+    hittable: true,
+  },
+  {
+    index: 1,
+    depth: 1,
+    parentIndex: 0,
+    type: 'XCUIElementTypeButton',
+    label: 'Save',
+    rect: { x: 20, y: 700, width: 100, height: 40 },
+    hittable: false,
+    interactionBlocked: 'covered',
+  },
+  {
+    index: 2,
+    depth: 1,
+    parentIndex: 0,
+    type: 'XCUIElementTypeButton',
+    label: 'Save',
+    rect: { x: 20, y: 200, width: 100, height: 40 },
+    hittable: true,
+  },
+];
+
+/** Static text inside a hittable row: the shape promotion exists for. */
+const PROMOTABLE_TREE: RawSnapshotNode[] = [
+  {
+    index: 0,
+    depth: 0,
+    type: 'XCUIElementTypeCell',
+    label: 'Account row',
+    rect: { x: 10, y: 20, width: 300, height: 60 },
+    hittable: true,
+  },
+  {
+    index: 1,
+    depth: 1,
+    parentIndex: 0,
+    type: 'XCUIElementTypeStaticText',
+    label: 'Account',
+    rect: { x: 24, y: 32, width: 80, height: 20 },
+    hittable: false,
+  },
+];
+
+/**
+ * A full-screen group whose only hittable ancestor IS the viewport root: the
+ * one tree where the two promoting stages disagree.
+ */
+const ROOT_ANCESTOR_TREE: RawSnapshotNode[] = [
+  {
+    index: 0,
+    depth: 0,
+    type: 'XCUIElementTypeApplication',
+    rect: { x: 0, y: 0, width: 390, height: 844 },
+    hittable: true,
+  },
+  {
+    index: 1,
+    depth: 1,
+    parentIndex: 0,
+    type: 'XCUIElementTypeGroup',
+    label: 'Content',
+    rect: { x: 0, y: 0, width: 390, height: 844 },
+    hittable: false,
+  },
+];
+
+function nodesOf(raw: RawSnapshotNode[]) {
+  return makeSnapshotState(raw).nodes;
+}
+
+function candidateIndexes(row: SelectorPipelinePolicyName): number[] {
+  return selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES[row], nodesOf(COVERED_TREE)).map(
+    (node) => node.index,
+  );
+}
+
+function targetFor(row: SelectorPipelinePolicyName, raw: RawSnapshotNode[], index: number) {
+  const nodes = nodesOf(raw);
+  return resolveSelectorPipelineTarget(SELECTOR_PIPELINE_POLICIES[row], nodes, nodes[index]!);
+}
+
+test('the occlusion stage decides candidacy: acting rows drop covered nodes, the rest keep them', () => {
+  for (const row of ['promotedTarget', 'resolvedTarget'] as const) {
+    assert.deepEqual(candidateIndexes(row), [0, 2], row);
+  }
+  // `refuse` rows see covered nodes (find ranks them, the probe diagnoses
+  // them) and `ignore` rows answer about the tree as captured.
+  for (const row of ['findAct', 'coveredDiagnosis', 'readText', 'readUnique'] as const) {
+    assert.deepEqual(candidateIndexes(row), [0, 1, 2], row);
+  }
+  for (const row of ['readAny', 'wait', 'findWait'] as const) {
+    assert.deepEqual(candidateIndexes(row), [0, 1, 2], row);
+  }
+});
+
+test('the occlusion stage decides refusal: every row that refuses covered targets, and every row that does not', () => {
+  for (const row of ['promotedTarget', 'resolvedTarget', 'findAct', 'coveredDiagnosis'] as const) {
+    const target = targetFor(row, COVERED_TREE, 1);
+    assert.equal(target.kind, 'occluded', row);
+    assert.equal(target.node.index, 1, row);
+  }
+  for (const row of ['readText', 'readUnique', 'readAny', 'wait', 'findWait'] as const) {
+    const target = targetFor(row, COVERED_TREE, 1);
+    assert.equal(target.kind, 'target', row);
+    assert.equal(target.node.index, 1, row);
+  }
+});
+
+test('the promotion stage retargets only for the rows that declare it', () => {
+  // Same tree, same node: the row is the whole difference.
+  assert.equal(targetFor('promotedTarget', PROMOTABLE_TREE, 1).node.index, 0);
+  assert.equal(targetFor('findAct', PROMOTABLE_TREE, 1).node.index, 0);
+  for (const row of ['resolvedTarget', 'readText', 'readUnique', 'readAny', 'wait'] as const) {
+    assert.equal(targetFor(row, PROMOTABLE_TREE, 1).node.index, 1, row);
+  }
+});
+
+test('find’s promotion stops below the viewport root; the tap row does not', () => {
+  // `find` ranks matches across the whole tree, so a promotion that lands on
+  // the root container would turn "the thing that matched" into "the screen".
+  assert.equal(targetFor('promotedTarget', ROOT_ANCESTOR_TREE, 1).node.index, 0);
+  assert.equal(targetFor('findAct', ROOT_ANCESTOR_TREE, 1).node.index, 1);
+});
+
+test('the off-screen stage refuses for acting rows and is skipped by observation rows', () => {
+  // The guard itself (including the iOS live-rect rescue) is exercised in
+  // commands/interaction/runtime/resolution.test.ts; this pins which rows
+  // reach it at all.
+  for (const row of ['promotedTarget', 'resolvedTarget'] as const) {
+    assert.equal(selectorPipelineRefusesOffscreen(SELECTOR_PIPELINE_POLICIES[row]), true, row);
+  }
+  for (const row of ROWS.filter((name) => name !== 'promotedTarget' && name !== 'resolvedTarget')) {
+    assert.equal(selectorPipelineRefusesOffscreen(SELECTOR_PIPELINE_POLICIES[row]), false, row);
+  }
+});
+
+test('the poll stage answers only for the rows that poll', () => {
+  for (const row of ['wait', 'findWait'] as const) {
+    assert.deepEqual(selectorPollBudget(SELECTOR_PIPELINE_POLICIES[row]), {
+      defaultTimeoutMs: 10_000,
+      intervalMs: 300,
+    });
+  }
+  for (const row of ROWS.filter((name) => name !== 'wait' && name !== 'findWait')) {
+    assert.throws(() => selectorPollBudget(SELECTOR_PIPELINE_POLICIES[row]), /no poll budget/, row);
+  }
+});
+
+test('pipeline rows declare only the stages these runners enforce', () => {
+  // The #1649 rule, carried to this table: a column nothing consumes is an
+  // unverifiable claim that reads as truth. Adding a field here fails until a
+  // runner above reads it and this suite drives every row through it.
+  for (const [name, policy] of Object.entries(SELECTOR_PIPELINE_POLICIES)) {
+    assert.deepEqual(
+      Object.keys(policy).sort(),
+      ['occlusion', 'offscreen', 'poll', 'promotion', 'resolution'],
+      `${name} declares a stage no runner consumes`,
+    );
+  }
+});
+
+test('every ambiguity row is named by a pipeline row', () => {
+  // The two tables are one policy split by what each layer can enforce. A
+  // resolution row no pipeline row names would be a contract with no pipeline
+  // — reachable only by a caller that bypassed this table.
+  const named = new Set(
+    Object.values(SELECTOR_PIPELINE_POLICIES).map((policy) => policy.resolution),
+  );
+  for (const [name, resolution] of Object.entries(SELECTOR_RESOLUTION_POLICIES)) {
+    assert.ok(named.has(resolution), `${name} is not consumed by any pipeline row`);
+  }
+});
+
+test('the documented per-caller pipelines are the ones declared', () => {
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(SELECTOR_PIPELINE_POLICIES).map(([name, policy]) => [
+        name,
+        [
+          policy.occlusion,
+          policy.offscreen,
+          policy.promotion,
+          policy.poll === 'none' ? 'no-poll' : 'poll',
+        ],
+      ]),
+    ),
+    {
+      promotedTarget: ['exclude-and-refuse', 'refuse', 'hittable-ancestor', 'no-poll'],
+      resolvedTarget: ['exclude-and-refuse', 'refuse', 'none', 'no-poll'],
+      coveredDiagnosis: ['refuse', 'ignore', 'none', 'no-poll'],
+      readText: ['ignore', 'ignore', 'none', 'no-poll'],
+      readUnique: ['ignore', 'ignore', 'none', 'no-poll'],
+      readAny: ['ignore', 'ignore', 'none', 'no-poll'],
+      findWait: ['ignore', 'ignore', 'none', 'poll'],
+      wait: ['ignore', 'ignore', 'none', 'poll'],
+      findAct: ['refuse', 'ignore', 'hittable-ancestor-below-root', 'no-poll'],
+    },
+  );
+});

--- a/src/core/selector-pipeline-policy.ts
+++ b/src/core/selector-pipeline-policy.ts
@@ -79,10 +79,26 @@ export type SelectorPollBudget = {
  */
 export type SelectorPollStage = SelectorPollBudget | 'none';
 
-export type SelectorPipelinePolicy = {
+/**
+ * A row whose result is the candidate SET, not a target: `find <q> list`.
+ * Only two stages can apply — which nodes are candidates, and how the matches
+ * are gathered — so those are the only two it may declare. Promotion, the
+ * off-screen guard, and a poll budget all presuppose a single element to
+ * retarget, keep on screen, or wait for; a listing has none, and declaring
+ * them here would be a claim no listing flow could execute (#1656 review).
+ *
+ * The narrower shape is load-bearing, not documentation: `runNodePipelineStages`
+ * and `selectorPollBudget` take the full row, so handing them a listing row is
+ * a compile error rather than a silently skipped stage.
+ */
+export type SelectorListPolicy = {
   /** The ambiguity contract this row resolves under (#1630). */
   resolution: SelectorResolutionPolicy;
   occlusion: SelectorOcclusionStage;
+};
+
+/** A row whose result is ONE target, and therefore runs the node stages too. */
+export type SelectorPipelinePolicy = SelectorListPolicy & {
   offscreen: SelectorOffscreenStage;
   promotion: SelectorPromotionStage;
   poll: SelectorPollStage;
@@ -165,9 +181,6 @@ export const SELECTOR_PIPELINE_POLICIES = {
   readList: {
     resolution: SELECTOR_RESOLUTION_POLICIES.readList,
     occlusion: 'ignore',
-    offscreen: 'ignore',
-    promotion: 'none',
-    poll: 'none',
   },
   /** Mutating `find` (#1625). */
   findAct: {
@@ -177,7 +190,7 @@ export const SELECTOR_PIPELINE_POLICIES = {
     promotion: 'hittable-ancestor-below-root',
     poll: 'none',
   },
-} as const satisfies Record<string, SelectorPipelinePolicy>;
+} as const satisfies Record<string, SelectorPipelinePolicy | SelectorListPolicy>;
 
 export type SelectorPipelinePolicyName = keyof typeof SELECTOR_PIPELINE_POLICIES;
 

--- a/src/core/selector-pipeline-policy.ts
+++ b/src/core/selector-pipeline-policy.ts
@@ -1,0 +1,262 @@
+import type { SnapshotNode } from '@agent-device/kernel/snapshot';
+import {
+  SELECTOR_RESOLUTION_POLICIES,
+  type SelectorResolutionPolicy,
+} from '@agent-device/selectors';
+import { isSnapshotNodeInteractionBlocked } from '../snapshot/snapshot-occlusion.ts';
+import {
+  isRootInteractionContainer,
+  resolveActionableTouchResolution,
+} from './interaction-targeting.ts';
+
+/**
+ * The structural half of the per-caller selector policy (#1656), companion to
+ * the ambiguity matrix in `@agent-device/selectors` (#1630/#1649).
+ *
+ * A caller names ONE row here and gets its whole pipeline shape: which
+ * ambiguity contract resolves the selector (`resolution`, the matrix row), and
+ * which structural stages run around that resolution — occlusion, off-screen,
+ * hittable-ancestor promotion, and the poll budget. Those four stages used to
+ * be per-caller pipeline code, so "`is` never consults occlusion" was true only
+ * as an ABSENCE of code: nothing declared it and nothing could fail if a later
+ * edit added it. Here it is a value, and the stage runners below are the only
+ * door to each stage, so the value decides.
+ *
+ * Rule of this table, inherited from the #1649 review: a row may only declare
+ * what these runners enforce. Every field is read by the runner named in its
+ * doc comment, and every row — including the ones whose stages are skips — is
+ * driven through those runners in selector-pipeline-policy.test.ts, so flipping
+ * any cell changes an assertion. Do not add a column until its runner exists;
+ * an unconsumed column reads as truth while being free to drift.
+ */
+
+/**
+ * Consumed by `selectorPipelineCandidates` (which nodes may match at all) and
+ * by `resolveSelectorPipelineTarget` (whether a covered target refuses).
+ *
+ * - `exclude-and-refuse` — covered nodes never become candidates, AND a covered
+ *   target refuses. Acting paths: tapping something an overlay covers is the
+ *   wrong-element bug the annotation exists to prevent.
+ * - `refuse` — candidacy is unfiltered, but a covered target refuses. Mutating
+ *   `find`, whose match ranking wants to SEE covered nodes, and the post-miss
+ *   diagnosis probe, whose whole question is "matched but covered?".
+ * - `ignore` — never consulted. Reads and `wait` answer about the tree as
+ *   captured; a covered element still exists, still has text, and still
+ *   satisfies a presence wait.
+ */
+export type SelectorOcclusionStage = 'exclude-and-refuse' | 'refuse' | 'ignore';
+
+/**
+ * Consumed by `throwIfOffscreenInteractionTarget`
+ * (commands/interaction/runtime/resolution.ts), the end-to-end enforcement
+ * point including the iOS live-rect rescue probe (#1542).
+ *
+ * - `refuse` — a target whose tap point lies outside the viewport refuses
+ *   instead of tapping coordinates nothing occupies.
+ * - `ignore` — reads, `wait`, the diagnosis probe, and mutating `find` (whose
+ *   click/fill re-enter the interaction leaf, where the acting row refuses).
+ */
+export type SelectorOffscreenStage = 'refuse' | 'ignore';
+
+/**
+ * Consumed by `resolveSelectorPipelineTarget`.
+ *
+ * - `hittable-ancestor` — retarget a non-tappable match to the actionable node
+ *   that owns it (`resolveActionableTouchResolution`). Tap-shaped commands.
+ * - `hittable-ancestor-below-root` — the same promotion, except a promotion
+ *   that lands on the viewport root container keeps the original match:
+ *   `find` ranks matches across the whole tree, and a root-sized target is a
+ *   tap on "the screen", not on the thing that matched.
+ * - `none` — act on the resolved node itself. `fill`/`focus` need the element
+ *   that takes the text or the focus, gesture endpoints name contact points,
+ *   and reads must not answer about an ancestor the caller did not select.
+ */
+export type SelectorPromotionStage = 'hittable-ancestor' | 'hittable-ancestor-below-root' | 'none';
+
+/** The poll budget of a row that polls, consumed by `selectorPollBudget`. */
+export type SelectorPollBudget = {
+  /** Used when the caller passes no explicit timeout. */
+  defaultTimeoutMs: number;
+  /** Delay between polls, clamped to the remaining budget. */
+  intervalMs: number;
+};
+
+/**
+ * Consumed by `selectorPollBudget`, which `createWaitPolling` derives its
+ * deadline and sleep from. `'none'` is a real answer, not an omission: a row
+ * that resolves against one capture has no polling contract, and asking for
+ * its budget is a bug rather than a defaulting opportunity.
+ */
+export type SelectorPollStage = SelectorPollBudget | 'none';
+
+export type SelectorPipelinePolicy = {
+  /** The ambiguity contract this row resolves under (#1630). */
+  resolution: SelectorResolutionPolicy;
+  occlusion: SelectorOcclusionStage;
+  offscreen: SelectorOffscreenStage;
+  promotion: SelectorPromotionStage;
+  poll: SelectorPollStage;
+};
+
+/** Shared by both wait loops; they differ only in what each poll resolves. */
+const WAIT_POLL_BUDGET: SelectorPollBudget = { defaultTimeoutMs: 10_000, intervalMs: 300 };
+
+export const SELECTOR_PIPELINE_POLICIES = {
+  /** `click`/`press`/`longpress`: the tap lands on the actionable owner of the match. */
+  promotedTarget: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.act,
+    occlusion: 'exclude-and-refuse',
+    offscreen: 'refuse',
+    promotion: 'hittable-ancestor',
+    poll: 'none',
+  },
+  /**
+   * `fill`/`focus`/`scroll`/gesture endpoints, and the native-ref preflight —
+   * every acting path that must keep the element it resolved. The preflight
+   * shares this row deliberately: it guards the backend fast path without ever
+   * changing which element the backend acts on (ADR 0011).
+   */
+  resolvedTarget: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.act,
+    occlusion: 'exclude-and-refuse',
+    offscreen: 'refuse',
+    promotion: 'none',
+    poll: 'none',
+  },
+  /** The post-miss probe deciding "no match" vs "matched but covered". */
+  coveredDiagnosis: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.actCoveredDiagnosis,
+    occlusion: 'refuse',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: 'none',
+  },
+  /** `get text`. */
+  readText: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.readText,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: 'none',
+  },
+  /** `is` non-exists predicates and `get attrs`. */
+  readUnique: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.readUnique,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: 'none',
+  },
+  /** `is exists` and find's read-only actions. */
+  readAny: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.readAny,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: 'none',
+  },
+  /** `find <q> wait`: the read row above, re-resolved under the wait budget. */
+  findWait: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.readAny,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: WAIT_POLL_BUDGET,
+  },
+  /** `wait` (selector and text targets). */
+  wait: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.wait,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: WAIT_POLL_BUDGET,
+  },
+  /** Mutating `find` (#1625). */
+  findAct: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.findAct,
+    occlusion: 'refuse',
+    offscreen: 'ignore',
+    promotion: 'hittable-ancestor-below-root',
+    poll: 'none',
+  },
+} as const satisfies Record<string, SelectorPipelinePolicy>;
+
+export type SelectorPipelinePolicyName = keyof typeof SELECTOR_PIPELINE_POLICIES;
+
+/**
+ * The rows an acting interaction may consume. Naming them as a type keeps
+ * `resolveInteractionTarget` from being pointed at a read row, which would
+ * silently drop the occlusion and off-screen stages from a device action.
+ */
+export type ActingPipelinePolicy = (typeof SELECTOR_PIPELINE_POLICIES)[
+  | 'promotedTarget'
+  | 'resolvedTarget'];
+
+/** Stage 1: the nodes this row lets a selector match against. */
+export function selectorPipelineCandidates(
+  policy: SelectorPipelinePolicy,
+  nodes: SnapshotNode[],
+): SnapshotNode[] {
+  if (policy.occlusion !== 'exclude-and-refuse') return nodes;
+  return nodes.filter((node) => !isSnapshotNodeInteractionBlocked(node));
+}
+
+/**
+ * Stage 2, post-resolution: promotion, then the occlusion verdict on what
+ * promotion produced — the order every acting caller ran by hand.
+ *
+ * `occluded` carries the node to NAME in the refusal, which is the promotion
+ * input when the match itself is covered (promotion declines to retarget away
+ * from a covered node) and the promotion output otherwise. The refusal shape
+ * stays with the caller: the same verdict is a thrown interaction error, a
+ * daemon response, or a diagnosis, and those are not interchangeable.
+ */
+export type SelectorPipelineTarget =
+  | { kind: 'target'; node: SnapshotNode }
+  | { kind: 'occluded'; node: SnapshotNode };
+
+export function resolveSelectorPipelineTarget(
+  policy: SelectorPipelinePolicy,
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+): SelectorPipelineTarget {
+  const promoted = promoteSelectorTarget(policy.promotion, nodes, node);
+  if (policy.occlusion === 'ignore') return { kind: 'target', node: promoted.node };
+  if (promoted.covered || isSnapshotNodeInteractionBlocked(promoted.node)) {
+    return { kind: 'occluded', node: promoted.node };
+  }
+  return { kind: 'target', node: promoted.node };
+}
+
+function promoteSelectorTarget(
+  stage: SelectorPromotionStage,
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+): { node: SnapshotNode; covered: boolean } {
+  if (stage === 'none') return { node, covered: false };
+  const resolution = resolveActionableTouchResolution(nodes, node);
+  if (resolution.reason === 'covered') return { node: resolution.node, covered: true };
+  if (
+    stage === 'hittable-ancestor-below-root' &&
+    isRootInteractionContainer(resolution.node, nodes[0]) &&
+    node.rect
+  ) {
+    return { node, covered: false };
+  }
+  return { node: resolution.node, covered: false };
+}
+
+/** Stage 3 is `throwIfOffscreenInteractionTarget`; this is the decision it reads. */
+export function selectorPipelineRefusesOffscreen(policy: SelectorPipelinePolicy): boolean {
+  return policy.offscreen === 'refuse';
+}
+
+/** Stage 4: the poll budget, for the rows that have one. */
+export function selectorPollBudget(policy: SelectorPipelinePolicy): SelectorPollBudget {
+  if (policy.poll === 'none') {
+    throw new Error(
+      'selector pipeline row resolves against one capture and declares no poll budget',
+    );
+  }
+  return policy.poll;
+}

--- a/src/core/selector-pipeline-policy.ts
+++ b/src/core/selector-pipeline-policy.ts
@@ -16,18 +16,14 @@ import {
  * A caller names ONE row here and gets its whole pipeline shape: which
  * ambiguity contract resolves the selector (`resolution`, the matrix row), and
  * which structural stages run around that resolution — occlusion, off-screen,
- * hittable-ancestor promotion, and the poll budget. Those four stages used to
- * be per-caller pipeline code, so "`is` never consults occlusion" was true only
- * as an ABSENCE of code: nothing declared it and nothing could fail if a later
- * edit added it. Here it is a value, and the stage runners below are the only
- * door to each stage, so the value decides.
+ * hittable-ancestor promotion, and the poll budget. The runners below are the
+ * only door to each stage, so a row that skips one still says so as a value:
+ * making `is` consult occlusion means editing this table, not adding a call.
  *
- * Rule of this table, inherited from the #1649 review: a row may only declare
- * what these runners enforce. Every field is read by the runner named in its
- * doc comment, and every row — including the ones whose stages are skips — is
- * driven through those runners in selector-pipeline-policy.test.ts, so flipping
- * any cell changes an assertion. Do not add a column until its runner exists;
- * an unconsumed column reads as truth while being free to drift.
+ * A row may only declare what these runners enforce (#1649 review). Every row,
+ * skips included, is driven through every runner in
+ * selector-pipeline-policy.test.ts, so flipping any cell changes an assertion —
+ * add a column only once a runner reads it.
  */
 
 /**
@@ -83,9 +79,9 @@ export type SelectorPollBudget = {
 
 /**
  * Consumed by `selectorPollBudget`, which `createWaitPolling` derives its
- * deadline and sleep from. `'none'` is a real answer, not an omission: a row
- * that resolves against one capture has no polling contract, and asking for
- * its budget is a bug rather than a defaulting opportunity.
+ * deadline and sleep from. `'none'` is an answer, not an omission: a row that
+ * resolves against one capture has no polling contract, so asking for its
+ * budget is a caller bug — never a place to default one in.
  */
 export type SelectorPollStage = SelectorPollBudget | 'none';
 
@@ -203,13 +199,13 @@ export function selectorPipelineCandidates(
 
 /**
  * Stage 2, post-resolution: promotion, then the occlusion verdict on what
- * promotion produced — the order every acting caller ran by hand.
+ * promotion produced.
  *
- * `occluded` carries the node to NAME in the refusal, which is the promotion
- * input when the match itself is covered (promotion declines to retarget away
- * from a covered node) and the promotion output otherwise. The refusal shape
- * stays with the caller: the same verdict is a thrown interaction error, a
- * daemon response, or a diagnosis, and those are not interchangeable.
+ * `occluded` carries the node to NAME in the refusal — the promotion input
+ * when the match itself is covered (promotion declines to retarget away from a
+ * covered node), the promotion output otherwise. The refusal SHAPE stays with
+ * the caller: this verdict becomes a thrown interaction error, a daemon
+ * response, or a diagnosis, and those are not interchangeable.
  */
 export type SelectorPipelineTarget =
   | { kind: 'target'; node: SnapshotNode }

--- a/src/core/selector-pipeline-policy.ts
+++ b/src/core/selector-pipeline-policy.ts
@@ -1,13 +1,7 @@
-import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import {
   SELECTOR_RESOLUTION_POLICIES,
   type SelectorResolutionPolicy,
 } from '@agent-device/selectors';
-import { isSnapshotNodeInteractionBlocked } from '../snapshot/snapshot-occlusion.ts';
-import {
-  isRootInteractionContainer,
-  resolveActionableTouchResolution,
-} from './interaction-targeting.ts';
 
 /**
  * The structural half of the per-caller selector policy (#1656), companion to
@@ -27,8 +21,8 @@ import {
  */
 
 /**
- * Consumed by `selectorPipelineCandidates` (which nodes may match at all) and
- * by `resolveSelectorPipelineTarget` (whether a covered target refuses).
+ * Read by the pipeline owner's candidacy stage (which nodes may match at all)
+ * and by its node stages (whether a covered target refuses).
  *
  * - `exclude-and-refuse` — covered nodes never become candidates, AND a covered
  *   target refuses. Acting paths: tapping something an overlay covers is the
@@ -55,7 +49,7 @@ export type SelectorOcclusionStage = 'exclude-and-refuse' | 'refuse' | 'ignore';
 export type SelectorOffscreenStage = 'refuse' | 'ignore';
 
 /**
- * Consumed by `resolveSelectorPipelineTarget`.
+ * Read by the pipeline owner's promotion stage.
  *
  * - `hittable-ancestor` — retarget a non-tappable match to the actionable node
  *   that owns it (`resolveActionableTouchResolution`). Tap-shaped commands.
@@ -69,7 +63,7 @@ export type SelectorOffscreenStage = 'refuse' | 'ignore';
  */
 export type SelectorPromotionStage = 'hittable-ancestor' | 'hittable-ancestor-below-root' | 'none';
 
-/** The poll budget of a row that polls, consumed by `selectorPollBudget`. */
+/** The poll budget of a row that polls, read by `selectorPollBudget`. */
 export type SelectorPollBudget = {
   /** Used when the caller passes no explicit timeout. */
   defaultTimeoutMs: number;
@@ -167,6 +161,14 @@ export const SELECTOR_PIPELINE_POLICIES = {
     promotion: 'none',
     poll: WAIT_POLL_BUDGET,
   },
+  /** `find <q> list`: enumerate matches; never narrows, never acts. */
+  readList: {
+    resolution: SELECTOR_RESOLUTION_POLICIES.readList,
+    occlusion: 'ignore',
+    offscreen: 'ignore',
+    promotion: 'none',
+    poll: 'none',
+  },
   /** Mutating `find` (#1625). */
   findAct: {
     resolution: SELECTOR_RESOLUTION_POLICIES.findAct,
@@ -180,79 +182,26 @@ export const SELECTOR_PIPELINE_POLICIES = {
 export type SelectorPipelinePolicyName = keyof typeof SELECTOR_PIPELINE_POLICIES;
 
 /**
+ * The two questions a row asks the engine, derived from its ambiguity contract
+ * rather than from a hand-kept list of row names: `reject-candidates` rows go
+ * through `listSelectorPipelineMatches` (the caller narrows or refuses), every
+ * other row through `resolveSelectorPipeline`. Pointing a route at the wrong
+ * family is a compile error, so a row cannot quietly change which door it uses.
+ */
+type PipelineRow = (typeof SELECTOR_PIPELINE_POLICIES)[SelectorPipelinePolicyName];
+
+export type CandidateSetPipelinePolicy = Extract<
+  PipelineRow,
+  { resolution: { ambiguity: 'reject-candidates' } }
+>;
+
+export type SingleTargetPipelinePolicy = Exclude<PipelineRow, CandidateSetPipelinePolicy>;
+
+/**
  * The rows an acting interaction may consume. Naming them as a type keeps
  * `resolveInteractionTarget` from being pointed at a read row, which would
- * silently drop the occlusion and off-screen stages from a device action.
+ * drop the occlusion and off-screen stages from a device action.
  */
 export type ActingPipelinePolicy = (typeof SELECTOR_PIPELINE_POLICIES)[
   | 'promotedTarget'
   | 'resolvedTarget'];
-
-/** Stage 1: the nodes this row lets a selector match against. */
-export function selectorPipelineCandidates(
-  policy: SelectorPipelinePolicy,
-  nodes: SnapshotNode[],
-): SnapshotNode[] {
-  if (policy.occlusion !== 'exclude-and-refuse') return nodes;
-  return nodes.filter((node) => !isSnapshotNodeInteractionBlocked(node));
-}
-
-/**
- * Stage 2, post-resolution: promotion, then the occlusion verdict on what
- * promotion produced.
- *
- * `occluded` carries the node to NAME in the refusal — the promotion input
- * when the match itself is covered (promotion declines to retarget away from a
- * covered node), the promotion output otherwise. The refusal SHAPE stays with
- * the caller: this verdict becomes a thrown interaction error, a daemon
- * response, or a diagnosis, and those are not interchangeable.
- */
-export type SelectorPipelineTarget =
-  | { kind: 'target'; node: SnapshotNode }
-  | { kind: 'occluded'; node: SnapshotNode };
-
-export function resolveSelectorPipelineTarget(
-  policy: SelectorPipelinePolicy,
-  nodes: SnapshotNode[],
-  node: SnapshotNode,
-): SelectorPipelineTarget {
-  const promoted = promoteSelectorTarget(policy.promotion, nodes, node);
-  if (policy.occlusion === 'ignore') return { kind: 'target', node: promoted.node };
-  if (promoted.covered || isSnapshotNodeInteractionBlocked(promoted.node)) {
-    return { kind: 'occluded', node: promoted.node };
-  }
-  return { kind: 'target', node: promoted.node };
-}
-
-function promoteSelectorTarget(
-  stage: SelectorPromotionStage,
-  nodes: SnapshotNode[],
-  node: SnapshotNode,
-): { node: SnapshotNode; covered: boolean } {
-  if (stage === 'none') return { node, covered: false };
-  const resolution = resolveActionableTouchResolution(nodes, node);
-  if (resolution.reason === 'covered') return { node: resolution.node, covered: true };
-  if (
-    stage === 'hittable-ancestor-below-root' &&
-    isRootInteractionContainer(resolution.node, nodes[0]) &&
-    node.rect
-  ) {
-    return { node, covered: false };
-  }
-  return { node: resolution.node, covered: false };
-}
-
-/** Stage 3 is `throwIfOffscreenInteractionTarget`; this is the decision it reads. */
-export function selectorPipelineRefusesOffscreen(policy: SelectorPipelinePolicy): boolean {
-  return policy.offscreen === 'refuse';
-}
-
-/** Stage 4: the poll budget, for the rows that have one. */
-export function selectorPollBudget(policy: SelectorPipelinePolicy): SelectorPollBudget {
-  if (policy.poll === 'none') {
-    throw new Error(
-      'selector pipeline row resolves against one capture and declares no poll budget',
-    );
-  }
-  return policy.poll;
-}

--- a/src/core/selector-pipeline.test.ts
+++ b/src/core/selector-pipeline.test.ts
@@ -9,10 +9,23 @@ import {
   runNodePipelineStages,
   selectorPollBudget,
 } from './selector-pipeline.ts';
-import {
-  SELECTOR_PIPELINE_POLICIES,
-  type SelectorPipelinePolicyName,
-} from './selector-pipeline-policy.ts';
+import { SELECTOR_PIPELINE_POLICIES } from './selector-pipeline-policy.ts';
+
+/**
+ * Rows whose result is ONE target. The listing row is absent by TYPE, not by
+ * omission: it declares no node stages, so the entries below cannot take it.
+ */
+const NODE_STAGE_ROWS = [
+  'promotedTarget',
+  'resolvedTarget',
+  'coveredDiagnosis',
+  'readText',
+  'readUnique',
+  'readAny',
+  'findWait',
+  'wait',
+  'findAct',
+] as const;
 
 /**
  * The owner's own contract: that it runs what a row declares, for every row.
@@ -23,7 +36,6 @@ import {
  * pipeline nothing calls, those would pass on a pipeline that ignores its row.
  */
 
-const ROWS = Object.keys(SELECTOR_PIPELINE_POLICIES) as SelectorPipelinePolicyName[];
 const MATCH = { platform: 'ios' as const };
 
 /** A covered button beside an uncovered twin, under a full-screen root. */
@@ -95,7 +107,11 @@ function nodesOf(raw: RawSnapshotNode[]): SnapshotNode[] {
   return makeSnapshotState(raw).nodes;
 }
 
-async function stagedIndex(row: SelectorPipelinePolicyName, raw: RawSnapshotNode[], index: number) {
+async function stagedIndex(
+  row: (typeof NODE_STAGE_ROWS)[number],
+  raw: RawSnapshotNode[],
+  index: number,
+) {
   const nodes = nodesOf(raw);
   const policy = SELECTOR_PIPELINE_POLICIES[row];
   const target = await runNodePipelineStages(policy, nodes, nodes[index]!, {
@@ -142,14 +158,9 @@ test('the occlusion stage decides refusal: every row that refuses a covered targ
     assert.equal(target.kind, 'occluded', row);
     assert.equal(target.node.index, 1, row);
   }
-  for (const row of [
-    'readText',
-    'readUnique',
-    'readAny',
-    'wait',
-    'findWait',
-    'readList',
-  ] as const) {
+  // `readList` is absent by construction: a listing row declares no node
+  // stages, so it has no occlusion verdict to make on a target.
+  for (const row of ['readText', 'readUnique', 'readAny', 'wait', 'findWait'] as const) {
     const target = await stagedIndex(row, COVERED_TREE, 1);
     assert.equal(target.kind, 'target', row);
     assert.equal(target.node.index, 1, row);
@@ -174,7 +185,7 @@ test('find’s promotion stops below the viewport root; the tap row does not', a
 
 test('the off-screen stage runs the refusal shape only for the rows that refuse', async () => {
   const nodes = nodesOf(PROMOTABLE_TREE);
-  for (const row of ROWS) {
+  for (const row of NODE_STAGE_ROWS) {
     let consulted = false;
     await runNodePipelineStages(SELECTOR_PIPELINE_POLICIES[row], nodes, nodes[0]!, {
       offscreen: async (node) => {
@@ -205,21 +216,46 @@ test('the poll stage answers only for the rows that poll', () => {
       intervalMs: 300,
     });
   }
-  for (const row of ROWS.filter((name) => name !== 'wait' && name !== 'findWait')) {
+  for (const row of NODE_STAGE_ROWS.filter((name) => name !== 'wait' && name !== 'findWait')) {
     assert.throws(() => selectorPollBudget(SELECTOR_PIPELINE_POLICIES[row]), /no poll budget/, row);
   }
 });
 
-test('pipeline rows declare only the stages these runners enforce', () => {
+test('a listing row cannot be handed the node stages it does not declare', () => {
+  // The `@ts-expect-error` directives ARE the assertion: a listing has no
+  // single target to retarget, keep on screen, or wait for, so widening
+  // `readList` to declare one of those stages makes these calls legal, leaves
+  // the directives unused, and fails the typecheck. Type-level rather than
+  // executed, because the point is that these entries never accept the row.
+
+  // @ts-expect-error a listing row declares no promotion or off-screen stage.
+  const nodeStages: Parameters<typeof runNodePipelineStages>[0] =
+    SELECTOR_PIPELINE_POLICIES.readList;
+  // @ts-expect-error a listing row declares no poll budget to ask for.
+  const pollBudget: Parameters<typeof selectorPollBudget>[0] = SELECTOR_PIPELINE_POLICIES.readList;
+
+  // The runtime half of the same claim, so the row cannot grow a node stage
+  // while the directives are updated to match.
+  assert.deepEqual(
+    Object.keys(SELECTOR_PIPELINE_POLICIES.readList).filter((stage) =>
+      ['promotion', 'offscreen', 'poll'].includes(stage),
+    ),
+    [],
+  );
+  assert.ok(nodeStages && pollBudget);
+});
+
+test('pipeline rows declare only the stages their kind enforces', () => {
   // The #1649 rule, carried to this table: a column nothing consumes is an
-  // unverifiable claim that reads as truth. Adding a field here fails until a
-  // runner reads it and every row is driven through that runner.
+  // unverifiable claim that reads as truth. A row declares the stages ITS KIND
+  // can run — a listing row that grew a `promotion` cell would be claiming a
+  // stage no listing flow executes, which is the same disease one level down.
+  const TARGET_ROW_STAGES = ['occlusion', 'offscreen', 'poll', 'promotion', 'resolution'];
+  const LIST_ROW_STAGES = ['occlusion', 'resolution'];
   for (const [name, policy] of Object.entries(SELECTOR_PIPELINE_POLICIES)) {
-    assert.deepEqual(
-      Object.keys(policy).sort(),
-      ['occlusion', 'offscreen', 'poll', 'promotion', 'resolution'],
-      `${name} declares a stage no runner consumes`,
-    );
+    const declared = Object.keys(policy).sort();
+    const expected = name === 'readList' ? LIST_ROW_STAGES : TARGET_ROW_STAGES;
+    assert.deepEqual(declared, expected, `${name} declares a stage its kind cannot run`);
   }
 });
 
@@ -238,15 +274,18 @@ test('every ambiguity row is named by a pipeline row', () => {
 test('the documented per-caller pipelines are the ones declared', () => {
   assert.deepEqual(
     Object.fromEntries(
-      Object.entries(SELECTOR_PIPELINE_POLICIES).map(([name, policy]) => [
-        name,
-        [
-          policy.occlusion,
-          policy.offscreen,
-          policy.promotion,
-          policy.poll === 'none' ? 'no-poll' : 'poll',
-        ],
-      ]),
+      NODE_STAGE_ROWS.map((name) => {
+        const policy = SELECTOR_PIPELINE_POLICIES[name];
+        return [
+          name,
+          [
+            policy.occlusion,
+            policy.offscreen,
+            policy.promotion,
+            policy.poll === 'none' ? 'no-poll' : 'poll',
+          ],
+        ];
+      }),
     ),
     {
       promotedTarget: ['exclude-and-refuse', 'refuse', 'hittable-ancestor', 'no-poll'],
@@ -257,7 +296,6 @@ test('the documented per-caller pipelines are the ones declared', () => {
       readAny: ['ignore', 'ignore', 'none', 'no-poll'],
       findWait: ['ignore', 'ignore', 'none', 'poll'],
       wait: ['ignore', 'ignore', 'none', 'poll'],
-      readList: ['ignore', 'ignore', 'none', 'no-poll'],
       findAct: ['refuse', 'ignore', 'hittable-ancestor-below-root', 'no-poll'],
     },
   );

--- a/src/core/selector-pipeline.test.ts
+++ b/src/core/selector-pipeline.test.ts
@@ -1,28 +1,30 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapshot';
 import { SELECTOR_RESOLUTION_POLICIES } from '@agent-device/selectors';
 import { makeSnapshotState } from '../__tests__/test-utils/index.ts';
 import {
-  SELECTOR_PIPELINE_POLICIES,
-  resolveSelectorPipelineTarget,
-  selectorPipelineCandidates,
-  selectorPipelineRefusesOffscreen,
+  listSelectorPipelineMatches,
+  resolveSelectorPipeline,
+  runNodePipelineStages,
   selectorPollBudget,
+} from './selector-pipeline.ts';
+import {
+  SELECTOR_PIPELINE_POLICIES,
   type SelectorPipelinePolicyName,
 } from './selector-pipeline-policy.ts';
 
 /**
- * #1656: every row is driven through every runner — including the rows whose
- * answer is "skip this stage", since a skip nothing exercises is a claim that
- * cannot fail. Flip any cell in the table and an assertion here changes.
- *
- * Which stages a given CALLER runs is a separate question, pinned by the
- * caller-level suites (resolution.test.ts, find handler tests, selector-read
- * policy tests).
+ * The owner's own contract: that it runs what a row declares, for every row.
+ * Whether a given COMMAND runs the row is proven where it can actually be
+ * falsified — against `get`/`is`/`wait`/`find` in
+ * commands/interaction/runtime/__tests__/selector-read-policy.test.ts and
+ * resolution.test.ts. Neither file alone is enough: this one would pass on a
+ * pipeline nothing calls, those would pass on a pipeline that ignores its row.
  */
 
 const ROWS = Object.keys(SELECTOR_PIPELINE_POLICIES) as SelectorPipelinePolicyName[];
+const MATCH = { platform: 'ios' as const };
 
 /** A covered button beside an uncovered twin, under a full-screen root. */
 const COVERED_TREE: RawSnapshotNode[] = [
@@ -42,15 +44,6 @@ const COVERED_TREE: RawSnapshotNode[] = [
     rect: { x: 20, y: 700, width: 100, height: 40 },
     hittable: false,
     interactionBlocked: 'covered',
-  },
-  {
-    index: 2,
-    depth: 1,
-    parentIndex: 0,
-    type: 'XCUIElementTypeButton',
-    label: 'Save',
-    rect: { x: 20, y: 200, width: 100, height: 40 },
-    hittable: true,
   },
 ];
 
@@ -98,74 +91,111 @@ const ROOT_ANCESTOR_TREE: RawSnapshotNode[] = [
   },
 ];
 
-function nodesOf(raw: RawSnapshotNode[]) {
+function nodesOf(raw: RawSnapshotNode[]): SnapshotNode[] {
   return makeSnapshotState(raw).nodes;
 }
 
-function candidateIndexes(row: SelectorPipelinePolicyName): number[] {
-  return selectorPipelineCandidates(SELECTOR_PIPELINE_POLICIES[row], nodesOf(COVERED_TREE)).map(
-    (node) => node.index,
-  );
-}
-
-function targetFor(row: SelectorPipelinePolicyName, raw: RawSnapshotNode[], index: number) {
+async function stagedIndex(row: SelectorPipelinePolicyName, raw: RawSnapshotNode[], index: number) {
   const nodes = nodesOf(raw);
-  return resolveSelectorPipelineTarget(SELECTOR_PIPELINE_POLICIES[row], nodes, nodes[index]!);
+  const policy = SELECTOR_PIPELINE_POLICIES[row];
+  const target = await runNodePipelineStages(policy, nodes, nodes[index]!, {
+    // Supplied for every row; only rows whose off-screen stage refuses reach it.
+    offscreen: async (node) => node,
+  });
+  return target;
 }
 
-test('the occlusion stage decides candidacy: acting rows drop covered nodes, the rest keep them', () => {
+test('the occlusion stage decides candidacy: acting rows drop covered nodes, the rest keep them', async () => {
+  const nodes = nodesOf(COVERED_TREE);
   for (const row of ['promotedTarget', 'resolvedTarget'] as const) {
-    assert.deepEqual(candidateIndexes(row), [0, 2], row);
+    const listed = listSelectorPipelineMatches(
+      SELECTOR_PIPELINE_POLICIES[row],
+      nodes,
+      'label="Save"',
+      MATCH,
+    );
+    assert.equal(listed.list, null, row);
   }
-  // `refuse` rows see covered nodes (find ranks them, the probe diagnoses
-  // them) and `ignore` rows answer about the tree as captured.
-  for (const row of ['findAct', 'coveredDiagnosis', 'readText', 'readUnique'] as const) {
-    assert.deepEqual(candidateIndexes(row), [0, 1, 2], row);
+  for (const row of ['findAct', 'readList'] as const) {
+    const listed = listSelectorPipelineMatches(
+      SELECTOR_PIPELINE_POLICIES[row],
+      nodes,
+      'label="Save"',
+      MATCH,
+    );
+    assert.equal(listed.list?.matchedNodes.length, 1, row);
   }
-  for (const row of ['readAny', 'wait', 'findWait'] as const) {
-    assert.deepEqual(candidateIndexes(row), [0, 1, 2], row);
+  for (const row of ['readText', 'readUnique', 'readAny', 'wait', 'findWait'] as const) {
+    const outcome = await resolveSelectorPipeline(
+      SELECTOR_PIPELINE_POLICIES[row],
+      nodes,
+      'label="Save"',
+      MATCH,
+    );
+    assert.equal(outcome.kind, 'target', row);
   }
 });
 
-test('the occlusion stage decides refusal: every row that refuses covered targets, and every row that does not', () => {
+test('the occlusion stage decides refusal: every row that refuses a covered target, and every row that does not', async () => {
   for (const row of ['promotedTarget', 'resolvedTarget', 'findAct', 'coveredDiagnosis'] as const) {
-    const target = targetFor(row, COVERED_TREE, 1);
+    const target = await stagedIndex(row, COVERED_TREE, 1);
     assert.equal(target.kind, 'occluded', row);
     assert.equal(target.node.index, 1, row);
   }
-  for (const row of ['readText', 'readUnique', 'readAny', 'wait', 'findWait'] as const) {
-    const target = targetFor(row, COVERED_TREE, 1);
+  for (const row of [
+    'readText',
+    'readUnique',
+    'readAny',
+    'wait',
+    'findWait',
+    'readList',
+  ] as const) {
+    const target = await stagedIndex(row, COVERED_TREE, 1);
     assert.equal(target.kind, 'target', row);
     assert.equal(target.node.index, 1, row);
   }
 });
 
-test('the promotion stage retargets only for the rows that declare it', () => {
+test('the promotion stage retargets only for the rows that declare it', async () => {
   // Same tree, same node: the row is the whole difference.
-  assert.equal(targetFor('promotedTarget', PROMOTABLE_TREE, 1).node.index, 0);
-  assert.equal(targetFor('findAct', PROMOTABLE_TREE, 1).node.index, 0);
+  assert.equal((await stagedIndex('promotedTarget', PROMOTABLE_TREE, 1)).node.index, 0);
+  assert.equal((await stagedIndex('findAct', PROMOTABLE_TREE, 1)).node.index, 0);
   for (const row of ['resolvedTarget', 'readText', 'readUnique', 'readAny', 'wait'] as const) {
-    assert.equal(targetFor(row, PROMOTABLE_TREE, 1).node.index, 1, row);
+    assert.equal((await stagedIndex(row, PROMOTABLE_TREE, 1)).node.index, 1, row);
   }
 });
 
-test('find’s promotion stops below the viewport root; the tap row does not', () => {
+test('find’s promotion stops below the viewport root; the tap row does not', async () => {
   // `find` ranks matches across the whole tree, so a promotion that lands on
   // the root container would turn "the thing that matched" into "the screen".
-  assert.equal(targetFor('promotedTarget', ROOT_ANCESTOR_TREE, 1).node.index, 0);
-  assert.equal(targetFor('findAct', ROOT_ANCESTOR_TREE, 1).node.index, 1);
+  assert.equal((await stagedIndex('promotedTarget', ROOT_ANCESTOR_TREE, 1)).node.index, 0);
+  assert.equal((await stagedIndex('findAct', ROOT_ANCESTOR_TREE, 1)).node.index, 1);
 });
 
-test('the off-screen stage refuses for acting rows and is skipped by observation rows', () => {
-  // The guard itself (including the iOS live-rect rescue) is exercised in
-  // commands/interaction/runtime/resolution.test.ts; this pins which rows
-  // reach it at all.
-  for (const row of ['promotedTarget', 'resolvedTarget'] as const) {
-    assert.equal(selectorPipelineRefusesOffscreen(SELECTOR_PIPELINE_POLICIES[row]), true, row);
+test('the off-screen stage runs the refusal shape only for the rows that refuse', async () => {
+  const nodes = nodesOf(PROMOTABLE_TREE);
+  for (const row of ROWS) {
+    let consulted = false;
+    await runNodePipelineStages(SELECTOR_PIPELINE_POLICIES[row], nodes, nodes[0]!, {
+      offscreen: async (node) => {
+        consulted = true;
+        return node;
+      },
+    });
+    const refuses = SELECTOR_PIPELINE_POLICIES[row].offscreen === 'refuse';
+    assert.equal(consulted, refuses, row);
   }
-  for (const row of ROWS.filter((name) => name !== 'promotedTarget' && name !== 'resolvedTarget')) {
-    assert.equal(selectorPipelineRefusesOffscreen(SELECTOR_PIPELINE_POLICIES[row]), false, row);
-  }
+});
+
+test('a row that refuses off-screen without a refusal shape fails loudly', async () => {
+  // What a flipped observation row hits on its real route: the row declares a
+  // refusal the route has no error to express, and that is a bug, not a
+  // silently skipped stage.
+  const nodes = nodesOf(PROMOTABLE_TREE);
+  await assert.rejects(
+    () => runNodePipelineStages(SELECTOR_PIPELINE_POLICIES.promotedTarget, nodes, nodes[0]!),
+    /supplies no refusal shape/,
+  );
 });
 
 test('the poll stage answers only for the rows that poll', () => {
@@ -183,7 +213,7 @@ test('the poll stage answers only for the rows that poll', () => {
 test('pipeline rows declare only the stages these runners enforce', () => {
   // The #1649 rule, carried to this table: a column nothing consumes is an
   // unverifiable claim that reads as truth. Adding a field here fails until a
-  // runner above reads it and this suite drives every row through it.
+  // runner reads it and every row is driven through that runner.
   for (const [name, policy] of Object.entries(SELECTOR_PIPELINE_POLICIES)) {
     assert.deepEqual(
       Object.keys(policy).sort(),
@@ -227,6 +257,7 @@ test('the documented per-caller pipelines are the ones declared', () => {
       readAny: ['ignore', 'ignore', 'none', 'no-poll'],
       findWait: ['ignore', 'ignore', 'none', 'poll'],
       wait: ['ignore', 'ignore', 'none', 'poll'],
+      readList: ['ignore', 'ignore', 'none', 'no-poll'],
       findAct: ['refuse', 'ignore', 'hittable-ancestor-below-root', 'no-poll'],
     },
   );

--- a/src/core/selector-pipeline.ts
+++ b/src/core/selector-pipeline.ts
@@ -27,13 +27,13 @@ import type {
  * cannot pair one row's candidate set with another row's ambiguity contract:
  * the row enters once, at the top.
  *
- * That containment is the point. While callers composed the stages by hand, a
- * read route could declare `promotion: 'none'` and be believed without
- * executing anything — the cell was true of the table and unfalsifiable in
- * production. Flipping any cell now changes what `get`, `is`, `wait`, `find`,
- * `click`, and `fill` do, because those routes run the row rather than
- * re-deriving it. `scripts/layering/selector-pipeline-ownership.ts` keeps the
- * raw engine unreachable from anywhere else.
+ * That containment is what makes a cell falsifiable. A route that composes the
+ * stages itself can declare `promotion: 'none'` and be believed without
+ * executing anything, which is true of the table and unprovable in production;
+ * because every route runs its row here instead of re-deriving it, flipping any
+ * cell changes what `get`, `is`, `wait`, `find`, `click`, and `fill` do.
+ * `scripts/layering/selector-pipeline-ownership.ts` keeps the raw engine
+ * unreachable from anywhere else, so that stays true.
  *
  * Three entries, because the rows genuinely ask two different questions of the
  * engine and one route family never asks it at all:

--- a/src/core/selector-pipeline.ts
+++ b/src/core/selector-pipeline.ts
@@ -1,0 +1,221 @@
+import type { SnapshotNode } from '@agent-device/kernel/snapshot';
+import {
+  listSelectorChainMatches,
+  resolveSelectorChainWithPolicy,
+  type SelectorChainMatchList,
+  type SelectorMatchOptions,
+} from '@agent-device/selectors';
+import { isSnapshotNodeInteractionBlocked } from '../snapshot/snapshot-occlusion.ts';
+import {
+  isRootInteractionContainer,
+  resolveActionableTouchResolution,
+} from './interaction-targeting.ts';
+import type {
+  CandidateSetPipelinePolicy,
+  SelectorPipelinePolicy,
+  SelectorPollBudget,
+  SelectorPromotionStage,
+  SingleTargetPipelinePolicy,
+} from './selector-pipeline-policy.ts';
+
+/**
+ * The owner of selector resolution (#1656). Every native route reaches the
+ * matching engine and the structural stages ONLY through the entries below,
+ * which take a policy row and run what it declares — including the stages it
+ * declares as skips. The stage functions themselves are private to this
+ * module, so a caller cannot run three stages and forget the fourth, and
+ * cannot pair one row's candidate set with another row's ambiguity contract:
+ * the row enters once, at the top.
+ *
+ * That containment is the point. While callers composed the stages by hand, a
+ * read route could declare `promotion: 'none'` and be believed without
+ * executing anything — the cell was true of the table and unfalsifiable in
+ * production. Flipping any cell now changes what `get`, `is`, `wait`, `find`,
+ * `click`, and `fill` do, because those routes run the row rather than
+ * re-deriving it. `scripts/layering/selector-pipeline-ownership.ts` keeps the
+ * raw engine unreachable from anywhere else.
+ *
+ * Three entries, because the rows genuinely ask two different questions of the
+ * engine and one route family never asks it at all:
+ * - `resolveSelectorPipeline` — rows that want ONE target (reads, `wait`, the
+ *   covered-diagnosis probe).
+ * - `listSelectorPipelineMatches` — `reject-candidates` rows, whose contract is
+ *   that the caller sees every candidate and narrows or refuses explicitly.
+ * - `runNodePipelineStages` — the node stages for a target that came from a
+ *   non-chain matcher (`@ref` lookup, find's fuzzy locator) or from a narrowed
+ *   candidate set. Not a bypass: it runs every stage the row declares.
+ */
+
+export type SelectorPipelineHooks = {
+  /**
+   * Runs on the resolution winner BEFORE promotion — the replay identity guard
+   * (ADR 0012 step 4), which must compare the node the selector actually bound
+   * to, not the container promotion may retarget to.
+   */
+  onResolved?: (node: SnapshotNode, nodes: SnapshotNode[]) => void;
+  /**
+   * The off-screen stage's refusal. Required by rows declaring
+   * `offscreen: 'refuse'` and never called for rows that ignore it, so a row
+   * flipped to refuse without giving its route a refusal shape fails loudly
+   * instead of silently observing.
+   */
+  offscreen?: (node: SnapshotNode, nodes: SnapshotNode[]) => Promise<SnapshotNode>;
+};
+
+export type SelectorPipelineTarget =
+  | { kind: 'target'; node: SnapshotNode }
+  | { kind: 'occluded'; node: SnapshotNode };
+
+export type SelectorPipelineOutcome =
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; selector: string; selectorIndex: number; matchedNodes: SnapshotNode[] }
+  /** `selector` is the ALTERNATIVE that matched, which is what a refusal names. */
+  | { kind: 'occluded'; node: SnapshotNode; selector: string }
+  | {
+      kind: 'target';
+      node: SnapshotNode;
+      selector: string;
+      selectorIndex: number;
+      matches: number;
+      matchedNodes: SnapshotNode[];
+    };
+
+/** Rows that resolve one target: candidacy, ambiguity, then every node stage. */
+export async function resolveSelectorPipeline(
+  policy: SingleTargetPipelinePolicy,
+  nodes: SnapshotNode[],
+  selector: string,
+  match: SelectorMatchOptions,
+  hooks: SelectorPipelineHooks = {},
+): Promise<SelectorPipelineOutcome> {
+  const outcome = resolveSelectorChainWithPolicy(
+    pipelineCandidates(policy, nodes),
+    selector,
+    policy.resolution,
+    match,
+  );
+  if (outcome.kind === 'none') return { kind: 'none' };
+  if (outcome.kind === 'ambiguous') {
+    return {
+      kind: 'ambiguous',
+      selector: outcome.selector,
+      selectorIndex: outcome.selectorIndex,
+      matchedNodes: outcome.matchedNodes,
+    };
+  }
+  const resolution = outcome.resolution;
+  const staged = await runNodePipelineStages(policy, nodes, resolution.node, hooks);
+  if (staged.kind === 'occluded') {
+    return { kind: 'occluded', node: staged.node, selector: resolution.selector };
+  }
+  return {
+    kind: 'target',
+    node: staged.node,
+    selector: resolution.selector,
+    selectorIndex: resolution.selectorIndex,
+    matches: resolution.matches,
+    matchedNodes: outcome.matchedNodes,
+  };
+}
+
+/**
+ * `reject-candidates` rows: the caller gets the whole candidate set of the
+ * first matching alternative and must narrow or refuse it, then bring the node
+ * it chose back through `runNodePipelineStages`.
+ *
+ * `candidates` is the tree as this row sees it — the candidacy stage's output.
+ * A caller that reasons about the surroundings of a match (find's ranking, the
+ * acting equivalence classification) must reason about THAT tree, or an
+ * overlay-covered node would come back as a competitor the row already excluded.
+ */
+export type SelectorPipelineMatches = {
+  candidates: SnapshotNode[];
+  list: SelectorChainMatchList | null;
+};
+
+export function listSelectorPipelineMatches(
+  policy: CandidateSetPipelinePolicy,
+  nodes: SnapshotNode[],
+  selector: string,
+  match: SelectorMatchOptions,
+): SelectorPipelineMatches {
+  const candidates = pipelineCandidates(policy, nodes);
+  return {
+    candidates,
+    list: listSelectorChainMatches(candidates, selector, {
+      ...match,
+      requireRect: policy.resolution.requireRect,
+    }),
+  };
+}
+
+/** Every node stage this row declares, in the order acting routes need them. */
+export async function runNodePipelineStages(
+  policy: SelectorPipelinePolicy,
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+  hooks: SelectorPipelineHooks = {},
+): Promise<SelectorPipelineTarget> {
+  hooks.onResolved?.(node, nodes);
+  const promoted = promoteTarget(policy.promotion, nodes, node);
+  if (policy.occlusion !== 'ignore') {
+    if (promoted.covered || isSnapshotNodeInteractionBlocked(promoted.node)) {
+      return { kind: 'occluded', node: promoted.node };
+    }
+  }
+  return { kind: 'target', node: await guardOffscreen(policy, nodes, promoted.node, hooks) };
+}
+
+/** The nodes this row lets a selector match against. */
+function pipelineCandidates(policy: SelectorPipelinePolicy, nodes: SnapshotNode[]): SnapshotNode[] {
+  if (policy.occlusion !== 'exclude-and-refuse') return nodes;
+  return nodes.filter((candidate) => !isSnapshotNodeInteractionBlocked(candidate));
+}
+
+/**
+ * `covered` reports that the match itself is blocked: promotion declines to
+ * retarget away from a covered node, so the caller names the node it asked
+ * about rather than an ancestor it never selected.
+ */
+function promoteTarget(
+  stage: SelectorPromotionStage,
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+): { node: SnapshotNode; covered: boolean } {
+  if (stage === 'none') return { node, covered: false };
+  const resolution = resolveActionableTouchResolution(nodes, node);
+  if (resolution.reason === 'covered') return { node: resolution.node, covered: true };
+  if (
+    stage === 'hittable-ancestor-below-root' &&
+    isRootInteractionContainer(resolution.node, nodes[0]) &&
+    node.rect
+  ) {
+    return { node, covered: false };
+  }
+  return { node: resolution.node, covered: false };
+}
+
+async function guardOffscreen(
+  policy: SelectorPipelinePolicy,
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+  hooks: SelectorPipelineHooks,
+): Promise<SnapshotNode> {
+  if (policy.offscreen !== 'refuse') return node;
+  if (!hooks.offscreen) {
+    throw new Error(
+      'selector pipeline row declares an off-screen refusal but this route supplies no refusal shape',
+    );
+  }
+  return await hooks.offscreen(node, nodes);
+}
+
+/** The poll stage: the budget `createWaitPolling` runs the row under. */
+export function selectorPollBudget(policy: SelectorPipelinePolicy): SelectorPollBudget {
+  if (policy.poll === 'none') {
+    throw new Error(
+      'selector pipeline row resolves against one capture and declares no poll budget',
+    );
+  }
+  return policy.poll;
+}

--- a/src/core/selector-pipeline.ts
+++ b/src/core/selector-pipeline.ts
@@ -1,10 +1,9 @@
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
+import type { SelectorChainMatchList, SelectorMatchOptions } from '@agent-device/selectors';
 import {
   listSelectorChainMatches,
   resolveSelectorChainWithPolicy,
-  type SelectorChainMatchList,
-  type SelectorMatchOptions,
-} from '@agent-device/selectors';
+} from '@agent-device/selectors/engine';
 import { isSnapshotNodeInteractionBlocked } from '../snapshot/snapshot-occlusion.ts';
 import {
   isRootInteractionContainer,
@@ -12,6 +11,7 @@ import {
 } from './interaction-targeting.ts';
 import type {
   CandidateSetPipelinePolicy,
+  SelectorListPolicy,
   SelectorPipelinePolicy,
   SelectorPollBudget,
   SelectorPromotionStage,
@@ -41,6 +41,9 @@ import type {
  *   covered-diagnosis probe).
  * - `listSelectorPipelineMatches` — `reject-candidates` rows, whose contract is
  *   that the caller sees every candidate and narrows or refuses explicitly.
+ *   A row whose RESULT is the candidate set (`find <q> list`) declares only the
+ *   two stages a listing can run, so the node-stage entries below reject it at
+ *   the type level rather than skipping stages it claimed.
  * - `runNodePipelineStages` — the node stages for a target that came from a
  *   non-chain matcher (`@ref` lookup, find's fuzzy locator) or from a narrowed
  *   candidate set. Not a bypass: it runs every stage the row declares.
@@ -167,7 +170,7 @@ export async function runNodePipelineStages(
 }
 
 /** The nodes this row lets a selector match against. */
-function pipelineCandidates(policy: SelectorPipelinePolicy, nodes: SnapshotNode[]): SnapshotNode[] {
+function pipelineCandidates(policy: SelectorListPolicy, nodes: SnapshotNode[]): SnapshotNode[] {
   if (policy.occlusion !== 'exclude-and-refuse') return nodes;
   return nodes.filter((candidate) => !isSnapshotNodeInteractionBlocked(candidate));
 }

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -77,11 +77,9 @@ type ResolvedMatch = {
   nodes: SnapshotState['nodes'];
   actionFlags: Record<string, unknown>;
   /**
-   * The occlusion verdict the `findAct` row produced for this match, carried
-   * rather than raised: `find click`/`fill` re-enter the interaction leaf,
-   * which refuses covered targets in the acting row's own error shape, so only
-   * the focus/type seam — which dispatches to the device directly — surfaces
-   * it here.
+   * Set when find's row refuses this match as covered. Only the focus/type
+   * seam surfaces it: click/fill re-enter the interaction leaf, which owns
+   * that refusal's shape and raises it against the same node.
    */
   occludedNode?: SnapshotState['nodes'][number];
 };
@@ -288,9 +286,8 @@ function resolveFindMatch(params: {
 }): FindMatchResult {
   const { nodes, locator, query, selectorExpression, flags, platform } = params;
   const pipeline = SELECTOR_PIPELINE_POLICIES.findAct;
-  // The occlusion stage of find's row: it declares `refuse`, so covered nodes
-  // stay candidates here (find ranks and reports them) and are refused later,
-  // at the target. Acting rows exclude them from candidacy instead.
+  // The occlusion stage of find's row: `refuse` keeps covered nodes as
+  // candidates here — find ranks and reports them — and refuses at the target.
   const searchableNodes = selectorPipelineCandidates(
     pipeline,
     nodes.filter((node) => !isRootInteractionContainer(node, nodes[0])),

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -6,15 +6,13 @@ import {
   checkFindArgs,
   parseFindSelectorExpression,
   type FindLocator,
-  resolveSelectorChainWithPolicy,
-  type PolicyResolutionOutcome,
   type SelectorResolutionPolicy,
 } from '@agent-device/selectors';
 import {
-  SELECTOR_PIPELINE_POLICIES,
-  resolveSelectorPipelineTarget,
-  selectorPipelineCandidates,
-} from '../../core/selector-pipeline-policy.ts';
+  listSelectorPipelineMatches,
+  runNodePipelineStages,
+} from '../../core/selector-pipeline.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../core/selector-pipeline-policy.ts';
 import {
   centerOfRect,
   type SnapshotQualityVerdict,
@@ -38,17 +36,6 @@ import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts'
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
 import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
 import { isSparseSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
-
-/**
- * Both branches of the `reject-candidates` contract produce a candidate set:
- * a single resolved match, or the full ambiguous set find must refuse (or
- * narrow) explicitly.
- */
-function policyMatchedNodes(outcome: PolicyResolutionOutcome): SnapshotState['nodes'] {
-  if (outcome.kind === 'ambiguous') return outcome.matchedNodes;
-  if (outcome.kind === 'resolved') return [outcome.resolution.node];
-  return [];
-}
 
 function assertRejectsCandidates(policy: SelectorResolutionPolicy): void {
   if (policy.ambiguity !== 'reject-candidates') {
@@ -171,8 +158,8 @@ export async function handleFindCommands(params: {
   // surface, the response must disclose that app content is occluded.
   if (!matchResult.ok) return withSystemSurfaceDisclosure(matchResult.response, snapshotResult);
   const node = matchResult.node;
-  // The promotion and occlusion stages of find's row, in one call.
-  const target = resolveSelectorPipelineTarget(SELECTOR_PIPELINE_POLICIES.findAct, nodes, node);
+  // Every node stage find's row declares, in one call.
+  const target = await runNodePipelineStages(SELECTOR_PIPELINE_POLICIES.findAct, nodes, node);
   const resolvedNode = target.node;
   const ref = `@${resolvedNode.ref}`;
   const actionFlags = { ...(req.flags ?? {}), noRecord: true };
@@ -286,12 +273,7 @@ function resolveFindMatch(params: {
 }): FindMatchResult {
   const { nodes, locator, query, selectorExpression, flags, platform } = params;
   const pipeline = SELECTOR_PIPELINE_POLICIES.findAct;
-  // The occlusion stage of find's row: `refuse` keeps covered nodes as
-  // candidates here — find ranks and reports them — and refuses at the target.
-  const searchableNodes = selectorPipelineCandidates(
-    pipeline,
-    nodes.filter((node) => !isRootInteractionContainer(node, nodes[0])),
-  );
+  const rooted = nodes.filter((node) => !isRootInteractionContainer(node, nodes[0]));
   // #1625: selector-shaped and text-shaped queries share ONE ambiguity
   // contract — multiple matches reject with candidates unless --first/--last
   // explicitly opts into positional narrowing. Selectors used to take the
@@ -299,16 +281,18 @@ function resolveFindMatch(params: {
   // own recovery advice ("use a selector") pointed agents at.
   const policy = pipeline.resolution;
   let matches: SnapshotState['nodes'];
+  let searchableNodes: SnapshotState['nodes'];
   if (selectorExpression) {
-    // Selector-shaped queries resolve through the policy interface, so the
-    // `reject-candidates` contract is the matrix's decision rather than a
-    // local convention. The locator branch cannot: it matches by fuzzy text
-    // scoring, not by selector chains, so it produces its candidate set with
-    // its own matcher and joins the shared contract below.
-    matches = policyMatchedNodes(
-      resolveSelectorChainWithPolicy(searchableNodes, selectorExpression, policy, { platform }),
-    );
+    // The `reject-candidates` door: the row's candidacy stage runs inside, and
+    // the whole candidate set comes back for find to rank and narrow.
+    const listed = listSelectorPipelineMatches(pipeline, rooted, selectorExpression, { platform });
+    searchableNodes = listed.candidates;
+    matches = listed.list?.matchedNodes ?? [];
   } else {
+    // The locator branch matches by fuzzy text scoring rather than by selector
+    // chains, so it produces its candidate set with its own matcher — under the
+    // same row, whose rect requirement it reads — and joins the contract below.
+    searchableNodes = rooted;
     matches = findBestMatchesByLocator(searchableNodes, locator, query, {
       requireRect: policy.requireRect,
     }).matches;

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -1,5 +1,4 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
-import { isViewportRootNode } from '@agent-device/contracts/snapshot';
 import type { PreresolvedInteractionTarget } from '@agent-device/contracts/interaction';
 import {
   findBestMatchesByLocator,
@@ -7,11 +6,15 @@ import {
   checkFindArgs,
   parseFindSelectorExpression,
   type FindLocator,
-  SELECTOR_RESOLUTION_POLICIES,
   resolveSelectorChainWithPolicy,
   type PolicyResolutionOutcome,
   type SelectorResolutionPolicy,
 } from '@agent-device/selectors';
+import {
+  SELECTOR_PIPELINE_POLICIES,
+  resolveSelectorPipelineTarget,
+  selectorPipelineCandidates,
+} from '../../core/selector-pipeline-policy.ts';
 import {
   centerOfRect,
   type SnapshotQualityVerdict,
@@ -22,10 +25,9 @@ import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
 import {
-  resolveActionableTouchNode,
+  isRootInteractionContainer,
   resolveActionableTouchResolution,
 } from '../../core/interaction-targeting.ts';
-import { isSnapshotNodeInteractionBlocked } from '../../snapshot/snapshot-occlusion.ts';
 import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
 import type { ElementMatchCandidateDetails } from '../../utils/error-candidates.ts';
 import { readCommandMessage, successText } from '../../utils/success-text.ts';
@@ -74,6 +76,14 @@ type ResolvedMatch = {
   ref: string;
   nodes: SnapshotState['nodes'];
   actionFlags: Record<string, unknown>;
+  /**
+   * The occlusion verdict the `findAct` row produced for this match, carried
+   * rather than raised: `find click`/`fill` re-enter the interaction leaf,
+   * which refuses covered targets in the acting row's own error shape, so only
+   * the focus/type seam — which dispatches to the device directly — surfaces
+   * it here.
+   */
+  occludedNode?: SnapshotState['nodes'][number];
 };
 
 type FindMatchResult =
@@ -163,10 +173,19 @@ export async function handleFindCommands(params: {
   // surface, the response must disclose that app content is occluded.
   if (!matchResult.ok) return withSystemSurfaceDisclosure(matchResult.response, snapshotResult);
   const node = matchResult.node;
-  const resolvedNode = resolveInteractiveMatchNode(nodes, node);
+  // The promotion and occlusion stages of find's row, in one call.
+  const target = resolveSelectorPipelineTarget(SELECTOR_PIPELINE_POLICIES.findAct, nodes, node);
+  const resolvedNode = target.node;
   const ref = `@${resolvedNode.ref}`;
   const actionFlags = { ...(req.flags ?? {}), noRecord: true };
-  const match: ResolvedMatch = { node, resolvedNode, ref, nodes, actionFlags };
+  const match: ResolvedMatch = {
+    node,
+    resolvedNode,
+    ref,
+    nodes,
+    actionFlags,
+    ...(target.kind === 'occluded' ? { occludedNode: target.node } : {}),
+  };
 
   const response = await dispatchFindAction(ctx, match, action, value);
   return response ? withSystemSurfaceDisclosure(response, snapshotResult) : response;
@@ -268,13 +287,20 @@ function resolveFindMatch(params: {
   platform: SessionState['device']['platform'];
 }): FindMatchResult {
   const { nodes, locator, query, selectorExpression, flags, platform } = params;
-  const searchableNodes = nodes.filter((node) => !isRootInteractionContainer(node, nodes[0]));
+  const pipeline = SELECTOR_PIPELINE_POLICIES.findAct;
+  // The occlusion stage of find's row: it declares `refuse`, so covered nodes
+  // stay candidates here (find ranks and reports them) and are refused later,
+  // at the target. Acting rows exclude them from candidacy instead.
+  const searchableNodes = selectorPipelineCandidates(
+    pipeline,
+    nodes.filter((node) => !isRootInteractionContainer(node, nodes[0])),
+  );
   // #1625: selector-shaped and text-shaped queries share ONE ambiguity
   // contract — multiple matches reject with candidates unless --first/--last
   // explicitly opts into positional narrowing. Selectors used to take the
   // first match silently, which was exactly the mis-binding path the error's
   // own recovery advice ("use a selector") pointed agents at.
-  const policy = SELECTOR_RESOLUTION_POLICIES.findAct;
+  const policy = pipeline.resolution;
   let matches: SnapshotState['nodes'];
   if (selectorExpression) {
     // Selector-shaped queries resolve through the policy interface, so the
@@ -387,36 +413,6 @@ function resolvedTouchScore(
 
 function rectArea(node: SnapshotState['nodes'][number]): number {
   return node.rect ? node.rect.width * node.rect.height : Number.POSITIVE_INFINITY;
-}
-
-function resolveInteractiveMatchNode(
-  nodes: SnapshotState['nodes'],
-  node: SnapshotState['nodes'][number],
-): SnapshotState['nodes'][number] {
-  const resolved = resolveActionableTouchNode(nodes, node);
-  if (isRootInteractionContainer(resolved, nodes[0]) && node.rect) return node;
-  return resolved;
-}
-
-function isRootInteractionContainer(
-  node: SnapshotState['nodes'][number],
-  root: SnapshotState['nodes'][number] | undefined,
-): boolean {
-  if (!root?.rect || !node.rect) return false;
-  if (!isViewportRootNode(node)) return false;
-  return rectsMatch(node.rect, root.rect);
-}
-
-function rectsMatch(
-  left: NonNullable<SnapshotState['nodes'][number]['rect']>,
-  right: NonNullable<SnapshotState['nodes'][number]['rect']>,
-): boolean {
-  return (
-    left.x === right.x &&
-    left.y === right.y &&
-    left.width === right.width &&
-    left.height === right.height
-  );
 }
 
 /**
@@ -556,7 +552,7 @@ async function dispatchFocusForFindMatch(
 }
 
 function rejectCoveredFindMatch(match: ResolvedMatch, interaction: string): DaemonResponse | null {
-  const blockedNode = [match.resolvedNode, match.node].find(isSnapshotNodeInteractionBlocked);
+  const blockedNode = match.occludedNode;
   if (!blockedNode) return null;
   return errorResponse(
     'COMMAND_FAILED',

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -281,19 +281,18 @@ function resolveFindMatch(params: {
   // own recovery advice ("use a selector") pointed agents at.
   const policy = pipeline.resolution;
   let matches: SnapshotState['nodes'];
-  let searchableNodes: SnapshotState['nodes'];
   if (selectorExpression) {
     // The `reject-candidates` door: the row's candidacy stage runs inside, and
     // the whole candidate set comes back for find to rank and narrow.
-    const listed = listSelectorPipelineMatches(pipeline, rooted, selectorExpression, { platform });
-    searchableNodes = listed.candidates;
-    matches = listed.list?.matchedNodes ?? [];
+    matches =
+      listSelectorPipelineMatches(pipeline, rooted, selectorExpression, { platform }).list
+        ?.matchedNodes ?? [];
   } else {
-    // The locator branch matches by fuzzy text scoring rather than by selector
-    // chains, so it produces its candidate set with its own matcher — under the
-    // same row, whose rect requirement it reads — and joins the contract below.
-    searchableNodes = rooted;
-    matches = findBestMatchesByLocator(searchableNodes, locator, query, {
+    // Fuzzy text scoring, not a selector chain: this branch brings its own
+    // matcher and reads the row's rect requirement. The row still governs the
+    // target it produces — occlusion and promotion run on it below, in the
+    // same node stages the selector branch reaches.
+    matches = findBestMatchesByLocator(rooted, locator, query, {
       requireRect: policy.requireRect,
     }).matches;
   }


### PR DESCRIPTION
Closes #1656; prework for #1739 (waves 4-5).

## What

#1649 landed the per-caller **ambiguity** matrix and deliberately dropped four structural columns — `occlusion`, `offscreenGuard`, `promotion`, `poll` — because nothing consumed them: flipping any of them left behavior and the suite green, so they read as truth while being free to drift. This adds the missing half **with an owner that executes it**.

`SELECTOR_PIPELINE_POLICIES` (`src/core/selector-pipeline-policy.ts`) gives each caller ONE row: the ambiguity row it resolves under, plus its four structural stages. `src/core/selector-pipeline.ts` is the only code that runs them, and the only code that may touch the matching engine:

| entry | for | runs |
|---|---|---|
| `resolveSelectorPipeline` | single-target rows (reads, `wait`, covered-diagnosis) | candidacy → ambiguity → replay-guard hook → promotion → occlusion → off-screen |
| `listSelectorPipelineMatches` | `reject-candidates` rows (`click`/`fill`, mutating `find`, `find list`) | candidacy → the candidate set **plus the tree the row sees** |
| `runNodePipelineStages` | targets from a non-chain matcher (`@ref`, find's fuzzy locator, a narrowed set) | every node stage the row declares |

The stage functions are private to the owner, so a caller cannot run three stages and forget the fourth, and cannot pair one row's candidate set with another row's ambiguity contract — the row enters once, at the top.

The table lives in `src/core/` rather than `packages/selectors`: R2 forbids `daemon/` importing `commands/`, and the selectors package is deliberately blind to occlusion annotations, backend probes and the wait clock, so a column there would be a claim nothing in that package could enforce.

## Review fix: the rows were bypassable (P1)

The first revision had read/wait routes composing `selectorPipelineCandidates(row, nodes)` with the raw `resolveSelectorChainWithPolicy(..., row.resolution)`. They never entered promotion or off-screen, so flipping a read row's cell changed only the policy unit tests — production `get`/`is`/`wait` were untouched. That is the same unverifiable-column failure one level down. Fixed in three parts:

1. **Owning interface** (above): every route now hands the owner a row and gets every stage, skips included.
2. **A refusal a row declares must exist.** A row with `offscreen: 'refuse'` must supply a refusal shape; flipping an observation row to `refuse` therefore fails on its real route instead of silently observing.
3. **R19 selector-pipeline-ownership** (`scripts/layering/`): the two engine entries moved to their own package subpath, `@agent-device/selectors/engine`, and only the owner may import it.

`find list` was an acknowledged bypass and is closed: it names a `readList` row (`reject-candidates`, no rect requirement — every match is the answer) instead of calling the engine.

### The engine door is a specifier, not a symbol

A name-shaped check cannot see the bypasses that matter: a namespace import, a re-export, and a deferred `import()` never mention the symbol it matches. R19 enforces on the SPECIFIER over the **resolved import graph**, where all of those are the same edge. Each form was planted into a shipped route and rejected by the repo-wide scan:

| planted into `selector-read.ts` | R19 |
|---|---|
| `import * as selectorEngine from '@agent-device/selectors/engine'` | red |
| `await import('@agent-device/selectors/engine')` inside a function | red |
| `export * from '@agent-device/selectors/engine'` in a sibling module | red |

`resolveImportEdges` **drops** an edge whose specifier resolves to nothing, so a specifier-keyed rule goes quiet rather than red if the subpath is ever retired. The gate now reports that as its own failure instead of scanning clean.

### Listing rows declare only what a listing can run

`find <q> list` resolves to a candidate SET: promotion, the off-screen guard and a poll budget have nothing to apply to, because a listing has no single element to retarget, keep on screen, or wait for. `readList` therefore declares two stages, not five (`SelectorListPolicy` = resolution + occlusion), and the narrow shape is load-bearing rather than documentation — `runNodePipelineStages` and `selectorPollBudget` take the full row, so a listing row cannot reach them:

```ts
// @ts-expect-error a listing row declares no promotion or off-screen stage.
const nodeStages: Parameters<typeof runNodePipelineStages>[0] = SELECTOR_PIPELINE_POLICIES.readList;
```

Widening `readList` back to five columns makes those directives unused and fails the typecheck (verified). Its one live cell, `occlusion`, is pinned on the shipped route: flipping it fails `find … list`.

### Rule id: R19, and a gate so the next collision is caught

R17/R18 belong to #1750. R19 verified free against `origin/main` and that PR's diff, then validated by **real merges in both directions** (not a file-level union): `#1750 → #1744` and `#1744 → #1750` both merge cleanly, the uniqueness gate passes in both, and the ids stay distinct (`R17 device-inventory-cutover`, `R18 contracts-implementation-authority`, `R19 selector-pipeline-ownership`).

Nothing caught R17 being taken twice, because two branches claiming one free number do not conflict in git — the files differ. `scripts/layering/rule-ids.ts` closes that: it collects rule-id declarations and fails when one id names two rules. Two notes on its construction:

- It matches **whole string literals**, which is what separates a declaration from prose that also names a rule (`'R17 holds the devices command to…'`). The first version keyed on `rule:` and missed #1750's `const RULE = '…'` shape — it would have been a gate that could not see the collision it exists for.
- `main` already has two collisions (R11 and R13, both named twice), which #1750 is renaming away. Those are allowed **transitionally, and each allowance expires with its collision**: an entry whose collision is absent from the scan fails as a stale allowance, so it has to be deleted in the same change that removes the collision and the list burns down to empty. A list that merely filtered those strings would fail open forever — after the rename, reintroducing either collision would be waved straight through.

  Verified against a scratch tree carrying #1750's rename: leaving the list untouched reports both entries stale, deleting them is clean, and reintroducing `R11 names contracts-implementation-authority and package-boundaries` afterwards is rejected. That last case is pinned as a unit regression using the exact old string.

## Flips fail through real command routes

Each cell was flipped one at a time and the failure observed on the **command** route, not on a runner call:

| flip | fails on |
|---|---|
| `readUnique.occlusion` → `exclude-and-refuse` | `get attrs` of a covered element |
| `readUnique.offscreen` → `refuse` | `get attrs` (covered + nested-text cases) |
| `readUnique.promotion` → `hittable-ancestor` | `get attrs` answers about the hittable ancestor instead of the matched text |
| `wait.occlusion` → `refuse` | `wait` on a covered match |
| `readAny.offscreen` → `refuse` | `is exists`, `find exists`, `find get_attrs` |
| `promotedTarget.promotion` → `none` | `runtime click still promotes non-touchable nodes` |
| `readList.occlusion` → `exclude-and-refuse` | `find … list` |
| an unconsumed column added to the table | "declares a stage its kind cannot run" |
| `readList` widened to declare node stages | typecheck (unused `@ts-expect-error`) |
| the engine imported outside the owner, in any import form | R19, on the repo-wide scan |

The `wait` route test needed an advancing clock first: with the frozen fixture clock a refused wait spun instead of reaching its deadline, so the flip hung rather than asserting — a test that could not have caught the regression it was written for.

## Live device validation

Repo CLI (`node bin/agent-device.mjs`), dedicated `--state-dir`, local iOS simulator (iPhone 16 Pro, Settings) and Android emulator (emulator-5554, Settings).

| route | row | command | outcome |
|---|---|---|---|
| `get text` | readText | `get text 'label="General"'` | `General` — disambiguated across the cell/text duplicates |
| `get attrs` | readUnique | `get attrs 'label="General"'` | `AMBIGUOUS_MATCH` — fail-closed by design |
| `get attrs` | readUnique | `get attrs 'role=cell label="General"'` | returns the **cell** `e28`, `hittable:false` — `promotion: none` live: a promoting row would have retargeted to a hittable ancestor |
| `is` | readUnique | `is visible 'role=cell label="General"'` | `Passed: is visible` |
| `find … exists` | readAny | `find 'role=cell label="Accessibility"' exists` | `Found: true` |
| `find … list` | readList | `find 'label="General"' list` | 4 matches (cell / other / button / text) — whole candidate set |
| `wait` | wait + poll budget | `wait 'role=cell label="Camera"' --json` | `waitedMs: 255` |
| `click` | promotedTarget | `click 'role=cell label="General"' --settle` | navigated into General (settle diff) |
| `fill` | resolvedTarget | `fill 'label="Search" editable=true' 'accessib' --settle` | search field became `accessib` (`@e69 [search] "accessib"`) |
| `find … click` | findAct → leaf | `find 'role=cell label="Privacy & Security"' click` | `Ref @e65 is off-screen and not safe to click` — the delegation `findAct` declares as `offscreen: 'ignore'`, refused by the acting row in the leaf |
| `find … click` | findAct | `find 'label="Continue"' click` | `Tapped @e8 (201, 829)` |

Android added the occlusion cell's decisive pair — **same screen, same selector, same covered element**:

| route | row | command | outcome |
|---|---|---|---|
| `get attrs` | readUnique (`occlusion: ignore`) | `get attrs 'label="Adaptive Battery"'` | answers, disclosing `"interactionBlocked": "covered"` |
| `click` | promotedTarget (`occlusion: exclude-and-refuse`) | `click 'label="Adaptive Battery"'` | `Selector … is covered by another visible element and cannot be tapped safely` |

Plus on Android: `find list` (1 match), `is visible`, `get attrs`, `wait` (`waitedMs: 743`), `click` (text promoted to its tappable ancestor, opened search), `fill` (`battery` → results). Both sessions closed cleanly.

## Behavior identity

- Acting refusals keep their exact message, label, `ref` and `interactionBlocked` in every branch; promotion declines to retarget away from a covered node, so the "both covered" case names the node it always did.
- The covered-diagnosis probe still names the matched **alternative**, not the whole expression.
- `find` carries its occlusion verdict to the focus/type seam: `find click`/`fill` re-enter the interaction leaf, which owns that refusal's shape (observed live above).
- The native-ref preflight names `resolvedTarget` (promotion `none`) — how ADR 0011's "the preflight never changes which element the backend acts on" becomes a declared property.
- `DEFAULT_WAIT_TIMEOUT_MS` and the 300 ms interval moved into the `wait` row; both wait loops read the values they did.
- ADR 0011's `occlusion`/`nonHittable` `via` pointers now name the runner that makes the decision rather than the predicate it applies.

## Validation

`pnpm check:affected --run`, `pnpm check:layering` (now including R19 and the rule-id uniqueness gate), `pnpm check:fallow`, `pnpm check:production-exports` (21 findings, unchanged from `origin/main`), typecheck, lint, format — all green, rebased on `origin/main`. No SessionState changes. No CLI/user-facing surface change, so no docs or skills updates.

## Not routed

`requireInteractive` stays a per-call-site boolean: it selects which **capture** to take, not one of the four stages, and folding it in would change what this PR is about.


