### PR TITLE
fix: surface remote install network causes

### DIFF
--- a/packages/kernel/src/errors.ts
+++ b/packages/kernel/src/errors.ts
@@ -56,6 +56,11 @@ export type DiagnosticsRecordRef = {
   requestId: string;
 };
 
+export type ErrorCause = {
+  message: string;
+  code?: string;
+};
+
 /**
  * Details bag for AppError. Free-form context is allowed, but these keys carry
  * meaning at normalize/render time and must keep their types:
@@ -88,6 +93,7 @@ export type AppErrorDetails = Record<string, unknown> & {
 export type NormalizedError = {
   code: string;
   message: string;
+  cause?: ErrorCause;
   hint?: string;
   diagnosticId?: string;
   /**
@@ -124,6 +130,7 @@ export type NormalizedError = {
 export type DaemonError = {
   code: string;
   message: string;
+  cause?: ErrorCause;
   hint?: string;
   diagnosticId?: string;
   /** Path on the DAEMON host. Meaningful to a local caller only (#1801). */
@@ -157,16 +164,21 @@ export class AppError extends Error {
 
 /** Rehydrate a daemon transport error into the error type used by local callers. */
 export function throwDaemonError(error: DaemonError): never {
-  throw new AppError(toAppErrorCode(error.code), error.message, {
-    ...(error.details ?? {}),
-    hint: error.hint,
-    diagnosticId: error.diagnosticId,
-    logPath: error.logPath,
-    logPathUnavailable: error.logPathUnavailable,
-    diagnosticsRecord: error.diagnosticsRecord,
-    retriable: error.retriable,
-    supportedOn: error.supportedOn,
-  });
+  throw new AppError(
+    toAppErrorCode(error.code),
+    error.message,
+    {
+      ...(error.details ?? {}),
+      hint: error.hint,
+      diagnosticId: error.diagnosticId,
+      logPath: error.logPath,
+      logPathUnavailable: error.logPathUnavailable,
+      diagnosticsRecord: error.diagnosticsRecord,
+      retriable: error.retriable,
+      supportedOn: error.supportedOn,
+    },
+    error.cause,
+  );
 }
 
 /**
@@ -246,10 +258,12 @@ export function normalizeError(err: unknown, context: NormalizeErrorContext = {}
   const supportedOn = stringDetail(details, 'supportedOn');
   const cleanDetails = stripDiagnosticMeta(details);
   const message = maybeEnrichCommandFailedMessage(appErr.code, appErr.message, details);
+  const cause = normalizeErrorCause(appErr.cause);
 
   return {
     code: appErr.code,
     message,
+    ...(cause !== undefined ? { cause } : {}),
     hint,
     diagnosticId,
     logPath,
@@ -260,6 +274,19 @@ export function normalizeError(err: unknown, context: NormalizeErrorContext = {}
     ...(supportedOn !== undefined ? { supportedOn } : {}),
     details: cleanDetails,
   };
+}
+
+function normalizeErrorCause(cause: unknown): ErrorCause | undefined {
+  if (!cause || typeof cause !== 'object') return undefined;
+  const candidate = cause as { message?: unknown; code?: unknown };
+  if (typeof candidate.message !== 'string' || candidate.message.length === 0) return undefined;
+  const redacted = redactDiagnosticData({
+    message: candidate.message,
+    ...(typeof candidate.code === 'string' && candidate.code.length > 0
+      ? { code: candidate.code }
+      : {}),
+  });
+  return redacted;
 }
 
 const GENERIC_EXIT_MESSAGE = /^\S+ exited with code -?\d+$/;

--- a/packages/kernel/src/errors.ts
+++ b/packages/kernel/src/errors.ts
@@ -1,4 +1,4 @@
-import { redactDiagnosticData } from './redaction.ts';
+import { redactDiagnosticData, sanitizeErrorCause as normalizeErrorCause } from './redaction.ts';
 
 /**
  * The known error codes as a value, so gates can enumerate them: every code
@@ -274,19 +274,6 @@ export function normalizeError(err: unknown, context: NormalizeErrorContext = {}
     ...(supportedOn !== undefined ? { supportedOn } : {}),
     details: cleanDetails,
   };
-}
-
-function normalizeErrorCause(cause: unknown): ErrorCause | undefined {
-  if (!cause || typeof cause !== 'object') return undefined;
-  const candidate = cause as { message?: unknown; code?: unknown };
-  if (typeof candidate.message !== 'string' || candidate.message.length === 0) return undefined;
-  const redacted = redactDiagnosticData({
-    message: candidate.message,
-    ...(typeof candidate.code === 'string' && candidate.code.length > 0
-      ? { code: candidate.code }
-      : {}),
-  });
-  return redacted;
 }
 
 const GENERIC_EXIT_MESSAGE = /^\S+ exited with code -?\d+$/;

--- a/packages/kernel/src/redaction.ts
+++ b/packages/kernel/src/redaction.ts
@@ -10,6 +10,19 @@ export function redactDiagnosticData<T>(input: T): T {
   return redactValue(input, new WeakSet<object>()) as T;
 }
 
+/** Sanitizes an untrusted structured cause before it crosses a process or client boundary. */
+export function sanitizeErrorCause(cause: unknown): { message: string; code?: string } | undefined {
+  if (!cause || typeof cause !== 'object') return undefined;
+  const candidate = cause as { message?: unknown; code?: unknown };
+  if (typeof candidate.message !== 'string' || candidate.message.length === 0) return undefined;
+  return redactDiagnosticData({
+    message: candidate.message,
+    ...(typeof candidate.code === 'string' && candidate.code.length > 0
+      ? { code: candidate.code }
+      : {}),
+  });
+}
+
 function redactValue(value: unknown, seen: WeakSet<object>, keyHint?: string): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === 'string') return redactString(value, keyHint);

