### PR TITLE
fix(ios-runner): reject CGRect.infinite in navigation frame guards

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Navigation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Navigation.swift
@@ -81,17 +81,16 @@ extension RunnerTests {
     return navigationBackKeywords.firstIndex { text.contains($0) }
   }
 
+  // isFinite/>0 alone don't reject CGRect.infinite — its origin (~-9e307) is finite.
+  static func isUsableNavigationFrame(_ frame: CGRect) -> Bool {
+    guard frame.width.isFinite, frame.height.isFinite, frame.width > 0, frame.height > 0 else {
+      return false
+    }
+    return !frame.isInfinite
+  }
+
   static func isTopNavigationControlFrame(_ candidate: CGRect, in window: CGRect) -> Bool {
-    guard
-      candidate.width.isFinite,
-      candidate.height.isFinite,
-      window.width.isFinite,
-      window.height.isFinite,
-      candidate.width > 0,
-      candidate.height > 0,
-      window.width > 0,
-      window.height > 0
-    else {
+    guard isUsableNavigationFrame(candidate), isUsableNavigationFrame(window) else {
       return false
     }
     // Accept the compact navigation/search header band without matching deep content controls.
@@ -100,7 +99,7 @@ extension RunnerTests {
   }
 
   static func topLeadingNavigationFallbackPoint(in frame: CGRect) -> CGPoint? {
-    guard frame.width.isFinite, frame.height.isFinite, frame.width > 0, frame.height > 0 else {
+    guard isUsableNavigationFrame(frame) else {
       return nil
     }
     // Aim at the standard leading navigation slot, bounded for compact and tablet widths.


### PR DESCRIPTION
## Summary

Fixes #1812.

`topLeadingNavigationFallbackPoint` and `isTopNavigationControlFrame` (`apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Navigation.swift`) validated only `width`/`height`, never the origin. `CGRect.infinite`'s origin (`-CGFLOAT_MAX/2` ≈ `-9e307`) is finite, so the existing `isFinite`/`> 0` guard let it through:

- `topLeadingNavigationFallbackPoint` synthesized a tap point at roughly `(-9e307, -9e307)` instead of declining.
- `isTopNavigationControlFrame` classified an unresolved frame as sitting inside the nav header band (`.infinite.midY == 0.0`, which falls inside `[0, 180]`).

There was already a correct precedent for detecting this exact rect in the same target — `TapPointPolicy.isAllowed` checks `windowFrame.isInfinite` (`RunnerTapPointPolicy.swift`). This PR extracts a shared `isUsableNavigationFrame(_:)` helper that adds the same `isInfinite` check on top of the existing finite/positive checks, and uses it in both navigation helpers, so there's a single definition instead of a size-only guard duplicated twice.

- [x] Fixed the helpers, not the tests — the two failing assertions describe the intended contract.

## Test plan

- [x] Built `AgentDeviceRunnerUITests` locally with `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1` (unit tests compiled in).
- [x] Ran the two previously-failing tests plus the rest of the navigation suite and the `TapPointPolicy` golden-parity test on iOS 26.2 / iPhone 17 Pro Simulator — all 7 pass:
  - `testTopLeadingNavigationFallbackPointRejectsInvalidFrame` ✅ (was failing)
  - `testTopNavigationControlFrameAcceptsOnlyHeaderBand` ✅ (was failing)
  - `testTopLeadingNavigationFallbackPointTargetsHeaderControlBand` ✅ (regression check — non-infinite frame still yields the same fallback point)
  - `testNavigationBackControlRankPrefersBackThenCloseThenCancel` ✅
  - `testNavigationBackPredicateUsesTheSharedKeywordTable` ✅
  - `testNavigationFallbackRequiresObservedVisualChange` ✅
  - `testTapPointPolicyMatchesGoldenParityTable` ✅ (unaffected)