### PR TITLE
fix: unify private AX scroll visibility

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -1,6 +1,8 @@
 import XCTest
 
 extension RunnerTests {
+  private static let privateAXProjectionTolerance: CGFloat = 1
+
   func privateAXPresentation(rawRoot: [String: Any], options: SnapshotOptions, viewport: CGRect)
     -> [SnapshotNode]
   {
@@ -24,15 +26,21 @@ extension RunnerTests {
     let rawType = privateAXPresentationInt(raw["type"]) ?? 0
     let enabled = privateAXPresentationBool(raw["enabled"]) ?? true
     let children = raw["children"] as? [[String: Any]] ?? []
+    let hasSemanticContent = [label, identifier, value].contains(where: { !$0.isEmpty })
     let elementType = flatSnapshotElementType(rawElementType: rawType)
     let hasFrame = !rect.isNull && !rect.isEmpty
+    let negligibleDecoration = parentIndex != nil
+      && !hasSemanticContent
+      && (!hasFrame
+        || rect.width <= Self.privateAXProjectionTolerance
+        || rect.height <= Self.privateAXProjectionTolerance)
     let onScreen = hasFrame
       && isVisibleInRegularSnapshot(
         rect,
         viewport: viewport,
         scrollContainerAnchor: scrollContext
       )
-    let presentationVisible = !hasFrame || onScreen
+    let presentationVisible = !negligibleDecoration && (!hasFrame || onScreen)
     let decision = flatSnapshotFilterDecision(
       FlatSnapshotFilterNode(isRoot: parentIndex == nil, label: label, identifier: identifier,
         valueText: value.isEmpty ? nil : value, visible: presentationVisible),
@@ -115,12 +123,14 @@ extension RunnerTests {
       "label": "Element", "frame": ["x": 0, "y": 0, "width": 402, "height": 874],
       "children": [["type": Int(XCUIElement.ElementType.scrollView.rawValue),
         "label": "Settings semantics", "frame": zero, "children": [[
-          "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero]]]]]
+          "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero],
+        ["type": Int(XCUIElement.ElementType.other.rawValue), "frame": zero]]]]]
     let nodes = privateAXPresentation(rawRoot: root,
       options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Settings semantics", "Theme"])
     XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, false])
+    XCTAssertFalse(nodes.contains { $0.type == "Other" })
     XCTAssertTrue(nodes.allSatisfy { $0.hiddenContentAbove == nil && $0.hiddenContentBelow == nil })
   }
 }

--- a/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
@@ -212,3 +212,54 @@ test('iOS target resolution preserves distinct nested controls matched by one ex
     resolveMaestroTargetFromSnapshot(snapshot, { selector: { text: 'Save.*' }, index: 1 }, 'ios'),
   ).toMatchObject({ ok: true, node: { index: 1 }, matches: 2 });
 });
+
+test('iOS target resolution keeps raw geometry bound to the canonical source node', () => {
+  const interactionSnapshot = makeSnapshot([
+    {
+      index: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 393, height: 852 },
+    },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Save',
+      rect: { x: 0, y: 100, width: 80, height: 48 },
+    },
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Save',
+      rect: { x: 200, y: 100, width: 80, height: 48 },
+    },
+  ]);
+  const canonicalSnapshot = makeSnapshot([
+    interactionSnapshot.nodes[0]!,
+    { ...interactionSnapshot.nodes[2]!, index: 1 },
+  ]);
+
+  expect(
+    resolveMaestroTargetFromSnapshot(
+      canonicalSnapshot,
+      { selector: { text: 'Save' }, allowAtomicSelectorDispatch: true },
+      'ios',
+      {
+        interactiveBounds: true,
+        interaction: {
+          snapshot: interactionSnapshot,
+          sourceIndexes: new Map([
+            [0, 0],
+            [1, 2],
+          ]),
+        },
+      },
+    ),
+  ).toMatchObject({
+    ok: true,
+    node: { index: 1 },
+    rect: { x: 200, y: 100, width: 80, height: 48 },
+    dispatchCandidates: 2,
+  });
+});

--- a/packages/maestro/src/internal/runtime-targets.ts
+++ b/packages/maestro/src/internal/runtime-targets.ts
@@ -3,6 +3,8 @@ import type { MaestroSelector } from './program-ir.ts';
 import type { MaestroPlatform } from './runtime-target-policy.ts';
 import { rankMaestroCandidates, selectMaestroSnapshotMatch } from './runtime-target-ranking.ts';
 import { pointInsideRect, stripUndefined } from './shared.ts';
