### PR TITLE
fix: report real claim results from daemon stop

### DIFF
--- a/src/cli/commands/__tests__/daemon.test.ts
+++ b/src/cli/commands/__tests__/daemon.test.ts
@@ -35,6 +35,7 @@ const GRACEFUL_RESULT: DaemonStopResult = {
   cleanupConfidence: 'known',
   claimsReleased: [],
   claimsOrphaned: [],
+  claimsSuperseded: [],
   providerReleases: { status: 'completed', released: [], pending: [] },
   warnings: [],
 };
@@ -79,7 +80,7 @@ test('merges a graceful shutdown report and cleans runner leases with the start-
       released: [{ leaseId: 'lease-1', provider: 'limrun' }],
       pending: [],
     },
-    claims: { released: [claim], orphaned: [] },
+    claims: { released: [claim], orphaned: [], superseded: [] },
   });
 
   try {
@@ -105,6 +106,7 @@ test('merges a graceful shutdown report and cleans runner leases with the start-
         // #1799: a graceful stop reports the claims it actually released.
         claimsReleased: [claim],
         claimsOrphaned: [],
+        claimsSuperseded: [],
       }),
       expect.any(Function),
     );

--- a/src/cli/commands/__tests__/daemon.test.ts
+++ b/src/cli/commands/__tests__/daemon.test.ts
@@ -68,11 +68,18 @@ test('merges a graceful shutdown report and cleans runner leases with the start-
   const stateDir = mkdtempForTestSync('agent-device-daemon-command-');
   mocks.readDaemonStopIdentity.mockReturnValue({ pid: 123, processStartTime: 'start-time' });
   mocks.stopDaemon.mockResolvedValue(GRACEFUL_RESULT);
+  const claim = {
+    deviceKey: 'local:android:none:emulator-5554',
+    session: 'default',
+    platform: 'android',
+    deviceId: 'emulator-5554',
+  };
   mocks.readDaemonShutdownReport.mockReturnValue({
     providerReleases: {
       released: [{ leaseId: 'lease-1', provider: 'limrun' }],
       pending: [],
     },
+    claims: { released: [claim], orphaned: [] },
   });
 
   try {
@@ -95,6 +102,9 @@ test('merges a graceful shutdown report and cleans runner leases with the start-
           released: [{ leaseId: 'lease-1', provider: 'limrun' }],
           pending: [],
         },
+        // #1799: a graceful stop reports the claims it actually released.
+        claimsReleased: [claim],
+        claimsOrphaned: [],
       }),
       expect.any(Function),
     );

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -46,6 +46,8 @@ function mergeShutdownReport(
           providerReleases: { status: 'completed', ...report.providerReleases },
           claimsReleased: report.claims.released,
           claimsOrphaned: report.claims.orphaned,
+          claimsSuperseded: report.claims.superseded,
+          warnings: [...stopped.warnings, ...supersededClaimWarnings(report.claims.superseded)],
         }
       : stopped;
   }
@@ -58,6 +60,16 @@ function mergeShutdownReport(
       'The graceful shutdown report is unavailable, so provider cleanup state is unknown. Provider allocations may remain active.',
     ],
   };
