### PR TITLE
fix(layering): resolve relative imports inside workspace packages referencing #1781

### DIFF
--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -111,6 +111,40 @@ test('neutral ownership zones reject value imports into higher layers', () => {
   });
 });
 
+test('a relative import resolves within its own workspace package src/, but not past it', () => {
+  const edges = resolveImportEdges(
+    new Map([
+      ['packages/contracts/src/facades/device.ts', "import '../device.ts';"],
+      ['packages/contracts/src/device.ts', 'export const device = true;'],
+      // A value cycle closed entirely inside one package must be as visible to R4 as
+      // one closed inside src/ — this is what #1781 A9-2 found invisible: `resolved`
+      // landed under `packages/<name>/src/`, so the old `resolved.startsWith('src/')`
+      // check dropped both edges and the reverse-reachability graph stopped at the
+      // package facade.
+      ['packages/contracts/src/cycle-a.ts', "import '../src/cycle-b.ts';"],
+      ['packages/contracts/src/cycle-b.ts', "import '../src/cycle-a.ts';"],
+      // A relative path that climbs out of any package's src/ (landing under a bare
+      // `packages/<name>/` with no `src/` segment) must still be refused by the
+      // model — R11 owns rejecting that import outright, but the graph itself must
+      // not silently resolve a target outside src/ and packages/*/src/.
+      ['packages/contracts/src/escape.ts', "import '../../outside-src.ts';"],
+      ['packages/outside-src.ts', 'export const outsideSrc = true;'],
+    ]),
+  );
+
+  assert.deepEqual(
+    edges.map(({ file, target }) => `${file} -> ${target}`).sort(),
+    [
+      'packages/contracts/src/cycle-a.ts -> packages/contracts/src/cycle-b.ts',
+      'packages/contracts/src/cycle-b.ts -> packages/contracts/src/cycle-a.ts',
+      'packages/contracts/src/facades/device.ts -> packages/contracts/src/device.ts',
+    ],
+  );
+  assert.deepEqual(findValueImportCycles(edges), [
+    ['packages/contracts/src/cycle-a.ts', 'packages/contracts/src/cycle-b.ts', 'packages/contracts/src/cycle-a.ts'],
+  ]);
+});
+
 test('type-only edges are ranked by R6 and ignored by R5, and vice versa', () => {
   const edges = resolveImportEdges(
     new Map([

--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -132,16 +132,17 @@ test('a relative import resolves within its own workspace package src/, but not 
     ]),
   );
 
-  assert.deepEqual(
-    edges.map(({ file, target }) => `${file} -> ${target}`).sort(),
-    [
-      'packages/contracts/src/cycle-a.ts -> packages/contracts/src/cycle-b.ts',
-      'packages/contracts/src/cycle-b.ts -> packages/contracts/src/cycle-a.ts',
-      'packages/contracts/src/facades/device.ts -> packages/contracts/src/device.ts',
-    ],
-  );
+  assert.deepEqual(edges.map(({ file, target }) => `${file} -> ${target}`).sort(), [
+    'packages/contracts/src/cycle-a.ts -> packages/contracts/src/cycle-b.ts',
+    'packages/contracts/src/cycle-b.ts -> packages/contracts/src/cycle-a.ts',
+    'packages/contracts/src/facades/device.ts -> packages/contracts/src/device.ts',
+  ]);
   assert.deepEqual(findValueImportCycles(edges), [
-    ['packages/contracts/src/cycle-a.ts', 'packages/contracts/src/cycle-b.ts', 'packages/contracts/src/cycle-a.ts'],
+    [
+      'packages/contracts/src/cycle-a.ts',
+      'packages/contracts/src/cycle-b.ts',
+      'packages/contracts/src/cycle-a.ts',
+    ],
   ]);
 });
 

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -198,6 +198,12 @@ export function unclassifiedZones(files: readonly string[]): string[] {
   return [...collectZones(files)].filter((zone) => classifyZone(zone) === 'unclassified').sort();
 }
 
+// A relative specifier resolves only within a source root: root `src/`, or a workspace
+// package's own `src/` (#1490 W0 added `packages/*/src/**` to the source set, but a bare
+// `src/`-prefix check left every intra-package relative import — e.g. a facade re-exporting
+// a sibling file — unresolved and invisible to the value-cycle and reverse-reachability graphs).
+const PACKAGE_SRC_PREFIX = /^packages\/[^/]+\/src\//;
+
 function resolveTargetFile(
   fromFile: string,
   spec: string,
@@ -225,7 +231,7 @@ function resolveTargetFile(
   }
   if (!spec.startsWith('.')) return null;
   const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), spec));
-  if (!resolved.startsWith('src/')) return null;
+  if (!resolved.startsWith('src/') && !PACKAGE_SRC_PREFIX.test(resolved)) return null;
   const candidates = [
     resolved,
     resolved.replace(/\.js$/, '.ts'),


### PR DESCRIPTION
## Summary

- `scripts/layering/model.ts` `resolveTargetFile()` dropped every relative import whose resolved path didn't start with `src/`. Since #1490 W0 added `packages/*/src/**` to the source set, this silently dropped every intra-package relative import (e.g. a facade re-exporting a sibling file) — R4 value-cycle rejection and reverse reachability (`pnpm depgraph affected`, `pnpm check:affected`) both stopped at the package facade. Found in #1781 A9-2.
- Fix: also resolve relative specifiers whose target lands under `packages/<name>/src/`, while still refusing anything outside `src/` and `packages/*/src/`.
- Added a regression test (`scripts/layering/model.test.ts`) proving intra-package relative resolution (including a value cycle closed entirely inside one package) and that a relative path escaping past a package's own `src/` is still refused. Verified red against the pre-fix code.

## Impact on the real tree

Measured directly against the repo (before vs after the fix):

- **+448** previously-invisible value edges and **+436** previously-invisible type-only edges now resolve inside workspace packages (e.g. `packages/contracts/src/device.ts` fan-in goes from 0 to 1).
- **R4 (value cycles): still 0.** No new value cycle is introduced by exposing these edges.
- **R6 (type-inversion baseline): still 7.** Intra-package edges share the same zone (package name), so they can never register as a spine back-edge by construction — R6 is unaffected by this bug class.
- **R9 (largest type cycle): still 46 files.** None of the newly-visible edges pull a package file into the existing SCC.

Since none of the baselines moved, `TYPE_INVERSION_BASELINE` and `DAEMON_MODULARITY_BASELINE`/`LARGEST_TYPE_CYCLE_ZONE_CEILINGS` are unchanged in this PR. No new R4 value cycle was found, so there is nothing to flag as a real finding beyond the reachability fix itself.

## Validation

- `pnpm check:layering` — 176 tests pass, gate reports OK with baselines unchanged (R6: 7, R9: 46)
- `pnpm depgraph:test`, `pnpm check:affected:test`, `pnpm check:gate-manifest:test` — all pass
- `pnpm check:affected --run` — all 52 selected checks pass on the rebased head (fails open to the full local set since `scripts/layering/` is workflow-tooling)
- Regression test proven red against pre-fix `model.ts` (reverted locally), green after
- No device-facing behavior; no live simulator/emulator evidence applies. Linux Smoke was cancelled after hanging in dependency installation (infra flake, unrelated to this diff) — rerun requested.

Scope: 2 files changed (`scripts/layering/model.ts`, `scripts/layering/model.test.ts`), no expansion beyond the layering model.
