### PR TITLE
fix: reject selector-shaped wait arguments instead of reading them as text

### DIFF
--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -113,6 +113,9 @@ function readWaitOptionsFromPositionals(
       ...readTimeoutOption(parsed.timeoutMs),
     };
   }
+  if (parsed.kind === 'invalid') {
+    throw new AppError('INVALID_ARGS', parsed.message);
+  }
   return {
     ...base,
     selector: parsed.selectorExpression,

--- a/src/core/wait-positionals.test.ts
+++ b/src/core/wait-positionals.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #1800: a positional list shaped like a selector (a recognized key, or an
+ * unrecognized `key=value`) must never silently degrade to a `text` wait —
+ * that degradation is exactly the shape that reads as "element absent" after
+ * a full timeout instead of the caller's own argument mistake. See #1035 for
+ * the sibling fix on click/press/fill/get.
+ */
+import assert from 'node:assert/strict';
+import fc from 'fast-check';
+import { test } from 'vitest';
+import { isValidSelectorExpression, SELECTOR_KEY_NAMES } from '@agent-device/selectors';
+import { PROPERTY_RUNS } from '../__tests__/test-utils/index.ts';
+import { parseWaitPositionals, resolveWaitBudgetMs } from './wait-positionals.ts';
+
+function assertInvalid(args: string[], messageFragment: string) {
+  const result = parseWaitPositionals(args);
+  assert.ok(result, `expected a result for ${JSON.stringify(args)}`);
+  assert.equal(result.kind, 'invalid');
+  if (result.kind !== 'invalid') return;
+  assert.ok(
+    result.message.includes(messageFragment),
+    `expected message to include ${JSON.stringify(messageFragment)}, got ${JSON.stringify(result.message)}`,
+  );
+}
+
+// --- the issue's reproduction shapes -----------------------------------
+
+test('a condition word followed by a selector-shaped value is rejected, not read as text (#1800 repro)', () => {
+  const result = parseWaitPositionals(['open', 'label="Open"', '25000']);
+  assert.ok(result);
+  assert.notEqual(result.kind, 'text');
+  assertInvalid(['open', 'label="Open"', '25000'], 'label="Open"');
+});
+
+test('"exists" followed by a selector-shaped value is rejected and points at the selector form', () => {
+  assertInvalid(['exists', 'label="x"', '100'], "wait 'visible");
+});
+
+test('unknown selector key is rejected with the supported-key list, not read as text', () => {
+  const result = parseWaitPositionals(['lbl="x"', '100']);
+  assert.ok(result);
+  assert.equal(result.kind, 'invalid');
+  if (result.kind !== 'invalid') return;
+  assert.equal(result.reason, 'unknown-selector-key');
+  assert.ok(result.message.includes('lbl'));
+  assert.ok(result.message.includes('label='));
+});
+
+// --- still-valid selector forms are untouched ---------------------------
+
+test('a valid selector still parses as selector', () => {
+  const result = parseWaitPositionals(['label="Open"', '5000']);
+  assert.deepEqual(result, {
+    kind: 'selector',
+    selectorExpression: 'label="Open"',
+    timeoutMs: 5000,
+  });
+});
+
+test('"visible" leading a valid selector still parses as selector (boolean key, not a condition word)', () => {
+  const result = parseWaitPositionals(['visible', 'label="Open"', '25000']);
+  assert.deepEqual(result, {
+    kind: 'selector',
+    selectorExpression: 'visible label="Open"',
+    timeoutMs: 25000,
+  });
+});
+
+// --- trailing tokens after a valid selector prefix are rejected too -----
+
+test('a valid selector prefix followed by an unquoted extra word is rejected, not merged into text', () => {
+  assertInvalid(['label="Open"', 'foo', '5000'], 'extra arguments');
+});
+
+// --- bare text keeps working ---------------------------------------------
+
+test('bare single-word text still parses as text', () => {
+  const result = parseWaitPositionals(['Continue', '1500']);
+  assert.deepEqual(result, { kind: 'text', text: 'Continue', timeoutMs: 1500 });
+});
+
+test('bare multi-word text still parses as text', () => {
+  const result = parseWaitPositionals(['Sign', 'in', '2000']);
+  assert.deepEqual(result, { kind: 'text', text: 'Sign in', timeoutMs: 2000 });
+});
+
+test('explicit "text" keyword form bypasses selector-shape rejection entirely', () => {
+  // Even though "label=Open" is selector-shaped, the explicit `text` keyword is the caller's
+  // unambiguous escape hatch and must always win.
+  const result = parseWaitPositionals(['text', 'label=Open', '5000']);
+  assert.deepEqual(result, { kind: 'text', text: 'label=Open', timeoutMs: 5000 });
+});
+
+test('free prose containing a bare "=" with no key stays literal text', () => {
+  const result = parseWaitPositionals(['Total', '=', '5', '3000']);
+  assert.deepEqual(result, { kind: 'text', text: 'Total = 5', timeoutMs: 3000 });
+});
+
+// --- documented boundary: a bare selector-key word alone is rejected, not text ---
+
+test('a single word that IS a recognized selector key is rejected rather than read as literal text', () => {
+  // "id" alone cannot become a valid selector (it needs a value), but it also must not silently
+  // become literal wait text — an agent that meant the word "id" has to say so via `wait text`.
+  assertInvalid(['id', '3000'], "wait text 'id'");
+});
+
+// --- resolveWaitBudgetMs stays sane for the new variant -------------------
+
+test('resolveWaitBudgetMs returns null for a rejected selector-shaped positional list', () => {
+  assert.equal(resolveWaitBudgetMs(['open', 'label="Open"', '25000']), null);
+});
+
+// --- properties over examples ---------------------------------------------
+
+const TEXT_SELECTOR_KEYS = SELECTOR_KEY_NAMES.filter((key) => !isValidSelectorExpression(key));
+const BOOLEAN_SELECTOR_KEYS = SELECTOR_KEY_NAMES.filter((key) => isValidSelectorExpression(key));
+
+const selectorValueArb = fc.oneof(
+  fc.constantFrom('Open', 'Sign in', "it's", 'a || b', 'key=value'),
+  fc.string({ minLength: 1, maxLength: 8 }).filter((value) => value.trim().length > 0),
+);
+
+/** One token of a generated, guaranteed-valid selector expression. */
+const selectorTokenArb: fc.Arbitrary<string> = fc.oneof(
+  fc
+    .record({ key: fc.constantFrom(...TEXT_SELECTOR_KEYS), value: selectorValueArb })
+    .map(({ key, value }) => `${key}=${JSON.stringify(value)}`),
+  fc.constantFrom(...BOOLEAN_SELECTOR_KEYS),
+);
+
+const validSelectorTokensArb: fc.Arbitrary<string[]> = fc.array(selectorTokenArb, {
+  minLength: 1,
+  maxLength: 3,
+});
+
+test('property: a generated valid selector expression never parses as text or invalid', () => {
+  fc.assert(
+    fc.property(validSelectorTokensArb, (tokens) => {
+      const result = parseWaitPositionals(tokens);
+      assert.ok(result);
+      assert.equal(result.kind, 'selector');
+    }),
+    { numRuns: PROPERTY_RUNS },
+  );
+});
+
+const plainWordArb = fc
+  .string({ minLength: 1, maxLength: 6 })
+  .filter(
+    (token) =>
+      token.trim().length > 0 &&
+      !token.includes('=') &&
+      !token.startsWith('@') &&
+      token !== 'text' &&
+      token !== 'stable' &&
+      Number.isNaN(Number(token)),
+  );
+
+const recognizedKeyValueTokenArb: fc.Arbitrary<string> = fc
+  .record({ key: fc.constantFrom(...SELECTOR_KEY_NAMES), value: selectorValueArb })
+  .map(({ key, value }) => `${key}=${JSON.stringify(value)}`);
+
+const unrecognizedKeyValueTokenArb: fc.Arbitrary<string> = fc
+  .record({
+    key: fc
+      .string({ minLength: 1, maxLength: 8 })
+      .filter(
+        (key) =>
+          /^[a-zA-Z][a-zA-Z0-9]*$/.test(key) &&
+          !SELECTOR_KEY_NAMES.includes(key.toLowerCase() as (typeof SELECTOR_KEY_NAMES)[number]),
+      ),
+    value: selectorValueArb,
+  })
+  .map(({ key, value }) => `${key}=${JSON.stringify(value)}`);
+
+const keyValueShapedTokenArb = fc.oneof(recognizedKeyValueTokenArb, unrecognizedKeyValueTokenArb);
+
+test('property: any positional list containing a key=value-shaped token never parses as text', () => {
+  fc.assert(
+    fc.property(
+      fc.array(plainWordArb, { maxLength: 3 }),
+      keyValueShapedTokenArb,
+      fc.nat({ max: 3 }),
+      (plainTokens, kvToken, insertAtRaw) => {
+        const insertAt = Math.min(insertAtRaw, plainTokens.length);
+        const tokens = [...plainTokens.slice(0, insertAt), kvToken, ...plainTokens.slice(insertAt)];
+        const result = parseWaitPositionals(tokens);
+        assert.ok(result);
+        assert.notEqual(result.kind, 'text');
+      },
+    ),
+    { numRuns: PROPERTY_RUNS },
+  );
+});