+}
+
+/** A superseded claim is not a failure to report as one, but the operator's
+ * device is now owned elsewhere, so it must not pass silently. */
+function supersededClaimWarnings(superseded: DaemonStopResult['claimsSuperseded']): string[] {
+  if (superseded.length === 0) return [];
+  const devices = superseded.map((claim) => claim.deviceId).join(', ');
+  return [
+    `Another owner had already claimed ${devices} before this daemon released it, so those devices are now owned elsewhere.`,
+  ];
 }
 
 function renderDaemonStop(

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -41,7 +41,12 @@ function mergeShutdownReport(
 ): DaemonStopResult {
   if (stopped.mode !== 'graceful' || report) {
     return report
-      ? { ...stopped, providerReleases: { status: 'completed', ...report.providerReleases } }
+      ? {
+          ...stopped,
+          providerReleases: { status: 'completed', ...report.providerReleases },
+          claimsReleased: report.claims.released,
+          claimsOrphaned: report.claims.orphaned,
+        }
       : stopped;
   }
   return {

--- a/src/daemon/__tests__/daemon-shutdown-report.test.ts
+++ b/src/daemon/__tests__/daemon-shutdown-report.test.ts
@@ -9,7 +9,14 @@ import {
 import { LeaseRegistry } from '../lease-registry.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
-test('round-trips provider release records without persisting lease credentials', () => {
+const claim = {
+  deviceKey: 'local:android:none:emulator-5554',
+  session: 'default',
+  platform: 'android',
+  deviceId: 'emulator-5554',
+};
+
+test('round-trips provider release and device claim records without lease credentials', () => {
   const stateDir = mkdtempForTestSync('agent-device-shutdown-report-');
   const lease = new LeaseRegistry().allocateLease({
     tenantId: 'tenant-a',
@@ -18,13 +25,36 @@ test('round-trips provider release records without persisting lease credentials'
   });
 
   try {
-    writeDaemonShutdownReport(stateDir, { released: [lease], pending: [lease] });
+    writeDaemonShutdownReport(stateDir, {
+      providerReleases: { released: [lease], pending: [lease] },
+      claims: { released: [claim], orphaned: [] },
+    });
 
     expect(readDaemonShutdownReport(stateDir)).toEqual({
       providerReleases: {
         released: [{ leaseId: lease.leaseId, provider: 'limrun' }],
         pending: [{ leaseId: lease.leaseId, provider: 'limrun' }],
       },
+      claims: { released: [claim], orphaned: [] },
+    });
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('a report written before claim reporting still reads its provider releases', () => {
+  const stateDir = mkdtempForTestSync('agent-device-shutdown-report-');
+  const reportPath = path.join(stateDir, 'daemon-shutdown.json');
+
+  try {
+    fs.writeFileSync(
+      reportPath,
+      JSON.stringify({ providerReleases: { released: [], pending: [] } }),
+    );
+
+    expect(readDaemonShutdownReport(stateDir)).toEqual({
+      providerReleases: { released: [], pending: [] },
+      claims: { released: [], orphaned: [] },
     });
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });

--- a/src/daemon/__tests__/daemon-shutdown-report.test.ts
+++ b/src/daemon/__tests__/daemon-shutdown-report.test.ts
@@ -27,7 +27,7 @@ test('round-trips provider release and device claim records without lease creden
   try {
     writeDaemonShutdownReport(stateDir, {
       providerReleases: { released: [lease], pending: [lease] },
-      claims: { released: [claim], orphaned: [] },
+      claims: { released: [claim], orphaned: [], superseded: [claim] },
     });
 
     expect(readDaemonShutdownReport(stateDir)).toEqual({
@@ -35,7 +35,7 @@ test('round-trips provider release and device claim records without lease creden
         released: [{ leaseId: lease.leaseId, provider: 'limrun' }],
         pending: [{ leaseId: lease.leaseId, provider: 'limrun' }],
       },
-      claims: { released: [claim], orphaned: [] },
+      claims: { released: [claim], orphaned: [], superseded: [claim] },
     });
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });
@@ -54,7 +54,7 @@ test('a report written before claim reporting still reads its provider releases'
 
     expect(readDaemonShutdownReport(stateDir)).toEqual({
       providerReleases: { released: [], pending: [] },
-      claims: { released: [], orphaned: [] },
+      claims: { released: [], orphaned: [], superseded: [] },
     });
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -254,8 +254,26 @@ test('clears only the exact owner token and identity, never a successor claim', 
     claimPath(root),
     JSON.stringify({ ...stored, ownerToken: 'successor-token', session: 'second' }),
   );
-  await clearDeviceClaim(acquired.ownership);
+  // Resolving is not releasing: the outcome is what a caller reporting
+  // ownership must read, since the successor's claim is deliberately kept.
+  assert.equal(await clearDeviceClaim(acquired.ownership), 'ownership-changed');
   assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.session, 'second');
+});
+
+test('reports the exact outcome of clearing an owned, missing, and unowned claim', async () => {
+  const root = useClaimsRoot();
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'owner',
+    workspace: '/worktrees/owner',
+    stateDir: root,
+  });
+  assert.equal(acquired.status, 'acquired');
+  if (acquired.status !== 'acquired') return;
+
+  assert.equal(await clearDeviceClaim(acquired.ownership), 'deleted');
+  assert.equal(await clearDeviceClaim(acquired.ownership), 'absent');
+  assert.equal(await clearDeviceClaim(undefined), 'absent');
 });
 
 test('keeps corrupt records visible and classifies dead owners without reclaiming either', () => {

--- a/src/daemon/daemon-shutdown-report.ts
+++ b/src/daemon/daemon-shutdown-report.ts
@@ -11,9 +11,11 @@ export type ProviderReleaseRecord = {
 
 /**
  * #1320: what happened to one session's device claim during graceful teardown.
- * `released` means the claim was cleared after the session reached a safe
+ * `released` means the claim was confirmed gone after the session reached a safe
  * terminal state; `orphaned` means teardown left it in place, so the exiting
- * daemon's dead owner identity is what later proves it reclaimable.
+ * daemon's dead owner identity is what later proves it reclaimable; `superseded`
+ * means another owner had already replaced it, so this daemon released nothing
+ * and left nothing to reconcile.
  */
 export type DeviceClaimRecord = {
   deviceKey: string;
@@ -30,6 +32,7 @@ export type DaemonShutdownReport = {
   claims: {
     released: DeviceClaimRecord[];
     orphaned: DeviceClaimRecord[];
+    superseded: DeviceClaimRecord[];
   };
 };
 
@@ -37,7 +40,11 @@ export function writeDaemonShutdownReport(
   stateDir: string,
   outcome: {
     providerReleases: { released: readonly DeviceLease[]; pending: readonly DeviceLease[] };
-    claims: { released: readonly DeviceClaimRecord[]; orphaned: readonly DeviceClaimRecord[] };
+    claims: {
+      released: readonly DeviceClaimRecord[];
+      orphaned: readonly DeviceClaimRecord[];
+      superseded: readonly DeviceClaimRecord[];
+    };
   },
 ): void {
   const report: DaemonShutdownReport = {
@@ -48,6 +55,7 @@ export function writeDaemonShutdownReport(
     claims: {
       released: [...outcome.claims.released],
       orphaned: [...outcome.claims.orphaned],
+      superseded: [...outcome.claims.superseded],
     },
   };
   const filePath = shutdownReportPath(stateDir);
@@ -109,11 +117,12 @@ function isProviderReleaseReport(
 
 function readClaimSection(value: { claims?: unknown }): DaemonShutdownReport['claims'] {
   const claims = value.claims;
-  if (!claims || typeof claims !== 'object') return { released: [], orphaned: [] };
-  const records = claims as { released?: unknown; orphaned?: unknown };
+  if (!claims || typeof claims !== 'object') return { released: [], orphaned: [], superseded: [] };
+  const records = claims as { released?: unknown; orphaned?: unknown; superseded?: unknown };
   return {
     released: readClaimRecords(records.released),
     orphaned: readClaimRecords(records.orphaned),
+    superseded: readClaimRecords(records.superseded),
   };
 }
 

--- a/src/daemon/daemon-shutdown-report.ts
+++ b/src/daemon/daemon-shutdown-report.ts
@@ -9,21 +9,45 @@ export type ProviderReleaseRecord = {
   provider?: string;
 };
 
+/**
+ * #1320: what happened to one session's device claim during graceful teardown.
+ * `released` means the claim was cleared after the session reached a safe
+ * terminal state; `orphaned` means teardown left it in place, so the exiting
+ * daemon's dead owner identity is what later proves it reclaimable.
+ */
+export type DeviceClaimRecord = {
+  deviceKey: string;
+  session: string;
+  platform: string;
+  deviceId: string;
+};
+
 export type DaemonShutdownReport = {
   providerReleases: {
     released: ProviderReleaseRecord[];
     pending: ProviderReleaseRecord[];
   };
+  claims: {
+    released: DeviceClaimRecord[];
+    orphaned: DeviceClaimRecord[];
+  };
 };
 
 export function writeDaemonShutdownReport(
   stateDir: string,
-  providerReleases: { released: readonly DeviceLease[]; pending: readonly DeviceLease[] },
+  outcome: {
+    providerReleases: { released: readonly DeviceLease[]; pending: readonly DeviceLease[] };
+    claims: { released: readonly DeviceClaimRecord[]; orphaned: readonly DeviceClaimRecord[] };
+  },
 ): void {
   const report: DaemonShutdownReport = {
     providerReleases: {
-      released: providerReleases.released.map(toProviderReleaseRecord),
-      pending: providerReleases.pending.map(toProviderReleaseRecord),
+      released: outcome.providerReleases.released.map(toProviderReleaseRecord),
+      pending: outcome.providerReleases.pending.map(toProviderReleaseRecord),
+    },
+    claims: {
+      released: [...outcome.claims.released],
+      orphaned: [...outcome.claims.orphaned],
     },
   };
   const filePath = shutdownReportPath(stateDir);
@@ -42,7 +66,10 @@ export function writeDaemonShutdownReport(
 export function readDaemonShutdownReport(stateDir: string): DaemonShutdownReport | null {
   try {
     const parsed = JSON.parse(fs.readFileSync(shutdownReportPath(stateDir), 'utf8')) as unknown;
-    return isDaemonShutdownReport(parsed) ? parsed : null;
+    if (!isProviderReleaseReport(parsed)) return null;
+    // A report left behind by a daemon that predates claim reporting still
+    // describes its provider releases honestly; it just knows nothing of claims.
+    return { ...parsed, claims: readClaimSection(parsed) };
   } catch {
     return null;
   }
@@ -65,7 +92,9 @@ function toProviderReleaseRecord(lease: DeviceLease): ProviderReleaseRecord {
   };
 }
 
-function isDaemonShutdownReport(value: unknown): value is DaemonShutdownReport {
+function isProviderReleaseReport(
+  value: unknown,
+): value is Omit<DaemonShutdownReport, 'claims'> & { claims?: unknown } {
   if (!value || typeof value !== 'object') return false;
   const releases = (value as { providerReleases?: unknown }).providerReleases;
   if (!releases || typeof releases !== 'object') return false;
@@ -75,6 +104,31 @@ function isDaemonShutdownReport(value: unknown): value is DaemonShutdownReport {
     Array.isArray(records.pending) &&
     records.released.every(isProviderReleaseRecord) &&
     records.pending.every(isProviderReleaseRecord)
+  );
+}
+
+function readClaimSection(value: { claims?: unknown }): DaemonShutdownReport['claims'] {
+  const claims = value.claims;
+  if (!claims || typeof claims !== 'object') return { released: [], orphaned: [] };
+  const records = claims as { released?: unknown; orphaned?: unknown };
+  return {
+    released: readClaimRecords(records.released),
+    orphaned: readClaimRecords(records.orphaned),
+  };
+}
+
+function readClaimRecords(value: unknown): DeviceClaimRecord[] {
+  return Array.isArray(value) ? value.filter(isDeviceClaimRecord) : [];
+}
+
+function isDeviceClaimRecord(value: unknown): value is DeviceClaimRecord {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<Record<keyof DeviceClaimRecord, unknown>>;
+  return (
+    typeof record.deviceKey === 'string' &&
+    typeof record.session === 'string' &&
+    typeof record.platform === 'string' &&
+    typeof record.deviceId === 'string'
   );
 }
 

--- a/src/daemon/daemon-stop.ts
+++ b/src/daemon/daemon-stop.ts
@@ -4,7 +4,7 @@ import { isAgentDeviceDaemonProcess, trySignalProcess } from './daemon-process.t
 import { isProcessAlive, waitForProcessExit } from '../utils/host-process.ts';
 import { sleep } from '../utils/timeouts.ts';
 import type { DaemonPaths } from './config.ts';
-import type { ProviderReleaseRecord } from './daemon-shutdown-report.ts';
+import type { DeviceClaimRecord, ProviderReleaseRecord } from './daemon-shutdown-report.ts';
 
 const DAEMON_STOP_GRACE_TIMEOUT_MS = 10_000;
 const DAEMON_STOP_KILL_TIMEOUT_MS = 2_000;
@@ -19,8 +19,13 @@ export type DaemonStopResult = {
   stopped: boolean;
   mode: 'graceful' | 'forced' | 'not-running';
   cleanupConfidence: 'known' | 'unknown';
-  claimsReleased: [];
-  claimsOrphaned: [];
+  /**
+   * #1320 claim results. Only a graceful stop can carry values: they come from
+   * the shutdown report the exiting daemon wrote, so a forced kill or a daemon
+   * that was not running reports none rather than claiming certainty.
+   */
+  claimsReleased: DeviceClaimRecord[];
+  claimsOrphaned: DeviceClaimRecord[];
   providerReleases: {
     status: 'completed' | 'unknown';
     released: ProviderReleaseRecord[];

--- a/src/daemon/daemon-stop.ts
+++ b/src/daemon/daemon-stop.ts
@@ -26,6 +26,8 @@ export type DaemonStopResult = {
    */
   claimsReleased: DeviceClaimRecord[];
   claimsOrphaned: DeviceClaimRecord[];
+  /** Claims another owner had already taken over; this daemon released nothing. */
+  claimsSuperseded: DeviceClaimRecord[];
   providerReleases: {
     status: 'completed' | 'unknown';
     released: ProviderReleaseRecord[];
@@ -71,6 +73,7 @@ export async function stopDaemon(params: {
       cleanupConfidence: 'known',
       claimsReleased: [],
       claimsOrphaned: [],
+      claimsSuperseded: [],
       providerReleases: { status: 'completed', released: [], pending: [] },
       warnings: [],
     };
@@ -94,6 +97,7 @@ export async function stopDaemon(params: {
     cleanupConfidence: 'unknown',
     claimsReleased: [],
     claimsOrphaned: [],
+    claimsSuperseded: [],
     providerReleases: { status: 'unknown', released: [], pending: null },
     warnings: [
       'The daemon was force-killed before provider lease state could be finalized. Provider allocations may remain active.',
@@ -153,6 +157,7 @@ function notRunningResult(): DaemonStopResult {
     cleanupConfidence: 'known',
     claimsReleased: [],
     claimsOrphaned: [],
+    claimsSuperseded: [],
     providerReleases: { status: 'completed', released: [], pending: [] },
     warnings: [],
   };

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -231,28 +231,44 @@ function isCurrentClaimOwner(
   );
 }
 
+/**
+ * What releasing a claim actually did. Resolving is not the same as releasing:
+ * clearing deliberately leaves a claim it does not own in place, so a caller
+ * that reports ownership must read this rather than the absence of a throw.
+ *
+ *  - `deleted`          — the claim this ownership acquired was removed.
+ *  - `absent`           — no claim remains for the device; nothing to remove.
+ *  - `ownership-changed`— a claim remains, but it is not the one we acquired
+ *                         (a successor owner, or a record we cannot attribute).
+ */
+export type DeviceClaimClearOutcome = 'deleted' | 'absent' | 'ownership-changed';
+
 export async function clearDeviceClaim(
   ownership: DeviceClaimSessionOwnership | undefined,
-): Promise<void> {
-  if (!ownership) return;
-  await withDeviceClaimLock(ownership.deviceKey, async () => {
-    const inspected = inspectDeviceClaimFile(resolveDeviceClaimPath(ownership.deviceKey));
-    if (!inspected?.claim) return;
+): Promise<DeviceClaimClearOutcome> {
+  if (!ownership) return 'absent';
+  return await withDeviceClaimLock(ownership.deviceKey, async () => {
+    const claimPath = resolveDeviceClaimPath(ownership.deviceKey);
+    const inspected = inspectDeviceClaimFile(claimPath);
+    if (!inspected) return 'absent';
     const claim = inspected.claim;
     if (
+      !claim ||
       claim.ownerToken !== ownership.ownerToken ||
       !ownerIdentityMatches(
         { pid: claim.ownerPid, startTime: claim.ownerStartTime },
         { pid: ownership.ownerPid, startTime: ownership.ownerStartTime },
       )
     ) {
-      return;
+      return 'ownership-changed';
     }
     try {
-      fs.unlinkSync(resolveDeviceClaimPath(ownership.deviceKey));
+      fs.unlinkSync(claimPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      return 'absent';
     }
+    return 'deleted';
   });
 }
 

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -24,12 +24,9 @@ import { closeDaemonServers } from './server-shutdown.ts';
 import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';
 import { finalizeDaemonSessionLease } from './daemon-session-lease-finalizer.ts';
-import {
-  clearDeviceClaim,
-  reconcileOrphanedDeviceClaims,
-  type DeviceClaimReconciler,
-} from '../device-claims.ts';
+import { reconcileOrphanedDeviceClaims, type DeviceClaimReconciler } from '../device-claims.ts';
 import { createDeviceClaimReconciler } from '../device-claim-reconciliation.ts';
+import { createDaemonShutdownClaimLedger } from './daemon-shutdown-claims.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -323,30 +320,36 @@ export async function startDaemonRuntime(
     );
   };
 
-  const teardownDaemonSession = async (session: SessionState): Promise<void> =>
-    await teardownDaemonSessionForShutdown({
-      session,
-      sessionStore,
-      stderr,
-      finalizeApplicationLifecycle: async (sessionToFinalize) =>
-        await finalizeDaemonSessionApplicationLifecycle({
-          gateway: deviceRuntimeGateway,
-          scope: createDaemonRecoveryPlatformScope(),
-          session: sessionToFinalize,
-          stateDir: baseDir,
-          runtimeHints: runtimeHintValues(sessionStore.getRuntimeHints(sessionToFinalize.name)),
-        }),
-      beforeDelete: async (sessionToFinalize) => {
-        await finalizeDaemonSessionLease({
-          session: sessionToFinalize,
-          leaseRegistry,
-          expiredProviderLeaseReleaser,
-          timeoutMs: DAEMON_SESSION_LEASE_RELEASE_TIMEOUT_MS,
-        });
-      },
-      afterSuccessfulTeardown: async (sessionToFinalize) =>
-        await clearDeviceClaim(sessionToFinalize.deviceClaim),
-    });
+  const shutdownClaimLedger = createDaemonShutdownClaimLedger();
+
+  const teardownDaemonSession = async (session: SessionState): Promise<void> => {
+    try {
+      await teardownDaemonSessionForShutdown({
+        session,
+        sessionStore,
+        stderr,
+        finalizeApplicationLifecycle: async (sessionToFinalize) =>
+          await finalizeDaemonSessionApplicationLifecycle({
+            gateway: deviceRuntimeGateway,
+            scope: createDaemonRecoveryPlatformScope(),
+            session: sessionToFinalize,
+            stateDir: baseDir,
+            runtimeHints: runtimeHintValues(sessionStore.getRuntimeHints(sessionToFinalize.name)),
+          }),
+        beforeDelete: async (sessionToFinalize) => {
+          await finalizeDaemonSessionLease({
+            session: sessionToFinalize,
+            leaseRegistry,
+            expiredProviderLeaseReleaser,
+            timeoutMs: DAEMON_SESSION_LEASE_RELEASE_TIMEOUT_MS,
+          });
+        },
+        afterSuccessfulTeardown: shutdownClaimLedger.releaseClaim,
+      });
+    } finally {
+      shutdownClaimLedger.finalize(session);
+    }
+  };
 
   const teardownDaemonSessions = async (): Promise<void> => {
     const sessionsToStop = sessionStore.toArray();
@@ -545,13 +548,18 @@ export async function startDaemonRuntime(
     const providerReleaseDrain = await expiredProviderLeaseReleaser.drain(
       DAEMON_PROVIDER_RELEASE_DRAIN_TIMEOUT_MS,
     );
-    writeDaemonShutdownReport(baseDir, providerReleaseDrain);
+    writeDaemonShutdownReport(baseDir, {
+      providerReleases: providerReleaseDrain,
+      claims: shutdownClaimLedger.claims,
+    });
     emitDiagnostic({
       level: providerReleaseDrain.pending.length === 0 ? 'info' : 'warn',
       phase: 'daemon_shutdown_provider_release_drain',
       data: {
         releasedLeaseIds: providerReleaseDrain.released.map((lease) => lease.leaseId),
         pendingLeaseIds: providerReleaseDrain.pending.map((lease) => lease.leaseId),
+        releasedDeviceKeys: shutdownClaimLedger.claims.released.map((claim) => claim.deviceKey),
+        orphanedDeviceKeys: shutdownClaimLedger.claims.orphaned.map((claim) => claim.deviceKey),
       },
     });
     expiredProviderLeaseReleaser.shutdown();

--- a/src/daemon/server/daemon-shutdown-claims.test.ts
+++ b/src/daemon/server/daemon-shutdown-claims.test.ts
@@ -4,14 +4,25 @@ import {
   isolatedDeviceClaimStores,
   retainOrphanedDeviceClaims,
 } from '../../__tests__/test-utils/device-claim-store.ts';
+import fs from 'node:fs';
 import { acquireDeviceClaim } from '../device-claims.ts';
+import { resolveDeviceClaimPath } from '../device-claim-paths.ts';
 import { inspectDeviceClaims } from '../device-claim-inspection.ts';
 import { createDaemonShutdownClaimLedger } from './daemon-shutdown-claims.ts';
 import type { SessionState } from '../types.ts';
 
 const setup = isolatedDeviceClaimStores('agent-device-shutdown-claim-ledger-');
 
-async function claimedSession(name: string): Promise<SessionState> {
+function claimRecord(session: SessionState, name: string) {
+  return {
+    deviceKey: session.deviceClaim?.deviceKey,
+    session: name,
+    platform: 'android',
+    deviceId: 'emulator-5554',
+  };
+}
+
+async function claimedSession(name: string): Promise<SessionState & { stateDir: string }> {
   const { stateDir } = setup();
   const acquired = await acquireDeviceClaim({
     device: ANDROID_EMULATOR,
@@ -22,6 +33,7 @@ async function claimedSession(name: string): Promise<SessionState> {
   });
   if (acquired.status !== 'acquired') throw new Error('expected an acquired claim');
   return {
+    stateDir,
     name,
     device: ANDROID_EMULATOR,
     deviceClaim: acquired.ownership,
@@ -38,15 +50,9 @@ test('a claim cleared after clean teardown is reported released', async () => {
   ledger.finalize(session);
 
   expect(ledger.claims).toEqual({
-    released: [
-      {
-        deviceKey: session.deviceClaim?.deviceKey,
-        session: 'default',
-        platform: 'android',
-        deviceId: 'emulator-5554',
-      },
-    ],
+    released: [claimRecord(session, 'default')],
     orphaned: [],
+    superseded: [],
   });
   expect(inspectDeviceClaims({})).toEqual([]);
 });
@@ -59,15 +65,36 @@ test('a claim left behind by a failed teardown is reported orphaned', async () =
   ledger.finalize(session);
 
   expect(ledger.claims.released).toEqual([]);
-  expect(ledger.claims.orphaned).toEqual([
-    {
-      deviceKey: session.deviceClaim?.deviceKey,
-      session: 'stuck',
-      platform: 'android',
-      deviceId: 'emulator-5554',
-    },
-  ]);
+  expect(ledger.claims.orphaned).toEqual([claimRecord(session, 'stuck')]);
   expect(inspectDeviceClaims({}).map((entry) => entry.claim?.session)).toEqual(['stuck']);
+});
+
+test('a claim replaced by a successor owner is reported superseded, never released', async () => {
+  const session = await claimedSession('replaced');
+  const deviceKey = session.deviceClaim?.deviceKey ?? '';
+  // The shape recovery leaves behind: this daemon's claim file is removed out
+  // from under it, and another owner claims the same device before this daemon
+  // reaches teardown. `clearDeviceClaim` finds a claim it does not own and
+  // deliberately leaves it alone, so "the call resolved" cannot mean "released".
+  fs.rmSync(resolveDeviceClaimPath(deviceKey));
+  const successor = await acquireDeviceClaim({
+    device: ANDROID_EMULATOR,
+    session: 'successor',
+    workspace: '/worktrees/successor',
+    stateDir: `${session.stateDir}-successor`,
+    reconcileOrphanedDeviceClaim: retainOrphanedDeviceClaims,
+  });
+  expect(successor.status).toBe('acquired');
+
+  const ledger = createDaemonShutdownClaimLedger();
+  await ledger.releaseClaim(session);
+  ledger.finalize(session);
+
+  expect(ledger.claims.released).toEqual([]);
+  expect(ledger.claims.orphaned).toEqual([]);
+  expect(ledger.claims.superseded).toEqual([claimRecord(session, 'replaced')]);
+  // The successor keeps its device: teardown must never delete a foreign claim.
+  expect(inspectDeviceClaims({}).map((entry) => entry.claim?.session)).toEqual(['successor']);
 });
 
 test('a session that never held a claim contributes nothing', async () => {
@@ -82,5 +109,5 @@ test('a session that never held a claim contributes nothing', async () => {
   await ledger.releaseClaim(session);
   ledger.finalize(session);
 
-  expect(ledger.claims).toEqual({ released: [], orphaned: [] });
+  expect(ledger.claims).toEqual({ released: [], orphaned: [], superseded: [] });
 });

--- a/src/daemon/server/daemon-shutdown-claims.test.ts
+++ b/src/daemon/server/daemon-shutdown-claims.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+import { ANDROID_EMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
+import {
+  isolatedDeviceClaimStores,
+  retainOrphanedDeviceClaims,
+} from '../../__tests__/test-utils/device-claim-store.ts';
+import { acquireDeviceClaim } from '../device-claims.ts';
+import { inspectDeviceClaims } from '../device-claim-inspection.ts';
+import { createDaemonShutdownClaimLedger } from './daemon-shutdown-claims.ts';
+import type { SessionState } from '../types.ts';
+
+const setup = isolatedDeviceClaimStores('agent-device-shutdown-claim-ledger-');
+
+async function claimedSession(name: string): Promise<SessionState> {
+  const { stateDir } = setup();
+  const acquired = await acquireDeviceClaim({
+    device: ANDROID_EMULATOR,
+    session: name,
+    workspace: stateDir,
+    stateDir,
+    reconcileOrphanedDeviceClaim: retainOrphanedDeviceClaims,
+  });
+  if (acquired.status !== 'acquired') throw new Error('expected an acquired claim');
+  return {
+    name,
+    device: ANDROID_EMULATOR,
+    deviceClaim: acquired.ownership,
+    createdAt: Date.now(),
+    actions: [],
+  };
+}
+
+test('a claim cleared after clean teardown is reported released', async () => {
+  const session = await claimedSession('default');
+  const ledger = createDaemonShutdownClaimLedger();
+
+  await ledger.releaseClaim(session);
+  ledger.finalize(session);
+
+  expect(ledger.claims).toEqual({
+    released: [
+      {
+        deviceKey: session.deviceClaim?.deviceKey,
+        session: 'default',
+        platform: 'android',
+        deviceId: 'emulator-5554',
+      },
+    ],
+    orphaned: [],
+  });
+  expect(inspectDeviceClaims({})).toEqual([]);
+});
+
+test('a claim left behind by a failed teardown is reported orphaned', async () => {
+  const session = await claimedSession('stuck');
+  const ledger = createDaemonShutdownClaimLedger();
+
+  // Teardown never reached a safe terminal state, so `releaseClaim` never runs.
+  ledger.finalize(session);
+
+  expect(ledger.claims.released).toEqual([]);
+  expect(ledger.claims.orphaned).toEqual([
+    {
+      deviceKey: session.deviceClaim?.deviceKey,
+      session: 'stuck',
+      platform: 'android',
+      deviceId: 'emulator-5554',
+    },
+  ]);
+  expect(inspectDeviceClaims({}).map((entry) => entry.claim?.session)).toEqual(['stuck']);
+});
+
+test('a session that never held a claim contributes nothing', async () => {
+  const ledger = createDaemonShutdownClaimLedger();
+  const session: SessionState = {
+    name: 'remote',
+    device: ANDROID_EMULATOR,
+    createdAt: Date.now(),
+    actions: [],
+  };
+
+  await ledger.releaseClaim(session);
+  ledger.finalize(session);
+
+  expect(ledger.claims).toEqual({ released: [], orphaned: [] });
+});

--- a/src/daemon/server/daemon-shutdown-claims.ts
+++ b/src/daemon/server/daemon-shutdown-claims.ts
@@ -1,0 +1,55 @@
+import { publicPlatformString } from '@agent-device/kernel/device';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { clearDeviceClaim } from '../device-claims.ts';
+import type { DeviceClaimRecord } from '../daemon-shutdown-report.ts';
+import type { SessionState } from '../types.ts';
+
+export type DaemonShutdownClaimLedger = Readonly<{
+  claims: { released: DeviceClaimRecord[]; orphaned: DeviceClaimRecord[] };
+  /** Runs only once a session's teardown reached a safe terminal state. */
+  releaseClaim(session: SessionState): Promise<void>;
+  /** Classifies the session's claim once its teardown has finished either way. */
+  finalize(session: SessionState): void;
+}>;
+
+/**
+ * #1320 claim results for `daemon stop`: `released` is a claim cleared after a
+ * clean teardown, `orphaned` is one this shutdown left in place. The exiting
+ * daemon's owner identity dies with the process, so an orphaned claim is exactly
+ * the cleanup-pending state proof-based reconciliation later resolves.
+ */
+export function createDaemonShutdownClaimLedger(): DaemonShutdownClaimLedger {
+  const released: DeviceClaimRecord[] = [];
+  const orphaned: DeviceClaimRecord[] = [];
+  const releasedSessions = new Set<string>();
+  return {
+    claims: { released, orphaned },
+    releaseClaim: async (session) => {
+      if (!session.deviceClaim) return;
+      try {
+        await clearDeviceClaim(session.deviceClaim);
+        releasedSessions.add(session.name);
+      } catch (error) {
+        emitDiagnostic({
+          level: 'warn',
+          phase: 'daemon_shutdown_device_claim_release_failed',
+          data: {
+            session: session.name,
+            deviceKey: session.deviceClaim.deviceKey,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    },
+    finalize: (session) => {
+      const claim = session.deviceClaim;
+      if (!claim) return;
+      (releasedSessions.has(session.name) ? released : orphaned).push({
+        deviceKey: claim.deviceKey,
+        session: session.name,
+        platform: publicPlatformString(session.device),
+        deviceId: session.device.id,
+      });
+    },
+  };
+}

--- a/src/daemon/server/daemon-shutdown-claims.ts
+++ b/src/daemon/server/daemon-shutdown-claims.ts
@@ -1,11 +1,17 @@
 import { publicPlatformString } from '@agent-device/kernel/device';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import { clearDeviceClaim } from '../device-claims.ts';
+import { clearDeviceClaim, type DeviceClaimClearOutcome } from '../device-claims.ts';
 import type { DeviceClaimRecord } from '../daemon-shutdown-report.ts';
 import type { SessionState } from '../types.ts';
 
+export type DaemonShutdownClaims = {
+  released: DeviceClaimRecord[];
+  orphaned: DeviceClaimRecord[];
+  superseded: DeviceClaimRecord[];
+};
+
 export type DaemonShutdownClaimLedger = Readonly<{
-  claims: { released: DeviceClaimRecord[]; orphaned: DeviceClaimRecord[] };
+  claims: DaemonShutdownClaims;
   /** Runs only once a session's teardown reached a safe terminal state. */
   releaseClaim(session: SessionState): Promise<void>;
   /** Classifies the session's claim once its teardown has finished either way. */
@@ -13,23 +19,30 @@ export type DaemonShutdownClaimLedger = Readonly<{
 }>;
 
 /**
- * #1320 claim results for `daemon stop`: `released` is a claim cleared after a
- * clean teardown, `orphaned` is one this shutdown left in place. The exiting
- * daemon's owner identity dies with the process, so an orphaned claim is exactly
- * the cleanup-pending state proof-based reconciliation later resolves.
+ * #1320 claim results for `daemon stop`, classified from what clearing actually
+ * did rather than from whether it threw:
+ *
+ *  - `released`   — the claim was confirmed gone after a clean teardown.
+ *  - `orphaned`   — teardown left our claim in place. The exiting daemon's owner
+ *                   identity dies with the process, so this is the
+ *                   cleanup-pending state proof-based reconciliation resolves.
+ *  - `superseded` — our claim was already replaced by another owner. It is
+ *                   neither released (we released nothing) nor orphaned (no
+ *                   claim of ours remains to reconcile), so it gets its own
+ *                   bucket instead of being folded into a list whose meaning it
+ *                   would break.
  */
 export function createDaemonShutdownClaimLedger(): DaemonShutdownClaimLedger {
-  const released: DeviceClaimRecord[] = [];
-  const orphaned: DeviceClaimRecord[] = [];
-  const releasedSessions = new Set<string>();
+  const claims: DaemonShutdownClaims = { released: [], orphaned: [], superseded: [] };
+  const outcomes = new Map<string, DeviceClaimClearOutcome>();
   return {
-    claims: { released, orphaned },
+    claims,
     releaseClaim: async (session) => {
       if (!session.deviceClaim) return;
       try {
-        await clearDeviceClaim(session.deviceClaim);
-        releasedSessions.add(session.name);
+        outcomes.set(session.name, await clearDeviceClaim(session.deviceClaim));
       } catch (error) {
+        // An unrecorded outcome stays orphaned: the claim may still be on disk.
         emitDiagnostic({
           level: 'warn',
           phase: 'daemon_shutdown_device_claim_release_failed',
@@ -44,12 +57,23 @@ export function createDaemonShutdownClaimLedger(): DaemonShutdownClaimLedger {
     finalize: (session) => {
       const claim = session.deviceClaim;
       if (!claim) return;
-      (releasedSessions.has(session.name) ? released : orphaned).push({
+      const record: DeviceClaimRecord = {
         deviceKey: claim.deviceKey,
         session: session.name,
         platform: publicPlatformString(session.device),
         deviceId: session.device.id,
-      });
+      };
+      switch (outcomes.get(session.name)) {
+        case 'deleted':
+        case 'absent':
+          claims.released.push(record);
+          return;
+        case 'ownership-changed':
+          claims.superseded.push(record);
+          return;
+        default:
+          claims.orphaned.push(record);
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #1809 (now merged), which this was split out of so that PR stayed scoped to the enforcement seam. Targets `main` and stands alone.

Refs #1799 (observation 3), #1320 (the "Claim results distinguish reconciled `claimsReleased` from cleanup-pending `claimsOrphaned`" acceptance item).

**Before:** `DaemonStopResult` typed `claimsReleased` and `claimsOrphaned` as the literal `[]`, and the graceful, forced and not-running paths each returned empty literals. The daemon-side release happened in `teardownDaemonSession` (`clearDeviceClaim`, outcome discarded) and the CLI's `mergeShutdownReport` overlaid only `providerReleases`. So a graceful stop that really did release a device claim reported none — confirmed live on 0.20.9 in #1809's validation.

**After:**

- `clearDeviceClaim` returns a typed `DeviceClaimClearOutcome` (`'deleted' | 'absent' | 'ownership-changed'`) instead of nothing. It deliberately leaves a claim it does not own in place, so resolving never meant releasing; a caller that reports ownership has to read the outcome. `'ownership-changed'` also now covers an unattributable record, which the old `!inspected?.claim` early return silently folded in with "file gone".
- Graceful teardown records each session's outcome through a small ledger (`src/daemon/server/daemon-shutdown-claims.ts`) and classifies from it:
  - **released** — absence confirmed (`deleted` or `absent`) after the session reached a safe terminal state.
  - **orphaned** — teardown left our claim in place, or clearing threw. Exactly #1320's cleanup-pending state: the exiting daemon's owner identity dies with the process, which is what later proves the claim reclaimable.
  - **superseded** — another owner had already replaced our claim. This is neither released (this daemon freed nothing) nor orphaned (#1320 defines orphaned as staleness proven with cleanup pending, and no claim of ours remains to reconcile), so it gets its own bucket rather than breaking the meaning of either list, and raises a `daemon stop` warning so a device now owned elsewhere cannot pass silently. `cleanupConfidence` stays `known`: the state is not uncertain, it is attributed elsewhere.
- `clearDeviceClaim` failures during shutdown are recorded as orphaned with a diagnostic instead of propagating out of `Promise.all` and aborting the rest of the shutdown.
- `DaemonShutdownReport` carries a `claims` section; `DaemonStopResult` types all three fields as arrays of a small claim summary (`deviceKey`, `session`, `platform`, `deviceId`); `mergeShutdownReport` overlays them next to provider releases.
- Forced and not-running stops stay empty, because they cannot know.
- A report written by a daemon that predates claim reporting still reads its provider releases and reports no claims, rather than being rejected as malformed.

No daemon wire surface change — `DaemonStopResult` is local CLI output.

## Validation

**Successor-claim regression, proven red first.** Against the pre-fix ledger, the successor's claim landed in `claimsReleased`:

```
FAIL src/daemon/server/daemon-shutdown-claims.test.ts >
     a claim replaced by a successor owner is reported superseded, never released
AssertionError: expected [ { …(4) } ] to deeply equal []
  93|   expect(ledger.claims.released).toEqual([]);
```

New/updated tests:
- `src/daemon/server/daemon-shutdown-claims.test.ts` — released / orphaned / superseded classification and the no-claim case, against the real claim store; the superseded case also asserts the successor's claim survives teardown untouched.
- `src/daemon/__tests__/device-claims.test.ts` — the existing successor test now asserts the returned `'ownership-changed'`, plus a case pinning `deleted` / `absent` / `absent` for owned, already-cleared, and no-ownership.
- `src/daemon/__tests__/daemon-shutdown-report.test.ts` — round-trips the claim section, and the pre-claim-reporting report still reads.
- `src/cli/commands/__tests__/daemon.test.ts` — the graceful merge now asserts the claims it carries.

Live (Android, `Pixel_9_Pro_XL` → `emulator-5554`), same command on both builds:

```
$ agent-device daemon stop --state-dir <A> --json        # 0.20.9
{ "stopped": true, "mode": "graceful", "claimsReleased": [], "claimsOrphaned": [], ... }
                                        # ...while the claim file WAS removed

$ agent-device daemon stop --state-dir <A> --json        # this branch
{
  "stopped": true, "mode": "graceful", "cleanupConfidence": "known",
  "claimsReleased": [ { "deviceKey": "local:android:none:emulator-5554", "session": "stop-claim",
                        "platform": "android", "deviceId": "emulator-5554" } ],
  "claimsOrphaned": [], ...
}
```

Gates: `pnpm format`, `pnpm exec tsc --noEmit`, `pnpm check:affected --run` (436 files / 3702 tests green, layering + fallow clean).

## Scope

10 files, +415/−49. No follow-ups; `device release` (#1320's explicit recovery surface) remains out of scope for both PRs.
