### PR TITLE
fix(ios): make custom-action reads atomically single-flight

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.h
@@ -97,6 +97,9 @@ FOUNDATION_EXPORT NSString *const RunnerAXSnapshotCustomActionsBlockedKey;
 /// adds no work", which is only observable as this counter standing still.
 + (NSInteger)customActionReadDispatchCount;
 
+/// Total reads refused by single-flight admission.
++ (NSInteger)customActionReadBlockedCount;
+
 /// The shared AX client (`XCUIDevice.accessibilityInterface`), or nil when the
 /// private interface is unavailable.
 + (nullable id)accessibilityClient;

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m
@@ -63,6 +63,9 @@ static atomic_int RunnerAXCustomActionReadsInFlight = 0;
 /// staying put, so it is recorded rather than inferred.
 static atomic_long RunnerAXCustomActionReadDispatches = 0;
 
+/// Total single-flight admission refusals.
+static atomic_long RunnerAXCustomActionReadBlocked = 0;
+
 /// Output caps. The element budget bounds how many elements we read; these
 /// bound what any ONE element can put in the response, so a pathological app
 /// cannot spend the whole snapshot on one node's action list.
@@ -514,17 +517,15 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
   if (![axClient respondsToSelector:selector]) {
     return nil;
   }
-  // Single flight. An abandoned read still owns the serial queue, so
-  // dispatching here would only queue work behind it — and repeating the
-  // capture would keep queueing more. Refuse without dispatching instead.
-  if (atomic_load(&RunnerAXCustomActionReadsInFlight) > 0) {
-    NSLog(@"AGENT_DEVICE_RUNNER_PRIVATE_AX_CUSTOM_ACTIONS_READ_BLOCKED");
+  int expectedReadsInFlight = 0;
+  if (!atomic_compare_exchange_strong(
+        &RunnerAXCustomActionReadsInFlight, &expectedReadsInFlight, 1)) {
+    atomic_fetch_add(&RunnerAXCustomActionReadBlocked, 1);
     return nil;
   }
   // The AX call is a synchronous XPC round trip with no timeout of its own, so
   // it runs off-thread behind a bounded wait. On timeout the result box is
   // never read, so a late-returning wedged call cannot race this thread.
-  atomic_fetch_add(&RunnerAXCustomActionReadsInFlight, 1);
   atomic_fetch_add(&RunnerAXCustomActionReadDispatches, 1);
   NSMutableArray *box = [NSMutableArray array];
   dispatch_semaphore_t finished = dispatch_semaphore_create(0);
@@ -543,7 +544,7 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
     }
     // Clear in-flight BEFORE signalling, so a waiter that wakes on this signal
     // never observes its own completed read as still outstanding.
-    atomic_fetch_sub(&RunnerAXCustomActionReadsInFlight, 1);
+    atomic_store(&RunnerAXCustomActionReadsInFlight, 0);
     dispatch_semaphore_signal(finished);
   });
   long waited = dispatch_semaphore_wait(
@@ -620,6 +621,11 @@ typedef id (*RunnerAXSnapshotMsgSend)(id, SEL, id, id, id, NSError **);
 + (NSInteger)customActionReadDispatchCount
 {
   return (NSInteger)atomic_load(&RunnerAXCustomActionReadDispatches);
+}
+
++ (NSInteger)customActionReadBlockedCount
+{
+  return (NSInteger)atomic_load(&RunnerAXCustomActionReadBlocked);
 }
 
 + (nullable id)accessibilityClient

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -587,6 +587,7 @@ extension RunnerTests {
     let hung = HungAXClientForTesting()
     let element = NSObject()
     let dispatchesBefore = RunnerAXSnapshotBridge.customActionReadDispatchCount()
+    let blockedBefore = RunnerAXSnapshotBridge.customActionReadBlockedCount()
     defer { hung.release() }
 
     // 1. First read wedges. The caller is freed by the deadline, but the call is
@@ -603,22 +604,17 @@ extension RunnerTests {
       RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 1)
 
     // 2. Repeats do NOT accumulate: no new dispatch, still exactly one in
-    //    flight, and they return immediately instead of paying the deadline.
+    //    flight, and every repeat is refused by single-flight admission.
     for _ in 0..<5 {
-      let started = Date()
       XCTAssertNil(
         RunnerAXSnapshotBridge.customActionNames(
           forElement: element, axClient: hung, completed: &completed))
       XCTAssertFalse(completed.boolValue)
-      // The refusal is an atomic check with no AX wait. XCTest's wall-clock
-      // sample can still include runner scheduling and diagnostic-log delivery
-      // under CI contention, so allow the 1s AX read deadline plus 0.5s of
-      // harness slack while keeping the no-work assertions below exact.
-      XCTAssertLessThan(-started.timeIntervalSinceNow, 1.5)
     }
     XCTAssertEqual(RunnerAXSnapshotBridge.customActionReadsInFlight(), 1)
     XCTAssertEqual(
       RunnerAXSnapshotBridge.customActionReadDispatchCount(), dispatchesBefore + 1)
+    XCTAssertEqual(RunnerAXSnapshotBridge.customActionReadBlockedCount(), blockedBefore + 5)
 
     // 3. A capture in that state discloses the skip rather than presenting the
     //    unread elements as action-free — and spends no read budget doing it.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -610,7 +610,11 @@ extension RunnerTests {
         RunnerAXSnapshotBridge.customActionNames(
           forElement: element, axClient: hung, completed: &completed))
       XCTAssertFalse(completed.boolValue)
-      XCTAssertLessThan(-started.timeIntervalSinceNow, 0.2)
+      // The refusal is an atomic check with no AX wait. XCTest's wall-clock
+      // sample can still include runner scheduling and diagnostic-log delivery
+      // under CI contention, so allow the 1s AX read deadline plus 0.5s of
+      // harness slack while keeping the no-work assertions below exact.
+      XCTAssertLessThan(-started.timeIntervalSinceNow, 1.5)
     }
     XCTAssertEqual(RunnerAXSnapshotBridge.customActionReadsInFlight(), 1)
     XCTAssertEqual(


### PR DESCRIPTION
## Summary

Keep custom-action AX reads truly single-flight under contention. Admission now atomically claims the only in-flight slot, and rejected reads return without queue dispatch, semaphore waiting, or synchronous per-refusal logging.

The regression asserts the production contract directly: five blocked admissions, one dispatched read, and one read still in flight. It no longer uses a wall-clock threshold.

## Root cause

The previous admission split its check and increment across two atomic operations, so concurrent callers could both observe an empty slot before either claimed it. The blocked branch also logged synchronously, making the XCTest's elapsed-time assertion measure runner scheduling and log delivery rather than the no-work containment invariant.

The fix uses one compare-and-exchange for admission and exposes the blocked-admission count alongside the existing dispatch and in-flight counters.

## Validation

- Planted red: the targeted regression failed with blocked admissions `0` instead of `5` before production incremented the new counter.
- Targeted `testHungCustomActionReadIsContainedAndRecovers` XCTest passed after the fix.
- All seven custom-action XCTest regressions from the iOS smoke step passed.
- `pnpm check:affected --run` passed; the Swift runner build/smoke lanes remain GitHub-authoritative.

Three files changed within the existing Apple runner snapshot module. No docs or skills changed because the public command behavior and guidance are unchanged.
