### PR TITLE
refactor(ios): route snapshot backends through presentation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -218,6 +218,12 @@ task touches:
 - Raw AX node: backend-owned iOS acquisition value before the snapshot presentation boundary. During
   the #1797 migration it temporarily carries existing derived fields so the seam can land without a
   wire-behavior change.
+- Snapshot acquisition: the result of one iOS snapshot backend attempt—raw AX nodes plus
+  attempt-level truncation, depth, and custom-action facts. Every capture-plan backend returns this
+  type, and the exhaustive backend switch routes it through `SnapshotPresentation` exactly once.
+- Presentation options: the source-of-truth iOS snapshot request policy accepted by
+  `SnapshotPresentation`. During the behavior-preserving #1797 migration acquisition still reads
+  these options to reproduce current backend-specific decisions.
 - Presented node: wire-facing iOS snapshot value constructed only by `SnapshotPresentation`; response
   payload assembly accepts this type rather than backend-owned raw values.
 - Snapshot capture plan: per-strategy ordered chain of iOS snapshot capture backends (recursive tree,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -103,11 +103,11 @@ extension RunnerTests {
     }
   }
 
-  func privateAXSnapshotCapture(
+  func privateAXSnapshotAcquisition(
     app: XCUIApplication,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     deadline: Date = .distantFuture
-  ) -> SnapshotBackendCapture? {
+  ) -> SnapshotAcquisition? {
     #if os(iOS) && targetEnvironment(simulator)
       let requestedDepth = options.depth ?? 64
       // An explicit --depth request is honored as asked: no accepted-depth
@@ -202,11 +202,9 @@ extension RunnerTests {
         effectiveDepth,
         deepExtension?[RunnerAXSnapshotDeepExtensionNodesAddedKey] as? Int ?? 0
       )
-      return SnapshotBackendCapture(
-        payload: DataPayload(
-          presenting: nodes,
-          truncated: (response["truncated"] as? Bool) == true
-        ),
+      return SnapshotAcquisition(
+        nodes: nodes,
+        truncated: (response["truncated"] as? Bool) == true,
         effectiveDepth: depthLimited ? effectiveDepth : nil,
         customActions: Self.privateAXCustomActionCoverage(
           response[RunnerAXSnapshotCustomActionsKey]
@@ -417,7 +415,7 @@ extension RunnerTests {
   func testCustomActionsRequestPinsPrivateAXBackend() throws {
     let asked = try JSONDecoder().decode(
       Command.self, from: Data(#"{"command":"snapshot","customActions":true}"#.utf8))
-    let options = Self.snapshotOptions(from: asked)
+    let options = Self.presentationOptions(from: asked)
     XCTAssertTrue(options.customActions)
     XCTAssertEqual(options.preferredBackend, SnapshotBackendKind.privateAX.rawValue)
     XCTAssertTrue(
@@ -428,12 +426,12 @@ extension RunnerTests {
     let pinned = try JSONDecoder().decode(
       Command.self,
       from: Data(#"{"command":"snapshot","customActions":true,"preferredBackend":"tree"}"#.utf8))
-    XCTAssertEqual(Self.snapshotOptions(from: pinned).preferredBackend, "tree")
+    XCTAssertEqual(Self.presentationOptions(from: pinned).preferredBackend, "tree")
 
     // And the default capture neither asks nor pins.
     let bare = try JSONDecoder().decode(Command.self, from: Data(#"{"command":"snapshot"}"#.utf8))
-    XCTAssertFalse(Self.snapshotOptions(from: bare).customActions)
-    XCTAssertNil(Self.snapshotOptions(from: bare).preferredBackend)
+    XCTAssertFalse(Self.presentationOptions(from: bare).customActions)
+    XCTAssertNil(Self.presentationOptions(from: bare).preferredBackend)
   }
 
   /// A request-pinned backend degraded nothing, so its verdict must not claim
@@ -639,7 +637,7 @@ extension RunnerTests {
     ]
     let nodes = privateAXPresentation(
       rawRoot: tree,
-      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 390, height: 844)
     )
 
@@ -664,7 +662,12 @@ extension RunnerTests {
     ]
     let nodes = privateAXPresentation(
       rawRoot: tree,
-      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: "homeScreen", raw: false),
+      options: PresentationOptions(
+        interactiveOnly: false,
+        depth: nil,
+        scope: "homeScreen",
+        raw: false
+      ),
       viewport: .infinite
     )
 
@@ -741,7 +744,7 @@ extension RunnerTests {
     ]
     let nodes = privateAXPresentation(
       rawRoot: tree,
-      options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
+      options: PresentationOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 390, height: 844)
     )
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1360,10 +1360,10 @@ extension RunnerTests {
   }
 
   /// Pure command→options projection, extracted so the runner unit bundle can
-  /// prove the decoded wire field actually reaches capture options (#1634 P2).
-  static func snapshotOptions(from command: Command) -> SnapshotOptions {
+  /// prove the decoded wire field actually reaches presentation options (#1634 P2).
+  static func presentationOptions(from command: Command) -> PresentationOptions {
     let customActions = command.customActions ?? false
-    return SnapshotOptions(
+    return PresentationOptions(
       interactiveOnly: command.interactiveOnly ?? false,
       depth: command.depth,
       scope: command.scope,
@@ -1378,7 +1378,7 @@ extension RunnerTests {
   }
 
   private func executeSnapshotPrepared(command: Command, activeApp: XCUIApplication) throws -> Response {
-    let options = Self.snapshotOptions(from: command)
+    let options = Self.presentationOptions(from: command)
     do {
       let payload: DataPayload
       if options.raw {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
@@ -119,7 +119,7 @@ extension RunnerTests {
 
   func flatSnapshotFilterDecision(
     _ node: FlatSnapshotFilterNode,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     visibilityPolicy: FlatSnapshotVisibilityPolicy,
     insideMatchedScope: Bool
   ) -> FlatSnapshotFilterDecision {
@@ -339,7 +339,7 @@ extension RunnerTests {
     XCTAssertTrue(
       flatSnapshotFilterDecision(
         visibleContent,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
@@ -347,7 +347,7 @@ extension RunnerTests {
     XCTAssertFalse(
       flatSnapshotFilterDecision(
         hiddenInteractive,
-        options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
@@ -355,7 +355,7 @@ extension RunnerTests {
     XCTAssertFalse(
       flatSnapshotFilterDecision(
         hiddenInteractive,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .viewportProjected,
         insideMatchedScope: false
       ).include
@@ -363,7 +363,7 @@ extension RunnerTests {
     XCTAssertTrue(
       flatSnapshotFilterDecision(
         hiddenInteractive,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
@@ -371,7 +371,7 @@ extension RunnerTests {
     XCTAssertTrue(
       flatSnapshotFilterDecision(
         hiddenRoot,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .viewportProjected,
         insideMatchedScope: false
       ).include
@@ -379,7 +379,7 @@ extension RunnerTests {
     XCTAssertTrue(
       flatSnapshotFilterDecision(
         decorative,
-        options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+        options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
         visibilityPolicy: .interactiveOnly,
         insideMatchedScope: false
       ).include
@@ -401,7 +401,7 @@ extension RunnerTests {
       valueText: nil,
       visible: true
     )
-    let options = SnapshotOptions(interactiveOnly: false, depth: nil, scope: "homeScreen", raw: false)
+    let options = PresentationOptions(interactiveOnly: false, depth: nil, scope: "homeScreen", raw: false)
 
     let rootDecision = flatSnapshotFilterDecision(
       scopeRoot,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
@@ -375,7 +375,7 @@ struct SnapshotRect: Codable {
   let height: Double
 }
 
-struct SnapshotOptions {
+struct PresentationOptions {
   let interactiveOnly: Bool
   let depth: Int?
   let scope: String?

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -3,7 +3,7 @@ import XCTest
 extension RunnerTests {
   private static let privateAXProjectionTolerance: CGFloat = 1
 
-  func privateAXPresentation(rawRoot: [String: Any], options: SnapshotOptions, viewport: CGRect)
+  func privateAXPresentation(rawRoot: [String: Any], options: PresentationOptions, viewport: CGRect)
     -> [RawAXNode]
   {
     var nodes: [RawAXNode] = []
@@ -15,7 +15,7 @@ extension RunnerTests {
   }
 
   private func appendPrivateAXNode(_ raw: [String: Any], to nodes: inout [RawAXNode],
-    hints: inout [Int: (above: Bool, below: Bool)], options: SnapshotOptions, viewport: CGRect,
+    hints: inout [Int: (above: Bool, below: Bool)], options: PresentationOptions, viewport: CGRect,
     depth: Int, parentIndex: Int?, insideMatchedScope: Bool,
     scrollContext: (index: Int, rect: CGRect)?, projectionCursor: FlatSnapshotProjectionCursor)
   {
@@ -119,7 +119,7 @@ extension RunnerTests {
         "children": [["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Profile picture", "frame": frame(16, 120, 44, 44)],
           ["type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": frame(16, 900, 360, 44)]]]]]
     let nodes = privateAXPresentation(rawRoot: root,
-      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Profile picture"])
     let scrollView = nodes.first { $0.type == "ScrollView" }
@@ -142,7 +142,7 @@ extension RunnerTests {
             "label": "Theme", "frame": frame(340, 96, 46, 44)]]]]]]]
 
     let nodes = privateAXPresentation(rawRoot: root,
-      options: SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
+      options: PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
 
     XCTAssertEqual(nodes.compactMap(\.label), ["Element"])
@@ -158,7 +158,7 @@ extension RunnerTests {
           "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero],
         ["type": Int(XCUIElement.ElementType.other.rawValue), "frame": zero]]]]]
     let nodes = privateAXPresentation(rawRoot: root,
-      options: SnapshotOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
+      options: PresentationOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Settings semantics", "Theme"])
     XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, false])

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -117,7 +117,7 @@ extension RunnerTests {
   // `boundedBlockingSystemAlertSnapshot`'s probe closure (see `systemModalProbeOverrideForTesting`
   // in RunnerTests.swift), so reverting this entry point to bypass the bounded probe fails the
   // regression test.
-  func snapshotFast(app: XCUIApplication, options: SnapshotOptions) throws -> DataPayload {
+  func snapshotFast(app: XCUIApplication, options: PresentationOptions) throws -> DataPayload {
     let deadline = Date().addingTimeInterval(Self.snapshotPlanBudget)
     if let blocking = boundedBlockingSystemAlertSnapshot(deadline: deadline) {
       return blocking
@@ -131,10 +131,10 @@ extension RunnerTests {
     )
   }
 
-  func recursiveTreeSnapshotPayload(
+  func recursiveTreeSnapshotAcquisition(
     context: SnapshotTraversalContext,
-    options: SnapshotOptions
-  ) -> DataPayload {
+    options: PresentationOptions
+  ) -> SnapshotAcquisition {
     var cachedDescendantElements: [XCUIElement]?
     func collapsedTabDescendants() -> [XCUIElement] {
       if let cachedDescendantElements {
@@ -315,14 +315,15 @@ extension RunnerTests {
 
     }
 
-    return DataPayload(
-      presenting: applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes),
-      truncated: false
+    return SnapshotAcquisition(
+      nodes: applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes),
+      truncated: false,
+      effectiveDepth: nil
     )
   }
 
   // See `snapshotFast` above: the single production entry point, no unit-test overload.
-  func snapshotRaw(app: XCUIApplication, options: SnapshotOptions) throws -> DataPayload {
+  func snapshotRaw(app: XCUIApplication, options: PresentationOptions) throws -> DataPayload {
     let deadline = Date().addingTimeInterval(Self.snapshotPlanBudget)
     if let blocking = boundedBlockingSystemAlertSnapshot(deadline: deadline) {
       return blocking
@@ -418,10 +419,10 @@ extension RunnerTests {
     return min(budget, deadlineRemaining)
   }
 
-  func rawTreeSnapshotPayload(
+  func rawTreeSnapshotAcquisition(
     context: SnapshotTraversalContext,
-    options: SnapshotOptions
-  ) throws -> DataPayload {
+    options: PresentationOptions
+  ) throws -> SnapshotAcquisition {
     var nodes: [RawAXNode] = []
 
     func walk(_ snapshot: XCUIElementSnapshot, depth: Int, parentIndex: Int?) throws {
@@ -460,19 +461,19 @@ extension RunnerTests {
     }
 
     try walk(context.rootSnapshot, depth: 0, parentIndex: nil)
-    return DataPayload(presenting: nodes, truncated: false)
+    return SnapshotAcquisition(nodes: nodes, truncated: false, effectiveDepth: nil)
   }
 
-  func snapshotFlatInteractive(
+  func querySweepSnapshotAcquisition(
     app: XCUIApplication,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     planDeadline: Date = .distantFuture
-  ) -> DataPayload {
+  ) -> SnapshotAcquisition {
     var nodes: [RawAXNode] = [
       interactiveRootNode(rect: .zero)
     ]
     if options.depth == 0 {
-      return DataPayload(presenting: nodes, truncated: false)
+      return SnapshotAcquisition(nodes: nodes, truncated: false, effectiveDepth: nil)
     }
 
     // Bounded by both its own sweep budget and the umbrella capture-plan deadline, so a
@@ -543,7 +544,7 @@ extension RunnerTests {
         )
       )
     }
-    return DataPayload(presenting: nodes, truncated: truncated)
+    return SnapshotAcquisition(nodes: nodes, truncated: truncated, effectiveDepth: nil)
   }
 
   func snapshotAccessibilityUnavailable(failure: SnapshotCaptureFailure) -> DataPayload {
@@ -588,7 +589,7 @@ extension RunnerTests {
   ) -> DataPayload {
     return DataPayload(
       message: message,
-      nodes: SnapshotPresentation.preservingCurrentSemantics([interactiveRootNode(rect: .zero)]),
+      nodes: [SnapshotPresentation.singleElementRead(interactiveRootNode(rect: .zero))],
       truncated: true,
       snapshotQuality: snapshotQuality,
       runnerFatal: runnerFatal,
@@ -669,7 +670,7 @@ extension RunnerTests {
   /// assertion instead of racing a fixed-timing guess.
   private func assertBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrain(
     entryPointName: String,
-    callEntryPoint: @escaping (XCUIApplication, SnapshotOptions) throws -> DataPayload
+    callEntryPoint: @escaping (XCUIApplication, PresentationOptions) throws -> DataPayload
   ) {
     let targetBundleId = "com.callstack.agentdevice.runner.missing.snapshot-timeout-test"
     let snapshotTarget = XCUIApplication(bundleIdentifier: targetBundleId)
@@ -707,7 +708,7 @@ extension RunnerTests {
     DispatchQueue(label: "agent-device.runner.tests.modal-probe-timeout").async {
       box.payload = try? callEntryPoint(
         snapshotTarget,
-        SnapshotOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false)
+        PresentationOptions(interactiveOnly: false, depth: nil, scope: nil, raw: false)
       )
 
       // 1) Penalty/busy accounting: must already be in place by the time the entry point
@@ -874,7 +875,7 @@ extension RunnerTests {
     label: String,
     identifier: String,
     valueText: String?,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     hittable: Bool,
     visible: Bool,
     regularSnapshot: Bool = false
@@ -926,7 +927,7 @@ extension RunnerTests {
 
   func makeSnapshotTraversalContext(
     app: XCUIApplication,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     captureDeadline: Date = .distantFuture,
     treeCaptureSliceBudgetOverride: TimeInterval? = nil
   ) throws -> SnapshotTraversalContext? {
@@ -1567,7 +1568,7 @@ extension RunnerTests {
     index: Int,
     parentIndex: Int?,
     viewport: CGRect,
-    options: SnapshotOptions
+    options: PresentationOptions
   ) -> RawAXNode? {
     var node: RawAXNode?
     let exceptionMessage = RunnerObjCExceptionCatcher.catchException({

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -250,7 +250,7 @@ extension RunnerTests {
   func runSnapshotCapturePlan(
     _ plan: [SnapshotBackendKind],
     app: XCUIApplication,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     terminal: SnapshotCaptureTerminalPolicy,
     deadline: Date? = nil
   ) throws -> DataPayload {
@@ -452,10 +452,11 @@ extension RunnerTests {
   private func captureWithBackend(
     _ kind: SnapshotBackendKind,
     app: XCUIApplication,
-    options: SnapshotOptions,
+    options: PresentationOptions,
     deadline: Date,
     treeCaptureSliceBudgetOverride: TimeInterval?
   ) throws -> SnapshotBackendCapture? {
+    let acquisition: SnapshotAcquisition?
     switch kind {
     case .recursiveTree:
       guard
@@ -468,28 +469,28 @@ extension RunnerTests {
       else {
         return nil
       }
-      let payload = try runMainThreadWork(
+      acquisition = try runMainThreadWork(
         command: nil,
         timeout: min(treeCaptureSliceBudget, max(0.5, deadline.timeIntervalSinceNow)),
         timeoutError: snapshotMainThreadTimeoutError("processing tree snapshot")
       ) {
         options.raw
-          ? try self.rawTreeSnapshotPayload(context: context, options: options)
-          : self.recursiveTreeSnapshotPayload(context: context, options: options)
+          ? try self.rawTreeSnapshotAcquisition(context: context, options: options)
+          : self.recursiveTreeSnapshotAcquisition(context: context, options: options)
       }
-      return SnapshotBackendCapture(payload: payload, effectiveDepth: nil)
     case .querySweep:
-      let payload = try runMainThreadWork(
+      acquisition = try runMainThreadWork(
         command: nil,
         timeout: min(Self.flatInteractiveFallbackBudget, max(0.1, deadline.timeIntervalSinceNow)),
         timeoutError: snapshotMainThreadTimeoutError("running query-sweep snapshot")
       ) {
-        self.snapshotFlatInteractive(app: app, options: options, planDeadline: deadline)
+        self.querySweepSnapshotAcquisition(app: app, options: options, planDeadline: deadline)
       }
-      return SnapshotBackendCapture(payload: payload, effectiveDepth: nil)
     case .privateAX:
-      return privateAXSnapshotCapture(app: app, options: options, deadline: deadline)
+      acquisition = privateAXSnapshotAcquisition(app: app, options: options, deadline: deadline)
     }
+    guard let acquisition else { return nil }
+    return SnapshotPresentation.present(acquisition, options: options)
   }
 
   // MARK: Quality classifier (the single source of "is this snapshot degraded")
@@ -815,7 +816,7 @@ extension RunnerTests {
   func testDecodedPreferredBackendReachesOptionsAndApplicablePlan() throws {
     let json = #"{"command":"snapshot","preferredBackend":"private-ax"}"#
     let command = try JSONDecoder().decode(Command.self, from: Data(json.utf8))
-    let options = Self.snapshotOptions(from: command)
+    let options = Self.presentationOptions(from: command)
     XCTAssertEqual(options.preferredBackend, "private-ax")
     XCTAssertFalse(options.raw)
 
@@ -833,7 +834,7 @@ extension RunnerTests {
     // A command without the field decodes to no pin and a normal plan.
     let bare = try JSONDecoder().decode(
       Command.self, from: Data(#"{"command":"snapshot"}"#.utf8))
-    XCTAssertNil(Self.snapshotOptions(from: bare).preferredBackend)
+    XCTAssertNil(Self.presentationOptions(from: bare).preferredBackend)
   }
 
   /// Same-backend evidence probes: a daemon-pinned private-AX capture takes the

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
@@ -23,6 +23,18 @@ struct RawAXNode {
   var actions: [String]? = nil
 }
 
+/// One backend attempt after acquisition and its current backend-specific interpretation.
+///
+/// Step 2 makes this the only input accepted by snapshot presentation. Later #1797 steps move the
+/// interpretation that still precedes this value into `SnapshotPresentation` without changing the
+/// capture-plan seam.
+struct SnapshotAcquisition {
+  let nodes: [RawAXNode]
+  let truncated: Bool
+  let effectiveDepth: Int?
+  var customActions: SnapshotCustomActionCoverage? = nil
+}
+
 /// The only snapshot node shape accepted by response payload assembly.
 ///
 /// Its initializer is private so a backend cannot bypass `SnapshotPresentation`. The encoded shape
@@ -64,25 +76,28 @@ struct PresentedNode: Codable {
 }
 
 enum SnapshotPresentation {
-  /// Transitional adapter for #1797 migration steps 1 and 2. Acquisition still computes today's
-  /// backend-specific decisions; this seam changes construction authority without changing output.
-  static func preservingCurrentSemantics(_ nodes: [RawAXNode]) -> [PresentedNode] {
-    nodes.map(PresentedNode.init(presenting:))
+  /// The capture plan's single presentation route for every snapshot backend.
+  ///
+  /// Step 2 preserves each backend's current decisions. `options` is deliberately part of the
+  /// stable interface now; later #1797 steps move those decisions behind this seam.
+  static func present(
+    _ acquisition: SnapshotAcquisition,
+    options _: PresentationOptions
+  ) -> SnapshotBackendCapture {
+    SnapshotBackendCapture(
+      payload: DataPayload(
+        nodes: acquisition.nodes.map(PresentedNode.init(presenting:)),
+        truncated: acquisition.truncated
+      ),
+      effectiveDepth: acquisition.effectiveDepth,
+      customActions: acquisition.customActions
+    )
   }
 
   /// Explicit carve-out for selector queries and system-modal reads that intentionally return one
   /// already-resolved element instead of traversing a snapshot backend.
   static func singleElementRead(_ node: RawAXNode) -> PresentedNode {
     PresentedNode(presenting: node)
-  }
-}
-
-extension DataPayload {
-  init(presenting nodes: [RawAXNode], truncated: Bool) {
-    self.init(
-      nodes: SnapshotPresentation.preservingCurrentSemantics(nodes),
-      truncated: truncated
-    )
   }
 }
 
@@ -113,12 +128,36 @@ extension RunnerTests {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
 
-    let encoded = try encoder.encode(SnapshotPresentation.preservingCurrentSemantics([raw]))
+    let capture = SnapshotPresentation.present(
+      SnapshotAcquisition(
+        nodes: [raw],
+        truncated: true,
+        effectiveDepth: 4,
+        customActions: SnapshotCustomActionCoverage(
+          read: 1,
+          candidates: 2,
+          truncated: 0,
+          blocked: false
+        )
+      ),
+      options: PresentationOptions(
+        interactiveOnly: true,
+        depth: nil,
+        scope: nil,
+        raw: false
+      )
+    )
+    let nodes = try XCTUnwrap(capture.payload.nodes)
+    let encoded = try encoder.encode(nodes)
 
     XCTAssertEqual(
       String(decoding: encoded, as: UTF8.self),
       #"[{"actions":["Open menu"],"depth":2,"enabled":true,"focused":true,"hiddenContentAbove":true,"hiddenContentBelow":true,"hittable":true,"identifier":"continue-button","index":3,"label":"Continue","parentIndex":1,"rect":{"height":44,"width":100,"x":10,"y":20},"selected":true,"type":"Button","value":"Ready"}]"#
     )
+    XCTAssertEqual(capture.payload.truncated, true)
+    XCTAssertEqual(capture.effectiveDepth, 4)
+    XCTAssertEqual(capture.customActions?.read, 1)
+    XCTAssertEqual(capture.customActions?.candidates, 2)
   }
 }
 #endif

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -99,8 +99,12 @@ metrics, and fallback rules, not as another special case inside the XCTest runne
 
 The acquire/present migration begins with a behavior-preserving typed seam: acquisition backends
 construct `RawAXNode`, `SnapshotPresentation` alone constructs `PresentedNode`, and response payloads
-accept only presented nodes. Until the remaining migration steps move interpretation into that seam,
-raw nodes intentionally carry the derived fields produced by the existing backends.
+accept only presented nodes. Its second behavior-preserving step makes every capture-plan backend
+return `SnapshotAcquisition` and routes the exhaustive backend switch through one
+`SnapshotPresentation.present` call. `PresentationOptions` is the stable request-policy input to
+that boundary. Until the remaining migration steps move interpretation into the boundary, acquisition
+still reads those options and raw nodes intentionally carry the derived fields produced by the
+existing backends.
 
 When adding new iOS snapshot behavior, maintainers should first decide which strategy owns it. If a
 change tries to make regular snapshots fast by dropping visible controls behind a node budget, or


### PR DESCRIPTION
## Summary

Route every iOS capture-plan backend through one SnapshotPresentation boundary while preserving each backend's current output semantics.

SnapshotAcquisition now carries nodes and attempt-level facts, PresentationOptions is the stable policy input, and only the presentation module assembles wire-facing nodes. Part of #1797.

Touches 10 files within the existing iOS snapshot module and its architecture vocabulary; scope did not expand beyond the planned command family.

## Validation

- Unit-enabled iOS runner build and focused presentation XCTest passed.
- Removing the custom-action handoff made the focused test fail with exactly two assertions, proving the routing check is non-vacuous; restoring it returned to 1/1 green.
- macOS runner build passed for the shared Swift path.
- XCTest selection and repository formatting checks passed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>