### PR TITLE
feat(ai-sdk): add agent-device/ai-sdk tool set and document the MCP zero-code path

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -13,6 +13,7 @@
     "src/sdk/contracts.ts",
     "src/sdk/selectors.ts",
     "src/sdk/finders.ts",
+    "src/ai-sdk/index.ts",
     "src/bin.ts",
     "src/client/companion-tunnel.ts",
     "src/daemon.ts",
@@ -32,6 +33,7 @@
     "examples/sdk/metro-runtime.ts",
     "examples/sdk/contracts-result.ts",
     "examples/sdk/batch-orchestration.ts",
+    "examples/sdk/ai-sdk-tools.ts",
     "test/scripts/metro-prepare-packaged-smoke.mjs",
     "test/integration/*.test.ts",
     "website/docs/404.mdx",
@@ -96,7 +98,7 @@
     },
     {
       "comment": "Published package surface (see package.json#exports); consumed by SDK users, not internally.",
-      "file": "src/sdk/*.ts",
+      "file": "{src/sdk/*.ts,src/ai-sdk/index.ts}",
       "exports": ["*"]
     },
     {

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,8 +10,9 @@ fenced TypeScript code block in the doc itself against the real `agent-device/*`
 ## sdk/
 
 Standalone scripts under [`sdk/`](./sdk) exercise the published `agent-device` export map —
-`agent-device`, `agent-device/metro`, `agent-device/contracts`, and `agent-device/batch` — the same
-way a Node consumer or the agent-device-cloud bridge would. Each file:
+`agent-device`, `agent-device/metro`, `agent-device/contracts`, `agent-device/batch`, and
+`agent-device/ai-sdk` — the same way a Node consumer or the agent-device-cloud bridge would. Each
+file:
 
 - has a top comment stating what it demonstrates and its prerequisites (daemon running,
   device/simulator available);
@@ -30,6 +31,7 @@ way a Node consumer or the agent-device-cloud bridge would. Each file:
 | [`metro-runtime.ts`](./sdk/metro-runtime.ts) | `agent-device/metro` | `normalizeBaseUrl`, `resolveRuntimeTransport` |
 | [`contracts-result.ts`](./sdk/contracts-result.ts) | `agent-device/contracts` | typed result consumption via `centerOfRect` |
 | [`batch-orchestration.ts`](./sdk/batch-orchestration.ts) | `agent-device/batch` | `runBatch` for a custom transport |
+| [`ai-sdk-tools.ts`](./sdk/ai-sdk-tools.ts) | `agent-device/ai-sdk` | `createAgentDeviceTools` driven by a `ToolLoopAgent` |
 
 ## test-app/
 

--- a/examples/sdk/ai-sdk-tools.ts
+++ b/examples/sdk/ai-sdk-tools.ts
@@ -1,0 +1,52 @@
+/**
+ * AI SDK tool set: build a typed tool set from the command registry with
+ * `createAgentDeviceTools()`, drive it through a `ToolLoopAgent`, then close
+ * the session — no hand-written tool definitions.
+ *
+ * Demonstrates: `createAgentDeviceTools` from the `agent-device/ai-sdk`
+ * subpath.
+ *
+ * Prerequisites: an `agent-device` daemon target (a booted iOS simulator),
+ * `ai` installed, and `AI_MODEL` set to a model available through your
+ * configured AI SDK provider. This file typechecks without any of those;
+ * running it for real also requires `pnpm build` first, so the package
+ * resolves at runtime.
+ *
+ * Run: node --experimental-strip-types examples/sdk/ai-sdk-tools.ts
+ */
+import { ToolLoopAgent } from 'ai';
+import { createAgentDeviceTools } from 'agent-device/ai-sdk';
+
+async function main(): Promise<void> {
+  const { tools, client, toolApproval } = await createAgentDeviceTools({
+    session: 'sdk-example-ai-sdk',
+    platform: 'ios',
+    // Closing the session is the one destructive action in this example's
+    // default tool set, so require a human decision before the model can call it.
+    approval: { close: 'user-approval' },
+  });
+
+  const agent = new ToolLoopAgent({
+    model: process.env.AI_MODEL!,
+    instructions: [
+      'Inspect the current UI before acting.',
+      'Verify the requested outcome with another snapshot before reporting success.',
+    ].join('\n'),
+    tools,
+    toolApproval,
+  });
+
+  try {
+    await client.apps.open({ app: 'com.apple.Preferences', platform: 'ios' });
+
+    const result = await agent.generate({
+      prompt: 'Open Notifications settings and report whether notifications are enabled.',
+    });
+
+    console.log(result.text);
+  } finally {
+    await client.sessions.close();
+  }
+}
+
+await main();

--- a/examples/sdk/tsconfig.json
+++ b/examples/sdk/tsconfig.json
@@ -11,7 +11,8 @@
       "agent-device/install-source": ["../../src/sdk/install-source.ts"],
       "agent-device/android-adb": ["../../src/sdk/android-adb.ts"],
       "agent-device/contracts": ["../../src/sdk/contracts.ts"],
-      "agent-device/finders": ["../../src/sdk/finders.ts"]
+      "agent-device/finders": ["../../src/sdk/finders.ts"],
+      "agent-device/ai-sdk": ["../../src/ai-sdk/index.ts"]
     }
   },
   // Scoped to this directory only: these examples import `agent-device/...`

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "./finders": {
       "types": "./dist/src/finders.d.ts",
       "import": "./dist/src/finders.js"
+    },
+    "./ai-sdk": {
+      "types": "./dist/src/ai-sdk.d.ts",
+      "import": "./dist/src/ai-sdk.js"
     }
   },
   "engines": {
@@ -256,10 +260,18 @@
     "yaml": "^2.9.0",
     "yauzl": "^3.4.0"
   },
+  "peerDependencies": {
+    "ai": "^6.0.0 || ^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "@agent-device/capture-kit": "workspace:*",
     "@agent-device/ad-replay": "workspace:*",
     "@agent-device/ad-script": "workspace:*",
+    "@agent-device/capture-kit": "workspace:*",
     "@agent-device/contracts": "workspace:*",
     "@agent-device/kernel": "workspace:*",
     "@agent-device/maestro": "workspace:*",
@@ -278,11 +290,13 @@
     "@chenglou/freerange": "^0.0.1",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^22.19.21",
     "@types/pngjs": "^6.0.5",
     "@types/tar-stream": "^3.1.4",
     "@types/yauzl": "^2.10.3",
     "@vitest/coverage-v8": "4.1.8",
+    "ai": "^7.0.66",
     "fallow": "^2.95.0",
     "fast-check": "^4.9.0",
     "oxc-parser": "^0.138.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: 9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.19.21)(supports-color@7.2.0))(vitest@4.1.8)
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21
@@ -114,6 +117,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
+      ai:
+        specifier: ^7.0.66
+        version: 7.0.66(zod@4.3.6)
       fallow:
         specifier: ^2.95.0
         version: 2.95.0
@@ -334,6 +340,22 @@ importers:
         version: 2.0.12(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.13)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0)
 
 packages:
