### PR TITLE
fix: declare frameworkTier on the hover descriptor

### DIFF
--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1058,6 +1058,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     targetIdentityVerification: 'pre-dispatch',
     catalog: { group: 'public' },
+    frameworkTier: 'extended',
     recordsSessionAction: true,
     recordingEffect: 'mutates-app',
     daemon: {


### PR DESCRIPTION
## Summary

main's Coverage job is red at 142d15633: #1786 added the public `hover` command without a `frameworkTier`, and #1804 (merged after) added the parity rule that every public descriptor declares one. Neither PR's own CI saw the combination. Every open PR's Coverage lane now fails on `parity.test.ts > frameworkTier is declared iff a command is public`.

`hover` is web-only pointer state, not part of the curated perceive/act loop, so it lands in `'extended'` (the parity test's pinned `'core'` set is unchanged).

## Validation

Red on main (revert of this one-liner): `AssertionError: hover declares frameworkTier iff it is a public command — 1 failed | 14 passed`. Green with it: parity + ai-sdk suites pass; `pnpm check:affected --run` green (426 files / 3641 tests). One file touched.