### PR TITLE
ci: park perf-nightly to dispatch and stop the coverage-gate cascade double-red (#1781 A3, A5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,7 @@ jobs:
         with: { gate: coverage-model }
 
       - name: Run coverage
+        id: run-coverage
         env:
           OUTPUT_ECONOMY_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         uses: ./.github/actions/run-gate
@@ -355,8 +356,11 @@ jobs:
       # and fails when changed-line coverage < the threshold in
       # scripts/coverage-changed/model.ts. The `coverage-waiver` PR label maps to
       # the waiver env, which skips the failure but still prints the numbers.
+      # Gated on the coverage step's own outcome (#1781 A5): when `Run coverage`
+      # fails, lcov.info is never written, so this step would just re-report that
+      # failure as its own red ("no lcov report") instead of a coverage verdict.
       - name: Enforce changed-line coverage gate
-        if: always() && github.event_name == 'pull_request'
+        if: steps.run-coverage.outcome == 'success' && github.event_name == 'pull_request'
         env:
           AGENT_DEVICE_COVERAGE_WAIVER: ${{ contains(github.event.pull_request.labels.*.name, 'coverage-waiver') }}
         uses: ./.github/actions/run-gate

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,14 +1,12 @@
 name: Perf Nightly
 
-# End-to-end command perf benchmark (scripts/perf). Scheduled + manual only — perf timing on
-# shared CI runners is noisy, so treat this as a trend/regression signal, not absolute numbers.
-# Reuses the same build artifacts as the device suites: the cached iOS XCUITest runner
-# (setup-apple-runner-build, ios-runner-prebuilt cache) and the Android replay host, and runs the CLI
-# from source via --experimental-strip-types (no dist build), matching the replay workflows.
+# Parked to workflow_dispatch by #1781 A3: it only writes a report and compares nothing, so it
+# structurally cannot catch a regression, and iOS wall-clock medians swing up to +122%
+# night-to-night at n=5 with no consumer reading the report. `pnpm perf` / scripts/perf are
+# unaffected — still runnable on demand. Un-park once a comparison step with multi-night
+# smoothing (someone reading it) exists, or a perf arc needs nightly data.
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       rounds:


### PR DESCRIPTION
## What / why

Two small, decided CI changes from #1781.

### A3 — park `perf-nightly.yml` to dispatch-only

`perf-nightly.yml` writes a JSON/markdown perf report and compares nothing (`scripts/perf/report.ts` just serializes the run; grepping `scripts/perf` + the workflow for `baseline|threshold|regress|compare|delta` finds zero implementation, only a comment stating the intent). It therefore structurally cannot report a regression — a run only turns red on a harness crash.

Evidence (60-day run history + artifact diff):
- 38/38 green since 2026-07-12; "success" only ever meant "didn't crash."
- iOS wall-clock medians swing wildly night-to-night at n=5, warmup=1 on a shared macOS runner: `type` +122%, `snapshot (deep)` +74%, `open (relaunch→root)` +60%, `boot device` +39%. A fixed-threshold comparator would mostly print noise without multi-night smoothing.
- No doc, README, or issue consumes the report (`grep -rniE "perf-nightly|scripts/perf" docs/ CONTEXT.md AGENTS.md README.md` → no hits; `gh issue list --search "perf-nightly"` → only #1781 itself).
- Cost: iOS job ~22min median on a macOS runner + Android ~9min, nightly. This is a public repo, so Actions minutes are free; the defensible cost is runner *occupancy*, not billing — ~22 min/night of a macOS runner held for a report nobody reads.

Implemented exactly the #1781 A1 parking pattern (`replays-manual.yml`): dropped the `schedule:` trigger, kept `workflow_dispatch`, added a short header comment naming the parking reason and the un-park condition. `pnpm perf` and `scripts/perf` are untouched — still runnable on demand.

**`scripts/gate/declarations.ts` unchanged.** perf-nightly declares no `pnpm gate <name>` check of its own — `pnpm perf` isn't a registered gate, and the only `gate:` reference in the file (`swift-runner-ios`, used to build the shared XCTest runner) is already declared and owned by other lanes (`ios.yml`, `xctest-nightly.yml`, `conformance-differential.yml`). `pnpm check:gate-manifest` reports the same `47 checks / 33 lanes` before and after this change, so nothing needed a `MANUAL_ONLY_OWNERS` entry.

Docs: the only `perf-nightly` mention outside the workflow itself is `docs/agents/contract-projection-output-economy-spike.md:159`, a dated investigation closeout describing a past one-off dispatch attempt — not living documentation asserting perf-nightly runs on a schedule. Left as-is; rewriting a historical log to match a later architecture change would misrepresent what happened at the time.

### A5 — stop the changed-line coverage gate's cascade double-red

In `ci.yml`'s `coverage` job, "Enforce changed-line coverage gate" ran `if: always() && github.event_name == 'pull_request'`. When the preceding "Run coverage" step (`unit-ci`, the vitest-coverage run) failed, `coverage/lcov.info` was never written, and the Enforce step then failed too with "no lcov report" — a second, redundant red from the same job, not a coverage verdict.

Retrospective (60-day window, 3259 CI runs): 17 runs had the Enforce step fail. 16/17 were this lcov-missing cascade (Run coverage already failed/crashed). Only 1/17 was a genuine, isolated block: run 32104571856 / PR #1804 ("feat(ai-sdk): add agent-device/ai-sdk tool set"), 6.90% changed-line coverage on a large new file — correctly caught, PR was fixed and merged.

Fix: gave "Run coverage" an explicit `id: run-coverage` and changed the Enforce step's condition to `steps.run-coverage.outcome == 'success' && github.event_name == 'pull_request'`. The checker script (`scripts/coverage-changed/run.ts`) is unchanged.

## Four lines — both lanes, as they stand after this change

**perf-nightly (parked, dispatch-only):**
- Catches: nothing automatically — no scheduled run, no comparison logic. Manual dispatch remains available for on-demand perf investigation.
- Evidence: 38/38 scheduled runs green since 2026-07-12 while iOS per-metric medians swung up to +122% night-to-night; no issue or doc ever consumed a report.
- Cost: frees ~22 min/night of macOS runner occupancy (Actions minutes are free on this public repo, so the saving is occupancy/capacity, not billing). `pnpm perf` / scripts/perf still cost nothing extra when run on demand.
- Kill-criterion: un-park when a comparison step with multi-night smoothing exists and has an owner reading it, or when a perf arc needs nightly data.

**changed-line coverage gate (still gating, cascade removed):**
- Catches: genuinely undertested new files/hunks that the repo-wide 78-80% average (`vitest.config.ts`) would hide — 1 confirmed instance in 60 days.
- Evidence: run 32104571856 / PR #1804, 6.90% changed-line coverage, real block, fixed and merged. 0 waivers granted (the `coverage-waiver` label doesn't exist in the repo).
- Cost: ~1s/PR (reuses the job's own lcov output; no extra vitest run).
- Kill-criterion: n/a — low-but-nonzero legitimate catch rate (1/3259 runs), now measured without the 16 cascade false-reds diluting the signal.

## Test plan

- [x] `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — clean
- [x] `pnpm check:gate-manifest` — `47 checks wired across 33 lanes, manual-only: replay-android, replay-ios, replay-ios-device` (unchanged before/after)
- [x] `pnpm check:gate-manifest:test` — 37/37 passing
- [x] YAML syntax validated (`yaml.safe_load`) for both changed workflow files
- [ ] CI watch on this PR — confirm the `coverage` job's Enforce step behavior is unaffected on the (expected) green path
