### PR TITLE
fix: keep snapshot interactor seam outside static cycles

### DIFF
--- a/src/daemon/handlers/snapshot-interactor-capture.ts
+++ b/src/daemon/handlers/snapshot-interactor-capture.ts
@@ -4,7 +4,6 @@ import type {
   SnapshotResult,
 } from '@agent-device/contracts/interaction';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import { getInteractor } from '../../core/interactors.ts';
 
 /**
  * Legacy snapshot consumers that have not moved to a device-runtime operation
@@ -16,6 +15,7 @@ export async function captureSnapshotWithInteractor(params: {
   runnerContext: RunnerContext;
   options: SnapshotOptions;
 }): Promise<SnapshotResult> {
+  const { getInteractor } = await import('../../core/interactors.ts');
   const interactor = await getInteractor(params.device, params.runnerContext);
   return await interactor.snapshot(params.options);
 }


### PR DESCRIPTION
## Summary

Keep the snapshot-specific interactor seam lazy so it no longer enlarges the daemon’s largest static type cycle.

The snapshot runtime migration added a new module between two existing SCC members. Loading `getInteractor` only when legacy snapshot capture executes preserves the mock seam and runtime behavior while restoring the existing R9/R10 ratchets instead of raising their ceilings.

Touched files: 1. Scope is limited to the snapshot interactor capture seam and did not expand beyond the initial module.

## Validation

- Red on pristine `main`: layering reported 47 files in the largest type cycle and 17 daemon-server members, above the 46/16 ratchets.
- Green after the change: layering reports 46 files, 16 daemon-server members, and zero value-import cycles.
- `pnpm check:affected --run`: all 7 selected checks passed; the related graph ran 1,218 tests across 180 files.
- One unrelated temp-directory cleanup race failed on the first related run and passed in isolation; the complete affected rerun then passed.

No docs or skills changed because this is an internal dependency-loading correction with no command or user-facing behavior change.
