### PR TITLE
docs: reposition README around mobile app automation for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,5 +251,9 @@ connect errors, retry policy, or command typing, start in
   help/metadata, README or `website/docs/**` when user-facing, and a help-conformance bench case
   (`scripts/help-conformance-*.mjs`) when command-planning guidance changes.
 - State in the final summary whether docs/skills were updated, and why not if they weren't.
+- README altitude: the intro is a category line, the job pitch with the platform list, and the
+  works-with/proof line — nothing else. Per-platform transports, tool names, vendor lists, and
+  support caveats go in "How it works" and `website/docs/**`. A new platform adds its name to the
+  intro list and its backend to "How it works", nothing more.
 
 When guidance conflicts, Hard Rules win, then scope, then testing, then style.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Let your coding agent verify its changes in the running app. `agent-device` lets agents inspect, control, debug, and verify apps on iOS, Android, and HarmonyOS (simulators, emulators, and physical devices), plus tvOS, Android TV, Amazon Vega OS TV (Vega Virtual Device), web, macOS, and Linux. Agents read token-efficient accessibility snapshots instead of reasoning over screenshots alone, act through refs and selectors, and save evidence for review. It also coordinates device access across parallel agent worktrees and connects to remote device clouds.
 
-Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Developers at [Expensify](https://www.callstack.com/blog/how-expensify-uses-agent-device-for-mobile-bug-evidence-and-profiling), [Shopify](https://x.com/mustafa01ali/status/2036577353178943826), and [others](#who-uses-agent-device) use it to verify their apps.
+Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Build your own agents and QA tools on the same runtime with the Node.js client and the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) guides. Developers at [Expensify](https://www.callstack.com/blog/how-expensify-uses-agent-device-for-mobile-bug-evidence-and-profiling), [Shopify](https://x.com/mustafa01ali/status/2036577353178943826), and [others](#who-uses-agent-device) use it to verify their apps.
 
 ## Quick start
 
@@ -88,7 +88,7 @@ See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) fo
 
 ### Script it from Node.js
 
-`createAgentDeviceClient()` gives Node.js code typed access to the same commands. Expose its methods as model tools or call them from orchestration code:
+`createAgentDeviceClient()` gives Node.js code typed access to the same commands. Expose its methods as model tools in your own agent (the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) guides show how) or call them from orchestration code:
 
 ```ts
 import { createAgentDeviceClient } from 'agent-device';
@@ -169,6 +169,10 @@ Yes. `agent-device` supports native iOS and Android apps, plus React Native, Exp
 ### How is it different from mobile MCP servers?
 
 The MCP server is one entry point to the same runtime used by the CLI and typed Node.js API. Sessions, device ownership, selectors, evidence, replay, CI workflows, and cloud routing stay consistent across all three.
+
+### Can I build my own agent or QA product on agent-device?
+
+Yes. The CLI, MCP server, and typed Node.js client are public surfaces over one runtime, so an agent you build gets the same sessions, selectors, evidence, replay, and device-cloud routing as a coding agent using the CLI. Start from the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api), [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk), or [Eve](https://oss.callstack.com/agent-device/docs/eve) guides.
 
 ### How is it different from Appium, Detox, or Maestro?
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Let your coding agent verify its changes in the running app. `agent-device` lets agents inspect, control, debug, and verify apps on iOS, Android, and HarmonyOS (simulators, emulators, and physical devices), plus tvOS, Android TV, Amazon Vega OS TV (Vega Virtual Device), web, macOS, and Linux. Agents read token-efficient accessibility snapshots instead of reasoning over screenshots alone, act through refs and selectors, and save evidence for review. It also coordinates device access across parallel agent worktrees and connects to remote device clouds.
 
-Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Build your own agents and QA tools on the same runtime with the Node.js client and the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) guides. Developers at [Expensify](https://www.callstack.com/blog/how-expensify-uses-agent-device-for-mobile-bug-evidence-and-profiling), [Shopify](https://x.com/mustafa01ali/status/2036577353178943826), and [others](#who-uses-agent-device) use it to verify their apps.
+Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP, or as the runtime under agents you build with the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) or [Eve](https://oss.callstack.com/agent-device/docs/eve). Developers at [Expensify](https://www.callstack.com/blog/how-expensify-uses-agent-device-for-mobile-bug-evidence-and-profiling), [Shopify](https://x.com/mustafa01ali/status/2036577353178943826), and [others](#who-uses-agent-device) use it to verify their apps.
 
 ## Quick start
 
@@ -31,9 +31,7 @@ agent-device doctor
 agent-device help workflow
 ```
 
