### PR TITLE
fix(ci): run the three checks no workflow was running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,17 @@ jobs:
         # rather than in its own job so the two can never be green independently.
         run: pnpm depgraph:test
 
+      # Tests for the TMPDIR redirection itself, hidden the same way as the check above.
+      #
+      # Deliberately NOT in Coverage next to `check:tmpdir-leaks`, where the subject matter
+      # would put it: vitest-tmpdir-global-setup.test.ts proves the lifecycle by spawning a
+      # real nested `vitest run`, and the Coverage lane already loses runs to
+      # `[vitest-pool]: Worker forks emitted error` when a fork is slow to terminate.
+      # Starting a nested Vitest seconds before the full instrumented suite is a contention
+      # risk with nothing to gain.
+      - name: Check the tmpdir redirection model
+        run: pnpm check:tmpdir-leaks:test
+
   affected-selector:
     name: Affected-check Selector
     runs-on: ubuntu-latest
@@ -287,6 +298,13 @@ jobs:
           OUTPUT_ECONOMY_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: pnpm test:coverage:ci
 
+      # The TMPDIR redirection both test lanes depend on (#1593/#1595). The check is a real
+      # package script that no workflow ran: it is reachable only through `check:unit`, an
+      # aggregate CI never invokes, so a leak regression could not fail a PR. Placed here
+      # because this is the lane whose instrumented suite would leak a run directory.
+      - name: Check for leaked temp directories
+        run: pnpm check:tmpdir-leaks
+
       - name: Upload contention-retry envelope
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -371,6 +389,11 @@ jobs:
       # failing `gh`.
       - name: Setup-fixture-app cache-failure fallback
         run: sh ./test/scripts/setup-fixture-app-fallback-smoke.sh
+
+      # The trusted-artifact contract the device lanes rely on to decide a cached fixture
+      # app is the one this commit expects. A real test file that no workflow ran.
+      - name: Check the trusted fixture-artifact contract
+        run: pnpm test:fixture-cache
 
   web-smoke:
     name: Web Platform Smoke


### PR DESCRIPTION
Step 1 of the landing plan agreed on #1753: the defect fix on its own, with none of the machinery.

**23 lines of `ci.yml`. No new code, no new scripts, no new dependencies.**

## The defect

Three real package scripts with real assertions that **no CI lane executes**:

| Script | What it asserts |
| --- | --- |
| `check:tmpdir-leaks` | no abandoned `agent-device-test-run-*` directory survives a run whose owning process died (#1593/#1595) |
| `check:tmpdir-leaks:test` | the redirection model itself — liveness detection, the Vitest globalSetup path, and the `node --test` wrapper |
| `test:fixture-cache` | the trusted-artifact contract the device lanes use to decide a cached fixture app matches this commit |

All three are reachable only through `check:unit`, an aggregate no workflow invokes. A regression in any of them could not fail a PR.

Verified by transitive script reachability over every workflow and composite action on `main`, plus direct grep: **zero references to any of the three anywhere in `.github`.** That is how they stayed hidden — a check that silently stops running looks exactly like a green build.

## Placement, and one deliberate exception

- **`check:tmpdir-leaks` → Coverage.** The lane whose instrumented suite is what would leak a run directory.
- **`test:fixture-cache` → Integration Tests.** Beside the fixture-app fallback smoke, which covers the same artifact contract.
- **`check:tmpdir-leaks:test` → Layering Guard**, *not* next to the check it covers. `vitest-tmpdir-global-setup.test.ts` proves the lifecycle by spawning a real nested `vitest run`, and the Coverage lane already loses runs to `[vitest-pool]: Worker forks emitted error` when a fork is slow to terminate. Starting a nested Vitest seconds before the full instrumented suite is a contention risk with nothing to gain.

## Evidence

**All three pass at this commit**, so this wires green gates rather than red ones:

```
check:tmpdir-leaks         PASS
check:tmpdir-leaks:test    PASS
test:fixture-cache         PASS
```

**Non-vacuity.** Planting an abandoned run directory makes the check fail and name it:

```
$ mkdir /tmp/agent-device-test-run-planted-99999999
$ pnpm check:tmpdir-leaks
Error: Found 1 abandoned agent-device-test-run-* directory in /tmp:
$ rmdir /tmp/agent-device-test-run-planted-99999999
$ pnpm check:tmpdir-leaks
No abandoned agent-device-test-run-* directories found in /tmp.
```

**Wiring verified structurally** rather than by eye — each target job parsed back out of the YAML and asserted to contain the exact command. That check caught a real mistake while writing this: my first attempt missed the Coverage step entirely, because an `env:` block sits between the step name and its `run:`.

## Scope

Part of #1429, which stays open. The ownership proof that would catch this class *automatically* is the subject of #1753 and is being redesigned after review — this PR deliberately carries none of it, so the immediate risk is removed now rather than waiting on that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkS4S8XXrfkJ8TD1VBKkvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkS4S8XXrfkJ8TD1VBKkvJ)_