### PR TITLE
test(android): restore full-tier lifecycle and observability scenarios (#1781 A1)

### DIFF
--- a/examples/test-app/replays/gesture-lab-android.ad
+++ b/examples/test-app/replays/gesture-lab-android.ad
@@ -1,5 +1,7 @@
-# Coordinates target the CI emulator profile: pixel_7, 1080x2400 @ 420 dpi
-# (gesture card spans y=754-1329 there). Another size/density moves the card
+# Coordinates target the CI emulator profile: pixel_7, 1080x2400 @ 420 dpi, where the gesture
+# targets span y=949-1525 (the two-pointer target is the left half, x=91-540). Multi-pointer
+# gestures start at the target's center: a start near an edge puts the second pointer outside
+# the view, which reads as "the gesture did nothing". Another size/density moves the targets
 # and the canary waits below fail honestly rather than silently passing.
 context platform=android kind=emulator timeout=60000
 
@@ -12,10 +14,10 @@ wait "Gesture lab" 30000
 wait "gesture canary ready" 5000
 wait "two-pointer pan activations 0" 5000
 
-gesture pan 220 1040 180 0 500
+gesture pan 300 1237 180 0 500
 wait "two-pointer pan activations 0" 5000
 
-gesture pan 220 1040 180 0 500 --pointer-count 2
+gesture pan 300 1237 180 0 500 --pointer-count 2
 wait "two-pointer pan activations 1" 5000
 
 gesture fling right 700 1040 300
@@ -29,7 +31,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture pinch 1.5 540 1040
+gesture pinch 1.5 540 1237
 wait "pan changed no, pinch changed yes, rotate changed no" 5000
 
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
@@ -37,7 +39,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture rotate 35 540 1040
+gesture rotate 35 540 1237
 wait "pan changed no, pinch changed no, rotate changed yes" 5000
 
 open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
@@ -45,7 +47,7 @@ react-native dismiss-overlay
 wait "gesture canary ready" 5000
 wait "pan changed no, pinch changed no, rotate changed no" 30000
 
-gesture transform 540 1040 60 0 1.75 30 600
+gesture transform 540 1237 60 0 1.75 30 600
 wait "pan changed yes, pinch changed yes, rotate changed yes" 5000
 
 close

--- a/examples/test-app/src/screens/CatalogScreen.tsx
+++ b/examples/test-app/src/screens/CatalogScreen.tsx
@@ -62,6 +62,10 @@ export function CatalogScreen(props: CatalogScreenProps) {
       onScroll={updateScrollState}
       scrollEventThrottle={16}
       showsVerticalScrollIndicator={false}
+      // Pins the scroll-state line (child index 1) so every state it reports stays on screen.
+      // Android accessibility snapshots carry on-screen nodes only, so a canary that scrolls
+      // away can only ever be read as "top" — the state it holds before anything scrolls.
+      stickyHeaderIndices={[1]}
     >
       <ScreenTitle
         badge={`${props.products.length} results`}

--- a/test/integration/android-emulator-e2e/live-form-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-form-scenario.ts
@@ -14,7 +14,7 @@ import {
 import { type LiveContext, runStep, verifyBehavior, verifyCommand } from './live-harness.ts';
 
 const C = PUBLIC_COMMANDS;
-const ANDROID_TEST_IME_PACKAGE = 'com.callstack.agentdevice.imehelper';
+export const ANDROID_TEST_IME_PACKAGE = 'com.callstack.agentdevice.imehelper';
 const ANDROID_TEST_IME_SERVICE = `${ANDROID_TEST_IME_PACKAGE}/.TestInputMethodService`;
 const KEYBOARD_VISIBILITY_TIMEOUT_MS = 10_000;
 const KEYBOARD_VISIBILITY_POLL_MS = 250;

--- a/test/integration/android-emulator-e2e/live-lifecycle-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-lifecycle-scenario.ts
@@ -2,25 +2,29 @@ import assert from 'node:assert/strict';
 
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 import { assertElementText, assertWaitText } from './live-assertions.ts';
+import { ANDROID_TEST_IME_PACKAGE } from './live-form-scenario.ts';
 import { type LiveContext, runStep, verifyBehavior, verifyCommand } from './live-harness.ts';
 
 const C = PUBLIC_COMMANDS;
 const AUTOMATION_DEEP_LINK =
   'agent-device-test-app:///automation?event=full.lifecycle&payload=%7B%22source%22%3A%22android-nightly%22%7D';
+const TABS_DEEP_LINK = 'agent-device-test-app:///';
 export const ANDROID_PERMISSION_PROMPT_COMMAND = ['alert', 'wait', '10000'] as const;
 
 export async function assertLifecycleAndSystem(context: LiveContext): Promise<void> {
-  await runStep(context, 'open Android fixture lifecycle route', [
-    'open',
-    context.appId,
-    '--relaunch',
-    AUTOMATION_DEEP_LINK,
-  ]);
-  await assertWaitText(context, 'Automation lab');
+  await openAutomationLab(context, 'open Android fixture lifecycle route');
 
   await assertPermissionRecovery(context);
   await assertPushBroadcast(context);
   await assertImeRecovery(context);
+}
+
+// Leaves the fixture on Automation lab with its permission controls on screen: Android
+// snapshots only carry on-screen nodes, and a relaunch always lands above the controls.
+async function openAutomationLab(context: LiveContext, step: string): Promise<void> {
+  await runStep(context, step, ['open', context.appId, '--relaunch', AUTOMATION_DEEP_LINK]);
+  await assertWaitText(context, 'Automation lab');
+  await runStep(context, `${step} (reveal automation controls)`, ['scroll', 'bottom']);
 }
 
 async function assertPermissionRecovery(context: LiveContext): Promise<void> {
@@ -39,9 +43,7 @@ async function assertPermissionRecovery(context: LiveContext): Promise<void> {
     'deny',
     'microphone',
   ]);
-  await runStep(context, 'background fixture before revoked permission readback', ['home']);
-  await runStep(context, 'restore fixture after microphone revocation', ['open', context.appId]);
-  await assertWaitText(context, 'Automation lab');
+  await openAutomationLab(context, 'restore fixture after microphone revocation');
   await assertElementText(context, 'id="automation-microphone-permission"', 'denied');
   verifyCommand(
     context,
@@ -51,10 +53,13 @@ async function assertPermissionRecovery(context: LiveContext): Promise<void> {
   verifyBehavior(
     context,
     'runtime-permission-recovery',
-    'fixture observed native prompt accept and deny, then app-active readback after pm revoke',
+    'fixture observed native prompt accept and deny, then relaunched readback after the pm revoke killed the app',
   );
 }
 
+// Android kills the app process whenever a *granted* runtime permission is revoked, and
+// `settings permission reset` revokes. Every reset therefore relaunches the fixture so the
+// following steps always run against a live Automation lab.
 async function resetAndRequestMicrophonePermission(
   context: LiveContext,
   action: 'accept' | 'deny' | 'accept after denial',
@@ -65,10 +70,7 @@ async function resetAndRequestMicrophonePermission(
     'reset',
     'microphone',
   ]);
-  await runStep(context, `scroll to microphone permission control before ${action}`, [
-    'scroll',
-    'bottom',
-  ]);
+  await openAutomationLab(context, `restore fixture after reset before ${action}`);
   await runStep(context, `request Android microphone permission for ${action}`, [
     'click',
     'id="automation-request-microphone"',
@@ -109,6 +111,18 @@ async function assertPushBroadcast(context: LiveContext): Promise<void> {
 }
 
 async function assertImeRecovery(context: LiveContext): Promise<void> {
+  // Automation lab is a root route without the tab bar, so the tabs have to be restored
+  // before the Form tab can be clicked. This section observes the system IME, and only
+  // closing the session puts the test IME back, so the reopen follows a close.
+  await runStep(context, 'release Android test IME before IME recovery', ['close']);
+  await runStep(context, 'return to Android fixture tabs before IME recovery', [
+    'open',
+    context.appId,
+    '--relaunch',
+    '--no-test-ime',
+    TABS_DEEP_LINK,
+  ]);
+  await assertWaitText(context, 'Agent Device Tester');
   await runStep(context, 'open Android fixture form for IME recovery', ['click', 'label="Form"']);
   await assertWaitText(context, 'Checkout form');
   await runStep(context, 'fill Android IME recovery field', [
@@ -121,8 +135,17 @@ async function assertImeRecovery(context: LiveContext): Promise<void> {
     'status',
   ]);
   assert.equal(status.json?.data?.visible, true, JSON.stringify(status.json));
+  // Names what `visible: true` only implies: the injecting test IME draws nothing, so reading
+  // it here would mean the reopen above failed to hand input back to the system keyboard.
+  assert.notEqual(
+    status.json?.data?.inputMethodPackage,
+    ANDROID_TEST_IME_PACKAGE,
+    JSON.stringify(status.json),
+  );
   await runStep(context, 'dismiss Android IME after fill recovery', ['keyboard', 'dismiss']);
-  await runStep(context, 'scroll to Android IME diagnostic', ['scroll', 'bottom']);
+  // The diagnostic sits between the IME field and the delivery choices, so scrolling to the
+  // bottom of the form scrolls past it.
+  await runStep(context, 'scroll to Android IME diagnostic', ['scroll', 'down', '0.3']);
   await assertWaitText(context, 'Android fill input was captured by the active keyboard');
   await assertElementText(context, 'id="field-ime-capture-target"', 'agent-device');
   verifyBehavior(

--- a/test/integration/android-emulator-e2e/live-observability-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-observability-scenario.ts
@@ -65,7 +65,9 @@ async function assertLogs(context: LiveContext): Promise<void> {
 
 async function assertTraceAndRecording(context: LiveContext): Promise<void> {
   const tracePath = path.join(context.artifactDir, 'fixture.adtrace');
-  await runStep(context, 'reveal Android quick actions before trace', ['scroll', 'down', '0.7']);
+  // 0.7 of a viewport scrolls the quick actions off the top on the pixel_7 profile the
+  // nightly lane pins; half a viewport puts the whole card on screen.
+  await runStep(context, 'reveal Android quick actions before trace', ['scroll', 'down', '0.5']);
   await runStep(context, 'start Android interaction trace', ['trace', 'start', tracePath]);
   await runStep(context, 'trace Android visible mutation', ['press', 'id="home-open-catalog"']);
   await runStep(context, 'stop Android interaction trace', ['trace', 'stop', tracePath]);
@@ -104,6 +106,9 @@ async function assertBatchAndEvents(context: LiveContext): Promise<void> {
   await runStep(context, 'return to Android fixture home before batch', ['click', 'label="Home"']);
   await runStep(context, 'restore Android fixture home title before batch', ['scroll', 'top']);
   await assertWaitText(context, 'Agent Device Tester');
+  // The release notice sits below the gesture lab card on the pixel_7 profile, and Android
+  // snapshots only carry on-screen nodes, so both batch targets are revealed first.
+  await runStep(context, 'reveal Android release notice before batch', ['scroll', 'down', '0.3']);
   const batch = await runStep(context, 'run Android nested semantic read batch', [
     'batch',
     '--steps',
@@ -114,7 +119,7 @@ async function assertBatchAndEvents(context: LiveContext): Promise<void> {
       },
       {
         command: 'is',
-        input: { predicate: 'visible', selector: 'id="home-title"' },
+        input: { predicate: 'visible', selector: 'id="release-notice"' },
       },
     ]),
   ]);
@@ -135,7 +140,9 @@ async function assertBatchAndEvents(context: LiveContext): Promise<void> {
     const result = await runStep(
       context,
       cursor === undefined ? 'read Android event timeline' : `read Android events from ${cursor}`,
-      cursor === undefined ? ['events', '4'] : ['events', '4', cursor],
+      // Each page read appends its own request events, so a page smaller than that tail
+      // never catches up with a full-tier session's timeline.
+      cursor === undefined ? ['events', '50'] : ['events', '50', cursor],
     );
     return (result.json?.data ?? {}) as EventTimelinePage;
   });

--- a/test/integration/android-emulator-e2e/live-observability-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-observability-scenario.ts
@@ -106,9 +106,10 @@ async function assertBatchAndEvents(context: LiveContext): Promise<void> {
   await runStep(context, 'return to Android fixture home before batch', ['click', 'label="Home"']);
   await runStep(context, 'restore Android fixture home title before batch', ['scroll', 'top']);
   await assertWaitText(context, 'Agent Device Tester');
-  // The release notice sits below the gesture lab card on the pixel_7 profile, and Android
-  // snapshots only carry on-screen nodes, so both batch targets are revealed first.
-  await runStep(context, 'reveal Android release notice before batch', ['scroll', 'down', '0.3']);
+  // Android snapshots only carry on-screen nodes, so both batch targets are revealed first.
+  // 0.3 of a viewport is the band where the gesture lab card and the release notice below it
+  // are on screen together on the pixel_7 profile the lane pins; by 0.4 the card is gone.
+  await runStep(context, 'reveal Android batch targets', ['scroll', 'down', '0.3']);
   const batch = await runStep(context, 'run Android nested semantic read batch', [
     'batch',
     '--steps',
@@ -119,7 +120,9 @@ async function assertBatchAndEvents(context: LiveContext): Promise<void> {
       },
       {
         command: 'is',
-        input: { predicate: 'visible', selector: 'id="release-notice"' },
+        // A sibling card, not the notice that owns `dismiss-notice`: resolving a child already
+        // proves its parent is present, so a parent target could not fail on its own.
+        input: { predicate: 'visible', selector: 'id="gesture-lab-card"' },
       },
     ]),
   ]);

--- a/test/integration/replays/android/fixture/01-navigation-scroll.ad
+++ b/test/integration/replays/android/fixture/01-navigation-scroll.ad
@@ -5,7 +5,7 @@ env APP_TARGET="com.callstack.agentdevicelab"
 
 open "${APP_TARGET}" --relaunch
 wait "Agent Device Tester" 30000
-click "label=\"Catalog, 0 new notifications\""
+click "label=\"Catalog\""
 wait "Catalog scroll: top" 5000
 swipe 220 700 220 380
 wait "Catalog scroll: down" 5000


### PR DESCRIPTION
## Summary

`#1781` A1. The nightly Android job (`Android Full Emulator Suite`) has failed every scheduled run since the full tier landed, always on the same assertion:

```
AssertionError [ERR_ASSERTION]: step: request Android microphone permission for deny
command: agent-device click id="automation-request-microphone" ...
"message": "Selector did not match: id=\"automation-request-microphone\"",
scenario: full:lifecycle-system
```

## Root cause

`settings permission reset microphone` maps to `pm revoke` (documented in `commands.md`), and Android kills the app process when a **granted** runtime permission is revoked. The `accept` round grants the permission; the reset that opens the `deny` round therefore terminates the fixture, and the click lands on the launcher.

Proven on the image the lane pins (`android-36 google_apis_playstore`, Pixel 7 profile):

```
--- reset (revoke) while NOT granted
pid: 4259                       # app survives
--- grant / revoke while GRANTED
pid after revoke:               # empty — process gone
topResumedActivity=ActivityRecord{... com.google.android.apps.nexuslauncher/.NexusLauncherActivity}
```

The nightly artifacts agree: in run 31990896404 the `scroll bottom` immediately before the failing click reports `"summary": "Already at bottom", "passes": 0` (the launcher is not scrollable), while the same step in the `accept` round scrolled 1440px.

### Why #1610 did not fix it

#1610 fixed a *different* defect in the same helper — a one-shot `alert get` racing the asynchronous prompt — by switching to `alert wait 10000`. That made the `accept` round reach its prompt, which moved the failure one step later, onto the revoke-kill. Before #1610 the job failed at `{"alert":null,"message":"No alert visible"}` (run 30974032723); from 2026-08-06 onwards it fails at the `deny` click (runs 31070190261, 31924041273, 31990896404).

### Why there was more than one defect

`full:lifecycle-system` (added in #1484) and `full:observability-artifacts` have never executed end to end — #1484 explicitly deferred to the *smoke* tier for device validation, and the nightly has died inside the first of them every night since. Running them live surfaced the whole chain:

| # | Defect | Symptom |
|---|--------|---------|
| 1 | reset revokes → app killed | `Selector did not match: id="automation-request-microphone"` |
| 2 | post-revoke readback used `home` + `open` | cold start lands on the tabs home, `wait "Automation lab"` times out |
| 3 | relaunched Automation lab starts above the controls | `get text id="automation-microphone-permission"` finds nothing (Android snapshots are on-screen only) |
| 4 | Automation lab is a root route without the tab bar | `click label="Form"` finds nothing |
| 5 | every `open` re-activates the test IME | `keyboard status` returns `visible:false`, `inputMethodPackage: …imehelper` |
| 6 | `scroll bottom` overshoots the IME diagnostic | `wait "Android fill input was captured…"` times out |
| 7 | `scroll down 0.7` overshoots the quick actions on pixel_7 | `press id="home-open-catalog"` finds nothing |
| 8 | batch targets below the fold / not co-visible | `get text id="dismiss-notice"` finds nothing |
| 9 | event page (4) smaller than the events each page read appends | `events pagination exceeded 100 pages` |

## What this changes

- `live-lifecycle-scenario.ts`: one `openAutomationLab` helper relaunches the deep-link route and reveals its controls; every permission reset and the post-revoke readback go through it. The IME section closes the session (the only thing that restores the previous IME), reopens the tabs root with `--no-test-ime`, and reveals the diagnostic with a bounded scroll.
- `live-observability-scenario.ts`: reveal distances corrected for the pinned `pixel_7` profile, the batch's `is` target changed to an element co-visible with `dismiss-notice`, and the event page size raised above the tail each page read appends.

- `examples/test-app/src/screens/CatalogScreen.tsx`: `stickyHeaderIndices` pins the scroll-state
  canary so Android can read it at any scroll offset.
- `examples/test-app/replays/gesture-lab-android.ad` and
  `test/integration/replays/android/fixture/01-navigation-scroll.ad`: one selector and the
  multi-pointer start points re-derived from the live fixture on the pinned profile.

No production code is touched.

## Validation

Live, on a local `Pixel_7_CI` AVD (API 36, `google_apis_playstore`, same profile/API as the lane), with the fixture APK and the packaged snapshot/IME helpers:

- Red before: `AGENT_DEVICE_ANDROID_E2E_SCENARIOS=full:lifecycle-system` reproduced the nightly assertion verbatim.
- Green after: the same filtered run passes (`pass 1`, `full:lifecycle-system: 38241ms`).
- Full tier, unfiltered, in lane order: bootstrap → inventory → automation-system → form-input → keyboard-ime → capture-close → **lifecycle-system** → **observability-artifacts** all pass.

`pnpm check:quick`, `pnpm format:check`, and `node --test test/integration/smoke-android-emulator-coverage.test.ts` (10/10) pass.

## Scope

Six files: `live-lifecycle-scenario.ts`, `live-observability-scenario.ts`, `live-form-scenario.ts`
(one constant exported), the `01-navigation-scroll.ad` and `gesture-lab-android.ad` fixtures, and
`CatalogScreen.tsx` in the fixture app. No production code.

## Full-tier evidence

Hosted, on the lane's own image — [run 32107665052](https://github.com/callstack/agent-device/actions/runs/32107665052), a `workflow_dispatch` of Replay Nightly on this exact head. All nine scenarios pass with no retries:

```
Android emulator live run: 324515ms
  smoke:fixture-bootstrap 13044ms   smoke:inventory 2972ms
  smoke:automation-system 83799ms   smoke:form-input 28573ms
  smoke:keyboard-ime 21224ms        smoke:capture-close 8770ms
  full:lifecycle-system 71423ms     full:observability-artifacts 26642ms
  full:fixture-replays 66515ms
✔ live Android emulator fixture E2E (324516ms)
```

That job still ends red on a **separate** suite that runs after the E2E — `pnpm gate replay-android`, `4 passed (8), 4 failed`, every failure carrying agent-device's own "a system surface … covers the app" diagnosis (`Silent, Collapse, Android System`). It starts on two Settings-app replays this PR does not touch, clears again three files later, and the gate has not executed since 2026-07-30 because the workflow's `set -eu` script never reached it while the E2E was failing. Detail in [this comment](https://github.com/callstack/agent-device/pull/1793#issuecomment-5324671100); deliberately left to a follow-up rather than widening this PR into a third suite.

### Local reproduction


The lane's own command passes end to end on a Pixel 7 / API 36 AVD (the profile and image
`replays-manual.yml` pins), against a CI-equivalent fixture APK — cached native plus head JS
through the same `repack-android-apk.sh` the workflow runs:

```
Android emulator live run: 153432ms
  smoke:fixture-bootstrap: 1735ms      smoke:inventory: 1140ms
  smoke:automation-system: 27585ms     smoke:form-input: 10205ms
  smoke:keyboard-ime: 6503ms           smoke:capture-close: 3673ms
  full:lifecycle-system: 33443ms       full:observability-artifacts: 21130ms
  full:fixture-replays: 46607ms
✔ live Android emulator fixture E2E   pass 1  fail 0
```

Getting there needed three more repairs, each a drift the lane had never executed far enough to
see:

- `01-navigation-scroll.ad` clicked `label="Catalog, 0 new notifications"`. #1543 made the cart
  badge conditional, so the live label is plain `Catalog` — which the iOS twin of this file
  already used.
- The catalog scroll canary sits inside the scrolling content, and Android snapshots carry
  on-screen nodes only, so every state except the initial `top` was unobservable — `wait
  "Catalog scroll: down|bottom|up"` could not pass at any swipe coordinates. Rather than tune
  the .ad around a canary that scrolls away, `stickyHeaderIndices` pins that one line, so all
  four states are readable at any offset on both platforms.
- `gesture-lab-android.ad` started its multi-pointer gestures at y=1040 — inside the target
  when the file was last repaired (#1538), but 90px from its top edge after #1567 moved the
  card (targets now span y=949-1525), so the second pointer landed outside the view and the
  gesture read as a no-op. Multi-pointer gestures now start at the target centre, and the
  header comment records the geometry they depend on. Isolated on device: `(220,1040)` fails at
  distance 180 *and* 500, `(300,1237)` passes at both — position, not distance.

One flake seen once in three full runs: `record stop` reported `Android screenrecord ownership
could not be confirmed for pid …` in `full:observability-artifacts`. It passed on the scenario
re-run and on the full re-run; it is a step this PR does not touch, so it is noted rather than
chased.

## CI note: the Coverage red was not this branch (input for #1781 A4)

`Coverage` failed three times on this PR with no failed test — `Error: [vitest-pool]: Worker forks emitted error` / `Caused by: Error: Worker exited unexpectedly`, last file logged before the ~36s gap always `subprocess-stub scripts/fuzz/corpus-replay.test.ts`, summary `Test Files 942 passed (943)`. It passes on re-run (job `95465796922`). What the evidence says:

- **Not the branch state.** `git diff --stat origin/main...HEAD` is six files — four scenario/harness files under `test/integration/android-emulator-e2e/`, one `.ad` replay fixture, and the fixture app screen — with `origin/main` an ancestor of HEAD and no lockfile or config change. (At the time this note was written the diff was the three scenario files; the fixture repairs below were added after.) And no Vitest project includes that directory (`vitest.config.ts`: `unit-core`, `subprocess-stub`, `provider-integration`, `interaction-contract`, `output-economy`) — these scenarios run under `node --test`. The Coverage job executes the same 943 files with or without this diff.
- **Not reproducible locally.** `pnpm test:coverage:ci` (the exact CI script) twice on this branch: run 1 exit 1 on an unrelated CPU-contention timeout (`runner-client.test.ts > ensureXctestrunArtifact aborts only the disconnected request build`, `Test timed out in 5000ms`) with **zero** `Worker exited unexpectedly`; run 2 fully green, `Test Files 943 passed (943)`, exit 0.
- **The same signature is hitting other branches.** Same afternoon, identical last-logged file and error: `claude/agent-device-issue-1783-9dcc8e` (job `95439415417`, 16:58) and `claude/agent-device-1774-67603d` (jobs `95428461468` at 16:07 and `95421425175` at 15:14). `95428461468` has this PR's exact shape — no failed test, one file unaccounted for (`940 passed (941)`).

So it is (b): a `subprocess-stub` fork being killed under runner load. Two properties make it a job-level red rather than a blip: that project runs `fileParallelism: false`, `maxWorkers: 1`, `isolate: true` while its tests spawn real processes, and a killed fork surfaces as an *unhandled error*, which `scripts/lib/contention-retry.ts` deliberately refuses to retry ("No retry: the run failed for a reason a rerun cannot re-check"). A human re-run then passes, which is the worst shape: the policy that exists to keep contention honest converts a killed worker into a red that only manual intervention clears. Handing that to **#1781 A4** (the subprocess-stub / contention-retry decision) rather than widening the retry policy from this PR.

## How to verify

Trigger the workflow manually on this branch and watch the Android job:

```
gh workflow run replays-nightly.yml --ref test/1781-a1-replays-nightly-android
```

Or locally, against a booted `pixel_7`/API 36 AVD:

```
AGENT_DEVICE_ANDROID_E2E=1 AGENT_DEVICE_ANDROID_E2E_TIER=full \
AGENT_DEVICE_ANDROID_E2E_SCENARIOS=full:lifecycle-system,full:observability-artifacts \
AGENT_DEVICE_ANDROID_SERIAL=<serial> \
AGENT_DEVICE_FIXTURE_APP_PATH=examples/test-app/android/app/build/outputs/apk/release/app-release.apk \
AGENT_DEVICE_FIXTURE_APP_ID=com.callstack.agentdevicelab \
node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-android-emulator.test.ts
```

Draft because the lane cannot go green until the replay fixture above is decided.
