### PR TITLE
refactor: tighten viewport runtime facts

### DIFF
--- a/packages/contracts/src/platform-runtime-unavailable.test.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.test.ts
@@ -29,11 +29,16 @@ test('generic unavailable binding preserves exact provider ownership and mode', 
   const binding = createUnavailablePlatformRuntimeBinding(device, owner, {
     appLog: { available: false, reason: 'unsupported-provider-mode' },
     network: { available: false, reason: 'owner-capability-missing' },
+    viewport: { available: false, reason: 'unsupported-platform-leaf' },
     lifecycle,
   });
 
   assert.equal(binding.owner, owner);
   assert.equal(binding.facts.device.providerMode, 'provider-runtime');
+  assert.deepEqual(binding.facts.operations.setViewport, {
+    available: false,
+    reason: 'unsupported-platform-leaf',
+  });
   assert.deepEqual(binding.operations, {});
   await binding[Symbol.asyncDispose]();
 });

--- a/packages/contracts/src/platform-runtime-unavailable.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.ts
@@ -25,7 +25,7 @@ export type UnavailablePlatformRuntimeFacts = Readonly<{
   network: RuntimeOperationUnavailability;
   screenRecording?: RuntimeOperationUnavailability;
   snapshot?: RuntimeOperationUnavailability;
-  viewport?: RuntimeOperationUnavailability;
+  viewport: RuntimeOperationUnavailability;
   readiness?: RuntimeOperationUnavailability;
   shutdown?: RuntimeOperationUnavailability;
   lifecycle: ApplicationLifecycleOperationFacts;
@@ -126,7 +126,7 @@ function freezeUnavailableFacts(
       ...(unavailable.screenRecording ?? unavailable.network),
     }),
     snapshot: Object.freeze({ ...(unavailable.snapshot ?? unavailable.network) }),
-    viewport: Object.freeze({ ...(unavailable.viewport ?? unavailable.network) }),
+    viewport: Object.freeze({ ...unavailable.viewport }),
     readiness: Object.freeze({ ...(unavailable.readiness ?? unavailable.network) }),
     shutdown: Object.freeze({ ...(unavailable.shutdown ?? unavailable.network) }),
     lifecycle: applicationLifecycleOperationFacts(unavailable.lifecycle),

--- a/packages/platform-linux/src/runtime.ts
+++ b/packages/platform-linux/src/runtime.ts
@@ -95,6 +95,7 @@ function linuxFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations>
     appLog: unsupportedPlatformLeaf,
     network: unsupportedPlatformLeaf,
     snapshot: snapshotKindUnavailable,
