### PR TITLE
fix: derive transition backend from capture

### DIFF
--- a/src/commands/interaction/runtime/settle-transition-baseline.test.ts
+++ b/src/commands/interaction/runtime/settle-transition-baseline.test.ts
@@ -20,8 +20,7 @@ test('settle recovers the session baseline when resolved target evidence is abse
     backend: {
       platform: 'ios',
       captureSnapshot: async () => ({
-        snapshot:
-          elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
+        snapshot: elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
       }),
     } satisfies AgentDeviceBackend,
     artifacts: createLocalArtifactAdapter(),
@@ -56,7 +55,10 @@ test('settle recovers the session baseline when resolved target evidence is abse
   );
 
   assert.equal(outcome.observation.settled, true);
-  assert.equal(outcome.settledNodes?.some((node) => node.label === 'action file'), false);
+  assert.equal(
+    outcome.settledNodes?.some((node) => node.label === 'action file'),
+    false,
+  );
   assert.ok(
     outcome.observation.waitedMs >= 1_500,
     `settled without recovered baseline after ${outcome.observation.waitedMs}ms`,
@@ -69,8 +71,7 @@ test('settle uses the authorized ref frame instead of a polluted evidence captur
     backend: {
       platform: 'ios',
       captureSnapshot: async () => ({
-        snapshot:
-          elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
+        snapshot: elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
       }),
     } satisfies AgentDeviceBackend,
     artifacts: createLocalArtifactAdapter(),
@@ -106,7 +107,10 @@ test('settle uses the authorized ref frame instead of a polluted evidence captur
   );
 
   assert.equal(outcome.observation.settled, true);
-  assert.equal(outcome.settledNodes?.some((node) => node.label === 'action file'), false);
+  assert.equal(
+    outcome.settledNodes?.some((node) => node.label === 'action file'),
+    false,
+  );
   assert.ok(
     outcome.observation.waitedMs >= 1_500,
     `settled against polluted evidence after ${outcome.observation.waitedMs}ms`,

--- a/src/commands/interaction/runtime/settle-transition-baseline.test.ts
+++ b/src/commands/interaction/runtime/settle-transition-baseline.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { AgentDeviceBackend } from '../../../backend.ts';
+import { createLocalArtifactAdapter } from '../../../io.ts';
+import {
+  createAgentDevice,
+  createMemorySessionStore,
+  localCommandPolicy,
+} from '../../../runtime.ts';
+import {
+  elementSettledRoomSnapshot,
+  elementThreadsNoticeSnapshot,
+  elementTransientRoomSnapshot,
+} from './stable-capture.fixtures.ts';
+import { settleAfterInteraction } from './settle.ts';
+
+test('settle recovers the session baseline when resolved target evidence is absent', async () => {
+  let elapsedMs = 0;
+  const runtime = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => ({
+        snapshot:
+          elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
+      }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([
+      {
+        name: 'default',
+        snapshot: elementThreadsNoticeSnapshot,
+        refFrameSnapshot: elementThreadsNoticeSnapshot,
+      },
+    ]),
+    policy: localCommandPolicy(),
+    clock: {
+      now: () => elapsedMs,
+      sleep: async (ms: number) => {
+        elapsedMs += ms;
+      },
+    },
+  });
+
+  const outcome = await settleAfterInteraction(
+    runtime,
+    { session: 'default' },
+    {
+      resolved: {
+        kind: 'ref',
+        point: { x: 201, y: 795 },
+        target: { kind: 'ref', ref: '@e5' },
+      },
+      quietMs: 500,
+      timeoutMs: 5_000,
+    },
+  );
+
+  assert.equal(outcome.observation.settled, true);
+  assert.equal(outcome.settledNodes?.some((node) => node.label === 'action file'), false);
+  assert.ok(
+    outcome.observation.waitedMs >= 1_500,
+    `settled without recovered baseline after ${outcome.observation.waitedMs}ms`,
+  );
+});

--- a/src/commands/interaction/runtime/settle-transition-baseline.test.ts
+++ b/src/commands/interaction/runtime/settle-transition-baseline.test.ts
@@ -62,3 +62,53 @@ test('settle recovers the session baseline when resolved target evidence is abse
     `settled without recovered baseline after ${outcome.observation.waitedMs}ms`,
   );
 });
+
+test('settle uses the authorized ref frame instead of a polluted evidence capture', async () => {
+  let elapsedMs = 0;
+  const runtime = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => ({
+        snapshot:
+          elapsedMs < 1_200 ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
+      }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([
+      {
+        name: 'default',
+        snapshot: elementThreadsNoticeSnapshot,
+        refFrameSnapshot: elementThreadsNoticeSnapshot,
+      },
+    ]),
+    policy: localCommandPolicy(),
+    clock: {
+      now: () => elapsedMs,
+      sleep: async (ms: number) => {
+        elapsedMs += ms;
+      },
+    },
+  });
+
+  const outcome = await settleAfterInteraction(
+    runtime,
+    { session: 'default' },
+    {
+      resolved: {
+        kind: 'ref',
+        point: { x: 201, y: 795 },
+        target: { kind: 'ref', ref: '@e5' },
+        preActionNodes: elementTransientRoomSnapshot.nodes,
+      },
+      quietMs: 500,
+      timeoutMs: 5_000,
+    },
+  );
+
+  assert.equal(outcome.observation.settled, true);
+  assert.equal(outcome.settledNodes?.some((node) => node.label === 'action file'), false);
+  assert.ok(
+    outcome.observation.waitedMs >= 1_500,
+    `settled against polluted evidence after ${outcome.observation.waitedMs}ms`,
+  );
+});

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -171,7 +171,9 @@ test('never-settling content returns settled: false without an actionable diff',
 
 test('private-ax recovery resets the settle budget once', async () => {
   const before = buttonSnapshot();
-  const recoveredAfter = welcomeSnapshot();
+  // Keep this a same-screen recovery so the test isolates the private-AX budget reset from the
+  // independently tested broad-transition confirmation window.
+  const recoveredAfter = buttonSnapshot();
   recoveredAfter.snapshotQuality = {
     state: 'recovered',
     backend: 'private-ax',

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -171,8 +171,6 @@ test('never-settling content returns settled: false without an actionable diff',
 
 test('private-ax recovery resets the settle budget once', async () => {
   const before = buttonSnapshot();
-  // Keep this a same-screen recovery so the test isolates the private-AX budget reset from the
-  // independently tested broad-transition confirmation window.
   const recoveredAfter = buttonSnapshot();
   recoveredAfter.snapshotQuality = {
     state: 'recovered',

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -73,7 +73,7 @@ export async function settleAfterInteraction(
 ): Promise<SettleOutcome> {
   return await settleAfterAction(runtime, options, {
     ...params,
-    baselineNodes: resolveBaselineNodes(params.resolved),
+    baselineNodes: await resolveBaselineNodes(runtime, options, params.resolved),
     actionPoint: params.resolved.point,
   });
 }
@@ -202,8 +202,20 @@ export function settleEvidence(
   return { ...after, changedFromBefore };
 }
 
-function resolveBaselineNodes(resolved: ResolvedInteractionTarget): SnapshotNode[] {
-  return 'preActionNodes' in resolved && resolved.preActionNodes ? resolved.preActionNodes : [];
+async function resolveBaselineNodes(
+  runtime: AgentDeviceRuntime,
+  options: CommandContext,
+  resolved: ResolvedInteractionTarget,
+): Promise<SnapshotNode[]> {
+  if ('preActionNodes' in resolved && resolved.preActionNodes?.length) {
+    return resolved.preActionNodes;
+  }
+  // Resolved-target evidence is best-effort at the contracts boundary. The session still owns the
+  // authoritative ref frame, so reuse it rather than silently turning a missing optional field
+  // into an empty transition/diff baseline. Fall back to the latest observation for point targets
+  // and pre-frame sessions.
+  const session = await runtime.sessions.get(options.session ?? 'default');
+  return session?.refFrameSnapshot?.nodes ?? session?.snapshot?.nodes ?? [];
 }
 
 function buildSettleDiff(

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -207,6 +207,13 @@ async function resolveBaselineNodes(
   options: CommandContext,
   resolved: ResolvedInteractionTarget,
 ): Promise<SnapshotNode[]> {
+  const session = await runtime.sessions.get(options.session ?? 'default');
+  // A ref is authorized against the stored ref frame. Keep that visible presentation as the
+  // transition baseline: a best-effort evidence recapture can recover through private AX and see
+  // covered background controls that were not actionable when the ref was issued.
+  if (resolved.kind === 'ref' && session?.refFrameSnapshot?.nodes.length) {
+    return session.refFrameSnapshot.nodes;
+  }
   if ('preActionNodes' in resolved && resolved.preActionNodes?.length) {
     return resolved.preActionNodes;
   }
@@ -214,7 +221,6 @@ async function resolveBaselineNodes(
   // authoritative ref frame, so reuse it rather than silently turning a missing optional field
   // into an empty transition/diff baseline. Fall back to the latest observation for point targets
   // and pre-frame sessions.
-  const session = await runtime.sessions.get(options.session ?? 'default');
   return session?.refFrameSnapshot?.nodes ?? session?.snapshot?.nodes ?? [];
 }
 

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -211,17 +211,36 @@ async function resolveBaselineNodes(
   // A ref is authorized against the stored ref frame. Keep that visible presentation as the
   // transition baseline: a best-effort evidence recapture can recover through private AX and see
   // covered background controls that were not actionable when the ref was issued.
-  if (resolved.kind === 'ref' && session?.refFrameSnapshot?.nodes.length) {
-    return session.refFrameSnapshot.nodes;
-  }
-  if ('preActionNodes' in resolved && resolved.preActionNodes?.length) {
-    return resolved.preActionNodes;
-  }
   // Resolved-target evidence is best-effort at the contracts boundary. The session still owns the
   // authoritative ref frame, so reuse it rather than silently turning a missing optional field
   // into an empty transition/diff baseline. Fall back to the latest observation for point targets
   // and pre-frame sessions.
+  return (
+    authorizedRefBaseline(resolved, session) ??
+    evidenceBaseline(resolved) ??
+    sessionBaseline(session)
+  );
+}
+
+function authorizedRefBaseline(
+  resolved: ResolvedInteractionTarget,
+  session: CommandSessionRecord | undefined,
+): SnapshotNode[] | undefined {
+  if (resolved.kind !== 'ref') return undefined;
+  return nonEmptyNodes(session?.refFrameSnapshot?.nodes);
+}
+
+function evidenceBaseline(resolved: ResolvedInteractionTarget): SnapshotNode[] | undefined {
+  if (!('preActionNodes' in resolved)) return undefined;
+  return nonEmptyNodes(resolved.preActionNodes);
+}
+
+function sessionBaseline(session: CommandSessionRecord | undefined): SnapshotNode[] {
   return session?.refFrameSnapshot?.nodes ?? session?.snapshot?.nodes ?? [];
+}
+
+function nonEmptyNodes(nodes: SnapshotNode[] | undefined): SnapshotNode[] | undefined {
+  return nodes?.length ? nodes : undefined;
 }
 
 function buildSettleDiff(

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -191,12 +191,7 @@ test('settle keeps the default quiet window for a larger partial projection', as
     { session: 'default' },
     {
       ...BROAD_TRANSITION_PARAMS,
-      broadTransitionBaselineNodes: elementSettingsSnapshot([
-        1_138,
-        1_423,
-        2_144,
-        2_434,
-      ]).nodes,
+      broadTransitionBaselineNodes: elementSettingsSnapshot([1_138, 1_423, 2_144, 2_434]).nodes,
     },
   );
 

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -144,7 +144,12 @@ test('settle confirms an iOS broad replacement when capture omits snapshot backe
   const outcome = await runStableCaptureLoop(
     runtime,
     { session: 'default' },
-    BROAD_TRANSITION_PARAMS,
+    {
+      ...BROAD_TRANSITION_PARAMS,
+      // Presented iOS modals can be complete interaction captures without retaining the
+      // Application root in their projection.
+      broadTransitionBaselineNodes: elementThreadsNoticeSnapshot.nodes.slice(1),
+    },
   );
 
   assert.equal(outcome.settled, true);
@@ -158,16 +163,13 @@ test('settle confirms an iOS broad replacement when capture omits snapshot backe
   );
 });
 
-test('settle keeps the default quiet window for a partial projection with low overlap', async () => {
-  const { runtime } = transitionRuntime({ settledAtMs: 1_200 });
+test('settle keeps the default quiet window for a partial post-action projection with low overlap', async () => {
+  const { runtime } = transitionRuntime({ omitViewportRoot: true, settledAtMs: 1_200 });
 
   const outcome = await runStableCaptureLoop(
     runtime,
     { session: 'default' },
-    {
-      ...BROAD_TRANSITION_PARAMS,
-      broadTransitionBaselineNodes: elementThreadsNoticeSnapshot.nodes.slice(1),
-    },
+    BROAD_TRANSITION_PARAMS,
   );
 
   assert.equal(outcome.settled, true);
@@ -241,6 +243,7 @@ function transitionRuntime(
     captureBackend?: 'tree' | 'private-ax';
     firstCaptureKeepsBaseline?: boolean;
     omitSnapshotBackend?: boolean;
+    omitViewportRoot?: boolean;
     settledAtMs?: number;
     sessionSnapshot?: SnapshotState;
   } = {},
@@ -261,16 +264,17 @@ function transitionRuntime(
       captureSnapshot: async () => {
         const keepsBaseline = options.firstCaptureKeepsBaseline === true && captures === 0;
         captures += 1;
+        const snapshot = keepsBaseline
+          ? elementThreadsNoticeSnapshot
+          : withCaptureBackend(
+              elapsedMs < settledAtMs ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
+              captureBackend,
+            );
         return {
           snapshot: withoutSnapshotBackend(
-            keepsBaseline
-              ? elementThreadsNoticeSnapshot
-              : withCaptureBackend(
-                  elapsedMs < settledAtMs
-                    ? elementTransientRoomSnapshot
-                    : elementSettledRoomSnapshot,
-                  captureBackend,
-                ),
+            options.omitViewportRoot === true
+              ? { ...snapshot, nodes: snapshot.nodes.slice(1) }
+              : snapshot,
             options.omitSnapshotBackend === true,
           ),
         };

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -192,14 +192,14 @@ test('settle honors an explicitly shorter quiet window across a broad replacemen
   assert.ok(outcome.waitedMs < 800, `short quiet window settled after ${outcome.waitedMs}ms`);
 });
 
-test('settle keeps the default quiet window for an overlapping local mutation', async () => {
+test('settle keeps the default quiet window for a backend-less overlapping local mutation', async () => {
   const localMutation = {
     ...elementSettledRoomSnapshot,
     nodes: elementSettledRoomSnapshot.nodes.map((node) =>
       node.label === 'Upload' ? { ...node, label: 'Add attachment' } : node,
     ),
   };
-  const { runtime } = staticSnapshotRuntime(localMutation);
+  const { runtime } = staticSnapshotRuntime(withoutSnapshotBackend(localMutation, true));
 
   const outcome = await runStableCaptureLoop(
     runtime,

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -135,6 +135,49 @@ test('settle confirms against the pre-action tree when the stored snapshot alrea
   );
 });
 
+test('settle confirms an iOS broad replacement when capture omits snapshot backend provenance', async () => {
+  const { runtime } = transitionRuntime({
+    omitSnapshotBackend: true,
+    settledAtMs: 1_200,
+  });
+
+  const outcome = await runStableCaptureLoop(
+    runtime,
+    { session: 'default' },
+    BROAD_TRANSITION_PARAMS,
+  );
+
+  assert.equal(outcome.settled, true);
+  assert.equal(
+    outcome.lastCapture?.snapshot.nodes.some((node) => node.label === 'action file'),
+    false,
+  );
+  assert.ok(
+    outcome.waitedMs >= 1_500,
+    `settled backend-less transition after ${outcome.waitedMs}ms`,
+  );
+});
+
+test('settle keeps the default quiet window for a partial projection with low overlap', async () => {
+  const { runtime } = transitionRuntime({ settledAtMs: 1_200 });
+
+  const outcome = await runStableCaptureLoop(
+    runtime,
+    { session: 'default' },
+    {
+      ...BROAD_TRANSITION_PARAMS,
+      broadTransitionBaselineNodes: elementThreadsNoticeSnapshot.nodes.slice(1),
+    },
+  );
+
+  assert.equal(outcome.settled, true);
+  assert.equal(
+    outcome.lastCapture?.snapshot.nodes.some((node) => node.label === 'action file'),
+    true,
+  );
+  assert.ok(outcome.waitedMs < 800, `partial projection settled after ${outcome.waitedMs}ms`);
+});
+
 test('settle honors an explicitly shorter quiet window across a broad replacement', async () => {
   const { runtime } = transitionRuntime();
 
@@ -197,6 +240,7 @@ function transitionRuntime(
   options: {
     captureBackend?: 'tree' | 'private-ax';
     firstCaptureKeepsBaseline?: boolean;
+    omitSnapshotBackend?: boolean;
     settledAtMs?: number;
     sessionSnapshot?: SnapshotState;
   } = {},
@@ -218,12 +262,17 @@ function transitionRuntime(
         const keepsBaseline = options.firstCaptureKeepsBaseline === true && captures === 0;
         captures += 1;
         return {
-          snapshot: keepsBaseline
-            ? elementThreadsNoticeSnapshot
-            : withCaptureBackend(
-                elapsedMs < settledAtMs ? elementTransientRoomSnapshot : elementSettledRoomSnapshot,
-                captureBackend,
-              ),
+          snapshot: withoutSnapshotBackend(
+            keepsBaseline
+              ? elementThreadsNoticeSnapshot
+              : withCaptureBackend(
+                  elapsedMs < settledAtMs
+                    ? elementTransientRoomSnapshot
+                    : elementSettledRoomSnapshot,
+                  captureBackend,
+                ),
+            options.omitSnapshotBackend === true,
+          ),
         };
       },
     } satisfies AgentDeviceBackend,
@@ -235,6 +284,12 @@ function transitionRuntime(
     clock,
   });
   return { runtime };
+}
+
+function withoutSnapshotBackend(snapshot: SnapshotState, omit: boolean): SnapshotState {
+  if (!omit) return snapshot;
+  const { backend: _backend, ...backendless } = snapshot;
+  return backendless;
 }
 
 function withCaptureBackend(

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -163,13 +163,41 @@ test('settle confirms an iOS broad replacement when capture omits snapshot backe
   );
 });
 
-test('settle keeps the default quiet window for a partial post-action projection with low overlap', async () => {
+test('settle confirms a tiny modal replacement through a partial post-action projection', async () => {
   const { runtime } = transitionRuntime({ omitViewportRoot: true, settledAtMs: 1_200 });
 
   const outcome = await runStableCaptureLoop(
     runtime,
     { session: 'default' },
     BROAD_TRANSITION_PARAMS,
+  );
+
+  assert.equal(outcome.settled, true);
+  assert.equal(
+    outcome.lastCapture?.snapshot.nodes.some((node) => node.label === 'action file'),
+    false,
+  );
+  assert.ok(
+    outcome.waitedMs >= 1_500,
+    `settled partial transitional tree after ${outcome.waitedMs}ms`,
+  );
+});
+
+test('settle keeps the default quiet window for a larger partial projection', async () => {
+  const { runtime } = transitionRuntime({ omitViewportRoot: true, settledAtMs: 1_200 });
+
+  const outcome = await runStableCaptureLoop(
+    runtime,
+    { session: 'default' },
+    {
+      ...BROAD_TRANSITION_PARAMS,
+      broadTransitionBaselineNodes: elementSettingsSnapshot([
+        1_138,
+        1_423,
+        2_144,
+        2_434,
+      ]).nodes,
+    },
   );
 
   assert.equal(outcome.settled, true);

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -114,7 +114,7 @@ test('settle confirms a broad replacement that begins after the first post-actio
 
 test('settle confirms against the pre-action tree when the stored snapshot already advanced', async () => {
   const { runtime } = transitionRuntime({
-    sessionSnapshot: elementTransientRoomSnapshot,
+    sessionSnapshot: { ...elementTransientRoomSnapshot, backend: undefined },
     settledAtMs: 1_200,
   });
 

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -194,7 +194,15 @@ function stableCaptureTransitionBaseline(
   // Application root and still be the complete interaction surface. Requiring the root only from
   // the candidate prevents scoped/synthetic post-action fragments from extending settle latency.
   const hasCompleteViewportProjection = snapshot?.nodes.some(isViewportRootNode) === true;
-  return baselineNodes && isXCTestCapture && hasCompleteViewportProjection
+  // Tiny pre-action surfaces are the other trustworthy completeness signal: iOS presents alerts
+  // and sheets as a handful of nodes, and their first post-dismissal capture can temporarily omit
+  // the viewport root. Treating that rootless replacement as an arbitrary scoped projection lets
+  // a coherent transitional tree win the default 500ms quiet window.
+  const hasTinyPresentedBaseline =
+    baselineNodes !== undefined && baselineNodes.length <= TINY_STABLE_TREE_NODE_COUNT;
+  return baselineNodes &&
+    isXCTestCapture &&
+    (hasCompleteViewportProjection || hasTinyPresentedBaseline)
     ? stableCaptureSignal({ ...snapshot, nodes: baselineNodes })
     : undefined;
 }

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -1,4 +1,5 @@
 import type { SnapshotNode, SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
+import { isViewportRootNode } from '@agent-device/contracts/snapshot';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { now, sleep } from '../../runtime-common.ts';
 import {
@@ -108,6 +109,7 @@ export async function runStableCaptureLoop(
     transitionBaseline ??= stableCaptureTransitionBaseline(
       params.broadTransitionBaselineNodes,
       capture.snapshot,
+      runtime.backend.platform,
     );
     const signal = stableCaptureSignal(capture.snapshot);
     requiredQuietMs = stableCaptureTransitionQuietMs({
@@ -180,8 +182,19 @@ export async function runStableCaptureLoop(
 function stableCaptureTransitionBaseline(
   baselineNodes: SnapshotNode[] | undefined,
   snapshot: Parameters<typeof stableCaptureSignal>[0] | undefined,
+  platform: AgentDeviceRuntime['backend']['platform'],
 ): StableCaptureSignal | undefined {
-  return baselineNodes && snapshot?.backend === 'xctest'
+  // SnapshotState.backend is optional at the runtime boundary. The bound iOS backend remains
+  // authoritative when a presented capture omits that provenance; a declared non-XCTest backend
+  // still wins so this confirmation cannot leak onto another capture implementation.
+  const isXCTestCapture =
+    snapshot?.backend === 'xctest' || (snapshot?.backend === undefined && platform === 'ios');
+  // A broad *screen* replacement needs complete viewport projections on both sides. Scoped or
+  // synthetic fragments can have low semantic overlap without representing navigation at all.
+  const hasCompleteViewportProjection =
+    baselineNodes?.some(isViewportRootNode) === true &&
+    snapshot?.nodes.some(isViewportRootNode) === true;
+  return baselineNodes && isXCTestCapture && hasCompleteViewportProjection
     ? stableCaptureSignal({ ...snapshot, nodes: baselineNodes })
     : undefined;
 }

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -189,11 +189,11 @@ function stableCaptureTransitionBaseline(
   // still wins so this confirmation cannot leak onto another capture implementation.
   const isXCTestCapture =
     snapshot?.backend === 'xctest' || (snapshot?.backend === undefined && platform === 'ios');
-  // A broad *screen* replacement needs complete viewport projections on both sides. Scoped or
-  // synthetic fragments can have low semantic overlap without representing navigation at all.
-  const hasCompleteViewportProjection =
-    baselineNodes?.some(isViewportRootNode) === true &&
-    snapshot?.nodes.some(isViewportRootNode) === true;
+  // A broad *screen* replacement needs a complete post-action viewport projection. The baseline
+  // comes from settle's authoritative pre-action capture, but a presented iOS modal can omit its
+  // Application root and still be the complete interaction surface. Requiring the root only from
+  // the candidate prevents scoped/synthetic post-action fragments from extending settle latency.
+  const hasCompleteViewportProjection = snapshot?.nodes.some(isViewportRootNode) === true;
   return baselineNodes && isXCTestCapture && hasCompleteViewportProjection
     ? stableCaptureSignal({ ...snapshot, nodes: baselineNodes })
     : undefined;

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -74,10 +74,7 @@ export async function runStableCaptureLoop(
   let deadlineMs = start + timeoutMs;
   let privateAxRecoveryBudgetReset = false;
   const session = await runtime.sessions.get(options.session ?? 'default');
-  const transitionBaseline = stableCaptureTransitionBaseline(
-    params.broadTransitionBaselineNodes,
-    session?.snapshot,
-  );
+  let transitionBaseline: StableCaptureSignal | undefined;
   let preferredBackend = preferredSnapshotBackendForVerdict(session?.snapshot?.snapshotQuality);
   // Cadence derives from the quiet window (never slower than the default
   // poll): a caller asking for a 50ms quiet window should not be forced onto a
@@ -108,6 +105,10 @@ export async function runStableCaptureLoop(
     }
     captures += 1;
     lastCapture = capture;
+    transitionBaseline ??= stableCaptureTransitionBaseline(
+      params.broadTransitionBaselineNodes,
+      capture.snapshot,
+    );
     const signal = stableCaptureSignal(capture.snapshot);
     requiredQuietMs = stableCaptureTransitionQuietMs({
       baseline: transitionBaseline,

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -187,24 +187,29 @@ function stableCaptureTransitionBaseline(
   // SnapshotState.backend is optional at the runtime boundary. The bound iOS backend remains
   // authoritative when a presented capture omits that provenance; a declared non-XCTest backend
   // still wins so this confirmation cannot leak onto another capture implementation.
-  const isXCTestCapture =
-    snapshot?.backend === 'xctest' || (snapshot?.backend === undefined && platform === 'ios');
+  if (!baselineNodes || !snapshot || !isBoundIosXCTestCapture(snapshot.backend, platform)) {
+    return undefined;
+  }
   // A broad *screen* replacement needs a complete post-action viewport projection. The baseline
   // comes from settle's authoritative pre-action capture, but a presented iOS modal can omit its
   // Application root and still be the complete interaction surface. Requiring the root only from
   // the candidate prevents scoped/synthetic post-action fragments from extending settle latency.
-  const hasCompleteViewportProjection = snapshot?.nodes.some(isViewportRootNode) === true;
+  const hasCompleteViewportProjection = snapshot.nodes.some(isViewportRootNode);
   // Tiny pre-action surfaces are the other trustworthy completeness signal: iOS presents alerts
   // and sheets as a handful of nodes, and their first post-dismissal capture can temporarily omit
   // the viewport root. Treating that rootless replacement as an arbitrary scoped projection lets
   // a coherent transitional tree win the default 500ms quiet window.
-  const hasTinyPresentedBaseline =
-    baselineNodes !== undefined && baselineNodes.length <= TINY_STABLE_TREE_NODE_COUNT;
-  return baselineNodes &&
-    isXCTestCapture &&
-    (hasCompleteViewportProjection || hasTinyPresentedBaseline)
-    ? stableCaptureSignal({ ...snapshot, nodes: baselineNodes })
-    : undefined;
+  const hasTinyPresentedBaseline = baselineNodes.length <= TINY_STABLE_TREE_NODE_COUNT;
+  if (!hasCompleteViewportProjection && !hasTinyPresentedBaseline) return undefined;
+  return stableCaptureSignal({ ...snapshot, nodes: baselineNodes });
+}
+
+function isBoundIosXCTestCapture(
+  backend: Parameters<typeof stableCaptureSignal>[0]['backend'],
+  platform: AgentDeviceRuntime['backend']['platform'],
+): boolean {
+  if (backend === 'xctest') return true;
+  return backend === undefined && platform === 'ios';
 }
 
 function stableCaptureTransitionQuietMs(params: {


### PR DESCRIPTION
## Summary

Confirm broad iOS screen replacements from the actual settle capture and the immutable pre-action presentation.

This prevents a coherent transitional private-AX tree from winning the default quiet window after dismissing a small modal. Ref targets recover the authoritative presentation from their session ref frame when best-effort pre-action evidence is absent or already polluted. Ordinary overlapping mutations and explicit short quiet periods retain their existing latency.

Scope: 5 files in the interaction settle/stable-capture runtime and focused tests; no expansion outside that module group.

## Validation

- Regression fixtures were observed red before the fixes for missing backend provenance, delayed first transitions, missing pre-action evidence, and polluted evidence; all are green after the owning baseline/confirmation changes.
- Model-free live iOS Element replay with the packed build: dismissing the Threads notice settled after 1.833s with only the collapsed composer; attachment actions appeared only after tapping Upload.
- Targeted private iOS benchmark reruns with the same packed build: GPT `element-25` completed in 71.1s with the attachment menu visibly open, and GPT `element-14` completed in 95.6s on the required Team Standup room-information screen. Luna xhigh judged both successful.
- `pnpm check:affected --run`: all 7 selected gates passed; 248 files / 1,990 related tests passed.
- Docs/skills unchanged: this repairs observation reliability without changing the public command surface or workflow guidance.
