### PR TITLE
refactor(ios): establish snapshot presentation seam

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -116,6 +116,7 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrainForSnapshotRaw \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotTraversalIdentityPreservesSameOriginNodesWithDifferentBounds \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotPresentationPreservesCurrentWireShape \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testFlatSnapshotProjectionMatchesElementReverseScrollCapture \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXDepthLimitedRequiresEveryFrontierResolved \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testDeepExtensionCountsMissedFrontiers \

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -215,6 +215,11 @@ task touches:
 
 ### Snapshots & capture
 
+- Raw AX node: backend-owned iOS acquisition value before the snapshot presentation boundary. During
+  the #1797 migration it temporarily carries existing derived fields so the seam can land without a
+  wire-behavior change.
+- Presented node: wire-facing iOS snapshot value constructed only by `SnapshotPresentation`; response
+  payload assembly accepts this type rather than backend-owned raw values.
 - Snapshot capture plan: per-strategy ordered chain of iOS snapshot capture backends (recursive tree,
   query sweep, private AX) run by one plan runner under a shared wall-clock budget; recovery ordering
   is declared data, never a per-call-site branch.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -203,7 +203,10 @@ extension RunnerTests {
         deepExtension?[RunnerAXSnapshotDeepExtensionNodesAddedKey] as? Int ?? 0
       )
       return SnapshotBackendCapture(
-        payload: DataPayload(nodes: nodes, truncated: (response["truncated"] as? Bool) == true),
+        payload: DataPayload(
+          presenting: nodes,
+          truncated: (response["truncated"] as? Bool) == true
+        ),
         effectiveDepth: depthLimited ? effectiveDepth : nil,
         customActions: Self.privateAXCustomActionCoverage(
           response[RunnerAXSnapshotCustomActionsKey]

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
@@ -416,22 +416,24 @@ extension RunnerTests {
     return try! JSONDecoder().decode(Command.self, from: Data(json.utf8))
   }
 
-  private func runnerJournalNode() -> SnapshotNode {
-    SnapshotNode(
-      index: 0,
-      type: "button",
-      label: "Continue",
-      identifier: "continue",
-      value: nil,
-      rect: SnapshotRect(x: 10, y: 20, width: 100, height: 44),
-      enabled: true,
-      focused: nil,
-      selected: nil,
-      hittable: true,
-      depth: 0,
-      parentIndex: nil,
-      hiddenContentAbove: nil,
-      hiddenContentBelow: nil
+  private func runnerJournalNode() -> PresentedNode {
+    SnapshotPresentation.singleElementRead(
+      RawAXNode(
+        index: 0,
+        type: "button",
+        label: "Continue",
+        identifier: "continue",
+        value: nil,
+        rect: SnapshotRect(x: 10, y: 20, width: 100, height: 44),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: true,
+        depth: 0,
+        parentIndex: nil,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
     )
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -229,21 +229,23 @@ extension RunnerTests {
     let identifier = element.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
     let valueText = String(describing: element.value ?? "")
       .trimmingCharacters(in: .whitespacesAndNewlines)
-    let node = SnapshotNode(
-      index: 0,
-      type: elementTypeName(element.elementType),
-      label: label.isEmpty ? nil : label,
-      identifier: identifier.isEmpty ? nil : identifier,
-      value: valueText.isEmpty ? nil : valueText,
-      rect: snapshotRect(from: element.frame),
-      enabled: element.isEnabled,
-      focused: nil,
-      selected: element.isSelected ? true : nil,
-      hittable: element.isHittable,
-      depth: 0,
-      parentIndex: nil,
-      hiddenContentAbove: nil,
-      hiddenContentBelow: nil
+    let node = SnapshotPresentation.singleElementRead(
+      RawAXNode(
+        index: 0,
+        type: elementTypeName(element.elementType),
+        label: label.isEmpty ? nil : label,
+        identifier: identifier.isEmpty ? nil : identifier,
+        value: valueText.isEmpty ? nil : valueText,
+        rect: snapshotRect(from: element.frame),
+        enabled: element.isEnabled,
+        focused: nil,
+        selected: element.isSelected ? true : nil,
+        hittable: element.isHittable,
+        depth: 0,
+        parentIndex: nil,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
     )
     return Response(
       ok: true,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
@@ -235,7 +235,7 @@ struct DataPayload: Codable {
   let text: String?
   let found: Bool?
   let items: [String]?
-  let nodes: [SnapshotNode]?
+  let nodes: [PresentedNode]?
   let truncated: Bool?
   let snapshotQuality: SnapshotQuality?
   let gestureStartUptimeMs: Double?
@@ -277,7 +277,7 @@ struct DataPayload: Codable {
     text: String? = nil,
     found: Bool? = nil,
     items: [String]? = nil,
-    nodes: [SnapshotNode]? = nil,
+    nodes: [PresentedNode]? = nil,
     truncated: Bool? = nil,
     snapshotQuality: SnapshotQuality? = nil,
     gestureStartUptimeMs: Double? = nil,
@@ -373,26 +373,6 @@ struct SnapshotRect: Codable {
   let y: Double
   let width: Double
   let height: Double
-}
-
-struct SnapshotNode: Codable {
-  let index: Int
-  let type: String
-  let label: String?
-  let identifier: String?
-  let value: String?
-  let rect: SnapshotRect
-  let enabled: Bool
-  let focused: Bool?
-  let selected: Bool?
-  let hittable: Bool
-  let depth: Int
-  let parentIndex: Int?
-  let hiddenContentAbove: Bool?
-  let hiddenContentBelow: Bool?
-  /// Names of the element's UIAccessibilityCustomActions, present only when the
-  /// capture asked for them and the element carries some.
-  var actions: [String]? = nil
 }
 
 struct SnapshotOptions {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -4,9 +4,9 @@ extension RunnerTests {
   private static let privateAXProjectionTolerance: CGFloat = 1
 
   func privateAXPresentation(rawRoot: [String: Any], options: SnapshotOptions, viewport: CGRect)
-    -> [SnapshotNode]
+    -> [RawAXNode]
   {
-    var nodes: [SnapshotNode] = []
+    var nodes: [RawAXNode] = []
     var hints: [Int: (above: Bool, below: Bool)] = [:]
     appendPrivateAXNode(rawRoot, to: &nodes, hints: &hints, options: options, viewport: viewport,
       depth: 0, parentIndex: nil, insideMatchedScope: false, scrollContext: nil,
@@ -14,7 +14,7 @@ extension RunnerTests {
     return applyHiddenContentHints(hints, to: nodes)
   }
 
-  private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [SnapshotNode],
+  private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [RawAXNode],
     hints: inout [Int: (above: Bool, below: Bool)], options: SnapshotOptions, viewport: CGRect,
     depth: Int, parentIndex: Int?, insideMatchedScope: Bool,
     scrollContext: (index: Int, rect: CGRect)?, projectionCursor: FlatSnapshotProjectionCursor)
@@ -65,7 +65,7 @@ extension RunnerTests {
     if include {
       currentIndex = nodes.count
       let typeName = elementType.map(elementTypeName) ?? "Element(\(rawType))"
-      nodes.append(SnapshotNode(index: nodes.count, type: typeName,
+      nodes.append(RawAXNode(index: nodes.count, type: typeName,
         label: label.isEmpty ? nil : label, identifier: identifier.isEmpty ? nil : identifier,
         value: value.isEmpty ? nil : value, rect: snapshotRect(from: rect), enabled: enabled,
         focused: privateAXPresentationBool(raw["focused"]) == true ? true : nil,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -147,7 +147,7 @@ extension RunnerTests {
       return result.elements
     }
 
-    var nodes: [SnapshotNode] = []
+    var nodes: [RawAXNode] = []
     var hiddenContentHintsByNodeIndex: [Int: (above: Bool, below: Bool)] = [:]
     let rootEvaluation = evaluateSnapshot(context.rootSnapshot, in: context)
     nodes.append(
@@ -316,7 +316,7 @@ extension RunnerTests {
     }
 
     return DataPayload(
-      nodes: applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes),
+      presenting: applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes),
       truncated: false
     )
   }
@@ -422,7 +422,7 @@ extension RunnerTests {
     context: SnapshotTraversalContext,
     options: SnapshotOptions
   ) throws -> DataPayload {
-    var nodes: [SnapshotNode] = []
+    var nodes: [RawAXNode] = []
 
     func walk(_ snapshot: XCUIElementSnapshot, depth: Int, parentIndex: Int?) throws {
       if let limit = options.depth, depth > limit { return }
@@ -460,7 +460,7 @@ extension RunnerTests {
     }
 
     try walk(context.rootSnapshot, depth: 0, parentIndex: nil)
-    return DataPayload(nodes: nodes, truncated: false)
+    return DataPayload(presenting: nodes, truncated: false)
   }
 
   func snapshotFlatInteractive(
@@ -468,11 +468,11 @@ extension RunnerTests {
     options: SnapshotOptions,
     planDeadline: Date = .distantFuture
   ) -> DataPayload {
-    var nodes: [SnapshotNode] = [
+    var nodes: [RawAXNode] = [
       interactiveRootNode(rect: .zero)
     ]
     if options.depth == 0 {
-      return DataPayload(nodes: nodes, truncated: false)
+      return DataPayload(presenting: nodes, truncated: false)
     }
 
     // Bounded by both its own sweep budget and the umbrella capture-plan deadline, so a
@@ -483,7 +483,7 @@ extension RunnerTests {
     let deadline = min(sweepDeadline, planDeadline)
     let viewport = safeSnapshotViewport(app: app)
     var seen = Set<String>()
-    var candidates: [SnapshotNode] = []
+    var candidates: [RawAXNode] = []
     let flatElements = flatInteractiveElements(app: app, deadline: deadline)
     var truncated = flatElements.truncated
     for element in flatElements.elements {
@@ -525,7 +525,7 @@ extension RunnerTests {
     nodes[0] = interactiveRootNode(rect: rootRect)
     for candidate in candidates {
       nodes.append(
-        SnapshotNode(
+        RawAXNode(
           index: nodes.count,
           type: candidate.type,
           label: candidate.label,
@@ -543,7 +543,7 @@ extension RunnerTests {
         )
       )
     }
-    return DataPayload(nodes: nodes, truncated: truncated)
+    return DataPayload(presenting: nodes, truncated: truncated)
   }
 
   func snapshotAccessibilityUnavailable(failure: SnapshotCaptureFailure) -> DataPayload {
@@ -588,7 +588,7 @@ extension RunnerTests {
   ) -> DataPayload {
     return DataPayload(
       message: message,
-      nodes: [interactiveRootNode(rect: .zero)],
+      nodes: SnapshotPresentation.preservingCurrentSemantics([interactiveRootNode(rect: .zero)]),
       truncated: true,
       snapshotQuality: snapshotQuality,
       runnerFatal: runnerFatal,
@@ -830,8 +830,8 @@ extension RunnerTests {
   }
 #endif
 
-  private func interactiveRootNode(rect: CGRect) -> SnapshotNode {
-    SnapshotNode(
+  private func interactiveRootNode(rect: CGRect) -> RawAXNode {
+    RawAXNode(
       index: 0,
       type: "Application",
       label: nil,
@@ -849,7 +849,7 @@ extension RunnerTests {
     )
   }
 
-  private func interactiveRootFrame(for candidates: [SnapshotNode]) -> CGRect {
+  private func interactiveRootFrame(for candidates: [RawAXNode]) -> CGRect {
     guard !candidates.isEmpty else {
       return .zero
     }
@@ -1120,8 +1120,8 @@ extension RunnerTests {
     depth: Int,
     index: Int,
     parentIndex: Int?
-  ) -> SnapshotNode {
-    return SnapshotNode(
+  ) -> RawAXNode {
+    return RawAXNode(
       index: index,
       type: elementTypeName(snapshot.elementType),
       label: evaluation.label.isEmpty ? nil : evaluation.label,
@@ -1241,7 +1241,7 @@ extension RunnerTests {
   }
 
   private func appendCollapsedTabFallbackNodes(
-    to nodes: inout [SnapshotNode],
+    to nodes: inout [RawAXNode],
     containerSnapshot: XCUIElementSnapshot,
     resolveElements: () -> [XCUIElement],
     depth: Int,
@@ -1306,14 +1306,14 @@ extension RunnerTests {
 
   func applyHiddenContentHints(
     _ hints: [Int: (above: Bool, below: Bool)],
-    to nodes: [SnapshotNode]
-  ) -> [SnapshotNode] {
+    to nodes: [RawAXNode]
+  ) -> [RawAXNode] {
     if hints.isEmpty { return nodes }
     return nodes.map { node in
       guard let hint = hints[node.index] else { return node }
       let hiddenContentAbove: Bool? = (node.hiddenContentAbove == true || hint.above) ? true : nil
       let hiddenContentBelow: Bool? = (node.hiddenContentBelow == true || hint.below) ? true : nil
-      return SnapshotNode(
+      return RawAXNode(
         index: node.index,
         type: node.type,
         label: node.label,
@@ -1339,7 +1339,7 @@ extension RunnerTests {
     startingIndex: Int,
     depth: Int,
     parentIndex: Int
-  ) -> [SnapshotNode] {
+  ) -> [RawAXNode] {
     if !containerSnapshot.children.isEmpty { return [] }
     guard shouldExpandCollapsedTabContainer(containerSnapshot) else { return [] }
     let containerFrame = containerSnapshot.frame
@@ -1378,7 +1378,7 @@ extension RunnerTests {
     if uniqueCandidates.count < 2 { return [] }
 
     return uniqueCandidates.enumerated().map { offset, node in
-      SnapshotNode(
+      RawAXNode(
         index: startingIndex + offset,
         type: node.type,
         label: node.label,
@@ -1401,8 +1401,8 @@ extension RunnerTests {
     element: XCUIElement,
     containerSnapshot: XCUIElementSnapshot,
     containerFrame: CGRect
-  ) -> SnapshotNode? {
-    var node: SnapshotNode?
+  ) -> RawAXNode? {
+    var node: RawAXNode?
     let exceptionMessage = RunnerObjCExceptionCatcher.catchException({
       if !element.exists { return }
       let elementType = element.elementType
@@ -1430,7 +1430,7 @@ extension RunnerTests {
         return
       }
 
-      node = SnapshotNode(
+      node = RawAXNode(
         index: 0,
         type: elementTypeName(elementType),
         label: label.isEmpty ? nil : label,
@@ -1568,8 +1568,8 @@ extension RunnerTests {
     parentIndex: Int?,
     viewport: CGRect,
     options: SnapshotOptions
-  ) -> SnapshotNode? {
-    var node: SnapshotNode?
+  ) -> RawAXNode? {
+    var node: RawAXNode?
     let exceptionMessage = RunnerObjCExceptionCatcher.catchException({
       if !element.exists { return }
       let frame = element.frame
@@ -1601,7 +1601,7 @@ extension RunnerTests {
         return
       }
 
-      node = SnapshotNode(
+      node = RawAXNode(
         index: index,
         type: elementTypeName(elementType),
         label: label.isEmpty ? nil : label,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -529,7 +529,7 @@ extension RunnerTests {
     }
   }
 
-  static func isSparseApplicationWindowTree(_ nodes: [SnapshotNode]) -> Bool {
+  static func isSparseApplicationWindowTree(_ nodes: [PresentedNode]) -> Bool {
     guard !nodes.isEmpty else { return false }
     let rootRects = nodes.compactMap { node in
       node.type == "Application" || node.type == "Window" ? node.rect : nil
@@ -564,7 +564,7 @@ extension RunnerTests {
   /// A leaf whose label joins many short segments is a container marked as an accessibility
   /// element: the platform folds every descendant into one merged node. Nothing below it can
   /// be addressed — by automation or by assistive tech. This is app-side; no backend recovers it.
-  static func collapsedLeafIndexes(_ nodes: [SnapshotNode]) -> [Int]? {
+  static func collapsedLeafIndexes(_ nodes: [PresentedNode]) -> [Int]? {
     let parents = Set(nodes.compactMap { $0.parentIndex })
     let collapsed = nodes.filter { node in
       guard !parents.contains(node.index) else { return false }
@@ -680,22 +680,24 @@ extension RunnerTests {
     identifier: String? = nil,
     hittable: Bool = false,
     parentIndex: Int? = nil
-  ) -> SnapshotNode {
-    SnapshotNode(
-      index: index,
-      type: type,
-      label: label,
-      identifier: identifier,
-      value: nil,
-      rect: snapshotRect(from: .zero),
-      enabled: true,
-      focused: nil,
-      selected: nil,
-      hittable: hittable,
-      depth: parentIndex == nil ? 0 : 1,
-      parentIndex: parentIndex,
-      hiddenContentAbove: nil,
-      hiddenContentBelow: nil
+  ) -> PresentedNode {
+    SnapshotPresentation.singleElementRead(
+      RawAXNode(
+        index: index,
+        type: type,
+        label: label,
+        identifier: identifier,
+        value: nil,
+        rect: snapshotRect(from: .zero),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: hittable,
+        depth: parentIndex == nil ? 0 : 1,
+        parentIndex: parentIndex,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
     )
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Backend-owned snapshot output before it crosses the presentation seam.
+///
+/// Step 1 deliberately carries the fields computed by today's backend-specific implementations.
+/// Later #1797 migration steps move those decisions behind `SnapshotPresentation` without changing
+/// either the acquisition interface or the wire-facing `PresentedNode` type.
+struct RawAXNode {
+  let index: Int
+  let type: String
+  let label: String?
+  let identifier: String?
+  let value: String?
+  let rect: SnapshotRect
+  let enabled: Bool
+  let focused: Bool?
+  let selected: Bool?
+  let hittable: Bool
+  let depth: Int
+  let parentIndex: Int?
+  let hiddenContentAbove: Bool?
+  let hiddenContentBelow: Bool?
+  var actions: [String]? = nil
+}
+
+/// The only snapshot node shape accepted by response payload assembly.
+///
+/// Its initializer is private so a backend cannot bypass `SnapshotPresentation`. The encoded shape
+/// intentionally remains byte-for-byte compatible with the former `SnapshotNode` wire model.
+struct PresentedNode: Codable {
+  let index: Int
+  let type: String
+  let label: String?
+  let identifier: String?
+  let value: String?
+  let rect: SnapshotRect
+  let enabled: Bool
+  let focused: Bool?
+  let selected: Bool?
+  let hittable: Bool
+  let depth: Int
+  let parentIndex: Int?
+  let hiddenContentAbove: Bool?
+  let hiddenContentBelow: Bool?
+  let actions: [String]?
+
+  fileprivate init(presenting raw: RawAXNode) {
+    index = raw.index
+    type = raw.type
+    label = raw.label
+    identifier = raw.identifier
+    value = raw.value
+    rect = raw.rect
+    enabled = raw.enabled
+    focused = raw.focused
+    selected = raw.selected
+    hittable = raw.hittable
+    depth = raw.depth
+    parentIndex = raw.parentIndex
+    hiddenContentAbove = raw.hiddenContentAbove
+    hiddenContentBelow = raw.hiddenContentBelow
+    actions = raw.actions
+  }
+}
+
+enum SnapshotPresentation {
+  /// Transitional adapter for #1797 migration steps 1 and 2. Acquisition still computes today's
+  /// backend-specific decisions; this seam changes construction authority without changing output.
+  static func preservingCurrentSemantics(_ nodes: [RawAXNode]) -> [PresentedNode] {
+    nodes.map(PresentedNode.init(presenting:))
+  }
+
+  /// Explicit carve-out for selector queries and system-modal reads that intentionally return one
+  /// already-resolved element instead of traversing a snapshot backend.
+  static func singleElementRead(_ node: RawAXNode) -> PresentedNode {
+    PresentedNode(presenting: node)
+  }
+}
+
+extension DataPayload {
+  init(presenting nodes: [RawAXNode], truncated: Bool) {
+    self.init(
+      nodes: SnapshotPresentation.preservingCurrentSemantics(nodes),
+      truncated: truncated
+    )
+  }
+}
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+import XCTest
+
+extension RunnerTests {
+  func testSnapshotPresentationPreservesCurrentWireShape() throws {
+    // Non-vacuity: setting PresentedNode.label to nil made this test execute once and fail on the
+    // missing `"label":"Continue"` field before the production mapping was restored.
+    let raw = RawAXNode(
+      index: 3,
+      type: "Button",
+      label: "Continue",
+      identifier: "continue-button",
+      value: "Ready",
+      rect: SnapshotRect(x: 10, y: 20, width: 100, height: 44),
+      enabled: true,
+      focused: true,
+      selected: true,
+      hittable: true,
+      depth: 2,
+      parentIndex: 1,
+      hiddenContentAbove: true,
+      hiddenContentBelow: true,
+      actions: ["Open menu"]
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    let encoded = try encoder.encode(SnapshotPresentation.preservingCurrentSemantics([raw]))
+
+    XCTAssertEqual(
+      String(decoding: encoded, as: UTF8.self),
+      #"[{"actions":["Open menu"],"depth":2,"enabled":true,"focused":true,"hiddenContentAbove":true,"hiddenContentBelow":true,"hittable":true,"identifier":"continue-button","index":3,"label":"Continue","parentIndex":1,"rect":{"height":44,"width":100,"x":10,"y":20},"selected":true,"type":"Button","value":"Ready"}]"#
+    )
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SystemModal.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SystemModal.swift
@@ -25,7 +25,7 @@ extension RunnerTests {
     ) else {
       return nil
     }
-    var nodes: [SnapshotNode] = [modalNode]
+    var nodes: [PresentedNode] = [modalNode]
 
     for action in actions {
       guard let actionNode = safeMakeSnapshotNode(
@@ -221,24 +221,26 @@ extension RunnerTests {
     depth: Int,
     parentIndex: Int? = nil,
     hittableOverride: Bool? = nil
-  ) -> SnapshotNode {
+  ) -> PresentedNode {
     let label = (labelOverride ?? element.label).trimmingCharacters(in: .whitespacesAndNewlines)
     let identifier = (identifierOverride ?? element.identifier).trimmingCharacters(in: .whitespacesAndNewlines)
-    return SnapshotNode(
-      index: index,
-      type: type,
-      label: label.isEmpty ? nil : label,
-      identifier: identifier.isEmpty ? nil : identifier,
-      value: nil,
-      rect: snapshotRect(from: element.frame),
-      enabled: element.isEnabled,
-      focused: nil,
-      selected: nil,
-      hittable: hittableOverride ?? element.isHittable,
-      depth: depth,
-      parentIndex: parentIndex,
-      hiddenContentAbove: nil,
-      hiddenContentBelow: nil
+    return SnapshotPresentation.singleElementRead(
+      RawAXNode(
+        index: index,
+        type: type,
+        label: label.isEmpty ? nil : label,
+        identifier: identifier.isEmpty ? nil : identifier,
+        value: nil,
+        rect: snapshotRect(from: element.frame),
+        enabled: element.isEnabled,
+        focused: nil,
+        selected: nil,
+        hittable: hittableOverride ?? element.isHittable,
+        depth: depth,
+        parentIndex: parentIndex,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
     )
   }
 
@@ -251,7 +253,7 @@ extension RunnerTests {
     depth: Int,
     parentIndex: Int? = nil,
     hittableOverride: Bool? = nil
-  ) -> SnapshotNode? {
+  ) -> PresentedNode? {
     safely("MODAL_NODE") {
       makeSnapshotNode(
         element: element,

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -54,9 +54,10 @@ strategies:
 - **Future AX-service strategy**: treat Bluesky-class failures as evidence that XCTest is
   not a complete semantic snapshot backend. A robust semantic fix should add a host-side simulator
   accessibility backend, similar in role to existing simulator accessibility inspection tools,
-  and normalize its output into the same `SnapshotNode` model. That backend can be simulator-only;
-  physical devices should use an equivalent non-XCTest semantic backend only if Apple exposes a
-  supported channel.
+  and acquire its output as `RawAXNode` values. Every backend crosses the same
+  `SnapshotPresentation` construction boundary before producing wire-facing `PresentedNode` values.
+  That backend can be simulator-only; physical devices should use an equivalent non-XCTest semantic
+  backend only if Apple exposes a supported channel.
 
 The daemon should make degraded output observable. If an iOS interactive snapshot contains only the
 application root or another sparse shape, surface a structured quality verdict and warning so
@@ -95,6 +96,11 @@ because retrying the same recursive capture is unlikely to reveal a different tr
 A future AX-service backend is the correct place to regain Bluesky-class semantic coverage. It
 should be added as a platform backend with its own lifecycle, protocol, normalization, timing
 metrics, and fallback rules, not as another special case inside the XCTest runner.
+
+The acquire/present migration begins with a behavior-preserving typed seam: acquisition backends
+construct `RawAXNode`, `SnapshotPresentation` alone constructs `PresentedNode`, and response payloads
+accept only presented nodes. Until the remaining migration steps move interpretation into that seam,
+raw nodes intentionally carry the derived fields produced by the existing backends.
 
 When adding new iOS snapshot behavior, maintainers should first decide which strategy owns it. If a
 change tries to make regular snapshots fast by dropping visible controls behind a node budget, or


### PR DESCRIPTION
## Summary

Establish the behavior-preserving iOS acquire/present boundary from #1797 migration step 1.

- acquisition backends now produce `RawAXNode` values
- `SnapshotPresentation` is the sole direct constructor of wire-facing `PresentedNode` values
- response payloads accept presented nodes, preventing backends from bypassing the boundary
- current snapshot JSON and backend behavior remain unchanged while later migration steps move interpretation behind the seam
- ADR 0004, domain vocabulary, and the PR XCTest selection reflect the new boundary

This touches 12 files within the iOS runner module group plus its architecture and CI ownership documents. It does not expand command behavior or public API surface.

Part of #1797.

## Validation

- `pnpm check:affected --run` passed all runnable checks
- isolated iOS and macOS XCTest runner builds passed
- `testSnapshotPresentationPreservesCurrentWireShape` executed once and passed on an iOS Simulator
- non-vacuity was proven by setting the production `label` mapping to `nil`: the same test executed once and failed on the missing `"label":"Continue"` field, then passed after restoration

GitHub-authoritative native/device lanes remain for CI.