+import { isDescendantOfSnapshotNode } from './snapshot-policy.ts';
+import { buildSnapshotNodeMap } from '@agent-device/contracts/snapshot';
 
 export type MaestroTargetQuery = {
   selector: MaestroSelector;
@@ -37,8 +39,10 @@ export function resolveMaestroTargetFromSnapshot(
   platform: MaestroPlatform,
   options: {
     interactiveBounds?: boolean;
-    interactiveRects?: ReadonlyMap<number, Rect>;
-    canonicalSnapshot?: SnapshotState;
+    interaction?: {
+      snapshot: SnapshotState;
+      sourceIndexes: ReadonlyMap<number, number>;
+    };
   } = {},
 ): MaestroTargetResolution {
   const candidates = rankMaestroCandidates(snapshot, query.selector, platform, query.childOf);
@@ -55,10 +59,12 @@ export function resolveMaestroTargetFromSnapshot(
   if (!target) {
     return failedTargetResolution(query, matches, rankedMatches, evidence);
   }
+  const interactionCandidates = resolveInteractionCandidates(target.node, query, platform, options);
+  const interactionTarget = interactionCandidates
+    ? selectMaestroSnapshotMatch(interactionCandidates.mapped, undefined)
+    : undefined;
   const rect =
-    options.interactiveBounds === true
-      ? (options.interactiveRects?.get(target.node.index) ?? target.rect)
-      : target.rect;
+    options.interactiveBounds === true ? (interactionTarget?.rect ?? target.rect) : target.rect;
   return {
     ok: true,
     node: target.node,
@@ -66,9 +72,39 @@ export function resolveMaestroTargetFromSnapshot(
     matches: rankedMatches.length,
     dispatchCandidates:
       platform === 'ios' && query.allowAtomicSelectorDispatch && !query.childOf
-        ? countCanonicalDispatchCandidates(query, { ...target, rect }, options.canonicalSnapshot)
+        ? countInteractionDispatchCandidates(target, interactionCandidates)
         : 0,
     evidence,
+  };
+}
+
+function resolveInteractionCandidates(
+  canonicalTarget: SnapshotNode,
+  query: MaestroTargetQuery,
+  platform: MaestroPlatform,
+  options: {
+    interaction?: {
+      snapshot: SnapshotState;
+      sourceIndexes: ReadonlyMap<number, number>;
+    };
+  },
+): { all: SnapshotNode[]; mapped: SnapshotNode[] } | undefined {
+  const interaction = options.interaction;
+  if (!interaction) return undefined;
+  const { snapshot, sourceIndexes } = interaction;
+  const sourceIndex = sourceIndexes.get(canonicalTarget.index);
+  if (sourceIndex === undefined) return undefined;
+  const source = snapshot.nodes.find((node) => node.index === sourceIndex);
+  if (!source) return undefined;
+  const byIndex = buildSnapshotNodeMap(snapshot.nodes);
+  const all = rankMaestroCandidates(snapshot, query.selector, platform, query.childOf).ranked;
+  return {
+    all,
+    mapped: all.filter(
+      (candidate) =>
+        candidate.index === source.index ||
+        isDescendantOfSnapshotNode(snapshot.nodes, candidate, source, byIndex),
+    ),
   };
 }
 
@@ -89,22 +125,16 @@ function failedTargetResolution(
   return { ok: false, message: `Maestro selector did not match${index}.`, evidence };
 }
 
-function countCanonicalDispatchCandidates(
-  query: MaestroTargetQuery,
+function countInteractionDispatchCandidates(
   target: { node: SnapshotNode; rect: Rect },
-  canonicalSnapshot: SnapshotState | undefined,
+  interactionCandidates: { all: SnapshotNode[]; mapped: SnapshotNode[] } | undefined,
 ): number {
-  if (!canonicalSnapshot) return 0;
-  const canonicalRankedMatches = rankMaestroCandidates(
-    canonicalSnapshot,
-    query.selector,
-    'ios',
-  ).ranked;
-  if (canonicalRankedMatches.length !== 1) return canonicalRankedMatches.length;
-  const canonicalTarget = selectMaestroSnapshotMatch(canonicalRankedMatches, undefined);
-  return canonicalTarget &&
-    canonicalTarget.node.hittable !== false &&
-    haveSameTapPoint(canonicalTarget.rect, target.rect)
+  if (!interactionCandidates) return 0;
+  if (interactionCandidates.all.length !== 1) return interactionCandidates.all.length;
+  const interactionTarget = selectMaestroSnapshotMatch(interactionCandidates.mapped, undefined);
+  return interactionTarget &&
+    interactionTarget.node.hittable !== false &&
+    haveSameTapPoint(interactionTarget.rect, target.rect)
     ? 1
     : 0;
 }

--- a/src/commands/interaction/runtime/stable-capture-signal.test.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
 import { stableCaptureSignal, stableCaptureSignalsEqual } from './stable-capture-signal.ts';
+import {
+  elementCollapsedScrollEdgeSnapshot,
+  elementSettingsSnapshot,
+} from './stable-capture.fixtures.ts';
 
 function snapshot(jitter: number, hiddenY: number) {
   return makeSnapshotState(
@@ -42,6 +46,7 @@ function snapshot(jitter: number, hiddenY: number) {
       },
     ],
     {
+      backend: 'xctest',
       snapshotQuality: {
         state: 'recovered',
         backend: 'private-ax',
@@ -67,6 +72,137 @@ test('private-ax stability tolerates one-pixel geometry jitter', () => {
     stableCaptureSignalsEqual(
       stableCaptureSignal(snapshot(0, 900)),
       stableCaptureSignal(snapshot(1, 900)),
+    ),
+    true,
+  );
+});
+
+test('regular snapshot stability ignores offscreen scroll-descendant churn', () => {
+  assert.equal(
+    stableCaptureSignalsEqual(
+      stableCaptureSignal(elementSettingsSnapshot([1_138, 1_423, 2_144, 2_434])),
+      stableCaptureSignal(elementSettingsSnapshot([1_187, 1_423, 1_858, 2_144, 2_261])),
+    ),
+    true,
+  );
+});
+
+test('private-ax stability ignores an evidenced collapsed run pinned to a scroll edge', () => {
+  const left = stableCaptureSignal(
+    elementCollapsedScrollEdgeSnapshot(['Enable in-app notifications', 'Clear cache']),
+  );
+  const right = stableCaptureSignal(
+    elementCollapsedScrollEdgeSnapshot(['Find your contacts', 'Report bug']),
+  );
+
+  assert.equal(stableCaptureSignalsEqual(left, right), true);
+  assert.equal(
+    left.nodes.some((node) => node.identity.includes('Visible table heading')),
+    true,
+  );
+});
+
+test('capture backend transitions reset otherwise identical visible semantics', () => {
+  const tree = snapshot(0, 700);
+  const privateAx = snapshot(0, 700);
+  tree.snapshotQuality = { state: 'healthy', backend: 'tree' };
+  privateAx.snapshotQuality = { state: 'recovered', backend: 'private-ax' };
+
+  assert.equal(
+    stableCaptureSignalsEqual(stableCaptureSignal(tree), stableCaptureSignal(privateAx)),
+    false,
+  );
+});
+
+test('non-iOS captures retain their backend-owned node projection', () => {
+  const left = snapshot(0, 900);
+  const right = snapshot(0, 980);
+  left.backend = 'android';
+  right.backend = 'android';
+
+  assert.equal(
+    stableCaptureSignalsEqual(stableCaptureSignal(left), stableCaptureSignal(right)),
+    false,
+  );
+});
+
+test('stable semantic projection keeps value-only nodes and drops geometryless structure', () => {
+  const state = snapshot(0, 700);
+  state.nodes.push(
+    {
+      index: 10,
+      ref: 'e10',
+      depth: 1,
+      parentIndex: 0,
+      type: 'StaticText',
+      value: 'Selected',
+      hittable: false,
+    },
+    {
+      index: 11,
+      ref: 'e11',
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      hittable: false,
+    },
+  );
+
+  const signal = stableCaptureSignal(state);
+
+  assert.equal(
+    signal.nodes.some((node) => node.identity.includes('#Selected')),
+    true,
+  );
+  assert.equal(
+    signal.nodes.some((node) => node.identity === 'Other##'),
+    false,
+  );
+});
+
+test('stable semantic projection stays linear on large scroll trees', () => {
+  const state = elementSettingsSnapshot(
+    Array.from({ length: 256 }, (_, offset) => 900 + offset * 49),
+  );
+  let nodeReads = 0;
+  state.nodes = new Proxy(state.nodes, {
+    get(target, property, receiver) {
+      if (typeof property === 'string' && /^\d+$/.test(property)) nodeReads += 1;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+  const signal = stableCaptureSignal(state);
+
+  assert.equal(signal.nodes.length, 4);
+  assert.ok(
+    nodeReads <= state.nodes.length * 20,
+    `projected ${state.nodes.length} nodes with ${nodeReads} node reads`,
+  );
+});
+
+test('stable semantic projection ignores subpixel private-ax decoration churn', () => {
+  const withDecoration = (widths: number[]) => {
+    const state = elementSettingsSnapshot([]);
+    state.snapshotQuality = { state: 'recovered', backend: 'private-ax' };
+    state.nodes.push(
+      ...widths.map((width, offset) => ({
+        index: offset + 3,
+        ref: `e${offset + 3}`,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Other',
+        rect: { x: 0, y: 152, width, height: 1 / 3 },
+        hittable: false,
+      })),
+    );
+    return state;
+  };
+
+  assert.equal(
+    stableCaptureSignalsEqual(
+      stableCaptureSignal(withDecoration([402, 402])),
+      stableCaptureSignal(withDecoration([382])),
     ),
     true,
   );

--- a/src/commands/interaction/runtime/stable-capture-signal.ts
+++ b/src/commands/interaction/runtime/stable-capture-signal.ts
@@ -1,34 +1,110 @@
-import type { Rect, SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
-import { isNodeVisibleOnScreen, isViewportRootNode } from '@agent-device/contracts/snapshot';
+import type {
+  Rect,
+  SnapshotCaptureBackend,
+  SnapshotNode,
+  SnapshotState,
+} from '@agent-device/kernel/snapshot';
+import {
+  isPositiveFiniteRect,
+  isRectVisibleInViewport,
+  pickLargestRect,
+} from '@agent-device/kernel/rect';
+import {
+  isTapPointInsideViewport,
+  isViewportRootNode,
+  resolveViewportRect,
+} from '@agent-device/contracts/snapshot';
+import { projectIosScrollVisibility } from '../../../snapshot/ios-scroll-visibility.ts';
 
 const GEOMETRY_TOLERANCE_PX = 1;
-export type StableCaptureSignal = { privateAX: boolean; nodes: SignalNode[] };
+export type StableCaptureSignal = {
+  captureBackend?: SnapshotCaptureBackend;
+  nodes: SignalNode[];
+};
 type SignalNode = { identity: string; rect?: Rect };
+type StableVisibilityContext = {
+  largestRootViewport: Rect | null;
+  nodes: SnapshotNode[];
+  rootViewports: Rect[];
+  hiddenIndexes: ReadonlySet<number>;
+  scrollByNodeIndex: ReadonlyMap<number, Pick<SnapshotNode, 'rect'>>;
+};
 
 export function stableCaptureSignal(
-  snapshot: Pick<SnapshotState, 'nodes' | 'snapshotQuality'>,
+  snapshot: Pick<SnapshotState, 'backend' | 'nodes' | 'snapshotQuality'>,
 ): StableCaptureSignal {
-  const privateAX = snapshot.snapshotQuality?.backend === 'private-ax';
-  // The runner already projects private AX by viewport intersection. Settle uses the stricter
-  // center-on-screen view so edge slivers whose intersection flips by a pixel do not restart the
-  // quiet window while the user-visible semantic surface remains unchanged.
-  const source = privateAX
-    ? snapshot.nodes.filter(
-        (node) => isViewportRootNode(node) || isNodeVisibleOnScreen(node, snapshot.nodes),
-      )
-    : snapshot.nodes;
+  // Settle compares a visible semantic projection within one capture backend. Backend trees may
+  // retain offscreen scroll descendants, and letting that internal churn into the signal keeps an
+  // otherwise quiet screen alive for the full budget. The center-on-screen rule also absorbs edge
+  // slivers whose intersection flips by a pixel.
+  const source =
+    snapshot.backend === 'xctest'
+      ? stableVisibleNodes(
+          snapshot.nodes,
+          projectIosScrollVisibility(snapshot.nodes, snapshot.snapshotQuality?.backend),
+        )
+      : snapshot.nodes;
   const nodes = source.map(stableCaptureNodeSignal);
   nodes.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
-  return { privateAX, nodes };
+  return { captureBackend: snapshot.snapshotQuality?.backend, nodes };
+}
+
+function stableVisibleNodes(
+  nodes: SnapshotNode[],
+  projection: ReturnType<typeof projectIosScrollVisibility>,
+): SnapshotNode[] {
+  const rootViewports = nodes.flatMap((node) =>
+    isViewportRootNode(node) && isPositiveFiniteRect(node.rect) ? [node.rect] : [],
+  );
+  const context: StableVisibilityContext = {
+    largestRootViewport: pickLargestRect(rootViewports),
+    nodes,
+    rootViewports,
+    hiddenIndexes: projection.hiddenIndexes,
+    scrollByNodeIndex: projection.scrollByNodeIndex,
+  };
+  return nodes.filter((node) => isStableVisibleNode(node, context));
+}
+
+function isStableVisibleNode(node: SnapshotNode, context: StableVisibilityContext): boolean {
+  if (context.hiddenIndexes.has(node.index)) return false;
+  if (isViewportRootNode(node)) return true;
+  const rect = node.rect;
+  const semantic = hasStableSemanticIdentity(node);
+  if (!rect) return semantic;
+  if (!isPositiveFiniteRect(rect) || isNegligibleStructure(rect, semantic)) return false;
+  const clippingAncestor = context.scrollByNodeIndex.get(node.index);
+  if (clippingAncestor?.rect && !isRectVisibleInViewport(node.rect!, clippingAncestor.rect)) {
+    return false;
+  }
+  return isTapPointInsideViewport(rect, resolveStableViewport(rect, context));
+}
+
+function isNegligibleStructure(rect: Rect, semantic: boolean): boolean {
+  return !semantic && (rect.width <= GEOMETRY_TOLERANCE_PX || rect.height <= GEOMETRY_TOLERANCE_PX);
+}
+
+function resolveStableViewport(rect: Rect, context: StableVisibilityContext): Rect | null {
+  // Private AX is simulator-only and normally has one app-sized root. Keep the shared multi-window
+  // selection semantics without rescanning the full node tree for every leaf.
+  return (
+    pickLargestRect(
+      context.rootViewports.filter((candidate) => isTapPointInsideViewport(rect, candidate)),
+    ) ??
+    context.largestRootViewport ??
+    resolveViewportRect(context.nodes, rect)
+  );
 }
 
 export function stableCaptureSignalsEqual(
   left: StableCaptureSignal | undefined,
   right: StableCaptureSignal,
 ): boolean {
-  // A backend transition changes the semantic representation even if this capture happens to
-  // contain equivalent nodes. Never let the quiet window span that transition.
-  if (!left || left.privateAX !== right.privateAX || left.nodes.length !== right.nodes.length)
+  if (
+    !left ||
+    left.captureBackend !== right.captureBackend ||
+    left.nodes.length !== right.nodes.length
+  )
     return false;
   return left.nodes.every((node, index) => {
     const candidate = right.nodes[index];
@@ -46,13 +122,24 @@ export function stableCaptureSignalsEqual(
 
 function stableCaptureNodeSignal(node: SnapshotNode): SignalNode {
   return {
-    identity: `${node.type ?? ''}#${node.label ?? ''}#${node.identifier ?? ''}`,
+    identity: `${node.type ?? ''}#${stableSemanticIdentity(node)}`,
     ...(node.rect
       ? {
           rect: { ...node.rect },
         }
       : {}),
   };
+}
+function stableSemanticIdentity(node: SnapshotNode): string {
+  return stableSemanticParts(node).join('#');
+}
+function hasStableSemanticIdentity(node: SnapshotNode): boolean {
+  return stableSemanticParts(node).some(Boolean);
+}
+function stableSemanticParts(node: SnapshotNode): string[] {
+  return [node.label, node.identifier, node.value].map((value) =>
+    typeof value === 'string' ? value.trim() : String(value ?? '').trim(),
+  );
 }
 function sortKey(node: SignalNode): string {
   const rect = node.rect;

--- a/src/commands/interaction/runtime/stable-capture.fixtures.ts
+++ b/src/commands/interaction/runtime/stable-capture.fixtures.ts
@@ -1,0 +1,116 @@
+import type { SnapshotState } from '@agent-device/kernel/snapshot';
+import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
+
+export function elementSettingsSnapshot(offscreenRowYs: number[]): SnapshotState {
+  return makeSnapshotState(
+    [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Application',
+        label: 'Element',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+        hittable: false,
+      },
+      {
+        index: 1,
+        depth: 1,
+        parentIndex: 0,
+        type: 'Table',
+        rect: { x: 0, y: 152, width: 402, height: 660 },
+        hittable: true,
+      },
+      {
+        index: 2,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Cell',
+        label: 'Visible profile row',
+        rect: { x: 0, y: 251, width: 402, height: 69 },
+        hittable: true,
+      },
+      {
+        index: 10_000,
+        depth: 2,
+        parentIndex: 1,
+        type: 'StaticText',
+        label: 'Visible table heading',
+        rect: { x: 0, y: 152, width: 180, height: 21 },
+        hittable: false,
+      },
+      ...offscreenRowYs.map((y, offset) => ({
+        index: offset + 3,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Cell',
+        label: '0',
+        rect: { x: 0, y, width: 402, height: 49 },
+        hittable: false,
+      })),
+    ],
+    {
+      backend: 'xctest',
+      snapshotQuality: {
+        state: 'healthy',
+        backend: 'tree',
+      },
+    },
+  );
+}
+
+export function elementCollapsedScrollEdgeSnapshot(labels: [string, string]): SnapshotState {
+  const state = elementSettingsSnapshot([997]);
+  state.snapshotQuality = { state: 'recovered', backend: 'private-ax' };
+  state.nodes.push(
+    {
+      index: 4,
+      ref: 'e4',
+      depth: 3,
+      parentIndex: 3,
+      type: 'StaticText',
+      label: labels[0],
+      rect: { x: 0, y: 152, width: 180, height: 21 },
+      hittable: false,
+    },
+    {
+      index: 5,
+      ref: 'e5',
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: labels[1],
+      rect: { x: 0, y: 152, width: 210, height: 21 },
+      hittable: false,
+    },
+    {
+      index: 6,
+      ref: 'e6',
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Auto',
+      rect: { x: 0, y: 152, width: 35, height: 21 },
+      hittable: false,
+    },
+    {
+      index: 7,
+      ref: 'e7',
+      depth: 3,
+      parentIndex: 1,
+      type: 'Switch',
+      rect: { x: 0, y: 152, width: 51, height: 31 },
+      hittable: true,
+    },
+    {
+      index: 8,
+      ref: 'e8',
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Message bubbles',
+      rect: { x: 0, y: 152, width: 180, height: 21 },
+      hittable: false,
+    },
+  );
+  return state;
+}

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { AgentDeviceBackend } from '../../../backend.ts';
+import { createLocalArtifactAdapter } from '../../../io.ts';
+import {
+  createAgentDevice,
+  createMemorySessionStore,
+  localCommandPolicy,
+} from '../../../runtime.ts';
+import { runStableCaptureLoop } from './stable-capture.ts';
+import { elementSettingsSnapshot } from './stable-capture.fixtures.ts';
+
+test('regular captures settle from visible semantics while offscreen rows churn', async () => {
+  let elapsedMs = 0;
+  const clock = {
+    now: () => elapsedMs,
+    sleep: async (ms: number) => {
+      elapsedMs += ms;
+    },
+  };
+  const snapshots = [
+    elementSettingsSnapshot([1_138, 1_423, 2_144, 2_434]),
+    elementSettingsSnapshot([1_187, 1_423, 1_858, 2_144, 2_261]),
+  ];
+  let captures = 0;
+  const runtime = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => ({ snapshot: snapshots[captures++ % snapshots.length]! }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore(),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  const outcome = await runStableCaptureLoop(
+    runtime,
+    { session: 'default' },
+    { quietMs: 100, timeoutMs: 1_000 },
+  );
+
+  assert.equal(outcome.settled, true);
+  assert.equal(outcome.captures, 2);
+  assert.ok(outcome.waitedMs < 200, `settled after ${outcome.waitedMs}ms`);
+});

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-observation.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-observation.test.ts
@@ -13,6 +13,7 @@ import {
   waitForTypedSnapshotStability,
 } from '../daemon-runtime-port-observation.ts';
 import { makeBaseRequest, makeDependencies, makeSnapshot } from './daemon-runtime-port-fixtures.ts';
+import { elementSettingsNodes } from '../../../../snapshot/ios-scroll-visibility.fixtures.ts';
 
 test('replaces pre-mutation evidence with the stable post-mutation snapshot', async () => {
   const requests: DaemonRequest[] = [];
@@ -127,6 +128,25 @@ test('computes expensive target evidence only for the command policies that cons
   expect(ordinary).not.toHaveProperty('dispatchSelector');
   expect(atomicRetry.surfaceSignature).toMatch(/^[a-f0-9]{64}$/);
   expect(atomicRetry.dispatchSelector).toEqual({ key: 'id', value: 'continue' });
+});
+
+test('uses iOS capture provenance when resolving Maestro targets', () => {
+  const treeSnapshot = makeSnapshot(elementSettingsNodes());
+  treeSnapshot.backend = 'xctest';
+  treeSnapshot.snapshotQuality = { state: 'healthy', backend: 'tree' };
+  const privateAxSnapshot = makeSnapshot(elementSettingsNodes());
+  privateAxSnapshot.backend = 'xctest';
+  privateAxSnapshot.snapshotQuality = { state: 'recovered', backend: 'private-ax' };
+  const query = { selector: { text: 'Theme' }, purpose: 'tap' as const, timeoutMs: 0 };
+  const context = { generation: 0, env: {} };
+
+  expect(
+    resolveTypedMaestroTarget({ query, context, snapshot: treeSnapshot, platform: 'ios' }).matched,
+  ).toBe(true);
+  expect(
+    resolveTypedMaestroTarget({ query, context, snapshot: privateAxSnapshot, platform: 'ios' })
+      .matched,
+  ).toBe(false);
 });
 
 test('compares snapshots before sleeping and captures once beyond a zero settle budget', async () => {

--- a/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
@@ -103,23 +103,22 @@ function resolveTargetFromSnapshot(params: {
   const frame = getSnapshotReferenceFrame(params.snapshot);
   const presentation =
     params.platform === 'ios'
-      ? buildIosInteractiveSnapshotPresentation(params.snapshot.nodes)
+      ? buildIosInteractiveSnapshotPresentation(
+          params.snapshot.nodes,
+          params.snapshot.snapshotQuality?.backend,
+        )
       : undefined;
+  const canonicalSnapshot = presentation
+    ? { ...params.snapshot, nodes: attachRefs(presentation.nodes) }
+    : params.snapshot;
   const resolution = resolveMaestroTargetFromSnapshot(
-    params.snapshot,
+    canonicalSnapshot,
     params.query,
     params.platform,
     {
       interactiveBounds: params.mode === 'tap',
-      interactiveRects: presentation
-        ? new Map(
-            [...presentation.sourceNodes].flatMap(([index, node]) =>
-              node.rect ? [[index, node.rect] as const] : [],
-            ),
-          )
-        : undefined,
-      canonicalSnapshot: presentation
-        ? { ...params.snapshot, nodes: attachRefs(presentation.nodes) }
+      interaction: presentation
+        ? { snapshot: params.snapshot, sourceIndexes: presentation.sourceIndexes }
         : undefined,
     },
   );

--- a/src/daemon/handlers/__tests__/snapshot-capture.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-capture.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest';
 import { buildSnapshotState } from '../snapshot-capture.ts';
 import { buildSnapshotVisibility } from '../../../snapshot/snapshot-visibility.ts';
+import { elementSettingsNodes } from '../../../snapshot/ios-scroll-visibility.fixtures.ts';
 
 test('buildSnapshotState handles undefined nodes gracefully', () => {
   const state = buildSnapshotState({ nodes: undefined, truncated: undefined }, undefined);
@@ -94,6 +95,24 @@ test('buildSnapshotState applies iOS interactive presentation for xctest snapsho
     ['CollectionView', undefined, 0],
     ['Cell', 'General', 1],
   ]);
+});
+
+test('buildSnapshotState scopes collapsed-run projection to private-ax capture provenance', () => {
+  const capture = (backend: 'tree' | 'private-ax') =>
+    buildSnapshotState(
+      {
+        nodes: elementSettingsNodes(),
+        backend: 'xctest',
+        quality: { state: 'healthy', backend },
+      },
+      { snapshotInteractiveOnly: true },
+    );
+
+  expect(capture('private-ax').nodes.some((node) => node.label === 'Theme')).toBe(false);
+  expect(
+    capture('private-ax').nodes.some((node) => node.label === 'Pinned flattened heading'),
+  ).toBe(true);
+  expect(capture('tree').nodes.some((node) => node.label === 'Theme')).toBe(true);
 });
 
 test('buildSnapshotState marks content covered by floating overlays as visible but blocked', () => {

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -169,8 +169,9 @@ export function buildSnapshotState(
     flags?.snapshotScope && data?.backend !== 'macos-helper'
       ? scopeSnapshotNodes(normalizedNodes, flags.snapshotScope)
       : normalizedNodes;
+  const snapshotQuality = snapshotCaptureAnnotationsFrom(data).quality;
   const presentableNodes = shouldPresentIosInteractiveSnapshot(data?.backend, flags)
-    ? presentIosInteractiveSnapshot(scopedNodes)
+    ? presentIosInteractiveSnapshot(scopedNodes, snapshotQuality?.backend)
     : scopedNodes;
   const nodes = attachRefs(
     snapshotRaw
@@ -180,7 +181,6 @@ export function buildSnapshotState(
             data?.backend === 'android' ? isAndroidInputMethodNode : undefined,
         }),
   );
-  const snapshotQuality = snapshotCaptureAnnotationsFrom(data).quality;
   return {
     nodes,
     truncated: data?.truncated,

--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -1,8 +1,9 @@
-import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import type { RawSnapshotNode, SnapshotCaptureBackend } from '@agent-device/kernel/snapshot';
 import { collectIosImplicitScrollableActions } from './actions.ts';
 import { collectIosPresentationNoiseSuppression } from './noise.ts';
 import { collectIosRowPresentation } from './rows.ts';
 import { collectIosWebSemanticPresentation } from './web.ts';
+import { collectIosViewportPresentation } from './viewport.ts';
 import {
   reindexSnapshotNodesWithSuppressedParents,
   type SnapshotTreeRuleContext,
@@ -18,22 +19,42 @@ const IOS_PRESENTATION_RULES: Array<
   collectIosPresentationNoiseSuppression,
 ];
 
-export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
-  return buildIosInteractiveSnapshotPresentation(nodes).nodes;
+export function presentIosInteractiveSnapshot(
+  nodes: RawSnapshotNode[],
+  captureBackend?: SnapshotCaptureBackend,
+): RawSnapshotNode[] {
+  return buildIosInteractiveSnapshotPresentation(nodes, captureBackend).nodes;
 }
 
 export type IosInteractiveSnapshotPresentation = {
   nodes: RawSnapshotNode[];
-  sourceNodes: ReadonlyMap<number, RawSnapshotNode>;
+  sourceIndexes: ReadonlyMap<number, number>;
 };
 
 export function buildIosInteractiveSnapshotPresentation(
   nodes: RawSnapshotNode[],
+  captureBackend?: SnapshotCaptureBackend,
 ): IosInteractiveSnapshotPresentation {
   if (nodes.length === 0) {
-    return { nodes, sourceNodes: new Map() };
+    return { nodes, sourceIndexes: new Map() };
   }
 
+  const sourceIndexes = new Map(nodes.map((node) => [node.index, node.index]));
+  const semanticPresentation = applyIosPresentationPass(nodes, sourceIndexes, captureBackend, true);
+  return applyIosPresentationPass(
+    semanticPresentation.nodes,
+    semanticPresentation.sourceIndexes,
+    captureBackend,
+    false,
+  );
+}
+
+function applyIosPresentationPass(
+  nodes: RawSnapshotNode[],
+  sourceIndexes: ReadonlyMap<number, number>,
+  captureBackend: SnapshotCaptureBackend | undefined,
+  includeSemanticRules: boolean,
+): IosInteractiveSnapshotPresentation {
   const replacements = new Map<number, RawSnapshotNode>();
   const semanticRepresentativeIndexes = new Set<number>();
   const sourceNodesByIndex = new Map(nodes.map((node) => [node.index, node]));
@@ -45,28 +66,32 @@ export function buildIosInteractiveSnapshotPresentation(
     suppressedIndexes,
   };
 
-  for (const rule of IOS_PRESENTATION_RULES) {
-    rule(nodes, ruleContext);
+  collectIosViewportPresentation(nodes, ruleContext, captureBackend);
+  if (includeSemanticRules) {
+    for (const rule of IOS_PRESENTATION_RULES) {
+      rule(nodes, ruleContext);
+    }
   }
 
   if (suppressedIndexes.size === 0 && replacements.size === 0) {
-    return { nodes, sourceNodes: sourceNodesByIndex };
+    return { nodes, sourceIndexes };
   }
 
   const presentedSourceNodes = nodes
     .filter((node) => !suppressedIndexes.has(node.index))
     .map((node) => replacements.get(node.index) ?? node);
-  const sourceNodes = new Map(presentedSourceNodes.map((node) => [node.index, node]));
-  for (const sourceIndex of suppressedIndexes) {
-    const replacement = replacements.get(sourceIndex);
-    if (replacement) sourceNodes.set(sourceIndex, replacement);
-  }
+  const presentedNodes = reindexSnapshotNodesWithSuppressedParents(
+    presentedSourceNodes,
+    suppressedIndexes,
+    nodes,
+  );
   return {
-    nodes: reindexSnapshotNodesWithSuppressedParents(
-      presentedSourceNodes,
-      suppressedIndexes,
-      nodes,
+    nodes: presentedNodes,
+    sourceIndexes: new Map(
+      presentedNodes.map((node, position) => [
+        node.index,
+        sourceIndexes.get(presentedSourceNodes[position]!.index)!,
+      ]),
     ),
-    sourceNodes,
   };
 }

--- a/src/daemon/snapshot-presentation/ios/scroll.ts
+++ b/src/daemon/snapshot-presentation/ios/scroll.ts
@@ -56,10 +56,19 @@ function applyScrollIndicatorReplacement(
   indicator: RawSnapshotNode,
   directions: { above: boolean; below: boolean },
 ): void {
+  const presentedContainer = context.replacements.get(container.index) ?? container;
   mergeReplacement(context.replacements, container, {
-    rect: deriveScrollableViewportRect(container.rect, indicator.rect) ?? container.rect,
-    hiddenContentAbove: mergeHiddenContentFlag(container.hiddenContentAbove, directions.above),
-    hiddenContentBelow: mergeHiddenContentFlag(container.hiddenContentBelow, directions.below),
+    rect:
+      deriveScrollableViewportRect(presentedContainer.rect, indicator.rect) ??
+      presentedContainer.rect,
+    hiddenContentAbove: mergeHiddenContentFlag(
+      presentedContainer.hiddenContentAbove,
+      directions.above,
+    ),
+    hiddenContentBelow: mergeHiddenContentFlag(
+      presentedContainer.hiddenContentBelow,
+      directions.below,
+    ),
   });
 }
 

--- a/src/daemon/snapshot-presentation/ios/viewport.test.ts
+++ b/src/daemon/snapshot-presentation/ios/viewport.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { elementSettingsNodes } from '../../../snapshot/ios-scroll-visibility.fixtures.ts';
+import { presentIosInteractiveSnapshot } from './index.ts';
+
+test('presents one visible Element scroll surface across iOS capture backends', () => {
+  const presented = presentIosInteractiveSnapshot(elementSettingsNodes(), 'private-ax');
+
+  assert.deepEqual(
+    presented.flatMap((node) => (node.label ? [node.label] : [])),
+    [
+      'Element',
+      'Visible table heading',
+      'Pinned flattened heading',
+      'Visible row',
+      'Partially clipped row',
+      'Visible clipped child',
+      'Visible co-located label',
+      'Visible co-located value',
+    ],
+  );
+  assert.equal(presented.find((node) => node.type === 'Table')?.hiddenContentBelow, true);
+});
+
+test('reprojects private-ax visibility after semantic rules tighten a scroll viewport', () => {
+  const edge = { x: 0, y: 100, width: 120, height: 20 };
+  const presented = presentIosInteractiveSnapshot(
+    [
+      { index: 0, depth: 0, type: 'Application' },
+      {
+        index: 1,
+        depth: 1,
+        parentIndex: 0,
+        type: 'Table',
+        rect: { x: 0, y: 100, width: 300, height: 500 },
+      },
+      { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'Visible', rect: edge },
+      {
+        index: 3,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Other',
+        label: 'Vertical scroll bar, 2 pages',
+        value: '0%',
+        rect: { x: 296, y: 100, width: 4, height: 400 },
+      },
+      {
+        index: 4,
+        depth: 2,
+        parentIndex: 1,
+        type: 'Cell',
+        label: 'Hidden precursor',
+        rect: { x: 0, y: 550, width: 300, height: 40 },
+      },
+      ...Array.from({ length: 4 }, (_, offset) => ({
+        index: offset + 5,
+        depth: 3,
+        parentIndex: 1,
+        type: 'StaticText',
+        label: `Collapsed ${offset + 1}`,
+        rect: edge,
+      })),
+    ],
+    'private-ax',
+  );
+
+  assert.deepEqual(
+    presented.flatMap((node) => (node.label ? [node.label] : [])),
+    ['Visible'],
+  );
+});

--- a/src/daemon/snapshot-presentation/ios/viewport.test.ts
+++ b/src/daemon/snapshot-presentation/ios/viewport.test.ts
@@ -69,3 +69,35 @@ test('reprojects private-ax visibility after semantic rules tighten a scroll vie
     ['Visible'],
   );
 });
+
+test('a bottomed scroll indicator preserves viewport-derived hidden content below', () => {
+  const presented = presentIosInteractiveSnapshot([
+    { index: 0, depth: 0, type: 'Application' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      rect: { x: 0, y: 100, width: 300, height: 400 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Offscreen',
+      rect: { x: 0, y: 700, width: 300, height: 40 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      label: 'Vertical scroll bar, 2 pages',
+      value: '100%',
+      rect: { x: 296, y: 100, width: 4, height: 350 },
+    },
+  ]);
+
+  assert.equal(presented.find((node) => node.type === 'Table')?.hiddenContentBelow, true);
+});

--- a/src/daemon/snapshot-presentation/ios/viewport.ts
+++ b/src/daemon/snapshot-presentation/ios/viewport.ts
@@ -1,0 +1,22 @@
+import type { RawSnapshotNode, SnapshotCaptureBackend } from '@agent-device/kernel/snapshot';
+import { projectIosScrollVisibility } from '../../../snapshot/ios-scroll-visibility.ts';
+import { mergeReplacement, type SnapshotTreeRuleContext } from '../tree.ts';
+
+export function collectIosViewportPresentation(
+  nodes: RawSnapshotNode[],
+  context: SnapshotTreeRuleContext,
+  captureBackend?: SnapshotCaptureBackend,
+): void {
+  const projection = projectIosScrollVisibility(nodes, captureBackend);
+  for (const index of projection.hiddenIndexes) {
+    context.suppressedIndexes.add(index);
+  }
+  for (const [scrollIndex, hint] of projection.hintsByScrollIndex) {
+    const scroll = context.sourceNodesByIndex.get(scrollIndex);
+    if (!scroll) continue;
+    mergeReplacement(context.replacements, scroll, {
+      ...(hint.above || scroll.hiddenContentAbove ? { hiddenContentAbove: true } : {}),
+      ...(hint.below || scroll.hiddenContentBelow ? { hiddenContentBelow: true } : {}),
+    });
+  }
+}

--- a/src/snapshot/ios-scroll-visibility.fixtures.ts
+++ b/src/snapshot/ios-scroll-visibility.fixtures.ts
@@ -1,0 +1,204 @@
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+
+const edge = { x: 0, y: 152, width: 180, height: 21 };
+
+export function elementSettingsNodes(): RawSnapshotNode[] {
+  return [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'Element',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      rect: { x: 0, y: 152, width: 402, height: 660 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Visible table heading',
+      rect: edge,
+      hittable: false,
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Pinned flattened heading',
+      rect: edge,
+      hittable: true,
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Visible row',
+      rect: { x: 0, y: 251, width: 402, height: 44 },
+      hittable: true,
+    },
+    {
+      index: 5,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Language',
+      rect: { x: 0, y: 2_000, width: 402, height: 44 },
+      hittable: false,
+    },
+    {
+      index: 6,
+      depth: 3,
+      parentIndex: 5,
+      type: 'StaticText',
+      label: 'Language',
+      rect: edge,
+      hittable: false,
+    },
+    {
+      index: 7,
+      depth: 4,
+      parentIndex: 5,
+      type: 'StaticText',
+      label: 'Hidden language detail',
+      rect: { x: 0, y: 2_000, width: 180, height: 21 },
+      hittable: false,
+    },
+    {
+      index: 8,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Theme',
+      rect: edge,
+      hittable: true,
+    },
+    {
+      index: 9,
+      depth: 4,
+      parentIndex: 8,
+      type: 'StaticText',
+      label: 'Theme detail',
+      rect: edge,
+      hittable: false,
+    },
+    {
+      index: 10,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Auto',
+      rect: edge,
+      hittable: false,
+    },
+    {
+      index: 11,
+      depth: 3,
+      parentIndex: 1,
+      type: 'Switch',
+      rect: edge,
+      hittable: true,
+    },
+    {
+      index: 12,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Message bubbles',
+      rect: edge,
+      hittable: false,
+    },
+    {
+      index: 13,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Partially clipped row',
+      rect: { x: 0, y: 100, width: 402, height: 60 },
+      hittable: true,
+    },
+    {
+      index: 14,
+      depth: 3,
+      parentIndex: 13,
+      type: 'StaticText',
+      label: 'Visible clipped child',
+      rect: { x: 20, y: 153, width: 160, height: 7 },
+      hittable: true,
+    },
+    {
+      index: 15,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Visible co-located label',
+      rect: { x: 0, y: 300, width: 180, height: 21 },
+      hittable: true,
+    },
+    {
+      index: 16,
+      depth: 3,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Visible co-located value',
+      rect: { x: 0, y: 300, width: 180, height: 21 },
+      hittable: false,
+    },
+    {
+      index: 17,
+      depth: 3,
+      parentIndex: 1,
+      type: 'Switch',
+      rect: { x: 0, y: 300, width: 180, height: 21 },
+      hittable: true,
+    },
+  ];
+}
+
+export function collapsedBoundaryNodes(options: {
+  candidateCount: number;
+  separator: boolean;
+}): RawSnapshotNode[] {
+  const nodes: RawSnapshotNode[] = [
+    { index: 0, depth: 0, type: 'Application' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      rect: { x: 0, y: 100, width: 300, height: 500 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      rect: { x: 0, y: 2_000, width: 300, height: 40 },
+    },
+    { index: 3, depth: 3, parentIndex: 2, type: 'StaticText', rect: edge },
+  ];
+  if (options.separator) {
+    nodes.push({ index: 4, depth: 2, parentIndex: 1, type: 'Cell', rect: edge });
+  }
+  const firstCandidateIndex = nodes.length;
+  nodes.push(
+    ...Array.from({ length: options.candidateCount }, (_, offset) => ({
+      index: firstCandidateIndex + offset,
+      depth: 3,
+      parentIndex: 1,
+      type: offset === options.candidateCount - 1 ? 'Switch' : 'StaticText',
+      label: `Visible composite ${offset + 1}`,
+      hittable: offset === options.candidateCount - 1,
+      rect: edge,
+    })),
+  );
+  return nodes;
+}

--- a/src/snapshot/ios-scroll-visibility.test.ts
+++ b/src/snapshot/ios-scroll-visibility.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import { projectIosScrollVisibility } from './ios-scroll-visibility.ts';
+import { collapsedBoundaryNodes, elementSettingsNodes } from './ios-scroll-visibility.fixtures.ts';
+
+test('projects collapsed offscreen descendants without hiding visible edge content', () => {
+  const projection = projectIosScrollVisibility(elementSettingsNodes(), 'private-ax');
+
+  assert.deepEqual(
+    [...projection.hiddenIndexes].sort((a, b) => a - b),
+    [5, 6, 7, 8, 9, 10, 11, 12],
+  );
+  assert.deepEqual(projection.hintsByScrollIndex.get(1), { above: false, below: true });
+});
+
+test('preserves co-located flattened controls away from the effective scroll edge', () => {
+  const projection = projectIosScrollVisibility(elementSettingsNodes(), 'private-ax');
+
+  assert.equal(projection.hiddenIndexes.has(15), false);
+  assert.equal(projection.hiddenIndexes.has(16), false);
+  assert.equal(projection.hiddenIndexes.has(17), false);
+});
+
+test('preserves three adjacent flattened controls below the collapsed-run threshold', () => {
+  const nodes = collapsedBoundaryNodes({ candidateCount: 3, separator: false });
+  assert.deepEqual(
+    [...projectIosScrollVisibility(nodes, 'private-ax').hiddenIndexes].sort((a, b) => a - b),
+    [2, 3],
+  );
+});
+
+test('a visible structural separator preserves four following flattened controls', () => {
+  const nodes = collapsedBoundaryNodes({ candidateCount: 4, separator: true });
+  assert.deepEqual(
+    [...projectIosScrollVisibility(nodes, 'private-ax').hiddenIndexes].sort((a, b) => a - b),
+    [2, 3],
+  );
+});
+
+test('projection is independent of backend node order', () => {
+  const nodes = elementSettingsNodes();
+  const shuffled = [...nodes].reverse();
+
+  assert.deepEqual(
+    [...projectIosScrollVisibility(shuffled, 'private-ax').hiddenIndexes].sort((a, b) => a - b),
+    [5, 6, 7, 8, 9, 10, 11, 12],
+  );
+});
+
+test('resolves deep non-scroll ancestry once per node', () => {
+  let parentReads = 0;
+  const nodes: RawSnapshotNode[] = [
+    { index: 0, depth: 0, type: 'Application' },
+    ...Array.from({ length: 128 }, (_, offset) => ({
+      index: offset + 1,
+      depth: offset + 1,
+      type: 'Other',
+      get parentIndex() {
+        parentReads += 1;
+        return offset;
+      },
+    })),
+  ];
+
+  projectIosScrollVisibility(nodes, 'tree');
+
+  assert.ok(parentReads < nodes.length * 10, `read parentIndex ${parentReads} times`);
+});
+
+test('classifies a deep collapsed-cluster subtree in linear parent reads', () => {
+  let parentReads = 0;
+  const edge = { x: 0, y: 100, width: 100, height: 20 };
+  const nodes: RawSnapshotNode[] = [
+    { index: 0, depth: 0, type: 'Application' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      rect: { x: 0, y: 100, width: 300, height: 500 },
+    },
+    { index: 2, depth: 2, parentIndex: 1, type: 'Cell', rect: edge },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      rect: { x: 0, y: 2_000, width: 300, height: 40 },
+    },
+    { index: 4, depth: 3, parentIndex: 3, type: 'StaticText', rect: edge },
+    { index: 5, depth: 3, parentIndex: 1, type: 'StaticText', rect: edge },
+    ...Array.from({ length: 128 }, (_, offset) => ({
+      index: offset + 6,
+      depth: offset + 4,
+      type: 'Other',
+      rect: edge,
+      get parentIndex() {
+        parentReads += 1;
+        return offset + 5;
+      },
+    })),
+    { index: 134, depth: 3, parentIndex: 1, type: 'StaticText', rect: edge },
+    { index: 135, depth: 3, parentIndex: 1, type: 'Switch', rect: edge },
+    { index: 136, depth: 3, parentIndex: 1, type: 'StaticText', rect: edge },
+  ];
+
+  const projection = projectIosScrollVisibility(nodes, 'private-ax');
+
+  assert.equal(projection.hiddenIndexes.has(136), true);
+  assert.ok(parentReads < nodes.length * 20, `read parentIndex ${parentReads} times`);
+});
+
+test('projects reverse-ordered deep ancestry without exhausting the call stack', () => {
+  const nodes: RawSnapshotNode[] = Array.from({ length: 12_000 }, (_, index) => ({
+    index,
+    depth: index,
+    ...(index > 0 ? { parentIndex: index - 1 } : {}),
+    type: index === 0 ? 'Application' : 'Other',
+  })).reverse();
+
+  assert.doesNotThrow(() => projectIosScrollVisibility(nodes, 'private-ax'));
+});

--- a/src/snapshot/ios-scroll-visibility.ts
+++ b/src/snapshot/ios-scroll-visibility.ts
@@ -1,0 +1,445 @@
+import type { RawSnapshotNode, SnapshotCaptureBackend } from '@agent-device/kernel/snapshot';
+import { isPositiveFiniteRect, isRectVisibleInViewport } from '@agent-device/kernel/rect';
+import { isScrollableNodeLike } from '@agent-device/contracts/snapshot';
+
+type HiddenDirection = 'above' | 'below';
+type ProjectionBuildState = {
+  byIndex: ReadonlyMap<number, RawSnapshotNode>;
+  effectiveLeadingEdgeByScrollIndex: Map<number, { x: number; y: number }>;
+  scrollByNodeIndex: Map<number, RawSnapshotNode>;
+  hiddenDirections: Map<number, HiddenDirection>;
+  hiddenIndexes: Set<number>;
+  hintsByScrollIndex: Map<number, { above: boolean; below: boolean }>;
+  resolvedIndexes: Set<number>;
+};
+type CollapsedClusterCollectionState = {
+  activeAncestorMemo: Map<number, boolean>;
+  activeCluster: RawSnapshotNode[];
+  activeClusterIndexes: Set<number>;
+  activeKey?: string;
+  pendingEvidenceKey?: string;
+};
+const MIN_COLLAPSED_PRIVATE_AX_CLUSTER_SIZE = 4;
+const PRIVATE_AX_EDGE_TOLERANCE_PX = 1;
+
+export type IosScrollVisibilityProjection = {
+  hiddenIndexes: Set<number>;
+  hintsByScrollIndex: Map<number, { above: boolean; below: boolean }>;
+  scrollByNodeIndex: Map<number, RawSnapshotNode>;
+};
+
+export function projectIosScrollVisibility(
+  nodes: RawSnapshotNode[],
+  captureBackend?: SnapshotCaptureBackend,
+): IosScrollVisibilityProjection {
+  const state: ProjectionBuildState = {
+    byIndex: new Map(nodes.map((node) => [node.index, node])),
+    effectiveLeadingEdgeByScrollIndex: new Map(),
+    scrollByNodeIndex: new Map(),
+    hiddenDirections: new Map(),
+    hiddenIndexes: new Set(),
+    hintsByScrollIndex: new Map(),
+    resolvedIndexes: new Set(),
+  };
+
+  for (const node of nodes) {
+    resolveBaseVisibility(node, state);
+  }
+  if (captureBackend === 'private-ax') {
+    collectEffectiveLeadingScrollEdges(nodes, state);
+    suppressCollapsedPrivateAxClusters(nodes, state);
+  }
+
+  return {
+    hiddenIndexes: state.hiddenIndexes,
+    hintsByScrollIndex: state.hintsByScrollIndex,
+    scrollByNodeIndex: state.scrollByNodeIndex,
+  };
+}
+
+function resolveBaseVisibility(node: RawSnapshotNode, state: ProjectionBuildState): void {
+  if (state.resolvedIndexes.has(node.index)) return;
+  const path = collectUnresolvedAncestry(node, state);
+  for (let position = path.length - 1; position >= 0; position -= 1) {
+    resolveCandidateVisibility(path[position]!, state);
+  }
+}
+
+function collectUnresolvedAncestry(
+  node: RawSnapshotNode,
+  state: ProjectionBuildState,
+): RawSnapshotNode[] {
+  const path: RawSnapshotNode[] = [];
+  const visited = new Set<number>();
+  let current: RawSnapshotNode | undefined = node;
+  while (current && !state.resolvedIndexes.has(current.index) && !visited.has(current.index)) {
+    visited.add(current.index);
+    path.push(current);
+    current =
+      typeof current.parentIndex === 'number' ? state.byIndex.get(current.parentIndex) : undefined;
+  }
+  return path;
+}
+
+function resolveCandidateVisibility(candidate: RawSnapshotNode, state: ProjectionBuildState): void {
+  const parent =
+    typeof candidate.parentIndex === 'number'
+      ? state.byIndex.get(candidate.parentIndex)
+      : undefined;
+  const scrollAncestor = resolveScrollAncestor(parent, state.scrollByNodeIndex);
+  state.resolvedIndexes.add(candidate.index);
+  if (!scrollAncestor) return;
+  state.scrollByNodeIndex.set(candidate.index, scrollAncestor);
+  const hidden = classifyBaseHiddenNode(
+    candidate,
+    parent,
+    scrollAncestor,
+    state.hiddenIndexes,
+    state.hiddenDirections,
+  );
+  if (hidden) rememberHiddenNode(candidate, scrollAncestor, hidden.direction, state);
+}
+
+function collectEffectiveLeadingScrollEdges(
+  nodes: RawSnapshotNode[],
+  state: ProjectionBuildState,
+): void {
+  for (const node of nodes) {
+    const candidate = effectiveLeadingEdgeCandidate(node, state.byIndex);
+    if (!candidate) continue;
+    const { edge, scroll } = candidate;
+    const current = state.effectiveLeadingEdgeByScrollIndex.get(scroll.index);
+    if (!current || edge.y < current.y) {
+      state.effectiveLeadingEdgeByScrollIndex.set(scroll.index, edge);
+    }
+  }
+}
+
+function effectiveLeadingEdgeCandidate(
+  node: RawSnapshotNode,
+  byIndex: ReadonlyMap<number, RawSnapshotNode>,
+): { edge: { x: number; y: number }; scroll: RawSnapshotNode } | undefined {
+  const scroll = directScrollableParent(node, byIndex);
+  if (!scroll) return undefined;
+  const rects = visibleRectPair(node, scroll);
+  if (!rects) return undefined;
+  return {
+    scroll,
+    edge: { x: rects.scroll.x, y: Math.max(rects.node.y, rects.scroll.y) },
+  };
+}
+
+function directScrollableParent(
+  node: RawSnapshotNode,
+  byIndex: ReadonlyMap<number, RawSnapshotNode>,
+): RawSnapshotNode | undefined {
+  if (node.parentIndex === undefined || typeof node.depth !== 'number') return undefined;
+  const parent = byIndex.get(node.parentIndex);
+  return parent &&
+    typeof parent.depth === 'number' &&
+    node.depth === parent.depth + 1 &&
+    isScrollableNodeLike(parent)
+    ? parent
+    : undefined;
+}
+
+function visibleRectPair(
+  node: RawSnapshotNode,
+  scroll: RawSnapshotNode,
+):
+  | {
+      node: NonNullable<RawSnapshotNode['rect']>;
+      scroll: NonNullable<RawSnapshotNode['rect']>;
+    }
+  | undefined {
+  if (!isPositiveFiniteRect(node.rect) || !isPositiveFiniteRect(scroll.rect)) return undefined;
+  return isRectVisibleInViewport(node.rect, scroll.rect)
+    ? { node: node.rect, scroll: scroll.rect }
+    : undefined;
+}
+
+function resolveScrollAncestor(
+  parent: RawSnapshotNode | undefined,
+  scrollByNodeIndex: ReadonlyMap<number, RawSnapshotNode>,
+): RawSnapshotNode | undefined {
+  if (!parent) return undefined;
+  return isScrollableNodeLike(parent) ? parent : scrollByNodeIndex.get(parent.index);
+}
+
+function rememberHiddenNode(
+  node: RawSnapshotNode,
+  scrollAncestor: RawSnapshotNode,
+  direction: HiddenDirection | undefined,
+  state: ProjectionBuildState,
+): void {
+  state.hiddenIndexes.add(node.index);
+  if (!direction) return;
+  state.hiddenDirections.set(node.index, direction);
+  rememberHint(state.hintsByScrollIndex, scrollAncestor.index, direction);
+}
+
+function classifyBaseHiddenNode(
+  node: RawSnapshotNode,
+  parent: RawSnapshotNode | undefined,
+  scrollAncestor: RawSnapshotNode,
+  hiddenIndexes: ReadonlySet<number>,
+  hiddenDirections: ReadonlyMap<number, HiddenDirection>,
+): { direction?: HiddenDirection } | undefined {
+  if (parent && hiddenIndexes.has(parent.index)) {
+    return { direction: hiddenDirections.get(parent.index) };
+  }
+  if (!isPositiveFiniteRect(node.rect) || !isPositiveFiniteRect(scrollAncestor.rect)) {
+    return undefined;
+  }
+  const offscreen = offscreenDirection(node.rect, scrollAncestor.rect);
+  if (offscreen) return { direction: offscreen };
+  if (!isRectVisibleInViewport(node.rect, scrollAncestor.rect)) return undefined;
+  return undefined;
+}
+
+function suppressCollapsedPrivateAxClusters(
+  nodes: RawSnapshotNode[],
+  state: ProjectionBuildState,
+): void {
+  for (const cluster of collectCollapsedPrivateAxClusters(nodes, state)) {
+    suppressCollapsedCluster(cluster, state.hiddenIndexes);
+  }
+  propagateSuppressionToDescendants(nodes, state);
+}
+
+function collectCollapsedPrivateAxClusters(
+  nodes: RawSnapshotNode[],
+  state: ProjectionBuildState,
+): RawSnapshotNode[][] {
+  const orderedNodes = isIndexOrdered(nodes) ? nodes : [...nodes].sort((a, b) => a.index - b.index);
+  const clusters: RawSnapshotNode[][] = [];
+  const collection: CollapsedClusterCollectionState = {
+    activeAncestorMemo: new Map(),
+    activeCluster: [],
+    activeClusterIndexes: new Set(),
+  };
+  for (const node of orderedNodes) {
+    advanceCollapsedPrivateAxCluster(node, state, collection, clusters);
+  }
+  clusters.push(collection.activeCluster);
+  return clusters;
+}
+
+function advanceCollapsedPrivateAxCluster(
+  node: RawSnapshotNode,
+  projection: ProjectionBuildState,
+  collection: CollapsedClusterCollectionState,
+  clusters: RawSnapshotNode[][],
+): void {
+  const scroll = projection.scrollByNodeIndex.get(node.index);
+  const evidenceKey = collapsedPrivateAxEvidenceKey(node, scroll, projection);
+  if (evidenceKey) {
+    collection.pendingEvidenceKey = evidenceKey;
+    return;
+  }
+  const candidateKey = collapsedPrivateAxCandidateKey(node, scroll, projection);
+  const key = candidateKey === collection.pendingEvidenceKey ? candidateKey : undefined;
+  if (shouldSkipCollapsedClusterBoundary(node, key, projection, collection)) return;
+  if (!key) collection.pendingEvidenceKey = undefined;
+  if (key !== collection.activeKey) resetCollapsedCluster(collection, clusters, key);
+  if (!key) return;
+  collection.activeCluster.push(node);
+  collection.activeClusterIndexes.add(node.index);
+}
+
+function shouldSkipCollapsedClusterBoundary(
+  node: RawSnapshotNode,
+  key: string | undefined,
+  projection: ProjectionBuildState,
+  collection: CollapsedClusterCollectionState,
+): boolean {
+  return (
+    !key &&
+    (projection.hiddenIndexes.has(node.index) ||
+      isActiveClusterDescendant(node, projection, collection))
+  );
+}
+
+function collapsedPrivateAxEvidenceKey(
+  node: RawSnapshotNode,
+  scroll: RawSnapshotNode | undefined,
+  projection: ProjectionBuildState,
+): string | undefined {
+  if (!scroll || !isCollapsedHiddenPrecursor(node, scroll, projection)) return undefined;
+  const edge = projection.effectiveLeadingEdgeByScrollIndex.get(scroll.index);
+  return edge ? collapsedPrivateAxClusterKeyForEdge(scroll, edge) : undefined;
+}
+
+function collapsedPrivateAxCandidateKey(
+  node: RawSnapshotNode,
+  scroll: RawSnapshotNode | undefined,
+  projection: ProjectionBuildState,
+): string | undefined {
+  return scroll && isCollapsedPrivateAxCandidate(node, scroll, projection)
+    ? collapsedPrivateAxClusterKey(node, scroll)
+    : undefined;
+}
+
+function isActiveClusterDescendant(
+  node: RawSnapshotNode,
+  projection: ProjectionBuildState,
+  collection: CollapsedClusterCollectionState,
+): boolean {
+  return hasAncestorInCluster(
+    node,
+    collection.activeClusterIndexes,
+    projection.byIndex,
+    collection.activeAncestorMemo,
+  );
+}
+
+function resetCollapsedCluster(
+  collection: CollapsedClusterCollectionState,
+  clusters: RawSnapshotNode[][],
+  key: string | undefined,
+): void {
+  clusters.push(collection.activeCluster);
+  collection.activeCluster = [];
+  collection.activeClusterIndexes = new Set();
+  collection.activeAncestorMemo = new Map();
+  collection.activeKey = key;
+}
+
+function propagateSuppressionToDescendants(
+  nodes: RawSnapshotNode[],
+  state: ProjectionBuildState,
+): void {
+  const inheritedSuppression = new Map<number, boolean>();
+  for (const node of nodes) {
+    if (hasSuppressedAncestor(node, state, inheritedSuppression)) {
+      state.hiddenIndexes.add(node.index);
+    }
+  }
+}
+
+function hasAncestorInCluster(
+  node: RawSnapshotNode,
+  clusterIndexes: ReadonlySet<number>,
+  byIndex: ReadonlyMap<number, RawSnapshotNode>,
+  memo: Map<number, boolean>,
+): boolean {
+  if (clusterIndexes.size === 0) return false;
+  return hasAncestorMatching(node, byIndex, memo, (index) => clusterIndexes.has(index));
+}
+
+function isIndexOrdered(nodes: RawSnapshotNode[]): boolean {
+  return nodes.every((node, index) => index === 0 || nodes[index - 1]!.index <= node.index);
+}
+
+function suppressCollapsedCluster(cluster: RawSnapshotNode[], hiddenIndexes: Set<number>): void {
+  if (cluster.length < MIN_COLLAPSED_PRIVATE_AX_CLUSTER_SIZE) return;
+  for (const node of cluster) hiddenIndexes.add(node.index);
+}
+
+function isCollapsedPrivateAxCandidate(
+  node: RawSnapshotNode,
+  scroll: RawSnapshotNode,
+  state: ProjectionBuildState,
+): boolean {
+  const edge = state.effectiveLeadingEdgeByScrollIndex.get(scroll.index);
+  return (
+    edge !== undefined &&
+    node.parentIndex === scroll.index &&
+    typeof node.depth === 'number' &&
+    typeof scroll.depth === 'number' &&
+    node.depth > scroll.depth + 1 &&
+    isPositiveFiniteRect(node.rect) &&
+    isAtEffectiveLeadingEdge(node, edge)
+  );
+}
+
+function isCollapsedHiddenPrecursor(
+  node: RawSnapshotNode,
+  scroll: RawSnapshotNode,
+  state: ProjectionBuildState,
+): boolean {
+  return (
+    state.hiddenIndexes.has(node.index) &&
+    state.hiddenDirections.has(node.index) &&
+    node.parentIndex === scroll.index &&
+    typeof node.depth === 'number' &&
+    typeof scroll.depth === 'number' &&
+    node.depth === scroll.depth + 1
+  );
+}
+
+function isAtEffectiveLeadingEdge(node: RawSnapshotNode, edge: { x: number; y: number }): boolean {
+  return Boolean(
+    node.rect &&
+    Math.abs(node.rect.x - edge.x) <= PRIVATE_AX_EDGE_TOLERANCE_PX &&
+    Math.abs(node.rect.y - edge.y) <= PRIVATE_AX_EDGE_TOLERANCE_PX,
+  );
+}
+
+function offscreenDirection(
+  rect: NonNullable<RawSnapshotNode['rect']>,
+  viewport: NonNullable<RawSnapshotNode['rect']>,
+): HiddenDirection | undefined {
+  if (rect.y + rect.height < viewport.y) return 'above';
+  if (rect.y > viewport.y + viewport.height) return 'below';
+  return undefined;
+}
+
+function collapsedPrivateAxClusterKey(node: RawSnapshotNode, scroll: RawSnapshotNode): string {
+  return collapsedPrivateAxClusterKeyForEdge(scroll, node.rect!);
+}
+
+function collapsedPrivateAxClusterKeyForEdge(
+  scroll: RawSnapshotNode,
+  edge: { x: number; y: number },
+): string {
+  return `${scroll.index}:${Math.round(edge.x)}:${Math.round(edge.y)}`;
+}
+
+function hasSuppressedAncestor(
+  node: RawSnapshotNode,
+  state: ProjectionBuildState,
+  memo: Map<number, boolean>,
+): boolean {
+  return hasAncestorMatching(node, state.byIndex, memo, (index) => state.hiddenIndexes.has(index));
+}
+
+function hasAncestorMatching(
+  node: RawSnapshotNode,
+  byIndex: ReadonlyMap<number, RawSnapshotNode>,
+  memo: Map<number, boolean>,
+  matches: (index: number) => boolean,
+): boolean {
+  const cached = memo.get(node.index);
+  if (cached !== undefined) return cached;
+  const path: number[] = [];
+  const visited = new Set<number>();
+  let current: RawSnapshotNode | undefined = node;
+  let result = false;
+  while (current?.parentIndex !== undefined && !visited.has(current.index)) {
+    visited.add(current.index);
+    path.push(current.index);
+    if (matches(current.parentIndex)) {
+      result = true;
+      break;
+    }
+    const parentResult = memo.get(current.parentIndex);
+    if (parentResult !== undefined) {
+      result = parentResult;
+      break;
+    }
+    current = byIndex.get(current.parentIndex);
+  }
+  for (const index of path) memo.set(index, result);
+  return result;
+}
+
+function rememberHint(
+  hints: Map<number, { above: boolean; below: boolean }>,
+  scrollIndex: number,
+  direction: HiddenDirection,
+): void {
+  const hint = hints.get(scrollIndex) ?? { above: false, below: false };
+  hint[direction] = true;
+  hints.set(scrollIndex, hint);
+}


### PR DESCRIPTION
## Summary

Prevent private-AX offscreen scroll content from becoming actionable or destabilizing settle by projecting one visible semantic surface through snapshot output, Maestro target resolution, and stability capture.

Preserve canonical-to-raw target provenance and scroll hints across composed presentation passes. Related to #1797.

This touches 18 files and intentionally spans the iOS runner, daemon presentation, settle signal, and Maestro interaction boundary because they consume the same snapshot semantics.

## Validation

On a disposable clone of the logged-in Element simulator, a forced private-AX action snapshot suppressed the known offscreen Language, Theme, Clear cache, Report bug, and Message bubbles nodes. After a bounded settled scroll, the real Language and Theme rows reappeared and Theme resolved semantically.

The composed-pass and bottomed-scroll-indicator regressions were each observed red before their fixes and green after restoration. Full pnpm check:affected --run passed locally; native and device lanes remain GitHub-authoritative.