### PR TITLE
fix: stabilize global flag declaration type

### DIFF
--- a/src/commands/cli-grammar/flag-groups.ts
+++ b/src/commands/cli-grammar/flag-groups.ts
@@ -96,7 +96,7 @@ export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
   'noRecord',
 );
 
-export const GLOBAL_FLAG_KEYS = new Set<FlagKey>([
+export const GLOBAL_FLAG_KEYS: ReadonlySet<FlagKey> = new Set([
   'json',
   'config',
   'help',


### PR DESCRIPTION
## Summary

Fixes #1871. `GLOBAL_FLAG_KEYS` now has an explicit `ReadonlySet<FlagKey>` declaration boundary, preventing TS2883 during declaration generation without changing runtime behavior.

Scope is limited to one file and did not expand beyond the CLI flag declaration.

## Validation

At exact head `272be87697265159d810d40b48f73e45bc9ec048`, the build no longer emits TS2883. `pnpm build` and `pnpm check:affected --run` passed locally; exact-head CI is authoritative and currently running.