### PR TITLE
fix(install-source): preserve URL credential validation error

### DIFF
--- a/src/platforms/__tests__/install-source-download.test.ts
+++ b/src/platforms/__tests__/install-source-download.test.ts
@@ -71,6 +71,7 @@ test('download errors do not disclose URL credentials or query values', async ()
       headers: { authorization: 'private-header' },
       signal: new AbortController().signal,
     }).catch((caught: unknown) => caught);
+    assert.match((error as Error).message, /credentials are not allowed/i);
     const serialized = JSON.stringify(error);
     for (const secret of ['private-user', 'private-pass', 'private-query', 'private-header']) {
       assert.equal(serialized.includes(secret), false, secret);

--- a/src/platforms/install-source-download.ts
+++ b/src/platforms/install-source-download.ts
@@ -179,13 +179,15 @@ function readHeader(
 }
 
 function parseSourceUrl(raw: string): URL {
+  let parsed: URL;
   try {
-    const parsed = new URL(raw);
-    if (parsed.username || parsed.password) {
-      throw new AppError('INVALID_ARGS', 'Source URL credentials are not allowed');
-    }
-    return parsed;
+    parsed = new URL(raw);
   } catch {
     throw new AppError('INVALID_ARGS', 'Invalid source URL');
   }
+
+  if (parsed.username || parsed.password) {
+    throw new AppError('INVALID_ARGS', 'Source URL credentials are not allowed');
+  }
+  return parsed;
 }


### PR DESCRIPTION
### Summary

Preserve the specific validation error for install-source URLs containing credentials.

`parseSourceUrl()` currently throws `Source URL credentials are not allowed`, but that error is immediately caught by the surrounding `catch` and replaced with the generic `Invalid source URL` error.

Move credential validation outside the URL parsing `try/catch` so malformed URLs still receive the generic error while valid URLs containing credentials retain the intended validation error.

### Test plan

- Extended the existing credential-redaction test to assert the specific credential validation error.
- The existing secret-redaction assertions remain in place.
- Full repository gates are pending GitHub Actions approval for this fork PR.