### PR TITLE
fix(layering): list the whole zone when R10's type-cycle ceiling is exceeded

### DIFF
--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -240,7 +240,7 @@ test('R10 zone overflow lists the whole zone so the joining member is visible', 
   for (const member of daemonMembers) {
     assert.ok(violation!.message.includes(member), `${member} missing from: ${violation!.message}`);
   }
-  assert.match(violation!.message, /1 of these joined with this change/);
+  assert.match(violation!.message, /1 over the ceiling — the member\(s\) that joined are among/);
 });
 
 // Growth was always rejected; a baseline left ABOVE the measured size used to be a suggestion

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -219,6 +219,30 @@ test('R9 records zone ceilings and keeps engine files outside the largest compon
   assert.ok(violations.some(({ message }) => /engine file entered/.test(message)));
 });
 
+// #1837: the zone violation used to name the alphabetically-first zone member — a file that had
+// been in the cycle all along — so the +1 was found only by diffing member lists between commits.
+// The ceiling records a count, not a membership, so the message lists every zone member instead.
+test('R10 zone overflow lists the whole zone so the joining member is visible', () => {
+  const zones = DAEMON_MODULARITY_BASELINE.largestTypeCycle.zoneMembers;
+  // Sorts after the daemon-server probes: the old first-member pick could not name it by luck.
+  const joined = 'src/daemon/snapshot-interactor-capture.ts';
+  const members = [...baselineTypeCycleMembers({ commands: zones.commands - 1 }), joined].sort();
+  const daemonMembers = members.filter((member) => member.startsWith('src/daemon/'));
+  assert.notEqual(daemonMembers[0], joined);
+
+  const violations = checkDaemonModularityRatchets(baselineEdges(), members);
+
+  assert.equal(violations.length, 1);
+  const [violation] = violations;
+  assert.equal(violation!.rule, 'R10 daemon-modularity');
+  assert.equal(violation!.file, 'scripts/layering/daemon-modularity.ts');
+  assert.match(violation!.message, /contains 17 daemon-server file\(s\) \(baseline 16\)/);
+  for (const member of daemonMembers) {
+    assert.ok(violation!.message.includes(member), `${member} missing from: ${violation!.message}`);
+  }
+  assert.match(violation!.message, /1 of these joined with this change/);
+});
+
 // Growth was always rejected; a baseline left ABOVE the measured size used to be a suggestion
 // in the success line, which is headroom the next change spends without a number moving.
 test('R9 rejects a baseline left above the measured cycle', () => {

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -172,7 +172,9 @@ function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[]
     // The ceiling records a count, not a membership, so the gate cannot name the file that
     // joined; naming the alphabetically-first member instead sent #1837's diagnosis to a file
     // that had been in the cycle all along. List the whole zone so the joining edge is one
-    // diff away from the author, who knows which of these files the change touched.
+    // diff away from the author, who knows which of these files the change touched. The
+    // overflow is net growth (a join and a departure cancel out), so it bounds nothing about
+    // how many members are new — only that at least one of the listed files is.
     violations.push({
       rule: 'R10 daemon-modularity',
       file: 'scripts/layering/daemon-modularity.ts',
@@ -180,9 +182,9 @@ function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[]
       message:
         `the largest type cycle now contains ${zoneMembers.length} ${zone} file(s) (baseline ` +
         `${allowed}); extraction must not trade one zone's locality for another's. ` +
-        `${zone} members: ${zoneMembers.join(', ')}. ${zoneMembers.length - allowed} of these ` +
-        `joined with this change (a new file, or a new import that closed the loop); cut that ` +
-        `edge rather than raising the ceiling.`,
+        `${zoneMembers.length - allowed} over the ceiling — the member(s) that joined are among ` +
+        `these ${zone} files: ${zoneMembers.join(', ')}. Cut the edge that pulled them in ` +
+        `rather than raising the ceiling.`,
     });
   }
 

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -165,15 +165,24 @@ function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[]
     });
   }
 
