### PR TITLE
fix(daemon): make request-timeout cleanup and hints platform-aware

### DIFF
--- a/src/daemon/client/__tests__/daemon-client-timeout-route.test.ts
+++ b/src/daemon/client/__tests__/daemon-client-timeout-route.test.ts
@@ -1,0 +1,241 @@
+// Production-seam coverage for the real request-timeout route.
+//
+// src/utils/__tests__/daemon-client.test.ts covers `resolveRequestTimeoutHint`
+// as a pure formatter, but a pure-formatter test cannot catch a bug in
+// CLEANUP ELIGIBILITY: whether `cleanupTimedOutIosRunnerBuilds` (the Apple
+// xcodebuild pkill sweep) actually runs. This file spies on the real
+// process-execution seam (`runCmdSync`, src/utils/exec.ts) and drives an
+// actual socket/HTTP timeout through `sendRequest` so the assertions exercise
+// the same code path a real client does.
+//
+// Why cleanup eligibility must stay unconditional for local timeouts: the
+// client's declared --platform is not authoritative for session-bound
+// execution. `applyStripLockPolicy` (src/daemon/request-lock-policy.ts) lets
+// an existing session's real device platform silently override a conflicting
+// declared selector under --session-lock strip, and the common session-bound
+// request omits --platform entirely. So a request declaring `platform:
+// 'android'` can still legitimately execute against an Apple-bound session
+// (the "rebound-session" case below), and a request with no platform at all
+// (the "unknown-session" case) is the common route the original bug misled.
+// A design that skips the pkill sweep based on the declared flag alone would
+// skip real cleanup in the rebound case — the dangerous direction. This test
+// proves the sweep always fires for local timeouts, and that the HINT text
+// (not the cleanup) is what carries the platform-evidence gating.
+
+import net from 'node:net';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { beforeEach, test, vi } from 'vitest';
+
+const { mockRunCmdSync } = vi.hoisted(() => ({ mockRunCmdSync: vi.fn() }));
+
+vi.mock('../../../utils/exec.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/exec.ts')>('../../../utils/exec.ts');
+  return { ...actual, runCmdSync: mockRunCmdSync };
+});
+
+import { AppError } from '@agent-device/kernel/errors';
+import { sendRequest } from '../daemon-client-transport.ts';
+import type { DaemonRequest } from '../../types.ts';
+import type { DaemonInfo } from '../daemon-client-metadata.ts';
+import type { DaemonPaths } from '../../config.ts';
+
+const TIMEOUT_MS = 120;
+
+// `snapshot`'s timeout policy preserves the daemon (onTimeout !==
+// 'reset-daemon'), so `handleRequestTimeout` never reaches
+// `resetDaemonAfterTimeout` (`process.kill`) here — keeping this suite
+// side-effect-free outside the mocked pkill sweep.
+const SNAPSHOT_COMMAND = 'snapshot';
+
+function dummyStatePaths(): DaemonPaths {
+  const baseDir = path.join(os.tmpdir(), 'agent-device-timeout-route-test');
+  return {
+    baseDir,
+    infoPath: path.join(baseDir, 'daemon.json'),
+    lockPath: path.join(baseDir, 'daemon.lock'),
+    logPath: path.join(baseDir, 'daemon.log'),
+    sessionsDir: path.join(baseDir, 'sessions'),
+  };
+}
+
+function buildRequest(platform: 'android' | 'ios' | undefined): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'default',
+    command: SNAPSHOT_COMMAND,
+    positionals: [],
+    flags: platform ? { platform } : {},
+    meta: { requestId: 'req-timeout-route' },
+  };
+}
+
+function startHangingSocketServer(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      // Accept the connection but never write a response — forces the
+      // client's own request-timeout envelope to fire.
+      socket.on('error', () => {});
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        resolve({ server, port: address.port });
+      } else {
+        reject(new Error('failed to bind hanging socket test server'));
+      }
+    });
+  });
+}
+
+function startHangingHttpServer(): Promise<{ server: http.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((_req, res) => {
+      // Never call res.end() — forces the client's own request-timeout
+      // envelope to fire instead of a real response.
+      res.on('error', () => {});
+    });
+    server.on('clientError', (_err, socket) => socket.destroy());
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        resolve({ server, port: address.port });
+      } else {
+        reject(new Error('failed to bind hanging http test server'));
+      }
+    });
+  });
+}
+
+beforeEach(() => {
+  mockRunCmdSync.mockReset();
+});
+
+test('socket timeout: pkill cleanup still runs for a declared non-Apple platform that actually terminates a runner (rebound-session case), and the hint claims Apple on that evidence', async () => {
+  // Simulates --session-lock strip silently rebinding this request onto an
+  // existing Apple session: the client declared `platform: 'android'`, but
+  // real Apple xcodebuild work was in flight and the pkill sweep kills it.
+  mockRunCmdSync.mockImplementation((cmd: string) =>
+    cmd === 'pkill'
+      ? { exitCode: 0, stdout: '', stderr: '' }
+      : { exitCode: 1, stdout: '', stderr: '' },
+  );
+
+  const { server, port } = await startHangingSocketServer();
+  try {
+    const info: DaemonInfo = { port, token: 'test-token', pid: process.pid };
+    const req = buildRequest('android');
+
+    await assert.rejects(
+      sendRequest(info, req, 'socket', dummyStatePaths(), TIMEOUT_MS),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        assert.match(error.details?.hint as string, /Apple runner work was aborted when detected/);
+        return true;
+      },
+    );
+  } finally {
+    server.close();
+  }
+
+  // The eligibility assertion: cleanup ran (all three kill patterns
+  // attempted) even though the request declared a non-Apple platform. A
+  // design that skips cleanup based on the declared flag would fail this.
+  const pkillCalls = mockRunCmdSync.mock.calls.filter(([cmd]) => cmd === 'pkill');
+  assert.equal(pkillCalls.length, 3);
+});
+
+test('http timeout: pkill cleanup still runs for an undeclared platform (unknown-session case) that terminates nothing, and the hint stays platform-neutral', async () => {
+  // Simulates the common session-bound request that never repeats
+  // --platform, on a real Android/web/Harmony session: no processes match
+  // the Apple-specific kill patterns.
+  mockRunCmdSync.mockImplementation(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+
+  const { server, port } = await startHangingHttpServer();
+  try {
+    const info: DaemonInfo = { httpPort: port, token: 'test-token', pid: process.pid };
+    const req = buildRequest(undefined);
+
+    await assert.rejects(
+      sendRequest(info, req, 'http', dummyStatePaths(), TIMEOUT_MS),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        const hint = error.details?.hint as string;
+        assert.doesNotMatch(hint, /Apple/);
+        assert.match(
+          hint,
+          /The timed-out snapshot request was canceled; the daemon was kept alive/,
+        );
+        return true;
+      },
+    );
+  } finally {
+    server.close();
+  }
+
+  // Cleanup still ran — this is the regression this suite exists to catch:
+  // an eligibility design keyed off the (here, absent) declared platform
+  // would either skip cleanup entirely or — under the original unconditional
+  // hint — falsely claim Apple involvement anyway. Neither happens here.
+  const pkillCalls = mockRunCmdSync.mock.calls.filter(([cmd]) => cmd === 'pkill');
+  assert.equal(pkillCalls.length, 3);
+});
+
+test('http timeout: an explicitly declared Apple platform keeps the Apple hint even when the sweep terminates nothing', async () => {
+  mockRunCmdSync.mockImplementation(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+
+  const { server, port } = await startHangingHttpServer();
+  try {
+    const info: DaemonInfo = { httpPort: port, token: 'test-token', pid: process.pid };
+    const req = buildRequest('ios');
+
+    await assert.rejects(
+      sendRequest(info, req, 'http', dummyStatePaths(), TIMEOUT_MS),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        assert.match(error.details?.hint as string, /Apple runner work was aborted when detected/);
+        return true;
+      },
+    );
+  } finally {
+    server.close();
+  }
+
+  const pkillCalls = mockRunCmdSync.mock.calls.filter(([cmd]) => cmd === 'pkill');
+  assert.equal(pkillCalls.length, 3);
+});
+
+test('remote HTTP timeout never runs the Apple pkill cleanup and uses the remote-specific hint', async () => {
+  mockRunCmdSync.mockImplementation(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+  const { server, port } = await startHangingHttpServer();
+  try {
+    const info: DaemonInfo = {
+      baseUrl: `http://127.0.0.1:${port}`,
+      token: 'test-token',
+      pid: process.pid,
+    };
+    const req = buildRequest('android');
+
+    await assert.rejects(
+      sendRequest(info, req, 'http', dummyStatePaths(), TIMEOUT_MS),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        assert.match(
+          error.details?.hint as string,
+          /verify the remote daemon URL, auth token, and remote host logs/,
+        );
+        return true;
+      },
+    );
+  } finally {
+    server.close();
+  }
+
+  assert.equal(mockRunCmdSync.mock.calls.length, 0);
+});