--- a/packages/kernel/src/redaction.ts
+++ b/packages/kernel/src/redaction.ts
@@ -5,6 +5,8 @@ const SECRET_TOKEN_RE =
 const SENSITIVE_ASSIGNMENT_RE =
   /\b([a-z0-9_-]*(?:api[_-]?key|token|secret|password|user[_-]?code|device[_-]?code|refresh[_-]?credential)[a-z0-9_-]*)(\s*[=:]\s*)("[^"]*"|'[^']*'|\S+)/gi;
 const URL_RE = /https?:\/\/[^\s"'<>]+/gi;
+const REDACTED_STRING_MAX_LENGTH = 400;
+const TRUNCATION_SUFFIX = '...<truncated>';
 
 export function redactDiagnosticData<T>(input: T): T {
   return redactValue(input, new WeakSet<object>()) as T;
@@ -48,7 +50,7 @@ function redactValue(value: unknown, seen: WeakSet<object>, keyHint?: string): u
 
 function redactString(value: string, keyHint?: string): string {
   const trimmed = value.trim();
-  if (!trimmed) return value;
+  if (!trimmed) return boundRedactedString(value);
   if (keyHint && SENSITIVE_KEY_RE.test(keyHint)) return '[REDACTED]';
   let output = redactUrls(trimmed);
   output = output.replace(SECRET_TOKEN_RE, '[REDACTED]');
@@ -60,9 +62,12 @@ function redactString(value: string, keyHint?: string): string {
       return `${key}${separator}[REDACTED]`;
     },
   );
-  if (output !== trimmed) return output;
-  if (trimmed.length > 400) return `${trimmed.slice(0, 200)}...<truncated>`;
-  return trimmed;
+  return boundRedactedString(output);
+}
+
+function boundRedactedString(value: string): string {
+  if (value.length <= REDACTED_STRING_MAX_LENGTH) return value;
+  return `${value.slice(0, REDACTED_STRING_MAX_LENGTH - TRUNCATION_SUFFIX.length)}${TRUNCATION_SUFFIX}`;
 }
 
 function redactUrls(value: string): string {

--- a/src/__tests__/daemon-error.test.ts
+++ b/src/__tests__/daemon-error.test.ts
@@ -52,3 +52,32 @@ test('throwDaemonError preserves details.divergence into the thrown AppError', (
   };
   assert.deepEqual(roundTripped.error.details?.divergence, divergence);
 });
+
+test('daemon error normalization and rehydration preserve a structured transport cause', () => {
+  const transportError = Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), {
+    code: 'ECONNREFUSED',
+  });
+  const wireError = normalizeError(
+    new AppError(
+      'COMMAND_FAILED',
+      'The daemon failed to fetch the app source',
+      undefined,
+      transportError,
+    ),
+  );
+
+  assert.deepEqual(wireError.cause, {
+    code: 'ECONNREFUSED',
+    message: 'connect ECONNREFUSED 10.0.0.1:443',
+  });
+
+  let caught: unknown;
+  try {
+    throwDaemonError(JSON.parse(JSON.stringify(wireError)) as DaemonError);
+  } catch (error) {
+    caught = error;
+  }
+
+  assert.ok(caught instanceof AppError);
+  assert.deepEqual(normalizeError(caught).cause, wireError.cause);
+});

--- a/src/__tests__/kernel/errors-metadata.test.ts
+++ b/src/__tests__/kernel/errors-metadata.test.ts
@@ -30,6 +30,24 @@ test('normalizeError adds default hint and strips diagnostic metadata from detai
   assert.equal(Object.hasOwn(normalized.details ?? {}, 'hint'), false);
 });
 
