### PR TITLE
fix(layering): keep the snapshot interactor seam out of the type cycle

### DIFF
--- a/src/daemon/handlers/snapshot-interactor-capture.ts
+++ b/src/daemon/handlers/snapshot-interactor-capture.ts
@@ -4,18 +4,22 @@ import type {
   SnapshotResult,
 } from '@agent-device/contracts/interaction';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import { getInteractor } from '../../core/interactors.ts';
 
 /**
  * Legacy snapshot consumers that have not moved to a device-runtime operation
  * still capture through the selected interactor. Keeping this seam snapshot-
  * specific avoids restoring the retired generic command dispatcher route.
+ *
+ * The interactor registry is loaded lazily, like the platform runtime host's
+ * local interactor resolver: this file stays readable without the interactor
+ * graph behind it (R9 type-cycle-size).
  */
 export async function captureSnapshotWithInteractor(params: {
   device: DeviceInfo;
   runnerContext: RunnerContext;
   options: SnapshotOptions;
 }): Promise<SnapshotResult> {
+  const { getInteractor } = await import('../../core/interactors.ts');
   const interactor = await getInteractor(params.device, params.runnerContext);
   return await interactor.snapshot(params.options);
 }


### PR DESCRIPTION
## Problem

The Layering Guard lane has failed on `main` since d76e0f94e (#1779), blocking every open PR:

- `[R9 type-cycle-size]` largest type-level import cycle grew to 47 files (baseline 46)
- `[R10 daemon-modularity]` 17 daemon-server files in that cycle (baseline 16)

#1825 lowered the baselines to 46/16 right before #1779 landed and grew the cycle by one file.

## Root cause

Diffing the SCC members at `ef6ec2995` (46) vs `main` (47), the single newcomer is `src/daemon/handlers/snapshot-interactor-capture.ts` — the small `vi.mock` seam #1779 added between `snapshot-capture.ts` and `core/interactors.ts`. There is no new type-only import: both its edges are value imports, and it sits on the existing loop

`request-generic-dispatch → snapshot-capture → (seam) → core/interactors → register-builtins → command-catalog → … → command-descriptor/types →(type) daemon-command-registry →(type) request-handler-chain → request-generic-dispatch`

Before #1779 `snapshot-capture.ts` reached `core/dispatch.ts` (already a member) directly, so no new node. `snapshot-runtime.ts` / `snapshot-runtime-binding.ts` / `snapshot-diff-legacy-admission.ts` are not in the SCC.

## Fix

The seam can't be inlined — ~50 daemon tests `vi.mock` it, and `legacy-snapshot-capture-fixture.ts` types itself off it — and `core/interactors.ts` is in the cycle for reasons unrelated to #1779. So the seam now loads the interactor registry lazily, mirroring how `platform-runtime-local-application-interactors.ts` already reaches `core/interactors.ts` from above:

```ts
const { getInteractor } = await import('../../core/interactors.ts');
```

The seam module is readable without the interactor graph behind it (the property R9 protects), and the SCC is back at 46 files / 16 daemon-server. Cost is one cached dynamic import per legacy capture, same as the runtime-host path already pays.

## Reviewer notes

- Considered and rejected: relocating the mock seam into `core/interactors.ts` (touches ~50 test files for a CI unblock) and raising the R9/R10 ceilings (the growth isn't warranted — it's a wrapper file). No daemon-server type-only edge exists that could be "declared below both modules" to peel a different node instead.
- Verified in a fresh-`pnpm install` worktree: `pnpm check:layering` OK (46/16), `pnpm typecheck`, `pnpm lint`, `vitest run src/daemon` (282 files / 2048 tests) all green.