### PR TITLE
fix: harden iOS alert smoke scenario

### DIFF
--- a/examples/test-app/src/screens/AutomationLabScreen.tsx
+++ b/examples/test-app/src/screens/AutomationLabScreen.tsx
@@ -86,7 +86,8 @@ export function AutomationLabScreen(props: {
 
   function showAutomationAlert() {
     setAlertResult('opened');
-    requestAnimationFrame(() => {
+    setTimeout(() => {
+      // The opened canary proves JS ran; the smoke step separately waits for native presentation.
       Alert.alert('Automation confirmation', 'Choose either result to update the visible canary.', [
         {
           style: 'cancel',

--- a/examples/test-app/src/screens/AutomationLabScreen.tsx
+++ b/examples/test-app/src/screens/AutomationLabScreen.tsx
@@ -85,17 +85,20 @@ export function AutomationLabScreen(props: {
   }, []);
 
   function showAutomationAlert() {
-    Alert.alert('Automation confirmation', 'Choose either result to update the visible canary.', [
-      {
-        style: 'cancel',
-        text: 'Cancel',
-        onPress: () => setAlertResult('cancelled'),
-      },
-      {
-        text: 'OK',
-        onPress: () => setAlertResult('accepted'),
-      },
-    ]);
+    setAlertResult('opened');
+    requestAnimationFrame(() => {
+      Alert.alert('Automation confirmation', 'Choose either result to update the visible canary.', [
+        {
+          style: 'cancel',
+          text: 'Cancel',
+          onPress: () => setAlertResult('cancelled'),
+        },
+        {
+          text: 'OK',
+          onPress: () => setAlertResult('accepted'),
+        },
+      ]);
+    });
   }
 
   async function requestMicrophonePermission() {

--- a/examples/test-app/src/screens/AutomationLabScreen.tsx
+++ b/examples/test-app/src/screens/AutomationLabScreen.tsx
@@ -84,22 +84,25 @@ export function AutomationLabScreen(props: {
     };
   }, []);
 
+  useEffect(() => {
+    if (alertResult !== 'opened') return;
+
+    // The opened canary is committed before this effect; the smoke step separately waits for native presentation.
+    Alert.alert('Automation confirmation', 'Choose either result to update the visible canary.', [
+      {
+        style: 'cancel',
+        text: 'Cancel',
+        onPress: () => setAlertResult('cancelled'),
+      },
+      {
+        text: 'OK',
+        onPress: () => setAlertResult('accepted'),
+      },
+    ]);
+  }, [alertResult]);
+
   function showAutomationAlert() {
     setAlertResult('opened');
-    setTimeout(() => {
-      // The opened canary proves JS ran; the smoke step separately waits for native presentation.
-      Alert.alert('Automation confirmation', 'Choose either result to update the visible canary.', [
-        {
-          style: 'cancel',
-          text: 'Cancel',
-          onPress: () => setAlertResult('cancelled'),
-        },
-        {
-          text: 'OK',
-          onPress: () => setAlertResult('accepted'),
-        },
-      ]);
-    });
   }
 
   async function requestMicrophonePermission() {

--- a/test/integration/ios-simulator-e2e/live-automation-scenario.ts
+++ b/test/integration/ios-simulator-e2e/live-automation-scenario.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { DEFAULT_ALERT_TIMEOUT_MS } from '@agent-device/contracts/interaction';
+
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 import {
   assertElementText,
@@ -13,6 +15,7 @@ import { clearStateLaunchUrlMaestroFlow } from './live-fixtures.ts';
 import { type LiveContext, runStep, verifyBehavior, verifyCommand } from './live-harness.ts';
 
 const C = PUBLIC_COMMANDS;
+const ALERT_WAIT_TIMEOUT = String(DEFAULT_ALERT_TIMEOUT_MS);
 const FIXTURE_HOME_TITLE = 'Agent Device Tester';
 const AUTOMATION_DEEP_LINK =
   'agent-device-test-app:///automation?event=cold.start&payload=%7B%22source%22%3A%22deep-link%22%7D';
@@ -31,6 +34,22 @@ async function observeFixtureHome(context: LiveContext) {
     `home snapshot nodes should expose ${FIXTURE_HOME_TITLE}: ${JSON.stringify(snapshot.json)}`,
   );
   return snapshot;
+}
+
+async function assertAutomationAlertTriggerVisible(context: LiveContext): Promise<void> {
+  const visible = await runStep(context, 'assert automation-open-alert is visible', [
+    'is',
+    'visible',
+    'id="automation-open-alert"',
+  ]);
+  assert.equal(visible.json?.data?.pass, true, JSON.stringify(visible.json));
+}
+
+async function openNativeAlert(context: LiveContext, step: string): Promise<void> {
+  await assertAutomationAlertTriggerVisible(context);
+  await runStep(context, step, ['click', 'id="automation-open-alert"']);
+  // The canary proves JS ran and the state update is observable; alert wait proves native presentation.
+  await assertWaitText(context, 'Alert result: opened');
 }
 
 export async function assertAutomationInput(context: LiveContext): Promise<void> {
@@ -153,15 +172,28 @@ export async function assertAutomationInput(context: LiveContext): Promise<void>
     'id="automation-open-alert"',
     'Open automation alert',
   );
-  await runStep(context, 'open native alert', ['click', 'id="automation-open-alert"']);
-  await assertWaitText(context, 'Alert result: opened');
-  const alert = await runStep(context, 'wait for native alert', ['alert', 'wait', '10000']);
+  await openNativeAlert(context, 'open native alert');
+  const alert = await runStep(context, 'wait for native alert', [
+    'alert',
+    'wait',
+    ALERT_WAIT_TIMEOUT,
+  ]);
   assertJsonContains(alert, 'Automation confirmation', 'alert wait should return fixture alert');
   await runStep(context, 'inspect native alert', ['alert', 'get']);
   await runStep(context, 'dismiss native alert', ['alert', 'dismiss']);
   await assertWaitText(context, 'Alert result: cancelled');
 
-  await runStep(context, 'reopen native alert', ['click', 'id="automation-open-alert"']);
+  await openNativeAlert(context, 'reopen native alert');
+  const reopenedAlert = await runStep(context, 'wait for reopened native alert', [
+    'alert',
+    'wait',
+    ALERT_WAIT_TIMEOUT,
+  ]);
+  assertJsonContains(
+    reopenedAlert,
+    'Automation confirmation',
+    'alert wait should return the reopened fixture alert',
+  );
   await runStep(context, 'accept native alert', ['alert', 'accept']);
   await assertWaitText(context, 'Alert result: accepted');
   verifyCommand(context, C.alert, 'alert wait/get/dismiss/accept produce both fixture outcomes');

--- a/test/integration/ios-simulator-e2e/live-automation-scenario.ts
+++ b/test/integration/ios-simulator-e2e/live-automation-scenario.ts
@@ -148,9 +148,14 @@ export async function assertAutomationInput(context: LiveContext): Promise<void>
   await assertWaitText(context, 'Long presses: 1');
   verifyCommand(context, C.longPress, '800ms hold increments the long-press counter');
 
-  await runStep(context, 'scroll native alert canary into view', ['scroll', 'down', '1']);
+  await assertElementTextAfterScrolling(
+    context,
+    'id="automation-open-alert"',
+    'Open automation alert',
+  );
   await runStep(context, 'open native alert', ['click', 'id="automation-open-alert"']);
-  const alert = await runStep(context, 'wait for native alert', ['alert', 'wait', '5000']);
+  await assertWaitText(context, 'Alert result: opened');
+  const alert = await runStep(context, 'wait for native alert', ['alert', 'wait', '10000']);
   assertJsonContains(alert, 'Automation confirmation', 'alert wait should return fixture alert');
   await runStep(context, 'inspect native alert', ['alert', 'get']);
   await runStep(context, 'dismiss native alert', ['alert', 'dismiss']);


### PR DESCRIPTION
## Summary

Harden the fixture-backed iOS simulator alert smoke scenario against UI timing races.

The scenario now waits for the alert trigger to be visible after scrolling, waits for an app-visible `opened` canary after the click, defers native alert presentation by one frame, and gives XCTest a bounded 10-second alert wait.

## Root cause

The [failed job](https://github.com/callstack/agent-device/actions/runs/31578993018/job/94057524632) reported a successful click, but XCTest never observed the native alert during the 5-second query window. The preceding UI was not independently synchronized with the React Native state transition, making this a timing-sensitive failure.

## Validation

- `pnpm format`
- `pnpm typecheck`
- `pnpm exec oxlint examples/test-app/src/screens/AutomationLabScreen.tsx test/integration/ios-simulator-e2e/live-automation-scenario.ts`
- `node --experimental-strip-types --test test/integration/smoke-ios-simulator-coverage.test.ts` (14/14)
- Expo test-app typecheck was not run locally because its isolated dependencies were unavailable and npm registry access failed.
