### PR TITLE
chore: restore unreleased version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-device",
-  "version": "0.20.10",
+  "version": "0.20.9",
   "description": "Mobile app automation and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
   "mcpName": "io.github.callstack/agent-device",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/callstack/agent-device",
     "source": "github"
   },
-  "version": "0.20.10",
+  "version": "0.20.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agent-device",
-      "version": "0.20.10",
+      "version": "0.20.9",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Restore package and MCP metadata to the published 0.20.9 version. This removes premature 0.20.10 release bookkeeping; v0.20.10 was never published and its tag has been removed.

Touched files: 2. Scope is limited to version metadata.

## Validation

`pnpm check:affected --run` passed, including MCP metadata validation. The npm registry still reports 0.20.9 as latest and 0.20.10 is absent.