### PR TITLE
refactor: route apps through request runtime

### DIFF
--- a/packages/capture-kit/src/platform-runtime-unavailable.test.ts
+++ b/packages/capture-kit/src/platform-runtime-unavailable.test.ts
@@ -36,6 +36,7 @@ test('builds one complete combined unavailable owner without fake operations', a
     'bootTarget',
     'bootTargetHeadless',
     'ensureReady',
+    'listApps',
     'networkDump',
     'screenRecordingCleanup',
     'screenRecordingReattach',

--- a/packages/capture-kit/src/platform-runtime-unavailable.ts
+++ b/packages/capture-kit/src/platform-runtime-unavailable.ts
@@ -13,6 +13,7 @@ import {
 
 export type UnavailablePlatformRuntimeFacts = Readonly<{
   appLog: RuntimeOperationUnavailability;
+  apps?: RuntimeOperationUnavailability;
   network: RuntimeOperationUnavailability;
   screenRecording?: RuntimeOperationUnavailability;
   readiness?: RuntimeOperationUnavailability;
@@ -20,6 +21,7 @@ export type UnavailablePlatformRuntimeFacts = Readonly<{
 
 type FrozenUnavailablePlatformRuntimeFacts = Readonly<{
   appLog: RuntimeOperationUnavailability;
+  apps: RuntimeOperationUnavailability;
   network: RuntimeOperationUnavailability;
   screenRecording: RuntimeOperationUnavailability;
   readiness: RuntimeOperationUnavailability;
@@ -75,7 +77,7 @@ export function createUnavailablePlatformRuntimeFacts(
   owner: RuntimeOwnerRef,
   unavailable: UnavailablePlatformRuntimeFacts,
 ): RuntimeFacts<PlatformRuntimeOperations> {
-  const { appLog, network, screenRecording, readiness } = freezeUnavailableFacts(unavailable);
+  const { appLog, apps, network, screenRecording, readiness } = freezeUnavailableFacts(unavailable);
   return Object.freeze({
     device: {
       ...deviceShape(device),
@@ -87,6 +89,7 @@ export function createUnavailablePlatformRuntimeFacts(
       appLogStart: appLog,
       appLogReattach: appLog,
       appLogCleanup: appLog,
+      listApps: apps,
       networkDump: network,
       screenRecordingStart: screenRecording,
       screenRecordingReattach: screenRecording,
@@ -103,6 +106,7 @@ function freezeUnavailableFacts(
 ): FrozenUnavailablePlatformRuntimeFacts {
   return Object.freeze({
     appLog: Object.freeze({ ...unavailable.appLog }),
+    apps: Object.freeze({ ...(unavailable.apps ?? unavailable.network) }),
     network: Object.freeze({ ...unavailable.network }),
     screenRecording: Object.freeze({
       ...(unavailable.screenRecording ?? unavailable.network),

--- a/packages/contracts/src/app-inventory-runtime.ts
+++ b/packages/contracts/src/app-inventory-runtime.ts
@@ -1,0 +1,40 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { AppsFilter } from './app-inventory.ts';
+
+export type InstalledAppInfo = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type ListAppsInput = Readonly<{
+  device: DeviceInfo;
+  filter: AppsFilter;
+}>;
+
+export type AppInventoryRuntimeOperations = Readonly<{
+  listApps(input: ListAppsInput): Promise<readonly InstalledAppInfo[]>;
+}>;
+
+export type AppInventoryRuntimeHost = Readonly<{
+  apple: Readonly<{
+    listApps(
+      device: DeviceInfo,
+      filter: AppsFilter,
+      signal: AbortSignal,
+    ): Promise<readonly InstalledAppInfo[]>;
+  }>;
+  android: Readonly<{
+    listApps(
+      device: DeviceInfo,
+      filter: AppsFilter,
+      signal: AbortSignal,
+    ): Promise<readonly InstalledAppInfo[]>;
+  }>;
+  harmonyos: Readonly<{
+    listApps(
+      device: DeviceInfo,
+      filter: AppsFilter,
+      signal: AbortSignal,
+    ): Promise<readonly InstalledAppInfo[]>;
+  }>;
+}>;

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -41,9 +41,9 @@ export {
   narrowDeviceBinding,
   providerRuntimeOwner,
   runtimeOwnerKey,
+  runtimeUse,
   sameRuntimeOwner,
 } from '../platform-runtime.ts';
-export { runtimeUse } from '../platform-runtime.ts';
 export type {
   BoundDeviceRuntime,
   DeviceBinding,

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -169,7 +169,6 @@ export type {
   NetworkRuntimePlan,
   NetworkRuntimePlanInput,
 } from '../network-runtime-plan.ts';
-export { defineUse } from '../platform-runtime-operations.ts';
 export type {
   AppInventoryRuntimeHost,
   AppInventoryRuntimeOperations,

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -41,6 +41,7 @@ export {
   narrowDeviceBinding,
   providerRuntimeOwner,
   runtimeOwnerKey,
+  runtimeUse,
   sameRuntimeOwner,
 } from '../platform-runtime.ts';
 export type {

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -41,7 +41,6 @@ export {
   narrowDeviceBinding,
   providerRuntimeOwner,
   runtimeOwnerKey,
-  runtimeUse,
   sameRuntimeOwner,
 } from '../platform-runtime.ts';
 export type {

--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -41,9 +41,9 @@ export {
   narrowDeviceBinding,
   providerRuntimeOwner,
   runtimeOwnerKey,
-  runtimeUse,
   sameRuntimeOwner,
 } from '../platform-runtime.ts';
+export { runtimeUse } from '../platform-runtime.ts';
 export type {
   BoundDeviceRuntime,
   DeviceBinding,
@@ -170,6 +170,13 @@ export type {
   NetworkRuntimePlanInput,
 } from '../network-runtime-plan.ts';
 export { defineUse } from '../platform-runtime-operations.ts';
+export type {
+  AppInventoryRuntimeHost,
+  AppInventoryRuntimeOperations,
+  InstalledAppInfo,
+  ListAppsInput,
+} from '../app-inventory-runtime.ts';
+export { appsRuntimeUse, defineUse } from '../platform-runtime-operations.ts';
 export type {
   PlatformRuntimeHost,
   PlatformRuntimeModule,

--- a/packages/contracts/src/platform-runtime-operations.ts
+++ b/packages/contracts/src/platform-runtime-operations.ts
@@ -1,4 +1,8 @@
 import type { AppLogRuntimeHost, AppLogRuntimeOperations } from './app-log-runtime.ts';
+import type {
+  AppInventoryRuntimeHost,
+  AppInventoryRuntimeOperations,
+} from './app-inventory-runtime.ts';
 import type { NetworkRuntimeHost, NetworkRuntimeOperations } from './network-runtime.ts';
 import type { ScreenRecordingRuntimeHost } from './screen-recording-runtime-host.ts';
 import type { ScreenRecordingRuntimeOperations } from './screen-recording-runtime.ts';
@@ -14,6 +18,7 @@ import {
 } from './platform-runtime.ts';
 
 export type PlatformRuntimeOperations = AppLogRuntimeOperations &
+  AppInventoryRuntimeOperations &
   NetworkRuntimeOperations &
   ScreenRecordingRuntimeOperations &
   DeviceReadinessRuntimeOperations;
@@ -30,6 +35,7 @@ export const bootTargetUse = defineUse({ required: ['bootTarget'] });
 export const bootTargetHeadlessUse = defineUse({
   required: ['bootTargetHeadless'],
 });
+export const appsRuntimeUse = defineUse({ required: ['ensureReady', 'listApps'] });
 export const deviceBootRuntimeUses = Object.freeze([bootTargetUse, bootTargetHeadlessUse] as const);
 
 export type DeviceReadinessRuntimePlan =
@@ -67,6 +73,7 @@ export function resolveDeviceReadinessRuntimePlan(
 export type PlatformRuntimeHost = AppLogRuntimeHost &
   NetworkRuntimeHost &
   Readonly<{
+    appInventory: AppInventoryRuntimeHost;
     screenRecording: ScreenRecordingRuntimeHost;
     deviceReadiness: DeviceReadinessRuntimeHost;
   }>;

--- a/packages/contracts/src/platform-runtime.test.ts
+++ b/packages/contracts/src/platform-runtime.test.ts
@@ -10,7 +10,7 @@ import {
   sameRuntimeOwner,
   type BoundDeviceRuntime,
   type DeviceBinding,
-} from './platform-runtime.ts';
+} from './facades/platform.ts';
 
 type TestOperations = {
   inspect: (input: Readonly<{ depth: number }>) => Promise<Readonly<{ nodes: number }>>;

--- a/packages/platform-android/src/network/runtime.test.ts
+++ b/packages/platform-android/src/network/runtime.test.ts
@@ -152,6 +152,11 @@ function host(options: {
       readProcessMarker: async () => options.marker,
     },
     networkTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
   };
 }
 
@@ -189,6 +194,11 @@ function unusedAppLogHost(): Omit<
       terminate: async () => 'already-missing',
     },
     processTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     clock: { now: () => 1, sleep: async () => {} },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },

--- a/packages/platform-android/src/runtime.test.ts
+++ b/packages/platform-android/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createAndroidPlatformRuntime } from './runtime.ts';
@@ -16,6 +16,7 @@ test.each([
   ['emulator', device],
   ['device', { ...device, kind: 'device' as const }],
 ])('classifies the Android %s runtime denominator', async (_name, runtimeDevice) => {
+  const listApps = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
   const host = {
     commands: {
       which: async () => 'tool',
@@ -24,6 +25,11 @@ test.each([
     toolchains: { prepare: async () => {} },
     clock: { now: () => 1, sleep: async () => {} },
     processTransports: { resolve: async () => ({ mode: 'local' as const }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps },
+      harmonyos: { listApps: async () => [] },
+    },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
       appleAutomation: { keepHot: () => {} },
@@ -60,6 +66,7 @@ test.each([
   const { facts } = binding;
   expect(facts.device.providerMode).toBe('local');
   expect(facts.operations.networkDump).toEqual({ available: true });
+  expect(facts.operations.listApps).toEqual({ available: true });
   expect(facts.operations.screenRecordingStart).toEqual({ available: true });
   expect(facts.operations.screenRecordingReattach).toEqual({ available: true });
   expect(facts.operations.screenRecordingCleanup).toEqual({ available: true });
@@ -71,6 +78,10 @@ test.each([
     id: runtimeDevice.id,
     booted: true,
   });
+  await expect(
+    binding.operations.listApps?.({ device: runtimeDevice, filter: 'all' }),
+  ).resolves.toEqual([{ id: 'com.example.app', name: 'Example' }]);
+  expect(listApps).toHaveBeenCalledWith(runtimeDevice, 'all', expect.any(AbortSignal));
 
   await expect(binding.operations.bootTarget?.({})).resolves.toMatchObject({
     id: runtimeDevice.id,

--- a/packages/platform-android/src/runtime.ts
+++ b/packages/platform-android/src/runtime.ts
@@ -7,6 +7,7 @@ import type {
   EnsureReadyInput,
 } from '@agent-device/contracts/platform';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createAndroidAppLogRuntime } from './logs/runtime.ts';
 import { dumpAndroidNetworkTraffic } from './network/runtime.ts';
 import { bindAndroidScreenRecordingRuntime } from './recording/runtime.ts';
@@ -35,6 +36,7 @@ export function createAndroidPlatformRuntime(host: PlatformRuntimeHost): Platfor
         ensureReady: available,
         bootTarget: available,
         bootTargetHeadless: device.kind === 'emulator' ? available : headlessUnavailable,
+        listApps: available,
       },
     });
   };
@@ -85,6 +87,12 @@ export function createAndroidPlatformRuntime(host: PlatformRuntimeHost): Platfor
                   ),
               }
             : {}),
+          listApps: async (input: { device: DeviceInfo; filter: 'all' | 'user-installed' }) =>
+            await host.appInventory.android.listApps(
+              input.device,
+              input.filter,
+              request.scope.signal,
+            ),
         }),
         [Symbol.asyncDispose]: async () => await logs[Symbol.asyncDispose](),
       }) satisfies DeviceBinding<PlatformRuntimeOperations>;

--- a/packages/platform-apple/src/network/runtime.test.ts
+++ b/packages/platform-apple/src/network/runtime.test.ts
@@ -122,6 +122,11 @@ function host(options: {
       readProcessMarker: async () => ({ status: 'missing' }),
     },
     networkTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
   };
 }
 
@@ -153,6 +158,11 @@ function unusedAppLogHost(): Omit<
       terminate: async () => 'already-missing',
     },
     processTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     clock: { now: () => 1, sleep: async () => {} },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },

--- a/packages/platform-apple/src/runtime.fixtures.ts
+++ b/packages/platform-apple/src/runtime.fixtures.ts
@@ -14,6 +14,11 @@ export function platformRuntimeHostFixture(): PlatformRuntimeHost {
       readProcessMarker: async () => ({ status: 'missing' }),
     },
     networkTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
       appleAutomation: { keepHot: () => {} },

--- a/packages/platform-apple/src/runtime.test.ts
+++ b/packages/platform-apple/src/runtime.test.ts
@@ -57,6 +57,9 @@ test.each([
   const { facts } = binding;
   expect(facts.device.providerMode).toBe('local');
   expect(facts.operations.networkDump).toEqual({ available: true });
+  expect(facts.operations.listApps.available).toBe(
+    device.appleOs !== 'watchos' && device.iosPhysicalDeviceBackend !== 'xctest',
+  );
   for (const operation of ['appLogInspect', 'appLogDoctor', 'appLogStart'] as const) {
     const fact = facts.operations[operation];
     expect(fact.available).toBe(available);
@@ -153,4 +156,31 @@ test('macOS readiness is a no-op while boot remains unavailable', async () => {
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({ booted: true });
   expect(ensureConnected).not.toHaveBeenCalled();
   expect(binding.operations.bootTarget).toBeUndefined();
+});
+
+test('routes Apple app inventory through the injected host facet', async () => {
+  const host = platformRuntimeHostFixture();
+  const listApps = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
+  const runtime = createApplePlatformRuntime({
+    ...host,
+    appInventory: {
+      ...host.appInventory,
+      apple: { listApps },
+    },
+  });
+  const device = appleDevice();
+  const binding = await runtime.bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: {
+      signal: new AbortController().signal,
+      diagnostics: { emit: () => {} },
+      progress: { report: () => {} },
+    },
+  });
+
+  await expect(binding.operations.listApps?.({ device, filter: 'all' })).resolves.toEqual([
+    { id: 'com.example.app', name: 'Example' },
+  ]);
+  expect(listApps).toHaveBeenCalledWith(device, 'all', expect.any(AbortSignal));
 });

--- a/packages/platform-apple/src/runtime.ts
+++ b/packages/platform-apple/src/runtime.ts
@@ -27,6 +27,24 @@ const headlessUnavailable = Object.freeze({
   hint: 'Headless boot is supported only for local Android emulators.',
 } as const);
 
+function appInventoryFacts(device: DeviceInfo) {
+  if (device.appleOs === 'watchos') {
+    return Object.freeze({
+      available: false,
+      reason: 'unsupported-platform-leaf' as const,
+      hint: 'watchOS app inventory is not supported.',
+    });
+  }
+  if (device.kind === 'device' && device.iosPhysicalDeviceBackend === 'xctest') {
+    return Object.freeze({
+      available: false,
+      reason: 'unsupported-device-backend' as const,
+      hint: 'App inventory is available only on CoreDevice-backed physical iOS devices.',
+    });
+  }
+  return available;
+}
+
 export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformRuntimeOwner {
   const appLogs = createAppleAppLogRuntime(host);
   const inspectFacts = async (device: DeviceInfo) => {
@@ -45,6 +63,7 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
         : leafRecordingFacts;
     const readiness = device.appleOs === 'watchos' ? unavailable : available;
     const boot = isMacOs(device) || device.appleOs === 'watchos' ? unavailable : available;
+    const apps = appInventoryFacts(device);
     return Object.freeze({
       device: logs.device,
       operations: {
@@ -56,6 +75,7 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
         ensureReady: readiness,
         bootTarget: boot,
         bootTargetHeadless: headlessUnavailable,
+        listApps: apps,
       },
     });
   };
@@ -93,6 +113,16 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
             ? {
                 bootTarget: async () =>
                   await ensureAppleReady(host, request.device, request.scope.signal),
+              }
+            : {}),
+          ...(facts.operations.listApps.available
+            ? {
+                listApps: async (input: { device: DeviceInfo; filter: 'all' | 'user-installed' }) =>
+                  await host.appInventory.apple.listApps(
+                    input.device,
+                    input.filter,
+                    request.scope.signal,
+                  ),
               }
             : {}),
         }),

--- a/packages/platform-harmonyos/src/runtime.test.ts
+++ b/packages/platform-harmonyos/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyPlatformRuntime } from './runtime.ts';
@@ -13,8 +13,10 @@ const device: DeviceInfo = {
 };
 
 test('classifies the HarmonyOS runtime denominator', async () => {
+  const listApps = vi.fn(async () => [{ id: 'com.example.application', name: 'application' }]);
   const host = {
     processTransports: { resolve: async () => ({ mode: 'local' as const }) },
+    appInventory: { harmonyos: { listApps } },
   } as unknown as PlatformRuntimeHost;
   const binding = await createHarmonyPlatformRuntime(host).bind({
     device,
@@ -38,5 +40,10 @@ test('classifies the HarmonyOS runtime denominator', async () => {
   expect(facts.operations.ensureReady).toEqual({ available: true });
   expect(facts.operations.bootTarget).toMatchObject({ available: false });
   expect(facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(facts.operations.listApps).toEqual({ available: true });
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({ booted: true });
+  await expect(binding.operations.listApps?.({ device, filter: 'all' })).resolves.toEqual([
+    { id: 'com.example.application', name: 'application' },
+  ]);
+  expect(listApps).toHaveBeenCalledWith(device, 'all', expect.any(AbortSignal));
 });

--- a/packages/platform-harmonyos/src/runtime.test.ts
+++ b/packages/platform-harmonyos/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyPlatformRuntime } from './runtime.ts';
@@ -13,8 +13,14 @@ const device: DeviceInfo = {
 };
 
 test('classifies the HarmonyOS runtime denominator', async () => {
+  const listApps = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
   const host = {
     processTransports: { resolve: async () => ({ mode: 'local' as const }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps },
+    },
   } as unknown as PlatformRuntimeHost;
   const binding = await createHarmonyPlatformRuntime(host).bind({
     device,
@@ -38,5 +44,10 @@ test('classifies the HarmonyOS runtime denominator', async () => {
   expect(facts.operations.ensureReady).toEqual({ available: true });
   expect(facts.operations.bootTarget).toMatchObject({ available: false });
   expect(facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(facts.operations.listApps).toEqual({ available: true });
+  await expect(binding.operations.listApps?.({ device, filter: 'all' })).resolves.toEqual([
+    { id: 'com.example.app', name: 'Example' },
+  ]);
+  expect(listApps).toHaveBeenCalledWith(device, 'all', expect.any(AbortSignal));
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({ booted: true });
 });

--- a/packages/platform-harmonyos/src/runtime.test.ts
+++ b/packages/platform-harmonyos/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyPlatformRuntime } from './runtime.ts';
@@ -13,14 +13,8 @@ const device: DeviceInfo = {
 };
 
 test('classifies the HarmonyOS runtime denominator', async () => {
-  const listApps = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
   const host = {
     processTransports: { resolve: async () => ({ mode: 'local' as const }) },
-    appInventory: {
-      apple: { listApps: async () => [] },
-      android: { listApps: async () => [] },
-      harmonyos: { listApps },
-    },
   } as unknown as PlatformRuntimeHost;
   const binding = await createHarmonyPlatformRuntime(host).bind({
     device,
@@ -44,10 +38,5 @@ test('classifies the HarmonyOS runtime denominator', async () => {
   expect(facts.operations.ensureReady).toEqual({ available: true });
   expect(facts.operations.bootTarget).toMatchObject({ available: false });
   expect(facts.operations.bootTargetHeadless).toMatchObject({ available: false });
-  expect(facts.operations.listApps).toEqual({ available: true });
-  await expect(binding.operations.listApps?.({ device, filter: 'all' })).resolves.toEqual([
-    { id: 'com.example.app', name: 'Example' },
-  ]);
-  expect(listApps).toHaveBeenCalledWith(device, 'all', expect.any(AbortSignal));
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({ booted: true });
 });

--- a/packages/platform-harmonyos/src/runtime.ts
+++ b/packages/platform-harmonyos/src/runtime.ts
@@ -5,6 +5,7 @@ import type {
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyAppLogRuntime } from './logs/runtime.ts';
 import {
   createHarmonyScreenRecordingOperations,
@@ -34,7 +35,7 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
         ensureReady: available,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
-        listApps: unavailable,
+        listApps: available,
       },
     });
   };
@@ -61,6 +62,12 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
               })
             : {}),
           ensureReady: async () => ({ ...request.device, booted: true }),
+          listApps: async (input: { device: DeviceInfo; filter: 'all' | 'user-installed' }) =>
+            await host.appInventory.harmonyos.listApps(
+              input.device,
+              input.filter,
+              request.scope.signal,
+            ),
         }),
         [Symbol.asyncDispose]: async () => await logs[Symbol.asyncDispose](),
       }) satisfies DeviceBinding<PlatformRuntimeOperations>;

--- a/packages/platform-harmonyos/src/runtime.ts
+++ b/packages/platform-harmonyos/src/runtime.ts
@@ -5,7 +5,6 @@ import type {
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
-import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyAppLogRuntime } from './logs/runtime.ts';
 import {
   createHarmonyScreenRecordingOperations,
@@ -35,7 +34,7 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
         ensureReady: available,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
-        listApps: available,
+        listApps: unavailable,
       },
     });
   };
@@ -53,12 +52,6 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
         facts,
         operations: Object.freeze({
           ...logs.operations,
-          listApps: async (input: { device: DeviceInfo; filter: 'all' | 'user-installed' }) =>
-            await host.appInventory.harmonyos.listApps(
-              input.device,
-              input.filter,
-              request.scope.signal,
-            ),
           ...(recordingFacts.available
             ? createHarmonyScreenRecordingOperations({
                 host,

--- a/packages/platform-harmonyos/src/runtime.ts
+++ b/packages/platform-harmonyos/src/runtime.ts
@@ -18,7 +18,6 @@ const unavailable = Object.freeze({
   available: false,
   reason: 'unsupported-platform-leaf',
 } as const);
-const available = Object.freeze({ available: true } as const);
 
 export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): PlatformRuntimeOwner {
   const appLogs = createHarmonyAppLogRuntime(host);

--- a/packages/platform-harmonyos/src/runtime.ts
+++ b/packages/platform-harmonyos/src/runtime.ts
@@ -5,6 +5,7 @@ import type {
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createHarmonyAppLogRuntime } from './logs/runtime.ts';
 import {
   createHarmonyScreenRecordingOperations,
@@ -12,6 +13,7 @@ import {
 } from './recording/runtime.ts';
 
 const owner = localRuntimeOwner('harmonyos');
+const available = Object.freeze({ available: true } as const);
 const unavailable = Object.freeze({
   available: false,
   reason: 'unsupported-platform-leaf',
@@ -34,6 +36,7 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
         ensureReady: available,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
+        listApps: available,
       },
     });
   };
@@ -51,6 +54,12 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
         facts,
         operations: Object.freeze({
           ...logs.operations,
+          listApps: async (input: { device: DeviceInfo; filter: 'all' | 'user-installed' }) =>
+            await host.appInventory.harmonyos.listApps(
+              input.device,
+              input.filter,
+              request.scope.signal,
+            ),
           ...(recordingFacts.available
             ? createHarmonyScreenRecordingOperations({
                 host,

--- a/packages/platform-linux/src/runtime.test.ts
+++ b/packages/platform-linux/src/runtime.test.ts
@@ -25,4 +25,5 @@ test('classifies the Linux runtime denominator as unavailable', async () => {
   expect(binding.facts.operations.ensureReady).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTarget).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(binding.facts.operations.listApps).toMatchObject({ available: false });
 });

--- a/packages/platform-vega/src/runtime.test.ts
+++ b/packages/platform-vega/src/runtime.test.ts
@@ -25,4 +25,5 @@ test('classifies the Vega runtime denominator as unavailable', async () => {
   expect(binding.facts.operations.ensureReady).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTarget).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(binding.facts.operations.listApps).toMatchObject({ available: false });
 });

--- a/packages/platform-web/src/runtime.test.ts
+++ b/packages/platform-web/src/runtime.test.ts
@@ -36,6 +36,7 @@ test('preserves a narrow web provider dump including empty successful entries', 
   expect(binding.facts.operations.ensureReady).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTarget).toMatchObject({ available: false });
   expect(binding.facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(binding.facts.operations.listApps).toMatchObject({ available: false });
 });
 
 test('keeps a web transport without dumpNetwork unavailable instead of throwing a stub', async () => {
@@ -162,6 +163,11 @@ function host(
       readProcessMarker: async () => ({ status: 'missing' }),
     },
     networkTransports: { resolve: async () => transport },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
       appleAutomation: { keepHot: () => {} },

--- a/packages/platform-web/src/runtime.ts
+++ b/packages/platform-web/src/runtime.ts
@@ -25,6 +25,11 @@ const readinessUnavailable = Object.freeze({
   available: false,
   reason: 'unsupported-platform-leaf',
 } as const);
+const appsUnavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-platform-leaf',
+  hint: 'apps is not supported on web targets.',
+} as const);
 
 export function createWebPlatformRuntime(host: PlatformRuntimeHost): PlatformRuntimeOwner {
   const inspectFacts = async (device: DeviceInfo) => {
@@ -131,6 +136,7 @@ function webRuntimeFacts(
       ensureReady: readinessUnavailable,
       bootTarget: readinessUnavailable,
       bootTargetHeadless: readinessUnavailable,
+      listApps: appsUnavailable,
     },
   });
 }

--- a/packages/provider-limrun/src/app-log-runtime.test.ts
+++ b/packages/provider-limrun/src/app-log-runtime.test.ts
@@ -28,6 +28,7 @@ test('rejects a cross-platform durable descriptor before provider reconnection',
     ownsDevice: () => true,
     openCurrent: async () => undefined,
     reconnect,
+    listApps: async () => [],
   });
   const binding = await owner.bind({
     device,
@@ -69,6 +70,7 @@ test('rejects cross-session paths before reconnecting or opening a provider read
     ownsDevice: () => true,
     openCurrent,
     reconnect,
+    listApps: async () => [],
   });
   const binding = await owner.bind({ device, intent: { kind: 'ordinary' }, scope });
   const envelope = createLimrunAppLogEnvelope({
@@ -129,6 +131,7 @@ test.each([
     ownsDevice: () => true,
     openCurrent: async () => undefined,
     reconnect,
+    listApps: async () => [],
   });
 
   await expect(
@@ -166,6 +169,7 @@ test('serves provider-owned network from the canonical session app log without l
     ownsDevice: () => true,
     openCurrent: async () => undefined,
     reconnect: async () => ({ status: 'missing' }),
+    listApps: async () => [],
   });
   const binding = await owner.bind({ device, intent: { kind: 'ordinary' }, scope });
   await expect(
@@ -204,6 +208,7 @@ test.each([
     ownsDevice: () => true,
     openCurrent: async () => undefined,
     reconnect: async () => ({ status: 'missing' }),
+    listApps: async () => [],
   });
   const binding = await owner.bind({ device: runtimeDevice, intent: { kind: 'ordinary' }, scope });
   expect(binding.facts.device.providerMode).toBe('provider-runtime');
@@ -211,6 +216,10 @@ test.each([
   expect(binding.facts.operations.ensureReady).toEqual({ available: true });
   expect(binding.facts.operations.bootTarget).toEqual({ available: true });
   expect(binding.facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(binding.facts.operations.listApps).toEqual({ available: true });
+  await expect(
+    binding.operations.listApps?.({ device: runtimeDevice, filter: 'all' }),
+  ).resolves.toEqual([]);
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({
     id: runtimeDevice.id,
     booted: true,
@@ -269,6 +278,11 @@ function unusedHost(): PlatformRuntimeHost {
       readProcessMarker: async () => ({ status: 'missing' }),
     },
     networkTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
       appleAutomation: { keepHot: () => {} },

--- a/packages/provider-limrun/src/app-log-runtime.ts
+++ b/packages/provider-limrun/src/app-log-runtime.ts
@@ -1,4 +1,5 @@
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { AppsFilter } from '@agent-device/contracts/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { parseLimrunDeviceId } from './device.ts';
 import type {
@@ -37,6 +38,11 @@ export type LimrunPlatformRuntimeOwnerOptions = Readonly<{
     descriptor: LimrunAppLogDescriptor,
     signal?: AbortSignal,
   ): Promise<LimrunAppLogReconnectOutcome>;
+  listApps(
+    device: DeviceInfo,
+    filter: AppsFilter,
+    signal: AbortSignal,
+  ): Promise<readonly { id: string; name: string }[]>;
 }>;
 
 const available = Object.freeze({ available: true } as const);
@@ -183,6 +189,7 @@ function bindLimrunAppLogs(
     },
     ensureReady: async () => ({ ...device, booted: true }),
     bootTarget: async () => ({ ...device, booted: true }),
+    listApps: async (input) => await options.listApps(input.device, input.filter, signal),
   } satisfies DeviceBinding<PlatformRuntimeOperations>['operations'];
   return Object.freeze({
     device,
@@ -234,6 +241,7 @@ function facts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations> {
       ensureReady: available,
       bootTarget: available,
       bootTargetHeadless: headlessUnavailable,
+      listApps: available,
     },
   });
 }

--- a/packages/provider-limrun/src/runtime.ts
+++ b/packages/provider-limrun/src/runtime.ts
@@ -379,6 +379,19 @@ async function loadLimrunPlatformRuntime(
     openCurrent: async (device) => runtime.currentAppLogReader(device),
     reconnect: async (descriptor, signal) =>
       await runtime.reconnectAppLogReader(descriptor, signal),
+    listApps: async (device, filter, signal) => {
+      signal.throwIfAborted();
+      const session = runtime.getDeviceSession(device);
+      if (!session) {
+        throw new AppError('DEVICE_NOT_FOUND', 'Limrun app inventory session is unavailable', {
+          deviceId: device.id,
+        });
+      }
+      return (await session.listApps(filter)).map((app) => ({
+        id: app.id,
+        name: app.name ?? app.id,
+      }));
+    },
   });
 }
 

--- a/packages/provider-webdriver/src/platform-runtime.test.ts
+++ b/packages/provider-webdriver/src/platform-runtime.test.ts
@@ -81,6 +81,10 @@ test.each([
   expect(binding.facts.operations.ensureReady).toEqual({ available: true });
   expect(binding.facts.operations.bootTarget).toEqual({ available: true });
   expect(binding.facts.operations.bootTargetHeadless).toMatchObject({ available: false });
+  expect(binding.facts.operations.listApps).toMatchObject({
+    available: false,
+    reason: 'owner-capability-missing',
+  });
   await expect(binding.operations.ensureReady?.({})).resolves.toMatchObject({
     id: runtimeDevice.id,
     booted: true,
@@ -146,6 +150,11 @@ function host(run: PlatformRuntimeHost['commands']['run']): PlatformRuntimeHost 
       readProcessMarker: async () => ({ status: 'missing' }),
     },
     networkTransports: { resolve: async () => ({ mode: 'local' }) },
+    appInventory: {
+      apple: { listApps: async () => [] },
+      android: { listApps: async () => [] },
+      harmonyos: { listApps: async () => [] },
+    },
     screenRecording: {
       outputs: { prepare: async () => {} },
       apple: {

--- a/packages/provider-webdriver/src/platform-runtime.ts
+++ b/packages/provider-webdriver/src/platform-runtime.ts
@@ -29,6 +29,11 @@ const headlessUnavailable = Object.freeze({
   reason: 'unsupported-provider-mode',
   hint: 'Headless boot is unavailable for provider-owned devices.',
 } as const);
+const appsUnavailable = Object.freeze({
+  available: false,
+  reason: 'owner-capability-missing' as const,
+  hint: 'WebDriver provider runtimes do not expose app inventory.',
+});
 
 export function createWebDriverPlatformRuntimeOwner(
   options: Readonly<{
@@ -124,6 +129,7 @@ function webDriverFacts(
       ensureReady: available,
       bootTarget: available,
       bootTargetHeadless: headlessUnavailable,
+      listApps: appsUnavailable,
     },
   });
 }

--- a/scripts/layering/runtime-command-cutover-fixtures.ts
+++ b/scripts/layering/runtime-command-cutover-fixtures.ts
@@ -8,7 +8,7 @@ export function sources(entries: readonly SourceEntry[]): ReadonlyMap<string, st
   return new Map(entries);
 }
 
-/** The four rows share one scan, so per-row assertions read their own rule's output. */
+/** The migrated rows share one scan, so per-row assertions read their own rule's output. */
 export function summariesFor(
   rule: string,
   entries: readonly SourceEntry[],

--- a/scripts/layering/runtime-command-cutover-policy.test.ts
+++ b/scripts/layering/runtime-command-cutover-policy.test.ts
@@ -6,7 +6,7 @@ import { cutoverRowDefects, type MigratedCommandCutover } from './runtime-comman
 import { PLANTED_ROW, rowFor, sources, summariesFor } from './runtime-command-cutover-fixtures.ts';
 
 // The mechanism itself (ADR 0019 §8): one planted row, one planted red. Per-row
-// acceptance for the four migrated commands lives in the table test.
+// acceptance for the migrated commands lives in the table test.
 
 const PLANTED_RULE = 'RPlanted planted-cutover';
 

--- a/scripts/layering/runtime-command-cutover-table.ts
+++ b/scripts/layering/runtime-command-cutover-table.ts
@@ -12,7 +12,7 @@ import { recordRuntimeDaemonMechanicsViolations } from './record-runtime-mechani
  * every row, and `cutoverRowDefects` rejects a row that leaves its claims unstated.
  *
  * Rule ids are per row: the layering report groups violations under R20 boot,
- * R17 devices, R14 logs, R15 network, R16 record.
+ * R19 apps, R17 devices, R14 logs, R15 network, R16 record.
  */
 export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
   {
@@ -39,6 +39,32 @@ export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
         bootTarget: ['handleSessionStateCommands'],
         bootTargetHeadless: ['handleSessionStateCommands'],
       },
+    },
+  },
+  {
+    rule: 'R19 apps-runtime-cutover',
+    command: 'apps',
+    subject: 'app inventory',
+    tier: 'request-scoped',
+    execution: 'device-runtime',
+    legacyRetirement: {
+      daemonOnlyRouteNames: [
+        'listAndroidApps',
+        'listIosApps',
+        'listHarmonyApps',
+        'resolveInstalledAppForDoctor',
+      ],
+    },
+    admissionMember: {
+      forms: ['computed-property'],
+      files: ['src/platforms/apple/plugin.ts'],
+      message: 'Apple plugin retains legacy apps support or hint closure',
+    },
+    runtimeTypeNames: ['AppInventoryRuntimeOperations'],
+    operations: { names: ['ensureReady', 'listApps'] },
+    singularExecution: {
+      routes: ['handleAppsInventory'],
+      operations: ['ensureReady', 'listApps'],
     },
   },
   {

--- a/scripts/layering/runtime-command-cutover-table.ts
+++ b/scripts/layering/runtime-command-cutover-table.ts
@@ -12,7 +12,7 @@ import { recordRuntimeDaemonMechanicsViolations } from './record-runtime-mechani
  * every row, and `cutoverRowDefects` rejects a row that leaves its claims unstated.
  *
  * Rule ids are per row: the layering report groups violations under R20 boot,
- * R19 apps, R17 devices, R14 logs, R15 network, R16 record.
+ * R21 apps, R17 devices, R14 logs, R15 network, R16 record.
  */
 export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
   {
@@ -42,7 +42,7 @@ export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
     },
   },
   {
-    rule: 'R19 apps-runtime-cutover',
+    rule: 'R21 apps-runtime-cutover',
     command: 'apps',
     subject: 'app inventory',
     tier: 'request-scoped',
@@ -65,6 +65,10 @@ export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
     singularExecution: {
       routes: ['handleAppsInventory'],
       operations: ['ensureReady', 'listApps'],
+      operationOwners: {
+        ensureReady: ['ensureAppsRuntimeReady'],
+        listApps: ['listAppsFromRuntime'],
+      },
     },
   },
   {

--- a/src/__tests__/contracts/apple-os-capability-table-parity.test.ts
+++ b/src/__tests__/contracts/apple-os-capability-table-parity.test.ts
@@ -67,7 +67,6 @@ const coreDeviceOnlyPhysicalOperationHint = (device: DeviceInfo): string | undef
     ? undefined
     : 'This command requires a CoreDevice-backed physical iOS device. The selected XCTest backend supports open, close, interactions, snapshots, and screenshots.';
 const SUPPORTS_REF: Record<string, (device: DeviceInfo) => boolean> = {
-  apps: supportsCoreDevicePhysicalOperation,
   install: supportsAppInstallation,
   reinstall: supportsAppInstallation,
   'install-from-source': supportsAppInstallation,

--- a/src/__tests__/contracts/apple-os-capability-table-parity.test.ts
+++ b/src/__tests__/contracts/apple-os-capability-table-parity.test.ts
@@ -98,7 +98,6 @@ const HINT_REF: Record<string, (device: DeviceInfo) => string | undefined> = {
     device.platform === 'apple'
       ? 'viewport resizes web targets only (--platform web). Apple screen geometry is fixed by the selected simulator or device type — open a different simulator to test another screen size.'
       : undefined,
-  apps: coreDeviceOnlyPhysicalOperationHint,
   install: coreDeviceOnlyPhysicalOperationHint,
   reinstall: coreDeviceOnlyPhysicalOperationHint,
   'install-from-source': coreDeviceOnlyPhysicalOperationHint,

--- a/src/core/__tests__/capabilities.test.ts
+++ b/src/core/__tests__/capabilities.test.ts
@@ -187,7 +187,6 @@ test('core commands support iOS simulator, iOS device, and Android', () => {
   assertCommandSupport(
     [
       'app-switcher',
-      'apps',
       'back',
       'boot',
       'click',
@@ -255,7 +254,7 @@ test('viewport resizing is admitted only on web, where a backend exists', () => 
 test('capabilities reject CoreDevice-only commands for XCTest-backed devices', () => {
   // Runtime-backed logs and record admission are proven from exact device facts in
   // their handler/runtime tests, never through this legacy matrix projection.
-  const coreDeviceOnlyCommands = ['apps', 'install', 'install-from-source', 'perf', 'reinstall'];
+  const coreDeviceOnlyCommands = ['install', 'install-from-source', 'perf', 'reinstall'];
   assertCommandSupport(coreDeviceOnlyCommands, [
     { device: iosDevice, expected: true, label: 'on CoreDevice' },
     { device: xctestIosDevice, expected: false, label: 'on XCTest backend' },
@@ -273,7 +272,6 @@ test('macOS supports the Apple runner interaction core but excludes mobile-only 
   assertCommandSupport(
     [
       'alert',
-      'apps',
       'back',
       'click',
       'close',
@@ -309,17 +307,7 @@ test('macOS supports the Apple runner interaction core but excludes mobile-only 
 
 test('tvOS follows iOS capability matrix by device kind', () => {
   assertCommandSupport(
-    [
-      'open',
-      'close',
-      'apps',
-      'screenshot',
-      'trigger-app-event',
-      'logs',
-      'reinstall',
-      'boot',
-      'shutdown',
-    ],
+    ['open', 'close', 'screenshot', 'trigger-app-event', 'logs', 'reinstall', 'boot', 'shutdown'],
     [{ device: tvOsSimulator, expected: true, label: 'on tvOS' }],
   );
   assertCommandSupport(
@@ -386,7 +374,6 @@ test('Linux supports desktop interaction commands and blocks mobile/unsupported 
     [
       'alert',
       'app-switcher',
-      'apps',
       'install',
       'install-from-source',
       'keyboard',
@@ -428,7 +415,6 @@ test('web supports only the initial browser interaction slice', () => {
     [
       'alert',
       'app-switcher',
-      'apps',
       'back',
       'clipboard',
       'diff',

--- a/src/core/__tests__/capability-plugin-routing-parity.test.ts
+++ b/src/core/__tests__/capability-plugin-routing-parity.test.ts
@@ -158,7 +158,6 @@ const HINT_REF: Record<string, (device: DeviceInfo) => string | undefined> = {
     device.platform === 'apple'
       ? 'viewport resizes web targets only (--platform web). Apple screen geometry is fixed by the selected simulator or device type — open a different simulator to test another screen size.'
       : undefined,
-  apps: coreDeviceOnlyPhysicalOperationHint,
   install: coreDeviceOnlyPhysicalOperationHint,
   reinstall: coreDeviceOnlyPhysicalOperationHint,
   'install-from-source': coreDeviceOnlyPhysicalOperationHint,
@@ -192,7 +191,6 @@ const HARMONYOS_SUPPORTED_COMMANDS_REF = new Set([
   'perf',
   'close',
   'back',
-  'apps',
   'appstate',
   'app-switcher',
   'click',
@@ -286,7 +284,6 @@ test('HarmonyOS advertises only the current HDC-backed command subset', () => {
 
   assert.deepEqual(availableCommands, [
     'app-switcher',
-    'apps',
     'appstate',
     'back',
     'click',

--- a/src/core/__tests__/capability-plugin-routing-parity.test.ts
+++ b/src/core/__tests__/capability-plugin-routing-parity.test.ts
@@ -131,7 +131,6 @@ const coreDeviceOnlyPhysicalOperationHint = (device: DeviceInfo): string | undef
 // end-to-end assertions cross-check this map against production: a command that
 // gains/loses a closure (or whose closure body changes) breaks parity.
 const SUPPORTS_REF: Record<string, (device: DeviceInfo) => boolean> = {
-  apps: supportsCoreDevicePhysicalOperation,
   install: supportsAppInstallation,
   reinstall: supportsAppInstallation,
   'install-from-source': supportsAppInstallation,

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -41,7 +41,6 @@ const HARMONYOS_SUPPORTED_COMMANDS = new Set<string>([
   'perf',
   'close',
   'back',
-  'apps',
   'appstate',
   'app-switcher',
   'click',

--- a/src/core/command-descriptor/__tests__/apps-runtime-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/apps-runtime-execution.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { appsRuntimeUse } from '@agent-device/contracts/platform';
+import { commandDescriptors } from '../registry.ts';
+
+test('apps declares the complete request-scoped runtime use', () => {
+  const descriptor = commandDescriptors.find((candidate) => candidate.name === 'apps');
+
+  expect(descriptor?.platformExecution).toEqual({
+    kind: 'device-runtime',
+    uses: [appsRuntimeUse],
+  });
+  expect(appsRuntimeUse.required).toEqual(['ensureReady', 'listApps']);
+  expect(appsRuntimeUse.preferred).toEqual([]);
+  expect(descriptor).not.toHaveProperty('capability');
+});

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -46,6 +46,7 @@ const UNROUTED_PUBLIC_COMMANDS = new Set<string>([PUBLIC_COMMANDS.installFromSou
 // exact runtime facts and therefore belong to the capability catalog without matrix rows.
 const NO_CAPABILITY_PUBLIC_COMMANDS = new Set<string>([
   PUBLIC_COMMANDS.appState,
+  PUBLIC_COMMANDS.apps,
   PUBLIC_COMMANDS.artifacts,
   PUBLIC_COMMANDS.batch,
   PUBLIC_COMMANDS.boot,

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -15,7 +15,6 @@ import type { PostActionObservationSupport } from './post-action-observation.ts'
 import {
   appLogRuntimePlanUses,
   appsRuntimeUse,
-  assertCommandPlatformExecution,
   assertRecordRuntimeExecution,
   deviceBootRuntimeUses,
   inventoryUse,

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -14,6 +14,8 @@ import { resolvePostActionObservationSupport } from './post-action-observation.t
 import type { PostActionObservationSupport } from './post-action-observation.ts';
 import {
   appLogRuntimePlanUses,
+  appsRuntimeUse,
+  assertCommandPlatformExecution,
   assertRecordRuntimeExecution,
   deviceBootRuntimeUses,
   inventoryUse,
@@ -215,11 +217,6 @@ const APP_RUNTIME_CAPABILITY = ALL_DEVICE_COMMAND_CAPABILITY;
 const VEGA_APP_RUNTIME_CAPABILITY = {
   ...APP_RUNTIME_CAPABILITY,
   vega: VEGA_VVD,
-} satisfies CommandCapability;
-const APP_INVENTORY_CAPABILITY = {
-  apple: APPLE_SIM_AND_DEVICE,
-  android: ANDROID_ALL,
-  linux: LINUX_NONE,
 } satisfies CommandCapability;
 const APP_INSTALL_CAPABILITY = {
   apple: APPLE_SIM_AND_DEVICE,
@@ -499,10 +496,9 @@ export const RAW_COMMAND_DESCRIPTORS = [
       lockPolicySelectorOverride: true,
       preferExplicitDeviceOverExistingSession: true,
     },
-    capability: APP_INVENTORY_CAPABILITY,
+    platformExecution: { kind: 'device-runtime', uses: [appsRuntimeUse] as const },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
-    platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
   {
     name: 'boot',

--- a/src/daemon/__tests__/app-log-resource-recovery.test.ts
+++ b/src/daemon/__tests__/app-log-resource-recovery.test.ts
@@ -352,6 +352,7 @@ function makeGateway(
           ensureReady: { available: true as const },
           bootTarget: { available: true as const },
           bootTargetHeadless: unavailableRecording,
+          listApps: unavailableRecording,
         },
       },
       operations,

--- a/src/daemon/__tests__/device-claim-reconciliation.test.ts
+++ b/src/daemon/__tests__/device-claim-reconciliation.test.ts
@@ -64,6 +64,7 @@ test('reconciles the dead owner session resources through their exact runtime ow
         ensureReady: unavailable,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
+        listApps: unavailable,
       },
     },
     operations: {

--- a/src/daemon/__tests__/request-router-record-runtime-lock.test.ts
+++ b/src/daemon/__tests__/request-router-record-runtime-lock.test.ts
@@ -169,6 +169,7 @@ function makeRecordingGateway(firstStartBlocked: Promise<void>) {
           ensureReady: unavailable,
           bootTarget: unavailable,
           bootTargetHeadless: unavailable,
+          listApps: unavailable,
         },
       },
       operations: {

--- a/src/daemon/__tests__/request-runtime-binding-router.test.ts
+++ b/src/daemon/__tests__/request-runtime-binding-router.test.ts
@@ -149,6 +149,7 @@ function makeGateway(disposeError?: Error) {
         ensureReady: { available: true as const },
         bootTarget: { available: true as const },
         bootTargetHeadless: unavailableRecording,
+        listApps: unavailableRecording,
       },
     },
     operations,

--- a/src/daemon/__tests__/request-runtime-binding.test.ts
+++ b/src/daemon/__tests__/request-runtime-binding.test.ts
@@ -329,6 +329,7 @@ function makeGateway(options: { inspectAvailable?: boolean } = {}) {
     ensureReady: vi.fn(async () => device('ready')),
     bootTarget: vi.fn(async () => device('booted')),
     bootTargetHeadless: vi.fn(async () => device('ready-headless')),
+    listApps: vi.fn(async () => []),
   };
   const facts = {
     device: {
@@ -352,6 +353,7 @@ function makeGateway(options: { inspectAvailable?: boolean } = {}) {
       ensureReady: { available: true } as const,
       bootTarget: { available: true } as const,
       bootTargetHeadless: { available: true } as const,
+      listApps: { available: true } as const,
     },
   };
   const bind = vi.fn(

--- a/src/daemon/__tests__/screen-recording-resource-recovery.test.ts
+++ b/src/daemon/__tests__/screen-recording-resource-recovery.test.ts
@@ -52,6 +52,7 @@ test('recovery cleans a recording through its exact runtime owner', async () => 
         ensureReady: unavailable,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
+        listApps: unavailable,
       },
     },
     operations: {

--- a/src/daemon/__tests__/test-device-runtime-gateway.ts
+++ b/src/daemon/__tests__/test-device-runtime-gateway.ts
@@ -41,6 +41,7 @@ export const unavailableDeviceRuntimeGateway: DeviceRuntimeGateway<PlatformRunti
           ensureReady: unavailable,
           bootTarget: unavailable,
           bootTargetHeadless: unavailable,
+          listApps: unavailable,
         },
       },
       operations: {},

--- a/src/daemon/apps-runtime.ts
+++ b/src/daemon/apps-runtime.ts
@@ -1,0 +1,23 @@
+import type { AppsFilter } from '@agent-device/contracts/device';
+import {
+  appsRuntimeUse,
+  type BoundDeviceRuntime,
+  type EnsureReadyInput,
+  type InstalledAppInfo,
+} from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+export function ensureAppsRuntimeReady(
+  runtime: BoundDeviceRuntime<typeof appsRuntimeUse>,
+  input: EnsureReadyInput,
+): Promise<DeviceInfo> {
+  return runtime.operations.ensureReady(input);
+}
+
+export function listAppsFromRuntime(
+  runtime: BoundDeviceRuntime<typeof appsRuntimeUse>,
+  device: DeviceInfo,
+  filter: AppsFilter,
+): Promise<readonly InstalledAppInfo[]> {
+  return runtime.operations.listApps({ device, filter });
+}

--- a/src/daemon/handlers/__tests__/network-runtime-harness.ts
+++ b/src/daemon/handlers/__tests__/network-runtime-harness.ts
@@ -53,6 +53,7 @@ export function createNetworkRuntime(
             ensureReady: unavailable,
             bootTarget: unavailable,
             bootTargetHeadless: unavailable,
+            listApps: unavailable,
           },
         },
         operations: networkFact.available ? { networkDump } : {},

--- a/src/daemon/handlers/__tests__/record-runtime.fixtures.ts
+++ b/src/daemon/handlers/__tests__/record-runtime.fixtures.ts
@@ -196,6 +196,7 @@ function makeRuntime(session: SessionState, options: RuntimeOptions = {}) {
         ensureReady: unavailable,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
+        listApps: unavailable,
       },
     },
     operations,

--- a/src/daemon/handlers/__tests__/session-capabilities.test.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.test.ts
@@ -1,8 +1,14 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
-import { makeAndroidSession, makeSessionStore } from '../../../__tests__/test-utils/index.ts';
+import {
+  LINUX_DEVICE,
+  WEB_DESKTOP_DEVICE,
+  makeAndroidSession,
+  makeSession,
+  makeSessionStore,
+} from '../../../__tests__/test-utils/index.ts';
 import { withTestDeviceInventoryProvider as withTargetDeviceResolutionScope } from '../../../__tests__/test-utils/device-inventory-gateways.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import {
@@ -13,7 +19,10 @@ import {
   type PlatformRuntimeOperations,
   type RuntimeProviderMode,
 } from '@agent-device/contracts/platform';
-import type { BindDeviceRuntime } from '../../request-runtime-binding.ts';
+import type {
+  BindDeviceRuntime,
+  InspectDeviceRuntimeFacts,
+} from '../../request-runtime-binding.ts';
 import { handleSessionCommands } from './session-command-harness.ts';
 
 function assertAndroidCapabilityHonesty(availableCommands: unknown): void {
@@ -28,6 +37,7 @@ test('capabilities reports supported commands for the selected session device', 
   const runtime = createAdmissionRuntime({
     appLogAvailable: true,
     networkAvailable: true,
+    appsAvailable: true,
     providerMode: 'local',
   });
 
@@ -43,6 +53,7 @@ test('capabilities reports supported commands for the selected session device', 
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     sessionStore,
     bindDevice: runtime.bindDevice,
+    inspectFacts: runtime.inspectFacts,
     invoke: async () => ({ ok: true, data: {} }),
   });
 
@@ -62,6 +73,7 @@ test('capabilities reports supported commands for the selected session device', 
       'press',
       'fill',
       'network',
+      PUBLIC_COMMANDS.apps,
       'perf',
       PUBLIC_COMMANDS.logs,
       PUBLIC_COMMANDS.gesture,
@@ -96,6 +108,7 @@ test('capabilities excludes logs from an unavailable provider-mode XCTest runtim
   const runtime = createAdmissionRuntime({
     appLogAvailable: false,
     networkAvailable: true,
+    appsAvailable: false,
     providerMode: 'provider-runtime',
   });
 
@@ -111,12 +124,14 @@ test('capabilities excludes logs from an unavailable provider-mode XCTest runtim
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     sessionStore,
     bindDevice: runtime.bindDevice,
+    inspectFacts: runtime.inspectFacts,
     invoke: async () => ({ ok: true, data: {} }),
   });
 
   expect(response?.ok).toBe(true);
   if (!response?.ok) return;
   expect(response.data?.availableCommands).not.toContain(PUBLIC_COMMANDS.logs);
+  expect(response.data?.availableCommands).not.toContain(PUBLIC_COMMANDS.apps);
   expect(response.data?.availableCommands).toContain(PUBLIC_COMMANDS.network);
   expect(runtime.uses).toEqual([
     { required: [], preferred: ['appLogInspect'] },
@@ -132,6 +147,7 @@ test('capabilities excludes network when the runtime fact is unavailable', async
   const runtime = createAdmissionRuntime({
     appLogAvailable: true,
     networkAvailable: false,
+    appsAvailable: false,
     providerMode: 'local',
   });
 
@@ -147,6 +163,7 @@ test('capabilities excludes network when the runtime fact is unavailable', async
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     sessionStore,
     bindDevice: runtime.bindDevice,
+    inspectFacts: runtime.inspectFacts,
     invoke: async () => ({ ok: true, data: {} }),
   });
 
@@ -155,6 +172,84 @@ test('capabilities excludes network when the runtime fact is unavailable', async
   expect(response.data?.availableCommands).toContain(PUBLIC_COMMANDS.logs);
   expect(response.data?.availableCommands).not.toContain(PUBLIC_COMMANDS.network);
 });
+
+const APPS_UNAVAILABLE_CAPABILITY_CASES = [
+  { label: 'Linux', device: LINUX_DEVICE, providerMode: 'local' },
+  { label: 'Web', device: WEB_DESKTOP_DEVICE, providerMode: 'local' },
+  {
+    label: 'watchOS',
+    device: {
+      platform: 'apple',
+      appleOs: 'watchos',
+      id: 'watchos-capabilities',
+      name: 'Apple Watch',
+      kind: 'device',
+      target: 'mobile',
+    } satisfies DeviceInfo,
+    providerMode: 'local',
+  },
+  {
+    label: 'XCTest physical iOS',
+    device: {
+      platform: 'apple',
+      appleOs: 'ios',
+      id: 'xctest-capabilities',
+      name: 'XCTest iPhone',
+      kind: 'device',
+      iosPhysicalDeviceBackend: 'xctest',
+    } satisfies DeviceInfo,
+    providerMode: 'provider-runtime',
+  },
+  {
+    label: 'WebDriver',
+    device: {
+      ...WEB_DESKTOP_DEVICE,
+      id: 'webdriver-capabilities',
+      name: 'WebDriver browser',
+    } satisfies DeviceInfo,
+    providerMode: 'provider-runtime',
+  },
+] as const satisfies ReadonlyArray<{
+  label: string;
+  device: DeviceInfo;
+  providerMode: RuntimeProviderMode;
+}>;
+
+test.each(APPS_UNAVAILABLE_CAPABILITY_CASES)(
+  'capabilities omits apps when $label runtime facts deny the operation',
+  async ({ label, device, providerMode }) => {
+    const sessionName = `capabilities-${label.toLowerCase().replaceAll(' ', '-')}`;
+    const sessionStore = makeSessionStore(`agent-device-capabilities-${label}-`);
+    sessionStore.set(sessionName, makeSession(sessionName, { device }));
+    const runtime = createAdmissionRuntime({
+      appLogAvailable: false,
+      networkAvailable: false,
+      appsAvailable: false,
+      providerMode,
+    });
+
+    const response = await handleSessionCommands({
+      req: {
+        token: 't',
+        session: sessionName,
+        command: PUBLIC_COMMANDS.capabilities,
+        positionals: [],
+        flags: {},
+      },
+      sessionName,
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      sessionStore,
+      bindDevice: runtime.bindDevice,
+      inspectFacts: runtime.inspectFacts,
+      invoke: async () => ({ ok: true, data: {} }),
+    });
+
+    expect(response?.ok).toBe(true);
+    if (!response?.ok) return;
+    expect(response.data?.availableCommands).not.toContain(PUBLIC_COMMANDS.apps);
+    expect(runtime.inspectFacts).toHaveBeenCalledOnce();
+  },
+);
 
 test('capabilities accepts a stopped Android AVD placeholder for explicit platform discovery', async () => {
   const stoppedAvd: DeviceInfo = {
@@ -201,6 +296,7 @@ test('capabilities accepts a stopped Android AVD placeholder for explicit platfo
 function createAdmissionRuntime(options: {
   appLogAvailable: boolean;
   networkAvailable: boolean;
+  appsAvailable: boolean;
   providerMode: RuntimeProviderMode;
 }) {
   const uses: Array<{ required: readonly string[]; preferred: readonly string[] }> = [];
@@ -208,12 +304,16 @@ function createAdmissionRuntime(options: {
     uses.push({ required: [...use.required], preferred: [...use.preferred] });
     return narrowDeviceBinding(createAdmissionBinding(device, options), use);
   };
-  return { bindDevice, uses };
+  const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(
+    async (device) => createAdmissionBinding(device, options).facts,
+  );
+  return { bindDevice, inspectFacts, uses };
 }
 
 type AdmissionRuntimeOptions = Readonly<{
   appLogAvailable: boolean;
   networkAvailable: boolean;
+  appsAvailable: boolean;
   providerMode: RuntimeProviderMode;
 }>;
 
@@ -222,6 +322,7 @@ function createAdmissionBinding(
   options: AdmissionRuntimeOptions,
 ): DeviceBinding<PlatformRuntimeOperations> {
   const unavailable = unavailableOperationFact(options.providerMode);
+  const appsFact = options.appsAvailable ? { available: true as const } : unavailable;
   return {
     device,
     owner:
@@ -249,10 +350,10 @@ function createAdmissionBinding(
         screenRecordingStart: unavailable,
         screenRecordingReattach: unavailable,
         screenRecordingCleanup: unavailable,
-        ensureReady: unavailable,
+        ensureReady: appsFact,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
-        listApps: unavailable,
+        listApps: appsFact,
       },
     },
     operations: {

--- a/src/daemon/handlers/__tests__/session-capabilities.test.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.test.ts
@@ -252,6 +252,7 @@ function createAdmissionBinding(
         ensureReady: unavailable,
         bootTarget: unavailable,
         bootTargetHeadless: unavailable,
+        listApps: unavailable,
       },
     },
     operations: {

--- a/src/daemon/handlers/__tests__/session-capabilities.test.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.test.ts
@@ -322,7 +322,7 @@ function createAdmissionBinding(
   options: AdmissionRuntimeOptions,
 ): DeviceBinding<PlatformRuntimeOperations> {
   const unavailable = unavailableOperationFact(options.providerMode);
-  const appsFact = options.appsAvailable ? { available: true as const } : unavailable;
+  const appsFact = appsOperationFact(options);
   return {
     device,
     owner:
@@ -372,6 +372,12 @@ function unavailableOperationFact(providerMode: RuntimeProviderMode) {
         ? ('unsupported-provider-mode' as const)
         : ('owner-capability-missing' as const),
   };
+}
+
+function appsOperationFact(options: AdmissionRuntimeOptions) {
+  return options.appsAvailable
+    ? ({ available: true } as const)
+    : unavailableOperationFact(options.providerMode);
 }
 
 const inspectAndroidAppLog: PlatformRuntimeOperations['appLogInspect'] = async () => ({

--- a/src/daemon/handlers/__tests__/session-capabilities.test.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.test.ts
@@ -173,6 +173,51 @@ test('capabilities excludes network when the runtime fact is unavailable', async
   expect(response.data?.availableCommands).not.toContain(PUBLIC_COMMANDS.network);
 });
 
+test('capabilities includes apps for the available HarmonyOS runtime fact', async () => {
+  const sessionName = 'harmony-capabilities';
+  const sessionStore = makeSessionStore('agent-device-capabilities-harmony-');
+  const harmonyDevice = {
+    platform: 'harmonyos',
+    id: 'harmony-capabilities',
+    name: 'HarmonyOS device',
+    kind: 'device',
+    target: 'mobile',
+    booted: true,
+  } as const;
+  sessionStore.set(sessionName, makeSession(sessionName, { device: harmonyDevice }));
+  const runtime = createAdmissionRuntime({
+    appLogAvailable: true,
+    networkAvailable: false,
+    appsAvailable: true,
+    providerMode: 'local',
+  });
+
+  const response = await withTargetDeviceResolutionScope(
+    async (request) => (request.platform === 'harmonyos' ? [harmonyDevice] : []),
+    async () =>
+      await handleSessionCommands({
+        req: {
+          token: 't',
+          session: sessionName,
+          command: PUBLIC_COMMANDS.capabilities,
+          positionals: [],
+          flags: {},
+        },
+        sessionName,
+        logPath: path.join(os.tmpdir(), 'daemon.log'),
+        sessionStore,
+        bindDevice: runtime.bindDevice,
+        inspectFacts: runtime.inspectFacts,
+        invoke: async () => ({ ok: true, data: {} }),
+      }),
+  );
+
+  expect(response?.ok).toBe(true);
+  if (!response?.ok) return;
+  expect(response.data?.availableCommands).toContain(PUBLIC_COMMANDS.apps);
+  expect(runtime.inspectFacts).toHaveBeenCalledOnce();
+});
+
 const APPS_UNAVAILABLE_CAPABILITY_CASES = [
   { label: 'Linux', device: LINUX_DEVICE, providerMode: 'local' },
   { label: 'Web', device: WEB_DESKTOP_DEVICE, providerMode: 'local' },

--- a/src/daemon/handlers/__tests__/session-command-harness.ts
+++ b/src/daemon/handlers/__tests__/session-command-harness.ts
@@ -74,6 +74,7 @@ function readinessFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperati
       ensureReady: device.appleOs === 'watchos' ? unavailable : available,
       bootTarget: normalAvailable ? available : unavailable,
       bootTargetHeadless: headlessAvailable ? available : unavailable,
+      listApps: unavailable,
     },
   };
 }
@@ -92,6 +93,7 @@ function readinessBinding(device: DeviceInfo): DeviceBinding<PlatformRuntimeOper
               (await mockEnsureReadyRuntime(input)) ?? { ...device, booted: true },
           }
         : {}),
+      listApps: async () => [],
       ...(device.platform === 'android' && device.kind === 'emulator'
         ? {
             bootTargetHeadless: async (input) =>

--- a/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
@@ -110,8 +110,10 @@ test('doctor preserves the legacy unsupported HarmonyOS target-app check', async
   const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => runtimeFacts());
   const ensureReady = vi.fn(async () => ({ ...harmonyDevice, booted: true }));
   const listApps = vi.fn(async () => [{ id: 'com.example.application', name: 'application' }]);
-  const bindDevice: BindDeviceRuntime = vi.fn(async (device, use) =>
-    narrowDeviceBinding(
+  const bindCount = vi.fn();
+  const bindDevice: BindDeviceRuntime = async (device, use) => {
+    bindCount();
+    return narrowDeviceBinding(
       {
         device,
         owner: localRuntimeOwner('harmonyos'),
@@ -120,8 +122,8 @@ test('doctor preserves the legacy unsupported HarmonyOS target-app check', async
         [Symbol.asyncDispose]: async () => {},
       },
       use,
-    ),
-  );
+    );
+  };
   const sessionName = 'doctor-harmony-app-runtime';
   const sessionStore = makeSessionStore('agent-device-doctor-harmony-');
   sessionStore.set(sessionName, {
@@ -158,7 +160,7 @@ test('doctor preserves the legacy unsupported HarmonyOS target-app check', async
     ]),
   );
   expect(inspectFacts).not.toHaveBeenCalled();
-  expect(bindDevice).not.toHaveBeenCalled();
+  expect(bindCount).not.toHaveBeenCalled();
   expect(ensureReady).not.toHaveBeenCalled();
   expect(listApps).not.toHaveBeenCalled();
 });

--- a/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
@@ -5,6 +5,12 @@ import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
 } from '../../request-runtime-binding.ts';
+import {
+  localRuntimeOwner,
+  narrowDeviceBinding,
+  type PlatformRuntimeOperations,
+  type RuntimeFacts,
+} from '@agent-device/contracts/platform';
 import { handleDoctorCommand } from '../session-doctor.ts';
 
 vi.mock('../session-doctor-device.ts', async (importOriginal) => {
@@ -70,4 +76,89 @@ test('doctor app checks retain runtime admission failures as a failed target-app
     ]),
   );
   expect(inspectFacts).toHaveBeenCalledOnce();
+});
+
+test('doctor preserves the legacy unsupported HarmonyOS target-app check', async () => {
+  const harmonyDevice = {
+    platform: 'harmonyos' as const,
+    id: 'harmony-doctor-device',
+    name: 'HarmonyOS doctor device',
+    kind: 'device' as const,
+    target: 'mobile' as const,
+    booted: true,
+  };
+  const available = { available: true } as const;
+  const unavailable = { available: false, reason: 'unsupported-platform-leaf' } as const;
+  const runtimeFacts = (): RuntimeFacts<PlatformRuntimeOperations> => ({
+    device: { family: 'harmonyos', kind: 'device', target: 'mobile', providerMode: 'local' },
+    operations: {
+      appLogInspect: unavailable,
+      appLogDoctor: unavailable,
+      appLogStart: unavailable,
+      appLogReattach: unavailable,
+      appLogCleanup: unavailable,
+      listApps: available,
+      networkDump: unavailable,
+      screenRecordingStart: unavailable,
+      screenRecordingReattach: unavailable,
+      screenRecordingCleanup: unavailable,
+      ensureReady: available,
+      bootTarget: unavailable,
+      bootTargetHeadless: unavailable,
+    },
+  });
+  const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => runtimeFacts());
+  const ensureReady = vi.fn(async () => ({ ...harmonyDevice, booted: true }));
+  const listApps = vi.fn(async () => [{ id: 'com.example.application', name: 'application' }]);
+  const bindDevice: BindDeviceRuntime = vi.fn(async (device, use) =>
+    narrowDeviceBinding(
+      {
+        device,
+        owner: localRuntimeOwner('harmonyos'),
+        facts: runtimeFacts(),
+        operations: { ensureReady, listApps },
+        [Symbol.asyncDispose]: async () => {},
+      },
+      use,
+    ),
+  );
+  const sessionName = 'doctor-harmony-app-runtime';
+  const sessionStore = makeSessionStore('agent-device-doctor-harmony-');
+  sessionStore.set(sessionName, {
+    name: sessionName,
+    device: harmonyDevice,
+    createdAt: Date.now(),
+    actions: [],
+  });
+
+  const response = await handleDoctorCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'doctor',
+      positionals: [],
+      flags: { session: sessionName, targetApp: 'com.example.application' },
+    },
+    sessionName,
+    sessionStore,
+    inspectFacts,
+    bindDevice,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (!response?.ok) return;
+  const checks = (response.data as { checks: Array<Record<string, unknown>> }).checks;
+  expect(checks).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: 'target-app',
+        status: 'info',
+        summary: 'Target app installation checks are not supported for harmonyos.',
+      }),
+    ]),
+  );
+  expect(inspectFacts).not.toHaveBeenCalled();
+  expect(bindDevice).not.toHaveBeenCalled();
+  expect(ensureReady).not.toHaveBeenCalled();
+  expect(listApps).not.toHaveBeenCalled();
 });

--- a/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-app-runtime.test.ts
@@ -1,0 +1,73 @@
+import { expect, test, vi } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { LINUX_DEVICE, makeSessionStore } from '../../../__tests__/test-utils/index.ts';
+import type {
+  BindDeviceRuntime,
+  InspectDeviceRuntimeFacts,
+} from '../../request-runtime-binding.ts';
+import { handleDoctorCommand } from '../session-doctor.ts';
+
+vi.mock('../session-doctor-device.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../session-doctor-device.ts')>();
+  return {
+    ...actual,
+    appendDeviceInventoryCheck: vi.fn(async () => undefined),
+  };
+});
+vi.mock('../session-doctor-toolchain.ts', () => ({
+  appendToolchainChecks: vi.fn(async () => {}),
+}));
+vi.mock('../session-doctor-android.ts', () => ({
+  appendAndroidChecks: vi.fn(async () => {}),
+}));
+vi.mock('../session-doctor-metro.ts', () => ({
+  probeMetro: vi.fn(async () => ({ id: 'metro', status: 'pass', summary: 'mocked' })),
+}));
+vi.mock('../session-doctor-web.ts', () => ({
+  appendWebBrowserLifecycleCheck: vi.fn(async () => {}),
+}));
+
+test('doctor app checks retain runtime admission failures as a failed target-app check', async () => {
+  const sessionName = 'doctor-app-runtime-failure';
+  const sessionStore = makeSessionStore('agent-device-doctor-app-runtime-');
+  sessionStore.set(sessionName, {
+    name: sessionName,
+    device: LINUX_DEVICE,
+    createdAt: Date.now(),
+    actions: [],
+  });
+  const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => {
+    throw new AppError('COMMAND_FAILED', 'runtime facts admission failed');
+  });
+  const bindDevice: BindDeviceRuntime = vi.fn(async () => {
+    throw new AppError('COMMAND_FAILED', 'runtime binding should not be reached');
+  });
+
+  const response = await handleDoctorCommand({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'doctor',
+      positionals: [],
+      flags: { session: sessionName, targetApp: 'com.example.app' },
+    },
+    sessionName,
+    sessionStore,
+    inspectFacts,
+    bindDevice,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (!response?.ok) return;
+  const checks = (response.data as { checks: Array<Record<string, unknown>> }).checks;
+  expect(checks).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: 'target-app',
+        status: 'fail',
+        summary: expect.stringContaining('runtime facts admission failed'),
+      }),
+    ]),
+  );
+  expect(inspectFacts).toHaveBeenCalledOnce();
+});

--- a/src/daemon/handlers/__tests__/session-inventory-apps-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-apps-runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import type { DaemonRequest } from '../../types.ts';
 import { makeSession, makeSessionStore } from './session-test-harness.ts';
 import { handleSessionInventoryCommands } from '../session-inventory.ts';
 import {
@@ -13,32 +13,40 @@ import type {
   InspectDeviceRuntimeFacts,
 } from '../../request-runtime-binding.ts';
 
-const HARMONY_DEVICE = {
-  platform: 'harmonyos' as const,
-  id: 'harmony-1',
-  name: 'HarmonyOS test device',
+const MACOS_DEVICE = {
+  platform: 'apple' as const,
+  appleOs: 'macos' as const,
+  id: 'macos-1',
+  name: 'macOS test host',
   kind: 'device' as const,
-  target: 'mobile' as const,
+  target: 'desktop' as const,
   booted: true,
 };
-const available = { available: true } as const;
+
+const appsAvailable = { available: true } as const;
 const unavailable = { available: false, reason: 'owner-capability-missing' } as const;
 
 function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
   return {
-    device: { family: 'harmonyos', kind: 'device', target: 'mobile', providerMode: 'local' },
+    device: {
+      family: 'apple',
+      appleOs: 'macos',
+      kind: 'device',
+      target: 'desktop',
+      providerMode: 'local',
+    },
     operations: {
       appLogInspect: unavailable,
       appLogDoctor: unavailable,
       appLogStart: unavailable,
       appLogReattach: unavailable,
       appLogCleanup: unavailable,
-      listApps: available,
+      listApps: appsAvailable,
       networkDump: unavailable,
       screenRecordingStart: unavailable,
       screenRecordingReattach: unavailable,
       screenRecordingCleanup: unavailable,
-      ensureReady: available,
+      ensureReady: appsAvailable,
       bootTarget: unavailable,
       bootTargetHeadless: unavailable,
     },
@@ -47,60 +55,56 @@ function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
 
 const inspectFactsImpl: InspectDeviceRuntimeFacts = async () => runtimeFacts();
 const inspectFacts = vi.fn(inspectFactsImpl);
-const ensureReady = vi.fn(async () => HARMONY_DEVICE);
-const listAppsOperation = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
+const ensureReady = vi.fn(async () => MACOS_DEVICE);
+const listApps = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
 let bindCount = 0;
-const bindDeviceImpl: BindDeviceRuntime = async (device, use) =>
-  narrowDeviceBinding(
+const bindDevice: BindDeviceRuntime = async (device, use) => {
+  bindCount += 1;
+  return narrowDeviceBinding(
     {
       device,
-      owner: localRuntimeOwner('harmonyos'),
+      owner: localRuntimeOwner('apple'),
       facts: runtimeFacts(),
       operations: {
         ensureReady,
-        listApps: listAppsOperation,
+        listApps,
       },
       [Symbol.asyncDispose]: async () => {},
     },
     use,
   );
-const bindDevice: BindDeviceRuntime = async (device, use) => {
-  bindCount += 1;
-  return await bindDeviceImpl(device, use);
 };
 
 beforeEach(() => {
   inspectFacts.mockClear();
   ensureReady.mockClear();
-  listAppsOperation.mockClear();
+  listApps.mockClear();
   bindCount = 0;
 });
 
-async function listApps(appsFilter: 'all' | 'user-installed'): Promise<DaemonResponse | null> {
-  const sessionName = `harmony-apps-${appsFilter}`;
+test('macOS apps consumes generic readiness and app inventory through one runtime bind', async () => {
+  const sessionName = 'macos-apps';
   const sessionStore = makeSessionStore();
-  sessionStore.set(sessionName, makeSession(sessionName, HARMONY_DEVICE));
+  sessionStore.set(sessionName, makeSession(sessionName, MACOS_DEVICE));
   const req: DaemonRequest = {
     token: 'test-token',
     session: sessionName,
     command: 'apps',
     positionals: [],
-    flags: { appsFilter },
+    flags: { appsFilter: 'all' },
   };
-  return await handleSessionInventoryCommands({
+
+  const response = await handleSessionInventoryCommands({
     req,
     sessionName,
     sessionStore,
     inspectFacts,
     bindDevice,
   });
-}
 
-test('HarmonyOS apps consumes generic readiness and app inventory through one runtime bind', async () => {
-  const response = await listApps('all');
   expect(response).toEqual({ ok: true, data: { apps: ['Example (com.example.app)'] } });
   expect(inspectFacts).toHaveBeenCalledOnce();
   expect(bindCount).toBe(1);
   expect(ensureReady).toHaveBeenCalledOnce();
-  expect(listAppsOperation).toHaveBeenCalledOnce();
+  expect(listApps).toHaveBeenCalledOnce();
 });

--- a/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
@@ -46,8 +46,10 @@ function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
 }
 
 const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => runtimeFacts());
-const bindDevice: BindDeviceRuntime = vi.fn(async (device, use) =>
-  narrowDeviceBinding(
+let bindCount = 0;
+const bindDevice: BindDeviceRuntime = async (device, use) => {
+  bindCount += 1;
+  return narrowDeviceBinding(
     {
       device,
       owner: localRuntimeOwner('harmonyos'),
@@ -56,12 +58,12 @@ const bindDevice: BindDeviceRuntime = vi.fn(async (device, use) =>
       [Symbol.asyncDispose]: async () => {},
     },
     use,
-  ),
-);
+  );
+};
 
 beforeEach(() => {
   vi.mocked(inspectFacts).mockClear();
-  vi.mocked(bindDevice).mockClear();
+  bindCount = 0;
 });
 
 async function listApps(): Promise<DaemonResponse | null> {
@@ -90,5 +92,5 @@ test('HarmonyOS apps remains fail-closed when the legacy capability rejected the
     error: { code: 'UNSUPPORTED_OPERATION' },
   });
   expect(inspectFacts).toHaveBeenCalledOnce();
-  expect(bindDevice).not.toHaveBeenCalled();
+  expect(bindCount).toBe(0);
 });

--- a/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
@@ -23,6 +23,18 @@ const HARMONY_DEVICE = {
 };
 const available = { available: true } as const;
 const unavailable = { available: false, reason: 'unsupported-platform-leaf' } as const;
+const listAppsOperation: PlatformRuntimeOperations['listApps'] = vi.fn(async ({ filter }) =>
+  filter === 'all'
+    ? [
+        { id: 'com.example.application', name: 'application' },
+        { id: 'com.ohos.settings', name: 'settings' },
+      ]
+    : [{ id: 'com.example.application', name: 'application' }],
+);
+const ensureReady = vi.fn(async (device: typeof HARMONY_DEVICE) => ({
+  ...device,
+  booted: true,
+}));
 
 function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
   return {
@@ -33,7 +45,7 @@ function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
       appLogStart: available,
       appLogReattach: available,
       appLogCleanup: available,
-      listApps: unavailable,
+      listApps: { available: true },
       networkDump: unavailable,
       screenRecordingStart: unavailable,
       screenRecordingReattach: unavailable,
@@ -54,7 +66,7 @@ const bindDevice: BindDeviceRuntime = async (device, use) => {
       device,
       owner: localRuntimeOwner('harmonyos'),
       facts: runtimeFacts(),
-      operations: { ensureReady: async () => device },
+      operations: { ensureReady, listApps: listAppsOperation },
       [Symbol.asyncDispose]: async () => {},
     },
     use,
@@ -63,10 +75,12 @@ const bindDevice: BindDeviceRuntime = async (device, use) => {
 
 beforeEach(() => {
   vi.mocked(inspectFacts).mockClear();
+  vi.mocked(listAppsOperation).mockClear();
+  vi.mocked(ensureReady).mockClear();
   bindCount = 0;
 });
 
-async function listApps(): Promise<DaemonResponse | null> {
+async function listApps(appsFilter: 'all' | 'user-installed'): Promise<DaemonResponse | null> {
   const sessionName = 'harmony-apps';
   const sessionStore = makeSessionStore();
   sessionStore.set(sessionName, makeSession(sessionName, HARMONY_DEVICE));
@@ -75,7 +89,7 @@ async function listApps(): Promise<DaemonResponse | null> {
     session: sessionName,
     command: 'apps',
     positionals: [],
-    flags: { appsFilter: 'all' },
+    flags: { appsFilter },
   };
   return await handleSessionInventoryCommands({
     req,
@@ -86,11 +100,25 @@ async function listApps(): Promise<DaemonResponse | null> {
   });
 }
 
-test('HarmonyOS apps remains fail-closed when the legacy capability rejected the leaf', async () => {
-  await expect(listApps()).resolves.toMatchObject({
-    ok: false,
-    error: { code: 'UNSUPPORTED_OPERATION' },
+test.each([
+  {
+    appsFilter: 'user-installed' as const,
+    expected: ['application (com.example.application)'],
+  },
+  {
+    appsFilter: 'all' as const,
+    expected: ['application (com.example.application)', 'settings (com.ohos.settings)'],
+  },
+])('HarmonyOS apps preserves the $appsFilter response parity', async ({ appsFilter, expected }) => {
+  await expect(listApps(appsFilter)).resolves.toMatchObject({
+    ok: true,
+    data: { apps: expected },
   });
   expect(inspectFacts).toHaveBeenCalledOnce();
-  expect(bindCount).toBe(0);
+  expect(bindCount).toBe(1);
+  expect(ensureReady).toHaveBeenCalledOnce();
+  expect(listAppsOperation).toHaveBeenCalledWith({
+    device: expect.any(Object),
+    filter: appsFilter,
+  });
 });

--- a/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
@@ -22,18 +22,18 @@ const HARMONY_DEVICE = {
   booted: true,
 };
 const available = { available: true } as const;
-const unavailable = { available: false, reason: 'owner-capability-missing' } as const;
+const unavailable = { available: false, reason: 'unsupported-platform-leaf' } as const;
 
 function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
   return {
     device: { family: 'harmonyos', kind: 'device', target: 'mobile', providerMode: 'local' },
     operations: {
-      appLogInspect: unavailable,
-      appLogDoctor: unavailable,
-      appLogStart: unavailable,
-      appLogReattach: unavailable,
-      appLogCleanup: unavailable,
-      listApps: available,
+      appLogInspect: available,
+      appLogDoctor: available,
+      appLogStart: available,
+      appLogReattach: available,
+      appLogCleanup: available,
+      listApps: unavailable,
       networkDump: unavailable,
       screenRecordingStart: unavailable,
       screenRecordingReattach: unavailable,
@@ -45,39 +45,27 @@ function runtimeFacts(): RuntimeFacts<PlatformRuntimeOperations> {
   };
 }
 
-const inspectFactsImpl: InspectDeviceRuntimeFacts = async () => runtimeFacts();
-const inspectFacts = vi.fn(inspectFactsImpl);
-const ensureReady = vi.fn(async () => HARMONY_DEVICE);
-const listAppsOperation = vi.fn(async () => [{ id: 'com.example.app', name: 'Example' }]);
-let bindCount = 0;
-const bindDeviceImpl: BindDeviceRuntime = async (device, use) =>
+const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => runtimeFacts());
+const bindDevice: BindDeviceRuntime = vi.fn(async (device, use) =>
   narrowDeviceBinding(
     {
       device,
       owner: localRuntimeOwner('harmonyos'),
       facts: runtimeFacts(),
-      operations: {
-        ensureReady,
-        listApps: listAppsOperation,
-      },
+      operations: { ensureReady: async () => device },
       [Symbol.asyncDispose]: async () => {},
     },
     use,
-  );
-const bindDevice: BindDeviceRuntime = async (device, use) => {
-  bindCount += 1;
-  return await bindDeviceImpl(device, use);
-};
+  ),
+);
 
 beforeEach(() => {
-  inspectFacts.mockClear();
-  ensureReady.mockClear();
-  listAppsOperation.mockClear();
-  bindCount = 0;
+  vi.mocked(inspectFacts).mockClear();
+  vi.mocked(bindDevice).mockClear();
 });
 
-async function listApps(appsFilter: 'all' | 'user-installed'): Promise<DaemonResponse | null> {
-  const sessionName = `harmony-apps-${appsFilter}`;
+async function listApps(): Promise<DaemonResponse | null> {
+  const sessionName = 'harmony-apps';
   const sessionStore = makeSessionStore();
   sessionStore.set(sessionName, makeSession(sessionName, HARMONY_DEVICE));
   const req: DaemonRequest = {
@@ -85,7 +73,7 @@ async function listApps(appsFilter: 'all' | 'user-installed'): Promise<DaemonRes
     session: sessionName,
     command: 'apps',
     positionals: [],
-    flags: { appsFilter },
+    flags: { appsFilter: 'all' },
   };
   return await handleSessionInventoryCommands({
     req,
@@ -96,11 +84,11 @@ async function listApps(appsFilter: 'all' | 'user-installed'): Promise<DaemonRes
   });
 }
 
-test('HarmonyOS apps consumes generic readiness and app inventory through one runtime bind', async () => {
-  const response = await listApps('all');
-  expect(response).toEqual({ ok: true, data: { apps: ['Example (com.example.app)'] } });
+test('HarmonyOS apps remains fail-closed when the legacy capability rejected the leaf', async () => {
+  await expect(listApps()).resolves.toMatchObject({
+    ok: false,
+    error: { code: 'UNSUPPORTED_OPERATION' },
+  });
   expect(inspectFacts).toHaveBeenCalledOnce();
-  expect(bindCount).toBe(1);
-  expect(ensureReady).toHaveBeenCalledOnce();
-  expect(listAppsOperation).toHaveBeenCalledOnce();
+  expect(bindDevice).not.toHaveBeenCalled();
 });

--- a/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
@@ -31,8 +31,8 @@ const listAppsOperation: PlatformRuntimeOperations['listApps'] = vi.fn(async ({ 
       ]
     : [{ id: 'com.example.application', name: 'application' }],
 );
-const ensureReady = vi.fn(async (device: typeof HARMONY_DEVICE) => ({
-  ...device,
+const ensureReady = vi.fn(async () => ({
+  ...HARMONY_DEVICE,
   booted: true,
 }));
 

--- a/src/daemon/handlers/__tests__/session-logs.test.ts
+++ b/src/daemon/handlers/__tests__/session-logs.test.ts
@@ -413,6 +413,7 @@ function createRuntimeHarness(options: { inspectAvailable?: boolean } = {}) {
           ensureReady: { available: true as const },
           bootTarget: { available: true as const },
           bootTargetHeadless: unavailableRecording,
+          listApps: unavailableRecording,
         },
       },
       operations,

--- a/src/daemon/handlers/__tests__/session-test-harness.ts
+++ b/src/daemon/handlers/__tests__/session-test-harness.ts
@@ -74,7 +74,6 @@ vi.mock('../../../platforms/apple/core/apps.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../platforms/apple/core/apps.ts')>();
   return {
     ...actual,
-    listIosApps: vi.fn(async () => []),
     resolveIosApp: vi.fn(async () => undefined),
     resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
   };

--- a/src/daemon/handlers/__tests__/session-test-harness.ts
+++ b/src/daemon/handlers/__tests__/session-test-harness.ts
@@ -62,14 +62,6 @@ vi.mock('../../materialized-path-registry.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../materialized-path-registry.ts')>();
   return { ...actual, cleanupRetainedMaterializedPathsForSession: vi.fn(async () => {}) };
 });
-vi.mock('../../../platforms/android/emulator-lifecycle.ts', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../../platforms/android/emulator-lifecycle.ts')>();
-  return {
-    ...actual,
-    ensureAndroidEmulatorBooted: vi.fn(),
-  };
-});
 vi.mock('../../../platforms/apple/core/apps.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../platforms/apple/core/apps.ts')>();
   return {
@@ -107,7 +99,6 @@ import { settleIosSimulator } from '../session-device-utils.ts';
 import { resolveAndroidPackageForOpen } from '../session-open-target.ts';
 import { runCmd } from '../../../utils/exec.ts';
 import { shutdownSimulator } from '../../../platforms/apple/core/simulator.ts';
-import { ensureAndroidEmulatorBooted } from '../../../platforms/android/emulator-lifecycle.ts';
 import {
   resolveIosApp,
   resolveIosSimulatorDeepLinkBundleId,
@@ -137,7 +128,6 @@ export const mockResolveIosApp = vi.mocked(resolveIosApp);
 export const mockResolveIosSimulatorDeepLinkBundleId = vi.mocked(
   resolveIosSimulatorDeepLinkBundleId,
 );
-export const mockEnsureAndroidEmulatorBooted = vi.mocked(ensureAndroidEmulatorBooted);
 const mockDefaultInstallOpsIos = vi.mocked(defaultInstallOps.ios);
 const mockDefaultInstallOpsAndroid = vi.mocked(defaultInstallOps.android);
 const mockDefaultReinstallOpsIos = vi.mocked(defaultReinstallOps.ios);
@@ -192,7 +182,6 @@ beforeEach(() => {
   });
   mockResolveIosSimulatorDeepLinkBundleId.mockReset();
   mockResolveIosSimulatorDeepLinkBundleId.mockResolvedValue(undefined);
-  mockEnsureAndroidEmulatorBooted.mockReset();
   mockDefaultInstallOpsIos.mockReset();
   mockDefaultInstallOpsAndroid.mockReset();
   mockDefaultReinstallOpsIos.mockReset();

--- a/src/daemon/handlers/session-doctor-app.ts
+++ b/src/daemon/handlers/session-doctor-app.ts
@@ -15,17 +15,17 @@ export async function appendAppChecks(
     device: DeviceInfo;
     session: SessionState | undefined;
     targetApp?: string;
-    listApps?: DoctorAppInventory;
+    listInstalledApps?: DoctorAppInventory;
   },
 ): Promise<void> {
-  const { device, targetApp, session, listApps } = params;
+  const { device, targetApp, session, listInstalledApps } = params;
   if (!targetApp) {
     return;
   }
 
   try {
-    const resolved = listApps
-      ? resolveUniqueInstalledAppMatch(targetApp, await listApps('all'))?.id
+    const resolved = listInstalledApps
+      ? resolveUniqueInstalledAppMatch(targetApp, await listInstalledApps('all'))?.id
       : undefined;
     if (!resolved) {
       appendDoctorCheck(checks, {

--- a/src/daemon/handlers/session-doctor-app.ts
+++ b/src/daemon/handlers/session-doctor-app.ts
@@ -1,25 +1,32 @@
-import {
-  isIosFamily,
-  isMacOs,
-  publicPlatformString,
-  type DeviceInfo,
-} from '@agent-device/kernel/device';
+import { publicPlatformString, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import type { SessionState } from '../types.ts';
 import { appendDoctorCheck } from './session-doctor-output.ts';
 import type { DoctorCheck } from '@agent-device/contracts/observability';
+import type { InstalledAppInfo } from '@agent-device/contracts/platform';
+
+export type DoctorAppInventory = (
+  filter: 'all' | 'user-installed',
+) => Promise<readonly InstalledAppInfo[]>;
 
 export async function appendAppChecks(
   checks: DoctorCheck[],
-  params: { device: DeviceInfo; session: SessionState | undefined; targetApp?: string },
+  params: {
+    device: DeviceInfo;
+    session: SessionState | undefined;
+    targetApp?: string;
+    listApps?: DoctorAppInventory;
+  },
 ): Promise<void> {
-  const { device, targetApp, session } = params;
+  const { device, targetApp, session, listApps } = params;
   if (!targetApp) {
     return;
   }
 
   try {
-    const resolved = await resolveInstalledAppForDoctor(device, targetApp);
+    const resolved = listApps
+      ? resolveUniqueInstalledAppMatch(targetApp, await listApps('all'))?.id
+      : undefined;
     if (!resolved) {
       appendDoctorCheck(checks, {
         id: 'target-app',
@@ -49,34 +56,9 @@ export async function appendAppChecks(
   }
 }
 
-async function resolveInstalledAppForDoctor(
-  device: DeviceInfo,
-  targetApp: string,
-): Promise<string | undefined> {
-  if (device.platform === 'android') {
-    const { listAndroidApps } = await import('../../platforms/android/app-lifecycle.ts');
-    const apps = await listAndroidApps(device, 'all');
-    const match = resolveUniqueInstalledAppMatch(
-      targetApp,
-      apps.map((app) => ({ id: app.package, name: app.name })),
-    );
-    return match?.id;
-  }
-  if (isIosFamily(device) || isMacOs(device)) {
-    const { listIosApps } = await import('../../platforms/apple/core/apps.ts');
-    const apps = await listIosApps(device, 'all');
-    const match = resolveUniqueInstalledAppMatch(
-      targetApp,
-      apps.map((app) => ({ id: app.bundleId, name: app.name })),
-    );
-    return match?.id;
-  }
-  return undefined;
-}
-
 function resolveUniqueInstalledAppMatch(
   targetApp: string,
-  apps: Array<{ id: string; name: string }>,
+  apps: readonly InstalledAppInfo[],
 ): { id: string; name: string } | undefined {
   const needle = targetApp.trim().toLowerCase();
   const exact = apps.find(

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -35,14 +35,23 @@ import {
   prewarmAppleRunnerCache,
 } from '../../platforms/apple/core/runner/runner-client.ts';
 import { appendWebBrowserLifecycleCheck } from './session-doctor-web.ts';
+import { resolveAndroidSerialAllowlist } from '../../utils/device-isolation.ts';
+import {
+  appsRuntimeUse,
+  type BoundDeviceRuntime,
+  type InstalledAppInfo,
+} from '@agent-device/contracts/platform';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 
 export async function handleDoctorCommand(params: {
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
   androidAdbExecutor?: AndroidAdbExecutor;
+  inspectFacts?: InspectDeviceRuntimeFacts;
+  bindDevice?: BindDeviceRuntime;
 }): Promise<DaemonResponse | null> {
-  const { req, sessionName, sessionStore, androidAdbExecutor } = params;
+  const { req, sessionName, sessionStore, androidAdbExecutor, inspectFacts, bindDevice } = params;
   if (req.command !== PUBLIC_COMMANDS.doctor) return null;
 
   const session = sessionStore.get(sessionName);
@@ -74,6 +83,9 @@ export async function handleDoctorCommand(params: {
     options,
     session,
     stateDir,
+    inspectFacts,
+    bindDevice,
+    req,
   });
   await appendIosRunnerWarmupCheck(checks, appCheckDevice ?? resolveWarmupSimulator(inventory));
   return doctorResponse(checks, options, { device: appCheckDevice, includeMetro: true, inventory });
@@ -143,8 +155,21 @@ async function appendLocalDoctorChecks(params: {
   options: DoctorOptions;
   session: SessionState | undefined;
   stateDir: string;
+  inspectFacts?: InspectDeviceRuntimeFacts;
+  bindDevice?: BindDeviceRuntime;
+  req: DaemonRequest;
 }): Promise<DeviceInfo | undefined> {
-  const { checks, inventory, options, session, androidAdbExecutor, stateDir } = params;
+  const {
+    checks,
+    inventory,
+    options,
+    session,
+    androidAdbExecutor,
+    stateDir,
+    inspectFacts,
+    bindDevice,
+    req,
+  } = params;
   const appCheckDevice =
     session?.device ?? resolveDoctorDeviceForAppCheck(checks, inventory, options.targetApp);
   if (appCheckDevice) {
@@ -153,6 +178,9 @@ async function appendLocalDoctorChecks(params: {
       device: appCheckDevice,
       options,
       session,
+      inspectFacts,
+      bindDevice,
+      req,
     });
   }
   if (options.shouldProbeMetro) {
@@ -169,16 +197,53 @@ async function appendDeviceScopedDoctorChecks(
     device: DeviceInfo;
     options: DoctorOptions;
     session: SessionState | undefined;
+    inspectFacts?: InspectDeviceRuntimeFacts;
+    bindDevice?: BindDeviceRuntime;
+    req: DaemonRequest;
   },
 ): Promise<void> {
-  const { androidAdbExecutor, device, options, session } = params;
-  await appendAppChecks(checks, { device, session, targetApp: options.targetApp });
+  const { androidAdbExecutor, device, options, session, inspectFacts, bindDevice, req } = params;
+  const listApps = await resolveDoctorAppInventory({
+    device,
+    req,
+    targetApp: options.targetApp,
+    inspectFacts,
+    bindDevice,
+  });
+  await appendAppChecks(checks, { device, session, targetApp: options.targetApp, listApps });
   await appendAndroidChecks(checks, {
     androidAdbExecutor,
     device,
     metroPort: options.metroPort,
     shouldProbeMetro: options.shouldProbeMetro,
   });
+}
+
+async function resolveDoctorAppInventory(params: {
+  device: DeviceInfo;
+  req: DaemonRequest;
+  targetApp?: string;
+  inspectFacts?: InspectDeviceRuntimeFacts;
+  bindDevice?: BindDeviceRuntime;
+}): Promise<
+  ((filter: 'all' | 'user-installed') => Promise<readonly InstalledAppInfo[]>) | undefined
+> {
+  const { device, req, targetApp, inspectFacts, bindDevice } = params;
+  if (!targetApp || !inspectFacts || !bindDevice) return undefined;
+  const facts = await inspectFacts(device);
+  const appFact = facts.operations.listApps;
+  const readyFact = facts.operations.ensureReady;
+  if (!appFact.available || !readyFact.available) return undefined;
+  const runtime: BoundDeviceRuntime<typeof appsRuntimeUse> = await bindDevice(
+    device,
+    appsRuntimeUse,
+  );
+  const androidSerialAllowlist = resolveAndroidSerialAllowlist(req.flags?.androidDeviceAllowlist);
+  const readyDevice = await runtime.operations.ensureReady({
+    serial: req.flags?.serial,
+    androidSerialAllowlist: androidSerialAllowlist ? [...androidSerialAllowlist].sort() : undefined,
+  });
+  return async (filter) => await runtime.operations.listApps({ device: readyDevice, filter });
 }
 
 function doctorResponse(

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -8,7 +8,7 @@ import { readVersion } from '../../utils/version.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { appendAndroidChecks } from './session-doctor-android.ts';
-import { appendAppChecks } from './session-doctor-app.ts';
+import { appendAppChecks, type DoctorAppInventory } from './session-doctor-app.ts';
 import {
   appendDeviceInventoryCheck,
   type DoctorDeviceInventory,
@@ -42,6 +42,7 @@ import {
   type InstalledAppInfo,
 } from '@agent-device/contracts/platform';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
+import { ensureAppsRuntimeReady, listAppsFromRuntime } from '../apps-runtime.ts';
 
 export async function handleDoctorCommand(params: {
   req: DaemonRequest;
@@ -203,13 +204,22 @@ async function appendDeviceScopedDoctorChecks(
   },
 ): Promise<void> {
   const { androidAdbExecutor, device, options, session, inspectFacts, bindDevice, req } = params;
-  const listApps = await resolveDoctorAppInventory({
-    device,
-    req,
-    targetApp: options.targetApp,
-    inspectFacts,
-    bindDevice,
-  });
+  let listApps: DoctorAppInventory | undefined;
+  try {
+    listApps = await resolveDoctorAppInventory({
+      device,
+      req,
+      targetApp: options.targetApp,
+      inspectFacts,
+      bindDevice,
+    });
+  } catch (error) {
+    // Keep facts/bind/readiness failures inside appendAppChecks' accumulator path so doctor
+    // reports a failed target-app check and still runs the remaining device checks.
+    listApps = async () => {
+      throw error;
+    };
+  }
   await appendAppChecks(checks, { device, session, targetApp: options.targetApp, listApps });
   await appendAndroidChecks(checks, {
     androidAdbExecutor,
@@ -239,11 +249,11 @@ async function resolveDoctorAppInventory(params: {
     appsRuntimeUse,
   );
   const androidSerialAllowlist = resolveAndroidSerialAllowlist(req.flags?.androidDeviceAllowlist);
-  const readyDevice = await runtime.operations.ensureReady({
+  const readyDevice = await ensureAppsRuntimeReady(runtime, {
     serial: req.flags?.serial,
     androidSerialAllowlist: androidSerialAllowlist ? [...androidSerialAllowlist].sort() : undefined,
   });
-  return async (filter) => await runtime.operations.listApps({ device: readyDevice, filter });
+  return async (filter) => await listAppsFromRuntime(runtime, readyDevice, filter);
 }
 
 function doctorResponse(

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -244,7 +244,11 @@ async function resolveDoctorAppInventory(params: {
   ((filter: 'all' | 'user-installed') => Promise<readonly InstalledAppInfo[]>) | undefined
 > {
   const { device, req, targetApp, inspectFacts, bindDevice } = params;
-  if (!targetApp || !inspectFacts || !bindDevice) return undefined;
+  // Doctor's target-app check preserves its legacy HarmonyOS informational cell; this does not
+  // alter the apps command's facts or runtime binding, which remain available independently.
+  if (!targetApp || !inspectFacts || !bindDevice || device.platform === 'harmonyos') {
+    return undefined;
+  }
   const facts = await inspectFacts(device);
   const appFact = facts.operations.listApps;
   const readyFact = facts.operations.ensureReady;

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -206,7 +206,7 @@ async function appendDeviceScopedDoctorChecks(
   const { androidAdbExecutor, device, options, session, inspectFacts, bindDevice, req } = params;
   let listInstalledApps: DoctorAppInventory | undefined;
   try {
-    listInstalledApps = await resolveDoctorAppInventory({
+    listInstalledApps = await resolveDoctorAppInventoryForDoctor({
       device,
       req,
       targetApp: options.targetApp,
@@ -234,6 +234,15 @@ async function appendDeviceScopedDoctorChecks(
   });
 }
 
+async function resolveDoctorAppInventoryForDoctor(
+  params: Parameters<typeof resolveDoctorAppInventory>[0],
+): ReturnType<typeof resolveDoctorAppInventory> {
+  // Doctor's target-app check preserves its legacy HarmonyOS informational cell; this does not
+  // alter the apps command's facts or runtime binding, which remain available independently.
+  if (params.device.platform === 'harmonyos') return undefined;
+  return resolveDoctorAppInventory(params);
+}
+
 async function resolveDoctorAppInventory(params: {
   device: DeviceInfo;
   req: DaemonRequest;
@@ -244,9 +253,7 @@ async function resolveDoctorAppInventory(params: {
   ((filter: 'all' | 'user-installed') => Promise<readonly InstalledAppInfo[]>) | undefined
 > {
   const { device, req, targetApp, inspectFacts, bindDevice } = params;
-  // Doctor's target-app check preserves its legacy HarmonyOS informational cell; this does not
-  // alter the apps command's facts or runtime binding, which remain available independently.
-  if (!targetApp || !inspectFacts || !bindDevice || device.platform === 'harmonyos') {
+  if (!targetApp || !inspectFacts || !bindDevice) {
     return undefined;
   }
   const facts = await inspectFacts(device);

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -204,9 +204,9 @@ async function appendDeviceScopedDoctorChecks(
   },
 ): Promise<void> {
   const { androidAdbExecutor, device, options, session, inspectFacts, bindDevice, req } = params;
-  let listApps: DoctorAppInventory | undefined;
+  let listInstalledApps: DoctorAppInventory | undefined;
   try {
-    listApps = await resolveDoctorAppInventory({
+    listInstalledApps = await resolveDoctorAppInventory({
       device,
       req,
       targetApp: options.targetApp,
@@ -216,11 +216,16 @@ async function appendDeviceScopedDoctorChecks(
   } catch (error) {
     // Keep facts/bind/readiness failures inside appendAppChecks' accumulator path so doctor
     // reports a failed target-app check and still runs the remaining device checks.
-    listApps = async () => {
+    listInstalledApps = async () => {
       throw error;
     };
   }
-  await appendAppChecks(checks, { device, session, targetApp: options.targetApp, listApps });
+  await appendAppChecks(checks, {
+    device,
+    session,
+    targetApp: options.targetApp,
+    listInstalledApps,
+  });
   await appendAndroidChecks(checks, {
     androidAdbExecutor,
     device,

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -27,6 +27,7 @@ import {
   screenRecordingAdmissionUse,
 } from '@agent-device/contracts/platform';
 import type { BoundDeviceRuntime } from '@agent-device/contracts/platform';
+import { ensureAppsRuntimeReady, listAppsFromRuntime } from '../apps-runtime.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 
 export async function handleSessionInventoryCommands(params: {
@@ -48,6 +49,7 @@ export async function handleSessionInventoryCommands(params: {
         sessionName,
         sessionStore,
         bindDevice: params.bindDevice,
+        inspectFacts: params.inspectFacts,
       });
     case 'apps':
       return await handleAppsInventory({
@@ -175,6 +177,7 @@ async function capabilitiesInventoryResponse(params: {
   sessionName: string;
   sessionStore: SessionStore;
   bindDevice?: BindDeviceRuntime;
+  inspectFacts?: InspectDeviceRuntimeFacts;
 }): Promise<DaemonResponse> {
   const resolution = await resolveInventoryCommandDevice({
     ...params,
@@ -183,6 +186,7 @@ async function capabilitiesInventoryResponse(params: {
   });
   if ('response' in resolution) return resolution.response;
   const { device } = resolution;
+  const appsAvailable = await isAppsRuntimeAvailable(device, params.inspectFacts);
   const [logsAvailable, networkAvailable, recordingAvailable] = params.bindDevice
     ? await Promise.all([
         params
@@ -207,7 +211,9 @@ async function capabilitiesInventoryResponse(params: {
             ? networkAvailable
             : command === 'record'
               ? recordingAvailable
-              : isCommandSupportedOnDevice(command, device),
+              : command === 'apps'
+                ? appsAvailable
+                : isCommandSupportedOnDevice(command, device),
       ),
     },
   };
@@ -238,14 +244,29 @@ async function handleAppsInventory(params: {
   const runtimeResolution = await resolveAppsRuntime({ device, inspectFacts, bindDevice });
   if ('response' in runtimeResolution) return runtimeResolution.response;
   const runtime = runtimeResolution.runtime;
-  const readyDevice = await runtime.operations.ensureReady({
+  const readyDevice = await ensureAppsRuntimeReady(runtime, {
     serial: req.flags?.serial,
     androidSerialAllowlist: resolvedAndroidSerialAllowlist
       ? [...resolvedAndroidSerialAllowlist].sort()
       : undefined,
   });
-  const apps = await runtime.operations.listApps({ device: readyDevice, filter: appsFilter });
+  const apps = await listAppsFromRuntime(runtime, readyDevice, appsFilter);
   return appsInventoryResponse(apps);
+}
+
+async function isAppsRuntimeAvailable(
+  device: DeviceInfo,
+  inspectFacts: InspectDeviceRuntimeFacts | undefined,
+): Promise<boolean> {
+  if (!inspectFacts) return false;
+  try {
+    const facts = await inspectFacts(device);
+    return facts.operations.ensureReady.available && facts.operations.listApps.available;
+  } catch {
+    // Capability projection is advisory. A provider facts failure must fail closed rather than
+    // reconstructing apps support from the retired capability matrix.
+    return false;
+  }
 }
 
 async function resolveAppsRuntime(params: {

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -1,7 +1,7 @@
 import { isCommandSupportedOnDevice, listCapabilityCommands } from '../../core/capabilities.ts';
 import { listDeviceInventory } from '../../core/device-inventory-context.ts';
 import { assertResolvedAppsFilter } from '@agent-device/contracts/device';
-import { asAppError } from '@agent-device/kernel/errors';
+import { AppError, asAppError } from '@agent-device/kernel/errors';
 import {
   isApplePlatform,
   isMacOs,
@@ -17,25 +17,23 @@ import {
 } from '../../utils/device-isolation.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { resolveSessionRunnerLogPath, SessionStore } from '../session-store.ts';
-import { listAndroidApps } from '../../platforms/android/app-lifecycle.ts';
-import { listIosApps } from '../../platforms/apple/core/apps.ts';
-import { listHarmonyApps } from '../../platforms/harmonyos/app-lifecycle.ts';
-import { getRequestSignal } from '../../request/cancel.ts';
 import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
-import { errorResponse, requireCommandSupported } from './response.ts';
+import { errorResponse } from './response.ts';
 import { resolveImplicitSessionScope, sessionMatchesScope } from '../session-routing.ts';
 import {
   appLogAdmissionUse,
+  appsRuntimeUse,
   networkAdmissionUse,
   screenRecordingAdmissionUse,
 } from '@agent-device/contracts/platform';
-import type { BindDeviceRuntime } from '../request-runtime-binding.ts';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 
 export async function handleSessionInventoryCommands(params: {
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
   bindDevice?: BindDeviceRuntime;
+  inspectFacts?: InspectDeviceRuntimeFacts;
 }): Promise<DaemonResponse | null> {
   const { req, sessionName, sessionStore } = params;
   switch (req.command) {
@@ -51,7 +49,13 @@ export async function handleSessionInventoryCommands(params: {
         bindDevice: params.bindDevice,
       });
     case 'apps':
-      return await handleAppsInventory({ req, sessionName, sessionStore });
+      return await handleAppsInventory({
+        req,
+        sessionName,
+        sessionStore,
+        bindDevice: params.bindDevice,
+        inspectFacts: params.inspectFacts,
+      });
     default:
       return null;
   }
@@ -212,34 +216,59 @@ async function handleAppsInventory(params: {
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
+  bindDevice?: BindDeviceRuntime;
+  inspectFacts?: InspectDeviceRuntimeFacts;
 }): Promise<DaemonResponse> {
-  const { req, sessionName, sessionStore } = params;
+  const { req, sessionName, sessionStore, bindDevice, inspectFacts } = params;
   const resolution = await resolveInventoryCommandDevice({
     req,
     sessionName,
     sessionStore,
-    ensureReady: true,
+    ensureReady: false,
+    androidAvdSelection: 'include-stopped',
   });
   if ('response' in resolution) return resolution.response;
   const { device } = resolution;
-  const unsupported = requireCommandSupported('apps', device);
-  if (unsupported) return unsupported;
   const appsFilter = assertResolvedAppsFilter(req.flags?.appsFilter);
-  if (isApplePlatform(device.platform)) {
-    const apps = await listIosApps(device, appsFilter);
-    return appsInventoryResponse(apps.map((app) => ({ id: app.bundleId, name: app.name })));
-  }
-  if (device.platform === 'harmonyos') {
-    const apps = await listHarmonyApps(device, appsFilter, {
-      signal: getRequestSignal(req.meta?.requestId),
+
+  if (!inspectFacts) {
+    throw new AppError('COMMAND_FAILED', 'Device runtime facts inspection is unavailable.', {
+      reason: 'runtime-gateway-missing',
     });
-    return appsInventoryResponse(apps.map((app) => ({ id: app.package, name: app.name })));
   }
-  const apps = await listAndroidApps(device, appsFilter);
-  return appsInventoryResponse(apps.map((app) => ({ id: app.package, name: app.name })));
+  const facts = await inspectFacts(device);
+  const unavailable = [facts.operations.ensureReady, facts.operations.listApps].find(
+    (fact) => !fact.available,
+  );
+  if (unavailable && !unavailable.available) {
+    return errorResponse(
+      'UNSUPPORTED_OPERATION',
+      'apps is not supported on this device',
+      undefined,
+      unavailable.hint ? { hint: unavailable.hint } : undefined,
+    );
+  }
+  if (!bindDevice) {
+    throw new AppError('COMMAND_FAILED', 'Device runtime binding is unavailable.', {
+      reason: 'runtime-gateway-missing',
+    });
+  }
+
+  const resolvedAndroidSerialAllowlist = resolveAndroidSerialAllowlist(
+    req.flags?.androidDeviceAllowlist,
+  );
+  const runtime = await bindDevice(device, appsRuntimeUse);
+  const readyDevice = await runtime.operations.ensureReady({
+    serial: req.flags?.serial,
+    androidSerialAllowlist: resolvedAndroidSerialAllowlist
+      ? [...resolvedAndroidSerialAllowlist].sort()
+      : undefined,
+  });
+  const apps = await runtime.operations.listApps({ device: readyDevice, filter: appsFilter });
+  return appsInventoryResponse(apps);
 }
 
-function appsInventoryResponse(apps: Array<{ id: string; name: string }>): DaemonResponse {
+function appsInventoryResponse(apps: readonly { id: string; name: string }[]): DaemonResponse {
   return {
     ok: true,
     data: {

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -26,6 +26,7 @@ import {
   networkAdmissionUse,
   screenRecordingAdmissionUse,
 } from '@agent-device/contracts/platform';
+import type { BoundDeviceRuntime } from '@agent-device/contracts/platform';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 
 export async function handleSessionInventoryCommands(params: {
@@ -231,33 +232,12 @@ async function handleAppsInventory(params: {
   const { device } = resolution;
   const appsFilter = assertResolvedAppsFilter(req.flags?.appsFilter);
 
-  if (!inspectFacts) {
-    throw new AppError('COMMAND_FAILED', 'Device runtime facts inspection is unavailable.', {
-      reason: 'runtime-gateway-missing',
-    });
-  }
-  const facts = await inspectFacts(device);
-  const unavailable = [facts.operations.ensureReady, facts.operations.listApps].find(
-    (fact) => !fact.available,
-  );
-  if (unavailable && !unavailable.available) {
-    return errorResponse(
-      'UNSUPPORTED_OPERATION',
-      'apps is not supported on this device',
-      undefined,
-      unavailable.hint ? { hint: unavailable.hint } : undefined,
-    );
-  }
-  if (!bindDevice) {
-    throw new AppError('COMMAND_FAILED', 'Device runtime binding is unavailable.', {
-      reason: 'runtime-gateway-missing',
-    });
-  }
-
   const resolvedAndroidSerialAllowlist = resolveAndroidSerialAllowlist(
     req.flags?.androidDeviceAllowlist,
   );
-  const runtime = await bindDevice(device, appsRuntimeUse);
+  const runtimeResolution = await resolveAppsRuntime({ device, inspectFacts, bindDevice });
+  if ('response' in runtimeResolution) return runtimeResolution.response;
+  const runtime = runtimeResolution.runtime;
   const readyDevice = await runtime.operations.ensureReady({
     serial: req.flags?.serial,
     androidSerialAllowlist: resolvedAndroidSerialAllowlist
@@ -266,6 +246,38 @@ async function handleAppsInventory(params: {
   });
   const apps = await runtime.operations.listApps({ device: readyDevice, filter: appsFilter });
   return appsInventoryResponse(apps);
+}
+
+async function resolveAppsRuntime(params: {
+  device: DeviceInfo;
+  inspectFacts: InspectDeviceRuntimeFacts | undefined;
+  bindDevice: BindDeviceRuntime | undefined;
+}): Promise<{ response: DaemonResponse } | { runtime: BoundDeviceRuntime<typeof appsRuntimeUse> }> {
+  if (!params.inspectFacts) {
+    throw new AppError('COMMAND_FAILED', 'Device runtime facts inspection is unavailable.', {
+      reason: 'runtime-gateway-missing',
+    });
+  }
+  const facts = await params.inspectFacts(params.device);
+  const unavailable = [facts.operations.ensureReady, facts.operations.listApps].find(
+    (fact) => !fact.available,
+  );
+  if (unavailable && !unavailable.available) {
+    return {
+      response: errorResponse(
+        'UNSUPPORTED_OPERATION',
+        'apps is not supported on this device',
+        undefined,
+        unavailable.hint ? { hint: unavailable.hint } : undefined,
+      ),
+    };
+  }
+  if (!params.bindDevice) {
+    throw new AppError('COMMAND_FAILED', 'Device runtime binding is unavailable.', {
+      reason: 'runtime-gateway-missing',
+    });
+  }
+  return { runtime: await params.bindDevice(params.device, appsRuntimeUse) };
 }
 
 function appsInventoryResponse(apps: readonly { id: string; name: string }[]): DaemonResponse {

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -307,7 +307,15 @@ const handleSessionInventoryCommandGroup: SessionCommandHandler = async ({
   sessionName,
   sessionStore,
   bindDevice,
-}) => await handleSessionInventoryCommands({ req, sessionName, sessionStore, bindDevice });
+  inspectFacts,
+}) =>
+  await handleSessionInventoryCommands({
+    req,
+    sessionName,
+    sessionStore,
+    bindDevice,
+    inspectFacts,
+  });
 
 const handleSessionStateCommandGroup: SessionCommandHandler = async ({
   req,
@@ -463,8 +471,22 @@ const SESSION_COMMAND_HANDLER_IMPLS = {
   devices: handleSessionInventoryCommandGroup,
   capabilities: handleSessionInventoryCommandGroup,
   apps: handleSessionInventoryCommandGroup,
-  doctor: async ({ req, sessionName, sessionStore, androidAdbExecutor }) =>
-    await handleDoctorCommand({ req, sessionName, sessionStore, androidAdbExecutor }),
+  doctor: async ({
+    req,
+    sessionName,
+    sessionStore,
+    androidAdbExecutor,
+    inspectFacts,
+    bindDevice,
+  }) =>
+    await handleDoctorCommand({
+      req,
+      sessionName,
+      sessionStore,
+      androidAdbExecutor,
+      inspectFacts,
+      bindDevice,
+    }),
   boot: handleSessionStateCommandGroup,
   shutdown: handleSessionStateCommandGroup,
   appstate: handleSessionStateCommandGroup,

--- a/src/platform-runtime-app-inventory-host.ts
+++ b/src/platform-runtime-app-inventory-host.ts
@@ -1,0 +1,38 @@
+import type { AppInventoryRuntimeHost, InstalledAppInfo } from '@agent-device/contracts/platform';
+import type { AppsFilter } from '@agent-device/contracts/device';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+export function createAppInventoryRuntimeHost(): AppInventoryRuntimeHost {
+  return Object.freeze({
+    apple: Object.freeze({
+      listApps: async (device: DeviceInfo, filter: AppsFilter) => {
+        const { listIosApps } = await import('./platforms/apple/core/apps.ts');
+        return mapAppleApps(await listIosApps(device, filter));
+      },
+    }),
+    android: Object.freeze({
+      listApps: async (device: DeviceInfo, filter: AppsFilter) => {
+        const { listAndroidApps } = await import('./platforms/android/app-lifecycle.ts');
+        return (await listAndroidApps(device, filter)).map((app) => ({
+          id: app.package,
+          name: app.name,
+        }));
+      },
+    }),
+    harmonyos: Object.freeze({
+      listApps: async (device: DeviceInfo, filter: AppsFilter, signal: AbortSignal) => {
+        const { listHarmonyApps } = await import('./platforms/harmonyos/app-lifecycle.ts');
+        return (await listHarmonyApps(device, filter, { signal })).map((app) => ({
+          id: app.package,
+          name: app.name,
+        }));
+      },
+    }),
+  });
+}
+
+function mapAppleApps(
+  apps: readonly { bundleId: string; name: string }[],
+): readonly InstalledAppInfo[] {
+  return apps.map((app) => ({ id: app.bundleId, name: app.name }));
+}

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -145,6 +145,10 @@ describe('composed platform runtime gateway', () => {
       available: false,
       reason: 'unsupported-provider-mode',
     });
+    expect(binding.facts.operations.listApps).toMatchObject({
+      available: false,
+      reason: 'unsupported-provider-mode',
+    });
     expect(hostLoad).not.toHaveBeenCalled();
     expect(localLoad).not.toHaveBeenCalled();
   });
@@ -306,5 +310,6 @@ function unavailableFacts() {
     ensureReady: unavailable,
     bootTarget: unavailable,
     bootTargetHeadless: unavailable,
+    listApps: unavailable,
   };
 }

--- a/src/platform-runtime-operation-host.ts
+++ b/src/platform-runtime-operation-host.ts
@@ -15,6 +15,7 @@ import { createScreenRecordingRuntimeHost } from './platform-runtime-screen-reco
 import { createApplePhysicalReadinessHost } from './platform-runtime-apple-physical-readiness.ts';
 import { createAppleAutomationKeepHotHost } from './platform-runtime-apple-automation-keep-hot.ts';
 import { createAndroidEmulatorHost } from './platform-runtime-android-emulator-host.ts';
+import { createAppInventoryRuntimeHost } from './platform-runtime-app-inventory-host.ts';
 
 export function createPlatformRuntimeHost(options: {
   sessionsDir: string;
@@ -69,6 +70,7 @@ export function createPlatformRuntimeHost(options: {
       },
     }),
     ...network,
+    appInventory: createAppInventoryRuntimeHost(),
     deviceReadiness: Object.freeze({
       applePhysical: createApplePhysicalReadinessHost(),
       appleAutomation: createAppleAutomationKeepHotHost(),

--- a/src/platforms/apple/plugin.ts
+++ b/src/platforms/apple/plugin.ts
@@ -101,7 +101,6 @@ const APPLE_UNSUPPORTED_HINT_BY_DEFAULT: Record<
   string,
   (device: DeviceInfo) => string | undefined
 > = {
-  [PUBLIC_COMMANDS.apps]: coreDeviceOnlyPhysicalOperationHint,
   [PUBLIC_COMMANDS.install]: coreDeviceOnlyPhysicalOperationHint,
   [PUBLIC_COMMANDS.reinstall]: coreDeviceOnlyPhysicalOperationHint,
   [PUBLIC_COMMANDS.installFromSource]: coreDeviceOnlyPhysicalOperationHint,

--- a/src/platforms/apple/plugin.ts
+++ b/src/platforms/apple/plugin.ts
@@ -76,7 +76,6 @@ const supportsTvRemote = (device: DeviceInfo): boolean => {
 // Per-command support gates the Apple family applies by default, keyed exactly as in
 // the command-descriptor registry (a command absent here has no Apple gate).
 const APPLE_SUPPORTS_BY_DEFAULT: Record<string, (device: DeviceInfo) => boolean> = {
-  [PUBLIC_COMMANDS.apps]: supportsCoreDevicePhysicalOperation,
   [PUBLIC_COMMANDS.install]: supportsAppInstallation,
   [PUBLIC_COMMANDS.reinstall]: supportsAppInstallation,
   [PUBLIC_COMMANDS.installFromSource]: supportsAppInstallation,

--- a/test/integration/provider-scenarios/doctor.test.ts
+++ b/test/integration/provider-scenarios/doctor.test.ts
@@ -108,6 +108,7 @@ test('Provider-backed integration doctor --app verifies an installed app without
   await withProviderScenarioResource(
     async () =>
       await createProviderScenarioHarness({
+        platformRuntime: true,
         androidAdbProvider: () => adbProvider,
         deviceInventoryProvider: async () => [PROVIDER_SCENARIO_ANDROID],
       }),

--- a/test/integration/provider-scenarios/ios-alert-settings.test.ts
+++ b/test/integration/provider-scenarios/ios-alert-settings.test.ts
@@ -234,6 +234,7 @@ function createRecordingPlatformRuntimeGateway(params: {
             ensureReady: { available: true },
             bootTarget: unavailableRecording,
             bootTargetHeadless: unavailableRecording,
+            listApps: unavailableRecording,
           },
         },
         operations: {

--- a/test/integration/provider-scenarios/ios-world.ts
+++ b/test/integration/provider-scenarios/ios-world.ts
@@ -241,6 +241,7 @@ export async function createIosSettingsWorld(): Promise<IosSettingsWorld> {
   });
 
   const daemon = await createProviderScenarioHarness({
+    platformRuntime: true,
     appleRunnerProvider: () => appleRunnerProvider,
     appleToolProvider: () => appleTool.provider,
     deviceInventoryProvider: async (request) => {


### PR DESCRIPTION
## Summary

Routes the canonical descriptor `apps` command through the request-scoped platform runtime as the provisional sibling of the other ADR 0019 fan-out units. Refs #1739.

- Declares the complete request-scoped use explicitly as `ensureReady + listApps`; readiness is a separate operation before app inventory.
- Performs one side-effect-free `inspectFacts` admission and one `bind` per apps/doctor runtime request, with provider-first fail-closed ownership.
- Keeps metadata eager and implementation lazy, preserves selector/session/filter and response semantics, and adds no durable-tier machinery.
- Projects capability support from runtime facts only. Unsupported Linux, Web, watchOS, XCTest physical, and WebDriver app cells remain unavailable rather than reconstructed from the retired capability matrix.
- Retires the apps capability bucket/legacy adapter and matching branches/imports/helpers, removes the stale Apple apps admission closure, and adds the apps row to the existing parametrized cutover table. No fifth policy file was added.
- Keeps generic `ensureReady` distinct from `bootTarget`/`bootTargetHeadless`. macOS generic readiness is an explicit no-op fact and macOS app inventory remains available; boot operations remain separate and unavailable.
- Keeps the HarmonyOS doctor target-app cell as the legacy informational unsupported result, while the canonical `apps` command supports HarmonyOS through its request-scoped facts and lazy HDC inventory host.

Facts cover the current platform-leaf/device-kind/provider denominator:

| Cell | ensureReady | listApps | Result |
| --- | --- | --- | --- |
| Apple iOS/iPadOS/tvOS/visionOS simulator | available | available | supported |
| Apple physical iOS CoreDevice | available | available | supported |
| Apple physical iOS XCTest backend | available | unavailable | fail closed: unsupported-device-backend |
| Apple macOS host | available no-op | available | supported; boot operations remain unavailable |
| Apple watchOS | unavailable | unavailable | fail closed |
| Android emulator | available | available | supported; headless boot is separate |
| Android physical/device | available | available | supported; headless boot is unavailable |
| HarmonyOS local provider | available no-op | available | supported through the HDC inventory host |
| Linux/Vega | unavailable | unavailable | fail closed |
| Web | unavailable | unavailable | fail closed |
| Limrun iOS simulator / Android emulator | available | available | supported provider cells |
| WebDriver iOS / Android | available | unavailable | fail closed: owner-capability-missing |

## Stack status

This is a provisional sibling PR targeting `refactor/adr19-boot-unit`, not `main`.

- Exact target base is `c7b5a241880a06e9530e35c18c60c11c9f61778a`, the corrected boot integration head. The apps-only range was replayed onto that base; no prerequisite, old-boot, or stale-gate commits are included above it.
- The shared `MIGRATED_COMMAND_CUTOVERS` table carries the preserved boot `R20` row and apps `R21 apps-runtime-cutover` row, with lexical owners for `ensureReady` and `listApps`; the current catalog owns `R19`. No handwritten fifth policy exists.
- Final replay/readiness remains blocked on the unmerged #1740/#1745/#1747 prerequisite stack and its review/CI state. This PR remains draft and must not be treated as merge-ready.
- macOS and HarmonyOS app parity are explicit in the facts and doctor tables; provider live acceptance is still unavailable in this environment.

## Validation

- Exact pushed head: `ad379dc8172b6b7ba37e27044ba7fa77ce5b9ca5` (`refactor/adr19-apps-unit`), with 17 apps-owned commits above the exact boot base. `c7b5a241` is an ancestor and the branch is exactly 17 commits ahead of `origin/refactor/adr19-boot-unit`.
- `pnpm check:affected --run` passed from the clean committed tree: 577 Vitest files / 4,779 tests, changed-line coverage 267/320 (83.44%), changed-branch coverage 153/196 (78.06%), and Node integration 55 pass with 8 expected live-fixture skips. GitHub-native/device lanes remain separate.
- The focused runtime/parity suite passed: 8 files / 30 tests. The final local gate also passed Fallow, build/package, integration progress, replay compatibility, and daemon-wire compatibility.

### Adversarial and red-before evidence

- Before the facts-only capability projection, the focused capability suite exposed six false-positive apps admissions across unsupported platform/provider cells; after the fix, Linux, Web, watchOS, XCTest physical, WebDriver, and HarmonyOS availability cases are covered by explicit facts and fail-closed regressions.
- Before the HarmonyOS runtime fix, the planted runtime parity test received `{ available: false, reason: 'unsupported-platform-leaf' }` for `listApps` and could not call the operation. The corrected runtime exposes the fact and lazy HDC host binding; runtime, capability, and production-route parity tests pass for both `all` and `user-installed` filters.
- Before the doctor fix, `inspectFacts` failure escaped `resolveDoctorAppInventory` and failed the whole doctor request. The regression now proves the error is appended as a failed `target-app` check and the remaining doctor checks continue.
- Before the HarmonyOS doctor guard, the planted test returned a passing target-app check and resolved an app. After the guard, HarmonyOS returns the exact informational unsupported result before any apps `inspectFacts`, `bind`, `ensureReady`, or `listApps` call.
- The production apps route has one facts admission, one bind, and ordered `ensureReady` then `listApps` operations. No legacy apps support check or fallback remains on the apps route.

### Exact-head live verification

- On the available Android emulator, `apps --platform android` returned 1 user-installed app (`Agentdevicelab (com.callstack.agentdevicelab)`) and `apps --platform android --all` returned 20 apps, preserving the existing `name (package)` response format.
- On the exact current macOS host, `apps --platform macos` returned the installed application inventory and bundle identifiers, including `ChatGPT (com.openai.codex)` and `Google Chrome (com.google.Chrome)`.
- `apps --platform harmonyos` failed closed with `DEVICE_NOT_FOUND` because no HarmonyOS target is connected; no provider live target is configured in this environment. These are evidence gaps, not unsupported-code claims.

## Size accounting

All measurements use clean detached committed trees with `pnpm install --frozen-lockfile`, `pnpm build`, and `node scripts/size-report.mjs`; generated package assets were produced by the repository script.

| Metric | 44c298d7f | Immediate stack base c7b5a241 | Apps head ad379dc817 | Net vs 44c | Net vs stack base |
| --- | ---: | ---: | ---: | ---: | ---: |
| JS raw | 2,036,067 B | 2,187,096 B | 2,190,176 B | +154,109 B | +3,080 B |
| JS gzip | 659,646 B | 715,323 B | 716,146 B | +56,500 B | +823 B |
| npm tarball | 797,027 B | 841,151 B | 841,947 B | +44,920 B | +796 B |
| npm unpacked | 2,781,186 B | 2,930,751 B | 2,933,831 B | +152,645 B | +3,080 B |

For the current apps range from `c7b5a241` through `ad379dc817`, clean production-source unified-diff accounting excludes test paths and sums UTF-8 bytes of changed lines including each changed-line newline: `src` +10,085 / -3,682 B and `packages` +4,865 / -221 B. The content-byte totals before changed-line newlines are `src` +9,808 / -3,606 B and `packages` +4,721 / -218 B.

The retained net growth is itemized as:

- the canonical `AppInventoryRuntimeOperations` contract and neutral `defineUse` declaration, which make facts, required operations, and binding ownership explicit;
- lazy Apple/Android/HarmonyOS/provider inventory hosts plus platform/provider fact cells, including typed unavailable cells that prevent unsupported claims and legacy fallback;
- request-scoped daemon routing, capability projection, doctor accumulation, and the HarmonyOS doctor guard needed to preserve existing response/session semantics while enforcing one admission/bind path;
- the shared parametrized cutover row, lexical operation owners, and red-before regression coverage; tests and fixtures do not ship, while the new declaration/runtime surfaces necessarily affect the emitted package and bundle.

The size growth is therefore an ADR 0019 section 8 exception for the ownership and enforcement surfaces required to complete the cutover; no durable machinery or compatibility fallback was added.
