### PR TITLE
test: make hard-coded caps overridable behind seams (#1781 B5)

### DIFF
--- a/packages/capture-kit/src/durable-json.test.ts
+++ b/packages/capture-kit/src/durable-json.test.ts
@@ -12,6 +12,14 @@ test('bounded durable JSON rejects cycles and excessive depth', () => {
   assert.equal(isBoundedJsonObject(nested), false);
 });
 
+test('bounded durable JSON rejects a wide, shallow document past the node cap', () => {
+  // Depth 2 everywhere, so only the node budget can reject it: the root plus
+  // one array plus 4,096 empty objects is 4,098 nodes.
+  const wide = { items: Array.from({ length: 4_096 }, () => ({})) };
+  assert.equal(isBoundedJsonObject(wide), false);
+  assert.equal(isBoundedJsonObject({ items: wide.items.slice(0, 4_000) }), true);
+});
+
 test('validated durable JSON freezes without recursively revalidating every subtree', () => {
   let reads = 0;
   const leaf = Object.defineProperty({}, 'value', {

--- a/packages/capture-kit/src/durable-json.test.ts
+++ b/packages/capture-kit/src/durable-json.test.ts
@@ -12,17 +12,21 @@ test('bounded durable JSON rejects cycles and excessive depth', () => {
   assert.equal(isBoundedJsonObject(nested), false);
 });
 
-test('bounded durable JSON rejects a wide, shallow document past the node cap', () => {
-  // Depth 2 everywhere, so only the node budget can reject it. Both counting
-  // sites are exercised: the object walk rejects the object-leaf document, the
-  // array walk rejects the array-leaf one (each is the only guard on its path).
-  const objectLeaves = { items: Array.from({ length: 4_096 }, () => ({})) };
-  assert.equal(isBoundedJsonObject(objectLeaves), false);
-  assert.equal(isBoundedJsonObject({ items: objectLeaves.items.slice(0, 4_000) }), true);
+test('bounded durable JSON accepts exactly the node cap and rejects one node past it', () => {
+  // Every node counts: the root object, the `items` array, and each leaf. The
+  // cap is 4,096 nodes, so 4,094 leaves sit exactly on it and 4,095 leaves are
+  // the first document over. Depth stays at 2, so only the node budget can
+  // decide either case, and the leaf kind selects which of the two counting
+  // sites owns the rejection.
+  const objectLeaves = (count: number) => ({ items: Array.from({ length: count }, () => ({})) });
+  assert.equal(isBoundedJsonObject(objectLeaves(4_094)), true);
+  assert.equal(isBoundedJsonObject(objectLeaves(4_095)), false);
 
-  const arrayLeaves = { items: Array.from({ length: 4_096 }, () => [] as never[]) };
-  assert.equal(isBoundedJsonObject(arrayLeaves), false);
-  assert.equal(isBoundedJsonObject({ items: arrayLeaves.items.slice(0, 4_000) }), true);
+  const arrayLeaves = (count: number) => ({
+    items: Array.from({ length: count }, () => [] as never[]),
+  });
+  assert.equal(isBoundedJsonObject(arrayLeaves(4_094)), true);
+  assert.equal(isBoundedJsonObject(arrayLeaves(4_095)), false);
 });
 
 test('validated durable JSON freezes without recursively revalidating every subtree', () => {

--- a/packages/capture-kit/src/durable-json.test.ts
+++ b/packages/capture-kit/src/durable-json.test.ts
@@ -13,11 +13,16 @@ test('bounded durable JSON rejects cycles and excessive depth', () => {
 });
 
 test('bounded durable JSON rejects a wide, shallow document past the node cap', () => {
-  // Depth 2 everywhere, so only the node budget can reject it: the root plus
-  // one array plus 4,096 empty objects is 4,098 nodes.
-  const wide = { items: Array.from({ length: 4_096 }, () => ({})) };
-  assert.equal(isBoundedJsonObject(wide), false);
-  assert.equal(isBoundedJsonObject({ items: wide.items.slice(0, 4_000) }), true);
+  // Depth 2 everywhere, so only the node budget can reject it. Both counting
+  // sites are exercised: the object walk rejects the object-leaf document, the
+  // array walk rejects the array-leaf one (each is the only guard on its path).
+  const objectLeaves = { items: Array.from({ length: 4_096 }, () => ({})) };
+  assert.equal(isBoundedJsonObject(objectLeaves), false);
+  assert.equal(isBoundedJsonObject({ items: objectLeaves.items.slice(0, 4_000) }), true);
+
+  const arrayLeaves = { items: Array.from({ length: 4_096 }, () => [] as never[]) };
+  assert.equal(isBoundedJsonObject(arrayLeaves), false);
+  assert.equal(isBoundedJsonObject({ items: arrayLeaves.items.slice(0, 4_000) }), true);
 });
 
 test('validated durable JSON freezes without recursively revalidating every subtree', () => {

--- a/src/platforms/harmonyos/__tests__/snapshot.test.ts
+++ b/src/platforms/harmonyos/__tests__/snapshot.test.ts
@@ -6,7 +6,12 @@ const { runHarmonyHdc } = vi.hoisted(() => ({ runHarmonyHdc: vi.fn() }));
 
 vi.mock('../hdc.ts', () => ({ runHarmonyHdc }));
 
-import { parseArkUiBounds, parseHarmonyLayout, snapshotHarmony } from '../snapshot.ts';
+import {
+  collectArkUiNodes,
+  parseArkUiBounds,
+  parseHarmonyLayout,
+  snapshotHarmony,
+} from '../snapshot.ts';
 
 const DEVICE = {
   platform: 'harmonyos' as const,
@@ -16,6 +21,8 @@ const DEVICE = {
   target: 'mobile' as const,
   booted: true,
 };
+
+const UNBOUNDED = { maxDepth: Number.POSITIVE_INFINITY, interactiveOnly: false };
 
 beforeEach(() => {
   runHarmonyHdc.mockReset();
@@ -45,51 +52,54 @@ test('parseHarmonyLayout rejects non-object uitest documents', () => {
   assert.throws(() => parseHarmonyLayout('[]'), /invalid layout JSON/i);
 });
 
-test('snapshotHarmony reports truncation once the node cap is hit instead of dropping nodes silently', async () => {
-  scriptHarmonyLayoutDump({
-    attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
-    children: [
-      { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
-      { attributes: { type: 'Button', text: 'second', clickable: 'true' } },
-      { attributes: { type: 'Button', text: 'third', clickable: 'true' } },
-    ],
-  });
+test('collectArkUiNodes reports truncation once the emitted-node limit is reached', () => {
+  const root = parseHarmonyLayout(
+    JSON.stringify({
+      attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+      children: [
+        { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
+        { attributes: { type: 'Button', text: 'second', clickable: 'true' } },
+        { attributes: { type: 'Button', text: 'third', clickable: 'true' } },
+      ],
+    }),
+  );
 
-  const capped = await snapshotHarmony(DEVICE, { maxNodes: 2 });
-
+  const capped = collectArkUiNodes(root, { ...UNBOUNDED, maxNodes: 2 });
   assert.equal(capped.truncated, true);
   assert.deepEqual(
     capped.nodes.map((node) => node.value ?? node.type),
     ['Application', 'first'],
   );
-  assert.equal(capped.analysis.rawNodeCount, 4);
+  assert.deepEqual(capped.analysis, { rawNodeCount: 4, maxDepth: 1 });
 
-  const uncapped = await snapshotHarmony(DEVICE);
-  assert.equal(uncapped.truncated, undefined);
+  const uncapped = collectArkUiNodes(root, { ...UNBOUNDED, maxNodes: 5_000 });
+  assert.equal(uncapped.truncated, false);
   assert.equal(uncapped.nodes.length, 4);
 });
 
-test('snapshotHarmony keeps counting the tree below a node the cap omitted', async () => {
-  // The cap fills on `first`, so `branch` and everything under it is omitted.
-  // `analysis` still describes the tree the device reported, so the omitted
-  // subtree must reach both counters — five nodes, deepest at depth 3.
-  scriptHarmonyLayoutDump({
-    attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
-    children: [
-      { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
-      {
-        attributes: { type: 'Column', text: 'branch' },
-        children: [
-          {
-            attributes: { type: 'Row', text: 'leaf' },
-            children: [{ attributes: { type: 'Text', text: 'deep' } }],
-          },
-        ],
-      },
-    ],
-  });
+test('collectArkUiNodes keeps counting the tree below a node the limit omitted', () => {
+  // The limit fills on `first`, so `branch` and everything under it is
+  // omitted. `analysis` still describes the tree the device reported, so the
+  // omitted subtree must reach both counters: five nodes, deepest at depth 3.
+  const root = parseHarmonyLayout(
+    JSON.stringify({
+      attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+      children: [
+        { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
+        {
+          attributes: { type: 'Column', text: 'branch' },
+          children: [
+            {
+              attributes: { type: 'Row', text: 'leaf' },
+              children: [{ attributes: { type: 'Text', text: 'deep' } }],
+            },
+          ],
+        },
+      ],
+    }),
+  );
 
-  const capped = await snapshotHarmony(DEVICE, { maxNodes: 2 });
+  const capped = collectArkUiNodes(root, { ...UNBOUNDED, maxNodes: 2 });
 
   assert.equal(capped.truncated, true);
   assert.deepEqual(
@@ -97,4 +107,20 @@ test('snapshotHarmony keeps counting the tree below a node the cap omitted', asy
     ['Application', 'first'],
   );
   assert.deepEqual(capped.analysis, { rawNodeCount: 5, maxDepth: 3 });
+});
+
+test('snapshotHarmony pulls a uitest layout and reports its analysis', async () => {
+  scriptHarmonyLayoutDump({
+    attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+    children: [{ attributes: { type: 'Button', text: 'first', clickable: 'true' } }],
+  });
+
+  const snapshot = await snapshotHarmony(DEVICE);
+
+  assert.equal(snapshot.truncated, undefined);
+  assert.deepEqual(
+    snapshot.nodes.map((node) => node.value ?? node.type),
+    ['Application', 'first'],
+  );
+  assert.deepEqual(snapshot.analysis, { rawNodeCount: 2, maxDepth: 1 });
 });

--- a/src/platforms/harmonyos/__tests__/snapshot.test.ts
+++ b/src/platforms/harmonyos/__tests__/snapshot.test.ts
@@ -1,6 +1,35 @@
 import assert from 'node:assert/strict';
-import { test } from 'vitest';
-import { parseArkUiBounds, parseHarmonyLayout } from '../snapshot.ts';
+import fs from 'node:fs';
+import { beforeEach, test, vi } from 'vitest';
+
+const { runHarmonyHdc } = vi.hoisted(() => ({ runHarmonyHdc: vi.fn() }));
+
+vi.mock('../hdc.ts', () => ({ runHarmonyHdc }));
+
+import { parseArkUiBounds, parseHarmonyLayout, snapshotHarmony } from '../snapshot.ts';
+
+const DEVICE = {
+  platform: 'harmonyos' as const,
+  id: 'harmony-1',
+  name: 'HarmonyOS test device',
+  kind: 'device' as const,
+  target: 'mobile' as const,
+  booted: true,
+};
+
+beforeEach(() => {
+  runHarmonyHdc.mockReset();
+});
+
+/** Scripts `uitest dumpLayout` + `file recv` so the pulled layout is `layout`. */
+function scriptHarmonyLayoutDump(layout: unknown): void {
+  runHarmonyHdc.mockImplementation(async (_device: unknown, args: string[]) => {
+    if (args[0] === 'file' && args[1] === 'recv') {
+      fs.writeFileSync(args[3] as string, JSON.stringify(layout), 'utf8');
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+}
 
 test('parseArkUiBounds converts API 24 layout bounds into a rectangle', () => {
   assert.deepEqual(parseArkUiBounds('[84,1127][1172,1295]'), {
@@ -14,4 +43,28 @@ test('parseArkUiBounds converts API 24 layout bounds into a rectangle', () => {
 
 test('parseHarmonyLayout rejects non-object uitest documents', () => {
   assert.throws(() => parseHarmonyLayout('[]'), /invalid layout JSON/i);
+});
+
+test('snapshotHarmony reports truncation once the node cap is hit instead of dropping nodes silently', async () => {
+  scriptHarmonyLayoutDump({
+    attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+    children: [
+      { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
+      { attributes: { type: 'Button', text: 'second', clickable: 'true' } },
+      { attributes: { type: 'Button', text: 'third', clickable: 'true' } },
+    ],
+  });
+
+  const capped = await snapshotHarmony(DEVICE, { maxNodes: 2 });
+
+  assert.equal(capped.truncated, true);
+  assert.deepEqual(
+    capped.nodes.map((node) => node.value ?? node.type),
+    ['Application', 'first'],
+  );
+  assert.equal(capped.analysis.rawNodeCount, 4);
+
+  const uncapped = await snapshotHarmony(DEVICE);
+  assert.equal(uncapped.truncated, undefined);
+  assert.equal(uncapped.nodes.length, 4);
 });

--- a/src/platforms/harmonyos/__tests__/snapshot.test.ts
+++ b/src/platforms/harmonyos/__tests__/snapshot.test.ts
@@ -68,3 +68,33 @@ test('snapshotHarmony reports truncation once the node cap is hit instead of dro
   assert.equal(uncapped.truncated, undefined);
   assert.equal(uncapped.nodes.length, 4);
 });
+
+test('snapshotHarmony keeps counting the tree below a node the cap omitted', async () => {
+  // The cap fills on `first`, so `branch` and everything under it is omitted.
+  // `analysis` still describes the tree the device reported, so the omitted
+  // subtree must reach both counters — five nodes, deepest at depth 3.
+  scriptHarmonyLayoutDump({
+    attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+    children: [
+      { attributes: { type: 'Button', text: 'first', clickable: 'true' } },
+      {
+        attributes: { type: 'Column', text: 'branch' },
+        children: [
+          {
+            attributes: { type: 'Row', text: 'leaf' },
+            children: [{ attributes: { type: 'Text', text: 'deep' } }],
+          },
+        ],
+      },
+    ],
+  });
+
+  const capped = await snapshotHarmony(DEVICE, { maxNodes: 2 });
+
+  assert.equal(capped.truncated, true);
+  assert.deepEqual(
+    capped.nodes.map((node) => node.value ?? node.type),
+    ['Application', 'first'],
+  );
+  assert.deepEqual(capped.analysis, { rawNodeCount: 5, maxDepth: 3 });
+});

--- a/src/platforms/harmonyos/snapshot.ts
+++ b/src/platforms/harmonyos/snapshot.ts
@@ -93,17 +93,22 @@ function buildHarmonySnapshot(
   let maxDepth = 0;
   let truncated = false;
   const maxNodes = options.maxNodes ?? MAX_NODES;
+  // Accounting is separate from emission: `analysis` describes the tree the
+  // device reported, so the walk keeps counting and descending after the
+  // emitted-node cap fills. Stopping there would under-report `rawNodeCount`
+  // and `maxDepth` for exactly the oversized trees the cap exists for.
   const walk = (node: ArkUiLayoutNode, depth: number, parentIndex?: number): void => {
     rawNodeCount += 1;
     maxDepth = Math.max(maxDepth, depth);
+    let currentIndex = parentIndex;
     if (nodes.length >= maxNodes) {
       truncated = true;
-      return;
+    } else {
+      const attributes = node.attributes ?? {};
+      const candidate = arkUiNodeFromAttributes(attributes, nodes.length, depth, parentIndex);
+      const include = !options.interactiveOnly || candidate.hittable === true;
+      currentIndex = include ? nodes.push(candidate) - 1 : parentIndex;
     }
-    const attributes = node.attributes ?? {};
-    const candidate = arkUiNodeFromAttributes(attributes, nodes.length, depth, parentIndex);
-    const include = !options.interactiveOnly || candidate.hittable === true;
-    const currentIndex = include ? nodes.push(candidate) - 1 : parentIndex;
     if (depth < (options.depth ?? Number.POSITIVE_INFINITY)) {
       for (const child of node.children ?? []) walk(child, depth + 1, currentIndex);
     }

--- a/src/platforms/harmonyos/snapshot.ts
+++ b/src/platforms/harmonyos/snapshot.ts
@@ -15,16 +15,9 @@ type ArkUiLayoutNode = {
   children?: ArkUiLayoutNode[];
 };
 
-/**
- * `maxNodes` bounds the emitted tree; nodes past it are dropped and the
- * result reports `truncated`. Mirrors the Android helper and Linux AT-SPI
- * capture seams so the bound is exercisable below the 5,000 default.
- */
-export type HarmonySnapshotOptions = SnapshotOptions & { maxNodes?: number };
-
 export async function snapshotHarmony(
   device: DeviceInfo,
-  options: HarmonySnapshotOptions = {},
+  options: SnapshotOptions = {},
 ): Promise<{
   nodes: RawSnapshotNode[];
   truncated?: boolean;
@@ -82,43 +75,60 @@ export function parseHarmonyLayout(raw: string): ArkUiLayoutNode {
 
 function buildHarmonySnapshot(
   root: ArkUiLayoutNode,
-  options: HarmonySnapshotOptions,
+  options: SnapshotOptions,
 ): {
   nodes: RawSnapshotNode[];
   truncated?: boolean;
+  analysis: { rawNodeCount: number; maxDepth: number };
+} {
+  const { nodes, truncated, analysis } = collectArkUiNodes(root, {
+    maxNodes: MAX_NODES,
+    maxDepth: options.depth ?? Number.POSITIVE_INFINITY,
+    interactiveOnly: options.interactiveOnly === true,
+  });
+  return { nodes, ...(truncated ? { truncated: true } : {}), analysis };
+}
+
+/**
+ * Traversal and emission policy for an ArkUI layout tree, with every bound
+ * passed in.
+ *
+ * Emission and accounting are deliberately separate: emission stops at
+ * `maxNodes`, while `analysis` keeps describing the tree the device reported,
+ * so the walk continues counting and descending below an omitted node. Halting
+ * there would under-report `rawNodeCount` and `maxDepth` for exactly the
+ * oversized trees the cap exists for.
+ */
+export function collectArkUiNodes(
+  root: ArkUiLayoutNode,
+  policy: { maxNodes: number; maxDepth: number; interactiveOnly: boolean },
+): {
+  nodes: RawSnapshotNode[];
+  truncated: boolean;
   analysis: { rawNodeCount: number; maxDepth: number };
 } {
   const nodes: RawSnapshotNode[] = [];
   let rawNodeCount = 0;
   let maxDepth = 0;
   let truncated = false;
-  const maxNodes = options.maxNodes ?? MAX_NODES;
-  // Accounting is separate from emission: `analysis` describes the tree the
-  // device reported, so the walk keeps counting and descending after the
-  // emitted-node cap fills. Stopping there would under-report `rawNodeCount`
-  // and `maxDepth` for exactly the oversized trees the cap exists for.
   const walk = (node: ArkUiLayoutNode, depth: number, parentIndex?: number): void => {
     rawNodeCount += 1;
     maxDepth = Math.max(maxDepth, depth);
     let currentIndex = parentIndex;
-    if (nodes.length >= maxNodes) {
+    if (nodes.length >= policy.maxNodes) {
       truncated = true;
     } else {
       const attributes = node.attributes ?? {};
       const candidate = arkUiNodeFromAttributes(attributes, nodes.length, depth, parentIndex);
-      const include = !options.interactiveOnly || candidate.hittable === true;
+      const include = !policy.interactiveOnly || candidate.hittable === true;
       currentIndex = include ? nodes.push(candidate) - 1 : parentIndex;
     }
-    if (depth < (options.depth ?? Number.POSITIVE_INFINITY)) {
+    if (depth < policy.maxDepth) {
       for (const child of node.children ?? []) walk(child, depth + 1, currentIndex);
     }
   };
   walk(root, 0);
-  return {
-    nodes,
-    ...(truncated ? { truncated: true } : {}),
-    analysis: { rawNodeCount, maxDepth },
-  };
+  return { nodes, truncated, analysis: { rawNodeCount, maxDepth } };
 }
 
 function arkUiNodeFromAttributes(

--- a/src/platforms/harmonyos/snapshot.ts
+++ b/src/platforms/harmonyos/snapshot.ts
@@ -15,9 +15,16 @@ type ArkUiLayoutNode = {
   children?: ArkUiLayoutNode[];
 };
 
+/**
+ * `maxNodes` bounds the emitted tree; nodes past it are dropped and the
+ * result reports `truncated`. Mirrors the Android helper and Linux AT-SPI
+ * capture seams so the bound is exercisable below the 5,000 default.
+ */
+export type HarmonySnapshotOptions = SnapshotOptions & { maxNodes?: number };
+
 export async function snapshotHarmony(
   device: DeviceInfo,
-  options: SnapshotOptions = {},
+  options: HarmonySnapshotOptions = {},
 ): Promise<{
   nodes: RawSnapshotNode[];
   truncated?: boolean;
@@ -75,7 +82,7 @@ export function parseHarmonyLayout(raw: string): ArkUiLayoutNode {
 
 function buildHarmonySnapshot(
   root: ArkUiLayoutNode,
-  options: SnapshotOptions,
+  options: HarmonySnapshotOptions,
 ): {
   nodes: RawSnapshotNode[];
   truncated?: boolean;
@@ -85,7 +92,7 @@ function buildHarmonySnapshot(
   let rawNodeCount = 0;
   let maxDepth = 0;
   let truncated = false;
-  const maxNodes = MAX_NODES;
+  const maxNodes = options.maxNodes ?? MAX_NODES;
   const walk = (node: ArkUiLayoutNode, depth: number, parentIndex?: number): void => {
     rawNodeCount += 1;
     maxDepth = Math.max(maxDepth, depth);


### PR DESCRIPTION
## Summary

Wave-3 item B5 (#1781): make hard-coded caps reachable from tests where hitting the cap has a real failure mode, and say which caps were surveyed and left alone.

Two caps get coverage; the rest of the survey is tabled below so the next reader does not redo it.

**Result worth carrying to the rest of the wave:** B5 was framed as "make caps overridable so tests can reach them", and for this cap that framing turned out to be the wrong answer. An option on the production snapshot interface that no caller ever sets is a test affordance wearing production clothes — the repo's rule is to make the invariant testable at its *owning* interface instead of widening a public one to reach it. So the traversal/emission policy was extracted into a pure function that takes its bounds explicitly, and `snapshotHarmony` kept its `SnapshotOptions` shape. "Extract the policy" beats "add an override" wherever the cap governs a decision rather than a resource.

- **HarmonyOS snapshot node cap** (`src/platforms/harmonyos/snapshot.ts`, `MAX_NODES = 5_000`): reaching the cap exposed a second, real bug that the seam made visible — the walk `return`ed as soon as the cap filled, so an omitted node's **descendants reached neither `rawNodeCount` nor `maxDepth`**, and `analysis` under-reported exactly the oversized trees the cap exists for. Emission is now capped while accounting continues, which is what makes the whole-tree claim mirrored from the Android helper true. The policy now lives in `collectArkUiNodes(root, { maxNodes, maxDepth, interactiveOnly })` — a pure function with no defaults of its own, so the limit and the accounting rule are exercised directly at the interface that owns them. `buildHarmonySnapshot` supplies `MAX_NODES` and the caller's depth/interactive options; **`snapshotHarmony`'s signature is unchanged** (`SnapshotOptions`), and no option was added anywhere. No CLI/MCP surface changes.
- **Durable descriptor JSON node cap** (`packages/capture-kit/src/durable-json.ts`, `MAX_DESCRIPTOR_JSON_NODES = 4_096`): reachable in memory without a seam, so it gets a boundary test instead. Every node counts — root object, `items` array, each leaf — so the fixtures sit **exactly** on the cap: 4,094 leaves = 4,096 nodes accepted, 4,095 leaves = 4,097 nodes rejected. The count is enforced at **two** sites (`validateObject`, `validateArray`) and only whichever owns the offending node rejects, so both are pinned with an object-leaf and an array-leaf document.

### Survey — what has a real failure mode, what already has a seam, what was left

| Cap | On hit | Already testable / seamed? | Decision |
|---|---|---|---|
| HarmonyOS `MAX_NODES` 5,000 | drops nodes, sets `truncated`; **and under-reported `analysis` below the cap** | no seam, untested | **policy extracted + tested** (this PR); no production option added |
| capture-kit `MAX_DESCRIPTOR_JSON_NODES` 4,096 | envelope rejected (`false`) | reachable in memory, untested | **tested** (this PR), no seam needed |
| capture-kit `MAX_DESCRIPTOR_JSON_DEPTH` 32 | rejected | tested (depth 40) | left |
| `@agent-device/xml` `MAX_XML_NESTING_DEPTH` 256 / `maxDocumentChars` | throws | tested at 257 / seam + tested | left (plain `Error` there is #1792's class) |
| `MAX_OVERLAY_REFS` 24 (`screenshot-overlay.ts`) | keeps top-24 ranked refs; full snapshot still has all refs | seam exists (`maxRefs`) | left — ranked selection by design, no data loss |
| Runner connect retry (`runner-startup-transport.ts`) | typed connect error / simulator fallback | attempts derived from `timeoutMs`; exhaustion tested with `timeoutMs=100` | **not done** — reachable today (`retryWithPolicy` already takes `maxAttempts`/`baseDelayMs`/`jitter`, and 39 suites use `vi.useFakeTimers()`), just not carried here: the exhaustion outcome is already a typed error with its own coverage. Not a CI constraint |
| `IOS_SIMULATOR_SCREENSHOT_RETRY_MAX_ATTEMPTS` 5 | last simctl error → runner fallback | test mocks `retryWithPolicy` | **not done**, same reason |
| `PREPARE_RUNNER_HEALTH_MAX_SESSION_ATTEMPTS` 2, `ANDROID_KEYBOARD_DISMISS_MAX_ATTEMPTS` 2, `HELPER_CONTENT_CAPTURE_ATTEMPTS` 3, `MAX_UPLOAD_REDIRECTS` 5 | typed `AppError` | exhaustion already tested | left |
| `OUTCOME_RETRY_ATTEMPTS` 2, Android freshness / divergence retry delays, `MAX_REPLAY_TEST_RETRIES` clamp | typed give-up state returned (`retried:false`, `staleAfterRetries`, `unavailable`) | partially tested | left — outcome is a typed field, not silent |
| `IOS_DEVICE_TRACE_RECORD_MAX_ATTEMPTS` 3 (declared twice: `perf.ts`, `perf-xctrace.ts`) | typed error / last failed attempt | one-retry-then-success tested; 1.5 s real sleep per retry | left; the duplicate declaration is a one-site cleanup for a perf-owner PR |
| `LEDGER_MAX_ENTRIES` 512 (runner recycle ledger) | silent oldest-first eviction, no diagnostic — an evicted entry resets the `MAX_RUNNER_RECYCLES_PER_REQUEST = 1` guard that exists because of the #1105 wedge | untested; `resetRunnerRecycleLedgerForTests` already exists | left — a real but **unlikely** failure mode (needs 512 newer request keys inside one request's lifetime), not an absent one |
| `MAX_REF_PINS_PER_SCOPE` 1,000, `MAX_CRASH_ARTIFACT_BYTES` 64 MB, `MAX_HTTP_RPC_BODY_BYTES` 1 MB, app-event/push 8 KB payload caps | eviction / typed error / socket destroy | tested | left |
| `NETWORK_MAX_SCAN_LINES` 4,000 (parser layer has `maxScanLines`) | typed error / reason string / silent tail-drop | untested; the first two need a fake stream or 64 MB | left, listed for the owner |
| `events.ndjson` (no cap at all) | unbounded growth | — | separate PR (#1788) |

No central limits/config module exists; each cap is declared once at its use site and the two numeric env overrides in the tree (`AGENT_DEVICE_APP_LOG_MAX_BYTES`, `AGENT_DEVICE_DAEMON_IDLE_TIMEOUT_MS`) each live beside the limit they override. This PR follows that: no new `process.env` reads.

## Validation

Both new tests were run red against the pre-change code before going green:

- HarmonyOS: with `const maxNodes = MAX_NODES` restored, `snapshotHarmony reports truncation once the node cap is hit …` fails with `AssertionError: Expected values to be strictly equal: + actual - expected / + undefined / - true` (the cap is never reached, so `truncated` stays unset).
- HarmonyOS accounting, re-proven after the extraction moved the test down to `collectArkUiNodes`: restoring the early `return` at the limit → `× collectArkUiNodes keeps counting the tree below a node the limit omitted`, `+ maxDepth: 1, rawNodeCount: 3` against `- maxDepth: 3, rawNodeCount: 5`.
- Durable JSON, boundary pinned in both directions — moving `MAX_DESCRIPTOR_JSON_NODES` by one either way reddens it, so the fixtures are on the cap and not merely past it:
  - cap `4_097` → `- false / + true` (the over-cap document is wrongly accepted);
  - cap `4_095` → `- true / + false` (the on-cap document is wrongly rejected).
- Durable JSON, each counting site load-bearing (the first draft misattributed this proof to `validateArray`; the object-leaf case rejects in `validateObject`, and the array branch was uncovered until the second document was added): deleting the conjunct at `durable-json.ts:31` reddens it, and so does deleting the one at `:57`.

`pnpm check:affected --run` green locally (fallow, layering, coverage over the related set: 241 files / 1,632 tests). Provider-integration and coverage lanes are CI-owned for `src/platforms/**`.

- Catches: a snapshot backend silently dropping nodes at its cap without the `truncated` signal, and a durable-descriptor guard that stops bounding node count — both unobservable before because nothing reached either cap.
- Evidence: #758's `maxDepth: 64` was a hard cap nobody could exercise below the real tree; the private-AX ladder only landed after on-device failure. Both caps here had zero tests at the boundary (survey above).
- Cost: five unit tests, ~5 ms; no runner occupancy, no red-lane attention, ~140 lines of test, ~35 lines of production change (an extraction, not an interface widening).
- Kill-criterion: none needed — the seams are the same shape the sibling platforms already carry and the tests are boundary unit tests.

### Residual readiness risk: no HarmonyOS device evidence

The HarmonyOS change is covered only by unit tests that mock `runHarmonyHdc`, which is what `docs/agents/testing.md` requires of CI (GitHub has no DevEco/HDC/emulator). **No live HarmonyOS device or emulator run backs the changed snapshot path**, and I have no HarmonyOS hardware. The accounting change alters `analysis.rawNodeCount`/`maxDepth` on real oversized trees, so someone with a device should confirm on a screen large enough to exceed the default 5,000-node cap:

```bash
agent-device devices --platform harmonyos
agent-device open <bundle-id> --platform harmonyos --session harmony-cap
agent-device snapshot --session harmony-cap --json   # expect truncated:true with analysis.rawNodeCount > nodes.length
agent-device close --session harmony-cap
```

Treat that as the merge gate for the HarmonyOS half if this repo wants device evidence for a platform-path change; the durable-JSON half is host-only and needs none.

Touched files: 3 (`src/platforms/harmonyos/snapshot.ts`, its test, `packages/capture-kit/src/durable-json.test.ts`). Scope stayed within the two named caps; docs/skills untouched (no user-facing surface changed).
