### PR TITLE
fix(android): let a covering sibling hide only what its content covers

### DIFF
--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -426,6 +426,29 @@ test('parseUiHierarchy keeps app content under an overlay whose only controls si
   );
 });
 
+test('parseUiHierarchy counts identifier-only markers toward what a covered sibling shows', () => {
+  // A screen container carrying testID markers whose only painted content is one corner icon,
+  // under a clickable header bar. The bar covers the icon, but the agent would also lose the
+  // markers, which sit well outside the bar — so the container is not covered.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.ViewGroup" resource-id="home-screen" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.ImageView" content-desc="Menu" bounds="[8,8][56,56]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.view.ViewGroup" resource-id="home-body" bounds="[0,120][390,844]" visible-to-user="true" drawing-order="2"/>
+    </node>
+    <node class="android.view.ViewGroup" bounds="[0,0][390,120]" clickable="true" enabled="true" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.TextView" text="Header" bounds="[72,40][300,80]" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.identifier === 'home-body'),
+    true,
+  );
+});
+
 test('parseUiHierarchy compares presented footprints so a sparse overlay never condemns a rich sibling', () => {
   // The overlay's only content is a corner badge; the sibling's content spans the screen. Box
   // geometry alone (overlay box ⊇ sibling box) would call this covered.

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -426,6 +426,29 @@ test('parseUiHierarchy keeps app content under an overlay whose only controls si
   );
 });
 
