### PR TITLE
fix: preserve compact snapshot action labels

### DIFF
--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -13,9 +13,9 @@ const IOS_PRESENTATION_RULES: Array<
 > = [
   // Semantic representatives must be collected before duplicate-label suppression.
   collectIosWebSemanticPresentation,
-  collectIosPresentationNoiseSuppression,
   collectIosImplicitScrollableActions,
   collectIosRowPresentation,
+  collectIosPresentationNoiseSuppression,
 ];
 
 export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnapshotNode[] {

--- a/src/daemon/snapshot-presentation/ios/rows.fixtures.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.fixtures.ts
@@ -1,0 +1,51 @@
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+
+const roomRowRect = { x: 0, y: 400, width: 402, height: 96 };
+
+export const elementClassicRoomListNodes: RawSnapshotNode[] = [
+  { index: 0, depth: 0, type: 'Application', label: 'Element Classic' },
+  { index: 1, depth: 1, parentIndex: 0, type: 'Table', label: 'HomeVCTableView' },
+  {
+    index: 2,
+    depth: 2,
+    parentIndex: 1,
+    type: 'Cell',
+    identifier: 'RecentTableViewCell',
+    label: 'Vertical scroll bar, 1 page',
+    rect: roomRowRect,
+  },
+  { index: 3, depth: 3, parentIndex: 2, type: 'StaticText', label: 'Book Club' },
+  {
+    index: 4,
+    depth: 3,
+    parentIndex: 2,
+    type: 'StaticText',
+    label: 'Dave: Loving it so far, the worldbuilding is great.',
+  },
+  { index: 5, depth: 3, parentIndex: 2, type: 'StaticText', label: '03:55' },
+  {
+    index: 6,
+    depth: 2,
+    parentIndex: 1,
+    type: 'Cell',
+    identifier: 'RecentTableViewCell',
+    label: 'Vertical scroll bar, 1 page',
+    rect: { ...roomRowRect, y: 496 },
+  },
+  { index: 7, depth: 3, parentIndex: 6, type: 'StaticText', label: 'Team Standup' },
+  { index: 8, depth: 3, parentIndex: 6, type: 'StaticText', label: 'Dave: No blockers from me.' },
+  { index: 9, depth: 3, parentIndex: 6, type: 'StaticText', label: '03:55' },
+];
+
+export const legitimatelyLabeledCellNodes: RawSnapshotNode[] = [
+  { index: 0, depth: 0, type: 'Application', label: 'Example' },
+  {
+    index: 1,
+    depth: 1,
+    parentIndex: 0,
+    type: 'Cell',
+    label: 'Stem Cell',
+    rect: roomRowRect,
+  },
+  { index: 2, depth: 2, parentIndex: 1, type: 'StaticText', label: 'Research details' },
+];

--- a/src/daemon/snapshot-presentation/ios/rows.fixtures.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.fixtures.ts
@@ -44,7 +44,7 @@ export const legitimatelyLabeledCellNodes: RawSnapshotNode[] = [
     depth: 1,
     parentIndex: 0,
     type: 'Cell',
-    label: 'Stem Cell',
+    label: 'StemCell',
     rect: roomRowRect,
   },
   { index: 2, depth: 2, parentIndex: 1, type: 'StaticText', label: 'Research details' },

--- a/src/daemon/snapshot-presentation/ios/rows.test.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { elementClassicRoomListNodes, legitimatelyLabeledCellNodes } from './rows.fixtures.ts';
+import { presentIosInteractiveSnapshot } from './index.ts';
+
+test('iOS row presentation associates generic room cells with their descendant titles', () => {
+  const nodes = presentIosInteractiveSnapshot(elementClassicRoomListNodes);
+
+  expect(nodes.filter((node) => node.type === 'Cell').map((node) => node.label)).toEqual([
+    'Book Club',
+    'Team Standup',
+  ]);
+  expect(nodes.filter((node) => node.label === 'Book Club')).toHaveLength(1);
+  expect(nodes.filter((node) => node.label === 'Team Standup')).toHaveLength(1);
+});
+
+test('iOS row presentation preserves a legitimate cell label', () => {
+  const nodes = presentIosInteractiveSnapshot(legitimatelyLabeledCellNodes);
+
+  expect(nodes.find((node) => node.type === 'Cell')?.label).toBe('Stem Cell');
+});

--- a/src/daemon/snapshot-presentation/ios/rows.test.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.test.ts
@@ -13,8 +13,8 @@ test('iOS row presentation associates generic room cells with their descendant t
   expect(nodes.filter((node) => node.label === 'Team Standup')).toHaveLength(1);
 });
 