-  const zoneCounts = countBy(members, targetDagZone);
-  for (const [zone, count] of zoneCounts) {
+  const membersByZone = groupBy(members, targetDagZone);
+  for (const [zone, zoneMembers] of membersByZone) {
     const allowed = baseline.zoneMembers[zone] ?? 0;
-    if (count <= allowed) continue;
+    if (zoneMembers.length <= allowed) continue;
+    // The ceiling records a count, not a membership, so the gate cannot name the file that
+    // joined; naming the alphabetically-first member instead sent #1837's diagnosis to a file
+    // that had been in the cycle all along. List the whole zone so the joining edge is one
+    // diff away from the author, who knows which of these files the change touched.
     violations.push({
       rule: 'R10 daemon-modularity',
-      file: members.find((member) => targetDagZone(member) === zone) ?? 'scripts/layering/check.ts',
+      file: 'scripts/layering/daemon-modularity.ts',
       line: 1,
-      message: `the largest type cycle now contains ${count} ${zone} file(s) (baseline ${allowed}); extraction must not trade one zone's locality for another's.`,
+      message:
+        `the largest type cycle now contains ${zoneMembers.length} ${zone} file(s) (baseline ` +
+        `${allowed}); extraction must not trade one zone's locality for another's. ` +
+        `${zone} members: ${zoneMembers.join(', ')}. ${zoneMembers.length - allowed} of these ` +
+        `joined with this change (a new file, or a new import that closed the loop); cut that ` +
+        `edge rather than raising the ceiling.`,
     });
   }
 
@@ -285,13 +294,18 @@ function isInsideInternalTree(file: string, roots: readonly string[]): boolean {
   return roots.some((root) => file.startsWith(path.posix.join(root, 'internal/')));
 }
 
-function countBy(values: readonly string[], keyOf: (value: string) => string): Map<string, number> {
-  const counts = new Map<string, number>();
+function groupBy(
+  values: readonly string[],
+  keyOf: (value: string) => string,
+): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
   for (const value of values) {
     const key = keyOf(value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const group = groups.get(key) ?? [];
+    group.push(value);
+    groups.set(key, group);
   }
-  return counts;
+  return groups;
 }
 
 export function daemonModularitySummary(): string {


### PR DESCRIPTION
## Summary

`pnpm check:layering` R10 named the wrong file when a zone exceeded its type-cycle ceiling. `checkTypeCycleBaseline` reported `members.find(<zone match>)` — the alphabetically-first zone member — so the #1825 × #1779 main break read `[R10] 17 daemon-server files (baseline 16) at src/daemon/daemon-command-registry.ts`, a file that had been in the cycle all along. The actual +1 (`src/daemon/handlers/snapshot-interactor-capture.ts`) was found only by diffing `largestTypeCycleMembers` between two commits, ~40 min in.

`LARGEST_TYPE_CYCLE_ZONE_CEILINGS` records a **count per zone, not a membership**, and the Layering Guard job checks out at depth 1, so there is no previous state to diff against inside the gate. The violation now lists every member of the over-budget zone (sorted) and annotates the ceiling table (`scripts/layering/daemon-modularity.ts:1`, like the sibling R9/R10 baseline violations) instead of an arbitrary member.

Before:
```
[R10 daemon-modularity] src/daemon/daemon-command-registry.ts:1 — the largest type cycle now contains 17 daemon-server file(s) (baseline 16); extraction must not trade one zone's locality for another's.
```
After (planted: ceiling lowered 16 → 15 on the real tree):
```
[R10 daemon-modularity] scripts/layering/daemon-modularity.ts:1 — the largest type cycle now contains 16 daemon-server file(s) (baseline 15); extraction must not trade one zone's locality for another's. 1 over the ceiling — the member(s) that joined are among these daemon-server files: src/daemon/daemon-command-registry.ts, src/daemon/deferred-interaction-outcome.ts, src/daemon/handlers/response.ts, src/daemon/handlers/snapshot-capture.ts, src/daemon/interaction-outcome-policy.ts, …, src/daemon/session-store.ts. Cut the edge that pulled them in rather than raising the ceiling.
```

The count is deliberately phrased as net overflow, not a join count: a change that adds two members and removes one prints `1 over the ceiling`, so the message bounds nothing except that at least one listed file is new.

No policy change: same ceilings, same rule id, same pass/fail set. Recording per-zone member lists (which would let the gate print the exact diff) would turn the count ratchet into a membership pin — a stricter policy the issue explicitly does not ask for; noted as an option, not taken.

Closes #1837. Refs #1781 A6, #1825, #1779.

## Validation

- New unit test `R10 zone overflow lists the whole zone so the joining member is visible` plants a daemon-server +1 (`src/daemon/snapshot-interactor-capture.ts`, chosen to sort *after* the probes so the old first-member pick could not name it by luck; commands −1 keeps R9's total pinned) and asserts the single violation annotates the ceiling table and names all 17 members.
- **Red against pre-fix code** (`git stash` the production file, run `scripts/layering/daemon-modularity.test.ts`):
  ```
  ✖ R10 zone overflow lists the whole zone so the joining member is visible
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    + 'src/daemon/probe-0.ts'
    - 'scripts/layering/daemon-modularity.ts'
  ℹ pass 9 / fail 1
  ```
  — the old code names the alphabetically-first probe. Restored: `ℹ pass 10 / fail 0`.
- Planted structural violation on the real tree (ceiling 16 → 15) prints the message quoted above; restored, `node scripts/layering/check.ts` is `Layering guard: OK … the largest type-level cycle is 46 files (R9)`.
- `pnpm check:affected --run`: all runnable checks passed (layering, lint, typecheck, format, mutation-selection tests).

Touched files: 2 (`scripts/layering/daemon-modularity.ts`, `scripts/layering/daemon-modularity.test.ts`). Scope stayed on the layering gate. No docs/skills change: the gate's own message is the user-facing surface.