+test('normalizeError redacts and bounds a structured cause before putting it on the wire', () => {
+  const cause = Object.assign(
+    new Error(
+      `request to https://example.com/app.apk?token=private-token failed: bearer private-token ${'x'.repeat(500)}`,
+    ),
+    { code: 'ECONNRESET' },
+  );
+
+  const normalized = normalizeError(
+    new AppError('COMMAND_FAILED', 'The daemon failed to fetch the app source', undefined, cause),
+  );
+
+  assert.equal(normalized.cause?.code, 'ECONNRESET');
+  assert.equal(normalized.cause?.message.includes('private-token'), false);
+  assert.match(normalized.cause?.message ?? '', /REDACTED/);
+  assert.ok((normalized.cause?.message.length ?? 0) < cause.message.length);
+});
+
 test('normalizeError provides app discovery guidance for app-not-installed errors', () => {
   const normalized = normalizeError(
     new AppError('APP_NOT_INSTALLED', 'No package found matching "chat"'),

--- a/src/__tests__/test-file-size-ratchet.test.ts
+++ b/src/__tests__/test-file-size-ratchet.test.ts
@@ -34,7 +34,7 @@ const TRIPWIRE_LINES = 1_000;
 // Exact current lengths. Lower a pin when its file shrinks; never raise one — extract instead.
 const PINNED_TEST_FILE_LINES: Readonly<Record<string, number>> = Object.freeze({
   'src/__tests__/remote-connection.test.ts': 2973,
-  'src/daemon/handlers/__tests__/snapshot-handler.test.ts': 2640,
+  'src/daemon/handlers/__tests__/snapshot-handler.test.ts': 2638,
   'src/commands/interaction/runtime/settle.test.ts': 2361,
   'src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts': 2031,
   'src/platforms/apple/core/__tests__/runner-session.test.ts': 2001,

--- a/src/client/client-normalizers.test.ts
+++ b/src/client/client-normalizers.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { normalizeOpenForegroundComposition } from './client-normalizers.ts';
+
+test('embedded daemon errors sanitize an untrusted cause before client exposure', () => {
+  const secret = 'adc_live_remote-secret';
+  const message =
+    `request to https://user:pass@example.test/app?token=${secret} failed: bearer ${secret} ` +
+    'x'.repeat(500);
+
+  const result = normalizeOpenForegroundComposition({
+    initialSnapshotError: {
+      code: 'COMMAND_FAILED',
+      message: 'capture failed',
+      cause: { code: `token=${secret}`, message },
+    },
+  });
+
+  const cause = result.initialSnapshotError?.cause;
+  assert.ok(cause);
+  assert.equal(JSON.stringify(cause).includes(secret), false);
+  assert.match(cause.message, /REDACTED/);
+  assert.ok(cause.message.length < message.length);
+  assert.equal(cause.code, 'token=[REDACTED]');
+});

--- a/src/client/client-normalizers.test.ts
+++ b/src/client/client-normalizers.test.ts
@@ -4,6 +4,7 @@ import { normalizeOpenForegroundComposition } from './client-normalizers.ts';
 
 test('embedded daemon errors sanitize an untrusted cause before client exposure', () => {
   const secret = 'adc_live_remote-secret';
+  const oversizedCode = `token=${secret} ${'c'.repeat(500)}`;
   const message =
     `request to https://user:pass@example.test/app?token=${secret} failed: bearer ${secret} ` +
     'x'.repeat(500);
@@ -12,7 +13,7 @@ test('embedded daemon errors sanitize an untrusted cause before client exposure'
     initialSnapshotError: {
       code: 'COMMAND_FAILED',
       message: 'capture failed',
-      cause: { code: `token=${secret}`, message },
+      cause: { code: oversizedCode, message },
     },
   });
 
@@ -20,6 +21,9 @@ test('embedded daemon errors sanitize an untrusted cause before client exposure'
   assert.ok(cause);
   assert.equal(JSON.stringify(cause).includes(secret), false);
   assert.match(cause.message, /REDACTED/);
-  assert.ok(cause.message.length < message.length);
-  assert.equal(cause.code, 'token=[REDACTED]');
+  assert.equal(cause.message.length, 400);
+  assert.match(cause.message, /<truncated>$/);
+  assert.match(cause.code ?? '', /^token=\[REDACTED\]/);
+  assert.equal(cause.code?.length, 400);
+  assert.match(cause.code ?? '', /<truncated>$/);
 });

--- a/src/client/client-normalizers.ts
+++ b/src/client/client-normalizers.ts
@@ -278,6 +278,7 @@ function normalizeDaemonError(value: unknown): DaemonError | undefined {
   if (!isRecord(value)) return undefined;
   if (typeof value.code !== 'string' || typeof value.message !== 'string') return undefined;
   const error: DaemonError = { code: value.code, message: value.message };
+  Object.assign(error, normalizeDaemonErrorCause(value.cause));
   for (const field of DAEMON_ERROR_STRING_FIELDS) {
     const candidate = value[field];
     if (typeof candidate === 'string') error[field] = candidate;
@@ -285,6 +286,16 @@ function normalizeDaemonError(value: unknown): DaemonError | undefined {
   if (isRecord(value.details)) error.details = value.details;
   if (typeof value.retriable === 'boolean') error.retriable = value.retriable;
   return error;
+}
+
+function normalizeDaemonErrorCause(value: unknown): Pick<DaemonError, 'cause'> | undefined {
+  if (!isRecord(value) || typeof value.message !== 'string') return undefined;
+  return {
+    cause: {
+      message: value.message,
+      ...(typeof value.code === 'string' ? { code: value.code } : {}),
+    },
+  };
 }
 
 /**

--- a/src/client/client-normalizers.ts
+++ b/src/client/client-normalizers.ts
@@ -17,6 +17,7 @@ import {
   type AppleOS,
 } from '@agent-device/kernel/device';
 import { AppError, type DaemonError } from '@agent-device/kernel/errors';
+import { sanitizeErrorCause } from '@agent-device/kernel/redaction';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { leaseScopeFromOptions, leaseScopeToRequestMeta } from '../core/lease-scope.ts';
 import type { DaemonRequest, SessionRuntimeHints } from '../daemon/types.ts';
@@ -289,13 +290,8 @@ function normalizeDaemonError(value: unknown): DaemonError | undefined {
 }
 
 function normalizeDaemonErrorCause(value: unknown): Pick<DaemonError, 'cause'> | undefined {
-  if (!isRecord(value) || typeof value.message !== 'string') return undefined;
-  return {
-    cause: {
-      message: value.message,
-      ...(typeof value.code === 'string' ? { code: value.code } : {}),
-    },
-  };
+  const cause = sanitizeErrorCause(value);
+  return cause ? { cause } : undefined;
 }
 
 /**

--- a/src/daemon/client/daemon-client-rpc.test.ts
+++ b/src/daemon/client/daemon-client-rpc.test.ts
@@ -5,6 +5,7 @@ import { handleDaemonHttpResponseBody } from './daemon-client-rpc.ts';
 
 test('HTTP RPC errors sanitize an untrusted cause before rehydration', () => {
   const secret = 'adc_agent_remote-secret';
+  const oversizedCode = `apiKey=${secret} ${'c'.repeat(500)}`;
   const message =
     `download https://user:pass@example.test/app?token=${secret} failed: bearer ${secret} ` +
     'x'.repeat(500);
@@ -16,7 +17,7 @@ test('HTTP RPC errors sanitize an untrusted cause before rehydration', () => {
         data: {
           code: 'COMMAND_FAILED',
           message: 'remote download failed',
-          cause: { code: `apiKey=${secret}`, message },
+          cause: { code: oversizedCode, message },
         },
       },
     }),
@@ -41,6 +42,9 @@ test('HTTP RPC errors sanitize an untrusted cause before rehydration', () => {
   assert.ok(cause);
   assert.equal(JSON.stringify(cause).includes(secret), false);
   assert.match(cause.message, /REDACTED/);
-  assert.ok(cause.message.length < message.length);
-  assert.equal(cause.code, 'apiKey=[REDACTED]');
+  assert.equal(cause.message.length, 400);
+  assert.match(cause.message, /<truncated>$/);
+  assert.match(cause.code ?? '', /^apiKey=\[REDACTED\]/);
+  assert.equal(cause.code?.length, 400);
+  assert.match(cause.code ?? '', /<truncated>$/);
 });

--- a/src/daemon/client/daemon-client-rpc.test.ts
+++ b/src/daemon/client/daemon-client-rpc.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { handleDaemonHttpResponseBody } from './daemon-client-rpc.ts';
+
+test('HTTP RPC errors sanitize an untrusted cause before rehydration', () => {
+  const secret = 'adc_agent_remote-secret';
+  const message =
+    `download https://user:pass@example.test/app?token=${secret} failed: bearer ${secret} ` +
+    'x'.repeat(500);
+  let rejected: unknown;
+
+  handleDaemonHttpResponseBody(
+    JSON.stringify({
+      error: {
+        data: {
+          code: 'COMMAND_FAILED',
+          message: 'remote download failed',
+          cause: { code: `apiKey=${secret}`, message },
+        },
+      },
+    }),
+    {
+      info: { token: 'daemon-token', pid: 1 },
+      req: {
+        command: 'apps_install_source',
+        positionals: [],
+        token: 'daemon-token',
+        session: 'test-session',
+      },
+      stateDir: '/tmp/agent-device-test',
+      resolve: () => undefined,
+      reject: (error) => {
+        rejected = error;
+      },
+    },
+  );
+
+  assert.ok(rejected instanceof AppError);
+  const cause = rejected.cause as { code?: string; message: string } | undefined;
+  assert.ok(cause);
+  assert.equal(JSON.stringify(cause).includes(secret), false);
+  assert.match(cause.message, /REDACTED/);
+  assert.ok(cause.message.length < message.length);
+  assert.equal(cause.code, 'apiKey=[REDACTED]');
+});

--- a/src/daemon/client/daemon-client-rpc.ts
+++ b/src/daemon/client/daemon-client-rpc.ts
@@ -4,6 +4,7 @@ import {
   toAppErrorCode,
   type DaemonError,
 } from '@agent-device/kernel/errors';
+import { sanitizeErrorCause } from '@agent-device/kernel/redaction';
 import { createRequestId } from '../../utils/diagnostics.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { materializeRemoteArtifacts } from '../../remote/daemon-artifacts.ts';
@@ -120,13 +121,7 @@ function toDaemonHttpRpcError(error: {
 }
 
 function readDaemonErrorCause(value: unknown): DaemonError['cause'] {
-  if (!value || typeof value !== 'object') return undefined;
-  const cause = value as Record<string, unknown>;
-  if (typeof cause.message !== 'string') return undefined;
-  return {
-    message: cause.message,
-    ...(typeof cause.code === 'string' ? { code: cause.code } : {}),
-  };
+  return sanitizeErrorCause(value);
 }
 
 function appErrorFromDaemonError(error: DaemonError, requestId: string | undefined): AppError {

--- a/src/daemon/client/daemon-client-rpc.ts
+++ b/src/daemon/client/daemon-client-rpc.ts
@@ -101,9 +101,11 @@ function toDaemonHttpRpcError(error: {
   data?: Record<string, unknown>;
 }): DaemonError {
   const data = error.data ?? {};
+  const cause = readDaemonErrorCause(data.cause);
   return {
     code: toAppErrorCode(data.code != null ? String(data.code) : undefined, 'COMMAND_FAILED'),
     message: String(data.message ?? error.message ?? 'Daemon RPC request failed'),
+    cause,
     details:
       typeof data.details === 'object' && data.details
         ? (data.details as Record<string, unknown>)
@@ -117,18 +119,33 @@ function toDaemonHttpRpcError(error: {
   };
 }
 
+function readDaemonErrorCause(value: unknown): DaemonError['cause'] {
+  if (!value || typeof value !== 'object') return undefined;
+  const cause = value as Record<string, unknown>;
+  if (typeof cause.message !== 'string') return undefined;
+  return {
+    message: cause.message,
+    ...(typeof cause.code === 'string' ? { code: cause.code } : {}),
+  };
+}
+
 function appErrorFromDaemonError(error: DaemonError, requestId: string | undefined): AppError {
-  return new AppError(toAppErrorCode(error.code, 'COMMAND_FAILED'), error.message, {
-    ...(error.details ?? {}),
-    hint: error.hint,
-    diagnosticId: error.diagnosticId,
-    logPath: error.logPath,
-    logPathUnavailable: error.logPathUnavailable,
-    diagnosticsRecord: error.diagnosticsRecord,
-    retriable: error.retriable,
-    supportedOn: error.supportedOn,
-    requestId,
-  });
+  return new AppError(
+    toAppErrorCode(error.code, 'COMMAND_FAILED'),
+    error.message,
+    {
+      ...(error.details ?? {}),
+      hint: error.hint,
+      diagnosticId: error.diagnosticId,
+      logPath: error.logPath,
+      logPathUnavailable: error.logPathUnavailable,
+      diagnosticsRecord: error.diagnosticsRecord,
+      retriable: error.retriable,
+      supportedOn: error.supportedOn,
+      requestId,
+    },
+    error.cause,
+  );
 }
 
 async function resolveDaemonHttpResult(

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -2611,10 +2611,10 @@ test('wait sleep bypasses sessionless runner cleanup wrapper', async () => {
   expect(response?.ok).toBe(true);
 });
 
+const returnOk = async () => 'ok';
+
 test('sessionless iOS runner cleanup stops the runner host app', async () => {
-  const result = await withSessionlessRunnerCleanup(undefined, iosSimulatorDevice, async () => {
-    return 'ok';
-  });
+  const result = await withSessionlessRunnerCleanup(undefined, iosSimulatorDevice, returnOk);
 
   expect(result).toBe('ok');
   expect(mockStopIosRunnerSession).toHaveBeenCalledWith(iosSimulatorDevice.id);
@@ -2627,9 +2627,7 @@ test('sessionless iOS runner cleanup stops the runner host app', async () => {
 test('sessionless iOS runner host close is best effort', async () => {
   mockCloseIosApp.mockRejectedValueOnce(new Error('terminate failed'));
 
-  const result = await withSessionlessRunnerCleanup(undefined, iosSimulatorDevice, async () => {
-    return 'ok';
-  });
+  const result = await withSessionlessRunnerCleanup(undefined, iosSimulatorDevice, returnOk);
 
   expect(result).toBe('ok');
   expect(mockStopIosRunnerSession).toHaveBeenCalledWith(iosSimulatorDevice.id);

--- a/src/mcp/__tests__/tool-error.test.ts
+++ b/src/mcp/__tests__/tool-error.test.ts
@@ -38,6 +38,21 @@ test('formatToolErrorText omits the candidates block for non-ambiguous errors', 
   assert.equal(text.includes('Candidates:'), false);
 });
 
+test('formatToolErrorText renders a structured cause', () => {
+  const err = new AppError(
+    'COMMAND_FAILED',
+    'The daemon failed to fetch the app source',
+    undefined,
+    Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    }),
+  );
+
+  const text = formatToolErrorText(normalizeToolError(err));
+
+  assert.match(text, /Cause: ECONNREFUSED connect ECONNREFUSED 10\.0\.0\.1:443/);
+});
+
 // Device-domain AMBIGUOUS_MATCH (findBootedAppleSimulatorWithApp,
 // src/core/dispatch-resolve.ts) keys its list `devices`, so the MCP text path
 // carries the udids the hint asks for — same block as the CLI.

--- a/src/mcp/tool-error.ts
+++ b/src/mcp/tool-error.ts
@@ -12,6 +12,10 @@ export function normalizeToolError(error: unknown): NormalizedError {
 
 export function formatToolErrorText(normalized: NormalizedError): string {
   const lines = [`Error (${normalized.code}): ${normalized.message}`];
+  if (normalized.cause) {
+    const code = normalized.cause.code ? `${normalized.cause.code} ` : '';
+    lines.push(`Cause: ${code}${normalized.cause.message}`);
+  }
   if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
   // #1597: printed unconditionally, same as the CLI text path
   // (src/utils/output.ts printHumanError) — an MCP-connected agent must see

--- a/src/platforms/__tests__/install-source-download.test.ts
+++ b/src/platforms/__tests__/install-source-download.test.ts
@@ -83,6 +83,39 @@ test('download errors do not disclose URL credentials or query values', async ()
   }
 });
 
+test('download identifies the daemon as the requester and preserves the network cause', async () => {
+  const tempRoot = await mkdtempForTest('agent-device-download-network-error-');
+  const lookup = vi
+    .spyOn(dns, 'lookup')
+    .mockImplementation(
+      async () =>
+        [{ address: '93.184.216.34', family: 4 }] as unknown as Awaited<
+          ReturnType<typeof dns.lookup>
+        >,
+    );
+  const transportError = Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), {
+    code: 'ECONNREFUSED',
+  });
+  const requestMock = vi
+    .spyOn(networkTransport, 'requestApprovedUrl')
+    .mockRejectedValue(transportError);
+  try {
+    const error = await downloadInstallSource({
+      tempDir: tempRoot,
+      url: 'https://example.com/app.apk',
+      signal: new AbortController().signal,
+    }).catch((caught: unknown) => caught);
+
+    assert.ok(error instanceof Error);
+    assert.equal(error.message, 'The daemon failed to fetch the app source');
+    assert.equal((error as { cause?: unknown }).cause, transportError);
+  } finally {
+    requestMock.mockRestore();
+    lookup.mockRestore();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('download rejects non-identity content encoding and malformed lengths', async () => {
   const tempRoot = await mkdtempForTest('agent-device-download-metadata-');
   const lookup = vi

--- a/src/platforms/install-source-download.ts
+++ b/src/platforms/install-source-download.ts
@@ -64,7 +64,12 @@ async function requestHop(
     });
   } catch (error) {
     if (error instanceof AppError) throw error;
-    throw new AppError('COMMAND_FAILED', 'App source network request failed', undefined, error);
+    throw new AppError(
+      'COMMAND_FAILED',
+      'The daemon failed to fetch the app source',
+      undefined,
+      error,
+    );
   }
 }
 

--- a/src/utils/__tests__/output-error.test.ts
+++ b/src/utils/__tests__/output-error.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { printHumanError } from '../output.ts';
+
+test('printHumanError renders a structured cause unconditionally', () => {
+  const err = new AppError(
+    'COMMAND_FAILED',
+    'The daemon failed to fetch the app source',
+    undefined,
+    Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    }),
+  );
+
+  const output = captureStderr(() => printHumanError(err));
+
+  assert.match(output, /Cause: ECONNREFUSED connect ECONNREFUSED 10\.0\.0\.1:443/);
+});
+
+function captureStderr(run: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  let output = '';
+  (process.stderr as unknown as { write: typeof process.stderr.write }).write = ((
+    chunk: unknown,
+  ) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    run();
+  } finally {
+    process.stderr.write = original;
+  }
+  return output;
+}

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -37,6 +37,10 @@ export function printHumanError(
 ): void {
   const normalized = err instanceof AppError ? normalizeError(err) : err;
   process.stderr.write(`Error (${normalized.code}): ${normalized.message}\n`);
+  if (normalized.cause) {
+    const code = normalized.cause.code ? `${normalized.cause.code} ` : '';
+    process.stderr.write(`Cause: ${code}${normalized.cause.message}\n`);
+  }
   if (normalized.hint) {
     process.stderr.write(`Hint: ${normalized.hint}\n`);
   }

--- a/test/wire-compat/ledger.json
+++ b/test/wire-compat/ledger.json
@@ -31,18 +31,19 @@
     "packages/kernel/src/contracts.ts#jsonRpcRequestSchema": "sha256:67e6b8a28b39a3883424a565ae7033c336dc2ea6b193e9b32bb98eb3e18dca7c",
     "packages/kernel/src/device.ts#PLATFORM_SELECTORS": "sha256:36e9da1cc660c0ddfb4cf52521f7f230341ff20e3ebda3405ba7c1799476c42d",
     "packages/kernel/src/device.ts#PlatformSelector": "sha256:61de3f003507ea2f53b396b0146c17670bf674a2db2132e19c462ca6c10cc8fd",
-    "packages/kernel/src/errors.ts#DaemonError": "sha256:af0f0f420277a57338dc59b7b443ec83d371e18768d064b7a265949e6435e976",
+    "packages/kernel/src/errors.ts#DaemonError": "sha256:ae49c9c9c8fb93bb6b31ab865f37cc8b0db6c1b6ff026cc2791425b772c162a6",
     "packages/kernel/src/errors.ts#DiagnosticsRecordRef": "sha256:c5ef4185d01814fbfddcdcf797ce892f6ebfe1fd3c3fa73c7560ce2d3b6fce60",
+    "packages/kernel/src/errors.ts#ErrorCause": "sha256:2f38679b0e9ec997fe8d94b5d5025404fd6ebb21f2c91ed2ab5d4133e578dfc4",
     "packages/kernel/src/errors.ts#NormalizeErrorContext": "sha256:98567378fc456335c8751474152edcf989e676ad0d9f4b54afdd8e6a96b03ae2",
-    "packages/kernel/src/errors.ts#NormalizedError": "sha256:ac2c600668420fe5b3d459f8e677676af83951fbad8ee1c2149092fd48e9d47c",
-    "packages/kernel/src/errors.ts#normalizeError": "sha256:f91f2fa4789075c838be9c42c04046b42d4ebb368eeb1b21194bdb000181e6ce",
+    "packages/kernel/src/errors.ts#NormalizedError": "sha256:dfe0e0066292d29eec7f6defea648dc488a6c0b62c268c3dac8233f8556e4bbb",
+    "packages/kernel/src/errors.ts#normalizeError": "sha256:5d9f906fd326676b4c3095cd6bd675c784cb26f36f4b8344a108cf5f7628f9dc",
     "packages/kernel/src/errors.ts#readDiagnosticsRecordRef": "sha256:3a210f401221c0a15eb75d488450034885c7b73be39f5e93424c72874d14c395",
     "src/commands/cli-grammar/types.ts#DaemonCommandRequest": "sha256:ea3f4118244711f0eaec0e471f62b0de42ca97181c085df165d37b63301a4619",
     "src/core/lease-scope.ts#LeaseRpcCommand": "sha256:714f66efa725a5d0654e492a76daeb4059caad31b79562cfc9133029ea95bfe5",
     "src/daemon/client/daemon-client-progress.ts#ProgressResponseFormat": "sha256:6d7a99ac13fd422671fd86f8fe093efa40ca369f4ae1f97c98d40a7132543637",
     "src/daemon/client/daemon-client-progress.ts#createInvalidDaemonResponseError": "sha256:0af812346b667a23fdfef641b242cd86d07edaa05eb928c4c531628c09a4031b",
     "src/daemon/client/daemon-client-progress.ts#shouldReadDaemonProgressStream": "sha256:6811404f41d8db3fa6fc751332c7186a2399ec7ecbc4e9c547d9cb9f14dbb350",
-    "src/daemon/client/daemon-client-rpc.ts#appErrorFromDaemonError": "sha256:6188ea43d4da42ea1dd8a61ab1f3d4a6e287ec0a0210b65f850dc3030fdcd508",
+    "src/daemon/client/daemon-client-rpc.ts#appErrorFromDaemonError": "sha256:ac4761006c71d93ccba9f8e37cbd4cf48283dbb22737c163dc9c1a878e154eea",
     "src/daemon/client/daemon-client-rpc.ts#buildHttpRpcPayload": "sha256:c12b5945e89defe3ede7d699a5caa9f006e1bb2d47ce9adbc7e7dac5670ab5c0",
     "src/daemon/client/daemon-client-rpc.ts#buildLeaseRpcParams": "sha256:1755f46be8c62e7a8eb409e9a94d61781c96ccbef3306702121aa94264d63267",
     "src/daemon/client/daemon-client-rpc.ts#handleDaemonHttpResponseBody": "sha256:8f1c4bba1918545db6296ad29b95f0baa9f949e7c23bc04d59e261130f14611e",
@@ -51,7 +52,7 @@
     "src/daemon/client/daemon-client-rpc.ts#parseDaemonHttpResponseBody": "sha256:0cbe39dbd09e321ec00854a1626a7d89b6344e59c6faabe2fe02504268b2d886",
     "src/daemon/client/daemon-client-rpc.ts#rejectDaemonHttpRpcError": "sha256:83b0312fe88bc3b3497de799e23d8d14455f665b7cf880f4617cd62b181351cd",
     "src/daemon/client/daemon-client-rpc.ts#resolveDaemonHttpResult": "sha256:296f9d376ce67c8cb20209bdf1c59c2423ffcfa35b5565a99e70271263149048",
-    "src/daemon/client/daemon-client-rpc.ts#toDaemonHttpRpcError": "sha256:ceb3286173ff05415ae71fe8dd974d9a2dfe4d33c9144ae219a3ee992b501e0e",
+    "src/daemon/client/daemon-client-rpc.ts#toDaemonHttpRpcError": "sha256:888246763c48670e7da893054d025744654f8715c3b4906312617a2b5028316b",
     "src/daemon/client/daemon-client-transport.ts#RemoteDaemonHealth": "sha256:38fe712390d247de59a74b9dc209fdf407ff5f9b1e32b698ae71ebc57569b66d",
     "src/daemon/client/daemon-client-transport.ts#readDaemonHttpHealth": "sha256:5e75af39e96045ce7faba986c900744cee76cdaa1e0df360ea38f3c020520711",
     "src/daemon/client/daemon-client-transport.ts#readHealthPayload": "sha256:5b15e14319b16aebf32d07336986a7f1f2a6b13cec1823ca9aa7c9f01bf1b0b6",
@@ -174,13 +175,13 @@
   "compatibleChanges": [
     {
       "declaration": "packages/kernel/src/errors.ts#DaemonError",
-      "digest": "sha256:af0f0f420277a57338dc59b7b443ec83d371e18768d064b7a265949e6435e976",
-      "rationale": "#1801 adds two optional error fields: `diagnosticsRecord` (session + request id locating the diagnostics record the daemon already names by path) and `logPathUnavailable` (client-set only). A peer on protocol 2 that does not send them is unchanged, and one that does not read them keeps parsing every field it read before."
+      "digest": "sha256:ae49c9c9c8fb93bb6b31ab865f37cc8b0db6c1b6ff026cc2791425b772c162a6",
+      "rationale": "#1801 and #1862 add optional error fields, most recently the structured `cause`. A peer on protocol 2 that does not send them is unchanged, and one that does not read them keeps parsing every field it read before."
     },
     {
       "declaration": "packages/kernel/src/errors.ts#NormalizedError",
-      "digest": "sha256:ac2c600668420fe5b3d459f8e677676af83951fbad8ee1c2149092fd48e9d47c",
-      "rationale": "#1801 adds the same two optional fields to the normalized error the daemon serializes; both are omitted unless set, so a released client parsing this payload sees the exact bytes it saw before whenever they are absent, and ignores them otherwise."
+      "digest": "sha256:dfe0e0066292d29eec7f6defea648dc488a6c0b62c268c3dac8233f8556e4bbb",
+      "rationale": "#1801 and #1862 add optional fields to the normalized error the daemon serializes, most recently `cause`; they are omitted unless set, and a released client ignores them otherwise."
     },
     {
       "declaration": "src/daemon/client/daemon-client-rpc.ts#handleDaemonHttpResponseBody",
@@ -189,8 +190,8 @@
     },
     {
       "declaration": "src/daemon/client/daemon-client-rpc.ts#toDaemonHttpRpcError",
-      "digest": "sha256:ceb3286173ff05415ae71fe8dd974d9a2dfe4d33c9144ae219a3ee992b501e0e",
-      "rationale": "#1801 client-side only: this now returns the parsed `DaemonError` instead of an `AppError` (construction moved to `appErrorFromDaemonError`) and additionally reads the optional `diagnosticsRecord`. Parsing of every previously read field is unchanged, so a released daemon\u2019s error payload is accepted exactly as before."
+      "digest": "sha256:888246763c48670e7da893054d025744654f8715c3b4906312617a2b5028316b",
+      "rationale": "#1801 and #1862 client-side only: this reads optional daemon error metadata, most recently the structured `cause`. Parsing of every previously read field is unchanged, so a released daemon's error payload is accepted exactly as before."
     },
     {
       "declaration": "src/daemon/downloadable-artifact-http.ts#readArtifactId",
@@ -204,8 +205,13 @@
     },
     {
       "declaration": "packages/kernel/src/errors.ts#normalizeError",
-      "digest": "sha256:f91f2fa4789075c838be9c42c04046b42d4ebb368eeb1b21194bdb000181e6ce",
-      "rationale": "#1801 lifts `diagnosticsRecord` / `logPathUnavailable` from details (and from a new optional context field) onto the normalized error and strips them from `details`, the same treatment `logPath` and `diagnosticId` already had. No previously emitted field changes shape or value."
+      "digest": "sha256:5d9f906fd326676b4c3095cd6bd675c784cb26f36f4b8344a108cf5f7628f9dc",
+      "rationale": "#1801 and #1862 lift optional metadata onto the normalized error, most recently a redacted structured `cause`. No previously emitted field changes shape or value, and peers that do not know the field ignore it."
+    },
+    {
+      "declaration": "src/daemon/client/daemon-client-rpc.ts#appErrorFromDaemonError",
+      "digest": "sha256:ac4761006c71d93ccba9f8e37cbd4cf48283dbb22737c163dc9c1a878e154eea",
+      "rationale": "#1862 client-side only: this rehydrates the new optional structured `cause` when present. Released daemons that omit it follow the unchanged path, and no request field or existing response field is narrowed."
     }
   ]
 }

--- a/test/wire-compat/surface.ts
+++ b/test/wire-compat/surface.ts
@@ -234,7 +234,13 @@ export const WIRE_SURFACE: readonly WireSurfaceGroup[] = [
         'DaemonArtifactType',
         'DaemonArtifactKnownType',
       ),
-      ...from(KERNEL_ERRORS, 'DaemonError', 'DiagnosticsRecordRef', 'readDiagnosticsRecordRef'),
+      ...from(
+        KERNEL_ERRORS,
+        'DaemonError',
+        'DiagnosticsRecordRef',
+        'ErrorCause',
+        'readDiagnosticsRecordRef',
+      ),
       // "These are wire values" — the progress module says so itself: the daemon
       // serializes them onto the response stream and the CLI reconstructs them.
       ...from(


### PR DESCRIPTION
## Summary

Surface the daemon-side network failure behind install-from-source instead of returning only a generic command error.

The daemon now preserves a centrally sanitized structured cause across every remote ingress. Redaction runs before one shared 400-character ceiling, so secrets, URLs, and oversized remote cause message/code values cannot escape through RPC, SDK, CLI, JSON, or MCP output. The top-level message also identifies the daemon as the host fetching the artifact.

The root cause was that AppError.cause was retained locally but dropped by normalizeError, so remote clients could not distinguish DNS, TLS, refused-connection, or egress failures.

Also deduplicates a repeated callback in the existing snapshot handler tests and lowers its ratchet to the resulting 2,638 lines.

Closes #1862

## Validation

Exact head: baffdb82e09cc201e3824a6d0b58de011b89d6e8

- Red proof: before the post-redaction bound, the adversarial HTTP and embedded-success causes were 580 and 582 characters instead of the asserted 400.
- Focused green: 3 files / 14 tests covering both remote ingress forms and kernel metadata.
- pnpm check:affected --run: all runnable checks passed; 874 files / 6,716 tests, changed-line coverage 25/25 (100%), provider integration, build, layering, fallow, and daemon wire compatibility.
- The unrelated Apple runner concurrency test that timed out once under the broad instrumented run passed in isolation in 148 ms; the final full run was green.

No live device run is needed: the failure occurs in daemon-side artifact download and error transport before platform installation begins. Regression coverage exercises the downloader, both remote ingress shapes, centralized redaction/bounding, daemon wire round-trip, CLI output, and MCP output.

Scope: 18 files, 332 additions / 48 deletions. The only expansion beyond install-source/error transport is the behavior-preserving snapshot test callback deduplication and its lowered ratchet; no device/platform behavior changes.