-test('iOS row presentation preserves a legitimate cell label', () => {
+test('iOS row presentation preserves a legitimate no-space cell label', () => {
   const nodes = presentIosInteractiveSnapshot(legitimatelyLabeledCellNodes);
 
-  expect(nodes.find((node) => node.type === 'Cell')?.label).toBe('Stem Cell');
+  expect(nodes.find((node) => node.type === 'Cell')?.label).toBe('StemCell');
 });

--- a/src/daemon/snapshot-presentation/ios/rows.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.ts
@@ -1,5 +1,6 @@
 import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
 import { normalizeType } from '@agent-device/contracts/snapshot';
+import { isSystemScrollIndicatorLabel } from '../../../utils/scroll-indicator.ts';
 import {
   areRectsApproximatelyEqual,
   collectDescendants,
@@ -15,12 +16,49 @@ export function collectIosRowPresentation(
 ): void {
   for (let position = 0; position < nodes.length; position += 1) {
     const row = nodes[position];
-    const rowLabel = row?.label?.trim();
+    const rowLabel = row ? resolveIosRowLabel(nodes, position, row, context) : undefined;
     if (!row?.rect || !rowLabel) {
       continue;
     }
     collectIosRowPresentationForNode(nodes, position, row, rowLabel, context);
   }
+}
+
+function resolveIosRowLabel(
+  nodes: RawSnapshotNode[],
+  position: number,
+  row: RawSnapshotNode,
+  context: SnapshotTreeRuleContext,
+): string | undefined {
+  const rowLabel = row.label?.trim();
+  if (
+    normalizeType(row.type ?? '') !== 'cell' ||
+    (rowLabel && !isImplementationCellLabel(rowLabel) && !isSystemScrollIndicatorLabel(rowLabel))
+  ) {
+    return rowLabel;
+  }
+
+  const titleNode = collectDescendants(nodes, position).find(isIosRowTitleCandidate);
+  const title = titleNode?.label?.trim();
+  if (!titleNode || !title) {
+    return rowLabel;
+  }
+  mergeReplacement(context.replacements, row, { label: title });
+  context.suppressedIndexes.add(titleNode.index);
+  return title;
+}
+
+function isImplementationCellLabel(label: string): boolean {
+  return label !== 'Cell' && /^[A-Z_$][A-Za-z0-9_$]*Cell$/.test(label);
+}
+
+function isIosRowTitleCandidate(node: RawSnapshotNode): boolean {
+  const label = node.label?.trim();
+  if (!label) {
+    return false;
+  }
+  const type = normalizeType(node.type ?? '');
+  return type === 'statictext' || type === 'text' || type === 'textview';
 }
 
 function collectIosRowPresentationForNode(

--- a/src/daemon/snapshot-presentation/ios/rows.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.ts
@@ -33,7 +33,9 @@ function resolveIosRowLabel(
   const rowLabel = row.label?.trim();
   if (
     normalizeType(row.type ?? '') !== 'cell' ||
-    (rowLabel && !isImplementationCellLabel(rowLabel) && !isSystemScrollIndicatorLabel(rowLabel))
+    (rowLabel &&
+      !isImplementationCellLabel(rowLabel, row.identifier) &&
+      !isSystemScrollIndicatorLabel(rowLabel))
   ) {
     return rowLabel;
   }
@@ -48,8 +50,8 @@ function resolveIosRowLabel(
   return title;
 }
 
-function isImplementationCellLabel(label: string): boolean {
-  return label !== 'Cell' && /^[A-Z_$][A-Za-z0-9_$]*Cell$/.test(label);
+function isImplementationCellLabel(label: string, identifier: string | undefined): boolean {
+  return identifier?.trim() === label && /^[A-Z_$][A-Za-z0-9_$]*Cell$/.test(label);
 }
 
 function isIosRowTitleCandidate(node: RawSnapshotNode): boolean {

--- a/src/daemon/snapshot-presentation/ios/scroll.ts
+++ b/src/daemon/snapshot-presentation/ios/scroll.ts
@@ -15,7 +15,8 @@ export function collectIosScrollIndicatorPresentation(
   context: SnapshotTreeRuleContext,
 ): void {
   for (const node of nodes) {
-    if (!isIosScrollIndicatorNode(node)) {
+    const presentedNode = context.replacements.get(node.index) ?? node;
+    if (!isIosScrollIndicatorNode(presentedNode)) {
       continue;
     }
     collectIosScrollIndicatorNodePresentation(node, context.sourceNodesByIndex, context);

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -87,6 +87,21 @@ test('parseUiHierarchy keeps visible Android nodes with meaningful test identifi
   );
 });
 
+test('interactive Android snapshots keep Compose semantic views inside actionable parents', () => {
+  const xml = `<hierarchy>
+  <node class="android.view.View" package="com.example.app" bounds="[923,158][1049,284]" clickable="true" visible-to-user="true">
+    <node class="android.view.View" package="com.example.app" content-desc="Start a call" bounds="[954,189][1017,252]" visible-to-user="true"/>
+    <node class="android.widget.Button" package="com.example.app" bounds="[933,168][1038,273]" visible-to-user="true"/>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { interactiveOnly: true });
+
+  assert.equal(result.nodes[0]?.hittable, true);
+  assert.equal(result.nodes[1]?.label, 'Start a call');
+  assert.equal(result.nodes[1]?.parentIndex, 0);
+});
+
 test('interactive Android snapshots keep a fixed sibling outside filtered scroll content (#1377)', () => {
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][400,800]" visible-to-user="true">

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -805,7 +805,10 @@ function shouldIncludeInteractiveProxyNode(
 ): boolean {
   if (!info.hasMeaningfulText && !info.hasMeaningfulId) return false;
   if (info.isVisual) return false;
-  if (info.isStructural && !ancestorCollection) return false;
+  // Compose commonly places the app-owned content description on a passive
+  // `android.view.View` inside the clickable container. Keep that semantic
+  // proxy so presentation can associate the label with the action.
+  if (info.isStructural && !ancestorCollection && !ancestorHittable) return false;
   return ancestorHittable || descendantHittable || ancestorCollection;
 }
 

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -645,6 +645,38 @@ test('formatSnapshotText promotes Android helper unlabeled action rows', () => {
   assert.match(raw, /"Mobile, Wi-Fi, hotspot"/);
 });
 
+test('formatSnapshotText promotes Android Compose leaf-view semantics to their action', () => {
+  const text = withNoColor(() =>
+    formatSnapshotText({
+      nodes: [
+        {
+          ref: 'e1',
+          index: 0,
+          depth: 0,
+          type: 'android.view.View',
+          rect: { x: 923, y: 158, width: 126, height: 126 },
+          hittable: true,
+        },
+        {
+          ref: 'e2',
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'android.view.View',
+          label: 'Start a call',
+          rect: { x: 954, y: 189, width: 63, height: 63 },
+        },
+      ],
+      truncated: false,
+      androidSnapshot: { backend: 'android-helper' },
+    }),
+  );
+
+  assert.match(text, /Snapshot: 1 visible nodes \(2 total\)/);
+  assert.match(text, /@e1 \[group\] "Start a call"/);
+  assert.doesNotMatch(text, /@e2/);
+});
+
 test('formatSnapshotText keeps passive row descendants that were not promoted', () => {
   const nodes = [
     {

--- a/src/utils/android-helper-presentation/structural-noise.ts
+++ b/src/utils/android-helper-presentation/structural-noise.ts
@@ -116,7 +116,7 @@ function collectPromotableRowContent(
   for (const descendant of descendants) {
     if (
       removed.has(descendant.index) ||
-      !isPassiveRowContent(descendant) ||
+      !isPromotableRowContent(descendant, descendants) ||
       !isRectContainedBy(descendant.rect, parent.rect)
     ) {
       continue;
@@ -129,6 +129,23 @@ function collectPromotableRowContent(
     labels.push(label);
   }
   return { label: labels.join(', '), removableIndexes };
+}
+
+function isPromotableRowContent(node: SnapshotNode, descendants: SnapshotNode[]): boolean {
+  if (isPassiveRowContent(node)) return true;
+
+  // Jetpack Compose can expose a content description through a passive leaf
+  // `View` rather than TextView/ImageView. It is safe to associate only the
+  // app-provided label of a leaf with its actionable containing row: promoting
+  // a structural subtree could otherwise hide independently actionable nodes.
+  const type = (node.type ?? '').toLowerCase();
+  return (
+    node.hittable !== true &&
+    !isEditableNode(node) &&
+    type.includes('view') &&
+    visibleNodeLabel(node).trim().length > 0 &&
+    !descendants.some((candidate) => candidate.parentIndex === node.index)
+  );
 }
 
 function isPassiveRowContent(node: SnapshotNode): boolean {


### PR DESCRIPTION
## Summary

Preserve app-owned action labels that compact snapshots previously dropped on iOS and Android.

- iOS promotes a cell’s descendant title when the cell exposes only an implementation or system scroll-indicator label, while preserving legitimate cell labels.
- Android retains passive Compose `View` semantics under hittable containers and promotes only labeled passive leaf views, avoiding independently actionable subtrees.
- Scope is intentionally cross-platform because the benchmark exposed the same public `snapshot -i` contract failure through different native accessibility shapes. Nine files are touched.

## Validation

- Red proof: focused regressions failed 2/78 on Android and returned no labeled iOS room cells before the fixes.
- `pnpm check:affected --run`: 316 test files / 2,745 tests passed; changed-line coverage 92.59%; format, lint, typecheck, layering, fallow, build, and provider checks passed.
- Live iOS Element Classic: `Book Club` and `Team Standup` are labeled `Cell` actions; clicking the promoted `Book Club` ref opened the room.
- Live Android Element X: compact helper output labels `Back`, `Start a call`, and `User menu` from app-owned Compose semantics.
- `pnpm build:android` passed.

Docs and skills are unchanged because this repairs existing snapshot semantics without changing commands, flags, or workflow guidance.