### PR TITLE
refactor(daemon): one capture-input builder and one admit-then-bind step

### DIFF
--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -19,7 +19,7 @@ import { interactionCliOutputFormatters } from '../../src/commands/interaction/o
 import { snapshotCliOutput } from '../../src/commands/capture/output.ts';
 import { openCliOutput } from '../../src/commands/management/output.ts';
 import { NEVER_SETTLED_HINT } from '../../src/commands/interaction/runtime/settle.ts';
-import { buildAmbiguousMatchError } from '../../src/daemon/handlers/find.ts';
+import { buildAmbiguousMatchError } from '../../src/daemon/handlers/find-match-resolution.ts';
 import { refMutationAdmissionResponse } from '../../src/daemon/handlers/interaction-ref-policy.ts';
 import { buildDeviceInUseBySessionError } from '../../src/daemon/handlers/session-open.ts';
 import { buildDeviceClaimConflictError } from '../../src/daemon/device-claim-conflict.ts';

--- a/src/daemon/handlers/find-match-resolution.ts
+++ b/src/daemon/handlers/find-match-resolution.ts
@@ -1,0 +1,189 @@
+import {
+  findBestMatchesByLocator,
+  type FindLocator,
+  type SelectorResolutionPolicy,
+} from '@agent-device/selectors';
+import { listSelectorPipelineMatches } from '../../core/selector-pipeline.ts';
+import { SELECTOR_PIPELINE_POLICIES } from '../../core/selector-pipeline-policy.ts';
+import { centerOfRect, type SnapshotState } from '@agent-device/kernel/snapshot';
+import {
+  isRootInteractionContainer,
+  resolveActionableTouchResolution,
+} from '../../core/interaction-targeting.ts';
+import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
+import type { ElementMatchCandidateDetails } from '../../utils/error-candidates.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import { errorResponse } from './response.ts';
+
+export type FindMatchResult =
+  | { ok: true; node: SnapshotState['nodes'][number] }
+  | { ok: false; response: DaemonResponse };
+
+function assertRejectsCandidates(policy: SelectorResolutionPolicy): void {
+  if (policy.ambiguity !== 'reject-candidates') {
+    throw new Error(`find's resolution policy must reject candidates, got "${policy.ambiguity}"`);
+  }
+}
+
+export function resolveFindMatch(params: {
+  nodes: SnapshotState['nodes'];
+  locator: FindLocator;
+  query: string;
+  selectorExpression: string | null;
+  flags: DaemonRequest['flags'];
+  platform: SessionState['device']['platform'];
+}): FindMatchResult {
+  const { nodes, locator, query, selectorExpression, flags, platform } = params;
+  const pipeline = SELECTOR_PIPELINE_POLICIES.findAct;
+  const rooted = nodes.filter((node) => !isRootInteractionContainer(node, nodes[0]));
+  // #1625: selector-shaped and text-shaped queries share ONE ambiguity
+  // contract — multiple matches reject with candidates unless --first/--last
+  // explicitly opts into positional narrowing. Selectors used to take the
+  // first match silently, which was exactly the mis-binding path the error's
+  // own recovery advice ("use a selector") pointed agents at.
+  const policy = pipeline.resolution;
+  let matches: SnapshotState['nodes'];
+  if (selectorExpression) {
+    // The `reject-candidates` door: the row's candidacy stage runs inside, and
+    // the whole candidate set comes back for find to rank and narrow.
+    matches =
+      listSelectorPipelineMatches(pipeline, rooted, selectorExpression, { platform }).list
+        ?.matchedNodes ?? [];
+  } else {
+    // Fuzzy text scoring, not a selector chain: this branch brings its own
+    // matcher and reads the row's rect requirement. The row still governs the
+    // target it produces — occlusion and promotion run on it below, in the
+    // same node stages the selector branch reaches.
+    matches = findBestMatchesByLocator(rooted, locator, query, {
+      requireRect: policy.requireRect,
+    }).matches;
+  }
+  matches = preferOnscreenMatches(matches, nodes);
+
+  if (matches.length > 1) {
+    // The row says candidates reject unless the caller narrowed explicitly;
+    // assert that rather than assuming, so a future row edit cannot silently
+    // turn this into first-match.
+    assertRejectsCandidates(policy);
+    const narrowed = narrowMultipleMatches(matches, flags);
+    if (!narrowed) {
+      return { ok: false, response: buildAmbiguousMatchError(matches, locator, query) };
+    }
+    matches = narrowed;
+  }
+
+  const node = matches[0] ?? null;
+  if (!node) {
+    return {
+      ok: false,
+      response: errorResponse('COMMAND_FAILED', 'find did not match any element'),
+    };
+  }
+  return { ok: true, node };
+}
+
+function narrowMultipleMatches(
+  matches: SnapshotState['nodes'],
+  flags: DaemonRequest['flags'],
+): SnapshotState['nodes'] | null {
+  if (flags?.findFirst) return [matches[0]!];
+  if (flags?.findLast) return [matches[matches.length - 1]!];
+  return null;
+}
+
+function preferOnscreenMatches(
+  matches: SnapshotState['nodes'],
+  nodes: SnapshotState['nodes'],
+): SnapshotState['nodes'] {
+  const viewport = nodes[0]?.rect;
+  if (!viewport) return matches;
+  const onscreen = matches.filter((node) => {
+    if (!node.rect) return false;
+    const center = centerOfRect(node.rect);
+    return (
+      center.x >= viewport.x &&
+      center.x <= viewport.x + viewport.width &&
+      center.y >= viewport.y &&
+      center.y <= viewport.y + viewport.height
+    );
+  });
+  return rankInteractiveMatches(onscreen.length > 0 ? onscreen : matches, nodes);
+}
+
+function rankInteractiveMatches(
+  matches: SnapshotState['nodes'],
+  nodes: SnapshotState['nodes'],
+): SnapshotState['nodes'] {
+  if (matches.length < 2) return matches;
+  return matches
+    .map((node, index) => ({ node, index, score: interactiveMatchScore(node, nodes) }))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return rectArea(left.node) - rectArea(right.node) || left.index - right.index;
+    })
+    .map((entry) => entry.node);
+}
+
+function interactiveMatchScore(
+  node: SnapshotState['nodes'][number],
+  nodes: SnapshotState['nodes'],
+): number {
+  const resolution = resolveActionableTouchResolution(nodes, node);
+  if (resolution.reason === 'covered') return 0;
+  const resolved = resolvedTouchScore(resolution, nodes[0]);
+  if (resolved > 0) return resolved;
+  if (node.hittable && node.rect && !isRootInteractionContainer(node, nodes[0])) return 3;
+  return node.rect ? 1 : 0;
+}
+
+function resolvedTouchScore(
+  resolution: ReturnType<typeof resolveActionableTouchResolution>,
+  root: SnapshotState['nodes'][number] | undefined,
+): number {
+  if (!resolution.node.rect) return 0;
+  if (resolution.reason === 'semantic-target' || resolution.reason === 'same-rect-descendant') {
+    return 4;
+  }
+  if (
+    resolution.reason === 'hittable-ancestor' &&
+    !isRootInteractionContainer(resolution.node, root)
+  ) {
+    return 2;
+  }
+  return 0;
+}
+
+function rectArea(node: SnapshotState['nodes'][number]): number {
+  return node.rect ? node.rect.width * node.rect.height : Number.POSITIVE_INFINITY;
+}
+// #1597: an agent reading an ambiguous-match error must be able to act on the
+// right @ref immediately, without a follow-up snapshot round trip. Candidate
+// lines reuse the exact snapshot-line renderer (`formatSnapshotLine`) so a
+// candidate reads identically to its row in `snapshot -i` output: ref, role,
+// label/identifier. Capped at AMBIGUOUS_MATCH_CANDIDATE_LIMIT to bound the
+// error payload — `matches` (the true total) is what a "+N more" marker is
+// computed from at render time (src/utils/error-candidates.ts).
+// Module-local: no consumer outside this file needs the raw cap, only the
+// already-capped `candidates` array on the response.
+const AMBIGUOUS_MATCH_CANDIDATE_LIMIT = 5;
+
+// Exported as the single AMBIGUOUS_MATCH producer so the help-benchmark
+// sample parity test renders the exact error this handler returns; a message
+// change here fails that gate instead of drifting past it.
+export function buildAmbiguousMatchError(
+  matches: SnapshotState['nodes'],
+  locator: FindLocator,
+  query: string,
+): DaemonResponse {
+  const candidateDetails: ElementMatchCandidateDetails = {
+    matches: matches.length,
+    candidates: matches
+      .slice(0, AMBIGUOUS_MATCH_CANDIDATE_LIMIT)
+      .map((candidate) => formatSnapshotLine(candidate, 0, false)),
+  };
+  return errorResponse(
+    'AMBIGUOUS_MATCH',
+    `find matched ${matches.length} elements for ${locator} "${query}". Use a more specific locator or selector.`,
+    { locator, query, ...candidateDetails },
+  );
+}

