### PR TITLE
fix: stabilize private AX settle snapshots

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -113,6 +113,8 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXDepthLimitedRequiresEveryFrontierResolved \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDeepExtensionCountsMissedFrontiers \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPreferredPrivateAXBackendPlansAsPenalized \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXRegularPresentationProjectsToViewportAndKeepsScrollHint \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDecodedPreferredBackendReachesOptionsAndApplicablePlan \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSparsePayloadReasonMatrix \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledNeedsEnoughSamples \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -115,6 +115,8 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPreferredPrivateAXBackendPlansAsPenalized \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXRegularPresentationProjectsToViewportAndKeepsScrollHint \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXScopeSelectsSubtreeNotMatchingLabels \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXInteractiveFiltersLoginLikeHiddenDrawer \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDecodedPreferredBackendReachesOptionsAndApplicablePlan \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSparsePayloadReasonMatrix \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRunnerScreenshotStabilitySettledNeedsEnoughSamples \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -175,15 +175,10 @@ extension RunnerTests {
 
       let rootFrame = privateAXRect(root["frame"])
       let viewport = privateAXSnapshotViewport(app: app, rootFrame: rootFrame)
-      var nodes: [SnapshotNode] = []
-      appendPrivateAXNode(
-        root,
-        to: &nodes,
+      let nodes = privateAXPresentation(
+        rawRoot: root,
         options: options,
-        viewport: viewport,
-        depth: 0,
-        parentIndex: nil,
-        insideMatchedScope: false
+        viewport: viewport
       )
       if nodes.count <= 1 {
         NSLog("AGENT_DEVICE_RUNNER_PRIVATE_AX_SNAPSHOT_SPARSE=%ld", nodes.count)
@@ -250,110 +245,7 @@ extension RunnerTests {
     }
   }
 
-  private func appendPrivateAXNode(
-    _ rawNode: [String: Any],
-    to nodes: inout [SnapshotNode],
-    options: SnapshotOptions,
-    viewport: CGRect,
-    depth: Int,
-    parentIndex: Int?,
-    insideMatchedScope: Bool
-  ) {
-    if let limit = options.depth, depth > limit { return }
-
-    let rect = privateAXRect(rawNode["frame"])
-    let label = privateAXString(rawNode["label"])
-    let identifier = privateAXString(rawNode["identifier"])
-    let value = privateAXString(rawNode["value"])
-    let rawType = privateAXInt(rawNode["type"]) ?? 0
-    let typeName = elementTypeName(rawElementType: rawType)
-    let enabled = privateAXBool(rawNode["enabled"]) ?? true
-    let visible = isVisibleInViewport(rect, viewport)
-    let interactiveCandidate = privateAXInteractiveCandidate(rawElementType: rawType)
-    let filterDecision = flatSnapshotFilterDecision(
-      FlatSnapshotFilterNode(
-        isRoot: parentIndex == nil,
-        label: label,
-        identifier: identifier,
-        valueText: value.isEmpty ? nil : value,
-        visible: visible
-      ),
-      options: options,
-      insideMatchedScope: insideMatchedScope
-    )
-    let include = filterDecision.include
-    let nowInsideScope = filterDecision.insideMatchedScope
-
-    let currentIndex: Int?
-    if include {
-      currentIndex = nodes.count
-      nodes.append(
-        SnapshotNode(
-          index: nodes.count,
-          type: typeName,
-          label: label.isEmpty ? nil : label,
-          identifier: identifier.isEmpty ? nil : identifier,
-          value: value.isEmpty ? nil : value,
-          rect: snapshotRect(from: rect),
-          enabled: enabled,
-          focused: privateAXBool(rawNode["focused"]) == true ? true : nil,
-          selected: privateAXBool(rawNode["selected"]) == true ? true : nil,
-          hittable: visible && enabled && interactiveCandidate,
-          depth: depth,
-          parentIndex: parentIndex,
-          hiddenContentAbove: nil,
-          hiddenContentBelow: nil,
-          actions: rawNode["actions"] as? [String]
-        )
-      )
-    } else {
-      currentIndex = parentIndex
-    }
-
-    guard let children = rawNode["children"] as? [[String: Any]] else {
-      return
-    }
-    for child in children {
-      appendPrivateAXNode(
-        child,
-        to: &nodes,
-        options: options,
-        viewport: viewport,
-        depth: depth + 1,
-        parentIndex: currentIndex,
-        insideMatchedScope: nowInsideScope
-      )
-    }
-  }
-
-  private func elementTypeName(rawElementType: Int) -> String {
-    if let type = flatSnapshotElementType(rawElementType: rawElementType) {
-      return elementTypeName(type)
-    }
-    return "Element(\(rawElementType))"
-  }
-
-  private func privateAXString(_ value: Any?) -> String {
-    guard let value else { return "" }
-    if let string = value as? String {
-      return string.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    return String(describing: value).trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
-  private func privateAXInt(_ value: Any?) -> Int? {
-    if let value = value as? Int { return value }
-    if let value = value as? NSNumber { return value.intValue }
-    return nil
-  }
-
-  private func privateAXBool(_ value: Any?) -> Bool? {
-    if let value = value as? Bool { return value }
-    if let value = value as? NSNumber { return value.boolValue }
-    return nil
-  }
-
-  private func privateAXRect(_ value: Any?) -> CGRect {
+  func privateAXRect(_ value: Any?) -> CGRect {
     guard let frame = value as? [String: Any] else {
       return .zero
     }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -634,15 +634,10 @@ extension RunnerTests {
         ],
       ],
     ]
-    var nodes: [SnapshotNode] = []
-    appendPrivateAXNode(
-      tree,
-      to: &nodes,
+    let nodes = privateAXPresentation(
+      rawRoot: tree,
       options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
-      viewport: CGRect(x: 0, y: 0, width: 390, height: 844),
-      depth: 0,
-      parentIndex: nil,
-      insideMatchedScope: false
+      viewport: CGRect(x: 0, y: 0, width: 390, height: 844)
     )
 
     let card = nodes.first { $0.label == "feedItem-by-whiskers.test" }
@@ -664,15 +659,10 @@ extension RunnerTests {
         ["type": 9, "label": "unrelated sibling", "children": []],
       ],
     ]
-    var nodes: [SnapshotNode] = []
-    appendPrivateAXNode(
-      tree,
-      to: &nodes,
+    let nodes = privateAXPresentation(
+      rawRoot: tree,
       options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: "homeScreen", raw: false),
-      viewport: .infinite,
-      depth: 0,
-      parentIndex: nil,
-      insideMatchedScope: false
+      viewport: .infinite
     )
 
     let labels = nodes.compactMap { $0.label ?? $0.identifier }
@@ -746,15 +736,10 @@ extension RunnerTests {
         ]
       ],
     ]
-    var nodes: [SnapshotNode] = []
-    appendPrivateAXNode(
-      tree,
-      to: &nodes,
+    let nodes = privateAXPresentation(
+      rawRoot: tree,
       options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
-      viewport: CGRect(x: 0, y: 0, width: 390, height: 844),
-      depth: 0,
-      parentIndex: nil,
-      insideMatchedScope: false
+      viewport: CGRect(x: 0, y: 0, width: 390, height: 844)
     )
 
     let labels = nodes.compactMap { $0.label }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
@@ -18,10 +18,16 @@ struct FlatSnapshotFilterDecision {
   let insideMatchedScope: Bool
 }
 
+enum FlatSnapshotVisibilityPolicy {
+  case interactiveOnly
+  case viewportProjected
+}
+
 extension RunnerTests {
   func flatSnapshotFilterDecision(
     _ node: FlatSnapshotFilterNode,
     options: SnapshotOptions,
+    visibilityPolicy: FlatSnapshotVisibilityPolicy,
     insideMatchedScope: Bool
   ) -> FlatSnapshotFilterDecision {
     let scope = options.scope?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -39,7 +45,9 @@ extension RunnerTests {
       include = true
     } else if scopeActive && !nowInsideScope {
       include = false
-    } else if options.interactiveOnly && !node.visible {
+    } else if !node.visible
+      && (options.interactiveOnly || visibilityPolicy == .viewportProjected)
+    {
       include = false
     } else {
       include = true
@@ -87,11 +95,19 @@ extension RunnerTests {
       valueText: nil,
       visible: true
     )
+    let hiddenRoot = FlatSnapshotFilterNode(
+      isRoot: true,
+      label: "App",
+      identifier: "",
+      valueText: nil,
+      visible: false
+    )
 
     XCTAssertTrue(
       flatSnapshotFilterDecision(
         visibleContent,
         options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
     )
@@ -99,6 +115,31 @@ extension RunnerTests {
       flatSnapshotFilterDecision(
         hiddenInteractive,
         options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .interactiveOnly,
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertFalse(
+      flatSnapshotFilterDecision(
+        hiddenInteractive,
+        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .viewportProjected,
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertTrue(
+      flatSnapshotFilterDecision(
+        hiddenInteractive,
+        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .interactiveOnly,
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertTrue(
+      flatSnapshotFilterDecision(
+        hiddenRoot,
+        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .viewportProjected,
         insideMatchedScope: false
       ).include
     )
@@ -106,13 +147,7 @@ extension RunnerTests {
       flatSnapshotFilterDecision(
         decorative,
         options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
-        insideMatchedScope: false
-      ).include
-    )
-    XCTAssertTrue(
-      flatSnapshotFilterDecision(
-        decorative,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
     )
@@ -138,6 +173,7 @@ extension RunnerTests {
     let rootDecision = flatSnapshotFilterDecision(
       scopeRoot,
       options: options,
+      visibilityPolicy: .interactiveOnly,
       insideMatchedScope: false
     )
     XCTAssertTrue(rootDecision.include)
@@ -147,6 +183,7 @@ extension RunnerTests {
       flatSnapshotFilterDecision(
         unmatchedDescendant,
         options: options,
+        visibilityPolicy: .interactiveOnly,
         insideMatchedScope: rootDecision.insideMatchedScope
       ).include
     )
@@ -154,6 +191,7 @@ extension RunnerTests {
       flatSnapshotFilterDecision(
         unmatchedDescendant,
         options: options,
+        visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
     )

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -8,15 +8,7 @@ extension RunnerTests {
     var hints: [Int: (above: Bool, below: Bool)] = [:]
     appendPrivateAXNode(rawRoot, to: &nodes, hints: &hints, options: options, viewport: viewport,
       depth: 0, parentIndex: nil, insideMatchedScope: false, scrollContext: nil)
-    guard !hints.isEmpty else { return nodes }
-    return nodes.map { node in
-      guard let hint = hints[node.index] else { return node }
-      return SnapshotNode(index: node.index, type: node.type, label: node.label,
-        identifier: node.identifier, value: node.value, rect: node.rect, enabled: node.enabled,
-        focused: node.focused, selected: node.selected, hittable: node.hittable, depth: node.depth,
-        parentIndex: node.parentIndex, hiddenContentAbove: hint.above ? true : node.hiddenContentAbove,
-        hiddenContentBelow: hint.below ? true : node.hiddenContentBelow, actions: node.actions)
-    }
+    return applyHiddenContentHints(hints, to: nodes)
   }
 
   private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
@@ -31,57 +23,56 @@ extension RunnerTests {
     let value = privateAXPresentationString(raw["value"])
     let rawType = privateAXPresentationInt(raw["type"]) ?? 0
     let enabled = privateAXPresentationBool(raw["enabled"]) ?? true
+    let children = raw["children"] as? [[String: Any]] ?? []
+    let elementType = flatSnapshotElementType(rawElementType: rawType)
     let hasFrame = !rect.isNull && !rect.isEmpty
-    let visible = (!hasFrame || isVisibleInViewport(rect, viewport))
-      && (!hasFrame || scrollContext.map { isVisibleInViewport(rect, $0.rect) } ?? true)
+    let onScreen = hasFrame
+      && isVisibleInRegularSnapshot(
+        rect,
+        viewport: viewport,
+        scrollContainerAnchor: scrollContext
+      )
+    let presentationVisible = !hasFrame || onScreen
     let decision = flatSnapshotFilterDecision(
       FlatSnapshotFilterNode(isRoot: parentIndex == nil, label: label, identifier: identifier,
-        valueText: value.isEmpty ? nil : value, visible: visible),
-      options: options, insideMatchedScope: insideMatchedScope)
-    let include = decision.include && (parentIndex == nil || visible)
+        valueText: value.isEmpty ? nil : value, visible: presentationVisible),
+      options: options, visibilityPolicy: .viewportProjected,
+      insideMatchedScope: insideMatchedScope)
+    let include = decision.include
 
-    if !include, !visible, let scrollContext, hasFrame {
-      var hint = hints[scrollContext.index] ?? (above: false, below: false)
-      if rect.maxY <= scrollContext.rect.minY { hint.above = true }
-      if rect.minY >= scrollContext.rect.maxY { hint.below = true }
-      hints[scrollContext.index] = hint
+    if !presentationVisible, let scrollContext {
+      rememberHiddenContentHint(for: rect, relativeTo: scrollContext, hints: &hints)
     }
 
     let currentIndex: Int?
     if include {
       currentIndex = nodes.count
-      let typeName = flatSnapshotElementType(rawElementType: rawType).map(elementTypeName)
-        ?? "Element(\(rawType))"
+      let typeName = elementType.map(elementTypeName) ?? "Element(\(rawType))"
       nodes.append(SnapshotNode(index: nodes.count, type: typeName,
         label: label.isEmpty ? nil : label, identifier: identifier.isEmpty ? nil : identifier,
         value: value.isEmpty ? nil : value, rect: snapshotRect(from: rect), enabled: enabled,
         focused: privateAXPresentationBool(raw["focused"]) == true ? true : nil,
         selected: privateAXPresentationBool(raw["selected"]) == true ? true : nil,
-        hittable: hasFrame && visible && enabled && privateAXInteractiveCandidate(rawElementType: rawType),
+        hittable: onScreen && enabled && privateAXInteractiveCandidate(rawElementType: rawType),
         depth: depth, parentIndex: parentIndex, hiddenContentAbove: nil, hiddenContentBelow: nil,
         actions: raw["actions"] as? [String]))
     } else { currentIndex = parentIndex }
 
     let nextScrollContext: (index: Int, rect: CGRect)?
-    if include, hasFrame, let type = flatSnapshotElementType(rawElementType: rawType),
-      Self.scrollContainerTypes.contains(type), let currentIndex {
-      nextScrollContext = (currentIndex, rect)
+    if include, let elementType, let currentIndex {
+      nextScrollContext = scrollContainerAnchor(
+        for: elementType,
+        hasChildren: !children.isEmpty,
+        visible: onScreen,
+        frame: rect,
+        nodeIndex: currentIndex
+      ) ?? scrollContext
     } else { nextScrollContext = scrollContext }
-    for child in raw["children"] as? [[String: Any]] ?? [] {
+    for child in children {
       appendPrivateAXNode(child, to: &nodes, hints: &hints, options: options, viewport: viewport,
         depth: depth + 1, parentIndex: currentIndex,
         insideMatchedScope: decision.insideMatchedScope, scrollContext: nextScrollContext)
     }
-  }
-
-  func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
-    options: SnapshotOptions, viewport: CGRect, depth: Int, parentIndex: Int?,
-    insideMatchedScope: Bool)
-  {
-    var hints: [Int: (above: Bool, below: Bool)] = [:]
-    appendPrivateAXNode(raw, to: &nodes, hints: &hints, options: options, viewport: viewport,
-      depth: depth, parentIndex: parentIndex, insideMatchedScope: insideMatchedScope,
-      scrollContext: nil)
   }
 
   private func privateAXPresentationString(_ value: Any?) -> String {
@@ -106,13 +97,16 @@ extension RunnerTests {
     let root: [String: Any] = ["type": Int(XCUIElement.ElementType.application.rawValue),
       "label": "Element", "frame": frame(0, 0, 402, 874), "children": [[
         "type": Int(XCUIElement.ElementType.scrollView.rawValue), "frame": frame(0, 96, 402, 700),
+        "actions": ["Scroll down"],
         "children": [["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Profile picture", "frame": frame(16, 120, 44, 44)],
           ["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": frame(16, 900, 360, 44)]]]]]
     let nodes = privateAXPresentation(rawRoot: root,
       options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Profile picture"])
-    XCTAssertEqual(nodes.first { $0.type == "ScrollView" }?.hiddenContentBelow, true)
+    let scrollView = nodes.first { $0.type == "ScrollView" }
+    XCTAssertEqual(scrollView?.hiddenContentBelow, true)
+    XCTAssertEqual(scrollView?.actions, ["Scroll down"])
   }
 
   func testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts() {
@@ -123,7 +117,7 @@ extension RunnerTests {
         "label": "Settings semantics", "frame": zero, "children": [[
           "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero]]]]]
     let nodes = privateAXPresentation(rawRoot: root,
-      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Settings semantics", "Theme"])
     XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, false])

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+extension RunnerTests {
+  func privateAXPresentation(rawRoot: [String: Any], options: SnapshotOptions, viewport: CGRect)
+    -> [SnapshotNode]
+  {
+    var nodes: [SnapshotNode] = []
+    var hints: [Int: (above: Bool, below: Bool)] = [:]
+    appendPrivateAXNode(rawRoot, to: &nodes, hints: &hints, options: options, viewport: viewport,
+      depth: 0, parentIndex: nil, insideMatchedScope: false, scrollContext: nil)
+    guard !hints.isEmpty else { return nodes }
+    return nodes.map { node in
+      guard let hint = hints[node.index] else { return node }
+      return SnapshotNode(index: node.index, type: node.type, label: node.label,
+        identifier: node.identifier, value: node.value, rect: node.rect, enabled: node.enabled,
+        focused: node.focused, selected: node.selected, hittable: node.hittable, depth: node.depth,
+        parentIndex: node.parentIndex, hiddenContentAbove: hint.above ? true : node.hiddenContentAbove,
+        hiddenContentBelow: hint.below ? true : node.hiddenContentBelow, actions: node.actions)
+    }
+  }
+
+  private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
+    hints: inout [Int: (above: Bool, below: Bool)], options: SnapshotOptions, viewport: CGRect,
+    depth: Int, parentIndex: Int?, insideMatchedScope: Bool,
+    scrollContext: (index: Int, rect: CGRect)?)
+  {
+    if let limit = options.depth, depth > limit { return }
+    let rect = privateAXRect(raw["frame"])
+    let label = privateAXPresentationString(raw["label"])
+    let identifier = privateAXPresentationString(raw["identifier"])
+    let value = privateAXPresentationString(raw["value"])
+    let rawType = privateAXPresentationInt(raw["type"]) ?? 0
+    let enabled = privateAXPresentationBool(raw["enabled"]) ?? true
+    let hasFrame = !rect.isNull && !rect.isEmpty
+    let visible = (!hasFrame || isVisibleInViewport(rect, viewport))
+      && (!hasFrame || scrollContext.map { isVisibleInViewport(rect, $0.rect) } ?? true)
+    let decision = flatSnapshotFilterDecision(
+      FlatSnapshotFilterNode(isRoot: parentIndex == nil, label: label, identifier: identifier,
+        valueText: value.isEmpty ? nil : value, visible: visible),
+      options: options, insideMatchedScope: insideMatchedScope)
+    let include = decision.include && (parentIndex == nil || visible)
+
+    if !include, !visible, let scrollContext, hasFrame {
+      var hint = hints[scrollContext.index] ?? (above: false, below: false)
+      if rect.maxY <= scrollContext.rect.minY { hint.above = true }
+      if rect.minY >= scrollContext.rect.maxY { hint.below = true }
+      hints[scrollContext.index] = hint
+    }
+
+    let currentIndex: Int?
+    if include {
+      currentIndex = nodes.count
+      let typeName = flatSnapshotElementType(rawElementType: rawType).map(elementTypeName)
+        ?? "Element(\(rawType))"
+      nodes.append(SnapshotNode(index: nodes.count, type: typeName,
+        label: label.isEmpty ? nil : label, identifier: identifier.isEmpty ? nil : identifier,
+        value: value.isEmpty ? nil : value, rect: snapshotRect(from: rect), enabled: enabled,
+        focused: privateAXPresentationBool(raw["focused"]) == true ? true : nil,
+        selected: privateAXPresentationBool(raw["selected"]) == true ? true : nil,
+        hittable: hasFrame && visible && enabled && privateAXInteractiveCandidate(rawElementType: rawType),
+        depth: depth, parentIndex: parentIndex, hiddenContentAbove: nil, hiddenContentBelow: nil,
+        actions: raw["actions"] as? [String]))
+    } else { currentIndex = parentIndex }
+
+    let nextScrollContext: (index: Int, rect: CGRect)?
+    if include, hasFrame, let type = flatSnapshotElementType(rawElementType: rawType),
+      Self.scrollContainerTypes.contains(type), let currentIndex {
+      nextScrollContext = (currentIndex, rect)
+    } else { nextScrollContext = scrollContext }
+    for child in raw["children"] as? [[String: Any]] ?? [] {
+      appendPrivateAXNode(child, to: &nodes, hints: &hints, options: options, viewport: viewport,
+        depth: depth + 1, parentIndex: currentIndex,
+        insideMatchedScope: decision.insideMatchedScope, scrollContext: nextScrollContext)
+    }
+  }
+
+  func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
+    options: SnapshotOptions, viewport: CGRect, depth: Int, parentIndex: Int?,
+    insideMatchedScope: Bool)
+  {
+    var hints: [Int: (above: Bool, below: Bool)] = [:]
+    appendPrivateAXNode(raw, to: &nodes, hints: &hints, options: options, viewport: viewport,
+      depth: depth, parentIndex: parentIndex, insideMatchedScope: insideMatchedScope,
+      scrollContext: nil)
+  }
+
+  private func privateAXPresentationString(_ value: Any?) -> String {
+    guard let value else { return "" }
+    return (value as? String ?? String(describing: value))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  private func privateAXPresentationInt(_ value: Any?) -> Int? {
+    (value as? Int) ?? (value as? NSNumber)?.intValue
+  }
+  private func privateAXPresentationBool(_ value: Any?) -> Bool? {
+    (value as? Bool) ?? (value as? NSNumber)?.boolValue
+  }
+}
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+extension RunnerTests {
+  func testPrivateAXRegularPresentationProjectsToViewportAndKeepsScrollHint() {
+    func frame(_ x: Double, _ y: Double, _ width: Double, _ height: Double) -> [String: Any] {
+      ["x": x, "y": y, "width": width, "height": height]
+    }
+    let root: [String: Any] = ["type": Int(XCUIElement.ElementType.application.rawValue),
+      "label": "Element", "frame": frame(0, 0, 402, 874), "children": [[
+        "type": Int(XCUIElement.ElementType.scrollView.rawValue), "frame": frame(0, 96, 402, 700),
+        "children": [["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Profile picture", "frame": frame(16, 120, 44, 44)],
+          ["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": frame(16, 900, 360, 44)]]]]]
+    let nodes = privateAXPresentation(rawRoot: root,
+      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
+    XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Profile picture"])
+    XCTAssertEqual(nodes.first { $0.type == "ScrollView" }?.hiddenContentBelow, true)
+  }
+
+  func testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts() {
+    let zero = ["x": 0, "y": 0, "width": 0, "height": 0]
+    let root: [String: Any] = ["type": Int(XCUIElement.ElementType.application.rawValue),
+      "label": "Element", "frame": ["x": 0, "y": 0, "width": 402, "height": 874],
+      "children": [["type": Int(XCUIElement.ElementType.scrollView.rawValue),
+        "label": "Settings semantics", "frame": zero, "children": [[
+          "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero]]]]]
+    let nodes = privateAXPresentation(rawRoot: root,
+      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
+    XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Settings semantics", "Theme"])
+    XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, false])
+    XCTAssertTrue(nodes.allSatisfy { $0.hiddenContentAbove == nil && $0.hiddenContentBelow == nil })
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -1163,7 +1163,7 @@ extension RunnerTests {
     return rect.intersects(viewport)
   }
 
-  private func isVisibleInRegularSnapshot(
+  func isVisibleInRegularSnapshot(
     _ rect: CGRect,
     viewport: CGRect,
     scrollContainerAnchor: (index: Int, rect: CGRect)?
@@ -1195,12 +1195,32 @@ extension RunnerTests {
     visible: Bool,
     nodeIndex: Int?
   ) -> (index: Int, rect: CGRect)? {
-    guard let nodeIndex else { return nil }
-    if !isScrollableContainer(snapshot, visible: visible) { return nil }
-    return (nodeIndex, snapshot.frame)
+    return scrollContainerAnchor(
+      for: snapshot.elementType,
+      hasChildren: !snapshot.children.isEmpty,
+      visible: visible,
+      frame: snapshot.frame,
+      nodeIndex: nodeIndex
+    )
   }
 
-  private func rememberHiddenContentHint(
+  func scrollContainerAnchor(
+    for elementType: XCUIElement.ElementType,
+    hasChildren: Bool,
+    visible: Bool,
+    frame: CGRect,
+    nodeIndex: Int?
+  ) -> (index: Int, rect: CGRect)? {
+    guard let nodeIndex else { return nil }
+    if !isScrollableContainer(
+      elementType: elementType,
+      hasChildren: hasChildren,
+      visible: visible
+    ) { return nil }
+    return (nodeIndex, frame)
+  }
+
+  func rememberHiddenContentHint(
     for frame: CGRect,
     relativeTo scrollContainerAnchor: (index: Int, rect: CGRect),
     hints: inout [Int: (above: Bool, below: Bool)]
@@ -1217,7 +1237,7 @@ extension RunnerTests {
     hints[scrollContainerAnchor.index] = hint
   }
 
-  private func applyHiddenContentHints(
+  func applyHiddenContentHints(
     _ hints: [Int: (above: Bool, below: Bool)],
     to nodes: [SnapshotNode]
   ) -> [SnapshotNode] {
@@ -1240,7 +1260,8 @@ extension RunnerTests {
         depth: node.depth,
         parentIndex: node.parentIndex,
         hiddenContentAbove: hiddenContentAbove,
-        hiddenContentBelow: hiddenContentBelow
+        hiddenContentBelow: hiddenContentBelow,
+        actions: node.actions
       )
     }
   }
@@ -1504,7 +1525,12 @@ extension RunnerTests {
         valueText: valueText,
         visible: visible
       )
-      if !flatSnapshotFilterDecision(filterNode, options: options, insideMatchedScope: false).include {
+      if !flatSnapshotFilterDecision(
+        filterNode,
+        options: options,
+        visibilityPolicy: .interactiveOnly,
+        insideMatchedScope: false
+      ).include {
         return
       }
 
@@ -1533,8 +1559,18 @@ extension RunnerTests {
   }
 
   private func isScrollableContainer(_ snapshot: XCUIElementSnapshot, visible: Bool) -> Bool {
-    if !visible { return false }
-    if !Self.scrollContainerTypes.contains(snapshot.elementType) { return false }
-    return !snapshot.children.isEmpty
+    return isScrollableContainer(
+      elementType: snapshot.elementType,
+      hasChildren: !snapshot.children.isEmpty,
+      visible: visible
+    )
+  }
+
+  private func isScrollableContainer(
+    elementType: XCUIElement.ElementType,
+    hasChildren: Bool,
+    visible: Bool
+  ) -> Bool {
+    return visible && hasChildren && Self.scrollContainerTypes.contains(elementType)
   }
 }

--- a/src/backend-snapshot-options.test.ts
+++ b/src/backend-snapshot-options.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { snapshotOptionsToFlags } from './backend-snapshot-options.ts';
+
+test('snapshot options map every backend preference into command flags', () => {
+  assert.deepEqual(
+    snapshotOptionsToFlags({
+      interactiveOnly: true,
+      scope: 'app',
+      depth: 7,
+      raw: true,
+      customActions: true,
+      includeHiddenContentHints: true,
+      preferredBackend: 'private-ax',
+    }),
+    {
+      snapshotInteractiveOnly: true,
+      snapshotScope: 'app',
+      snapshotDepth: 7,
+      snapshotRaw: true,
+      snapshotCustomActions: true,
+      snapshotIncludeHiddenContentHints: true,
+      snapshotPreferredBackend: 'private-ax',
+    },
+  );
+});

--- a/src/backend-snapshot-options.ts
+++ b/src/backend-snapshot-options.ts
@@ -1,0 +1,30 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
+import type { BackendSnapshotOptions } from './backend.ts';
+
+type RoutedSnapshotOption = keyof Omit<BackendSnapshotOptions, 'includeRects' | 'outPath'>;
+
+const SNAPSHOT_OPTION_FLAGS = {
+  interactiveOnly: 'snapshotInteractiveOnly',
+  scope: 'snapshotScope',
+  depth: 'snapshotDepth',
+  raw: 'snapshotRaw',
+  customActions: 'snapshotCustomActions',
+  includeHiddenContentHints: 'snapshotIncludeHiddenContentHints',
+  preferredBackend: 'snapshotPreferredBackend',
+} as const satisfies Record<RoutedSnapshotOption, keyof CommandFlags>;
+
+type SnapshotFlagOverrides = Partial<
+  Pick<CommandFlags, (typeof SNAPSHOT_OPTION_FLAGS)[RoutedSnapshotOption]>
+>;
+
+export function snapshotOptionsToFlags(
+  options: BackendSnapshotOptions | undefined,
+): SnapshotFlagOverrides {
+  if (!options) return {};
+  return Object.fromEntries(
+    Object.entries(SNAPSHOT_OPTION_FLAGS).flatMap(([optionKey, flagKey]) => {
+      const value = options[optionKey as RoutedSnapshotOption];
+      return value === undefined ? [] : [[flagKey, value]];
+    }),
+  ) as SnapshotFlagOverrides;
+}

--- a/src/commands/interaction/runtime/selector-read-shared.ts
+++ b/src/commands/interaction/runtime/selector-read-shared.ts
@@ -52,6 +52,7 @@ export async function captureSelectorSnapshot(
     includeRects?: boolean;
     interactiveOnly?: boolean;
     includeHiddenContentHints?: boolean;
+    preferredBackend?: 'private-ax';
   } = {
     updateSession: true,
   },
@@ -68,6 +69,9 @@ export async function captureSelectorSnapshot(
     scope: captureOptions.scope ?? options.scope,
     raw: options.raw,
     includeRects: captureOptions.includeRects,
+    ...(captureOptions.preferredBackend
+      ? { preferredBackend: captureOptions.preferredBackend }
+      : {}),
     ...(captureOptions.includeHiddenContentHints !== undefined
       ? { includeHiddenContentHints: captureOptions.includeHiddenContentHints }
       : {}),

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -208,6 +208,40 @@ test('private-ax recovery resets the settle budget once', async () => {
   assert.equal(captures, 4);
 });
 
+test('press --settle pins an already-established private-ax observation backend', async () => {
+  const established = welcomeSnapshot();
+  established.snapshotQuality = {
+    state: 'recovered',
+    backend: 'private-ax',
+    reasonCode: 'deferred',
+    reason: 'penalty',
+  };
+  const preferredBackends: Array<string | undefined> = [];
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async (_context, options) => {
+        preferredBackends.push(options?.preferredBackend);
+        return { snapshot: established };
+      },
+      tap: async () => ({ ok: true }),
+      fill: async () => ({ ok: true }),
+      longPress: async () => ({ ok: true }),
+      typeText: async () => {},
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot: established }]),
+    policy: localCommandPolicy(),
+    clock: createFakeClock(),
+  });
+  await device.interactions.press(selector('label=Next'), {
+    session: 'default',
+    settle: { quietMs: 500, timeoutMs: 2_000 },
+  });
+  assert.equal(preferredBackends[0], undefined);
+  assert.deepEqual(new Set(preferredBackends.slice(1)), new Set(['private-ax']));
+});
+
 test('penalty-deferred private-ax captures do not reset the settle budget', async () => {
   // Same shape as the reset test above, but the verdict says the circuit breaker PRE-selected
   // private AX ('deferred'): the capture paid no grind, so the loop keeps its original budget

--- a/src/commands/interaction/runtime/stable-capture-signal.test.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
+import { stableCaptureSignal, stableCaptureSignalsEqual } from './stable-capture-signal.ts';
+
+function snapshot(jitter: number, hiddenY: number) {
+  return makeSnapshotState(
+    [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Application',
+        label: 'Element',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+        hittable: false,
+      },
+      {
+        index: 1,
+        depth: 1,
+        parentIndex: 0,
+        type: 'ScrollView',
+        rect: { x: 0, y: 96, width: 402, height: 700 },
+        hittable: true,
+      },
+      {
+        index: 2,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Button',
+        label: 'Profile',
+        rect: { x: 17 + jitter, y: 120, width: 44, height: 44 },
+        hittable: true,
+      },
+      {
+        index: 3,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Button',
+        label: 'Theme',
+        rect: { x: 16, y: hiddenY, width: 360, height: 44 },
+        hittable: false,
+      },
+    ],
+    {
+      snapshotQuality: {
+        state: 'recovered',
+        backend: 'private-ax',
+        reasonCode: 'deferred',
+        reason: 'penalty',
+      },
+    },
+  );
+}
+
+test('private-ax stability ignores offscreen churn and boundary-crossing one-pixel jitter', () => {
+  assert.equal(
+    stableCaptureSignalsEqual(
+      stableCaptureSignal(snapshot(0, 900)),
+      stableCaptureSignal(snapshot(1, 980)),
+    ),
+    true,
+  );
+});

--- a/src/commands/interaction/runtime/stable-capture-signal.test.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.test.ts
@@ -52,12 +52,52 @@ function snapshot(jitter: number, hiddenY: number) {
   );
 }
 
-test('private-ax stability ignores offscreen churn and boundary-crossing one-pixel jitter', () => {
+test('private-ax stability ignores offscreen churn', () => {
   assert.equal(
     stableCaptureSignalsEqual(
       stableCaptureSignal(snapshot(0, 900)),
-      stableCaptureSignal(snapshot(1, 980)),
+      stableCaptureSignal(snapshot(0, 980)),
     ),
     true,
+  );
+});
+
+test('private-ax stability tolerates one-pixel geometry jitter', () => {
+  assert.equal(
+    stableCaptureSignalsEqual(
+      stableCaptureSignal(snapshot(0, 900)),
+      stableCaptureSignal(snapshot(1, 900)),
+    ),
+    true,
+  );
+});
+
+test('regular snapshot stability preserves rounded geometry tolerance', () => {
+  const left = snapshot(0, 900);
+  const right = snapshot(0.6, 900);
+  left.snapshotQuality = { state: 'healthy', backend: 'tree' };
+  right.snapshotQuality = { state: 'healthy', backend: 'tree' };
+  assert.equal(
+    stableCaptureSignalsEqual(stableCaptureSignal(left), stableCaptureSignal(right)),
+    true,
+  );
+});
+
+test('a semantic identity change is never stable', () => {
+  const changed = snapshot(0, 900);
+  changed.nodes[2]!.label = 'Settings';
+  assert.equal(
+    stableCaptureSignalsEqual(stableCaptureSignal(snapshot(0, 900)), stableCaptureSignal(changed)),
+    false,
+  );
+});
+
+test('geometry movement beyond the stability tolerance is never stable', () => {
+  assert.equal(
+    stableCaptureSignalsEqual(
+      stableCaptureSignal(snapshot(0, 900)),
+      stableCaptureSignal(snapshot(3, 900)),
+    ),
+    false,
   );
 });

--- a/src/commands/interaction/runtime/stable-capture-signal.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.ts
@@ -1,14 +1,17 @@
-import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
+import type { Rect, SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
 import { isNodeVisibleOnScreen, isViewportRootNode } from '@agent-device/contracts/snapshot';
 
-const PRIVATE_AX_GEOMETRY_TOLERANCE = 4;
+const GEOMETRY_TOLERANCE_PX = 1;
 export type StableCaptureSignal = { privateAX: boolean; nodes: SignalNode[] };
-type SignalNode = { identity: string; rect?: [number, number, number, number] };
+type SignalNode = { identity: string; rect?: Rect };
 
 export function stableCaptureSignal(
   snapshot: Pick<SnapshotState, 'nodes' | 'snapshotQuality'>,
 ): StableCaptureSignal {
   const privateAX = snapshot.snapshotQuality?.backend === 'private-ax';
+  // The runner already projects private AX by viewport intersection. Settle uses the stricter
+  // center-on-screen view so edge slivers whose intersection flips by a pixel do not restart the
+  // quiet window while the user-visible semantic surface remains unchanged.
   const source = privateAX
     ? snapshot.nodes.filter(
         (node) => isViewportRootNode(node) || isNodeVisibleOnScreen(node, snapshot.nodes),
@@ -23,15 +26,20 @@ export function stableCaptureSignalsEqual(
   left: StableCaptureSignal | undefined,
   right: StableCaptureSignal,
 ): boolean {
+  // A backend transition changes the semantic representation even if this capture happens to
+  // contain equivalent nodes. Never let the quiet window span that transition.
   if (!left || left.privateAX !== right.privateAX || left.nodes.length !== right.nodes.length)
     return false;
   return left.nodes.every((node, index) => {
     const candidate = right.nodes[index];
     if (!candidate || node.identity !== candidate.identity) return false;
     if (!node.rect || !candidate.rect) return node.rect === candidate.rect;
-    const tolerance = left.privateAX ? PRIVATE_AX_GEOMETRY_TOLERANCE : 0;
-    return node.rect.every(
-      (value, coordinate) => Math.abs(value - candidate.rect![coordinate]!) <= tolerance,
+    const nodeRect = node.rect;
+    const candidateRect = candidate.rect;
+    return (['x', 'y', 'width', 'height'] as const).every(
+      (coordinate) =>
+        Math.abs(Math.round(nodeRect[coordinate]) - Math.round(candidateRect[coordinate])) <=
+        GEOMETRY_TOLERANCE_PX,
     );
   });
 }
@@ -41,11 +49,12 @@ function stableCaptureNodeSignal(node: SnapshotNode): SignalNode {
     identity: `${node.type ?? ''}#${node.label ?? ''}#${node.identifier ?? ''}`,
     ...(node.rect
       ? {
-          rect: [node.rect.x, node.rect.y, node.rect.width, node.rect.height] as SignalNode['rect'],
+          rect: { ...node.rect },
         }
       : {}),
   };
 }
 function sortKey(node: SignalNode): string {
-  return `${node.identity}#${node.rect?.join(',') ?? ''}`;
+  const rect = node.rect;
+  return `${node.identity}#${rect ? `${rect.x},${rect.y},${rect.width},${rect.height}` : ''}`;
 }

--- a/src/commands/interaction/runtime/stable-capture-signal.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.ts
@@ -1,0 +1,51 @@
+import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
+import { isNodeVisibleOnScreen, isViewportRootNode } from '@agent-device/contracts/snapshot';
+
+const PRIVATE_AX_GEOMETRY_TOLERANCE = 4;
+export type StableCaptureSignal = { privateAX: boolean; nodes: SignalNode[] };
+type SignalNode = { identity: string; rect?: [number, number, number, number] };
+
+export function stableCaptureSignal(
+  snapshot: Pick<SnapshotState, 'nodes' | 'snapshotQuality'>,
+): StableCaptureSignal {
+  const privateAX = snapshot.snapshotQuality?.backend === 'private-ax';
+  const source = privateAX
+    ? snapshot.nodes.filter(
+        (node) => isViewportRootNode(node) || isNodeVisibleOnScreen(node, snapshot.nodes),
+      )
+    : snapshot.nodes;
+  const nodes = source.map(stableCaptureNodeSignal);
+  nodes.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+  return { privateAX, nodes };
+}
+
+export function stableCaptureSignalsEqual(
+  left: StableCaptureSignal | undefined,
+  right: StableCaptureSignal,
+): boolean {
+  if (!left || left.privateAX !== right.privateAX || left.nodes.length !== right.nodes.length)
+    return false;
+  return left.nodes.every((node, index) => {
+    const candidate = right.nodes[index];
+    if (!candidate || node.identity !== candidate.identity) return false;
+    if (!node.rect || !candidate.rect) return node.rect === candidate.rect;
+    const tolerance = left.privateAX ? PRIVATE_AX_GEOMETRY_TOLERANCE : 0;
+    return node.rect.every(
+      (value, coordinate) => Math.abs(value - candidate.rect![coordinate]!) <= tolerance,
+    );
+  });
+}
+
+function stableCaptureNodeSignal(node: SnapshotNode): SignalNode {
+  return {
+    identity: `${node.type ?? ''}#${node.label ?? ''}#${node.identifier ?? ''}`,
+    ...(node.rect
+      ? {
+          rect: [node.rect.x, node.rect.y, node.rect.width, node.rect.height] as SignalNode['rect'],
+        }
+      : {}),
+  };
+}
+function sortKey(node: SignalNode): string {
+  return `${node.identity}#${node.rect?.join(',') ?? ''}`;
+}

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -1,4 +1,4 @@
-import type { SnapshotNode, SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
+import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { now, sleep } from '../../runtime-common.ts';
 import {
@@ -7,6 +7,11 @@ import {
   type SelectorSnapshotOptions,
 } from './selector-read-shared.ts';
 import { runWithinWaitDeadline } from './wait-deadline.ts';
+import {
+  stableCaptureSignal,
+  stableCaptureSignalsEqual,
+  type StableCaptureSignal,
+} from './stable-capture-signal.ts';
 
 /**
  * The quiet-window stable-capture loop shared by `wait stable` and the
@@ -56,12 +61,14 @@ export async function runStableCaptureLoop(
   const start = now(runtime);
   let deadlineMs = start + timeoutMs;
   let privateAxRecoveryBudgetReset = false;
+  const session = await runtime.sessions.get(options.session ?? 'default');
+  let preferredBackend = preferredStableCaptureBackend(session?.snapshot?.snapshotQuality);
   // Cadence derives from the quiet window (never slower than the default
   // poll): a caller asking for a 50ms quiet window should not be forced onto a
   // 300ms grid — and tests inject the budget instead of waiting real time.
   const pollMs = Math.min(STABLE_POLL_INTERVAL_MS, Math.max(STABLE_MIN_POLL_MS, quietMs));
   let captures = 0;
-  let lastDigest: string | undefined;
+  let lastDigest: StableCaptureSignal | undefined;
   let lastNodeCount = 0;
   let lastCapture: CapturedSnapshot | undefined;
   let quietSinceMs = start;
@@ -70,6 +77,7 @@ export async function runStableCaptureLoop(
       runtime,
       options,
       deadlineMs - now(runtime),
+      preferredBackend,
     );
     if (!capture) {
       return {
@@ -83,12 +91,18 @@ export async function runStableCaptureLoop(
     }
     captures += 1;
     lastCapture = capture;
-    const digest = digestSnapshotNodes(capture.snapshot.nodes);
+    const digest = stableCaptureSignal(capture.snapshot);
+    preferredBackend = preferredStableCaptureBackend(
+      capture.snapshot.snapshotQuality,
+      preferredBackend,
+    );
     const nowMs = now(runtime);
     if (
-      params.resetBudgetOnPrivateAxRecovery === true &&
-      !privateAxRecoveryBudgetReset &&
-      isPrivateAxRecovery(capture.snapshot.snapshotQuality)
+      shouldResetPrivateAxRecoveryBudget(
+        params.resetBudgetOnPrivateAxRecovery,
+        privateAxRecoveryBudgetReset,
+        capture.snapshot.snapshotQuality,
+      )
     ) {
       privateAxRecoveryBudgetReset = true;
       deadlineMs = Math.max(deadlineMs, nowMs + timeoutMs);
@@ -106,7 +120,7 @@ export async function runStableCaptureLoop(
       await sleep(runtime, recoveryDelayMs);
       continue;
     }
-    if (digest !== lastDigest) {
+    if (!stableCaptureSignalsEqual(lastDigest, digest)) {
       lastDigest = digest;
       lastNodeCount = capture.snapshot.nodes.length;
       quietSinceMs = nowMs;
@@ -182,6 +196,21 @@ function stableCaptureDelayMs(params: {
   return Math.min(cadenceMs, lastUsefulWakeMs);
 }
 
+function preferredStableCaptureBackend(
+  verdict: SnapshotQualityVerdict | undefined,
+  current?: 'private-ax',
+): 'private-ax' | undefined {
+  return current ?? (verdict?.backend === 'private-ax' ? 'private-ax' : undefined);
+}
+
+function shouldResetPrivateAxRecoveryBudget(
+  resetRequested: boolean | undefined,
+  alreadyReset: boolean,
+  verdict: SnapshotQualityVerdict | undefined,
+): boolean {
+  return resetRequested === true && !alreadyReset && isPrivateAxRecovery(verdict);
+}
+
 // Intentionally does not update the session snapshot: the stable loop captures
 // an interactive-only tree purely as a settle signal, and overwriting the
 // session's richer cached snapshot with the filtered tree would degrade
@@ -197,6 +226,7 @@ async function captureStableSignalWithinDeadline(
   runtime: AgentDeviceRuntime,
   options: CommandContext & SelectorSnapshotOptions,
   remainingMs: number,
+  preferredBackend?: 'private-ax',
 ): Promise<CapturedSnapshot | undefined> {
   const result = await runWithinWaitDeadline(runtime, options, remainingMs, async (signal) => {
     return await captureSelectorSnapshot(
@@ -205,19 +235,9 @@ async function captureStableSignalWithinDeadline(
       {
         updateSession: false,
         interactiveOnly: true,
+        preferredBackend,
       },
     );
   });
   return result.timedOut ? undefined : result.value;
-}
-
-function digestSnapshotNodes(nodes: SnapshotNode[]): string {
-  return nodes.map(digestSnapshotNode).join('|');
-}
-
-function digestSnapshotNode(node: SnapshotNode): string {
-  const rect = node.rect
-    ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)},${Math.round(node.rect.width)},${Math.round(node.rect.height)}`
-    : '';
-  return `${node.type ?? ''}#${node.label ?? ''}#${node.identifier ?? ''}#${rect}`;
 }

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -12,6 +12,7 @@ import {
   stableCaptureSignalsEqual,
   type StableCaptureSignal,
 } from './stable-capture-signal.ts';
+import { preferredSnapshotBackendForVerdict } from '../../../snapshot-quality/verdict.ts';
 
 /**
  * The quiet-window stable-capture loop shared by `wait stable` and the
@@ -62,13 +63,13 @@ export async function runStableCaptureLoop(
   let deadlineMs = start + timeoutMs;
   let privateAxRecoveryBudgetReset = false;
   const session = await runtime.sessions.get(options.session ?? 'default');
-  let preferredBackend = preferredStableCaptureBackend(session?.snapshot?.snapshotQuality);
+  let preferredBackend = preferredSnapshotBackendForVerdict(session?.snapshot?.snapshotQuality);
   // Cadence derives from the quiet window (never slower than the default
   // poll): a caller asking for a 50ms quiet window should not be forced onto a
   // 300ms grid — and tests inject the budget instead of waiting real time.
   const pollMs = Math.min(STABLE_POLL_INTERVAL_MS, Math.max(STABLE_MIN_POLL_MS, quietMs));
   let captures = 0;
-  let lastDigest: StableCaptureSignal | undefined;
+  let lastSignal: StableCaptureSignal | undefined;
   let lastNodeCount = 0;
   let lastCapture: CapturedSnapshot | undefined;
   let quietSinceMs = start;
@@ -91,23 +92,22 @@ export async function runStableCaptureLoop(
     }
     captures += 1;
     lastCapture = capture;
-    const digest = stableCaptureSignal(capture.snapshot);
-    preferredBackend = preferredStableCaptureBackend(
-      capture.snapshot.snapshotQuality,
-      preferredBackend,
-    );
+    const signal = stableCaptureSignal(capture.snapshot);
+    preferredBackend ??= preferredSnapshotBackendForVerdict(capture.snapshot.snapshotQuality);
     const nowMs = now(runtime);
-    if (
-      shouldResetPrivateAxRecoveryBudget(
-        params.resetBudgetOnPrivateAxRecovery,
-        privateAxRecoveryBudgetReset,
-        capture.snapshot.snapshotQuality,
-      )
-    ) {
+    const recoveredDeadlineMs = extendedDeadlineAfterPrivateAxRecovery({
+      resetRequested: params.resetBudgetOnPrivateAxRecovery,
+      alreadyReset: privateAxRecoveryBudgetReset,
+      verdict: capture.snapshot.snapshotQuality,
+      nowMs,
+      timeoutMs,
+      deadlineMs,
+    });
+    if (recoveredDeadlineMs !== undefined) {
       privateAxRecoveryBudgetReset = true;
-      deadlineMs = Math.max(deadlineMs, nowMs + timeoutMs);
+      deadlineMs = recoveredDeadlineMs;
       quietSinceMs = nowMs;
-      lastDigest = digest;
+      lastSignal = signal;
       lastNodeCount = capture.snapshot.nodes.length;
       const recoveryDelayMs = stableCaptureDelayMs({
         nowMs,
@@ -120,8 +120,8 @@ export async function runStableCaptureLoop(
       await sleep(runtime, recoveryDelayMs);
       continue;
     }
-    if (!stableCaptureSignalsEqual(lastDigest, digest)) {
-      lastDigest = digest;
+    if (!stableCaptureSignalsEqual(lastSignal, signal)) {
+      lastSignal = signal;
       lastNodeCount = capture.snapshot.nodes.length;
       quietSinceMs = nowMs;
     } else if (captures >= 2 && nowMs - quietSinceMs >= quietMs) {
@@ -156,6 +156,24 @@ function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boole
     verdict.backend === 'private-ax' &&
     verdict.reasonCode !== 'deferred'
   );
+}
+
+function extendedDeadlineAfterPrivateAxRecovery(params: {
+  resetRequested: boolean | undefined;
+  alreadyReset: boolean;
+  verdict: SnapshotQualityVerdict | undefined;
+  nowMs: number;
+  timeoutMs: number;
+  deadlineMs: number;
+}): number | undefined {
+  if (
+    params.resetRequested !== true ||
+    params.alreadyReset ||
+    !isPrivateAxRecovery(params.verdict)
+  ) {
+    return undefined;
+  }
+  return Math.max(params.deadlineMs, params.nowMs + params.timeoutMs);
 }
 
 /**
@@ -194,21 +212,6 @@ function stableCaptureDelayMs(params: {
     return remainingBudgetMs >= QUIET_DEADLINE_EPSILON_MS ? remainingBudgetMs : 0;
   }
   return Math.min(cadenceMs, lastUsefulWakeMs);
-}
-
-function preferredStableCaptureBackend(
-  verdict: SnapshotQualityVerdict | undefined,
-  current?: 'private-ax',
-): 'private-ax' | undefined {
-  return current ?? (verdict?.backend === 'private-ax' ? 'private-ax' : undefined);
-}
-
-function shouldResetPrivateAxRecoveryBudget(
-  resetRequested: boolean | undefined,
-  alreadyReset: boolean,
-  verdict: SnapshotQualityVerdict | undefined,
-): boolean {
-  return resetRequested === true && !alreadyReset && isPrivateAxRecovery(verdict);
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures

--- a/src/daemon/handlers/__tests__/interaction-settle-private-ax-route.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-settle-private-ax-route.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import { contextFromFlags as buildDaemonContext } from '../../context.ts';
+import { handleInteractionCommands } from '../interaction.ts';
+
+vi.mock('../../../platforms/apple/core/runner/runner-client.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/apple/core/runner/runner-client.ts')>();
+  return {
+    ...actual,
+    runAppleRunnerCommand: vi.fn(async () => ({})),
+  };
+});
+
+import { runAppleRunnerCommand } from '../../../platforms/apple/core/runner/runner-client.ts';
+
+const mockRunnerCommand = vi.mocked(runAppleRunnerCommand);
+const nodes = [
+  { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
+  {
+    index: 1,
+    parentIndex: 0,
+    type: 'Button',
+    label: 'Continue',
+    rect: { x: 20, y: 100, width: 120, height: 44 },
+    hittable: true,
+  },
+  ...Array.from({ length: 4 }, (_, offset) => ({
+    index: offset + 2,
+    parentIndex: 0,
+    type: 'Button',
+    label: `Action ${offset + 1}`,
+    rect: { x: 20, y: 160 + offset * 50, width: 120, height: 44 },
+    hittable: true,
+  })),
+];
+const privateAxQuality = {
+  state: 'recovered' as const,
+  backend: 'private-ax' as const,
+  reasonCode: 'requested-backend' as const,
+};
+
+beforeEach(() => {
+  mockRunnerCommand.mockReset();
+  mockRunnerCommand.mockImplementation(async (_device, command) => {
+    if (command.command === 'snapshot') return { nodes, snapshotQuality: privateAxQuality };
+    return {};
+  });
+});
+
+test('daemon press --settle pins private-ax on emitted snapshot runner requests', async () => {
+  const sessionName = 'press-settle-private-ax-route';
+  const sessionStore = makeSessionStore();
+  sessionStore.set(
+    sessionName,
+    makeIosSession(sessionName, {
+      appBundleId: 'com.example.fixture',
+      snapshot: makeSnapshotState(nodes, {
+        backend: 'xctest',
+        snapshotQuality: { ...privateAxQuality, reasonCode: 'deferred' },
+      }),
+    }),
+  );
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['label=Continue'],
+      flags: { settle: true, settleQuietMs: 25, timeoutMs: 1_000 },
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags: (flags, appBundleId, traceLogPath) =>
+      buildDaemonContext('', flags, appBundleId, traceLogPath),
+  });
+
+  expect(response?.ok).toBe(true);
+  const snapshotCommands = mockRunnerCommand.mock.calls
+    .map(([, command]) => command)
+    .filter((command) => command.command === 'snapshot');
+  expect(snapshotCommands.length).toBeGreaterThanOrEqual(3);
+  const preferredBackends = snapshotCommands.map((command) => command.preferredBackend);
+  expect(preferredBackends).toEqual([
+    undefined,
+    ...Array.from({ length: preferredBackends.length - 1 }, () => 'private-ax' as const),
+  ]);
+});

--- a/src/daemon/handlers/interaction-ios-tap-outcome.ts
+++ b/src/daemon/handlers/interaction-ios-tap-outcome.ts
@@ -1,8 +1,11 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import type { InteractionTarget } from '@agent-device/contracts/interaction';
-import type { SnapshotState } from '@agent-device/kernel/snapshot';
+import type { SnapshotQualityVerdict, SnapshotState } from '@agent-device/kernel/snapshot';
 import { asAppError } from '@agent-device/kernel/errors';
-import { isSparseSnapshotQualityVerdict } from '../../snapshot-quality/verdict.ts';
+import {
+  isSparseSnapshotQualityVerdict,
+  preferredSnapshotBackendForVerdict,
+} from '../../snapshot-quality/verdict.ts';
 import { summarizeAxEvidence } from '../../utils/ax-digest.ts';
 import { getRequestSignal } from '../../request/cancel.ts';
 import { isLocalIosRunnerSession } from '../direct-ios-selector.ts';
@@ -58,7 +61,7 @@ export async function corroborateIosTapFailure(
 
   const after = await captureCorroborationSnapshot(
     params,
-    baseline.snapshot.snapshotQuality?.backend,
+    baseline.snapshot.snapshotQuality,
     baseline.presentation,
   );
   if (!after || !hasMatchingPresentation(baseline.snapshot, after, params.command)) {
@@ -113,10 +116,11 @@ function readCorroborationBaseline(
 
 async function captureCorroborationSnapshot(
   params: IosTapCorroborationParams,
-  baselineBackend: string | undefined,
+  baselineVerdict: SnapshotQualityVerdict | undefined,
   presentation: SnapshotPresentation | undefined,
 ): Promise<SnapshotState | undefined> {
   try {
+    const preferredBackend = preferredSnapshotBackendForVerdict(baselineVerdict);
     return await params.captureSnapshotForSession(
       params.session,
       matchingCaptureFlags(params.flags, presentation),
@@ -128,7 +132,7 @@ async function captureCorroborationSnapshot(
         // screens are exactly where the capture plan flips between XCTest and
         // private-AX (the penalty boundary) — pin the probe to the baseline's
         // backend instead of failing closed on the mismatch.
-        ...(baselineBackend === 'private-ax' ? { preferredBackend: 'private-ax' as const } : {}),
+        ...(preferredBackend ? { preferredBackend } : {}),
         signal: getRequestSignal(params.requestId),
       },
     );

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -73,6 +73,7 @@ function createInteractionBackend(
         params.contextFromFlags,
         {
           interactiveOnly: options?.interactiveOnly === true,
+          preferredBackend: options?.preferredBackend,
           includeRects: options?.includeRects === true,
           signal: context.signal,
         },

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -6,6 +6,7 @@ import type { ContextFromFlags } from './interaction-common.ts';
 import { captureSnapshot } from './snapshot-capture.ts';
 import { setSessionSnapshot } from '../session-snapshot.ts';
 import { isSparseSnapshotQualityVerdict } from '../../snapshot-quality/verdict.ts';
+import { snapshotOptionsToFlags } from '../../backend-snapshot-options.ts';
 
 export type CaptureSnapshotForSession = (
   session: SessionState,
@@ -36,8 +37,7 @@ export async function captureSnapshotForSession(
 ): Promise<SnapshotState> {
   const effectiveFlags = {
     ...(flags ?? {}),
-    snapshotInteractiveOnly: options.interactiveOnly,
-    ...(options.preferredBackend ? { snapshotPreferredBackend: options.preferredBackend } : {}),
+    ...snapshotOptionsToFlags(options),
   };
   const dispatchContext = contextFromFlags(
     effectiveFlags,

--- a/src/daemon/selector-runtime-backend.test.ts
+++ b/src/daemon/selector-runtime-backend.test.ts
@@ -4,6 +4,7 @@ import { createSelectorRuntimeForDevice } from './selector-runtime-backend.ts';
 import { SessionStore } from './session-store.ts';
 import type { SessionState } from './types.ts';
 import { mkdtempForTestSync } from '../__tests__/test-utils/tmp-dir.ts';
+import { makeSnapshotState } from '../__tests__/test-utils/index.ts';
 
 vi.mock('../platforms/apple/core/runner/runner-client.ts', async (importOriginal) => {
   const actual =
@@ -73,4 +74,69 @@ test('wait text passes its poll deadline signal to the Apple runner fast path', 
   ).rejects.toThrow(/timed out/i);
   expect(observedSignal).toBeDefined();
   expect(observedSignal?.aborted).toBe(true);
+});
+
+test('daemon wait stable pins private-ax on emitted snapshot runner requests', async () => {
+  const sessionName = 'ios-wait-stable-private-ax';
+  const sessionStore = new SessionStore(
+    path.join(mkdtempForTestSync('selector-runtime-'), 'sessions'),
+  );
+  const nodes = [
+    { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
+    ...Array.from({ length: 5 }, (_, offset) => ({
+      index: offset + 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: `Action ${offset + 1}`,
+      rect: { x: 20, y: 100 + offset * 50, width: 120, height: 44 },
+      hittable: true,
+    })),
+  ];
+  const snapshot = makeSnapshotState(nodes, {
+    snapshotQuality: { state: 'recovered', backend: 'private-ax', reasonCode: 'deferred' },
+  });
+  const session: SessionState = {
+    name: sessionName,
+    device,
+    appBundleId: 'com.example.fixture',
+    createdAt: Date.now(),
+    actions: [],
+    snapshot,
+  };
+  sessionStore.set(sessionName, session);
+  mockRunnerCommand.mockImplementation(async (_device, command) => {
+    if (command.command !== 'snapshot') return {};
+    return {
+      nodes,
+      snapshotQuality: {
+        state: 'recovered',
+        backend: 'private-ax',
+        reasonCode: 'requested-backend',
+      },
+    };
+  });
+  const runtime = createSelectorRuntimeForDevice({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'wait',
+      positionals: ['stable', '25', '1000'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    session,
+    device,
+  });
+
+  await runtime.selectors.wait({
+    session: sessionName,
+    target: { kind: 'stable', quietMs: 25, timeoutMs: 1_000 },
+  });
+
+  const snapshotCommands = mockRunnerCommand.mock.calls
+    .map(([, command]) => command)
+    .filter((command) => command.command === 'snapshot');
+  expect(snapshotCommands.length).toBeGreaterThanOrEqual(2);
+  expect(snapshotCommands.every((command) => command.preferredBackend === 'private-ax')).toBe(true);
 });

--- a/src/daemon/selector-runtime-backend.ts
+++ b/src/daemon/selector-runtime-backend.ts
@@ -1,9 +1,4 @@
-import type { CommandFlags } from '@agent-device/contracts/command';
-import type {
-  AgentDeviceBackend,
-  BackendSnapshotOptions,
-  BackendSnapshotResult,
-} from '../backend.ts';
+import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import { resolveTargetDevice } from '../core/dispatch.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { isMacOs, isApplePlatform, publicPlatformString } from '@agent-device/kernel/device';
@@ -24,6 +19,7 @@ import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { createSelectorCaptureRuntime } from './selector-capture-runtime.ts';
 import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 import { getRequestSignal } from '../request/cancel.ts';
+import { snapshotOptionsToFlags } from '../backend-snapshot-options.ts';
 
 export type SelectorRuntimeParams = {
   req: DaemonRequest;
@@ -47,17 +43,6 @@ type AppleRunnerFindTextTarget = {
   appBundleId: string;
   traceLogPath?: string;
 };
-
-type SnapshotFlagOverrides = Partial<
-  Pick<
-    CommandFlags,
-    | 'snapshotInteractiveOnly'
-    | 'snapshotScope'
-    | 'snapshotDepth'
-    | 'snapshotRaw'
-    | 'snapshotIncludeHiddenContentHints'
-  >
->;
 
 export function createSelectorRuntimeForDevice(params: SelectorRuntimeDeviceParams) {
   return createAgentDevice({
@@ -122,7 +107,7 @@ function createSelectorBackend(params: SelectorRuntimeDeviceParams): AgentDevice
     captureSnapshot: async (context, options): Promise<BackendSnapshotResult> => {
       const flags = {
         ...req.flags,
-        ...snapshotFlagOverrides(options),
+        ...snapshotOptionsToFlags(options),
       };
       const includeRects = options?.includeRects === true;
       const snapshotScope = options?.scope ?? req.flags?.snapshotScope;
@@ -160,19 +145,6 @@ function createSelectorBackend(params: SelectorRuntimeDeviceParams): AgentDevice
       found: await findText(params, text, context.signal),
     }),
   };
-}
-
-function snapshotFlagOverrides(options: BackendSnapshotOptions | undefined): SnapshotFlagOverrides {
-  const { interactiveOnly, scope, depth, raw, includeHiddenContentHints } = options ?? {};
-  const flags: SnapshotFlagOverrides = {};
-  if (interactiveOnly !== undefined) flags.snapshotInteractiveOnly = interactiveOnly;
-  if (scope !== undefined) flags.snapshotScope = scope;
-  if (depth !== undefined) flags.snapshotDepth = depth;
-  if (raw !== undefined) flags.snapshotRaw = raw;
-  if (includeHiddenContentHints !== undefined) {
-    flags.snapshotIncludeHiddenContentHints = includeHiddenContentHints;
-  }
-  return flags;
 }
 
 async function findText(

--- a/src/snapshot-quality/__tests__/verdict.test.ts
+++ b/src/snapshot-quality/__tests__/verdict.test.ts
@@ -1,7 +1,11 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
-import { isSparseSnapshotQualityVerdict, readSnapshotQualityVerdict } from '../verdict.ts';
+import {
+  isSparseSnapshotQualityVerdict,
+  preferredSnapshotBackendForVerdict,
+  readSnapshotQualityVerdict,
+} from '../verdict.ts';
 
 test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
   const verdict = readSnapshotQualityVerdict({
@@ -48,4 +52,16 @@ test('isSparseSnapshotQualityVerdict identifies sparse captures', () => {
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'sparse', backend: 'private-ax' }), true);
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'healthy', backend: 'tree' }), false);
   assert.equal(isSparseSnapshotQualityVerdict(undefined), false);
+});
+
+test('preferredSnapshotBackendForVerdict pins only private-ax captures', () => {
+  assert.equal(
+    preferredSnapshotBackendForVerdict({ state: 'recovered', backend: 'private-ax' }),
+    'private-ax',
+  );
+  assert.equal(
+    preferredSnapshotBackendForVerdict({ state: 'healthy', backend: 'tree' }),
+    undefined,
+  );
+  assert.equal(preferredSnapshotBackendForVerdict(undefined), undefined);
 });

--- a/src/snapshot-quality/verdict.ts
+++ b/src/snapshot-quality/verdict.ts
@@ -85,3 +85,9 @@ export function isSparseSnapshotQualityVerdict(
 ): verdict is SnapshotQualityVerdict {
   return verdict?.state === 'sparse';
 }
+
+export function preferredSnapshotBackendForVerdict(
+  verdict: SnapshotQualityVerdict | undefined,
+): 'private-ax' | undefined {
+  return verdict?.backend === 'private-ax' ? 'private-ax' : undefined;
+}


### PR DESCRIPTION
## Summary

Project private-AX snapshots to the visible viewport, retaining excluded content only as scroll hints.

Stabilize settle observations by pinning private AX after fallback and comparing the visible semantic projection with bounded geometry tolerance. Geometry-less semantic nodes remain visible to agents but cannot become interaction targets.

This touches 8 files across the iOS private-AX fallback and the shared settle runtime; scope stayed within snapshot capture and settle behavior. No public CLI or skill behavior changed.

## Validation

- `pnpm check:affected --run` passed: 1,942 affected tests and 100% changed-line coverage.
- Built the iOS runner with unit tests enabled and ran the two focused private-AX XCTest regressions twice: 2/2 passed with zero failures.
- Proved the settle backend-pinning regression red by temporarily removing the production forwarding, then restored the fix and verified green.
- Deleted the disposable verification simulators after the run.