--- a/src/daemon/client/daemon-client-timeout.ts
+++ b/src/daemon/client/daemon-client-timeout.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../core/command-descriptor/types.ts';
 import type { DaemonRequest } from '../types.ts';
 import type { DaemonPaths } from '../config.ts';
+import type { PlatformSelector } from '@agent-device/kernel/device';
 import {
   removeDaemonInfo,
   removeDaemonLock,
@@ -22,6 +23,17 @@ const IOS_RUNNER_XCODEBUILD_KILL_PATTERNS = [
   'xcodebuild .*AgentDeviceRunner\\.env\\.session-',
   'xcodebuild build-for-testing .*apple/runner/AgentDeviceRunner/AgentDeviceRunner\\.xcodeproj',
 ];
+
+// `--platform` selectors that name (or alias) an Apple device. The client
+// only ever knows what this exact request declared — there is no session
+// lookup at this layer (src/daemon/client/ stays import-free of
+// src/platforms) — so an undeclared platform fails safe toward "could be
+// Apple" rather than toward "definitely not Apple".
+const APPLE_PLATFORM_SELECTORS: ReadonlySet<PlatformSelector> = new Set(['apple', 'ios', 'macos']);
+
+function mayInvolveAppleDevice(platform: PlatformSelector | undefined): boolean {
+  return platform === undefined || APPLE_PLATFORM_SELECTORS.has(platform);
+}
 
 type BoundedTimeoutPolicy = CommandTimeoutPolicy & { envelopeMs: number };
 type FlagTimeoutBudget = Extract<CommandTimeoutBudget, { source: 'flag' }>;
@@ -98,8 +110,10 @@ export function handleRequestTimeout(
   command: string | undefined,
   remote: boolean,
   timeoutMs: number,
+  platform: PlatformSelector | undefined,
 ): AppError {
-  const cleanup = remote ? { terminated: 0 } : cleanupTimedOutIosRunnerBuilds();
+  const mayInvolveApple = mayInvolveAppleDevice(platform);
+  const cleanup = remote || !mayInvolveApple ? { terminated: 0 } : cleanupTimedOutIosRunnerBuilds();
   const resetDaemon = !remote && shouldResetDaemonAfterRequestTimeout(command);
   const daemonReset = resetDaemon
     ? resetDaemonAfterTimeout(info, statePaths)
@@ -122,7 +136,7 @@ export function handleRequestTimeout(
   return new AppError('COMMAND_FAILED', 'Daemon request timed out', {
     timeoutMs,
     requestId,
-    hint: resolveRequestTimeoutHint({ remote, resetDaemon, command }),
+    hint: resolveRequestTimeoutHint({ remote, resetDaemon, command, mayInvolveApple }),
   });
 }
 
@@ -135,23 +149,32 @@ export function shouldResetDaemonAfterRequestTimeout(command: string | undefined
   return resolveCommandTimeoutPolicy(command).onTimeout === 'reset-daemon';
 }
 
-function resolveRequestTimeoutHint(params: {
+// Exported for direct hint-matrix testing: handleRequestTimeout also triggers
+// real pkill/process-kill side effects, so its wording is verified through
+// this pure sub-function rather than the full timeout path.
+export function resolveRequestTimeoutHint(params: {
   remote: boolean;
   resetDaemon: boolean;
   command: string | undefined;
+  mayInvolveApple: boolean;
 }): string {
-  const { remote, resetDaemon, command } = params;
+  const { remote, resetDaemon, command, mayInvolveApple } = params;
   if (remote) {
     return 'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.';
   }
   if (!resetDaemon) {
     const iosPrepareHint =
-      command === PUBLIC_COMMANDS.snapshot
+      mayInvolveApple && command === PUBLIC_COMMANDS.snapshot
         ? ' If this was the first Apple-platform snapshot on the device, run agent-device prepare ios-runner with the same --platform before snapshot/test so runner startup is handled explicitly.'
         : '';
-    return `Retry with --debug and check daemon diagnostics logs. The timed-out ${command ?? 'request'} request was canceled and Apple runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected.${iosPrepareHint}`;
+    const appleCleanupNote = mayInvolveApple
+      ? ' and Apple runner work was aborted when detected'
+      : '';
+    return `Retry with --debug and check daemon diagnostics logs. The timed-out ${command ?? 'request'} request was canceled${appleCleanupNote}; the daemon was kept alive so the session can still be closed or inspected.${iosPrepareHint}`;
   }
-  return 'Retry with --debug and check daemon diagnostics logs. Timed-out Apple runner xcodebuild processes were terminated when detected.';
+  return mayInvolveApple
+    ? 'Retry with --debug and check daemon diagnostics logs. Timed-out Apple runner xcodebuild processes were terminated when detected.'
+    : 'Retry with --debug and check daemon diagnostics logs. The daemon was reset after the timeout.';
 }
 
 function cleanupTimedOutIosRunnerBuilds(): { terminated: number; error?: string } {

--- a/src/daemon/client/daemon-client-timeout.ts
+++ b/src/daemon/client/daemon-client-timeout.ts
@@ -24,15 +24,20 @@ const IOS_RUNNER_XCODEBUILD_KILL_PATTERNS = [
   'xcodebuild build-for-testing .*apple/runner/AgentDeviceRunner/AgentDeviceRunner\\.xcodeproj',
 ];
 
-// `--platform` selectors that name (or alias) an Apple device. The client
-// only ever knows what this exact request declared — there is no session
-// lookup at this layer (src/daemon/client/ stays import-free of
-// src/platforms) — so an undeclared platform fails safe toward "could be
-// Apple" rather than toward "definitely not Apple".
-const APPLE_PLATFORM_SELECTORS: ReadonlySet<PlatformSelector> = new Set(['apple', 'ios', 'macos']);
+// `--platform` selectors that AFFIRMATIVELY name (or alias) an Apple device.
+// This is deliberately narrower than "not proven non-Apple": the client's
+// declared platform is not authoritative for session-bound execution (see
+// the eligibility note on `handleRequestTimeout` below), so an undeclared or
+// declared-non-Apple platform is not evidence of anything — it only counts
+// as Apple evidence when it says so outright.
+const AFFIRMATIVE_APPLE_PLATFORM_SELECTORS: ReadonlySet<PlatformSelector> = new Set([
+  'apple',
+  'ios',
+  'macos',
+]);
 
-function mayInvolveAppleDevice(platform: PlatformSelector | undefined): boolean {
-  return platform === undefined || APPLE_PLATFORM_SELECTORS.has(platform);
+function isAffirmativelyApplePlatform(platform: PlatformSelector | undefined): boolean {
+  return platform !== undefined && AFFIRMATIVE_APPLE_PLATFORM_SELECTORS.has(platform);
 }
 
 type BoundedTimeoutPolicy = CommandTimeoutPolicy & { envelopeMs: number };
@@ -112,12 +117,30 @@ export function handleRequestTimeout(
   timeoutMs: number,
   platform: PlatformSelector | undefined,
 ): AppError {
-  const mayInvolveApple = mayInvolveAppleDevice(platform);
-  const cleanup = remote || !mayInvolveApple ? { terminated: 0 } : cleanupTimedOutIosRunnerBuilds();
+  // Cleanup eligibility stays UNCONDITIONAL for every local (non-remote)
+  // timeout, on purpose: the request's declared --platform is not
+  // authoritative for session-bound execution. An existing session's real
+  // device platform can silently override a conflicting declared selector
+  // (`applyStripLockPolicy` in request-lock-policy.ts, reached via
+  // --session-lock strip), and the common session-bound request omits
+  // --platform entirely — so there is no client-visible signal that proves
+  // a request cannot touch an Apple runner. The pkill patterns are
+  // Apple-process-name-specific, so sweeping them on a non-Apple host or
+  // session matches nothing and costs a few no-op subprocess spawns, never
+  // a wrong skip.
+  const cleanup = remote ? { terminated: 0 } : cleanupTimedOutIosRunnerBuilds();
   const resetDaemon = !remote && shouldResetDaemonAfterRequestTimeout(command);
   const daemonReset = resetDaemon
     ? resetDaemonAfterTimeout(info, statePaths)
     : { forcedKill: false };
+  // The HINT, unlike cleanup, may only name Apple-runner involvement on
+  // evidence this call site actually has: an explicitly declared Apple
+  // platform selector, or the cleanup itself having terminated a matching
+  // process (proof positive regardless of what --platform claimed). Any
+  // other combination — undeclared platform, declared non-Apple platform,
+  // zero processes terminated — gets platform-neutral wording instead of
+  // asserting Apple specifics the client cannot back up.
+  const appleCleanupEvidence = isAffirmativelyApplePlatform(platform) || cleanup.terminated > 0;
   emitDiagnostic({
     level: 'error',
     phase: 'daemon_request_timeout',
@@ -136,7 +159,7 @@ export function handleRequestTimeout(
   return new AppError('COMMAND_FAILED', 'Daemon request timed out', {
     timeoutMs,
     requestId,
-    hint: resolveRequestTimeoutHint({ remote, resetDaemon, command, mayInvolveApple }),
+    hint: resolveRequestTimeoutHint({ remote, resetDaemon, command, appleCleanupEvidence }),
   });
 }
 
@@ -151,28 +174,32 @@ export function shouldResetDaemonAfterRequestTimeout(command: string | undefined
 
 // Exported for direct hint-matrix testing: handleRequestTimeout also triggers
 // real pkill/process-kill side effects, so its wording is verified through
-// this pure sub-function rather than the full timeout path.
+// this pure sub-function rather than the full timeout path (see also the
+// production-seam route tests in
+// src/daemon/client/__tests__/daemon-client-timeout-route.test.ts, which
+// prove the cleanup-eligibility side of this contract that a pure formatter
+// test cannot).
 export function resolveRequestTimeoutHint(params: {
   remote: boolean;
   resetDaemon: boolean;
   command: string | undefined;
-  mayInvolveApple: boolean;
+  appleCleanupEvidence: boolean;
 }): string {
-  const { remote, resetDaemon, command, mayInvolveApple } = params;
+  const { remote, resetDaemon, command, appleCleanupEvidence } = params;
   if (remote) {
     return 'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.';
   }
   if (!resetDaemon) {
     const iosPrepareHint =
-      mayInvolveApple && command === PUBLIC_COMMANDS.snapshot
+      appleCleanupEvidence && command === PUBLIC_COMMANDS.snapshot
         ? ' If this was the first Apple-platform snapshot on the device, run agent-device prepare ios-runner with the same --platform before snapshot/test so runner startup is handled explicitly.'
         : '';
-    const appleCleanupNote = mayInvolveApple
+    const appleCleanupNote = appleCleanupEvidence
       ? ' and Apple runner work was aborted when detected'
       : '';
     return `Retry with --debug and check daemon diagnostics logs. The timed-out ${command ?? 'request'} request was canceled${appleCleanupNote}; the daemon was kept alive so the session can still be closed or inspected.${iosPrepareHint}`;
   }
-  return mayInvolveApple
+  return appleCleanupEvidence
     ? 'Retry with --debug and check daemon diagnostics logs. Timed-out Apple runner xcodebuild processes were terminated when detected.'
     : 'Retry with --debug and check daemon diagnostics logs. The daemon was reset after the timeout.';
 }

--- a/src/daemon/client/daemon-client-transport.ts
+++ b/src/daemon/client/daemon-client-transport.ts
@@ -322,6 +322,7 @@ async function sendSocketRequest(
                 req.command,
                 false,
                 timeoutMs,
+                req.flags?.platform,
               ),
             );
           }, timeoutMs)
@@ -436,6 +437,7 @@ async function sendHttpRequest(
                 req.command,
                 remote,
                 timeoutMs,
+                req.flags?.platform,
               ),
             );
           }, timeoutMs)

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -252,24 +252,30 @@ test('read-only polling command timeouts preserve the daemon like snapshot', () 
   assert.equal(shouldResetDaemonAfterRequestTimeout('open'), true);
 });
 
-test('request timeout hint stops asserting Apple runner specifics for a known non-Apple platform', () => {
-  // Before this change, handleRequestTimeout ran the Apple-runner pkill
-  // cleanup and emitted Apple-specific hint wording for EVERY local timeout,
-  // regardless of the request's --platform. That was misleading for
-  // Android/web/Harmony sessions, which never had any Apple runner work to
-  // abort. The hint now only claims Apple-runner cleanup happened when the
-  // request's declared platform could actually be Apple (known-Apple, or
-  // genuinely undeclared — fail-safe toward keeping the claim).
+test('request timeout hint only names Apple runner cleanup on actual evidence', () => {
+  // Before this change, handleRequestTimeout emitted Apple-specific hint
+  // wording for EVERY local timeout, regardless of the request's
+  // --platform. That was misleading for Android/web/Harmony sessions, which
+  // never had any Apple runner work to abort.
+  //
+  // The fix is evidence-based, not platform-guess-based:
+  // `appleCleanupEvidence` is true only when the request declared an
+  // AFFIRMATIVELY Apple platform (apple/ios/macos) or the pkill cleanup
+  // itself terminated a matching process — never from an undeclared or
+  // declared-non-Apple platform alone. (Why not trust the declared platform
+  // directly: it is not authoritative for session-bound execution — see
+  // `handleRequestTimeout`'s comment and the production-seam coverage in
+  // daemon-client-timeout-route.test.ts for the cleanup-eligibility half of
+  // this contract that this pure formatter test cannot prove.)
 
-  // Known-Apple and undeclared (fail-safe) platforms both resolve to
-  // mayInvolveApple: true and keep the exact historical wording — nothing
-  // regresses for the common case.
+  // appleCleanupEvidence: true keeps the exact historical wording — nothing
+  // regresses for the true-Apple case.
   assert.equal(
     resolveRequestTimeoutHint({
       remote: false,
       resetDaemon: false,
       command: 'press',
-      mayInvolveApple: true,
+      appleCleanupEvidence: true,
     }),
     'Retry with --debug and check daemon diagnostics logs. The timed-out press request was canceled and Apple runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected.',
   );
@@ -278,7 +284,7 @@ test('request timeout hint stops asserting Apple runner specifics for a known no
       remote: false,
       resetDaemon: true,
       command: 'open',
-      mayInvolveApple: true,
+      appleCleanupEvidence: true,
     }),
     'Retry with --debug and check daemon diagnostics logs. Timed-out Apple runner xcodebuild processes were terminated when detected.',
   );
@@ -287,19 +293,22 @@ test('request timeout hint stops asserting Apple runner specifics for a known no
       remote: false,
       resetDaemon: false,
       command: 'snapshot',
-      mayInvolveApple: true,
+      appleCleanupEvidence: true,
     }),
     'Retry with --debug and check daemon diagnostics logs. The timed-out snapshot request was canceled and Apple runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected. If this was the first Apple-platform snapshot on the device, run agent-device prepare ios-runner with the same --platform before snapshot/test so runner startup is handled explicitly.',
   );
 
-  // Known non-Apple platform: no Apple-runner claim in any branch, and the
-  // Apple-only iOS-prepare follow-up drops entirely.
+  // appleCleanupEvidence: false — no Apple-runner claim in any branch, and
+  // the Apple-only iOS-prepare follow-up drops entirely. This is the
+  // motivating fix: it fires equally whether the platform was declared
+  // non-Apple OR left undeclared (the common session-bound case), because
+  // neither is Apple evidence on its own.
   assert.equal(
     resolveRequestTimeoutHint({
       remote: false,
       resetDaemon: false,
       command: 'press',
-      mayInvolveApple: false,
+      appleCleanupEvidence: false,
     }),
     'Retry with --debug and check daemon diagnostics logs. The timed-out press request was canceled; the daemon was kept alive so the session can still be closed or inspected.',
   );
@@ -308,7 +317,7 @@ test('request timeout hint stops asserting Apple runner specifics for a known no
       remote: false,
       resetDaemon: true,
       command: 'open',
-      mayInvolveApple: false,
+      appleCleanupEvidence: false,
     }),
     'Retry with --debug and check daemon diagnostics logs. The daemon was reset after the timeout.',
   );
@@ -317,18 +326,18 @@ test('request timeout hint stops asserting Apple runner specifics for a known no
       remote: false,
       resetDaemon: false,
       command: 'snapshot',
-      mayInvolveApple: false,
+      appleCleanupEvidence: false,
     }),
     'Retry with --debug and check daemon diagnostics logs. The timed-out snapshot request was canceled; the daemon was kept alive so the session can still be closed or inspected.',
   );
 