--- a/src/daemon/handlers/find-target-capture.ts
+++ b/src/daemon/handlers/find-target-capture.ts
@@ -1,0 +1,77 @@
+import type { FindLocator } from '@agent-device/selectors';
+import type { SnapshotQualityVerdict, SnapshotState } from '@agent-device/kernel/snapshot';
+import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
+import { SessionStore } from '../session-store.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import { errorResponse } from './response.ts';
+
+/** The tree a mutating find resolves its target against, plus what the capture disclosed. */
+export type FindTargetTree = {
+  nodes: SnapshotState['nodes'];
+  snapshotQuality?: SnapshotQualityVerdict;
+  systemSurfaceOnly?: boolean;
+};
+
+/**
+ * Find's target capture. A mutating find (click/fill/focus/type) resolves its target from its
+ * own capture rather than the read-only selector runtime's, with find's two sparse-recovery
+ * policies and none of the selector read cache tiers — one question, kept out of the route.
+ */
+export function createFindTargetCapture(
+  params: Readonly<{
+    device: SessionState['device'];
+    session: SessionState;
+    req: DaemonRequest;
+    logPath: string;
+    locator: FindLocator;
+    query: string;
+    sessionStore: SessionStore;
+    sessionName: string;
+  }>,
+): () => Promise<FindTargetTree> {
+  const { device, session, req, logPath, locator, query, sessionStore, sessionName } = params;
+  const captureRuntime = createSelectorCaptureRuntime({
+    device,
+    session,
+    sessionStore,
+    sessionName,
+    req,
+    logPath,
+  });
+  return async () => {
+    // Interaction targets need the full interactive tree so duplicate labels can
+    // be resolved against viewport visibility before an off-screen subtree wins.
+    const { snapshot } = await captureRuntime.capture({
+      flags: {
+        ...req.flags,
+        snapshotInteractiveOnly: true,
+      },
+      recovery: {
+        legacyIosSparse: {
+          query,
+          shouldScope: shouldScopeFind(locator),
+        },
+        sparseVerdictQueryScope: {
+          query,
+          shouldScope: shouldScopeFind(locator),
+        },
+      },
+    });
+    return {
+      nodes: snapshot.nodes,
+      snapshotQuality: snapshot.snapshotQuality,
+      systemSurfaceOnly: snapshot.systemSurfaceOnly,
+    };
+  };
+}
+
+export function sparseFindSnapshotResponse(verdict: SnapshotQualityVerdict): DaemonResponse {
+  return errorResponse('COMMAND_FAILED', 'find could not read the current accessibility tree', {
+    reason: verdict.reason,
+    hint: 'The snapshot quality verdict is sparse. Use screenshot as visual truth, navigate with coordinates if needed, then retry find after reaching a readable screen.',
+  });
+}
+
+function shouldScopeFind(locator: FindLocator): boolean {
+  return locator !== 'role';
+}

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -1,47 +1,27 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
 import type { PreresolvedInteractionTarget } from '@agent-device/contracts/interaction';
 import {
-  findBestMatchesByLocator,
   isReadOnlyFindAction,
   checkFindArgs,
   parseFindSelectorExpression,
   type FindLocator,
-  type SelectorResolutionPolicy,
 } from '@agent-device/selectors';
