### PR TITLE
ci: bound the Linux apt install so a stalled mirror fails fast

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,10 +45,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Unbounded, this step could not fail — it could only stall. On 2026-08-19 a slow mirror
+      # held apt past the job's 30-minute budget on four main-branch runs and several unrelated
+      # PRs, which reported as a red check on branches that never ran a line of project code.
+      # Two bounds fix that: apt retries and times out each mirror request itself (a blip
+      # self-heals without a manual re-run), and `timeout-minutes` is the backstop for a mirror
+      # that drips bytes slowly enough to defeat the socket timeout. A healthy install takes
+      # about a minute, so six is generous.
       - name: Install Linux desktop dependencies
+        timeout-minutes: 6
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
+          set -euo pipefail
+          APT_OPTS=(
+            -o Acquire::Retries=2
+            -o Acquire::http::Timeout=15
+            -o Acquire::https::Timeout=15
+            # The runner's own unattended-upgrades timer holds the dpkg lock; wait, don't hang.
+            -o DPkg::Lock::Timeout=60
+          )
+          sudo apt-get update -qq "${APT_OPTS[@]}"
+          sudo apt-get install -y -qq "${APT_OPTS[@]}" \
             xvfb \
             xdotool \
             scrot \


### PR DESCRIPTION
## Problem

The `Install Linux desktop dependencies` step in `.github/workflows/linux.yml` had no bound of its own, so it could not fail — only stall.

On 2026-08-19, PR #1856 run [32268264207](https://github.com/callstack/agent-device/actions/runs/32268264207) was cancelled at this step on both attempts (30m24s each). Everything downstream — Setup toolchain, Start Xvfb and D-Bus, Run Linux replay smoke test — reported as skipped. In the same window, three Linux runs on unrelated branches (`agent/wave4-get`, `test/1781-b1-daemon-leak-oracle`, `claude/1832-c3-residues`) were stuck at the identical step and four main-branch runs were cancelled. Environmental, not branch-specific.

The result is a red check on branches that never executed a line of project code, and a 30-minute runner burn per attempt.

## Change

Two bounds, 18 lines, package list untouched:

- **`timeout-minutes: 6`** — a stall now surfaces as a named step failure in six minutes instead of a cancelled job at thirty, leaving the job 24 of its 30 minutes for the smoke test it exists to run. A healthy install takes about a minute.
- **apt options** — `Acquire::http[s]::Timeout=15` bounds a mirror that connects and then goes quiet, `Acquire::Retries=2` absorbs a transient blip, and `DPkg::Lock::Timeout=60` bounds the runner's own `unattended-upgrades` timer, which stalls identically and is a plausible alternate cause of the same symptom.

## Notes on what this deliberately does *not* do

An earlier draft added a bash retry loop with per-attempt `timeout` wrappers and an `archive.ubuntu.com` mirror fallback (~80 lines). Dropped: `Acquire::Retries` already retries inside apt, the `timeout` wrappers existed only to make the outer loop work during a stall, and the mirror fallback was ~25 lines of `sed` across two sources formats to salvage a job that now just fails clearly. It also can't be made unconditional — `archive.ubuntu.com` is slower from Azure-hosted runners.

Caching the apt packages or baking them into a prebuilt image would remove the network from the hot path entirely, but caching `.deb`s still needs `apt-get update` for dependency resolution, so only the image approach actually delivers that — and that's a CI-infrastructure change, not a hardening of this step. Worth a separate issue if stalls recur.

**Tradeoff:** a fast transient failure that apt's own retries miss now fails the job rather than self-healing, traded against carrying a bash retry loop in CI.

## Verification

Locally: YAML parses, `shellcheck -s bash` clean on the extracted script, and the `APT_OPTS` array verified to expand onto both apt calls with all 10 packages intact.

The 6-minute fast-fail can only be confirmed by a real run, since a stall depends on mirror conditions that aren't reproducible locally. This PR's own Linux job exercises the happy path.