--- a/src/core/wait-positionals.ts
+++ b/src/core/wait-positionals.ts
@@ -1,12 +1,27 @@
 import { parseTimeout } from '../utils/parse-timeout.ts';
-import { isValidSelectorExpression, splitSelectorFromArgs } from '@agent-device/selectors';
+import {
+  detectUnknownSelectorKeyToken,
+  isRoleHintWord,
+  isSelectorToken,
+  isValidSelectorExpression,
+  SELECTOR_KEY_NAMES,
+  splitSelectorFromArgs,
+} from '@agent-device/selectors';
+
+export type WaitInvalidReason = 'unknown-selector-key' | 'selector-shaped-text';
 
 export type WaitParsed =
   | { kind: 'sleep'; durationMs: number }
   | { kind: 'ref'; rawRef: string; timeoutMs: number | null }
   | { kind: 'selector'; selectorExpression: string; timeoutMs: number | null }
   | { kind: 'text'; text: string; timeoutMs: number | null }
-  | { kind: 'stable'; quietMs: number | null; timeoutMs: number | null };
+  | { kind: 'stable'; quietMs: number | null; timeoutMs: number | null }
+  | { kind: 'invalid'; reason: WaitInvalidReason; message: string };
+
+// Words that name a wait CONDITION rather than a selector key. A caller leading with one of these
+// almost certainly wants the selector form — `visible`/`hidden` are already selector keys, so they
+// never reach this list; they parse as valid boolean-key selector terms instead (#1800).
+const CONDITION_WORDS = new Set(['exists', 'present', 'appears', 'gone', 'disappears']);
 
 export function parseWaitPositionals(args: string[]): WaitParsed | null {
   const firstArg = args[0];
@@ -14,24 +29,122 @@ export function parseWaitPositionals(args: string[]): WaitParsed | null {
   const sleepMs = parseTimeout(firstArg);
   if (sleepMs !== null) return { kind: 'sleep', durationMs: sleepMs };
   const timeoutMs = parseTimeout(args[args.length - 1]);
-  if (firstArg === 'text') {
-    const text = timeoutMs !== null ? args.slice(1, -1).join(' ') : args.slice(1).join(' ');
-    return { kind: 'text', text: text.trim(), timeoutMs };
-  }
-  if (firstArg === 'stable') {
-    const rest = args.slice(1);
-    const stableTimeoutMs = rest.length > 1 ? parseTimeout(rest[1]) : null;
-    const quietMs = rest.length > 0 ? parseTimeout(rest[0]) : null;
-    return { kind: 'stable', quietMs, timeoutMs: stableTimeoutMs };
-  }
+  if (firstArg === 'text') return parseTextKeyword(args, timeoutMs);
+  if (firstArg === 'stable') return parseStableKeyword(args);
   if (firstArg.startsWith('@')) return { kind: 'ref', rawRef: firstArg, timeoutMs };
+  return parseSelectorOrText(args, timeoutMs);
+}
+
+function parseTextKeyword(args: string[], timeoutMs: number | null): WaitParsed {
+  const text = timeoutMs !== null ? args.slice(1, -1).join(' ') : args.slice(1).join(' ');
+  return { kind: 'text', text: text.trim(), timeoutMs };
+}
+
+function parseStableKeyword(args: string[]): WaitParsed {
+  const rest = args.slice(1);
+  const stableTimeoutMs = rest.length > 1 ? parseTimeout(rest[1]) : null;
+  const quietMs = rest.length > 0 ? parseTimeout(rest[0]) : null;
+  return { kind: 'stable', quietMs, timeoutMs: stableTimeoutMs };
+}
+
+/**
+ * The fallback path once `wait` isn't a keyword form, a sleep, or a `@ref`: either a full selector
+ * expression, or literal text. #1800: a token shaped like a selector (a recognized key, or an
+ * unrecognized `key=value`) must never silently degrade to literal text just because the overall
+ * positional list failed to parse as a full selector expression — that is exactly the shape that
+ * reads as an absent element after a full timeout instead of the caller's own mistake.
+ */
+function parseSelectorOrText(args: string[], timeoutMs: number | null): WaitParsed {
   const argsWithoutTimeout = timeoutMs !== null ? args.slice(0, -1) : args.slice();
   const split = splitSelectorFromArgs(argsWithoutTimeout);
   if (split && split.rest.length === 0 && isValidSelectorExpression(split.selectorExpression)) {
     return { kind: 'selector', selectorExpression: split.selectorExpression, timeoutMs };
   }
+  const rejection = detectSelectorShapedRejection(argsWithoutTimeout, split);
+  if (rejection) return rejection;
   const text = timeoutMs !== null ? args.slice(0, -1).join(' ') : args.join(' ');
   return { kind: 'text', text: text.trim(), timeoutMs };
+}
+
+function detectSelectorShapedRejection(
+  argsWithoutTimeout: string[],
+  split: { selectorExpression: string; rest: string[] } | null,
+): Extract<WaitParsed, { kind: 'invalid' }> | null {
+  for (const token of argsWithoutTimeout) {
+    const unknownKey = detectUnknownSelectorKeyToken(token);
+    if (unknownKey) {
+      return {
+        kind: 'invalid',
+        reason: 'unknown-selector-key',
+        message: formatUnknownSelectorKeyMessage(unknownKey, argsWithoutTimeout),
+      };
+    }
+  }
+  if (split && split.rest.length > 0) {
+    return {
+      kind: 'invalid',
+      reason: 'selector-shaped-text',
+      message: formatTrailingArgsMessage(split, argsWithoutTimeout),
+    };
+  }
+  if (argsWithoutTimeout.some((token) => isSelectorToken(token))) {
+    return {
+      kind: 'invalid',
+      reason: 'selector-shaped-text',
+      message: formatSelectorShapedMessage(argsWithoutTimeout),
+    };
+  }
+  return null;
+}
+
+function formatUnknownSelectorKeyMessage(
+  unknownKey: { key: string; value: string },
+  argsWithoutTimeout: string[],
+): string {
+  const raw = argsWithoutTimeout.join(' ');
+  const hintValue = isRoleHintWord(unknownKey.key)
+    ? `role=${unknownKey.key} label="${unknownKey.value}"`
+    : `label="${unknownKey.value}"`;
+  return (
+    `Unknown selector key "${unknownKey.key}" in "${raw}". Supported: ${SELECTOR_KEY_NAMES.join(', ')}. ` +
+    `Use wait '${hintValue}' [timeoutMs] to wait for the selector, or wait text '${raw}' [timeoutMs] to wait for the literal text "${raw}".`
+  );
+}
+
+function formatTrailingArgsMessage(
+  split: { selectorExpression: string; rest: string[] },
+  argsWithoutTimeout: string[],
+): string {
+  const raw = argsWithoutTimeout.join(' ');
+  return (
+    `Selector ${split.selectorExpression} is followed by unexpected extra arguments: "${split.rest.join(' ')}". ` +
+    `Selector values with spaces need quotes, e.g. label="Sign in". ` +
+    `Use wait '<selector>' [timeoutMs], or wait text '${raw}' [timeoutMs] to wait for the literal text "${raw}".`
+  );
+}
+
+function formatSelectorShapedMessage(argsWithoutTimeout: string[]): string {
+  const raw = argsWithoutTimeout.join(' ');
+  const plainTokens = argsWithoutTimeout.filter((token) => !isSelectorToken(token));
+  const selectorTokens = argsWithoutTimeout.filter((token) => isSelectorToken(token));
+  if (plainTokens.length > 0) {
+    const offending = plainTokens[0]!;
+    const conditionHint = CONDITION_WORDS.has(offending.toLowerCase())
+      ? ` "${offending}" describes a condition, not a selector key. Use the selector form: ` +
+        `wait 'visible ${selectorTokens.join(' ')}' [timeoutMs] to wait for it to appear, or ` +
+        `wait 'hidden ${selectorTokens.join(' ')}' [timeoutMs] to wait for it to disappear.`
+      : ` "${offending}" is not a recognized selector key (${SELECTOR_KEY_NAMES.join(', ')}).`;
+    return (
+      `"${raw}" mixes plain word "${offending}" with selector-shaped "${selectorTokens.join(' ')}", ` +
+      `so it is neither a valid selector nor safe as literal text.${conditionHint} ` +
+      `Use wait '<selector>' [timeoutMs] for a selector, or wait text '${raw}' [timeoutMs] to wait for the literal text "${raw}".`
+    );
+  }
+  return (
+    `"${raw}" looks like a selector key but is not a valid selector expression. ` +
+    `Use wait '<selector>' [timeoutMs], e.g. wait '${argsWithoutTimeout[0]}="value"' [timeoutMs], ` +
+    `or wait text '${raw}' [timeoutMs] to wait for the literal text "${raw}".`
+  );
 }
 
 /**
@@ -44,5 +157,6 @@ export function resolveWaitBudgetMs(positionals: string[]): number | null {
   const parsed = parseWaitPositionals(positionals);
   if (!parsed) return null;
   if (parsed.kind === 'sleep') return parsed.durationMs;
+  if (parsed.kind === 'invalid') return null;
   return parsed.timeoutMs;
 }

--- a/src/daemon/handlers/__tests__/snapshot.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot.test.ts
@@ -107,9 +107,14 @@ test('parseWaitArgs parses selector expression with timeout', () => {
   }
 });
 
-test('parseWaitArgs falls back to text when selector-like token is invalid', () => {
+// #1800: this used to fall back to a literal-text wait for "foo=bar" — a caller typo (or a
+// straight-up unrecognized selector key) that can only ever time out, never match. It is now a
+// typed rejection instead. Full coverage of the rejection shapes lives in
+// src/core/wait-positionals.test.ts, which mirrors this module's source topology.
+test('parseWaitArgs rejects an unrecognized selector-like key=value token instead of reading it as text', () => {
   const result = parseWaitArgs(['foo=bar', '5000']);
-  assert.deepEqual(result, { kind: 'text', text: 'foo=bar', timeoutMs: 5000 });
+  assert.ok(result);
+  assert.equal(result.kind, 'invalid');
 });
 
 test('parseWaitArgs parses bare multi-word text', () => {

--- a/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
+++ b/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
@@ -161,3 +161,18 @@ test('a replayed wait with a landmark guard refuses at the deadline when only im
   expect(response.error.details?.reason).toBe(WAIT_LANDMARK_MISMATCH_REASON);
   expect(response.error.details?.matchCount).toBe(1);
 });
+
+// #1800: this seam is what BOTH a live CLI wait and a replayed `.ad` wait step
+// dispatch through, so the selector-shaped-text rejection has to happen here,
+// before any device/session work — not just in the CLI-only reader.
+test('a selector-shaped positional list that fails to parse as a selector is rejected before dispatch', async () => {
+  const { response } = await runWait({
+    req: waitReq({ positionals: ['open', 'label="Open"', '25000'] }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toContain('label="Open"');
+  expect(mockDispatch).not.toHaveBeenCalled();
+});

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -275,6 +275,7 @@ export async function dispatchWaitViaRuntime(
   const { req, sessionName, sessionStore } = params;
   const parsed = parseWaitPositionals(req.positionals ?? []);
   if (!parsed) return errorResponse('INVALID_ARGS', 'wait requires a duration or text');
+  if (parsed.kind === 'invalid') return errorResponse('INVALID_ARGS', parsed.message);
   const { session, device } = await resolveSessionDevice(sessionStore, sessionName, req.flags);
   if (parsed.kind !== 'sleep') {
     const unsupported = requireCommandSupported('wait', device);
@@ -620,7 +621,9 @@ function parseGetTarget(req: DaemonRequest):
 }
 
 function toWaitTarget(
-  parsed: WaitParsed,
+  // 'invalid' is rejected by the caller before this point; excluding it here makes the
+  // kind-by-kind narrowing below exhaustive without a runtime fallback branch (#1800).
+  parsed: Exclude<WaitParsed, { kind: 'invalid' }>,
   session: SessionState | undefined,
   recordedLandmark?: TargetAnnotationV1,
 ) {


### PR DESCRIPTION
## Summary

`wait` accepted an argument shape its grammar does not hold, joined the leftover positionals into one literal-text string, and then waited out the **full** timeout for text that could never appear on screen — reading as a false "element absent" instead of the caller's own mistake.

Before (0.20.10):
```
$ agent-device wait open 'label="Open"' 25000
Error (COMMAND_FAILED): wait timed out for text: open label="Open"
```
(after the full 25s timeout, exit code non-zero but read as "element not found")

After:
```
$ agent-device wait open 'label="Open"' 25000
Error (INVALID_ARGS): "open label="Open"" mixes plain word "open" with selector-shaped
"label="Open"", so it is neither a valid selector nor safe as literal text. "open" is not
a recognized selector key (id, role, text, label, value, appname, windowtitle, visible,
hidden, editable, selected, focused, enabled, hittable). Use wait '<selector>' [timeoutMs]
for a selector, or wait text 'open label="Open"' [timeoutMs] to wait for the literal text
"open label="Open"".
```
(immediate, before any device work)

`parseWaitPositionals` (`src/core/wait-positionals.ts`) now returns a typed `invalid`
variant whenever, after stripping the trailing timeout, a positional token is
selector-shaped — a recognized selector key (`isSelectorToken`), or an unrecognized
`key=value` (`detectUnknownSelectorKeyToken`) — but the token list does not form a
valid selector expression, or a valid selector prefix is followed by unquoted trailing
tokens. The message:
- names the offending token and, for an unrecognized key, lists the supported keys plus
  a `label=`/`role=` "did you mean" hint (mirrors #1035's click/press/fill/get fix);
- points a condition word (`exists`, `present`, `appears`, `gone`, `disappears`) at the
  selector form, e.g. `wait 'visible label="Open"' [timeoutMs]` — `visible`/`hidden`
  are already selector keys, so they parse correctly and are unaffected;
- always offers the explicit escape hatch: `wait text '<text>' [timeoutMs]`.

Bare text (`wait Continue 1500`, `wait Sign in 2000`) and the explicit `text` keyword
form are untouched — including the documented boundary that a single word matching a
recognized selector key (e.g. `wait id 3000`) is now rejected rather than silently
read as literal text, since it must go through `wait text 'id' 3000` to disambiguate.

`resolveWaitBudgetMs` (used by the command descriptor's timeout-policy budget) returns
`null` for a rejected list, same as an unparseable one. `dispatchWaitViaRuntime`
(`src/daemon/selector-runtime.ts`) — the one seam both a live CLI wait and a replayed
`.ad` wait step dispatch through — rejects before any session/device work. Excluding
`invalid` from the type `toWaitTarget` accepts makes its kind-by-kind narrowing
exhaustive at compile time, with no runtime fallback branch.

Closes #1800

## Validation

- New `src/core/wait-positionals.test.ts`: the issue's repro shapes (`open`/`exists` +
  selector value), an unknown `key=value` token, a valid selector prefix followed by an
  unquoted trailing word, `visible`/bare-text/`text`-keyword forms staying unaffected,
  the bare-recognized-key-word boundary (`wait id 3000`), and two fast-check properties
  — a generated valid selector expression never parses as `text`, and any token list
  containing a `key=value`-shaped token never parses as `text`.
- Proved red: stashed the three production files (`wait-positionals.ts`, `wait.ts`,
  `selector-runtime.ts`) and reran the new/updated tests against pre-fix code. All 9
  assertions failed as expected — 7 asserted `'text'`/a stale budget instead of
  `'invalid'`, the property test found `["", 'editable="!"', 0]` as a counterexample in
  one run, and the new `dispatchWaitViaRuntime` daemon-dispatch test **hung to the
  5000ms test timeout** (the pre-fix code actually dispatches and polls instead of
  rejecting immediately) — confirming this is exactly the "silent full-timeout" defect
  class from the issue, not a vacuous pin. Restored the fix; all 45 tests pass.
- Updated the pre-existing `snapshot.test.ts` case that had codified the bug
  (`parseWaitArgs falls back to text when selector-like token is invalid`, using
  `foo=bar` — an unrecognized key) to assert the new `invalid` rejection.
- Added one test at the shared daemon-dispatch seam
  (`wait-landmark-recording.test.ts`) proving `dispatchWaitViaRuntime` — the route both
  a live CLI wait and a replayed `.ad` wait step call — rejects before any
  session/device work, since neither the `.ad` script grammar
  (`packages/ad-script`) nor `test/replay-compat` interpret wait's positional shape at
  parse time (`pnpm exec vitest run --project unit-core test/replay-compat` — all 55
  cases pass unchanged, no corpus verdict moved).
- `pnpm check:affected --run` green (format, lint, typecheck, layering, fallow, build,
  and the full `vitest-related` selection — 424 files / 3651 tests). `wait-positionals.ts`
  isn't a mutation-kernel module (`scripts/mutation/modules.ts`) and I didn't touch
  `packages/selectors/src/**`, so the mutation gate wasn't selected — confirmed by the
  selector's own output.
- Live iOS Simulator (`iPhone 17 Pro`, isolated `--state-dir`, `com.apple.Preferences`):
  - `wait open 'label="General"' 3000` → immediate `INVALID_ARGS` in 0.32s (not a 3s
    timeout), quoting the same message shape as above.
  - `wait exists 'label="General"' 3000` → immediate `INVALID_ARGS` in 0.068s, with the
    condition-word hint (`wait 'visible label="General"' [timeoutMs]`).
  - `wait 'label="General"' 3000` → correctly dispatched and got a legitimate
    `AMBIGUOUS_MATCH` (multiple "General" nodes on the live Settings screen — pre-existing,
    by-design direct-iOS-selector behavior, unrelated to this fix); `wait 'role="button"
    label="General"' 3000` (disambiguated) → exit 0.
  - `wait General 3000` (bare text) → exit 0.
  - `wait text 'General' 3000` (explicit form) → exit 0.
  - Session closed, daemon stopped, simulator shut down; no stray processes remained for
    the udid afterward.

Docs: no `website/docs`/`docs/adr` change needed — the accepted `wait` forms are
unchanged, only a previously-silent-degrading input now gets a typed refusal instead of
a timeout (same precedent as #1035's click "Did you mean" fix, which also didn't touch
docs).

6 files changed (5 touched, 1 new test file); scope stayed within the `wait` command
family (`src/core/wait-positionals.ts`, its CLI reader, and the one daemon dispatch
seam) plus test updates — no scope expansion.