-import {
-  listSelectorPipelineMatches,
-  runNodePipelineStages,
-} from '../../core/selector-pipeline.ts';
+import { runNodePipelineStages } from '../../core/selector-pipeline.ts';
 import { SELECTOR_PIPELINE_POLICIES } from '../../core/selector-pipeline-policy.ts';
-import {
-  centerOfRect,
-  type SnapshotQualityVerdict,
-  type SnapshotState,
-} from '@agent-device/kernel/snapshot';
+import { centerOfRect, type SnapshotState } from '@agent-device/kernel/snapshot';
 import { expireRefFrame } from '../ref-frame.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
-import {
-  isRootInteractionContainer,
-  resolveActionableTouchResolution,
-} from '../../core/interaction-targeting.ts';
-import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
-import type { ElementMatchCandidateDetails } from '../../utils/error-candidates.ts';
 import { readCommandMessage, successText } from '../../utils/success-text.ts';
 import { errorResponse, noActiveSessionError } from './response.ts';
 import { withSystemSurfaceDisclosure } from './system-surface-disclosure.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
+import { resolveFindMatch } from './find-match-resolution.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
-import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
+import { createFindTargetCapture, sparseFindSnapshotResponse } from './find-target-capture.ts';
 import { isSparseSnapshotQualityVerdict } from '../../snapshot-quality/verdict.ts';