+
+  '@ai-sdk/gateway@4.0.52':
+    resolution: {integrity: sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
@@ -1561,6 +1583,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1749,6 +1774,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
@@ -1786,6 +1815,9 @@ packages:
 
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@yuku-codegen/binding-darwin-arm64@0.5.44':
     resolution: {integrity: sha512-mpZc7hrjl/qxcbEMS6vVLE0lO4DjiXCvrp3gYbZ58bbmsSxSGCTlOCA0lpeLXAKOZxe0ZrVoqKteaewFF2Vbuw==}
@@ -1925,6 +1957,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.66:
+    resolution: {integrity: sha512-wBUyoCYF3GVr+62nelBgR8YbpTSsMZrzFyOOjiwijylNSM2TFCW35C+Pml2vc59/WLMpyhS/LWZ55M+B9DAcSg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -2535,6 +2573,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3657,6 +3698,26 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@4.0.52(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.27(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider@4.0.7':
+    dependencies:
+      json-schema: 0.4.0
 
   '@andrewbranch/untar.js@1.0.3': {}
 
@@ -4797,6 +4858,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -4900,6 +4963,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -4954,6 +5019,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@workflow/serde@4.1.0': {}
 
   '@yuku-codegen/binding-darwin-arm64@0.5.44':
     optional: true
@@ -5030,6 +5097,13 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@7.0.66(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.52(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
+      zod: 4.3.6
 
   ajv@8.18.0:
     dependencies:
@@ -5647,6 +5721,8 @@ snapshots:
   json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 

--- a/scripts/__tests__/package-closure-audit.test.ts
+++ b/scripts/__tests__/package-closure-audit.test.ts
@@ -26,7 +26,11 @@ afterEach(() => {
 });
 
 /** Lays out a fake installed package: shipped files plus the `dependencies` the manifest declares. */
-function fixturePackage(files: Record<string, string>, dependencies: string[] = []): () => void {
+function fixturePackage(
+  files: Record<string, string>,
+  dependencies: string[] = [],
+  peerDependencies: string[] = [],
+): () => void {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-closure-fixture-'));
   tempRoots.push(root);
   for (const [relative, source] of Object.entries(files)) {
@@ -36,6 +40,7 @@ function fixturePackage(files: Record<string, string>, dependencies: string[] = 
   }
   const manifest: PackedManifest = {
     dependencies: Object.fromEntries(dependencies.map((name) => [name, '1.0.0'])),
+    peerDependencies: Object.fromEntries(peerDependencies.map((name) => [name, '1.0.0'])),
   };
   return () => void auditDependencyClosure(root, manifest);
 }
@@ -90,6 +95,31 @@ for (const [form, template] of Object.entries(LAZY_FORMS)) {
     audit();
   });
 }
+
+// agent-device/ai-sdk imports the optional peer `ai`, resolved from the consumer's own
+// install rather than ours — the audit must accept `peerDependencies` as a valid answer to
+// "how does this import resolve," the same way it accepts `dependencies`.
+test('an import satisfied only by a peerDependency satisfies the closure audit', () => {
+  const audit = fixturePackage({ 'dist/ai-sdk.js': "import { tool } from 'ai';" }, [], ['ai']);
+  audit();
+});
+
+test('an import satisfied by neither dependencies nor peerDependencies still fails the closure audit', () => {
+  const audit = fixturePackage({ 'dist/ai-sdk.js': "import { tool } from 'ai';" });
+  assert.throws(audit, (error: Error) => {
+    assert.match(
+      error.message,
+      /Imported but not declared in "dependencies" or "peerDependencies"/,
+    );
+    assert.match(error.message, /ai in dist\/ai-sdk\.js/);
+    return true;
+  });
+});
+
+test('a peerDependency does not exempt a declared dependency from the "never imported" check', () => {
+  const audit = fixturePackage({ 'dist/cli.js': 'export const x = 1;' }, ['pngjs'], ['ai']);
+  assert.throws(audit, /Declared in "dependencies" but never imported[\s\S]*- pngjs/);
+});
 
 test('a subpath import is attributed to the package that must be declared', () => {
   const audit = fixturePackage({ 'dist/cli.js': 'await import(`@limrun/api/client`);' }, [

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -49,6 +49,7 @@ const TARGET_DAG_RANK = new Map([
   ['cli-schema', 3],
   ['commands', 3],
   ['mcp', 3],
+  ['ai-sdk', 4],
   ['client', 4],
   ['compat', 4],
   ['daemon-server', 4],

--- a/scripts/lib/shipped-imports.ts
+++ b/scripts/lib/shipped-imports.ts
@@ -49,6 +49,16 @@ import { walkFiles } from './walk-files.ts';
 
 export type PackedManifest = {
   dependencies?: Record<string, string>;
+  /**
+   * A peer dependency (e.g. `ai` for `agent-device/ai-sdk`) is resolved from
+   * the consumer's own install, not ours — but it is still a truthful answer
+   * to "how does a shipped import of this package resolve," so it counts
+   * toward the forward half of the audit below. Whether it is optional
+   * doesn't change that: an *optional* peer only changes whether npm errors
+   * when it's absent, not whether declaring it is the correct fix for an
+   * import the shipped files actually make.
+   */
+  peerDependencies?: Record<string, string>;
 };
 
 /** Every file extension the package ships that Node can resolve a specifier from. */
@@ -237,17 +247,18 @@ export function auditDependencyClosure(
   installedRoot: string,
   manifest: PackedManifest,
 ): Map<string, string[]> {
-  const declared = new Set(Object.keys(manifest.dependencies ?? {}));
+  const dependencies = new Set(Object.keys(manifest.dependencies ?? {}));
+  const declared = new Set([...dependencies, ...Object.keys(manifest.peerDependencies ?? {})]);
   const importedBy = shippedImports(installedRoot);
   const problems = [
     ...mismatch(
-      'Imported but not declared in "dependencies" (a published install cannot resolve these):',
+      'Imported but not declared in "dependencies" or "peerDependencies" (a published install cannot resolve these):',
       [...importedBy].filter(([name]) => !declared.has(name)).flatMap(([, sites]) => sites),
       'Declare the package, or add it to `deps.alwaysBundle` in tsdown.config.ts.',
     ),
     ...mismatch(
       'Declared in "dependencies" but never imported (every user installs these for nothing):',
-      [...declared].filter((name) => !importedBy.has(name)),
+      [...dependencies].filter((name) => !importedBy.has(name)),
       'Remove the dependency, or stop bundling it in tsdown.config.ts.',
     ),
   ];

--- a/src/__tests__/package-exports.test.ts
+++ b/src/__tests__/package-exports.test.ts
@@ -33,6 +33,7 @@ const supportedSubpaths = [
   './contracts',
   './selectors',
   './finders',
+  './ai-sdk',
 ];
 const typeOnlySubpaths = new Set(['./remote-config']);
 

--- a/src/ai-sdk/__tests__/index.test.ts
+++ b/src/ai-sdk/__tests__/index.test.ts
@@ -90,6 +90,34 @@ test('defaults to the core tool set and pins the session for every call', async 
   ]);
 });
 
+test('MCP transport/config controls are hidden from the schema and cannot reach the executor', async () => {
+  const { tools } = await createAgentDeviceTools({ session: 'pinned-session' });
+
+  const schema = rawSchemaOf(tools, 'snapshot');
+  for (const field of ['stateDir', 'includeCost', 'responseLevel', 'mcpOutputFormat']) {
+    assert.equal(field in schema.properties, false, `${field} must not be model-visible`);
+  }
+
+  // Simulate a caller that bypasses schema validation (e.g. a non-conforming
+  // provider) and supplies these fields directly: the pinned session must
+  // still hold, and none of them may reach the shared executor.
+  await executeOf(
+    tools,
+    'snapshot',
+  )({
+    interactiveOnly: true,
+    stateDir: '/tmp/attacker-controlled-state-dir',
+    includeCost: true,
+    responseLevel: 'full',
+    mcpOutputFormat: 'json',
+    session: 'attacker-supplied-session',
+  });
+
+  assert.deepEqual(executorCalls, [
+    { name: 'snapshot', input: { interactiveOnly: true, session: 'pinned-session' } },
+  ]);
+});
+
 test("set: 'all' includes extended-tier commands too", async () => {
   const { tools } = await createAgentDeviceTools({ session: 's', set: 'all' });
   assert.ok('devices' in tools, 'set: all reaches every MCP-exposed command, not just core');

--- a/src/ai-sdk/__tests__/index.test.ts
+++ b/src/ai-sdk/__tests__/index.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { afterEach, test, vi } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import type { AgentDeviceClient } from '../../client/client-types.ts';
+import type { ToolResult } from '../../mcp/command-tools.ts';
+
+const createClientCalls: unknown[] = [];
+const executorCalls: Array<{ name: string; input: Record<string, unknown> }> = [];
+
+const defaultExecuteResult: ToolResult = {
+  isError: false,
+  structuredContent: { ok: true },
+  content: [{ type: 'text', text: 'ok' }],
+};
+let executeResult: (
+  name: string,
+  input: Record<string, unknown>,
+) => Promise<ToolResult> = async () => defaultExecuteResult;
+
+vi.mock('../../agent-device-client.ts', () => ({
+  createAgentDeviceClient: (config: unknown) => {
+    createClientCalls.push(config);
+    return { marker: 'stub-client' } as unknown as AgentDeviceClient;
+  },
+}));
+
+vi.mock('../../mcp/command-tools.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../mcp/command-tools.ts')>();
+  return {
+    ...actual,
+    createCommandToolExecutor: () => ({
+      execute: async (name: string, input: Record<string, unknown>) => {
+        executorCalls.push({ name, input });
+        return executeResult(name, input);
+      },
+    }),
+  };
+});
+
+const { createAgentDeviceTools } = await import('../index.ts');
+
+afterEach(() => {
+  createClientCalls.length = 0;
+  executorCalls.length = 0;
+  executeResult = async () => defaultExecuteResult;
+});
+
+// jsonSchema() (from the real, installed `ai` package) stores the raw schema
+// under `.jsonSchema`, so this reads exactly what the model would see.
+function rawSchemaOf(
+  tools: Awaited<ReturnType<typeof createAgentDeviceTools>>['tools'],
+  name: string,
+) {
+  return (
+    tools[name] as unknown as {
+      inputSchema: { jsonSchema: { properties: Record<string, unknown> } };
+    }
+  ).inputSchema.jsonSchema;
+}
+
+function executeOf(
+  tools: Awaited<ReturnType<typeof createAgentDeviceTools>>['tools'],
+  name: string,
+) {
+  return tools[name]!.execute as (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+test('defaults to the core tool set and pins the session for every call', async () => {
+  const { tools, client, toolApproval } = await createAgentDeviceTools({ session: 'my-session' });
+
+  assert.deepEqual(createClientCalls, [{ session: 'my-session' }]);
+  assert.equal((client as unknown as { marker: string }).marker, 'stub-client');
+  assert.equal(toolApproval, undefined);
+
+  assert.ok('snapshot' in tools, 'snapshot is core-tier');
+  assert.equal(
+    'devices' in tools,
+    false,
+    'devices is extended-tier, excluded from the core default',
+  );
+
+  const schema = rawSchemaOf(tools, 'snapshot');
+  assert.equal('session' in schema.properties, false, 'session is always hidden from the model');
+  assert.equal('mcpOutputFormat' in schema.properties, false, 'mcpOutputFormat is always hidden');
+  assert.ok('platform' in schema.properties, 'platform stays visible when not pinned');
+
+  await executeOf(tools, 'snapshot')({ interactiveOnly: true });
+  assert.deepEqual(executorCalls, [
+    { name: 'snapshot', input: { interactiveOnly: true, session: 'my-session' } },
+  ]);
+});
+
+test("set: 'all' includes extended-tier commands too", async () => {
+  const { tools } = await createAgentDeviceTools({ session: 's', set: 'all' });
+  assert.ok('devices' in tools, 'set: all reaches every MCP-exposed command, not just core');
+  assert.ok(Object.keys(tools).length > 20);
+});
+
+test('platform is pinned per call and removed from the input schema', async () => {
+  const { tools } = await createAgentDeviceTools({ session: 's', platform: 'ios' });
+
+  const schema = rawSchemaOf(tools, 'open');
+  assert.equal('platform' in schema.properties, false);
+
+  await executeOf(tools, 'open')({ app: 'com.example.app' });
+  assert.deepEqual(executorCalls, [
+    { name: 'open', input: { app: 'com.example.app', session: 's', platform: 'ios' } },
+  ]);
+});
+
+test('a command error is re-thrown as the normalized AppError, not swallowed', async () => {
+  executeResult = async () => ({
+    isError: true,
+    structuredContent: {
+      code: 'DEVICE_NOT_FOUND',
+      message: 'No device matched the selector',
+      details: { hint: 'try a broader selector' },
+    },
+    content: [{ type: 'text', text: 'Error (DEVICE_NOT_FOUND): No device matched the selector' }],
+  });
+
+  const { tools } = await createAgentDeviceTools({ session: 's' });
+
+  await assert.rejects(executeOf(tools, 'snapshot')({}), (error: unknown) => {
+    assert.ok(error instanceof AppError);
+    assert.equal(error.code, 'DEVICE_NOT_FOUND');
+    assert.match(error.message, /No device matched the selector/);
+    return true;
+  });
+});
+
+test('approval is returned as toolApproval, ready for ToolLoopAgent', async () => {
+  const { toolApproval } = await createAgentDeviceTools({
+    session: 's',
+    approval: { close: 'user-approval' },
+  });
+  assert.deepEqual(toolApproval, { close: 'user-approval' });
+});

--- a/src/ai-sdk/__tests__/missing-peer-dependency.test.ts
+++ b/src/ai-sdk/__tests__/missing-peer-dependency.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+
+// `ai` is an optional peer dependency; this simulates the real "not installed"
+// resolution failure a consumer would hit, isolated to its own file so the
+// other ai-sdk tests can still exercise the real, installed `ai` package.
+vi.mock('ai', () => {
+  throw new Error("Cannot find package 'ai' imported from agent-device/ai-sdk");
+});
+
+const { createAgentDeviceTools } = await import('../index.ts');
+
+test('createAgentDeviceTools() reports a clear error when the optional peer dependency is missing', async () => {
+  await assert.rejects(createAgentDeviceTools({ session: 's' }), (error: unknown) => {
+    assert.ok(error instanceof AppError);
+    assert.equal(error.code, 'MISSING_PEER_DEPENDENCY');
+    assert.match(error.message, /requires the optional peer dependency 'ai'/);
+    assert.match(error.message, /pnpm add ai/);
+    return true;
+  });
+});

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -1,0 +1,150 @@
+import type { jsonSchema, ToolApprovalStatus, ToolSet } from 'ai';
+import type { PlatformSelector } from '@agent-device/kernel/device';
+import { AppError, type NormalizedError } from '@agent-device/kernel/errors';
+import { createAgentDeviceClient } from '../agent-device-client.ts';
+import type { AgentDeviceClient } from '../client/client-types.ts';
+import type { JsonSchema } from '../commands/command-contract.ts';
+import { resolveCommandFrameworkTier } from '../core/command-descriptor/registry.ts';
+import { createCommandToolExecutor, listCommandTools } from '../mcp/command-tools.ts';
+import { formatToolErrorText } from '../mcp/tool-error.ts';
+
+/**
+ * `'core'` — the curated perceive/act loop (see the `frameworkTier` pinning
+ * test in `src/core/command-descriptor/__tests__/parity.test.ts`). `'all'`
+ * exposes every MCP-exposed command, same set the MCP server surfaces.
+ */
+export type AgentDeviceToolSet = 'core' | 'all';
+
+export type CreateAgentDeviceToolsOptions = {
+  /**
+   * The agent-device session every tool call targets. Required: pinning one
+   * session here is what lets the model call these tools without ever seeing
+   * (or being able to typo) a session name — mirroring the "keep the client
+   * outside tool execution so calls share one named session" guidance in the
+   * AI SDK doc.
+   */
+  session: string;
+  /**
+   * When set, pins every tool call to this platform the same way `session` is
+   * pinned, and removes `platform` from the tools' input schemas. Omit it to
+   * let each call (and the daemon's own default-device selection) decide.
+   */
+  platform?: PlatformSelector;
+  /** Which tools to build. Defaults to `'core'`. */
+  set?: AgentDeviceToolSet;
+  /**
+   * Per-command approval policy, keyed by command name (e.g. `install`,
+   * `close`). Returned as `toolApproval`, ready to pass straight to
+   * `ToolLoopAgent`/`generateText`/`streamText` — see
+   * https://ai-sdk.dev/docs/agents/tool-approvals. `tool()`'s own
+   * `needsApproval` option is deprecated in favor of this, so this factory
+   * never sets it.
+   */
+  approval?: Partial<Record<string, ToolApprovalStatus>>;
+};
+
+export type AgentDeviceTools = {
+  tools: ToolSet;
+  client: AgentDeviceClient;
+  toolApproval?: Partial<Record<string, ToolApprovalStatus>>;
+};
+
+// Hidden unconditionally: `session` is always pinned by this factory, and
+// `mcpOutputFormat` only selects between the MCP text-content renderings —
+// irrelevant here since `execute` below returns structuredContent directly
+// and never reads a tool's rendered text.
+const ALWAYS_HIDDEN_SCHEMA_FIELDS = ['session', 'mcpOutputFormat'] as const;
+
+// The registry's hand-rolled JsonSchema type and `jsonSchema()`'s expected
+// JSONSchema7 (re-exported from @ai-sdk/provider, not from `ai` itself) are
+// structurally close but not identical (e.g. `type` is a plain `string`
+// here); derive the exact expected type from `jsonSchema` itself instead of
+// adding a dependency on @ai-sdk/provider just for this one annotation.
+type Json7Schema = Parameters<typeof jsonSchema>[0];
+
+/**
+ * Builds an AI SDK tool set from the same command registry the MCP server
+ * exposes (`listCommandTools()` / `createCommandToolExecutor()`), so the two
+ * integrations stay in lockstep without a hand-maintained tool list. Uses
+ * `jsonSchema()` against the registry's JSON Schema directly — no zod layer.
+ *
+ * `ai` is an optional peer dependency, so it is imported lazily here rather
+ * than at module scope: importing `agent-device/ai-sdk` itself never
+ * requires `ai` to be installed, only calling this function does.
+ *
+ * The returned `client` is a plain `agent-device` client for the same
+ * session, for the host's own setup/teardown (e.g. `client.apps.open(...)`
+ * before the loop, `client.sessions.close()` in a `finally`); the tools
+ * themselves execute through the registry's own executor, independent of
+ * this instance.
+ */
+export async function createAgentDeviceTools(
+  options: CreateAgentDeviceToolsOptions,
+): Promise<AgentDeviceTools> {
+  const { jsonSchema, tool } = await importAiSdk();
+  const { session, platform, set = 'core', approval } = options;
+  const client = createAgentDeviceClient({
+    session,
+    ...(platform ? { lockPlatform: platform } : {}),
+  });
+  const executor = createCommandToolExecutor();
+
+  const hiddenFields = new Set<string>(ALWAYS_HIDDEN_SCHEMA_FIELDS);
+  if (platform) hiddenFields.add('platform');
+
+  const tools: ToolSet = {};
+  for (const definition of listCommandTools()) {
+    if (set === 'core' && resolveCommandFrameworkTier(definition.name) !== 'core') continue;
+
+    tools[definition.name] = tool({
+      description: definition.description,
+      inputSchema: jsonSchema<Record<string, unknown>>(
+        omitSchemaProperties(definition.inputSchema, hiddenFields) as unknown as Json7Schema,
+      ),
+      ...(definition.outputSchema
+        ? { outputSchema: jsonSchema(definition.outputSchema as unknown as Json7Schema) }
+        : {}),
+      execute: async (input) => {
+        const filledInput = {
+          ...input,
+          session,
+          ...(platform ? { platform } : {}),
+        };
+        const result = await executor.execute(definition.name, filledInput);
+        if (result.isError) {
+          // command-tools.ts's executor already normalizes a caught error into
+          // this exact shape as `structuredContent` (ADR 0012) — reuse it
+          // instead of re-normalizing an already-normalized error.
+          const normalized = result.structuredContent as NormalizedError;
+          throw new AppError(normalized.code, formatToolErrorText(normalized), normalized.details);
+        }
+        return result.structuredContent ?? {};
+      },
+    });
+  }
+
+  return { tools, client, ...(approval ? { toolApproval: approval } : {}) };
+}
+
+async function importAiSdk(): Promise<typeof import('ai')> {
+  try {
+    return await import('ai');
+  } catch (error) {
+    throw new AppError(
+      'MISSING_PEER_DEPENDENCY',
+      "createAgentDeviceTools() requires the optional peer dependency 'ai'. Install it with `pnpm add ai` (or npm/yarn equivalent).",
+      undefined,
+      error,
+    );
+  }
+}
+
+function omitSchemaProperties(schema: JsonSchema, hidden: ReadonlySet<string>): JsonSchema {
+  if (!schema.properties) return schema;
+  const properties: Record<string, JsonSchema> = {};
+  for (const [key, value] of Object.entries(schema.properties)) {
+    if (!hidden.has(key)) properties[key] = value;
+  }
+  const required = schema.required?.filter((key) => !hidden.has(key));
+  return { ...schema, properties, ...(required ? { required } : {}) };
+}

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -49,11 +49,26 @@ export type AgentDeviceTools = {
   toolApproval?: Partial<Record<string, ToolApprovalStatus>>;
 };
 
-// Hidden unconditionally: `session` is always pinned by this factory, and
-// `mcpOutputFormat` only selects between the MCP text-content renderings —
-// irrelevant here since `execute` below returns structuredContent directly
-// and never reads a tool's rendered text.
-const ALWAYS_HIDDEN_SCHEMA_FIELDS = ['session', 'mcpOutputFormat'] as const;
+// Hidden unconditionally, from both the schema the model sees and the input
+// `execute` forwards to the shared executor:
+//  - `session` is always pinned by this factory — the whole point is that a
+//    tool call can never target a session other than the one passed in.
+//  - `stateDir` selects which daemon state directory (and therefore which
+//    daemon/session namespace) a call resolves against. Left model-visible,
+//    it would let a call escape the pinned session into another daemon's
+//    state entirely, defeating that guarantee.
+//  - `mcpOutputFormat`, `includeCost`, `responseLevel` are MCP tool-config
+//    knobs, not command arguments; irrelevant here since `execute` below
+//    returns structuredContent directly and never reads a tool's rendered
+//    text, and shaping the response is this factory's decision, not the
+//    model's.
+const ALWAYS_HIDDEN_FIELDS = [
+  'session',
+  'stateDir',
+  'mcpOutputFormat',
+  'includeCost',
+  'responseLevel',
+] as const;
 
 // The registry's hand-rolled JsonSchema type and `jsonSchema()`'s expected
 // JSONSchema7 (re-exported from @ai-sdk/provider, not from `ai` itself) are
@@ -89,7 +104,7 @@ export async function createAgentDeviceTools(
   });
   const executor = createCommandToolExecutor();
 
-  const hiddenFields = new Set<string>(ALWAYS_HIDDEN_SCHEMA_FIELDS);
+  const hiddenFields = new Set<string>(ALWAYS_HIDDEN_FIELDS);
   if (platform) hiddenFields.add('platform');
 
   const tools: ToolSet = {};
@@ -105,8 +120,12 @@ export async function createAgentDeviceTools(
         ? { outputSchema: jsonSchema(definition.outputSchema as unknown as Json7Schema) }
         : {}),
       execute: async (input) => {
+        // Strip hidden fields from the model's input too, not just the schema
+        // it was generated from: `additionalProperties: false` should already
+        // reject an out-of-schema field, but the pinned session/state-dir
+        // guarantee must hold even if some caller bypasses schema validation.
         const filledInput = {
-          ...input,
+          ...omitHidden(input, hiddenFields),
           session,
           ...(platform ? { platform } : {}),
         };
@@ -141,10 +160,19 @@ async function importAiSdk(): Promise<typeof import('ai')> {
 
 function omitSchemaProperties(schema: JsonSchema, hidden: ReadonlySet<string>): JsonSchema {
   if (!schema.properties) return schema;
-  const properties: Record<string, JsonSchema> = {};
-  for (const [key, value] of Object.entries(schema.properties)) {
-    if (!hidden.has(key)) properties[key] = value;
-  }
   const required = schema.required?.filter((key) => !hidden.has(key));
-  return { ...schema, properties, ...(required ? { required } : {}) };
+  return {
+    ...schema,
+    properties: omitHidden(schema.properties, hidden),
+    ...(required ? { required } : {}),
+  };
+}
+
+/** Shared by both the schema (over `.properties`) and the runtime input (over the call itself). */
+function omitHidden<T>(record: Record<string, T>, hidden: ReadonlySet<string>): Record<string, T> {
+  const result: Record<string, T> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (!hidden.has(key)) result[key] = value;
+  }
+  return result;
 }

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -19,6 +19,7 @@ import {
   commandDescriptors,
   listDescriptorCatalogCommandNames,
   listMcpExposedCommandNames,
+  resolveCommandFrameworkTier,
   resolveCommandRecordsSessionAction,
   resolveCommandRecordingEffect,
   resolveTargetIdentityVerification,
@@ -405,6 +406,50 @@ test('recordingEffect resolves request-sensitive observation and mutation subcom
     }),
     'mutates-app',
   );
+});
+
+test('frameworkTier is declared iff a command is public, and never elsewhere', () => {
+  for (const descriptor of RAW_COMMAND_DESCRIPTORS) {
+    const isPublic = descriptor.catalog.group === 'public';
+    assert.equal(
+      'frameworkTier' in descriptor,
+      isPublic,
+      `${descriptor.name} declares frameworkTier iff it is a public command`,
+    );
+  }
+});
+
+// Pins the default tool set framework adapters (agent-device/ai-sdk,
+// @agent-device/eve) build from `set: 'core'`: the perceive/act loop a
+// typical tool-calling agent needs without being handed dozens of
+// device-management, observability, or recording tools up front. A new public
+// command lands in 'extended' unless this test is updated deliberately —
+// widening 'core' should be a reviewed decision, not a silent side effect of
+// adding a command.
+test("frameworkTier pins exactly the 'core' command set", () => {
+  const core = commandDescriptors
+    .filter((descriptor) => resolveCommandFrameworkTier(descriptor.name) === 'core')
+    .map((descriptor) => descriptor.name)
+    .sort();
+
+  assert.deepEqual(core, [
+    'alert',
+    'back',
+    'click',
+    'close',
+    'fill',
+    'find',
+    'get',
+    'is',
+    'open',
+    'press',
+    'screenshot',
+    'scroll',
+    'snapshot',
+    'swipe',
+    'type',
+    'wait',
+  ]);
 });
 
 test('targetIdentityVerification pins exactly the evidence-carrying command set (ADR 0012 / #1349)', () => {

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -34,6 +34,7 @@ import { readDeclaredPlatformExecution } from './platform-execution-entry.ts';
 import type {
   CommandCatalogGroup,
   CommandDescriptor,
+  CommandFrameworkTier,
   RecordingEffect,
   CommandResponseDataTransform,
   CommandTimeoutPolicy,
@@ -390,6 +391,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'artifacts',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/artifacts.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'lease', refFrameEffect: 'preserve', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
@@ -435,6 +437,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'devices',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/device.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -451,6 +454,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'capabilities',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/device.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -468,6 +472,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'doctor',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/doctor.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -485,6 +490,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'apps',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/app.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -501,6 +507,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'boot',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/device.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'may-invalidate', sessionKind: 'state' },
     platformExecution: { kind: 'device-runtime', uses: deviceBootRuntimeUses },
@@ -511,6 +518,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'shutdown',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/device.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'may-invalidate', sessionKind: 'state' },
     platformExecution: { kind: 'device-runtime', use: shutdownTargetUse },
@@ -521,6 +529,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'appstate',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public', key: 'appState' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'preserve', sessionKind: 'state' },
     platformExecution: { kind: 'device-runtime', uses: appStateRuntimeUses },
@@ -531,6 +540,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'perf',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/perf/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'session', refFrameEffect: 'preserve', sessionKind: 'observability' },
@@ -543,6 +553,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'logs',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/observability/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'preserve', sessionKind: 'observability' },
     platformExecution: { kind: 'device-runtime', uses: appLogRuntimePlanUses },
@@ -553,6 +564,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'events',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/observability/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -569,6 +581,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'network',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/observability/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'preserve', sessionKind: 'observability' },
     platformExecution: { kind: 'device-runtime', use: networkDumpUse },
@@ -579,6 +592,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'audio',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/observability/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'preserve', sessionKind: 'observability' },
     capability: {
@@ -594,6 +608,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'replay',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/replay/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -611,6 +626,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'test',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/replay/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: {
       route: 'session',
@@ -645,6 +661,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'clipboard',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'session', refFrameEffect: 'preserve' },
@@ -662,6 +679,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'keyboard',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: keyboardRecordingEffect,
     daemon: {
@@ -683,6 +701,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'install',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/install.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'session', refFrameEffect: 'may-invalidate' },
@@ -694,6 +713,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'reinstall',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/install.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'session', refFrameEffect: 'may-invalidate' },
@@ -730,6 +750,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'push',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/push.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'session', refFrameEffect: 'may-invalidate' },
@@ -741,6 +762,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'trigger-app-event',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/push.ts'] as const } : {}),
     catalog: { group: 'public', key: 'triggerAppEvent' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'session', refFrameEffect: 'may-invalidate' },
@@ -754,6 +776,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'open',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/app.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -770,6 +793,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'prepare',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/prepare.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'preserve' },
     // Runner warm-up builds are the longest fixed envelope; --timeout overrides.
@@ -786,6 +810,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'batch',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/batch/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: false,
     daemon: { route: 'session', refFrameEffect: 'delegated' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
@@ -796,6 +821,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'close',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/app.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -814,6 +840,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'snapshot',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/snapshot.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'snapshot', refFrameEffect: 'preserve' },
@@ -829,6 +856,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'diff',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/diff.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'snapshot', refFrameEffect: 'preserve' },
@@ -841,6 +869,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'wait',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/wait.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     // #1349: a wait's landmark may legitimately be absent when the step
@@ -861,6 +890,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'alert',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/alert.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: alertRecordingEffect,
     daemon: { route: 'snapshot', refFrameEffect: alertRefFrameEffect },
@@ -877,6 +907,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'settings',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/settings.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'snapshot', refFrameEffect: 'may-invalidate' },
@@ -896,6 +927,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'react-native',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/react-native/index.ts'] as const } : {}),
     catalog: { group: 'public', key: 'reactNative' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'reactNative', refFrameEffect: 'may-invalidate' },
@@ -908,6 +940,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'record',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/recording/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: {
@@ -924,6 +957,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'trace',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/recording/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'recordTrace', refFrameEffect: 'preserve' },
@@ -935,6 +969,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'find',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: findRecordingEffect,
     daemon: { route: 'find', refFrameEffect: 'may-invalidate' },
@@ -956,6 +991,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -975,6 +1011,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -995,6 +1032,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public', key: 'longPress' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1020,6 +1058,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1039,6 +1078,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'type',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1057,6 +1097,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'interaction', refFrameEffect: 'preserve' },
@@ -1080,6 +1121,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'interaction', refFrameEffect: 'preserve' },
@@ -1094,6 +1136,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'back',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
     capability: {
       ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS.capability,
@@ -1107,6 +1150,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'gesture',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     targetIdentityVerification: 'pre-dispatch',
@@ -1124,6 +1168,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'home',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
     capability: {
       ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS.capability,
@@ -1135,6 +1180,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'tv-remote',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public', key: 'tvRemote' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1157,6 +1203,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'orientation',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1178,6 +1225,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'scroll',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
     timeoutPolicy: postActionObservationTimeoutPolicy('scroll', DEFAULT_TIMEOUT_POLICY),
     postActionObservation: postActionObservation('scroll'),
@@ -1187,6 +1235,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'swipe',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {
@@ -1203,6 +1252,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'focus',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
     platformExecution: LEGACY_PLATFORM_EXECUTION,
   },
@@ -1210,6 +1260,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'screenshot',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/capture/screenshot.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'core',
     recordsSessionAction: true,
     recordingEffect: 'observes-app',
     daemon: { route: 'generic', refFrameEffect: 'preserve' },
@@ -1223,6 +1274,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'viewport',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/viewport.ts'] as const } : {}),
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: { route: 'generic', refFrameEffect: 'may-invalidate' },
@@ -1243,6 +1295,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'app-switcher',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/system/index.ts'] as const } : {}),
     catalog: { group: 'public', key: 'appSwitcher' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     // ADR 0014: app-switcher previously reached the generic daemon leaf via the
@@ -1265,6 +1318,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'install-from-source',
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/management/install.ts'] as const } : {}),
     catalog: { group: 'public', key: 'installFromSource' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     platformExecution: { kind: 'device-runtime', use: readyMaterializeAndDeployAppUse },
@@ -1575,6 +1629,20 @@ export function resolveCommandResponseDataTransform(
 export function resolveCommandRecordsSessionAction(command: string | undefined): boolean {
   if (command === undefined) return false;
   return COMMAND_DESCRIPTOR_BY_NAME.get(command)?.recordsSessionAction ?? false;
+}
+
+/**
+ * The declared {@link CommandFrameworkTier} for a public command, or
+ * `undefined` for a command that never declares one (every non-public
+ * command, by construction — see the parity test). Framework adapters
+ * (`agent-device/ai-sdk`, `@agent-device/eve`) read this to build their
+ * default tool set instead of hand-listing tool names.
+ */
+export function resolveCommandFrameworkTier(
+  command: string | undefined,
+): CommandFrameworkTier | undefined {
+  if (command === undefined) return undefined;
+  return COMMAND_DESCRIPTOR_BY_NAME.get(command)?.frameworkTier;
 }
 
 /**

--- a/src/core/command-descriptor/types.ts
+++ b/src/core/command-descriptor/types.ts
@@ -75,6 +75,24 @@ export type CommandTimeoutPolicy = {
 
 export type CommandCatalogGroup = 'public' | 'internal' | 'local-cli' | 'dispatch-alias';
 
+/**
+ * Which default tool set a framework adapter (`agent-device/ai-sdk`, the
+ * planned `@agent-device/eve` package) includes a public command in.
+ *  - `'core'`     — the small, curated perceive/act loop a typical tool-calling
+ *                   agent needs by default: launch, observe, interact, read,
+ *                   verify, wait, navigate, and system-dialog handling.
+ *  - `'extended'` — everything else public: device/session management,
+ *                   observability, recording/replay, and specialized or
+ *                   destructive commands. Still available with an explicit
+ *                   opt-in (e.g. `set: 'all'`), just excluded from the default
+ *                   tool set so a model isn't handed dozens of rarely-needed
+ *                   tools up front.
+ * Declared per public command so the classification lives beside the rest of
+ * that command's descriptor facets instead of a separate hand-maintained list
+ * in the adapter code; `resolveCommandFrameworkTier` reads it back.
+ */
+export type CommandFrameworkTier = 'core' | 'extended';
+
 export type CommandCatalogFacet = {
   /**
    * The command catalog group. This is explicit on every descriptor so new
@@ -144,6 +162,8 @@ export type TargetIdentityVerification = 'pre-dispatch' | 'post-resolution';
  *                   command traits.
  *  - `catalog` — command identity projection metadata. Every descriptor
  *                   declares its catalog group explicitly.
+ *  - `frameworkTier` — which default tool set a framework adapter includes a
+ *                   public command in (see {@link CommandFrameworkTier}).
  *  - `dispatch` — whether src/core/dispatch.ts accepts this command name as a
  *                   platform dispatch target.
  *
@@ -162,6 +182,8 @@ type CommandDescriptorBase = {
   postActionObservation?: PostActionObservationSupport;
   responseDataTransform?: CommandResponseDataTransform;
   catalog: CommandCatalogFacet;
+  /** Required iff `catalog.group === 'public'`; see {@link CommandFrameworkTier}. */
+  frameworkTier?: CommandFrameworkTier;
   dispatch?: CommandDispatchFacet;
   /** Internal-only ADR 0019 cutover discriminant; public projections must ignore it. */
   platformExecution: CommandPlatformExecution;

--- a/test/integration/installed-package-metro.test.ts
+++ b/test/integration/installed-package-metro.test.ts
@@ -288,6 +288,7 @@ test('installed package exposes Node APIs and packaged companion tunnel entrypoi
         ).sort();
         const subpathSmoke = {
           '.': (mod) => mod.centerOfRect({ x: 0, y: 0, width: 10, height: 4 }),
+          './ai-sdk': (mod) => typeof mod.createAgentDeviceTools,
           './android-adb': (mod) => {
             const manager = mod.createAndroidPortReverseManager(async () => ({
               stdout: '',
@@ -387,6 +388,7 @@ test('installed package exposes Node APIs and packaged companion tunnel entrypoi
     assert.deepEqual(imports.smokedSubpaths, imports.exportSubpaths);
     assert.deepEqual(imports.subpathSmokeResults, {
       '.': { x: 5, y: 2 },
+      './ai-sdk': 'function',
       './android-adb': 'function',
       './artifacts': 'undefined',
       './batch': 'INVALID_ARGS',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
     contracts: 'src/sdk/contracts.ts',
     selectors: 'src/sdk/selectors.ts',
     finders: 'src/sdk/finders.ts',
+    'ai-sdk': 'src/ai-sdk/index.ts',
     'internal/bin': 'src/bin.ts',
     'internal/companion-tunnel': 'src/client/companion-tunnel.ts',
     'internal/daemon': 'src/daemon.ts',

--- a/website/docs/docs/ai-sdk.md
+++ b/website/docs/docs/ai-sdk.md
@@ -4,15 +4,92 @@ title: AI SDK
 
 # AI SDK
 
-[Vercel's AI SDK](https://ai-sdk.dev/) can expose `agent-device` client methods as typed tools in a Node.js agent. `ToolLoopAgent` owns the model loop, while `createAgentDeviceClient()` owns the device session and keeps tool implementations aligned with the CLI command contracts.
+[Vercel's AI SDK](https://ai-sdk.dev/) can drive `agent-device` three ways, in increasing order of setup: point `@ai-sdk/mcp` at the MCP server with no hand-written code, build a typed tool set in-process with `agent-device/ai-sdk`, or hand-write individual tools for full control over the surface.
 
-Install the integration dependencies:
+## Zero-code: the MCP server
+
+`agent-device mcp` starts the same [MCP server](/docs/agent-setup#mcp-server) documented for Claude Code, Cursor, and other MCP clients — every installed command, as a structured tool, over the same execution path as the CLI. [`@ai-sdk/mcp`](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools)'s `createMCPClient()` connects to it and converts its tools into AI SDK tools directly, so there is no `agent-device` import at all:
+
+```bash
+pnpm add ai @ai-sdk/mcp
+```
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
+import { ToolLoopAgent } from 'ai';
+
+const mcpClient = await createMCPClient({
+  transport: new Experimental_StdioMCPTransport({
+    command: 'npx',
+    args: ['agent-device', 'mcp'],
+  }),
+});
+
+try {
+  const agent = new ToolLoopAgent({
+    model: process.env.AI_MODEL!,
+    tools: await mcpClient.tools(),
+  });
+
+  const result = await agent.generate({
+    prompt: 'Open com.example.app on iOS, navigate to Notifications, and verify notifications are enabled.',
+  });
+
+  console.log(result.text);
+} finally {
+  await mcpClient.close();
+}
+```
+
+This hands the model every command `agent-device mcp` exposes — dozens of tools, spanning device management and observability as well as interaction. For a smaller, curated default, use `agent-device/ai-sdk` below instead.
+
+## `agent-device/ai-sdk`: a typed tool set in-process
+
+`createAgentDeviceTools()` builds AI SDK tools from the same command registry the MCP server uses, in-process (no subprocess), pinned to one named session:
+
+```bash
+pnpm add agent-device ai
+```
+
+```ts
+import { ToolLoopAgent } from 'ai';
+import { createAgentDeviceTools } from 'agent-device/ai-sdk';
+
+const { tools, client, toolApproval } = await createAgentDeviceTools({
+  session: 'ai-sdk-agent',
+  platform: 'ios',
+  approval: { close: 'user-approval' },
+});
+
+const agent = new ToolLoopAgent({
+  model: process.env.AI_MODEL!,
+  tools,
+  toolApproval,
+});
+
+try {
+  await client.apps.open({ app: 'com.example.app', platform: 'ios' });
+
+  const result = await agent.generate({
+    prompt: 'Navigate to Notifications and verify that notifications are enabled.',
+  });
+
+  console.log(result.text);
+} finally {
+  await client.sessions.close();
+}
+```
+
+`set: 'core'` (the default) exposes the perceive/act loop most agents need — open, close, snapshot, click, press, fill, type, get, is, find, wait, back, scroll, swipe, alert, screenshot; pass `set: 'all'` for every command the MCP server exposes, matching the zero-code path above. `approval` maps command names to an [AI SDK tool approval status](https://ai-sdk.dev/docs/agents/tool-approvals) and is returned as `toolApproval`, ready to pass straight to `ToolLoopAgent`.
+
+## Hand-written tools
+
+Write tools by hand when you want a surface smaller than `core`, or application-specific input validation and result shaping. The example below gives the model two deliberately small tools: one for observing the current UI and one for pressing an element returned by that observation.
 
 ```bash
 pnpm add agent-device ai zod
 ```
-
-The example below gives the model two deliberately small tools: one for observing the current UI and one for pressing an element returned by that observation.
 
 ```ts
 import { ToolLoopAgent, tool } from 'ai';
@@ -65,14 +142,12 @@ try {
 
 Set `AI_MODEL` to a model available through your configured AI SDK provider. See the AI SDK references for [`ToolLoopAgent`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent) and [`tool()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool).
 
-## Designing device tools
-
-Prefer focused tools over a single tool that accepts an arbitrary command name and arguments:
+Guidance for hand-written tools:
 
 - Validate tool input with a schema. In particular, constrain element refs to values such as `@e12` and make the model observe before acting.
 - Keep the `agent-device` client outside tool execution so calls share one named session.
 - Return typed client results directly unless the result needs an application-specific projection.
 - Let the host application own session cleanup with `try`/`finally`; do not rely on the model to close the session.
-- Use AI SDK's `needsApproval` option for actions that require human confirmation in your product.
+- Use AI SDK's [`toolApproval`](https://ai-sdk.dev/docs/agents/tool-approvals) option for actions that require human confirmation in your product — `tool()`'s own `needsApproval` is deprecated in its favor.
 
 See [Node.js API](/docs/client-api) for the complete client surface and runnable, typechecked `agent-device` examples.

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -91,6 +91,9 @@ Supported public entry points for Node consumers:
   - `runtime.getDeviceSession(device)`
   - types: `LimrunRuntimeOptions`, `LimrunDeviceSession`, `LimrunAndroidDeviceSession`,
     `LimrunIosDeviceSession`, `LimrunIosCommandExecution`
+- `agent-device/ai-sdk`
+  - `createAgentDeviceTools(options)`
+  - types: `AgentDeviceToolSet`, `AgentDeviceTools`, `CreateAgentDeviceToolsOptions`
 
 ## Basic usage
 


### PR DESCRIPTION
## Summary

Follow-up to #1780's README repositioning: gives AI SDK users three ways to drive `agent-device`, in increasing order of setup, and closes a real gap in the publishing gate along the way.

- **Zero-code**: documents `@ai-sdk/mcp`'s `createMCPClient()` pointed at `agent-device mcp` via stdio — no `agent-device` import at all.
- **`agent-device/ai-sdk`** (new subpath): `createAgentDeviceTools({ session, platform?, set?, approval? })` builds AI SDK tools from the same command registry the MCP server uses (`listCommandTools()` / `createCommandToolExecutor()`), so the two integrations can't drift apart. No zod layer — JSON Schema goes straight through `jsonSchema()`.
- **Hand-written tools**: kept, now framed as the "smaller than core, or app-specific shaping" option, with a stale `needsApproval` reference fixed to the current `toolApproval` API.

```ts
import { ToolLoopAgent } from 'ai';
import { createAgentDeviceTools } from 'agent-device/ai-sdk';

const { tools, client, toolApproval } = await createAgentDeviceTools({
  session: 'ai-sdk-agent',
  platform: 'ios',
  approval: { close: 'user-approval' },
});

const agent = new ToolLoopAgent({ model: process.env.AI_MODEL!, tools, toolApproval });
```

`set: 'core'` (default) exposes a curated perceive/act loop — open, close, snapshot, click, press, fill, type, get, is, find, wait, back, scroll, swipe, alert, screenshot — driven by a new `frameworkTier: 'core' | 'extended'` descriptor facet declared on every public command (registry-owned, not a hand list in the adapter). `set: 'all'` matches the MCP server's full surface. Two new tests in `parity.test.ts` pin the classification so it can't drift silently.

`ai` is an **optional peer dependency**, imported lazily inside `createAgentDeviceTools()` rather than at module scope — `import('agent-device/ai-sdk')` never requires `ai` to be installed, only calling the factory does (with a clear `MISSING_PEER_DEPENDENCY` error if it's missing). This surfaced a real gap: `scripts/check-package.ts`'s publishing gate imports every `exports` entry from a clean install and audits every shipped bare specifier against `dependencies` — it had no concept of peer dependencies, since this package has never shipped one before. Extended `scripts/lib/shipped-imports.ts` to also accept `peerDependencies`, with new fixture tests.

## Validation

- `pnpm typecheck` (root + `examples/sdk/tsconfig.json`), `oxlint`, `oxfmt --check` clean on every touched file.
- `pnpm build` — new `dist/src/ai-sdk.{js,d.ts}` outputs; confirmed `ai` is external (not bundled) and the built module has zero static top-level `import ... from "ai"`.
- Full `unit-core` suite: 869 files / 6630 tests passing, including the extended `command-descriptor` parity suite, `client-api-examples-drift`, `command-tools`, and the new `package-closure-audit` fixtures.
- `client-api.md`'s fenced snippets still compile against real exports (`test/integration/client-api-doc-snippets.test.ts`).
- Manually reproduced the actual publishing-gate scenario end-to-end (`npm pack` → clean external install with **no** `ai` present): all 13 `exports` entries import cleanly, `createAgentDeviceTools()` throws the intended `MISSING_PEER_DEPENDENCY` error without `ai`, and with `ai` installed returns 16 tools for `set: 'core'` / 55 for `set: 'all'`, with `toolApproval` passed through correctly.

## Notes

- The `core` classification (16 commands) is a first cut — flagging for review rather than treating as final.
- Docs-only change for the MCP zero-code section; runtime validation doesn't apply there beyond the code compiling, which isn't separately gated (only `client-api.md`'s snippets are compiled, not `ai-sdk.md`'s).
- Scope: 14 files touched (2 new). A handful of unrelated, pre-existing `scripts/maestro-conformance/corpus/*.yaml` quote-style changes were present in this worktree before this work started and are intentionally left out of this PR.