### PR TITLE
fix: install dependencies for iOS runner releases

### DIFF
--- a/.github/workflows/release-ios-runner.yml
+++ b/.github/workflows/release-ios-runner.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           ref: ${{ github.event.inputs.checkout_ref || github.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '24.13'
 


### PR DESCRIPTION
## Summary

Install the pinned pnpm workspace dependencies before building iOS runner release assets.

The release workflow previously configured Node alone, so the runner build could fail with `ERR_MODULE_NOT_FOUND` for workspace packages. It now uses the repository shared toolchain action, matching regular iOS CI.

This touches one release workflow file and does not change runtime or public CLI behavior.

## Validation

- `pnpm check:affected --run` passed the complete fail-open workflow/tooling gate.
- Confirmed the shared setup action installs dependencies with the repository-pinned pnpm version.