-Run `agent-device doctor` yourself before handing the CLI to an agent. The installed CLI help defines current behavior. `agent-device help workflow` links to guides for debugging, replay, React Native profiling, and other tasks.
-
-From here, pick how your agent uses it: the CLI in a terminal, MCP tools in an agent client, or the typed client in Node.js code.
+Run `doctor` yourself before handing the CLI to an agent; `help workflow` links to the guides for debugging, replay, and profiling, and the installed help always matches the installed version.
 
 ### Drive an app from the CLI
 
@@ -63,15 +61,13 @@ agent-device screenshot ./contact-form.png
 agent-device close
 ```
 
-Use refs only from the latest output. Do not assume an earlier `@eN` still identifies the same element. After a command with `--settle` (`scroll` and `back` support it too), use the refs in its diff. Take another snapshot only if the diff omits what you need.
-
-Snapshots use the app's accessibility tree. Clear labels, roles, and test IDs make agent runs more reliable. Use screenshots and videos as evidence or when accessibility data is poor. Use refs and selectors for actions and assertions when you can.
+Refs are only valid from the latest output: after a `--settle` command, use the refs in its diff, and take a new snapshot only if the diff omits what you need. Snapshots come from the app's accessibility tree, so clear labels, roles, and test IDs make agent runs more reliable; use screenshots and video as evidence or when accessibility data is poor.
 
 ![agent-device demo showing Codex using agent-device to create a new contact in the iOS Contacts app from a simple prompt](./website/docs/public/agent-device-contacts.gif)
 
 ### Add MCP tools to your agent
 
-`agent-device mcp` starts the official stdio MCP server. It exposes structured tools for the installed commands, backed by the same execution path as the CLI. Add it to Cursor, Claude Code, Windsurf, or another MCP client:
+`agent-device mcp` starts the official stdio MCP server, exposing the installed commands as structured tools over the same execution path as the CLI:
 
 ```json
 {
@@ -88,7 +84,7 @@ See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) fo
 
 ### Script it from Node.js
 
-`createAgentDeviceClient()` gives Node.js code typed access to the same commands. Expose its methods as model tools in your own agent (the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) guides show how) or call them from orchestration code:
+`createAgentDeviceClient()` gives Node.js code typed access to the same commands, as model tools in your own agent or from orchestration code:
 
 ```ts
 import { createAgentDeviceClient } from 'agent-device';
@@ -103,7 +99,7 @@ if (button) await client.interactions.press({ ref: button.ref });
 await client.sessions.close();
 ```
 
