### PR TITLE
fix(layering): unblock main — raise the daemon-server R9 ceiling for #1779's snapshot interactor seam

### DIFF
--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -73,8 +73,8 @@ test('daemon modularity baseline records the measured R7 ownership pressure', ()
     Object.values(SESSION_STATE_FIELD_OWNERS).reduce((sum, owners) => sum + owners.length, 0),
     DAEMON_MODULARITY_BASELINE.sessionState.ownerFileClaims,
   );
-  assert.equal(TYPE_CYCLE_BASELINE, 46);
-  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 16);
+  assert.equal(TYPE_CYCLE_BASELINE, 47);
+  assert.equal(DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers['daemon-server'], 17);
   assert.equal('daemon' in DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers, false);
 });
 
@@ -230,6 +230,6 @@ test('R9 rejects a baseline left above the measured cycle', () => {
 
   assert.equal(violations.length, 1);
   assert.match(violations[0]!.rule, /^R9 /);
-  assert.match(violations[0]!.message, /dropped to 45 files \(baseline 46\)/);
+  assert.match(violations[0]!.message, /dropped to 46 files \(baseline 47\)/);
   assert.match(violations[0]!.message, /Lower LARGEST_TYPE_CYCLE_ZONE_CEILINGS by the same 1/);
 });

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -7,7 +7,9 @@ const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
   client: 1,
   commands: 14,
   core: 10,
-  'daemon-server': 16,
+  // 17 since d76e0f94e (#1779): snapshot-capture.ts -> handlers/snapshot-interactor-capture.ts ->
+  // core/interactors.ts wedges the new interactor seam between two members, so it joins the cycle.
+  'daemon-server': 17,
   platforms: 2,
 };
 


### PR DESCRIPTION
**main is red on the Layering Guard job.** This unblocks it. Not a draft.

## Cause: two green PRs, one interaction

Neither PR is wrong; they were green against their own bases and never met until merge.

- **#1825** (`ef6ec2995`, "make R9 shrink mandatory") pinned `LARGEST_TYPE_CYCLE_ZONE_CEILINGS` to the then-measured values: `daemon-server: 16`, total `46`. The shrink is now mandatory, so the ceiling is an equality pin, not headroom.
- **#1779** (`d76e0f94e`, "migrate snapshot to device runtime") merged after it and added one new file that joins the largest type-level cycle.

`pnpm check:layering` on `9a0d6dead`:

```
[R9 type-cycle-size] scripts/layering/daemon-modularity.ts:1 —
  the largest type-level import cycle grew to 47 files (baseline 46).
[R10 daemon-modularity] src/daemon/daemon-command-registry.ts:1 —
  the largest type cycle now contains 17 daemon-server file(s) (baseline 16)
```

## The joining edge

The +1 node is **`src/daemon/handlers/snapshot-interactor-capture.ts`** (new in `d76e0f94e`), a choke point wedged between two files that were already cycle members:

```
src/daemon/handlers/snapshot-capture.ts        (member)
  -> src/daemon/handlers/snapshot-interactor-capture.ts   (new, line 22, value)
  -> src/core/interactors.ts  (getInteractor)  (member, line 7, value)
```

A new file that value-imports one SCC member and is value-imported by another always joins the SCC — +1 node, no new edges.

Attribution is a measured member-list diff of `largestTypeCycleMembers`, taken at `a853734f0` (#1779's parent, 46 members) vs `d76e0f94e` (47 members). The only differing line is `+ src/daemon/handlers/snapshot-interactor-capture.ts`.

**Note on the R10 message**: it names `src/daemon/daemon-command-registry.ts`, which is *not* the file that grew — that file was already a member at `a853734f0`. `checkTypeCycleBaseline` reports `members.find(m => targetDagZone(m) === zone)`, i.e. the alphabetically first member of the over-budget zone. Worth a follow-up; deliberately not touched here.

## The fix: explicit ceiling raise (option 3 of the brief)

`daemon-server: 16 -> 17` in `scripts/layering/daemon-modularity.ts`, with a one-line comment naming `d76e0f94e` and the joining edge. `TYPE_CYCLE_BASELINE` is derived from the zone ceilings, so the total follows to 47 automatically. `daemon-modularity.test.ts` pins both numbers as literals, so they move with it.

**I did not break the edge**, and the maintainer should decide whether that is acceptable. The zero-growth shape (per the #1633 precedent: host the seam in an existing cycle node) means deleting `snapshot-interactor-capture.ts` and moving the `getInteractor` call back into `snapshot-capture.ts` or up into `core/interactors.ts`. That module is the deliberate `vi.mock` seam for **43 test files** (`grep -rl snapshot-interactor-capture src` → 44 including itself); relocating it changes every one of those mock paths to a module whose other exports those tests still need unmocked. That is a real refactor, not a red-main fix. Happy to follow up with it as a separate PR if preferred — this PR only restores the gate to matching reality.

## check:layering after the fix

```
Layering guard: OK — 1312 source files satisfy R2-R3 and contain no value-import cycles ...
the largest type-level cycle is 47 files (R9); R10 pins R7 at 21 writer-owned fields /
25 owner claims, R9 at 47 files with zone ceilings, 2 external daemon/types.ts importers,
and zero forbidden logical-module imports beyond 0 recorded migration import(s) ...
```

## Test plan

- `pnpm check:layering` — green (47 total / 17 daemon-server), 178/178 layering unit tests pass
- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm format:check` — green
- No production code touched; only `scripts/layering/daemon-modularity.ts` and its test.
