### PR TITLE
refactor(layering): give each colliding rule id its own number

### DIFF
--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -111,7 +111,7 @@ only that composition module may import a concrete platform package; reusable ty
 through type-only platform imports. Platform packages may import contracts, kernel/domain packages,
 and explicitly injected host capabilities; they may not import daemon requests or responses, mutable
 session state, command catalogs/grammar, root implementation files, sibling platform packages, or raw
-process primitives outside the shared host-command port. R11 applies these rules to static, type-only,
+process primitives outside the shared host-command port. R13 applies these rules to static, type-only,
 dynamic, and re-export edges; package-owned tests may import their own public façade. Contracts may
 depend on kernel vocabulary but never on concrete platform packages or daemon implementation types.
 

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -33,10 +33,12 @@
 //     owner" shape as R7's SessionState ownership, applied to bin.ts's `--help` fast path.
 //   - Over PLATFORM PACKAGE COMPOSITION: six private metadata façades meet at the exact root
 //     composition file; premature implementation loading and forbidden cross-boundary edges fail (R13).
-//   - Over the DEVICES COMMAND CUTOVER: the handler calls the neutral inventory gateway and no
-//     superseded inventory module, import, or identifier remains in production (R13).
 //   - Over COMMAND-ATOMIC RUNTIME CUTOVERS: retired logs, network, and record routes/admission cannot
 //     coexist with their operation-fact-derived descriptor and handler paths (R14-R16).
+//   - Over the DEVICES COMMAND CUTOVER: the handler calls the neutral inventory gateway and no
+//     superseded inventory module, import, or identifier remains in production (R17).
+//   - Over CONTRACTS PRODUCTION SOURCE: contracts owns vocabulary only — host, process, and timer
+//     mechanics belong in capture-kit or an adapter (R18).
 // Only `(root)` is unranked among src/ zones (see `UNRANKED_ZONES` in model.ts):
 // it holds entrypoints and composition roots. Extracted workspace package zones
 // are classified separately and held behind R11 instead of the src folder spine.

--- a/scripts/layering/contracts-implementation-policy.ts
+++ b/scripts/layering/contracts-implementation-policy.ts
@@ -3,7 +3,7 @@ import type { LayeringViolation } from './model.ts';
 
 export type ContractsProductionSource = Readonly<{ path: string; source: string }>;
 
-const RULE = 'R11 contracts-implementation-authority';
+const RULE = 'R18 contracts-implementation-authority';
 const FORBIDDEN_HOST_MODULES = /^(?:node:)?(?:child_process|fs|timers)(?:\/|$)/;
 const FORBIDDEN_TIMER_CALLS = new Set([
   'clearImmediate',

--- a/scripts/layering/device-inventory-cutover-policy.ts
+++ b/scripts/layering/device-inventory-cutover-policy.ts
@@ -1,7 +1,7 @@
 import { parseSync } from 'oxc-parser';
 import type { LayeringViolation } from './model.ts';
 
-const RULE = 'R13 device-inventory-cutover';
+const RULE = 'R17 device-inventory-cutover';
 const HANDLER_FILE = 'src/daemon/handlers/session-inventory.ts';
 const INVENTORY_IMPORT_SOURCES = new Set([
   '../../core/device-inventory-context.ts',
@@ -253,5 +253,5 @@ export function checkDeviceInventoryCutover(
 }
 
 export function deviceInventoryCutoverSummary(): string {
-  return 'the devices command has one gateway-owned inventory route and no legacy route';
+  return 'R17 holds the devices command to one gateway-owned inventory route with no legacy route';
 }

--- a/scripts/layering/rule-ids.ts
+++ b/scripts/layering/rule-ids.ts
@@ -54,15 +54,12 @@ export function duplicateRuleIds(declarations: readonly RuleDeclaration[]): stri
 }
 
 /**
- * Collisions that predate this gate: `main` reuses R11 and R13 for two rules
- * each, which #1750 is renaming to R17/R18. Transitional, and each entry
- * expires on contact — see `ruleIdCollisionFailures`. Empty is the end state,
- * and the gate gets there on its own.
+ * Empty, which is the end state: the R11 and R13 collisions this list was opened
+ * for are gone (contracts-implementation-authority moved to R18, device-inventory-cutover
+ * to R17), so their allowances expired and were deleted with them. Every id now names
+ * exactly one rule, and an entry here would admit a collision nobody is fixing.
  */
-export const KNOWN_RULE_ID_COLLISIONS: readonly string[] = [
-  'R11 names contracts-implementation-authority and package-boundaries',
-  'R13 names device-inventory-cutover and platform-package-substrate',
-];
+export const KNOWN_RULE_ID_COLLISIONS: readonly string[] = [];
 
 /**
  * Both halves of the transition, because an allowance that outlives the thing


### PR DESCRIPTION
## Summary

Give each layering rule number one meaning and make future collisions fail at the guard boundary.

- Keep device inventory at R17, contracts implementation authority at R18, and selector-pipeline ownership at R19.
- Derive the rule catalog from the guard's own non-test policy sources and reject ambiguous IDs before findings are grouped or annotated.
- Remove duplicate contracts-authority reporting and retire the temporary collision allowances now that the allocation is clean.
- Correct ADR 0019's platform-package rule reference from R11 to R13.

This is a structural-only change: five files, 13 additions / 14 deletions versus its exact base, with no production bundle delta or live-device requirement.

## Validation

- exact head `d32f70298`
- full authoritative GitHub CI is green, including all four smoke lanes
- the derived catalog reports unique rule IDs through R19
- planted regressions cover the former R11/R13 collisions, syntax variants, comments/prose, and the exact post-fix allocation

Docs were updated only for ADR 0019's corrected rule reference. Skills were not changed because CLI behavior and workflow guidance are unchanged.
