### PR TITLE
chore(format): ignore .claude/** in oxfmt so a main-checkout format can't sweep worktrees

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "printWidth": 100,
   "sortPackageJson": false,
   "ignorePatterns": [
+    ".claude/**",
     "dist/**",
     "node_modules/**",
     "**/*.md",


### PR DESCRIPTION
## What
Add `.claude/**` to `.oxfmtrc.json` `ignorePatterns`.

## Why
`pnpm format` run from the main checkout walks into `.claude/worktrees/*/`. The existing ignore `scripts/maestro-conformance/corpus/**` is anchored at the repo root, so it does not match `.claude/worktrees/<wt>/scripts/maestro-conformance/corpus/**`, and oxfmt (with `singleQuote: true`) rewrote the byte-exact conformance oracle corpus in every worktree — 45 files × 15 worktrees, all at 2026-08-17 20:59:34, main's own corpus untouched. `.claude/` is only ignored via the user's global gitignore, which oxfmt does not read.

## Checks
- `oxfmt --check .` green.
- No behaviour change for CI (`.claude/` never exists on runners).

Related: #1781 (worktree-heavy workflow).