-  // Remote requests were never Apple-specific and stay platform-independent.
+  // Remote requests were never Apple-specific and stay evidence-independent.
   assert.equal(
     resolveRequestTimeoutHint({
       remote: true,
       resetDaemon: false,
       command: 'press',
-      mayInvolveApple: false,
+      appleCleanupEvidence: false,
     }),
     'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.',
   );

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -23,6 +23,7 @@ import { canConnectSocket } from '../../daemon/client/daemon-client-transport.ts
 import { DAEMON_RPC_PROTOCOL_VERSION } from '../../daemon/http-health.ts';
 import {
   resolveDaemonRequestTimeoutMs,
+  resolveRequestTimeoutHint,
   shouldResetDaemonAfterRequestTimeout,
 } from '../../daemon/client/daemon-client-timeout.ts';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
@@ -249,6 +250,88 @@ test('read-only polling command timeouts preserve the daemon like snapshot', () 
   // timeouts preserve the daemon too (#1105); non-capture commands still reset.
   assert.equal(shouldResetDaemonAfterRequestTimeout('press'), false);
   assert.equal(shouldResetDaemonAfterRequestTimeout('open'), true);
+});
+
+test('request timeout hint stops asserting Apple runner specifics for a known non-Apple platform', () => {
+  // Before this change, handleRequestTimeout ran the Apple-runner pkill
+  // cleanup and emitted Apple-specific hint wording for EVERY local timeout,
+  // regardless of the request's --platform. That was misleading for
+  // Android/web/Harmony sessions, which never had any Apple runner work to
+  // abort. The hint now only claims Apple-runner cleanup happened when the
+  // request's declared platform could actually be Apple (known-Apple, or
+  // genuinely undeclared — fail-safe toward keeping the claim).
+
+  // Known-Apple and undeclared (fail-safe) platforms both resolve to
+  // mayInvolveApple: true and keep the exact historical wording — nothing
+  // regresses for the common case.
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: false,
+      command: 'press',
+      mayInvolveApple: true,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. The timed-out press request was canceled and Apple runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected.',
+  );
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: true,
+      command: 'open',
+      mayInvolveApple: true,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. Timed-out Apple runner xcodebuild processes were terminated when detected.',
+  );
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: false,
+      command: 'snapshot',
+      mayInvolveApple: true,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. The timed-out snapshot request was canceled and Apple runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected. If this was the first Apple-platform snapshot on the device, run agent-device prepare ios-runner with the same --platform before snapshot/test so runner startup is handled explicitly.',
+  );
+
+  // Known non-Apple platform: no Apple-runner claim in any branch, and the
+  // Apple-only iOS-prepare follow-up drops entirely.
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: false,
+      command: 'press',
+      mayInvolveApple: false,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. The timed-out press request was canceled; the daemon was kept alive so the session can still be closed or inspected.',
+  );
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: true,
+      command: 'open',
+      mayInvolveApple: false,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. The daemon was reset after the timeout.',
+  );
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: false,
+      resetDaemon: false,
+      command: 'snapshot',
+      mayInvolveApple: false,
+    }),
+    'Retry with --debug and check daemon diagnostics logs. The timed-out snapshot request was canceled; the daemon was kept alive so the session can still be closed or inspected.',
+  );
+
+  // Remote requests were never Apple-specific and stay platform-independent.
+  assert.equal(
+    resolveRequestTimeoutHint({
+      remote: true,
+      resetDaemon: false,
+      command: 'press',
+      mayInvolveApple: false,
+    }),
+    'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.',
+  );
 });
 
 test('wait request timeout extends past the user-supplied wait budget', () => {


### PR DESCRIPTION
Part of #1739 (independent cleanups)

**Update (978dbfaa0):** maintainer review found a real correctness inversion
in the first pass (see review thread below) — this revision redesigns the
fix around a strict split between cleanup eligibility and hint wording. The
section below is rewritten to describe the current design; see PR history
for the superseded first pass.

## What

Every local request timeout ran the Apple-runner `xcodebuild` pkill cleanup
(`IOS_RUNNER_XCODEBUILD_KILL_PATTERNS`) and emitted Apple-specific hint text
("Apple runner work was aborted", "Timed-out Apple runner xcodebuild
processes were terminated") regardless of the session's actual platform —
misleading for Android/web/Harmony timeouts.

## Investigation: what platform context is available at this layer, and why it's not authoritative

`src/daemon/client/` is outside the R3 platforms-seam and stays import-free
of `src/platforms`. Both timeout call sites in `daemon-client-transport.ts`
hold the exact `req: DaemonRequest` they sent, and `req.flags?.platform` is
the client-declared `--platform` selector for that request.

The first pass of this PR used that flag directly to decide whether to run
the Apple cleanup at all. Maintainer review (thymikee) found this backwards
in two ways, traced to `src/daemon/request-lock-policy.ts`:

1. **`applyStripLockPolicy`'s existing-session branch** (reached via
   `--session-lock strip`) strips a conflicting declared selector and
   backfills `flags.platform` from the *session's real device*
   (`publicPlatformString(existingSession.device)`) — server-side, after the
   client has already sent the request. A request that declared
   `--platform android` against an existing Apple-bound session can
   therefore legitimately execute Apple work. Skipping the pkill cleanup
   because the client saw `android` would skip cleanup that was actually
   needed — the dangerous direction.
2. **The common session-bound request omits `--platform` entirely** (no
   conflict to strip, so `flags.platform` stays `undefined` all the way
   through normalization too). Treating `undefined` as "fail-safe toward
   Apple" — my first pass's choice — meant the hint kept its Apple wording
   on exactly this common route, so the *motivating* bug (misleading Apple
   hints on ordinary Android/web/Harmony session timeouts) stayed unfixed.

**Eligibility conclusion:** at the client layer, a session-bound request is
never provably non-rebindable to Apple from its own flags alone — there is
no session-state lookup available here, by design (no `src/platforms`
import, no new plumbing). So the redesign does not try to prove
non-rebindability at all.

## Fix — split eligibility from wording

- **Cleanup eligibility is unconditional again** for every local (non-remote)
  timeout — the same behavior as before this PR touched the file. The pkill
  patterns are Apple-process-name-specific, so sweeping them on a non-Apple
  host/session matches nothing and costs a few no-op subprocess spawns —
  never a wrong skip. This removes the dangerous-direction bug entirely: the
  sweep can no longer be skipped based on a stale/absent client-side flag.
- **The hint is evidence-based**, not flag-based:
  `appleCleanupEvidence = isAffirmativelyApplePlatform(platform) ||
  cleanup.terminated > 0` — true only when the request declared an
  affirmatively Apple platform (`apple`/`ios`/`macos`), or the cleanup
  itself actually terminated a matching process (proof positive regardless
  of what `--platform` claimed). Any other combination — undeclared
  platform, declared non-Apple platform, zero processes terminated — gets
  platform-neutral wording. This is what fixes the motivating bug on its
  common route: an undeclared-platform Android/web/Harmony timeout runs the
  (harmless, no-op) cleanup, terminates nothing, and the hint goes neutral.
- Both `sendSocketRequest` and `sendHttpRequest` in
  `daemon-client-transport.ts` still pass `req.flags?.platform` through —
  it now only feeds the affirmative-platform half of the hint's evidence
  check, never cleanup eligibility.

## Before/after hint matrix

| resetDaemon | appleCleanupEvidence | Hint |
| --- | --- | --- |
| false | true (explicit Apple selector, or cleanup terminated something) | *(unchanged historical wording)* "...The timed-out `<command>` request was canceled and Apple runner work was aborted when detected; the daemon was kept alive..." |
| false | false (no Apple selector and nothing terminated) | *(new)* "...The timed-out `<command>` request was canceled; the daemon was kept alive..." (no Apple claim) |
| true | true | *(unchanged)* "...Timed-out Apple runner xcodebuild processes were terminated when detected." |
| true | false | *(new)* "...The daemon was reset after the timeout." (no Apple claim) |
| n/a | remote | *(unchanged)* platform-independent remote wording |

`snapshot`'s iOS-prepare follow-up sentence is also gated on
`appleCleanupEvidence` and drops entirely when it's false.

## Testing

**Pure formatter matrix** (`src/utils/__tests__/daemon-client.test.ts`):
extended with a fixture test asserting the full before/after matrix above
against `resolveRequestTimeoutHint` directly, byte-for-byte.

**Production-seam route tests** (new file,
`src/daemon/client/__tests__/daemon-client-timeout-route.test.ts`) — added
because the pure formatter test cannot catch a bug in cleanup *eligibility*,
only in hint *wording*. This file spies on the real process-execution seam
(`runCmdSync`, `src/utils/exec.ts`, via `vi.mock`) and drives an actual
socket/HTTP timeout through the real `sendRequest` against a hanging local
server, asserting on the real rejected `AppError`. Four cases:

1. **Socket, rebound-session simulation**: declares `platform: 'android'`,
   pkill mock reports a termination → cleanup still runs (3 pkill calls
   asserted) AND the hint claims Apple, on the termination evidence — proves
   the dangerous-direction bug is gone.
2. **HTTP, unknown-session simulation**: undeclared platform, pkill
   terminates nothing → cleanup still runs (3 pkill calls asserted) but the
   hint stays neutral — proves the motivating bug is fixed on its common
   route.
3. **HTTP, explicit Apple platform**: declares `platform: 'ios'`, pkill
   terminates nothing → hint still claims Apple (affirmative-selector
   evidence, honors the existing "when detected" hedge).
4. **HTTP, remote** (`info.baseUrl` set): pkill never invoked at all;
   remote-specific hint.

**Proved red before the fix**, per repo convention: `git stash push --
src/daemon/client/daemon-client-timeout.ts` reverted just that file back to
this PR's first (already-pushed, now-superseded) commit `82aa5ade2`, then
reran the new route-test file. 2 of 4 cases failed exactly as predicted:
case 1 failed because the flawed code skipped cleanup on the declared
`android` flag (no Apple evidence at all despite the real termination —
the dangerous-direction proof); case 2 failed because the flawed code's
undeclared-platform fail-safe still emitted the Apple claim with zero
evidence (proves the original bug survived under the first pass). Restored
the fix (`git stash pop`) and reran — all 4 green.

`pnpm check:affected --run` (multiple full runs): the unit-test portion
itself has been 100% green across every run (807 test files / 6439 tests,
typecheck/lint/format/layering/build/daemon-wire-compat all pass). Local
runs on this shared host intermittently fail only at the
`check-tmpdir-leaks.ts` gate, flagging `/tmp/agent-device-test-run-*`
directories confirmed to belong to other concurrent sessions on the same
host (verified: the specific flagged directories no longer exist by the
time they're inspected, while several *other* `agent-device-test-run-*`
directories with timestamps spanning many hours sit in `/tmp` at the same
time — not produced by this diff's own test runs). Noting this honestly
rather than claiming a fully clean local run: CI runs `check:affected` on
this pushed head in an isolated runner where that host-sharing noise does
not exist, and is the authoritative signal here.

## Scope

Hint-wording + cleanup-eligibility logic only, no redesign of the timeout
system, no `src/platforms` import added to `src/daemon/client/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