+    viewport: unsupportedPlatformLeaf,
     readiness: unsupportedPlatformLeaf,
     lifecycle: applicationLifecycleOperationFacts({
       resolveOpenTarget: openTarget,

--- a/packages/platform-vega/src/runtime.ts
+++ b/packages/platform-vega/src/runtime.ts
@@ -83,6 +83,7 @@ function vegaFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations> 
     appLog: unsupportedPlatformLeaf,
     network: unsupportedPlatformLeaf,
     snapshot: unsupportedPlatformLeaf,
+    viewport: unsupportedPlatformLeaf,
     readiness: unsupportedPlatformLeaf,
     lifecycle: applicationLifecycleOperationFacts({
       resolveOpenTarget: openTarget,

--- a/packages/provider-limrun/src/app-log-runtime.ts
+++ b/packages/provider-limrun/src/app-log-runtime.ts
@@ -187,6 +187,7 @@ export function createLimrunPlatformRuntimeOwner(
             appState: liveSessionUnavailable,
             appDeployment: liveSessionUnavailable,
             network: liveSessionUnavailable,
+            viewport: liveSessionUnavailable,
             readiness: liveSessionUnavailable,
             shutdown: liveSessionUnavailable,
             lifecycle: limrunLifecycleFacts(device, false),

--- a/packages/provider-webdriver/src/platform-runtime.ts
+++ b/packages/provider-webdriver/src/platform-runtime.ts
@@ -258,11 +258,12 @@ function webDriverFacts(
   device: DeviceInfo,
 ): RuntimeFacts<PlatformRuntimeOperations> {
   if (!webDriverSessionActive(options, device)) {
-    const unavailable = createUnavailablePlatformRuntimeFacts(device, options.owner, {
+    return createUnavailablePlatformRuntimeFacts(device, options.owner, {
       appLog: inactiveSession,
       appDeployment: inactiveSession,
       network: inactiveSession,
       screenRecording: inactiveSession,
+      viewport: inactiveSession,
       lifecycle: applicationLifecycleOperationFacts({
         resolveOpenTarget: inactiveSession,
         prepareApplicationOpen: inactiveSession,
@@ -275,47 +276,6 @@ function webDriverFacts(
         configureProviderPortReverse: inactiveSession,
       }),
     });
-    return Object.freeze({
-      device: unavailable.device,
-      operations: {
-        appLogInspect: inactiveSession,
-        appLogDoctor: inactiveSession,
-        appLogStart: inactiveSession,
-        appLogReattach: inactiveSession,
-        appLogCleanup: inactiveSession,
-        deployApp: inactiveSession,
-        materializeAppSource: inactiveSession,
-        deployMaterializedApp: inactiveSession,
-        sendPushNotification: inactiveSession,
-        appState: inactiveSession,
-        networkDump: inactiveSession,
-        screenRecordingStart: inactiveSession,
-        screenRecordingReattach: inactiveSession,
-        screenRecordingCleanup: inactiveSession,
-        ...snapshotRuntimeOperationFacts({
-          capture: inactiveSession,
-          customActions: inactiveSession,
-          withoutActiveApp: inactiveSession,
-        }),
-        ...viewportRuntimeOperationFacts({ setViewport: inactiveSession }),
-        ensureReady: inactiveSession,
-        bootTarget: inactiveSession,
-        bootTargetHeadless: inactiveSession,
-        listApps: inactiveSession,
-        shutdownTarget: inactiveSession,
-        ...applicationLifecycleOperationFacts({
-          resolveOpenTarget: inactiveSession,
-          prepareApplicationOpen: inactiveSession,
-          openApplication: inactiveSession,
-          applyRuntimeHints: inactiveSession,
-          clearRuntimeHints: inactiveSession,
-          closeApplication: inactiveSession,
-          finalizeApplicationClose: inactiveSession,
-          prepareAppleRunner: inactiveSession,
-          configureProviderPortReverse: inactiveSession,
-        }),
-      },
-    });
   }
   const deployment = options.deployment?.fact(device) ?? deploymentUnavailable;
   const unavailable = createUnavailablePlatformRuntimeFacts(device, options.owner, {
@@ -323,25 +283,19 @@ function webDriverFacts(
     appDeployment: deploymentUnavailable,
     network: appLogUnavailable,
     screenRecording: recordingUnavailable,
+    viewport: viewportUnavailable,
     lifecycle: webDriverLifecycleFacts(device),
   });
   return Object.freeze({
     device: unavailable.device,
     operations: {
-      appLogInspect: appLogUnavailable,
-      appLogDoctor: appLogUnavailable,
-      appLogStart: appLogUnavailable,
-      appLogReattach: appLogUnavailable,
-      appLogCleanup: appLogUnavailable,
+      ...unavailable.operations,
       deployApp: deployment,
       materializeAppSource: deployment,
       deployMaterializedApp: deployment,
       sendPushNotification: pushUnavailable,
       appState: appStateUnavailable,
       networkDump: available,
-      screenRecordingStart: recordingUnavailable,
-      screenRecordingReattach: recordingUnavailable,
-      screenRecordingCleanup: recordingUnavailable,
       ...snapshotRuntimeOperationFacts({
         capture:
           options.snapshotAvailable !== false &&
@@ -367,7 +321,6 @@ function webDriverFacts(
         reason: 'unsupported-provider-mode',
         hint: 'WebDriver owns the target lifecycle for provider-owned devices.',
       },
-      ...webDriverLifecycleFacts(device),
     },
   });
 }

--- a/src/daemon/handlers/__tests__/session-state.test.ts
+++ b/src/daemon/handlers/__tests__/session-state.test.ts
@@ -44,6 +44,7 @@ test('boot rejects --headless outside Android directly', async () => {
           createUnavailablePlatformRuntimeFacts(device, localRuntimeOwner('apple'), {
             appLog: { available: false, reason: 'owner-capability-missing' },
             network: { available: false, reason: 'owner-capability-missing' },
+            viewport: { available: false, reason: 'owner-capability-missing' },
             readiness: { available: false, reason: 'unsupported-device-kind' },
             lifecycle: applicationLifecycleOperationFacts({
               resolveOpenTarget: { available: false, reason: 'owner-capability-missing' },
@@ -127,6 +128,7 @@ test('appstate rejects web before Android app-state backend dispatch', async () 
             appLog: { available: false, reason: 'unsupported-platform-leaf' },
             appState: { available: false, reason: 'unsupported-platform-leaf' },
             network: { available: false, reason: 'unsupported-platform-leaf' },
+            viewport: { available: false, reason: 'unsupported-platform-leaf' },
             readiness: { available: false, reason: 'unsupported-platform-leaf' },
             lifecycle: applicationLifecycleOperationFacts({
               resolveOpenTarget: { available: false, reason: 'unsupported-platform-leaf' },

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -46,6 +46,7 @@ describe('composed platform runtime gateway', () => {
     const baseFacts = createUnavailablePlatformRuntimeFacts(webDevice, owner, {
       appLog: unavailable,
       network: unavailable,
+      viewport: unavailable,
       lifecycle: applicationLifecycleOperationFacts({
         resolveOpenTarget: unavailable,
         prepareApplicationOpen: unavailable,

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -303,6 +303,7 @@ function unavailableProviderBinding(
     appLog: unavailable,
     appState: unavailable,
     network: unavailable,
+    viewport: unavailable,
     lifecycle: unavailableProviderLifecycleFacts(unavailable),
   });
 }
@@ -319,6 +320,7 @@ function unavailableProviderFacts(runtime: ProviderDeviceRuntime, device: Device
       appLog: unavailable,
       appState: unavailable,
       network: unavailable,
+      viewport: unavailable,
       readiness: unavailable,
       lifecycle: unavailableProviderLifecycleFacts(unavailable),
     },


### PR DESCRIPTION
## Summary

Require every unavailable runtime constructor to classify viewport explicitly.
Consolidate WebDriver unavailable facts onto the shared constructor, removing 47 duplicated production lines and the viewport-to-network fallback.

Scope: **9 files**, confined to unavailable-runtime fact classification and WebDriver consolidation. No CLI or behavior change.

Follow-up to #1864 and #1739.

## Validation

- `pnpm check`
- `pnpm check:affected --run`
- planted red: omitting Limrun's viewport classification fails with TS2741
- full core gate: 922 files, 6,992 tests
- post-rebase affected gate: 548 files, 4,316 tests; changed-line coverage 1/1 (100%)
- exact-head GitHub lanes passed before merge

## Accounting

- source: 19 lines added, 53 removed (net -34)
- packaged: raw JS -750 B, gzip JS -91 B, npm tarball -120 B, unpacked -750 B
