### PR TITLE
fix: hide clamped descendants of offscreen iOS rows

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -116,6 +116,7 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrainForSnapshotRaw \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotTraversalIdentityPreservesSameOriginNodesWithDifferentBounds \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testFlatSnapshotProjectionMatchesElementReverseScrollCapture \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXDepthLimitedRequiresEveryFrontierResolved \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDeepExtensionCountsMissedFrontiers \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPreferredPrivateAXBackendPlansAsPenalized \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
@@ -23,7 +23,100 @@ enum FlatSnapshotVisibilityPolicy {
   case viewportProjected
 }
 
+enum FlatSnapshotGeometry {
+  case geometryless
+  case framed(intersectsViewportAndScrollClip: Bool)
+}
+
+enum FlatSnapshotDescendantVisibility: Equatable {
+  case independent
+  case owned
+}
+
+struct FlatSnapshotProjectionCursor {
+  static let root = FlatSnapshotProjectionCursor(ancestorProjectedOut: false)
+
+  private let ancestorProjectedOut: Bool
+
+  var isProjectedOut: Bool { ancestorProjectedOut }
+
+  func project(
+    geometry: FlatSnapshotGeometry,
+    descendantVisibility: FlatSnapshotDescendantVisibility
+  ) -> FlatSnapshotProjectionDecision {
+    let nodeProjectedOut: Bool
+    switch geometry {
+    case .geometryless:
+      nodeProjectedOut = false
+    case .framed(let intersectsViewportAndScrollClip):
+      nodeProjectedOut = !intersectsViewportAndScrollClip
+    }
+    let presentationVisible = !ancestorProjectedOut && !nodeProjectedOut
+    let descendantsProjectedOut = ancestorProjectedOut
+      || (nodeProjectedOut && descendantVisibility == .owned)
+    return FlatSnapshotProjectionDecision(
+      presentationVisible: presentationVisible,
+      descendants: FlatSnapshotProjectionCursor(
+        ancestorProjectedOut: descendantsProjectedOut
+      )
+    )
+  }
+}
+
+struct FlatSnapshotProjectionDecision {
+  let presentationVisible: Bool
+  let descendants: FlatSnapshotProjectionCursor
+}
+
+struct FlatSnapshotProjectionTransition {
+  let decision: FlatSnapshotProjectionDecision
+  let hiddenContentFrame: CGRect?
+}
+
 extension RunnerTests {
+  func flatSnapshotGeometry(
+    frame: CGRect,
+    intersectsViewportAndScrollClip: Bool
+  ) -> FlatSnapshotGeometry {
+    if frame.isNull || frame.isEmpty { return .geometryless }
+    return .framed(intersectsViewportAndScrollClip: intersectsViewportAndScrollClip)
+  }
+
+  func flatSnapshotDescendantVisibility(
+    elementType: XCUIElement.ElementType?,
+    hasChildren: Bool
+  ) -> FlatSnapshotDescendantVisibility {
+    guard hasChildren, let elementType else { return .independent }
+    if elementType == .cell || Self.scrollContainerTypes.contains(elementType) {
+      return .owned
+    }
+    return .independent
+  }
+
+  func flatSnapshotProjectionTransition(
+    frame: CGRect,
+    intersectsViewportAndScrollClip: Bool,
+    elementType: XCUIElement.ElementType?,
+    hasChildren: Bool,
+    cursor: FlatSnapshotProjectionCursor
+  ) -> FlatSnapshotProjectionTransition {
+    let hasFrame = !frame.isNull && !frame.isEmpty
+    return FlatSnapshotProjectionTransition(
+      decision: cursor.project(
+        geometry: flatSnapshotGeometry(
+          frame: frame,
+          intersectsViewportAndScrollClip: intersectsViewportAndScrollClip
+        ),
+        descendantVisibility: flatSnapshotDescendantVisibility(
+          elementType: elementType,
+          hasChildren: hasChildren
+        )
+      ),
+      hiddenContentFrame: !cursor.isProjectedOut && hasFrame
+        && !intersectsViewportAndScrollClip ? frame : nil
+    )
+  }
+
   func flatSnapshotFilterDecision(
     _ node: FlatSnapshotFilterNode,
     options: SnapshotOptions,
@@ -73,6 +166,146 @@ extension RunnerTests {
   }
 
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
+  func testFlatSnapshotProjectionMatchesElementReverseScrollCapture() {
+    struct FixtureNode {
+      let label: String
+      let type: XCUIElement.ElementType
+      let frame: CGRect
+      let children: [FixtureNode]
+    }
+
+    let tableFrame = CGRect(x: 0, y: 152.333, width: 402, height: 659.667)
+    let visibleRowFrame = CGRect(x: 0, y: 251.333, width: 402, height: 43.667)
+    let offscreenThemeRowFrame = CGRect(x: 0, y: 2044.333, width: 402, height: 44)
+    let clampedThemeFrame = CGRect(x: 0, y: 152.333, width: 53, height: 20.333)
+    let geometrylessFrame = CGRect.zero
+    var visibleLabels: [String] = []
+    var hints: [Int: (above: Bool, below: Bool)] = [:]
+
+    func visit(
+      _ node: FixtureNode,
+      cursor: FlatSnapshotProjectionCursor,
+      scrollAnchor: (index: Int, rect: CGRect)?
+    ) {
+      let intersects = isVisibleInRegularSnapshot(
+        node.frame,
+        viewport: CGRect(x: 0, y: 0, width: 402, height: 874),
+        scrollContainerAnchor: scrollAnchor
+      )
+      let transition = flatSnapshotProjectionTransition(
+        frame: node.frame,
+        intersectsViewportAndScrollClip: intersects,
+        elementType: node.type,
+        hasChildren: !node.children.isEmpty,
+        cursor: cursor
+      )
+      if transition.decision.presentationVisible { visibleLabels.append(node.label) }
+      if let hiddenFrame = transition.hiddenContentFrame, let scrollAnchor {
+        rememberHiddenContentHint(
+          for: hiddenFrame,
+          relativeTo: scrollAnchor,
+          hints: &hints
+        )
+      }
+      let nextScrollAnchor = Self.scrollContainerTypes.contains(node.type)
+        && transition.decision.presentationVisible
+        ? (index: 0, rect: node.frame) : scrollAnchor
+      for child in node.children {
+        visit(
+          child,
+          cursor: transition.decision.descendants,
+          scrollAnchor: nextScrollAnchor
+        )
+      }
+    }
+
+    let fixture = FixtureNode(
+      label: "Table",
+      type: .table,
+      frame: tableFrame,
+      children: [
+        FixtureNode(
+          label: "Profile Picture",
+          type: .cell,
+          frame: visibleRowFrame,
+          children: [
+            FixtureNode(
+              label: "Profile semantics",
+              type: .staticText,
+              frame: geometrylessFrame,
+              children: [
+                FixtureNode(
+                  label: "Profile detail",
+                  type: .staticText,
+                  frame: visibleRowFrame,
+                  children: []
+                )
+              ]
+            )
+          ]
+        ),
+        // Element reports this row at y=2044 but clamps Theme and Auto to the table's top edge.
+        FixtureNode(
+          label: "Theme row",
+          type: .cell,
+          frame: offscreenThemeRowFrame,
+          children: [
+            FixtureNode(
+              label: "Theme",
+              type: .staticText,
+              frame: clampedThemeFrame,
+              children: []
+            ),
+            FixtureNode(
+              label: "Auto",
+              type: .staticText,
+              frame: clampedThemeFrame,
+              children: []
+            )
+          ]
+        ),
+        FixtureNode(
+          label: "Offscreen wrapper",
+          type: .other,
+          frame: offscreenThemeRowFrame,
+          children: [
+            FixtureNode(
+              label: "Visible overlay",
+              type: .staticText,
+              frame: visibleRowFrame,
+              children: []
+            )
+          ]
+        )
+      ]
+    )
+    visit(fixture, cursor: .root, scrollAnchor: nil)
+
+    XCTAssertEqual(
+      visibleLabels,
+      ["Table", "Profile Picture", "Profile semantics", "Profile detail", "Visible overlay"]
+    )
+    XCTAssertEqual(hints.count, 1)
+    XCTAssertEqual(hints[0]?.above, false)
+    XCTAssertEqual(hints[0]?.below, true)
+
+    let scopedRoot = flatSnapshotProjectionTransition(
+      frame: offscreenThemeRowFrame,
+      intersectsViewportAndScrollClip: false,
+      elementType: .cell,
+      hasChildren: true,
+      cursor: .root
+    )
+    let scopedClampedChild = flatSnapshotProjectionTransition(
+      frame: clampedThemeFrame,
+      intersectsViewportAndScrollClip: true,
+      elementType: .staticText,
+      hasChildren: false,
+      cursor: scopedRoot.decision.descendants
+    )
+    XCTAssertFalse(scopedClampedChild.decision.presentationVisible)
+  }
+
   func testFlatSnapshotFilterDecisionMatrixCoversOptions() {
     let visibleContent = FlatSnapshotFilterNode(
       isRoot: false,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -10,14 +10,14 @@ extension RunnerTests {
     var hints: [Int: (above: Bool, below: Bool)] = [:]
     appendPrivateAXNode(rawRoot, to: &nodes, hints: &hints, options: options, viewport: viewport,
       depth: 0, parentIndex: nil, insideMatchedScope: false, scrollContext: nil,
-      ancestorOffscreen: false)
+      projectionCursor: .root)
     return applyHiddenContentHints(hints, to: nodes)
   }
 
   private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
     hints: inout [Int: (above: Bool, below: Bool)], options: SnapshotOptions, viewport: CGRect,
     depth: Int, parentIndex: Int?, insideMatchedScope: Bool,
-    scrollContext: (index: Int, rect: CGRect)?, ancestorOffscreen: Bool)
+    scrollContext: (index: Int, rect: CGRect)?, projectionCursor: FlatSnapshotProjectionCursor)
   {
     if let limit = options.depth, depth > limit { return }
     let rect = privateAXRect(raw["frame"])
@@ -41,8 +41,15 @@ extension RunnerTests {
         viewport: viewport,
         scrollContainerAnchor: scrollContext
       )
-    let offscreen = ancestorOffscreen || (hasFrame && !onScreen)
-    let presentationVisible = !offscreen && !negligibleDecoration
+    let projectionTransition = flatSnapshotProjectionTransition(
+      frame: rect,
+      intersectsViewportAndScrollClip: onScreen,
+      elementType: elementType,
+      hasChildren: !children.isEmpty,
+      cursor: projectionCursor
+    )
+    let projection = projectionTransition.decision
+    let presentationVisible = projection.presentationVisible && !negligibleDecoration
     let decision = flatSnapshotFilterDecision(
       FlatSnapshotFilterNode(isRoot: parentIndex == nil, label: label, identifier: identifier,
         valueText: value.isEmpty ? nil : value, visible: presentationVisible),
@@ -50,8 +57,8 @@ extension RunnerTests {
       insideMatchedScope: insideMatchedScope)
     let include = decision.include
 
-    if !ancestorOffscreen && hasFrame && !onScreen, let scrollContext {
-      rememberHiddenContentHint(for: rect, relativeTo: scrollContext, hints: &hints)
+    if let hiddenFrame = projectionTransition.hiddenContentFrame, let scrollContext {
+      rememberHiddenContentHint(for: hiddenFrame, relativeTo: scrollContext, hints: &hints)
     }
 
     let currentIndex: Int?
@@ -82,7 +89,7 @@ extension RunnerTests {
       appendPrivateAXNode(child, to: &nodes, hints: &hints, options: options, viewport: viewport,
         depth: depth + 1, parentIndex: currentIndex,
         insideMatchedScope: decision.insideMatchedScope, scrollContext: nextScrollContext,
-        ancestorOffscreen: offscreen)
+        projectionCursor: projection.descendants)
     }
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -30,6 +30,15 @@ extension RunnerTests {
     let visible: Bool
   }
 
+  private struct SnapshotTraversalEntry {
+    let snapshot: XCUIElementSnapshot
+    let depth: Int
+    let visibleDepth: Int
+    let parentIndex: Int?
+    let nearestScrollAnchor: (index: Int, rect: CGRect)?
+    let projectionCursor: FlatSnapshotProjectionCursor
+  }
+
   struct SnapshotCaptureFailure: Error {
     let code: String
     let message: String
@@ -166,23 +175,67 @@ extension RunnerTests {
       visible: rootEvaluation.visible,
       nodeIndex: 0
     )
-    var stack: [(XCUIElementSnapshot, Int, Int, Int?, (index: Int, rect: CGRect)?)] =
-      context.rootSnapshot.children.map {
-        ($0, 1, 1, 0, rootScrollAnchor)
-      }
+    #if os(iOS)
+      let rootProjection = flatSnapshotProjectionTransition(
+        frame: context.rootSnapshot.frame,
+        intersectsViewportAndScrollClip: rootEvaluation.visible,
+        elementType: context.rootSnapshot.elementType,
+        hasChildren: !context.rootSnapshot.children.isEmpty,
+        cursor: .root
+      )
+      let rootDescendantProjectionCursor = rootProjection.decision.descendants
+    #else
+      let rootDescendantProjectionCursor = FlatSnapshotProjectionCursor.root
+    #endif
+    var stack: [SnapshotTraversalEntry] = context.rootSnapshot.children.map {
+      SnapshotTraversalEntry(
+        snapshot: $0,
+        depth: 1,
+        visibleDepth: 1,
+        parentIndex: 0,
+        nearestScrollAnchor: rootScrollAnchor,
+        projectionCursor: rootDescendantProjectionCursor
+      )
+    }
 
-    while let (snapshot, depth, visibleDepth, parentIndex, nearestScrollAnchor) = stack.popLast() {
+    while let entry = stack.popLast() {
+      let snapshot = entry.snapshot
+      let depth = entry.depth
+      let visibleDepth = entry.visibleDepth
+      let parentIndex = entry.parentIndex
+      let nearestScrollAnchor = entry.nearestScrollAnchor
+      let projectionCursor = entry.projectionCursor
       if let limit = options.depth, depth > limit { continue }
 
       let evaluation = evaluateSnapshot(snapshot, in: context)
-      let regularVisible = isVisibleInRegularSnapshot(
+      let intersectsViewportAndScrollClip = isVisibleInRegularSnapshot(
         snapshot.frame,
         viewport: context.viewport,
         scrollContainerAnchor: nearestScrollAnchor
       )
-      if !regularVisible, let nearestScrollAnchor {
+      #if os(iOS)
+        let projectionTransition = flatSnapshotProjectionTransition(
+          frame: snapshot.frame,
+          intersectsViewportAndScrollClip: intersectsViewportAndScrollClip,
+          elementType: snapshot.elementType,
+          hasChildren: !snapshot.children.isEmpty,
+          cursor: projectionCursor
+        )
+        let projection = projectionTransition.decision
+      #else
+        let projectionTransition = FlatSnapshotProjectionTransition(
+          decision: FlatSnapshotProjectionDecision(
+            presentationVisible: intersectsViewportAndScrollClip,
+            descendants: .root
+          ),
+          hiddenContentFrame: !intersectsViewportAndScrollClip ? snapshot.frame : nil
+        )
+        let projection = projectionTransition.decision
+      #endif
+      if let hiddenFrame = projectionTransition.hiddenContentFrame, let nearestScrollAnchor
+      {
         rememberHiddenContentHint(
-          for: snapshot.frame,
+          for: hiddenFrame,
           relativeTo: nearestScrollAnchor,
           hints: &hiddenContentHintsByNodeIndex
         )
@@ -194,7 +247,7 @@ extension RunnerTests {
         valueText: evaluation.valueText,
         options: options,
         hittable: evaluation.hittable,
-        visible: regularVisible,
+        visible: projection.presentationVisible,
         regularSnapshot: true
       )
 
@@ -217,7 +270,7 @@ extension RunnerTests {
           nextScrollContainerAnchor =
             scrollContainerAnchor(
               for: snapshot,
-              visible: regularVisible,
+              visible: intersectsViewportAndScrollClip,
               nodeIndex: currentIndex
             )
             ?? nearestScrollAnchor
@@ -225,7 +278,16 @@ extension RunnerTests {
           nextScrollContainerAnchor = nearestScrollAnchor
         }
         for child in snapshot.children.reversed() {
-          stack.append((child, depth + 1, nextVisibleDepth, currentIndex, nextScrollContainerAnchor))
+          stack.append(
+            SnapshotTraversalEntry(
+              snapshot: child,
+              depth: depth + 1,
+              visibleDepth: nextVisibleDepth,
+              parentIndex: currentIndex,
+              nearestScrollAnchor: nextScrollContainerAnchor,
+              projectionCursor: projection.descendants
+            )
+          )
         }
       }
 
@@ -819,6 +881,11 @@ extension RunnerTests {
   ) -> Bool {
     let type = snapshot.elementType
     let hasContent = !label.isEmpty || !identifier.isEmpty || (valueText != nil)
+    #if os(iOS)
+      if regularSnapshot && !visible && type != .application && type != .window {
+        return false
+      }
+    #endif
     if options.interactiveOnly {
       if isScrollableContainer(snapshot, visible: visible) { return true }
       #if os(macOS)


### PR DESCRIPTION
## Summary

Prevent iOS recursive-tree and private-AX snapshots from exposing clamped descendants of offscreen rows.

Both backends now share one typed projection transition for geometry normalization, row/scroll-container ownership, descendant propagation, and hidden-content hint eligibility. Geometryless semantics and visible children under generic wrappers remain available. Adds an exact Element reverse-scroll regression to the iOS runner lane.

Related to #1797; this fixes the observed presentation divergence without claiming the broader acquisition/presentation redesign.

## Validation

- Live iOS Element verification on a disposable clone: Settings scroll down settled in 2689ms; reverse scroll settled in 2711ms; Theme/Auto absent; hiddenContentBelow preserved.
- Red/green Element geometry regression, then five focused iOS runner XTests passing.
- AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest:ios
- pnpm check:affected --run