### PR TITLE
fix: apply shared viewport guards to Android snapshots

### DIFF
--- a/packages/maestro/src/internal/snapshot-policy.ts
+++ b/packages/maestro/src/internal/snapshot-policy.ts
@@ -1,16 +1,11 @@
 import {
   buildSnapshotNodeMap,
-  findNearestScrollableAncestor,
   findSnapshotAncestor,
+  isNodeVisibleInEffectiveViewport,
   isUsefulVisibilityAnchor,
-  isViewportRootNode,
 } from '@agent-device/contracts/snapshot';
-import {
-  containsPoint,
-  isPositiveFiniteRect,
-  isRectVisibleInViewport,
-} from '@agent-device/kernel/rect';
-import type { Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
+import { isPositiveFiniteRect } from '@agent-device/kernel/rect';
+import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 
 export function isMaestroNodeVisible(
   node: SnapshotNode,
@@ -18,19 +13,20 @@ export function isMaestroNodeVisible(
   platform: 'android' | 'ios',
 ): boolean {
   if (platform === 'android' && node.visibleToUser === false) return false;
+  const byIndex = buildSnapshotNodeMap(nodes);
   if (isPositiveFiniteRect(node.rect)) {
-    return isVisibleInEffectiveViewport(node, nodes);
+    return isNodeVisibleInEffectiveViewport(node, nodes, byIndex);
   }
   if (node.rect) return false;
   if (platform !== 'android' && node.hittable === true) return true;
-  const anchor = findSnapshotAncestor(nodes, node, buildSnapshotNodeMap(nodes), (parent) =>
+  const anchor = findSnapshotAncestor(nodes, node, byIndex, (parent) =>
     isUsefulVisibilityAnchor(parent, platform) ? parent : null,
   );
   if (!anchor) return false;
   if (!isPositiveFiniteRect(anchor.rect)) {
     return platform !== 'android' && anchor.hittable === true;
   }
-  return isVisibleInEffectiveViewport(anchor, nodes);
+  return isNodeVisibleInEffectiveViewport(anchor, nodes, byIndex);
 }
 
 export function isDescendantOfSnapshotNode(
@@ -43,26 +39,5 @@ export function isDescendantOfSnapshotNode(
     findSnapshotAncestor(nodes, node, nodeByIndex, (candidate) =>
       candidate.index === ancestor.index ? candidate : null,
     ),
-  );
-}
-
-function isVisibleInEffectiveViewport(node: SnapshotNode, nodes: SnapshotNode[]): boolean {
-  if (!node.rect) return true;
-  const byIndex = buildSnapshotNodeMap(nodes);
-  const viewport =
-    findNearestScrollableAncestor(node, byIndex, (ancestor) => Boolean(ancestor.rect))?.rect ??
-    resolveRootViewport(nodes, node.rect);
-  return viewport ? isRectVisibleInViewport(node.rect, viewport) : true;
-}
-
-function resolveRootViewport(nodes: SnapshotNode[], target: Rect): Rect | null {
-  const viewportRects = nodes
-    .filter((node) => node.rect && isViewportRootNode(node))
-    .map((node) => node.rect!)
-    .sort((left, right) => right.width * right.height - left.width * left.height);
-  const centerX = target.x + target.width / 2;
-  const centerY = target.y + target.height / 2;
-  return (
-    viewportRects.find((rect) => containsPoint(rect, centerX, centerY)) ?? viewportRects[0] ?? null
   );
 }

--- a/src/core/interaction-targeting.test.ts
+++ b/src/core/interaction-targeting.test.ts
@@ -5,7 +5,6 @@ import {
   distinctRectPairArb,
   makeSnapshotState,
   PROPERTY_RUNS,
-  scrollingContainerTypeArb,
 } from '../__tests__/test-utils/index.ts';
 import {
   classifyActionableTouchCandidates,
@@ -15,6 +14,15 @@ import {
   ELEMENT14_DISTINCT_SUBTREE_NODES,
   EQUIVALENT_WRAPPER_CHAIN_NODES,
 } from './interaction-targeting.fixtures.ts';
+
+const scrollingContainerTypeArb = fc.constantFrom(
+  'ScrollView',
+  'Table',
+  'CollectionView',
+  'android.widget.ListView',
+  'android.widget.GridView',
+  'androidx.recyclerview.widget.RecyclerView',
+);
 
 test('collapses one same-label wrapper chain to its shared actionable node', () => {
   const snapshot = makeSnapshotState(EQUIVALENT_WRAPPER_CHAIN_NODES);
@@ -68,10 +76,11 @@ test('promotes static text inside a hittable row to the row', () => {
 });
 
 test.each([
-  'XCUIElementTypeScrollView',
-  'XCUIElementTypeTable',
-  'XCUIElementTypeCollectionView',
+  'ScrollView',
+  'Table',
+  'CollectionView',
   'android.widget.ListView',
+  'android.widget.GridView',
   'androidx.recyclerview.widget.RecyclerView',
 ])('does not promote a labeled region to its %s container', (containerType) => {
   const snapshot = makeSnapshotState([
@@ -98,6 +107,66 @@ test.each([
 
   assert.equal(resolution.reason, 'overly-broad-ancestor');
   assert.equal(resolution.node.label, 'Second tab');
+});
+
+test('does not promote an Android target to a full-screen content root without a viewport-root node', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'android.widget.FrameLayout',
+      rect: { x: 0, y: 0, width: 1080, height: 2400 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.TextView',
+      label: 'Settings',
+      rect: { x: 48, y: 300, width: 220, height: 72 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'overly-broad-ancestor');
+  assert.equal(resolution.node.label, 'Settings');
+});
+
+test('treats Android GridView as a scroll container during touch retargeting', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.GridView',
+      rect: { x: 0, y: 120, width: 390, height: 420 },
+      hittable: true,
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'android.widget.TextView',
+      label: 'Grid item',
+      rect: { x: 24, y: 180, width: 120, height: 48 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[2]!);
+
+  assert.equal(resolution.reason, 'overly-broad-ancestor');
+  assert.equal(resolution.node.label, 'Grid item');
 });
 
 test('never promotes a differently sized or positioned target to a scrolling container', () => {

--- a/src/core/interaction-targeting.ts
+++ b/src/core/interaction-targeting.ts
@@ -1,10 +1,10 @@
 import type { Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
-import { centerOfRect } from '@agent-device/kernel/snapshot';
-import { containsPoint, pickLargestRect } from '@agent-device/kernel/rect';
 import {
   findNearestAncestor,
+  isScrollableNodeLike,
   normalizeType,
   isViewportRootNode,
+  resolveViewportRect,
 } from '@agent-device/contracts/snapshot';
 import { isSnapshotNodeInteractionBlocked } from '../snapshot/snapshot-occlusion.ts';
 import {
@@ -229,31 +229,25 @@ function isOverlyBroadAncestor(
 }
 
 function isScrollingContainer(node: SnapshotNode): boolean {
-  const type = normalizeType(node.type ?? '');
-  return (
-    type.includes('scrollview') ||
-    type.includes('scrollarea') ||
-    type.includes('listview') ||
-    type.includes('recyclerview') ||
-    type.includes('collectionview') ||
-    type === 'list' ||
-    type === 'table' ||
-    type === 'collection'
-  );
+  return isScrollableNodeLike(node);
 }
 
 function resolveRootViewportRect(nodes: SnapshotNode[], targetRect: Rect): Rect | null {
-  const targetCenter = centerOfRect(targetRect);
   const viewportRects = nodes
     .filter(isViewportRootNode)
     .map((node) => normalizeRect(node.rect))
     .filter((rect): rect is Rect => rect !== null);
-  if (viewportRects.length === 0) return null;
+  if (viewportRects.length > 0) {
+    return resolveViewportRect(nodes, targetRect, viewportRects);
+  }
+  return hasAndroidClassNameNodes(nodes) ? resolveViewportRect(nodes, targetRect) : null;
+}
 
-  const containingRects = viewportRects.filter((rect) =>
-    containsPoint(rect, targetCenter.x, targetCenter.y),
-  );
-  return pickLargestRect(containingRects.length > 0 ? containingRects : viewportRects);
+function hasAndroidClassNameNodes(nodes: readonly SnapshotNode[]): boolean {
+  return nodes.some((node) => {
+    const type = node.type ?? '';
+    return type.startsWith('android.') || type.startsWith('androidx.');
+  });
 }
 
 function isRectViewportSized(rect: Rect, viewportRect: Rect): boolean {


### PR DESCRIPTION
## What
Fixes #1609. Android snapshots without viewport-root nodes could skip viewport guards for touch targeting and Maestro visibility.

## Fix
Interaction targeting and Maestro visibility now reuse the shared contracts viewport / visibility logic while preserving the existing non-Android no-root behavior.

## Test
Added Android root-less and GridView regression cases.