-See the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api) and the [runnable examples](https://github.com/callstack/agent-device/tree/main/examples/sdk) for typed error handling, batching, and the other public entry points.
+See the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api), the [runnable examples](https://github.com/callstack/agent-device/tree/main/examples/sdk), and the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) integration guides.
 
 ## What agents can do
 
@@ -128,9 +124,9 @@ With the CLI installed, prompts like these work end to end:
 
 ## Next steps
 
-- **Set up your agent**: run the CLI from Cursor, Codex, Claude Code, Windsurf, or another agent terminal. See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) for skills, rules, MCP tools, and setup for each client.
-- **Try the sample app**: clone the repo and run the bundled Expo test app. [Quick Start](https://oss.callstack.com/agent-device/docs/quick-start) covers a guided run with screenshots, replay, and performance data.
-- **Build repeatable tests**: use [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) to repeat tests. Use [Debugging & Profiling](https://oss.callstack.com/agent-device/docs/debugging-profiling) to find bugs.
+- [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup): skills, project rules, and per-client setup for Cursor, Codex, Claude Code, Windsurf, and others.
+- [Quick Start](https://oss.callstack.com/agent-device/docs/quick-start): a guided run on the bundled Expo test app with screenshots, replay, and performance data.
+- [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) and [Debugging & Profiling](https://oss.callstack.com/agent-device/docs/debugging-profiling): repeatable tests and bug hunting.
 
 ## Where to run agent-device
 
@@ -172,7 +168,7 @@ The MCP server is one entry point to the same runtime used by the CLI and typed 
 
 ### Can I build my own agent or QA product on agent-device?
 
-Yes. The CLI, MCP server, and typed Node.js client are public surfaces over one runtime, so an agent you build gets the same sessions, selectors, evidence, replay, and device-cloud routing as a coding agent using the CLI. Start from the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api), [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk), or [Eve](https://oss.callstack.com/agent-device/docs/eve) guides.
+Yes. The typed Node.js client is a public surface over that same runtime, so an agent you build inherits everything above. Start from the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api), [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk), or [Eve](https://oss.callstack.com/agent-device/docs/eve) guides.
 
 ### How is it different from Appium, Detox, or Maestro?
 
@@ -180,7 +176,7 @@ With `agent-device`, an agent reads app state and chooses each command at run ti
 
 ### Can agent-device run in CI?
 
-Yes. Record a run as an `.ad` script, replay it locally or in CI, and save screenshots, logs, and other artifacts for review. See [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) or start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml).
+Yes. Record a run as an `.ad` script, replay it in CI, and keep the screenshots and logs as artifacts; the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml) is a working example.
 
 ## Articles and videos
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
 [![Glama MCP server](https://glama.ai/mcp/servers/callstack/agent-device/badges/score.svg)](https://glama.ai/mcp/servers/callstack/agent-device)
 
-**Mobile app automation and verification for AI coding agents.** Inspect, control, debug, and test apps through the CLI, built-in MCP server, or typed Node.js API.
+**Mobile app automation and verification for AI coding agents.** Give coding agents a live app feedback loop through a CLI, built-in MCP server, or typed Node.js API.
 
 <!-- Intro rule: category line, job pitch with the platform list, works-with/proof line, nothing else. Per-platform transports, tool names, vendor lists, and support caveats belong in "How it works" and website/docs, never here. Every name in the proof line must link to public evidence. -->
 
@@ -139,7 +139,7 @@ The same session and evidence model works at every step: the agent explores the 
 | Path | Best for | Start with |
 | --- | --- | --- |
 | Local | Trying commands and debugging apps on simulators, emulators, physical devices, macOS, and Linux. | Follow the Quick Start. |
-| CI/CD | Automated pull request and merge validation with replay scripts and captured artifacts. | Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
+| CI/CD | Automated pull request and merge validation with replay scripts and captured artifacts. | Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). |
 | Cloud / remote | Linux runners, managed devices, and remote jobs. | Set up a [remote proxy](https://oss.callstack.com/agent-device/docs/remote-proxy), connect a [device cloud](https://oss.callstack.com/agent-device/docs/device-clouds) (BrowserStack, AWS Device Farm, Limrun), or [contact Callstack](mailto:hello@callstack.com) for team QA. |
 
 ## How it works
@@ -165,6 +165,10 @@ Yes. `agent-device mcp` starts the official stdio MCP server. The Quick start ab
 ### Does it work with React Native, Expo, Flutter, and native apps?
 
 Yes. `agent-device` supports native iOS and Android apps, plus React Native, Expo, and Flutter apps on supported targets. The commands and evidence vary by target.
+
+### How is it different from mobile MCP servers?
+
+The MCP server is one entry point to the same runtime used by the CLI and typed Node.js API. Sessions, device ownership, selectors, evidence, replay, CI workflows, and cloud routing stay consistent across all three.
 
 ### How is it different from Appium, Detox, or Maestro?
 

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) fo
 import { createAgentDeviceClient } from 'agent-device';
 
 const client = createAgentDeviceClient({ session: 'qa-run' });
-await client.apps.open({ app: 'com.apple.Preferences', platform: 'ios' });
-
-const snapshot = await client.capture.snapshot({ interactiveOnly: true });
-const button = snapshot.nodes.find((node) => node.role === 'button');
-if (button) await client.interactions.press({ ref: button.ref });
-
-await client.sessions.close();
+try {
+  await client.apps.open({ app: 'com.apple.Preferences', platform: 'ios' });
+  const snapshot = await client.capture.snapshot({ interactiveOnly: true });
+  const button = snapshot.nodes.find((node) => node.role === 'button');
+  if (button) await client.interactions.press({ ref: button.ref });
+} finally {
+  await client.sessions.close();
+}
 ```
 
 See the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api), the [runnable examples](https://github.com/callstack/agent-device/tree/main/examples/sdk), and the [AI SDK](https://oss.callstack.com/agent-device/docs/ai-sdk) and [Eve](https://oss.callstack.com/agent-device/docs/eve) integration guides.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=agent-device" align="center">
   <picture>
-    <img alt="agent-device: device automation CLI for AI agents" src="website/docs/public/agent-device-banner.jpg">
+    <img alt="agent-device: mobile app automation and verification for AI coding agents" src="website/docs/public/agent-device-banner.jpg">
   </picture>
 </a>
 
@@ -13,13 +13,24 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
 [![Glama MCP server](https://glama.ai/mcp/servers/callstack/agent-device/badges/score.svg)](https://glama.ai/mcp/servers/callstack/agent-device)
 
-Let your coding agent verify its changes in the running app.
+**Mobile app automation, testing, and verification for AI coding agents.** Available as a CLI, an official MCP server, and a typed Node.js API.
 
-`agent-device` lets coding agents inspect, control, and verify apps on iOS, Android, HarmonyOS, tvOS, Android TV, Amazon Vega OS TV through the Vega Virtual Device (VVD), web, macOS, and Linux. Agents can read token-efficient accessibility snapshots where supported, find elements by ref or selector, run device actions, and save evidence for review. HarmonyOS support uses HDC and ArkUI `uitest` on connected devices and DevEco emulators; use `capabilities --platform harmonyos` to inspect its evidence-backed command subset. Initial Vega OS support is VVD-only and covers discovery, app lifecycle, and complete TV-remote control; physical Fire TV, capture, and selector backends remain unsupported.
+<!-- Intro rule: category line, job pitch with the platform list, works-with/proof line, nothing else. Per-platform transports, tool names, vendor lists, and support caveats belong in "How it works" and website/docs, never here. -->
 
-Your coding agent or QA tool reads each result and chooses the next command. `agent-device` runs the command and saves evidence when asked.
+Let your coding agent verify its changes in the running app. `agent-device` lets agents inspect, control, debug, and verify apps on iOS, Android, and HarmonyOS (simulators, emulators, and physical devices), plus tvOS, Android TV, Amazon Vega OS TV (Vega Virtual Device), web, macOS, and Linux. Agents read token-efficient accessibility snapshots instead of reasoning over screenshots alone, act through refs and selectors, and save evidence for review. It also coordinates device access across parallel agent worktrees and connects to remote device clouds.
 
-`agent-device` uses the inspect-act-verify process from Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser) for mobile, TV, and desktop apps. Basic `--platform web` support runs `agent-browser` in the same session and replay system.
+Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Teams at JPMorgan Chase, Expensify, Shopify, and [others](#who-uses-agent-device) use it to verify their apps.
+
+## What agents can do
+
+- **Inspect app state** through accessibility snapshots, refs, selectors, and React Native component trees.
+- **Act on visible UI** by tapping or pressing elements, filling fields, scrolling, making gestures, waiting, asserting state, and handling alerts.
+- **Diagnose failures** with screenshots, video, logs, traces, network data, performance samples, crash details, and React profiles.
+- **Repeat workflows** by saving working steps as `.ad` scripts for local use or CI. Export strict Maestro YAML when needed.
+
+See [Commands](https://oss.callstack.com/agent-device/docs/commands) for the commands and evidence each target supports.
+
+![Diagram of the agentic development loop: humans assign tasks, agents write and review code, agent-device verifies mobile apps, pull requests receive evidence, and bugs or performance issues lead to fixes](./website/docs/public/agentic-development-loop.svg)
 
 ## Quick start
 
@@ -32,6 +43,10 @@ agent-device help workflow
 ```
 
 Run `agent-device doctor` yourself before handing the CLI to an agent. The installed CLI help defines current behavior. `agent-device help workflow` links to guides for debugging, replay, React Native profiling, and other tasks.
+
+From here, pick how your agent uses it: the CLI in a terminal, MCP tools in an agent client, or the typed client in Node.js code.
+
+### Drive an app from the CLI
 
 Add a contact in the built-in iOS Contacts app:
 
@@ -59,30 +74,105 @@ agent-device screenshot ./contact-form.png
 agent-device close
 ```
 
-Use refs only from the latest output. Do not assume an earlier `@eN` still identifies the same element. After a command with `--settle`, use the refs in its diff. Take another snapshot only if the diff omits what you need.
-
-`--settle` works the same way on `scroll` and `back`, so scroll-then-observe and back-then-observe are one call too.
+Use refs only from the latest output. Do not assume an earlier `@eN` still identifies the same element. After a command with `--settle` (`scroll` and `back` support it too), use the refs in its diff. Take another snapshot only if the diff omits what you need.
 
 Snapshots use the app's accessibility tree. Clear labels, roles, and test IDs make agent runs more reliable. Use screenshots and videos as evidence or when accessibility data is poor. Use refs and selectors for actions and assertions when you can.
 
 ![agent-device demo showing Codex using agent-device to create a new contact in the iOS Contacts app from a simple prompt](./website/docs/public/agent-device-contacts.gif)
 
-## What agents can do
+### Add MCP tools to your agent
 
-- **Inspect app state** through accessibility snapshots, refs, selectors, and React Native component trees.
-- **Act on visible UI** by tapping or pressing elements, filling fields, scrolling, making gestures, waiting, asserting state, and handling alerts.
-- **Diagnose failures** with screenshots, video, logs, traces, network data, performance samples, crash details, and React profiles.
-- **Repeat workflows** by saving working steps as `.ad` scripts for local use or CI. Export strict Maestro YAML when needed.
+`agent-device mcp` starts the official stdio MCP server. It exposes structured tools for the installed commands, backed by the same execution path as the CLI. Add it to Cursor, Claude Code, Windsurf, or another MCP client:
 
-See [Commands](https://oss.callstack.com/agent-device/docs/commands) for the commands and evidence each target supports.
+```json
+{
+  "mcpServers": {
+    "agent-device": {
+      "command": "agent-device",
+      "args": ["mcp"]
+    }
+  }
+}
+```
 
-![Diagram of the agentic development loop: humans assign tasks, agents write and review code, agent-device verifies mobile apps, pull requests receive evidence, and bugs or performance issues lead to fixes](./website/docs/public/agentic-development-loop.svg)
+See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) for per-client setup and when to prefer plain CLI over MCP.
+
+### Script it from Node.js
+
+`createAgentDeviceClient()` gives Node.js code typed access to the same commands. Expose its methods as model tools or call them from orchestration code:
+
+```ts
+import { createAgentDeviceClient } from 'agent-device';
+
+const client = createAgentDeviceClient({ session: 'qa-run' });
+await client.apps.open({ app: 'com.apple.Preferences', platform: 'ios' });
+
+const snapshot = await client.capture.snapshot({ interactiveOnly: true });
+const button = snapshot.nodes.find((node) => node.role === 'button');
+if (button) await client.interactions.press({ ref: button.ref });
+
+await client.sessions.close();
+```
+
+See the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api) and the [runnable examples](https://github.com/callstack/agent-device/tree/main/examples/sdk) for typed error handling, batching, and the other public entry points.
+
+## What to ask your agent
+
+With the CLI installed, prompts like these work end to end:
+
+- "Implement the onboarding screen, run it on the iOS simulator and Android emulator, and attach screenshots."
+- "Reproduce this crash and capture the logs that lead up to it."
+- "Check whether this change causes unnecessary React Native re-renders."
+- "Explore the checkout flow once, save it as a replay script, and run it in CI."
+- "Verify this pull request on a physical device and attach reviewable evidence."
 
 ## Next steps
 
 - **Set up your agent**: run the CLI from Cursor, Codex, Claude Code, Windsurf, or another agent terminal. See [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) for skills, rules, MCP tools, and setup for each client.
 - **Try the sample app**: clone the repo and run the bundled Expo test app. [Quick Start](https://oss.callstack.com/agent-device/docs/quick-start) covers a guided run with screenshots, replay, and performance data.
 - **Build repeatable tests**: use [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) to repeat tests. Use [Debugging & Profiling](https://oss.callstack.com/agent-device/docs/debugging-profiling) to find bugs.
+
+## Where to run agent-device
+
+The same session and evidence model works at every step: the agent explores the app, captures evidence, saves a replay, runs it in CI, and moves onto remote devices.
+
+| Path | Best for | Start with |
+| --- | --- | --- |
+| Local | Trying commands and debugging apps on simulators, emulators, physical devices, macOS, and Linux. | Follow the Quick Start. |
+| CI/CD | Automated pull request and merge validation with replay scripts and captured artifacts. | Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
+| Cloud / remote | Linux runners, managed devices, and remote jobs. | Set up a [remote proxy](https://oss.callstack.com/agent-device/docs/remote-proxy), connect a [device cloud](https://oss.callstack.com/agent-device/docs/device-clouds) (BrowserStack, AWS Device Farm, Limrun), or [contact Callstack](mailto:hello@callstack.com) for team QA. |
+
+## How it works
+
+`agent-device` keeps device state in sessions. It sends commands to XCTest on iOS and tvOS, ADB and the snapshot helper on Android, HDC and ArkUI `uitest` on HarmonyOS, Vega CLI/VDA on the Vega Virtual Device, a local helper on macOS, and AT-SPI on Linux.
+
+Support depth varies by target. Newer backends such as HarmonyOS and Vega OS cover a subset of commands; run `agent-device capabilities --platform <platform>` to see what a target supports.
+
+Sessions are scoped to the caller's git worktree, and host-local device claims stop parallel agents from taking over each other's simulators and emulators. The same commands drive hosted devices on [BrowserStack, AWS Device Farm, and Limrun](https://oss.callstack.com/agent-device/docs/device-clouds).
+
+`agent-device` uses the inspect-act-verify process from Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser) for mobile, TV, and desktop apps. Basic `--platform web` support runs `agent-browser` in the same session and replay system.
+
+## FAQ
+
+### What is agent-device?
+
+`agent-device` is a command-line tool and MCP server that lets AI coding agents inspect, control, and verify mobile apps and save evidence for review. It supports iOS, Android, HarmonyOS, TV, web, macOS, and Linux.
+
+### Is there an MCP server for mobile app automation?
+
+Yes. `agent-device mcp` starts the official stdio MCP server. The Quick start above has the client config, and [AI Agent Setup](https://oss.callstack.com/agent-device/docs/agent-setup) covers per-client details.
+
+### Does it work with React Native, Expo, Flutter, and native apps?
+
+Yes. `agent-device` supports native iOS and Android apps, plus React Native, Expo, and Flutter apps on supported targets. The commands and evidence vary by target.
+
+### How is it different from Appium, Detox, or Maestro?
+
+With `agent-device`, an agent reads app state and chooses each command at run time. Teams use Appium, Detox, and Maestro to write and maintain test suites. `agent-device` can complement them by saving its runs as `.ad` scripts or exporting them as strict Maestro YAML.
+
+### Can agent-device run in CI?
+
+Yes. Record a run as an `.ad` script, replay it locally or in CI, and save screenshots, logs, and other artifacts for review. See [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) or start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml).
 
 ## Articles and videos
 
@@ -98,38 +188,6 @@ See [Commands](https://oss.callstack.com/agent-device/docs/commands) for the com
 - [Verifying mobile apps with agent-device](https://youtu.be/kZDU-k5r9kE)
 - [Using agent-device in an AI coding workflow](https://youtu.be/dfVG_aNPkW4)
 - [Cloud agents that test mobile apps on real devices](https://youtu.be/r5P0detC4bs?is=_KB6SZbLFRB1au_z)
-
-## Where to run agent-device
-
-| Path | Best for | Start with |
-| --- | --- | --- |
-| Local | Trying commands and debugging apps on simulators, emulators, physical devices, macOS, and Linux. | Follow the Quick Start. |
-| CI/CD | Automated pull request and merge validation with replay scripts and captured artifacts. | Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
-| Cloud / remote | Linux runners, managed devices, and remote jobs. | Use [Agent Device Cloud](https://agent-device.dev/cloud), set a remote profile with [Commands](https://oss.callstack.com/agent-device/docs/commands), or [contact Callstack](mailto:hello@callstack.com) for team QA. |
-
-## How it works
-
-`agent-device` keeps device state in sessions. It sends commands to XCTest on iOS and tvOS, ADB and the snapshot helper on Android, HDC and ArkUI `uitest` on HarmonyOS, Vega CLI/VDA on the Vega Virtual Device, a local helper on macOS, and AT-SPI on Linux.
-
-Node.js apps can use the typed client or public subpaths. `agent-device/android-adb` provides the Android ADB provider interface, helpers for logcat, the clipboard, the keyboard, and apps, and port reverse management.
-
-## FAQ
-
-### What is agent-device?
-
-`agent-device` is a command-line tool that lets coding agents inspect, control, and verify apps and save evidence for review. It supports iOS, Android, HarmonyOS, TV, web, macOS, and Linux.
-
-### Does it work with React Native, Expo, Flutter, and native apps?
-
-Yes. `agent-device` supports native iOS and Android apps, plus React Native, Expo, and Flutter apps on supported targets. The commands and evidence vary by target.
-
-### How is it different from Appium, Detox, or Maestro?
-
-With `agent-device`, an agent reads app state and chooses each command at run time. Teams use Appium, Detox, and Maestro to write and maintain test suites. `agent-device` can complement them by saving its runs as `.ad` scripts or exporting them as strict Maestro YAML.
-
-### Can agent-device run in CI?
-
-Yes. Record a run as an `.ad` script, replay it locally or in CI, and save screenshots, logs, and other artifacts for review. See [Replay & E2E](https://oss.callstack.com/agent-device/docs/replay-e2e) or start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml).
 
 ## Who uses agent-device?
 

--- a/README.md
+++ b/README.md
@@ -13,24 +13,13 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
 [![Glama MCP server](https://glama.ai/mcp/servers/callstack/agent-device/badges/score.svg)](https://glama.ai/mcp/servers/callstack/agent-device)
 
-**Mobile app automation, testing, and verification for AI coding agents.** Available as a CLI, an official MCP server, and a typed Node.js API.
+**Mobile app automation and verification for AI coding agents.** Inspect, control, debug, and test apps through the CLI, built-in MCP server, or typed Node.js API.
 
-<!-- Intro rule: category line, job pitch with the platform list, works-with/proof line, nothing else. Per-platform transports, tool names, vendor lists, and support caveats belong in "How it works" and website/docs, never here. -->
+<!-- Intro rule: category line, job pitch with the platform list, works-with/proof line, nothing else. Per-platform transports, tool names, vendor lists, and support caveats belong in "How it works" and website/docs, never here. Every name in the proof line must link to public evidence. -->
 
 Let your coding agent verify its changes in the running app. `agent-device` lets agents inspect, control, debug, and verify apps on iOS, Android, and HarmonyOS (simulators, emulators, and physical devices), plus tvOS, Android TV, Amazon Vega OS TV (Vega Virtual Device), web, macOS, and Linux. Agents read token-efficient accessibility snapshots instead of reasoning over screenshots alone, act through refs and selectors, and save evidence for review. It also coordinates device access across parallel agent worktrees and connects to remote device clouds.
 
-Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Teams at JPMorgan Chase, Expensify, Shopify, and [others](#who-uses-agent-device) use it to verify their apps.
-
-## What agents can do
-
-- **Inspect app state** through accessibility snapshots, refs, selectors, and React Native component trees.
-- **Act on visible UI** by tapping or pressing elements, filling fields, scrolling, making gestures, waiting, asserting state, and handling alerts.
-- **Diagnose failures** with screenshots, video, logs, traces, network data, performance samples, crash details, and React profiles.
-- **Repeat workflows** by saving working steps as `.ad` scripts for local use or CI. Export strict Maestro YAML when needed.
-
-See [Commands](https://oss.callstack.com/agent-device/docs/commands) for the commands and evidence each target supports.
-
-![Diagram of the agentic development loop: humans assign tasks, agents write and review code, agent-device verifies mobile apps, pull requests receive evidence, and bugs or performance issues lead to fixes](./website/docs/public/agentic-development-loop.svg)
+Works with Claude Code, Codex, Cursor, Windsurf, Cline, Goose, and any agent that can run a CLI or connect over MCP. Developers at [Expensify](https://www.callstack.com/blog/how-expensify-uses-agent-device-for-mobile-bug-evidence-and-profiling), [Shopify](https://x.com/mustafa01ali/status/2036577353178943826), and [others](#who-uses-agent-device) use it to verify their apps.
 
 ## Quick start
 
@@ -115,6 +104,17 @@ await client.sessions.close();
 ```
 
 See the [Node.js API](https://oss.callstack.com/agent-device/docs/client-api) and the [runnable examples](https://github.com/callstack/agent-device/tree/main/examples/sdk) for typed error handling, batching, and the other public entry points.
+
+## What agents can do
+
+- **Inspect app state** through accessibility snapshots, refs, selectors, and React Native component trees.
+- **Act on visible UI** by tapping or pressing elements, filling fields, scrolling, making gestures, waiting, asserting state, and handling alerts.
+- **Diagnose failures** with screenshots, video, logs, traces, network data, performance samples, crash details, and React profiles.
+- **Repeat workflows** by saving working steps as `.ad` scripts for local use or CI. Export strict Maestro YAML when needed.
+
+See [Commands](https://oss.callstack.com/agent-device/docs/commands) for the commands and evidence each target supports.
+
+![Diagram of the agentic development loop: humans assign tasks, agents write and review code, agent-device verifies mobile apps, pull requests receive evidence, and bugs or performance issues lead to fixes](./website/docs/public/agentic-development-loop.svg)
 
 ## What to ask your agent
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device",
   "version": "0.20.8",
-  "description": "Mobile app automation, testing, and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
+  "description": "Mobile app automation and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
   "mcpName": "io.github.callstack/agent-device",
   "license": "MIT",
   "author": "Callstack",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device",
   "version": "0.20.8",
-  "description": "Agent-native CLI for AI app automation across iOS, Android, tvOS, Android TV, macOS, Linux, and web.",
+  "description": "Mobile app automation, testing, and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
   "mcpName": "io.github.callstack/agent-device",
   "license": "MIT",
   "author": "Callstack",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.callstack/agent-device",
   "title": "agent-device",
-  "description": "Let AI agents inspect, control, and debug real iOS, Android, desktop, and TV apps",
+  "description": "MCP server for mobile app automation: verify, control, and debug iOS, Android, TV, and desktop apps",
   "repository": {
     "url": "https://github.com/callstack/agent-device",
     "source": "github"

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -7,7 +7,7 @@ export default withCallstackPreset(
     docs: {
       title: 'agent-device',
       description:
-        'Agent-native CLI for AI mobile testing, React Native QA, Expo app verification, simulator and emulator automation, app observability, and replayable device workflows.',
+        'Mobile app automation and verification for AI coding agents: CLI, MCP server, and Node.js API for mobile testing, React Native QA, Expo app verification, simulator and emulator automation, and replayable device workflows.',
       editUrl: 'https://github.com/callstack/agent-device/edit/main/website',
       rootUrl: 'https://oss.callstack.com/agent-device',
       rootDir: 'docs',

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -7,7 +7,7 @@ export default withCallstackPreset(
     docs: {
       title: 'agent-device',
       description:
-        'Mobile app automation and verification for AI coding agents: CLI, MCP server, and Node.js API for mobile testing, React Native QA, Expo app verification, simulator and emulator automation, and replayable device workflows.',
+        'Mobile app automation and verification for AI coding agents through a CLI, MCP server, and typed Node.js API.',
       editUrl: 'https://github.com/callstack/agent-device/edit/main/website',
       rootUrl: 'https://oss.callstack.com/agent-device',
       rootDir: 'docs',


### PR DESCRIPTION
## Summary

Repositions the README so it leads with the category and the three surfaces before differentiating on verification and evidence: category keywords first so humans and search engines can classify it, verification and evidence as the differentiator.

Before: the intro opened with the job statement, then a dense platform paragraph carrying per-platform caveats (HarmonyOS uses HDC and ArkUI `uitest`; Vega OS is VVD-only), then the Vercel attribution. Zero occurrences of "mobile app automation" or "MCP server" above the fold. MCP setup and the Node.js client were only reachable through docs links; capabilities and proof were below the entire Quick start.

After:

- Category line first: mobile app automation and verification for AI coding agents, through the CLI, built-in MCP server, or typed Node.js API. Then the job pitch with a keyword-richer platform sentence, then a works-with/proof line (documented client list; every named proof point links to public evidence).
- Quick start follows the hero directly; "What agents can do" and the loop diagram sit below the walkthrough.
- Quick start now has three labeled paths after the shared install step: CLI walkthrough (unchanged), MCP `mcpServers` config, and a ten-line `createAgentDeviceClient()` snippet mirroring `examples/sdk/client-session.ts`.
- New "What to ask your agent" section with five developer prompts; a one-sentence product ladder atop "Where to run"; two AEO-shaped FAQ entries.
- Per-platform transports and caveats moved to "How it works", with one sentence pointing at `agent-device capabilities --platform <platform>` as the authoritative depth check.
- Cloud/remote row points at the remote proxy and device clouds docs instead of `agent-device.dev/cloud`.
- npm `description`, `server.json` registry description (99/100 chars), and the rspress site description (110 chars) use the same category phrasing.
- Em dashes and evaluative filler removed per the Callstack humanizer skill; the tone-of-voice reference was checked and already passes.

Guard against the original drift (a contributor appending "HarmonyOS uses HDC…" to the intro because the Vega caveat had already set the pattern): the pattern-seeding sentences are gone, an inline HTML comment above the intro states the rule at the point of edit, and AGENTS.md "Docs & skills" gets a README-altitude rule.

Length: 207 lines / ~1580 words, up from 149 / ~1150; the growth is the MCP + Node quick starts, prompts, and proof line, with duplicated Node subpath and FAQ text removed.

## Validation

Docs and metadata only, no runtime behavior changes. `node scripts/sync-mcp-metadata.mjs --check` passes for the new `server.json` description. Node snippet method names and optional `udid` verified against `packages/contracts/src/client-app.ts` and the SDK example. The repo's format gate (oxfmt) does not take markdown, and the prettier warnings on README/AGENTS pre-exist this change on main.

Not covered here: GitHub About text (repo settings), the agent-device.dev H1 and client-specific landing pages from the same analysis. 5 files touched; scope grew from a HarmonyOS-sentence cleanup to a README repositioning during the session.

