### PR TITLE
test(cli-help): gate every help example against the CLI schema

### DIFF
--- a/src/cli/parser/__tests__/cli-help-examples.test.ts
+++ b/src/cli/parser/__tests__/cli-help-examples.test.ts
@@ -1,0 +1,130 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { parseArgs } from '../args.ts';
+import { buildCommandUsageText, buildUsageText, helpTopicIds } from '../cli-help.ts';
+import { listCliCommandNames } from '../../../command-catalog.ts';
+import { readInputFromCli } from '../../../commands/cli-grammar.ts';
+import { isCommandName } from '../../../commands/command-metadata.ts';
+import { readVersion } from '../../../utils/version.ts';
+
+// Help is the agent-facing contract, and agents copy its example lines verbatim, so an example the
+// CLI schema rejects is a broken command surface — not a docs nit (#1765: `help react-native`
+// advertised `open --metro-host/--metro-port` for four releases before `open` accepted them).
+// The example set cannot be enumerated from a hand-written list without drifting from the text that
+// actually ships, so it is read back out of the rendered help itself: every line that starts with
+// `agent-device ` is either a runnable example or a synopsis shape, and shapes are exactly the ones
+// carrying placeholder syntax in an unquoted token (`<value>`, `[optional]`, `a|b`). Runnable ones
+// go through the production parser plus the command's CLI reader.
+//
+// Boundary: only line-leading examples are checked. Examples embedded mid-sentence in a command's
+// detail prose have no reliable end delimiter (`127.0.0.1`, `flow.log` and a sentence-final period
+// are indistinguishable), so they stay out rather than guessing where the command stops.
+
+const PLACEHOLDER_SYNTAX = /[<>[\]|]/;
+
+type Token = { value: string; quoted: boolean };
+
+type HelpExample = { surface: string; line: string; argv: string[] };
+
+const TOKEN_PATTERN = /'([^']*)'|"([^"]*)"|(\S+)/g;
+
+/** Shell-style split that remembers quoting, so `--steps '[{"command":…}]'` stays one argument. */
+function tokenize(line: string): Token[] {
+  return [...line.matchAll(TOKEN_PATTERN)].map(([, single, double, bare]) => {
+    const quoted = single ?? double;
+    return quoted === undefined ? { value: bare!, quoted: false } : { value: quoted, quoted: true };
+  });
+}
+
+/** Every help text a `--help`/`help <topic>` call can print, keyed by the argument that prints it. */
+function helpSurfaces(): Array<{ name: string; lines: string[] }> {
+  const topics = new Set(helpTopicIds());
+  const surfaces = [{ name: 'help', lines: buildUsageText().split('\n') }];
+  for (const topic of topics) {
+    const text = buildCommandUsageText(topic);
+    assert.ok(text, `Expected help text for topic ${topic}`);
+    const lines = text.split('\n');
+    // `withVersionHeader` swaps the authored `agent-device help <topic>` first line for a version
+    // banner. Drop it by construction (asserted, so a format change cannot silently swallow a real
+    // example line here instead).
+    assert.equal(lines[0], `agent-device ${readVersion()} — ${topic}`);
+    surfaces.push({ name: topic, lines: lines.slice(1) });
+  }
+  for (const command of listCliCommandNames()) {
+    if (topics.has(command)) continue;
+    const text = buildCommandUsageText(command);
+    if (text) surfaces.push({ name: command, lines: text.split('\n') });
+  }
+  return surfaces;
+}
+
+function collectHelpExamples(): HelpExample[] {
+  const examples: HelpExample[] = [];
+  for (const surface of helpSurfaces()) {
+    for (const rawLine of surface.lines) {
+      const line = rawLine.trim();
+      if (!line.startsWith('agent-device ')) continue;
+      const tokens = tokenize(line).slice(1);
+      // Whole-token quoting is the only shape modelled; a quote inside a bare token (`--k='a b'`)
+      // would split wrong, so fail loudly rather than parse garbage.
+      assert.ok(
+        !tokens.some((token) => !token.quoted && /['"]/.test(token.value)),
+        `Unsupported quoting in help example: ${line}`,
+      );
+      if (tokens.some((token) => !token.quoted && PLACEHOLDER_SYNTAX.test(token.value))) continue;
+      examples.push({
+        surface: surface.name,
+        line,
+        argv: tokens.map((token) => token.value),
+      });
+    }
+  }
+  return examples;
+}
+
+function checkExample(example: HelpExample): string | null {
+  try {
+    const parsed = parseArgs(example.argv, { strictFlags: true });
+    if (parsed.command && isCommandName(parsed.command)) {
+      readInputFromCli(parsed.command, parsed.positionals, parsed.flags);
+    }
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `[help ${example.surface}] ${example.line}\n    ${message}`;
+  }
+}
+
+test('every runnable example printed by CLI help is accepted by the CLI schema', () => {
+  const failures = collectHelpExamples()
+    .map(checkExample)
+    .filter((failure): failure is string => failure !== null);
+  assert.deepEqual(
+    failures,
+    [],
+    `Help advertises commands the CLI rejects:\n${failures.join('\n')}`,
+  );
+});
+
+test('help react-native keeps its multi-worktree open example runnable', () => {
+  const examples = collectHelpExamples().filter(
+    (example) => example.surface === 'react-native' && example.argv.includes('--metro-port'),
+  );
+  assert.equal(examples.length, 2);
+  for (const example of examples) {
+    const parsed = parseArgs(example.argv, { strictFlags: true });
+    assert.equal(parsed.command, 'open');
+    assert.equal(parsed.flags.metroHost, '127.0.0.1');
+    assert.equal(typeof parsed.flags.metroPort, 'number');
+  }
+});
+
+test('help macos keeps its menu bar example runnable', () => {
+  const examples = collectHelpExamples().filter((example) => example.surface === 'macos');
+  const surfaceExamples = examples.filter((example) => example.argv.includes('--surface'));
+  assert.ok(surfaceExamples.length > 0, 'Expected a macos --surface example');
+  // The surface is bound once by open and kept on the session (`snapshot-capture.ts` reads
+  // `session.surface`), so only open takes --surface.
+  assert.deepEqual([...new Set(surfaceExamples.map((example) => example.argv[0]))], ['open']);
+  assert.ok(examples.some((example) => example.argv[0] === 'snapshot'));
+});

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -287,7 +287,7 @@ test('usageForCommand resolves web help topic', async () => {
   const help = await usageForCommand('web');
   if (help === null) throw new Error('Expected web help text');
   assert.match(help, /^agent-device \S+ — web/);
-  assert.match(help, /agent-device uses a managed, pinned agent-browser backend/);
+  assert.match(help, /Browser mechanics come from a managed, pinned agent-browser backend/);
   assert.match(help, /agent-device owns command\/session\/replay integration/);
   assert.match(help, /agent-browser owns browser launch, page control, screenshots/);
   assert.match(

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -291,7 +291,7 @@ Vega OS:
   vega virtual-device stop
   Use a component ID from the app package or Vega SDK tooling; agent-device app inventory is not yet supported.
   Use --serial VirtualDevice for explicit VVD selection.
-  agent-device does not boot the VVD implicitly.
+  The VVD is never booted implicitly; start it with vega virtual-device start.
   Snapshot, screenshot, selectors, install, touch/text/gesture, logs, and performance commands remain unsupported until their Vega backends are implemented.
 
 Buttons:
@@ -838,6 +838,7 @@ Open and inspect:
   agent-device snapshot -i --platform macos
 
 Surfaces:
+  --surface is an open flag; the session keeps it, so later commands do not repeat it.
   --surface app            normal app session
   --surface frontmost-app  inspect whichever app is frontmost
   --surface desktop        desktop-wide surface
@@ -845,7 +846,7 @@ Surfaces:
 
 Menu bar app example:
   agent-device open "Agent Device Tester Menu" --platform macos --surface menubar
-  agent-device snapshot -i --platform macos --surface menubar
+  agent-device snapshot -i --platform macos
 
 Context menu example:
   agent-device click @e66 --button secondary --platform macos
@@ -865,7 +866,7 @@ Rules:
 Use --platform web only for the minimal browser command loop exposed through agent-device.
 
 Dependency:
-  agent-device uses a managed, pinned agent-browser backend for browser mechanics. agent-device owns command/session/replay integration, selectors/refs at the command surface, and artifact routing; agent-browser owns browser launch, page control, screenshots, and browser-specific behavior.
+  Browser mechanics come from a managed, pinned agent-browser backend. agent-device owns command/session/replay integration, selectors/refs at the command surface, and artifact routing; agent-browser owns browser launch, page control, screenshots, and browser-specific behavior.
   Use --platform web when a browser step belongs inside an agent-device session, replay, batch, MCP, or typed-client flow. Use agent-browser directly for standalone web automation.
   Before first use, set up and verify the managed backend:
     agent-device web setup


### PR DESCRIPTION
## Summary

`agent-device help react-native` recommended `open --metro-host/--metro-port` while `open` rejected both flags with `INVALID_ARGS` — help was ahead of the CLI schema for four releases. The reported command works on `main` today (`open` gained the flags in #1217), but nothing stopped the drift from happening, and a second instance was still live.

What changed:

- **New conformance gate.** Every example the CLI prints — root usage, all 20 help topics, all 67 command helps — is read back out of the rendered text and run through the production parser (`parseArgs(..., { strictFlags: true })`) plus the command's CLI reader. 274 examples check today. Lines whose unquoted tokens carry placeholder syntax (`<value>`, `[optional]`, `a|b`) are synopsis shapes and are skipped; quoted arguments such as `batch --steps '[{"command":…}]'` stay in scope.
- **`help macos` fix.** It advertised `agent-device snapshot -i --platform macos --surface menubar`, which the CLI rejects — `--surface` is an `open` flag, and the session keeps it (`snapshot-capture.ts` reads `session.surface`). The example drops the flag and the Surfaces block now says so explicitly.
- **Two prose lines reworded** (`help tv`, `help web`) so no help line starts with `agent-device ` unless it is a command. That keeps the gate's rule total instead of needing an allowlist, and removes two sentences an agent could read as commands.

Before/after for the macOS case:

```
$ agent-device snapshot -i --platform macos --surface menubar
Error (INVALID_ARGS): Flag --surface is not supported for command snapshot.

$ agent-device help macos    # now prints
  agent-device open "Agent Device Tester Menu" --platform macos --surface menubar
  agent-device snapshot -i --platform macos
```

Closes #1765

## Validation

`pnpm check:affected --run` green (38 files / 499 tests), plus `check:layering` and `check:fallow`.

The gate was proven red before green, twice against real defects rather than a synthetic one:

- Reverting `open`'s `...METRO_RELOAD_FLAGS` (recreating the released 0.19.3 schema) fails it with the issue's verbatim error: `Flags --metro-host, --metro-port are not supported for command open.` on both `help react-native` example lines.
- Restoring `--surface menubar` on the macOS snapshot example fails it with `Flag --surface is not supported for command snapshot.`

Live CLI evidence for the reported command shape, against a deliberately nonexistent device so no real one was claimed:

```
$ agent-device open "React Navigation Example" --platform ios --device NoSuchDeviceXYZ \
    --session rn-probe-1765 --metro-host 127.0.0.1 --metro-port 8081 --relaunch
Error (DEVICE_NOT_FOUND): No device named NoSuchDeviceXYZ
```

It now fails at device resolution instead of flag validation, which is the issue's expected behavior. The probe session's daemon was stopped.

## Scope and gaps

Three files, one module group (CLI help/parser). No website docs change: `website/docs/docs/commands.md` already documents `--surface` on `open` only and shows a bare `snapshot -i` after it, which is what the help now matches.

Known boundary, stated in the test header: only line-leading examples are checked. Examples embedded mid-sentence in command detail prose (`… for example agent-device open "Expo Go" exp://127.0.0.1:8081 --platform ios.`) have no reliable end delimiter — `127.0.0.1`, `.log`, and a sentence-final period are indistinguishable — so guessing where the command stops would trade this class of bug for false failures. Example blocks, the copy-paste surface, are fully covered.