+test('parseUiHierarchy keeps app content under a focusable full-screen overlay holding one clickable icon', () => {
+  // The Telegram wrapper from #1733, but with one floating clickable icon inside it. The icon makes
+  // the wrapper a covering candidate; its focusability must still not paint the box, or the wrapper
+  // condemns the whole app under it exactly as it did before #1733.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.TextView" text="Your phone number" bounds="[24,200][366,260]" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.EditText" text="208 379 7171" bounds="[24,320][366,380]" clickable="true" focusable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    </node>
+    <node class="android.view.View" bounds="[0,0][390,844]" enabled="true" visible-to-user="true" focusable="true" drawing-order="3">
+      <node class="android.widget.ImageView" content-desc="Attach" bounds="[330,780][380,830]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.deepEqual(
+    result.nodes.filter((node) => node.label).map((node) => node.label),
+    ['Your phone number', '208 379 7171', 'Attach'],
+  );
+});
+
 test('parseUiHierarchy counts identifier-only markers toward what a covered sibling shows', () => {
   // A screen container carrying testID markers whose only painted content is one corner icon,
   // under a clickable header bar. The bar covers the icon, but the agent would also lose the

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -269,7 +269,7 @@ test('parseUiHierarchy reads an omitted clickable attribute the same as clickabl
   const tree = (clickable: string) => `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
-      <node class="android.widget.TextView" text="Foreground tile" bounds="[24,120][366,200]" enabled="true" visible-to-user="true" focusable="true" ${clickable} drawing-order="1"/>
+      <node class="android.widget.TextView" text="Foreground tile" bounds="[0,120][390,844]" enabled="true" visible-to-user="true" focusable="true" ${clickable} drawing-order="1"/>
     </node>
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
       <node class="android.widget.TextView" text="Background row" bounds="[0,220][280,280]" enabled="true" visible-to-user="true" focusable="true" ${clickable} drawing-order="1"/>
@@ -329,10 +329,15 @@ test('parseUiHierarchy prunes descendants of Android nodes that are not visible 
 });
 
 test('parseUiHierarchy prunes lower drawing-order subtrees covered by a foreground sibling', () => {
+  // A pushed screen (header + full-width rows) drawn above a still-attached drawer surface. The
+  // pushed screen's presented content lies over the drawer's content, so the drawer is covered.
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
-      <node class="android.widget.Button" text="Foreground action" bounds="[24,420][366,480]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.Button" content-desc="Back" bounds="[8,40][56,88]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.TextView" text="Foreground screen" bounds="[72,44][300,84]" enabled="true" visible-to-user="true" drawing-order="2"/>
+      <node class="android.widget.Button" text="Foreground action" bounds="[0,120][390,180]" clickable="true" enabled="true" visible-to-user="true" drawing-order="3"/>
+      <node class="android.widget.Button" text="Foreground footer" bounds="[0,780][390,844]" clickable="true" enabled="true" visible-to-user="true" drawing-order="4"/>
     </node>
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
       <node class="android.widget.ScrollView" bounds="[0,120][300,844]" scrollable="true" clickable="true" enabled="true" visible-to-user="true" drawing-order="1">
@@ -350,6 +355,69 @@ test('parseUiHierarchy prunes lower drawing-order subtrees covered by a foregrou
   assert.equal(
     result.nodes.some((node) => node.label === 'Hidden drawer action'),
     false,
+  );
+});
+
+test('parseUiHierarchy keeps app content under a full-screen overlay holding one floating icon (#1806)', () => {
+  // DoraemonKit injects a full-screen FrameLayout above the whole Activity purely as a drag surface
+  // for a small floating icon. It presents only the icon, so it can only hide what sits under it.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][1224,2860]" visible-to-user="true" drawing-order="0">
+    <node class="android.widget.LinearLayout" bounds="[0,0][1224,2860]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.TextView" text="Editor" bounds="[48,160][600,240]" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.Button" text="Save" bounds="[48,2600][1176,2760]" clickable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    </node>
+    <node class="android.widget.FrameLayout" resource-id="com.example.app:id/dokit_contentview_id" content-desc="dokit_contentview_id_DokitFrameLayout[1]" bounds="[0,146][1224,2912]" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.ImageView" content-desc="DoKit" bounds="[1000,1200][1189,1389]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.deepEqual(
+    result.nodes.filter((node) => node.label).map((node) => node.label),
+    ['Editor', 'Save', 'dokit_contentview_id_DokitFrameLayout[1]', 'DoKit'],
+  );
+});
+
+test('parseUiHierarchy keeps app content beside an empty labelled full-screen placeholder (#1806)', () => {
+  // A match_parent placeholder container that stays VISIBLE and only receives a fragment later.
+  // Its content-desc is an announcement, not paint: it draws nothing over the app.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.widget.LinearLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.Button" text="Toolbar action" bounds="[0,40][390,100]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+    <node class="android.widget.FrameLayout" resource-id="com.example.app:id/panel_host" content-desc="View[1]" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2"/>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.equal(
+    result.nodes.some((node) => node.label === 'Toolbar action'),
+    true,
+  );
+});
+
+test('parseUiHierarchy compares presented footprints so a sparse overlay never condemns a rich sibling', () => {
+  // The overlay's only content is a corner badge; the sibling's content spans the screen. Box
+  // geometry alone (overlay box ⊇ sibling box) would call this covered.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.Button" text="Top action" bounds="[24,60][366,120]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.Button" text="Bottom action" bounds="[24,760][366,820]" clickable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    </node>
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.Button" text="Badge" bounds="[330,20][380,70]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.deepEqual(
+    result.nodes.filter((node) => node.label).map((node) => node.label),
+    ['Top action', 'Bottom action', 'Badge'],
   );
 });
 
@@ -556,9 +624,10 @@ test('parseUiHierarchy keeps an overlapped text leaf drawn inside a composite wi
 });
 
 test('parseUiHierarchy still condemns a clickable leaf covered by a foreground sibling', () => {
+  // A tap-to-dismiss scrim is itself a touch target, so it hides its whole box.
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
-    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+    <node class="android.view.ViewGroup" bounds="[0,0][390,844]" clickable="true" enabled="true" visible-to-user="true" drawing-order="2">
       <node class="android.widget.Button" text="Modal action" bounds="[24,420][366,480]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
     </node>
     <node class="android.widget.Button" text="Behind the modal" bounds="[0,220][280,280]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>

--- a/src/platforms/android/__tests__/ui-hierarchy.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy.test.ts
@@ -329,14 +329,16 @@ test('parseUiHierarchy prunes descendants of Android nodes that are not visible 
 });
 
 test('parseUiHierarchy prunes lower drawing-order subtrees covered by a foreground sibling', () => {
-  // A pushed screen (header + full-width rows) drawn above a still-attached drawer surface. The
-  // pushed screen's presented content lies over the drawer's content, so the drawer is covered.
+  // A pushed screen (header, scrollable body, footer) drawn above a still-attached drawer surface.
+  // The pushed screen's presented content lies over the drawer's content, so the drawer is covered.
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
       <node class="android.widget.Button" content-desc="Back" bounds="[8,40][56,88]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
       <node class="android.widget.TextView" text="Foreground screen" bounds="[72,44][300,84]" enabled="true" visible-to-user="true" drawing-order="2"/>
-      <node class="android.widget.Button" text="Foreground action" bounds="[0,120][390,180]" clickable="true" enabled="true" visible-to-user="true" drawing-order="3"/>
+      <node class="android.widget.ScrollView" bounds="[0,120][390,780]" scrollable="true" enabled="true" visible-to-user="true" drawing-order="3">
+        <node class="android.widget.Button" text="Foreground action" bounds="[24,140][366,200]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      </node>
       <node class="android.widget.Button" text="Foreground footer" bounds="[0,780][390,844]" clickable="true" enabled="true" visible-to-user="true" drawing-order="4"/>
     </node>
     <node class="android.view.ViewGroup" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
@@ -396,6 +398,31 @@ test('parseUiHierarchy keeps app content beside an empty labelled full-screen pl
   assert.equal(
     result.nodes.some((node) => node.label === 'Toolbar action'),
     true,
+  );
+});
+
+test('parseUiHierarchy keeps app content under an overlay whose only controls sit in opposite corners', () => {
+  // Two floating controls in opposite corners present two corners, not the screen between them.
+  // A bounding box of the presented content would span the viewport and condemn the whole app.
+  const xml = `<hierarchy>
+  <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="0">
+    <node class="android.widget.LinearLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="1">
+      <node class="android.widget.TextView" text="Editor" bounds="[24,60][300,120]" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.ScrollView" bounds="[0,140][390,760]" scrollable="true" enabled="true" visible-to-user="true" drawing-order="2">
+        <node class="android.widget.Button" text="Save" bounds="[24,400][366,460]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      </node>
+    </node>
+    <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" drawing-order="2">
+      <node class="android.widget.ImageView" content-desc="Debug menu" bounds="[8,8][56,56]" clickable="true" enabled="true" visible-to-user="true" drawing-order="1"/>
+      <node class="android.widget.ImageView" content-desc="Frame stats" bounds="[334,788][382,836]" clickable="true" enabled="true" visible-to-user="true" drawing-order="2"/>
+    </node>
+  </node>
+</hierarchy>`;
+
+  const result = parseUiHierarchy(xml, 800, { raw: true });
+  assert.deepEqual(
+    result.nodes.filter((node) => node.label).map((node) => node.label),
+    ['Editor', 'Save', 'Debug menu', 'Frame stats'],
   );
 });
 

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -452,13 +452,20 @@ type AndroidNodeInclusionInfo = {
   isVisual: boolean;
 };
 
-type AndroidTreePruneState = {
-  actionableContentMemo: WeakMap<AndroidNode, boolean>;
+type AndroidFootprint = {
+  /** Bounding box of what the subtree presents (agent targets and labelled leaves), if anything. */
+  rect: Rect | null;
+  hasAgentTarget: boolean;
 };
 
-type AndroidCoveringCandidate = AndroidNode & {
-  rect: Rect;
+type AndroidTreePruneState = {
+  footprintMemo: WeakMap<AndroidNode, AndroidFootprint>;
+};
+
+type AndroidCoveringCandidate = {
+  node: AndroidNode;
   drawingOrder: number;
+  footprint: Rect;
 };
 
 const ANDROID_WINDOW_TYPE_APPLICATION = 1;
@@ -525,7 +532,7 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
   discardInactiveAndroidApplicationWindows(root);
   // UiAutomation can expose covered React Native navigation surfaces in the same accessibility
   // window. If a higher drawing-order sibling covers them, agents should see the foreground surface.
-  pruneAndroidCoveredSubtrees(root, { actionableContentMemo: new WeakMap() });
+  pruneAndroidCoveredSubtrees(root, { footprintMemo: new WeakMap() });
   applyAndroidScrollActionHints(root);
   return root;
 }
@@ -550,22 +557,59 @@ function hasSemanticContent(node: AndroidNode): boolean {
   return hasMeaningfulLabel(node) || hasMeaningfulIdentifier(node);
 }
 
-/** Focusability is traversal, not paint, so it is not evidence a node hides anything (#1733). */
+/**
+ * Focusability is traversal, not paint (#1733), and a label is an announcement, not paint (#1806):
+ * a container's content-desc describes its children and an empty labelled View draws nothing. Only
+ * a touch target is direct evidence that a node hides what lies under its box.
+ */
 function hasDirectOcclusionEvidence(node: AndroidNode): boolean {
-  return node.visibleToUser !== false && (isTouchTarget(node) || hasSemanticContent(node));
+  return node.visibleToUser !== false && isTouchTarget(node);
 }
 
 /** Evidence the node is a real surface because it contains something an agent could drive. */
 function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePruneState): boolean {
-  const cached = state.actionableContentMemo.get(node);
-  if (cached !== undefined) return cached;
-  const result = node.children.some(
-    (child) =>
-      child.visibleToUser !== false &&
-      (isAgentTarget(child) || hasDescendantOcclusionEvidence(child, state)),
+  return node.children.some(
+    (child) => child.visibleToUser !== false && subtreeFootprint(child, state).hasAgentTarget,
   );
-  state.actionableContentMemo.set(node, result);
-  return result;
+}
+
+/**
+ * Where a subtree visibly presents something: the bounding box of its agent targets and labelled
+ * leaves. A full-screen debug overlay holding one floating icon presents only that icon, so it can
+ * only hide what sits under the icon, never the whole app behind it (#1806).
+ */
+function subtreeFootprint(node: AndroidNode, state: AndroidTreePruneState): AndroidFootprint {
+  const cached = state.footprintMemo.get(node);
+  if (cached !== undefined) return cached;
+  let hasAgentTarget = isAgentTarget(node);
+  let rect: Rect | null =
+    (isAgentTarget(node) || isLabelledLeaf(node)) && hasPositiveRect(node) ? node.rect : null;
+  for (const child of node.children) {
+    if (child.visibleToUser === false) continue;
+    const childFootprint = subtreeFootprint(child, state);
+    hasAgentTarget ||= childFootprint.hasAgentTarget;
+    rect = unionRect(rect, childFootprint.rect);
+  }
+  const footprint = { rect, hasAgentTarget };
+  state.footprintMemo.set(node, footprint);
+  return footprint;
+}
+
+function isLabelledLeaf(node: AndroidNode): boolean {
+  return node.children.length === 0 && hasMeaningfulLabel(node);
+}
+
+function unionRect(left: Rect | null, right: Rect | null): Rect | null {
+  if (!left) return right;
+  if (!right) return left;
+  const x = Math.min(left.x, right.x);
+  const y = Math.min(left.y, right.y);
+  return {
+    x,
+    y,
+    width: Math.max(left.x + left.width, right.x + right.width) - x,
+    height: Math.max(left.y + left.height, right.y + right.height) - y,
+  };
 }
 
 /**
@@ -598,32 +642,45 @@ function pruneAndroidCoveredSubtrees(node: AndroidNode, state: AndroidTreePruneS
     return;
   }
   const siblings = node.children;
-  const coveringCandidates = siblings.filter((sibling) => canCoverSibling(sibling, state));
+  const coveringCandidates = siblings
+    .map((sibling) => coveringCandidateOf(sibling, state))
+    .filter((candidate) => candidate !== null);
   if (coveringCandidates.length === 0) return;
-  node.children = siblings.filter((child) => shouldKeepAndroidSibling(child, coveringCandidates));
+  node.children = siblings.filter((child) =>
+    shouldKeepAndroidSibling(child, coveringCandidates, state),
+  );
 }
 
 function shouldKeepAndroidSibling(
   node: AndroidNode,
   coveringCandidates: AndroidCoveringCandidate[],
+  state: AndroidTreePruneState,
 ): boolean {
   return (
-    isPresentationLeaf(node) || !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates)
+    isPresentationLeaf(node) ||
+    !isCoveredByHigherDrawingOrderSibling(node, coveringCandidates, state)
   );
 }
 
+/**
+ * Covered means the sibling's presented content lies under the candidate's presented content.
+ * Comparing footprints rather than boxes lets two stacked screens with the same layout margins
+ * still register as covered, while a sparse overlay never condemns a rich screen.
+ */
 function isCoveredByHigherDrawingOrderSibling(
   node: AndroidNode,
   coveringCandidates: AndroidCoveringCandidate[],
+  state: AndroidTreePruneState,
 ): boolean {
   if (node.visibleToUser === false || node.drawingOrder === undefined || !hasPositiveRect(node)) {
     return false;
   }
-  for (const sibling of coveringCandidates) {
-    if (sibling === node || sibling.drawingOrder <= node.drawingOrder) {
+  const coveredRect = subtreeFootprint(node, state).rect ?? node.rect;
+  for (const candidate of coveringCandidates) {
+    if (candidate.node === node || candidate.drawingOrder <= node.drawingOrder) {
       continue;
     }
-    if (rectCoverage(sibling.rect, node.rect) >= 0.9) {
+    if (rectCoverage(candidate.footprint, coveredRect) >= 0.9) {
       return true;
     }
   }
@@ -635,21 +692,20 @@ function hasMeaningfulIdentifier(node: AndroidNode): boolean {
   return Boolean(identifier && !isGenericAndroidId(identifier));
 }
 
-function canCoverSibling(
+/** The single occlusion classification. Covering is never re-derived from a raw attribute. */
+function coveringCandidateOf(
   node: AndroidNode,
   state: AndroidTreePruneState,
-): node is AndroidCoveringCandidate {
-  return (
-    node.visibleToUser !== false &&
-    node.drawingOrder !== undefined &&
-    hasPositiveRect(node) &&
-    hasOcclusionEvidence(node, state)
-  );
-}
-
-/** The single occlusion classification. Covering is never re-derived from a raw attribute. */
-function hasOcclusionEvidence(node: AndroidNode, state: AndroidTreePruneState): boolean {
-  return hasDirectOcclusionEvidence(node) || hasDescendantOcclusionEvidence(node, state);
+): AndroidCoveringCandidate | null {
+  const { drawingOrder } = node;
+  if (node.visibleToUser === false || drawingOrder === undefined || !hasPositiveRect(node)) {
+    return null;
+  }
+  if (!hasDirectOcclusionEvidence(node) && !hasDescendantOcclusionEvidence(node, state)) {
+    return null;
+  }
+  const footprint = subtreeFootprint(node, state).rect;
+  return footprint ? { node, drawingOrder, footprint } : null;
 }
 
 function hasMeaningfulLabel(node: AndroidNode): boolean {

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -452,8 +452,10 @@ type AndroidNodeInclusionInfo = {
 };
 
 type AndroidFootprint = {
-  /** Boxes of what the subtree presents: touch/focus targets, scrollables and labelled leaves. */
-  rects: Rect[];
+  /** Boxes of what the subtree paints: touch targets, scrollables and labelled leaves. */
+  paints: Rect[];
+  /** Boxes of what an agent would see of the subtree: `paints` plus labelled/identified nodes. */
+  shows: Rect[];
   hasAgentTarget: boolean;
 };
 
@@ -573,35 +575,60 @@ function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePru
 }
 
 /**
- * Where a subtree visibly presents something: the boxes of its touch-consuming surfaces (touch
- * targets, scrollables), focus targets and labelled leaves. A full-screen debug overlay holding one
- * floating icon presents only that icon, so it can only hide what sits under the icon, never the
- * whole app behind it (#1806). The rects are kept apart rather than merged into one bounding box:
- * two controls in opposite corners present two corners, not the screen between them.
+ * What a subtree paints and what it shows. Paint is the boxes of its touch-consuming surfaces
+ * (touch targets, scrollables) and labelled leaves: a full-screen debug overlay
+ * holding one floating icon paints only that icon, so it can only hide what sits under the icon,
+ * never the whole app behind it (#1806). Rects are kept apart rather than merged into one bounding
+ * box: two controls in opposite corners paint two corners, not the screen between them.
+ *
+ * Shows adds every labelled or identified node — a testID marker or a described container paints
+ * nothing, so it never helps a candidate cover, but an agent would still lose it, so it always
+ * counts toward what a covered sibling has.
  */
 function subtreeFootprint(node: AndroidNode, state: AndroidTreePruneState): AndroidFootprint {
   const cached = state.footprintMemo.get(node);
   if (cached !== undefined) return cached;
-  let footprint: AndroidFootprint;
-  if (presentsOwnBox(node) && hasPositiveRect(node)) {
-    // Its box is presented as a whole; whatever it contains lies inside that box.
-    footprint = { rects: [node.rect], hasAgentTarget: isAgentTarget(node) };
-  } else {
-    footprint = { rects: [], hasAgentTarget: isAgentTarget(node) };
-    for (const child of node.children) {
-      if (child.visibleToUser === false) continue;
-      const childFootprint = subtreeFootprint(child, state);
-      footprint.hasAgentTarget ||= childFootprint.hasAgentTarget;
-      footprint.rects.push(...childFootprint.rects);
-    }
-  }
+  const footprint = hasPositiveRect(node)
+    ? footprintWithinBox(node, node.rect, state)
+    : childrenFootprint(node, state);
   state.footprintMemo.set(node, footprint);
   return footprint;
 }
 
-function presentsOwnBox(node: AndroidNode): boolean {
+function footprintWithinBox(
+  node: AndroidNode,
+  ownBox: Rect,
+  state: AndroidTreePruneState,
+): AndroidFootprint {
+  if (paintsOwnBox(node)) {
+    // The whole box is painted; whatever it contains lies inside that box.
+    return { paints: [ownBox], shows: [ownBox], hasAgentTarget: isAgentTarget(node) };
+  }
+  const footprint = childrenFootprint(node, state);
+  if (hasSemanticContent(node)) footprint.shows.push(ownBox);
+  return footprint;
+}
+
+function childrenFootprint(node: AndroidNode, state: AndroidTreePruneState): AndroidFootprint {
+  const footprint: AndroidFootprint = {
+    paints: [],
+    shows: [],
+    hasAgentTarget: isAgentTarget(node),
+  };
+  for (const child of node.children) {
+    if (child.visibleToUser === false) continue;
+    const childFootprint = subtreeFootprint(child, state);
+    footprint.hasAgentTarget ||= childFootprint.hasAgentTarget;
+    footprint.paints.push(...childFootprint.paints);
+    footprint.shows.push(...childFootprint.shows);
+  }
+  return footprint;
+}
+
+/** Focusability is traversal, not paint (#1733); a container's label describes its children. */
+function paintsOwnBox(node: AndroidNode): boolean {
   return (
-    isAgentTarget(node) ||
+    isTouchTarget(node) ||
     node.scrollable === true ||
     (node.children.length === 0 && hasMeaningfulLabel(node))
   );
@@ -704,8 +731,8 @@ function shouldKeepAndroidSibling(
 }
 
 /**
- * Covered means the sibling's presented content lies under the candidate's presented content, by
- * actual overlapped area. Comparing footprints rather than boxes lets two stacked screens with the
+ * Covered means everything an agent would see of the sibling lies under what the candidate paints,
+ * by actual overlapped area. Comparing footprints rather than boxes lets two stacked screens with the
  * same layout margins still register as covered, while a sparse overlay never condemns a rich
  * screen however far apart its controls sit.
  */
@@ -717,8 +744,8 @@ function isCoveredByHigherDrawingOrderSibling(
   if (node.visibleToUser === false || node.drawingOrder === undefined || !hasPositiveRect(node)) {
     return false;
   }
-  const footprint = subtreeFootprint(node, state).rects;
-  const coveredRects = footprint.length > 0 ? footprint : [node.rect];
+  const shows = subtreeFootprint(node, state).shows;
+  const coveredRects = shows.length > 0 ? shows : [node.rect];
   for (const candidate of coveringCandidates) {
     if (candidate.node === node || candidate.drawingOrder <= node.drawingOrder) {
       continue;
@@ -747,7 +774,7 @@ function coveringCandidateOf(
   if (!hasDirectOcclusionEvidence(node) && !hasDescendantOcclusionEvidence(node, state)) {
     return null;
   }
-  const footprint = subtreeFootprint(node, state).rects;
+  const footprint = subtreeFootprint(node, state).paints;
   return footprint.length > 0 ? { node, drawingOrder, footprint } : null;
 }
 

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -2,7 +2,6 @@ import type { RawSnapshotNode, Rect, SnapshotOptions } from '@agent-device/kerne
 import { parseBounds } from '@agent-device/kernel/bounds';
 import { decodeXmlCharacterReferences } from '@agent-device/xml';
 import { isScrollableType } from '@agent-device/contracts/snapshot';
-import { intersectArea } from '../../utils/screenshot-geometry.ts';
 import {
   type AndroidSystemChromeProvenance,
   isAndroidSystemChromeWindowResourceId,
@@ -453,8 +452,8 @@ type AndroidNodeInclusionInfo = {
 };
 
 type AndroidFootprint = {
-  /** Bounding box of what the subtree presents (agent targets and labelled leaves), if anything. */
-  rect: Rect | null;
+  /** Boxes of what the subtree presents: touch/focus targets, scrollables and labelled leaves. */
+  rects: Rect[];
   hasAgentTarget: boolean;
 };
 
@@ -465,7 +464,7 @@ type AndroidTreePruneState = {
 type AndroidCoveringCandidate = {
   node: AndroidNode;
   drawingOrder: number;
-  footprint: Rect;
+  footprint: Rect[];
 };
 
 const ANDROID_WINDOW_TYPE_APPLICATION = 1;
@@ -574,42 +573,84 @@ function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePru
 }
 
 /**
- * Where a subtree visibly presents something: the bounding box of its agent targets and labelled
- * leaves. A full-screen debug overlay holding one floating icon presents only that icon, so it can
- * only hide what sits under the icon, never the whole app behind it (#1806).
+ * Where a subtree visibly presents something: the boxes of its touch-consuming surfaces (touch
+ * targets, scrollables), focus targets and labelled leaves. A full-screen debug overlay holding one
+ * floating icon presents only that icon, so it can only hide what sits under the icon, never the
+ * whole app behind it (#1806). The rects are kept apart rather than merged into one bounding box:
+ * two controls in opposite corners present two corners, not the screen between them.
  */
 function subtreeFootprint(node: AndroidNode, state: AndroidTreePruneState): AndroidFootprint {
   const cached = state.footprintMemo.get(node);
   if (cached !== undefined) return cached;
-  let hasAgentTarget = isAgentTarget(node);
-  let rect: Rect | null =
-    (isAgentTarget(node) || isLabelledLeaf(node)) && hasPositiveRect(node) ? node.rect : null;
-  for (const child of node.children) {
-    if (child.visibleToUser === false) continue;
-    const childFootprint = subtreeFootprint(child, state);
-    hasAgentTarget ||= childFootprint.hasAgentTarget;
-    rect = unionRect(rect, childFootprint.rect);
+  let footprint: AndroidFootprint;
+  if (presentsOwnBox(node) && hasPositiveRect(node)) {
+    // Its box is presented as a whole; whatever it contains lies inside that box.
+    footprint = { rects: [node.rect], hasAgentTarget: isAgentTarget(node) };
+  } else {
+    footprint = { rects: [], hasAgentTarget: isAgentTarget(node) };
+    for (const child of node.children) {
+      if (child.visibleToUser === false) continue;
+      const childFootprint = subtreeFootprint(child, state);
+      footprint.hasAgentTarget ||= childFootprint.hasAgentTarget;
+      footprint.rects.push(...childFootprint.rects);
+    }
   }
-  const footprint = { rect, hasAgentTarget };
   state.footprintMemo.set(node, footprint);
   return footprint;
 }
 
-function isLabelledLeaf(node: AndroidNode): boolean {
-  return node.children.length === 0 && hasMeaningfulLabel(node);
+function presentsOwnBox(node: AndroidNode): boolean {
+  return (
+    isAgentTarget(node) ||
+    node.scrollable === true ||
+    (node.children.length === 0 && hasMeaningfulLabel(node))
+  );
 }
 
-function unionRect(left: Rect | null, right: Rect | null): Rect | null {
-  if (!left) return right;
-  if (!right) return left;
-  const x = Math.min(left.x, right.x);
-  const y = Math.min(left.y, right.y);
-  return {
-    x,
-    y,
-    width: Math.max(left.x + left.width, right.x + right.width) - x,
-    height: Math.max(left.y + left.height, right.y + right.height) - y,
-  };
+/** Fraction of the covered rects' union that lies under the covering rects' union. */
+function unionCoverage(coveringRects: Rect[], coveredRects: Rect[]): number {
+  const xs = compressedEdges([...coveringRects, ...coveredRects], (rect) => [
+    rect.x,
+    rect.x + rect.width,
+  ]);
+  const ys = compressedEdges([...coveringRects, ...coveredRects], (rect) => [
+    rect.y,
+    rect.y + rect.height,
+  ]);
+  const covering = markCells(coveringRects, xs, ys);
+  const covered = markCells(coveredRects, xs, ys);
+  let coveredArea = 0;
+  let overlapArea = 0;
+  for (let column = 0; column < xs.length - 1; column += 1) {
+    const width = xs[column + 1]! - xs[column]!;
+    for (let row = 0; row < ys.length - 1; row += 1) {
+      const cell = column * (ys.length - 1) + row;
+      if (!covered[cell]) continue;
+      const area = width * (ys[row + 1]! - ys[row]!);
+      coveredArea += area;
+      if (covering[cell]) overlapArea += area;
+    }
+  }
+  return coveredArea <= 0 ? 0 : overlapArea / coveredArea;
+}
+
+function compressedEdges(rects: Rect[], edgesOf: (rect: Rect) => [number, number]): number[] {
+  return [...new Set(rects.flatMap(edgesOf))].sort((left, right) => left - right);
+}
+
+function markCells(rects: Rect[], xs: number[], ys: number[]): Uint8Array {
+  const rows = ys.length - 1;
+  const cells = new Uint8Array((xs.length - 1) * rows);
+  for (const rect of rects) {
+    const firstColumn = xs.indexOf(rect.x);
+    const lastColumn = xs.indexOf(rect.x + rect.width);
+    const firstRow = ys.indexOf(rect.y);
+    const lastRow = ys.indexOf(rect.y + rect.height);
+    for (let column = firstColumn; column < lastColumn; column += 1) {
+      cells.fill(1, column * rows + firstRow, column * rows + lastRow);
+    }
+  }
+  return cells;
 }
 
 /**
@@ -663,9 +704,10 @@ function shouldKeepAndroidSibling(
 }
 
 /**
- * Covered means the sibling's presented content lies under the candidate's presented content.
- * Comparing footprints rather than boxes lets two stacked screens with the same layout margins
- * still register as covered, while a sparse overlay never condemns a rich screen.
+ * Covered means the sibling's presented content lies under the candidate's presented content, by
+ * actual overlapped area. Comparing footprints rather than boxes lets two stacked screens with the
+ * same layout margins still register as covered, while a sparse overlay never condemns a rich
+ * screen however far apart its controls sit.
  */
 function isCoveredByHigherDrawingOrderSibling(
   node: AndroidNode,
@@ -675,12 +717,13 @@ function isCoveredByHigherDrawingOrderSibling(
   if (node.visibleToUser === false || node.drawingOrder === undefined || !hasPositiveRect(node)) {
     return false;
   }
-  const coveredRect = subtreeFootprint(node, state).rect ?? node.rect;
+  const footprint = subtreeFootprint(node, state).rects;
+  const coveredRects = footprint.length > 0 ? footprint : [node.rect];
   for (const candidate of coveringCandidates) {
     if (candidate.node === node || candidate.drawingOrder <= node.drawingOrder) {
       continue;
     }
-    if (rectCoverage(candidate.footprint, coveredRect) >= 0.9) {
+    if (unionCoverage(candidate.footprint, coveredRects) >= 0.9) {
       return true;
     }
   }
@@ -704,8 +747,8 @@ function coveringCandidateOf(
   if (!hasDirectOcclusionEvidence(node) && !hasDescendantOcclusionEvidence(node, state)) {
     return null;
   }
-  const footprint = subtreeFootprint(node, state).rect;
-  return footprint ? { node, drawingOrder, footprint } : null;
+  const footprint = subtreeFootprint(node, state).rects;
+  return footprint.length > 0 ? { node, drawingOrder, footprint } : null;
 }
 
 function hasMeaningfulLabel(node: AndroidNode): boolean {
@@ -715,12 +758,6 @@ function hasMeaningfulLabel(node: AndroidNode): boolean {
 
 function hasPositiveRect(node: AndroidNode): node is AndroidNode & { rect: Rect } {
   return Boolean(node.rect && node.rect.width > 0 && node.rect.height > 0);
-}
-
-function rectCoverage(coveringRect: Rect, targetRect: Rect): number {
-  const targetArea = targetRect.width * targetRect.height;
-  if (targetArea <= 0) return 0;
-  return intersectArea(coveringRect, targetRect) / targetArea;
 }
 
 function applyAndroidScrollActionHints(root: AndroidUiHierarchy): void {


### PR DESCRIPTION
## Summary

On Android, `snapshot` returned a 2–4 node tree for a fully rendered screen whenever a higher drawing-order sibling with sparse content sat over the app UI — a DoraemonKit full-screen drag surface holding one floating icon, or an empty labelled `match_parent` placeholder container.

`pruneAndroidCoveredSubtrees` credited a covering sibling with painting its **whole box** as soon as it had any agent target anywhere inside it, or a label of its own. Both #1806 patterns qualified and took the entire app subtree with them.

Occlusion is now spatial:

- A subtree's footprint is two sets of rectangles, kept apart rather than merged into a bounding box. **Paints** — touch targets, scrollables (they consume touches over their box) and labelled leaves — is what a candidate can cover with. **Shows** adds every labelled or identified node (testID markers, described containers): they paint nothing, so they never help a candidate cover, but an agent would lose them, so they always count toward what a covered sibling has. A full-screen overlay holding one icon paints only that icon; two controls in opposite corners paint two corners, not the screen between them.
- A sibling is covered when ≥ 90 % of the area of what it shows (or its box, if it shows nothing) lies under what the candidate paints, measured by actual overlapped area (coordinate-compressed cell sweep). Comparing footprint to footprint keeps two stacked screens with matching layout margins registering as covered.
- A node's **own label is no longer paint evidence** — a container's content-desc describes its children; an empty labelled View draws nothing. This mirrors #1733 (focusability is traversal, not paint). Only a touch target still hides its full box, so a tap-to-dismiss scrim keeps condemning what's under it.

No flag, no hint: the defect can't be expressed rather than being detected.

Closes #1806.

## Validation

**Live, Pixel 9 Pro XL API 37 emulator.** Added a DoKit-shaped overlay to the test app (full-screen non-clickable `View` with `accessibilityLabel`, one small `Pressable` inside; not committed) and drove the built CLI:

```
# pre-fix parser
Snapshot: 2 nodes
Hint: sparse accessibility snapshot returned 2 nodes; snapshot state is invalid or unavailable…
@e1 [group] "DK"
@e2 [text] "DK"

# this branch
Snapshot: 13 visible nodes (37 total)
@e2 [scroll-area] "home-title, Agent Device Tester, 0 in cart, …" [scrollable]
@e11 [button] "Drag source" … @e35 [group] "Settings" @e36 [group] "DK"
```

**Helper-XML A/B** (same XML through pre-fix and fixed parser, raw + interactive): with the overlay, home / catalog / form / product-detail all went from the same 45-node skeleton (21 interactive) to 116 / 125 / 111 / 83 nodes with every app label recovered and none lost. Product detail (a native-stack push over the Catalog tab) shows only the pushed screen — no Catalog leak. Settings, Chrome, launcher and the pre-`collapsable={false}` build (where RN flattened the overlay away) are byte-identical old vs new.

**Unit.** Six new fixtures fail on the pre-fix parser: the DoKit overlay, the empty labelled placeholder, a sparse-overlay-vs-rich-sibling footprint case, an overlay whose only controls sit in opposite corners (also fails on the first revision's bounding-box model, which is what it pins), a container of testID markers with one covered corner icon (fails on the second revision's single-footprint model), and a focusable full-screen wrapper holding one clickable icon over app content (fails if focusability is allowed to paint a candidate's box). Three existing fixtures were the exact synthetic shape the fix stops calling covered (a full-screen box with one small element over a full-screen box with an element elsewhere) and were rewritten to realistic covering content — a pushed screen with header + scrollable body + footer, a full-width tile, and a clickable scrim; the boundary they pin still holds.

**Fuzz.** 20 k random 2–3-sibling trees over the attribute space (bounds incl. child overflow, drawing-order, clickable/focusable/scrollable, text, resource-id), pre-fix vs fixed parser, disagreements classified by direction. "New prunes more" — the only direction that can produce a *new* sparse-snapshot bug — is 0.14 % with children clipped to parents (0.8 % with overflow), and every inspected case is the intended rule: everything the target shows lies fully under a higher touch/scroll surface or an overflowing labelled leaf. The rest is the pruner being more conservative.

`check:affected` set green locally: format, lint, typecheck, layering, fallow, build, vitest-related.

## Notes

- Not done (out of scope): the reporter's escape-hatch flag and a "pruned by occlusion" hint. Both would be detectors for a condition the parser no longer produces.
- Live-run quirk hit along the way, unrelated: `open` immediately after `close` on the same emulator reported `DEVICE_IN_USE` by the just-closed session for a couple of seconds.
