### PR TITLE
fix(ios): use current devicectl capture-screenshot syntax for physical devices

### DIFF
--- a/src/platforms/apple/core/__tests__/physical-device-screenshot.test.ts
+++ b/src/platforms/apple/core/__tests__/physical-device-screenshot.test.ts
@@ -1,7 +1,47 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { shouldFallbackToRunnerForIosScreenshot } from '../physical-device-screenshot.ts';
+import { IOS_DEVICE } from '../../../../__tests__/test-utils/index.ts';
+import {
+  captureCoreDeviceScreenshot,
+  shouldFallbackToRunnerForIosScreenshot,
+} from '../physical-device-screenshot.ts';
+import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
 import { AppError } from '@agent-device/kernel/errors';
+
+test('captureCoreDeviceScreenshot invokes devicectl with the current capture-screenshot syntax', async () => {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+
+  await withAppleToolProvider(
+    createLocalAppleToolProvider({
+      runCommand: async (cmd, args) => {
+        calls.push({ cmd, args });
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    }),
+    async () =>
+      await captureCoreDeviceScreenshot(IOS_DEVICE, '/tmp/out.png', {
+        runRunnerCommand: async () => {
+          throw new Error('devicectl capture should have succeeded without a runner fallback');
+        },
+      }),
+  );
+
+  assert.deepEqual(calls, [
+    {
+      cmd: 'xcrun',
+      args: [
+        'devicectl',
+        'device',
+        'capture',
+        'screenshot',
+        '--device',
+        IOS_DEVICE.id,
+        '--destination',
+        '/tmp/out.png',
+      ],
+    },
+  ]);
+});
 
 test('shouldFallbackToRunnerForIosScreenshot detects removed devicectl subcommand output', () => {
   const error = new AppError('COMMAND_FAILED', 'Failed to capture iOS screenshot', {

--- a/src/platforms/apple/core/physical-device-screenshot.ts
+++ b/src/platforms/apple/core/physical-device-screenshot.ts
@@ -25,10 +25,13 @@ export async function captureCoreDeviceScreenshot(
 ): Promise<void> {
   if (!options.preferRunner) {
     try {
-      await runIosDevicectl(['device', 'screenshot', '--device', device.id, outPath], {
-        action: 'capture iOS screenshot',
-        deviceId: device.id,
-      });
+      await runIosDevicectl(
+        ['device', 'capture', 'screenshot', '--device', device.id, '--destination', outPath],
+        {
+          action: 'capture iOS screenshot',
+          deviceId: device.id,
+        },
+      );
       return;
     } catch (error) {
       if (!shouldFallbackToRunnerForIosScreenshot(error)) throw error;


### PR DESCRIPTION
## Summary
- The physical-iOS direct-capture path ran `devicectl device screenshot --device <id> <path>`, which current Xcode `devicectl` rejects with `Unknown option '--device'`, forcing every physical-device screenshot into the slower XCTest runner fallback.
- Xcode's `devicectl` now requires `devicectl device capture screenshot --device <id> --destination <path>`. Updated the invocation in [physical-device-screenshot.ts](src/platforms/apple/core/physical-device-screenshot.ts) accordingly.

Fixes #1760

## Test plan
- [x] Added a regression test asserting the exact `devicectl` args (`device capture screenshot --device <id> --destination <path>`) — [physical-device-screenshot.test.ts](src/platforms/apple/core/__tests__/physical-device-screenshot.test.ts)
- [x] `npx vitest run src/platforms/apple/core/__tests__/` — 504/504 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` on changed files — clean
- [x] Live verification on a connected, unlocked physical iPhone (`thymikee-iphone`): `agent-device screenshot` produced a valid 1206x2622 PNG via the direct `devicectl` path with no XCTest fallback triggered