### PR TITLE
fix(maestro): refresh targets after transient selector misses

### DIFF
--- a/packages/contracts/src/facades/interaction.ts
+++ b/packages/contracts/src/facades/interaction.ts
@@ -72,6 +72,7 @@ export {
   INTERACTION_GUARANTEES,
   INTERACTION_PATH_IDS,
 } from '../interaction-guarantees.ts';
+export { INTERACTION_ERROR_REASONS } from '../interaction-error.ts';
 export type {
   GuaranteeEnforcement,
   InteractionGuarantee,

--- a/packages/contracts/src/interaction-error.ts
+++ b/packages/contracts/src/interaction-error.ts
@@ -1,0 +1,4 @@
+/** Machine-readable `error.details.reason` values shared by interaction producers and adapters. */
+export const INTERACTION_ERROR_REASONS = {
+  selectorNotFound: 'selector_not_found',
+} as const;

--- a/packages/maestro/src/internal/support-matrix.ts
+++ b/packages/maestro/src/internal/support-matrix.ts
@@ -1,6 +1,6 @@
 export const MAESTRO_COMPAT_SUPPORTED_CAPABILITIES = [
   'Flows: launchApp; runFlow file/inline with platform, visibility, and limited boolean conditions; onFlowStart/onFlowComplete; repeat.times and retry.',
-  'Interactions: tapOn, doubleTapOn, longPressOn, inputText, eraseText, openLink, hideKeyboard, basic pressKey, and back; targets support index, childOf, label, points, and optional.',
+  'Interactions: tapOn, doubleTapOn, longPressOn, inputText on the focused element, eraseText, openLink, hideKeyboard, basic pressKey, and back; tap targets poll until available and support index, childOf, label, points, and optional.',
   'Assertions and navigation: assertVisible, assertNotVisible, extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
   'Scripts: ordered runScript file/env scripts with http.post, json, and output variables.',
 ] as const;

--- a/src/cli-schema/cli-help-command-usage.test.ts
+++ b/src/cli-schema/cli-help-command-usage.test.ts
@@ -240,6 +240,7 @@ test('command usage describes delayed typing flags', async () => {
   assert.match(typeHelp, /--delay-ms <ms>/);
   assert.match(fillHelp, /--delay-ms <ms>/);
   assert.match(fillHelp, /--record-as <VAR>/);
+  assert.match(fillHelp, /label="Email" editable=true/);
 });
 
 test('snapshot command usage documents diff alias', async () => {

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -103,6 +103,8 @@ test('usageForCommand resolves Maestro compatibility help topic', async () => {
   assert.match(help, /Supported subset:/);
   assert.match(help, /runFlow file\/inline/);
   assert.match(help, /tapOn, doubleTapOn, longPressOn/);
+  assert.match(help, /inputText on the focused element/);
+  assert.match(help, /tap targets poll until available/);
   assert.match(help, /Boundaries:/);
   assert.match(help, /iOS and Android only/);
   assert.match(help, /AD_VAR_\* overrides it/);
@@ -474,6 +476,8 @@ test('usageForCommand resolves manual QA help topic', async () => {
   assert.match(help, /A bare screenshot\/snapshot is not verification/);
   assert.match(help, /use fill <target> <text> --settle to replace/);
   assert.match(help, /use type only to append to an already-focused field/);
+  assert.match(help, /label="Email" editable=true/);
+  assert.match(help, /press 'label="Follow"' --settle/);
   assert.match(help, /Do not use placeholders such as @ref/);
   assert.match(help, /wait_target_absent: a readable capture ran and found no match/);
   assert.match(help, /wait_capture_stalled: no readable capture finished before the deadline/);

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -89,14 +89,14 @@ Command shapes:
   agent-device open https://example.com/deep-link
   agent-device snapshot -i
   agent-device press @e12 --settle
-  agent-device press 'label="Follow"'
+  agent-device press 'label="Follow"' --settle
   agent-device fill @e13 "qa@example.com" --settle
   agent-device wait text "Order placed" 3000
   agent-device close
   --relaunch forces fresh app state; a deep link/URL open does not need it. Labels with an apostrophe or quote (label="Don't leave") are shell-quoting hazards: prefer the @ref from the latest snapshot/settle output over quoting the literal label.
 
 Targets:
-  Prefer refs from the latest snapshot -i or settled diff. Use durable selectors when the label/id is known: label="Search", id="submit", role=button label="Follow".
+  Prefer refs from the latest snapshot -i or settled diff. Use durable selectors when the label/id is known: label="Search", id="submit", role=button label="Follow". If label text matches both a field and its caption, target the field with label="Email" editable=true.
   For text fields, use fill <target> <text> --settle to replace the field value; use type only to append to an already-focused field.
   Do not use placeholders such as @ref, @eN, <button>, or <selector> in a final command plan. If the ref is unknown, first run snapshot -i.
   Coordinates are fallback-only after refs/selectors fail or accessibility omits the target; use screenshot or snapshot -i --json to choose a visible center point.

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -248,6 +248,8 @@ const fillCommandFacet = defineCommandFacet({
   name: 'fill',
   text: {
     summary: 'Replace text in a UI input',
+    cliDetail:
+      'When visible label text also matches a non-input element, constrain the target with editable=true, for example fill \'label="Email" editable=true\' "qa@example.com".',
   },
   metadata: metadata('fill'),
   definition: fillCommandDefinition,

--- a/src/commands/interaction/runtime/resolution.test.ts
+++ b/src/commands/interaction/runtime/resolution.test.ts
@@ -10,6 +10,7 @@ import {
 import { resolveRecordedTarget } from '@agent-device/selectors';
 import { makeSnapshotState } from '../../../__tests__/test-utils/index.ts';
 import type { Point } from '@agent-device/kernel/snapshot';
+import { INTERACTION_ERROR_REASONS } from '@agent-device/contracts/interaction';
 import {
   clickRefE2,
   coveredByTabBarSnapshot,
@@ -85,6 +86,21 @@ test('runtime selector interactions fall back to a full snapshot when interactiv
     { interactiveOnly: true, includeRects: true },
     { interactiveOnly: false, includeRects: true },
   ]);
+});
+
+test('runtime selector misses carry a structured reason for retrying adapters', async () => {
+  const device = createInteractionDevice(makeSnapshotState([]));
+
+  await assert.rejects(
+    () => device.interactions.press(selector('id="profile-button"'), { session: 'default' }),
+    (error: unknown) => {
+      assert.equal(
+        (error as { details?: Record<string, unknown> }).details?.reason,
+        INTERACTION_ERROR_REASONS.selectorNotFound,
+      );
+      return true;
+    },
+  );
 });
 
 test('runtime press refuses a selector that resolves to an off-screen element', async () => {

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -48,6 +48,7 @@ import type {
   ResolutionDisclosure,
   ResolvedInteractionTarget,
 } from '@agent-device/contracts/interaction';
+import { INTERACTION_ERROR_REASONS } from '@agent-device/contracts/interaction';
 import type {
   BackendActionResult,
   BackendCommandContext,
@@ -437,7 +438,10 @@ async function selectorInteractionFailure(params: {
   return new AppError(
     'COMMAND_FAILED',
     formatSelectorFailure(selectorExpression, diagnostics, { unique: true }),
-    { hint: selectorFailureHint(diagnostics) },
+    {
+      reason: INTERACTION_ERROR_REASONS.selectorNotFound,
+      hint: selectorFailureHint(diagnostics),
+    },
   );
 }
 

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -28,6 +28,7 @@ import type {
   ResolvedTarget,
   SelectorTarget,
 } from '@agent-device/contracts/interaction';
+import { INTERACTION_ERROR_REASONS } from '@agent-device/contracts/interaction';
 import type { RuntimeCommand } from '../../runtime-types.ts';
 import { assertExpectedResolvedTarget, type ExpectedResolvedTarget } from './resolution.ts';
 import {
@@ -346,7 +347,7 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
       formatSelectorFailure(selectorExpression, [], { unique: true }),
       {
         command: 'is',
-        reason: 'selector_not_found',
+        reason: INTERACTION_ERROR_REASONS.selectorNotFound,
         predicate: predicate,
         selector: selectorExpression,
         hint: selectorFailureHint([]),

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-selector-fallback.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-selector-fallback.test.ts
@@ -1,0 +1,93 @@
+import { INTERACTION_ERROR_REASONS } from '@agent-device/contracts/interaction';
+import type { DaemonError } from '@agent-device/kernel/errors';
+import { expect, test } from 'vitest';
+import type { DaemonRequest } from '../../../types.ts';
+import { createDaemonMaestroRuntimePort } from '../daemon-runtime-port.ts';
+import { makeBaseRequest, makeDependencies } from './daemon-runtime-port-fixtures.ts';
+
+function makeSelectorDispatchPort(firstClickError: DaemonError) {
+  const requests: DaemonRequest[] = [];
+  let snapshots = 0;
+  let clicks = 0;
+  const port = createDaemonMaestroRuntimePort({
+    baseReq: makeBaseRequest({ flags: { platform: 'ios', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      requests.push(request);
+      if (request.command === 'click') {
+        clicks += 1;
+        return clicks === 1 ? { ok: false, error: firstClickError } : { ok: true, data: {} };
+      }
+      snapshots += 1;
+      return {
+        ok: true,
+        data: {
+          createdAt: snapshots,
+          nodes: [
+            {
+              index: 0,
+              type: 'Application',
+              rect: { x: 0, y: 0, width: 402, height: 874 },
+            },
+            {
+              index: 1,
+              parentIndex: 0,
+              type: 'Button',
+              identifier: 'profile-button',
+              rect: { x: snapshots === 1 ? 20 : 160, y: 100, width: 120, height: 44 },
+            },
+          ],
+        },
+      };
+    },
+    dependencies: makeDependencies(),
+    platform: 'ios',
+  });
+  return { port, requests };
+}
+
+async function tapProfileButton(port: ReturnType<typeof makeSelectorDispatchPort>['port']) {
+  await port.execute({
+    command: {
+      kind: 'tapOn',
+      source: { line: 2 },
+      target: { space: 'target', selector: { id: 'profile-button' } },
+    },
+    generation: 0,
+    env: {},
+    invalidateObservation() {},
+  });
+}
+
+test('falls back to fresh Maestro resolution when nested selector resolution misses transiently', async () => {
+  const { port, requests } = makeSelectorDispatchPort({
+    code: 'COMMAND_FAILED',
+    message: 'Selector did not match: id="profile-button"',
+    details: { reason: INTERACTION_ERROR_REASONS.selectorNotFound },
+  });
+
+  await tapProfileButton(port);
+
+  expect(requests.map((request) => request.command)).toEqual([
+    'snapshot',
+    'click',
+    'snapshot',
+    'click',
+  ]);
+  expect(requests.filter(({ command }) => command === 'click').at(-1)?.positionals).toEqual([
+    '220',
+    '122',
+  ]);
+});
+
+test('does not fall back for an unrelated COMMAND_FAILED response', async () => {
+  const { port, requests } = makeSelectorDispatchPort({
+    code: 'COMMAND_FAILED',
+    message: 'Keyboard dispatch timed out.',
+  });
+
+  await expect(tapProfileButton(port)).rejects.toMatchObject({
+    code: 'COMMAND_FAILED',
+    message: 'Keyboard dispatch timed out.',
+  });
+  expect(requests.map((request) => request.command)).toEqual(['snapshot', 'click']);
+});

--- a/src/daemon/adapters/maestro/daemon-runtime-tap.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-tap.ts
@@ -1,4 +1,5 @@
 import { AppError, asAppError } from '@agent-device/kernel/errors';
+import { INTERACTION_ERROR_REASONS } from '@agent-device/contracts/interaction';
 import type { Rect } from '@agent-device/kernel/snapshot';
 import {
   MAESTRO_RUNTIME_ADAPTER_POLICY,
@@ -242,8 +243,13 @@ async function clickSelector(
 }
 
 function isAtomicSelectorFallbackError(error: unknown): boolean {
-  const code = asAppError(error).code;
-  return code === 'AMBIGUOUS_MATCH' || code === 'ELEMENT_NOT_FOUND' || code === 'ELEMENT_OFFSCREEN';
+  const appError = asAppError(error);
+  return (
+    appError.code === 'AMBIGUOUS_MATCH' ||
+    appError.code === 'ELEMENT_NOT_FOUND' ||
+    appError.code === 'ELEMENT_OFFSCREEN' ||
+    appError.details?.reason === INTERACTION_ERROR_REASONS.selectorNotFound
+  );
 }
 
 export async function clickMaestroTargetPoint(

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -71,7 +71,7 @@ agent-device test ./maestro-flows --maestro --platform android --artifacts-dir .
 Supported subset:
 
 - Flows: `launchApp`; `runFlow` file/inline with platform, visibility, and limited boolean conditions; `onFlowStart`/`onFlowComplete`; `repeat.times` and retry.
-- Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText`, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; targets support `index`, `childOf`, `label`, points, and `optional`.
+- Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText` on the focused element, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; tap targets poll until available and support `index`, `childOf`, `label`, points, and `optional`.
 - Assertions and navigation: `assertVisible`, `assertNotVisible`, `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
 - Scripts: ordered `runScript` file/env scripts with `http.post`, `json`, and `output` variables.
 


### PR DESCRIPTION
## Summary

Maestro tap targets now recover when atomic iOS selector dispatch races a changing accessibility tree and the nested public click reports a structured selector-not-found result.

Before, the adapter refreshed geometry for runner-native ELEMENT_NOT_FOUND, ELEMENT_OFFSCREEN, and AMBIGUOUS_MATCH errors, but missed the equivalent shared tree-resolution outcome because it arrived as generic COMMAND_FAILED text. The shared interaction boundary now carries the existing selector_not_found reason, and Maestro uses that typed reason to re-resolve against a fresh snapshot. Unrelated COMMAND_FAILED responses remain terminal.

Standalone command guidance now distinguishes settle/wait behavior, and text-entry help shows how to disambiguate a caption and input with:

    agent-device fill 'label="Email" editable=true' "qa@example.com" --settle

## Validation

A deterministic adapter regression reproduces the reported Selector did not match: id="profile-button" response, verifies a fresh snapshot and coordinate dispatch, and went red before the implementation change. A paired negative regression proves an unrelated COMMAND_FAILED response is not retried.

At commit 2b2ee58df, the required chained `pnpm check:affected --run` passed before push: 4,483 related tests, 100% changed-line and changed-branch coverage, Maestro conformance, provider integration, contracts, package verification, typecheck, lint, layering, and all other locally runnable selected checks.

This touches 13 files. Scope remains within the shared interaction error contract, Maestro tap adapter, regression tests, and matching CLI/website documentation.

Live iOS device/simulator reproduction against the reporters app was not available locally, so this PR remains draft. GitHub iOS smoke and conformance differential lanes are authoritative for the published head.