### PR TITLE
fix(batch): preserve typed error recovery signals

### DIFF
--- a/src/core/__tests__/batch.test.ts
+++ b/src/core/__tests__/batch.test.ts
@@ -75,6 +75,21 @@ test('batch preserves typed error recovery signals from a failing step', async (
   assert.equal(response.error.supportedOn, 'android, web');
 });
 
+test('batch keeps unknown typed error recovery signals absent', async () => {
+  const response = await runBatch(batchRequest(['open']), 'session', async () => ({
+    ok: false,
+    error: {
+      code: 'INVALID_ARGS',
+      message: 'bad args',
+    },
+  }));
+
+  assert.equal(response.ok, false);
+  if (response.ok) return;
+  assert.equal('retriable' in response.error, false);
+  assert.equal('supportedOn' in response.error, false);
+});
+
 test('batch elides intermediate steps to digest, final step keeps requested level (full)', async () => {
   const seen: (ResponseLevel | undefined)[] = [];
   const response = await runBatch(

--- a/src/core/__tests__/batch.test.ts
+++ b/src/core/__tests__/batch.test.ts
@@ -58,6 +58,23 @@ function batchRequest(commands: string[], responseLevel?: ResponseLevel): BatchR
   };
 }
 
+test('batch preserves typed error recovery signals from a failing step', async () => {
+  const response = await runBatch(batchRequest(['open']), 'session', async () => ({
+    ok: false,
+    error: {
+      code: 'DEVICE_IN_USE',
+      message: 'device busy',
+      retriable: true,
+      supportedOn: 'android, web',
+    },
+  }));
+
+  assert.equal(response.ok, false);
+  if (response.ok) return;
+  assert.equal(response.error.retriable, true);
+  assert.equal(response.error.supportedOn, 'android, web');
+});
+
 test('batch elides intermediate steps to digest, final step keeps requested level (full)', async () => {
   const seen: (ResponseLevel | undefined)[] = [];
   const response = await runBatch(

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -7,7 +7,7 @@ import {
   type ResponseLevel,
   isNonDefaultResponseLevel,
 } from '@agent-device/kernel/contracts';
-import { AppError, asAppError } from '@agent-device/kernel/errors';
+import { AppError, asAppError, type DaemonError } from '@agent-device/kernel/errors';
 import { isRecord } from '../utils/parsing.ts';
 import {
   DEFAULT_BATCH_MAX_STEPS,
@@ -105,6 +105,8 @@ export async function runBatch(
             hint: stepResponse.error.hint,
             diagnosticId: stepResponse.error.diagnosticId,
             logPath: stepResponse.error.logPath,
+            retriable: stepResponse.error.retriable,
+            supportedOn: stepResponse.error.supportedOn,
             details: {
               ...(stepResponse.error.details ?? {}),
               step: stepResponse.step,
@@ -250,14 +252,7 @@ async function runBatchStep(
   | {
       ok: false;
       step: number;
-      error: {
-        code: string;
-        message: string;
-        hint?: string;
-        diagnosticId?: string;
-        logPath?: string;
-        details?: Record<string, unknown>;
-      };
+      error: DaemonError;
     }
 > {
   const stepStartedAt = Date.now();

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -105,8 +105,12 @@ export async function runBatch(
             hint: stepResponse.error.hint,
             diagnosticId: stepResponse.error.diagnosticId,
             logPath: stepResponse.error.logPath,
-            retriable: stepResponse.error.retriable,
-            supportedOn: stepResponse.error.supportedOn,
+            ...(stepResponse.error.retriable === undefined
+              ? {}
+              : { retriable: stepResponse.error.retriable }),
+            ...(stepResponse.error.supportedOn === undefined
+              ? {}
+              : { supportedOn: stepResponse.error.supportedOn }),
             details: {
               ...(stepResponse.error.details ?? {}),
               step: stepResponse.step,


### PR DESCRIPTION
### Summary

Preserve structured recovery signals from a failing batch step.

`DaemonError` can carry `retriable` and `supportedOn`, but `runBatch()` rebuilt the failing step error without forwarding either field. That meant the same underlying failure lost machine-readable recovery guidance when invoked through `batch`.

This change:

- forwards `retriable` and `supportedOn` when present;
- keeps those keys absent when the underlying error does not classify them;
- uses the canonical `DaemonError` type instead of a narrower local copy;
- adds regression coverage for both preservation and absence semantics.

### Test plan

- Added unit coverage for preserving `retriable` / `supportedOn`.
- Added coverage that unknown recovery signals remain absent.
- Full repository gates are pending GitHub Actions approval for this fork PR.