-
-function assertRejectsCandidates(policy: SelectorResolutionPolicy): void {
-  if (policy.ambiguity !== 'reject-candidates') {
-    throw new Error(`find's resolution policy must reject candidates, got "${policy.ambiguity}"`);
-  }
-}
 
 type FindContext = {
   req: DaemonRequest;
@@ -70,10 +50,6 @@ type ResolvedMatch = {
    */
   occludedNode?: SnapshotState['nodes'][number];
 };
-
-type FindMatchResult =
-  | { ok: true; node: SnapshotState['nodes'][number] }
-  | { ok: false; response: DaemonResponse };
 
 export async function handleFindCommands(params: {
   req: DaemonRequest;
@@ -116,7 +92,7 @@ export async function handleFindCommands(params: {
   if (!session) return noActiveSessionError();
   const device = session.device;
   const selectorExpression = parseFindSelectorExpression(locator, query);
-  const fetchNodes = createFindNodeFetcher({
+  const readTargetTree = createFindTargetCapture({
     device,
     session,
     req,
@@ -141,7 +117,7 @@ export async function handleFindCommands(params: {
     publicFlags: publicFindFlags(req.flags),
   };
 
-  const snapshotResult = await fetchNodes();
+  const snapshotResult = await readTargetTree();
   if (isSparseSnapshotQualityVerdict(snapshotResult.snapshotQuality)) {
     return sparseFindSnapshotResponse(snapshotResult.snapshotQuality);
   }
@@ -200,200 +176,6 @@ async function dispatchFindAction(
 }
 
 // --- Per-action handlers ---
-
-type FindSnapshotResult = {
-  nodes: SnapshotState['nodes'];
-  snapshotQuality?: SnapshotQualityVerdict;
-  systemSurfaceOnly?: boolean;
-};
-
-type FindNodeFetcher = () => Promise<FindSnapshotResult>;
-
-function createFindNodeFetcher(params: {
-  device: SessionState['device'];
-  session: SessionState;
-  req: DaemonRequest;
-  logPath: string;
-  locator: FindLocator;
-  query: string;
-  sessionStore: SessionStore;
-  sessionName: string;
-}): FindNodeFetcher {
-  const { device, session, req, logPath, locator, query } = params;
-  const { sessionStore, sessionName } = params;
-  const captureRuntime = createSelectorCaptureRuntime({
-    device,
-    session,
-    sessionStore,
-    sessionName,
-    req,
-    logPath,
-  });
-  return async () => {
-    // Interaction targets need the full interactive tree so duplicate labels can
-    // be resolved against viewport visibility before an off-screen subtree wins.
-    const { snapshot } = await captureRuntime.capture({
-      flags: {
-        ...req.flags,
-        snapshotInteractiveOnly: true,
-      },
-      recovery: {
-        legacyIosSparse: {
-          query,
-          shouldScope: shouldScopeFind(locator),
-        },
-        sparseVerdictQueryScope: {
-          query,
-          shouldScope: shouldScopeFind(locator),
-        },
-      },
-    });
-    return {
-      nodes: snapshot.nodes,
-      snapshotQuality: snapshot.snapshotQuality,
-      systemSurfaceOnly: snapshot.systemSurfaceOnly,
-    };
-  };
-}
-
-function sparseFindSnapshotResponse(verdict: SnapshotQualityVerdict): DaemonResponse {
-  return errorResponse('COMMAND_FAILED', 'find could not read the current accessibility tree', {
-    reason: verdict.reason,
-    hint: 'The snapshot quality verdict is sparse. Use screenshot as visual truth, navigate with coordinates if needed, then retry find after reaching a readable screen.',
-  });
-}
-
-function resolveFindMatch(params: {
-  nodes: SnapshotState['nodes'];
-  locator: FindLocator;
-  query: string;
-  selectorExpression: string | null;
-  flags: DaemonRequest['flags'];
-  platform: SessionState['device']['platform'];
-}): FindMatchResult {
-  const { nodes, locator, query, selectorExpression, flags, platform } = params;
-  const pipeline = SELECTOR_PIPELINE_POLICIES.findAct;
-  const rooted = nodes.filter((node) => !isRootInteractionContainer(node, nodes[0]));
-  // #1625: selector-shaped and text-shaped queries share ONE ambiguity
-  // contract — multiple matches reject with candidates unless --first/--last
-  // explicitly opts into positional narrowing. Selectors used to take the
-  // first match silently, which was exactly the mis-binding path the error's
-  // own recovery advice ("use a selector") pointed agents at.
-  const policy = pipeline.resolution;
-  let matches: SnapshotState['nodes'];
-  if (selectorExpression) {
-    // The `reject-candidates` door: the row's candidacy stage runs inside, and
-    // the whole candidate set comes back for find to rank and narrow.
-    matches =
-      listSelectorPipelineMatches(pipeline, rooted, selectorExpression, { platform }).list
-        ?.matchedNodes ?? [];
-  } else {
-    // Fuzzy text scoring, not a selector chain: this branch brings its own
-    // matcher and reads the row's rect requirement. The row still governs the
-    // target it produces — occlusion and promotion run on it below, in the
-    // same node stages the selector branch reaches.
-    matches = findBestMatchesByLocator(rooted, locator, query, {
-      requireRect: policy.requireRect,
-    }).matches;
-  }
-  matches = preferOnscreenMatches(matches, nodes);
-
-  if (matches.length > 1) {
-    // The row says candidates reject unless the caller narrowed explicitly;
-    // assert that rather than assuming, so a future row edit cannot silently
-    // turn this into first-match.
-    assertRejectsCandidates(policy);
-    const narrowed = narrowMultipleMatches(matches, flags);
-    if (!narrowed) {
-      return { ok: false, response: buildAmbiguousMatchError(matches, locator, query) };
-    }
-    matches = narrowed;
-  }
-
-  const node = matches[0] ?? null;
-  if (!node) {
-    return {
-      ok: false,
-      response: errorResponse('COMMAND_FAILED', 'find did not match any element'),
-    };
-  }
-  return { ok: true, node };
-}
-
-function narrowMultipleMatches(
-  matches: SnapshotState['nodes'],
-  flags: DaemonRequest['flags'],
-): SnapshotState['nodes'] | null {
-  if (flags?.findFirst) return [matches[0]!];
-  if (flags?.findLast) return [matches[matches.length - 1]!];
-  return null;
-}
-
-function preferOnscreenMatches(
-  matches: SnapshotState['nodes'],
-  nodes: SnapshotState['nodes'],
-): SnapshotState['nodes'] {
-  const viewport = nodes[0]?.rect;
-  if (!viewport) return matches;
-  const onscreen = matches.filter((node) => {
-    if (!node.rect) return false;
-    const center = centerOfRect(node.rect);
-    return (
-      center.x >= viewport.x &&
-      center.x <= viewport.x + viewport.width &&
-      center.y >= viewport.y &&
-      center.y <= viewport.y + viewport.height
-    );
-  });
-  return rankInteractiveMatches(onscreen.length > 0 ? onscreen : matches, nodes);
-}
-
-function rankInteractiveMatches(
-  matches: SnapshotState['nodes'],
-  nodes: SnapshotState['nodes'],
-): SnapshotState['nodes'] {
-  if (matches.length < 2) return matches;
-  return matches
-    .map((node, index) => ({ node, index, score: interactiveMatchScore(node, nodes) }))
-    .sort((left, right) => {
-      if (right.score !== left.score) return right.score - left.score;
-      return rectArea(left.node) - rectArea(right.node) || left.index - right.index;
-    })
-    .map((entry) => entry.node);
-}
-
-function interactiveMatchScore(
-  node: SnapshotState['nodes'][number],
-  nodes: SnapshotState['nodes'],
-): number {
-  const resolution = resolveActionableTouchResolution(nodes, node);
-  if (resolution.reason === 'covered') return 0;
-  const resolved = resolvedTouchScore(resolution, nodes[0]);
-  if (resolved > 0) return resolved;
-  if (node.hittable && node.rect && !isRootInteractionContainer(node, nodes[0])) return 3;
-  return node.rect ? 1 : 0;
-}
-
-function resolvedTouchScore(
-  resolution: ReturnType<typeof resolveActionableTouchResolution>,
-  root: SnapshotState['nodes'][number] | undefined,
-): number {
-  if (!resolution.node.rect) return 0;
-  if (resolution.reason === 'semantic-target' || resolution.reason === 'same-rect-descendant') {
-    return 4;
-  }
-  if (
-    resolution.reason === 'hittable-ancestor' &&
-    !isRootInteractionContainer(resolution.node, root)
-  ) {
-    return 2;
-  }
-  return 0;
-}
-
-function rectArea(node: SnapshotState['nodes'][number]): number {
-  return node.rect ? node.rect.width * node.rect.height : Number.POSITIVE_INFINITY;
-}
 
 /**
  * #1654: hand the interaction leaf the node this find already resolved, so the
@@ -561,40 +343,4 @@ function recordFindAction(ctx: FindContext, match: ResolvedMatch, action: string
 
 function publicFindFlags(flags: DaemonRequest['flags']): Record<string, unknown> {
   return { ...(stripInternalInteractionFlags(flags) ?? {}) };
-}
-
-// #1597: an agent reading an ambiguous-match error must be able to act on the
-// right @ref immediately, without a follow-up snapshot round trip. Candidate
-// lines reuse the exact snapshot-line renderer (`formatSnapshotLine`) so a
-// candidate reads identically to its row in `snapshot -i` output: ref, role,
-// label/identifier. Capped at AMBIGUOUS_MATCH_CANDIDATE_LIMIT to bound the
-// error payload — `matches` (the true total) is what a "+N more" marker is
-// computed from at render time (src/utils/error-candidates.ts).
-// Module-local: no consumer outside this file needs the raw cap, only the
-// already-capped `candidates` array on the response.
-const AMBIGUOUS_MATCH_CANDIDATE_LIMIT = 5;
-
-// Exported as the single AMBIGUOUS_MATCH producer so the help-benchmark
-// sample parity test renders the exact error this handler returns; a message
-// change here fails that gate instead of drifting past it.
-export function buildAmbiguousMatchError(
-  matches: SnapshotState['nodes'],
-  locator: FindLocator,
-  query: string,
-): DaemonResponse {
-  const candidateDetails: ElementMatchCandidateDetails = {
-    matches: matches.length,
-    candidates: matches
-      .slice(0, AMBIGUOUS_MATCH_CANDIDATE_LIMIT)
-      .map((candidate) => formatSnapshotLine(candidate, 0, false)),
-  };
-  return errorResponse(
-    'AMBIGUOUS_MATCH',
-    `find matched ${matches.length} elements for ${locator} "${query}". Use a more specific locator or selector.`,
-    { locator, query, ...candidateDetails },
-  );
-}
-
-function shouldScopeFind(locator: FindLocator): boolean {
-  return locator !== 'role';
 }

--- a/src/daemon/snapshot-runtime-binding.ts
+++ b/src/daemon/snapshot-runtime-binding.ts
@@ -7,7 +7,7 @@ import {
   type SnapshotRuntimePlan,
 } from '@agent-device/contracts/platform';
 import { buildIosOpenCommandHint } from './ios-app-session-hint.ts';
-import { contextFromFlags } from './context.ts';
+import { buildRuntimeCaptureInput } from './snapshot-runtime-capture-input.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from './request-runtime-binding.ts';
 import { SessionStore } from './session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
@@ -41,20 +41,31 @@ type ResolvedSnapshotCaptureRuntime =
     }>
   | Readonly<{ ok: false; response: DaemonResponse }>;
 
-/** Resolves one plan, inspects its owner facts once, then returns one bound capture closure. */
-export async function resolveBoundSnapshotCaptureRuntime(
-  params: SnapshotRuntimeRouteParams,
-  command: 'snapshot' | 'diff',
-): Promise<ResolvedSnapshotCaptureRuntime> {
-  const { req, sessionName, sessionStore } = params;
-  const { session, device } = await resolveSessionDevice(sessionStore, sessionName, req.flags);
-  const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
-  if (!resolvedScope.ok) return { ok: false, response: resolvedScope };
+/** A capture operation parametrized by intent, so a polling caller can capture repeatedly
+ * under the one binding it was admitted for. */
+type BoundSnapshotCapture = (input: CaptureSnapshotInput) => Promise<SnapshotResult>;
 
-  const plan = resolveSnapshotRuntimePlan({
-    customActions: req.flags?.snapshotCustomActions === true,
-    hasActiveApp: session?.appBundleId !== undefined,
-  });
+type AdmittedSnapshotCapture =
+  | Readonly<{ ok: true; capture: BoundSnapshotCapture }>
+  | Readonly<{ ok: false; response: DaemonResponse }>;
+
+/**
+ * The ONE admit-then-bind path for every request-bound snapshot capture (ADR 0019 §9):
+ * side-effect-free facts inspection, refusal before any binding, then exactly one bind on
+ * the admitted device. `snapshot`/`diff` supply the four-way custom-actions plan and the
+ * selector family the active-app plan; a new consumer supplies a plan and a command name.
+ */
+async function admitAndBindSnapshotCapture(
+  params: Readonly<{
+    command: string;
+    device: SessionState['device'];
+    session: SessionState | undefined;
+    plan: SnapshotRuntimePlan;
+    inspectFacts?: InspectDeviceRuntimeFacts;
+    bindDevice?: BindDeviceRuntime;
+  }>,
+): Promise<AdmittedSnapshotCapture> {
+  const { command, device, session, plan } = params;
   const admission = await admitRuntimePlan({ device, plan, inspectFacts: params.inspectFacts });
   if (!admission.admitted) {
     return {
@@ -68,15 +79,49 @@ export async function resolveBoundSnapshotCaptureRuntime(
       }),
     };
   }
-
   const runtime = await bindSnapshotCaptureRuntime(params.bindDevice, admission);
-  const captureInput = buildRuntimeCaptureInput(params, session, resolvedScope.scope);
+  return Object.freeze({
+    ok: true,
+    capture: async (input: CaptureSnapshotInput) => await runtime.captureSnapshot(input),
+  });
+}
+
+/** Resolves one plan, inspects its owner facts once, then returns one bound capture closure. */
+export async function resolveBoundSnapshotCaptureRuntime(
+  params: SnapshotRuntimeRouteParams,
+  command: 'snapshot' | 'diff',
+): Promise<ResolvedSnapshotCaptureRuntime> {
+  const { req, sessionName, sessionStore } = params;
+  const { session, device } = await resolveSessionDevice(sessionStore, sessionName, req.flags);
+  const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
+  if (!resolvedScope.ok) return { ok: false, response: resolvedScope };
+
+  const bound = await admitAndBindSnapshotCapture({
+    command,
+    device,
+    session,
+    plan: resolveSnapshotRuntimePlan({
+      customActions: req.flags?.snapshotCustomActions === true,
+      hasActiveApp: session?.appBundleId !== undefined,
+    }),
+    inspectFacts: params.inspectFacts,
+    bindDevice: params.bindDevice,
+  });
+  if (!bound.ok) return bound;
+
+  const captureInput = buildRuntimeCaptureInput({
+    flags: req.flags,
+    logPath: params.logPath,
+    meta: req.meta,
+    session,
+    snapshotScope: resolvedScope.scope,
+  });
   return Object.freeze({
     ok: true,
     session,
     device,
     snapshotScope: resolvedScope.scope,
-    captureSnapshot: async () => await runtime.captureSnapshot(captureInput),
+    captureSnapshot: async () => await bound.capture(captureInput),
   });
 }
 
@@ -145,7 +190,7 @@ type SnapshotPlanUnavailableParams = {
   fact: RuntimeOperationFact;
   session: SessionState | undefined;
   device: SessionState['device'];
-  command: 'snapshot' | 'diff';
+  command: string;
 };
 
 async function snapshotPlanUnavailableResponse(
@@ -186,46 +231,4 @@ function snapshotCustomActionsUnavailableResponse(
           : params.fact.hint,
     },
   );
-}
-
-function buildRuntimeCaptureInput(
-  params: Readonly<{ req: DaemonRequest; logPath: string }>,
-  session: SessionState | undefined,
-  snapshotScope: string | undefined,
-): CaptureSnapshotInput {
-  const { req, logPath } = params;
-  const flags = req.flags ?? {};
-  const { appBundleId, trace, surface } = session ?? {};
-  const { requestId } = req.meta ?? {};
-  const context = contextFromFlags(
-    logPath,
-    flags,
-    appBundleId,
-    trace?.outPath,
-    requestId,
-    req.meta,
-  );
-  return {
-    options: {
-      appBundleId,
-      interactiveOnly: flags.snapshotInteractiveOnly,
-      preferredBackend: flags.snapshotPreferredBackend,
-      depth: flags.snapshotDepth,
-      scope: snapshotScope,
-      raw: flags.snapshotRaw,
-      customActions: flags.snapshotCustomActions,
-      includeHiddenContentHints: flags.snapshotIncludeHiddenContentHints,
-      surface,
-    },
-    execution: {
-      requestId: context.requestId,
-      verbose: context.verbose,
-      logPath: context.logPath,
-      traceLogPath: context.traceLogPath,
-      iosXctestrunFile: context.iosXctestrunFile,
-      iosXctestDerivedDataPath: context.iosXctestDerivedDataPath,
-      iosXctestEnvDir: context.iosXctestEnvDir,
-      runnerLeaseContext: context.runnerLeaseContext,
-    },
-  };
 }

--- a/src/daemon/snapshot-runtime-capture-input.ts
+++ b/src/daemon/snapshot-runtime-capture-input.ts
@@ -1,0 +1,53 @@
+import type { CommandFlags } from '@agent-device/contracts/command';
+import type { CaptureSnapshotInput } from '@agent-device/contracts/platform';
+import { contextFromFlags } from './context.ts';
+import type { DaemonRequest, SessionState } from './types.ts';
+
+/**
+ * The one place a daemon request becomes neutral capture intent. `snapshot` and `diff` build
+ * theirs here; a repeated-capture consumer builds one per capture from its own effective flags
+ * and scope. One builder is what stops those shapes drifting on which flag reaches the platform.
+ */
+export function buildRuntimeCaptureInput(
+  params: Readonly<{
+    flags: CommandFlags | undefined;
+    logPath: string;
+    meta?: DaemonRequest['meta'];
+    session: SessionState | undefined;
+    snapshotScope: string | undefined;
+  }>,
+): CaptureSnapshotInput {
+  const { flags, logPath, meta, session, snapshotScope } = params;
+  const { appBundleId, trace, surface } = session ?? {};
+  const context = contextFromFlags(
+    logPath,
+    flags,
+    appBundleId,
+    trace?.outPath,
+    meta?.requestId,
+    meta,
+  );
+  return {
+    options: {
+      appBundleId,
+      interactiveOnly: flags?.snapshotInteractiveOnly,
+      preferredBackend: flags?.snapshotPreferredBackend,
+      depth: flags?.snapshotDepth,
+      scope: snapshotScope,
+      raw: flags?.snapshotRaw,
+      customActions: flags?.snapshotCustomActions,
+      includeHiddenContentHints: flags?.snapshotIncludeHiddenContentHints,
+      surface,
+    },
+    execution: {
+      requestId: context.requestId,
+      verbose: context.verbose,
+      logPath: context.logPath,
+      traceLogPath: context.traceLogPath,
+      iosXctestrunFile: context.iosXctestrunFile,
+      iosXctestDerivedDataPath: context.iosXctestDerivedDataPath,
+      iosXctestEnvDir: context.iosXctestEnvDir,
+      runnerLeaseContext: context.runnerLeaseContext,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Behaviour-neutral cleanup around the request-bound snapshot capture path. **No descriptor changes its platform execution, no contract surface is added, and no workspace package is touched** — the diff is five source files plus one test-helper import path. Three things:

- **One capture-input builder.** `buildRuntimeCaptureInput` moves out of `snapshot-runtime-binding.ts` into `snapshot-runtime-capture-input.ts` — the one place a daemon request becomes neutral `CaptureSnapshotInput`. Its parameter list is exactly what `snapshot`/`diff` pass; nothing speculative.
- **One named admit-then-bind step.** The snapshot/diff resolver's admission sequence — side-effect-free facts inspection, refusal before any binding, then exactly one bind on the device the admission was minted for — becomes `admitAndBindSnapshotCapture`, module-private. Same behaviour, one place.
- **`handlers/find.ts` splits, 600 → 346 lines.** It was already past the 300-line tripwire and answered three questions at once. The target-capture policy (interactive-only tree plus find's two sparse-recovery re-captures) and the match-resolution pipeline (locator/selector matching, on-screen preference, interactive ranking, the ambiguous-match error) move to focused modules. Pure refactor: identical behaviour, response shapes, capture path, and tests.

## Scope note

This PR was re-scoped twice under review, each time correctly:

1. It began as the **`find` cutover**. Declaring `find` `device-runtime` claims its whole platform-execution projection (ADR 0019 §6), while `find focus` and `find type` still reach the device through `dispatchCommand` — Wave 5 surfaces — and a third edge of the same class, `find <q> get text` → `dispatchCommand(device, 'read')`, is shared with `get`. `find` keeps `LEGACY_PLATFORM_EXECUTION`, its capability bucket, its `requireCommandSupported('find', …)` admission, and its `HARMONYOS_SUPPORTED_COMMANDS` / `WEB_QUERY_COMMANDS` entries. Rule id **R35 is withdrawn from the cutover table entirely** rather than left half-claimed, and stays reserved for find's real cutover.
2. It then carried the **selector capture seam**, and then **`CaptureSnapshotInput.signal`** with its exported `captureSnapshotSignal` helper and Apple/Linux composition. Both are now gone, removed for the same reason: ADR 0019 §10 prohibits a facet PR with no consuming command, and §6 admits an early behaviour-neutral substrate only when it is *dead-code clean*.

   On the signal contract specifically: an earlier revision of this body carried it with a caveat that no caller set the field. Review escalated that caveat to a blocker, and rightly — an unset contract field means production exercises only the `undefined` branch, and this PR could not carry a regression proving the per-poll abort and quiescence behaviour it claimed. **The field, the helper, and the Apple/Linux composition sites now land in #1875 (`wait`)**, whose `runWithinWaitDeadline` is the route that actually sets it and which owns the regression proving the deadline aborts an in-flight capture, waits for it to quiesce, and produces `capture-stalled` rather than `target-absent`. The selector capture seam went to **#1877 (`get`)** on the same principle. Both were handed over as reviewed patches with design notes.

What remains has live production consumers today and is dead-code clean: `check:production-exports` is unchanged from `main`.

## Validation

`pnpm check:affected --run` from a clean committed tree. Behaviour neutrality is carried by the existing suites rather than new assertions — `snapshot`, `diff`, and `find` keep their existing paths, and every touched command's test file is byte-identical to `main`, so they exercise the split `find` route unchanged. `pnpm check:layering` is green with the migrated-command list identical to `main`.

## Tradeoffs and known gaps

- Both extractions have a **single consumer today**. They are named steps, not deduplication — the second caller is the selector family, arriving with `get`. `admitAndBindSnapshotCapture` is deliberately module-private so this PR does not grow the export surface; `get`'s patch flips it to exported, a one-word change.
- Source size: root production TypeScript **+3,394 B**, workspace-package production TypeScript **+0 B**. Of the root figure, **+1,250 B** is the `find.ts` three-way split (module headers, imports, exports — the unavoidable cost of a split the tripwire required) and **+2,144 B** the two extractions, of which roughly 1.4 kB is the capture-input builder *moving* rather than new code. Packaged deltas: see the CI Size report on this head rather than a local comparison.
- No behaviour, CLI, help, or docs change, so nothing in `website/docs/**` or `skills/**` was touched.

Touched files: 6. Scope narrowed three times; it never expanded.
