### PR TITLE
docs: simplify AI SDK integration guide

### DIFF
--- a/website/docs/docs/ai-sdk.md
+++ b/website/docs/docs/ai-sdk.md
@@ -12,7 +12,7 @@ pnpm add agent-device ai
 
 Make an iOS simulator or device [available to agent-device](/docs/agent-setup), then configure an AI SDK model. String model IDs use AI Gateway by default:
 
-```env
+```dotenv
 AI_GATEWAY_API_KEY=your_api_key
 AI_MODEL=provider/model
 ```

--- a/website/docs/docs/ai-sdk.md
+++ b/website/docs/docs/ai-sdk.md
@@ -4,49 +4,7 @@ title: AI SDK
 
 # AI SDK
 
-[Vercel's AI SDK](https://ai-sdk.dev/) can drive `agent-device` three ways, in increasing order of setup: point `@ai-sdk/mcp` at the MCP server with no hand-written code, build a typed tool set in-process with `agent-device/ai-sdk`, or hand-write individual tools for full control over the surface.
-
-## Zero-code: the MCP server
-
-`agent-device mcp` starts the same [MCP server](/docs/agent-setup#mcp-server) documented for Claude Code, Cursor, and other MCP clients — every installed command, as a structured tool, over the same execution path as the CLI. [`@ai-sdk/mcp`](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools)'s `createMCPClient()` connects to it and converts its tools into AI SDK tools directly, so there is no `agent-device` import at all:
-
-```bash
-pnpm add ai @ai-sdk/mcp
-```
-
-```ts
-import { createMCPClient } from '@ai-sdk/mcp';
-import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
-import { ToolLoopAgent } from 'ai';
-
-const mcpClient = await createMCPClient({
-  transport: new Experimental_StdioMCPTransport({
-    command: 'npx',
-    args: ['agent-device', 'mcp'],
-  }),
-});
-
-try {
-  const agent = new ToolLoopAgent({
-    model: process.env.AI_MODEL!,
-    tools: await mcpClient.tools(),
-  });
-
-  const result = await agent.generate({
-    prompt: 'Open com.example.app on iOS, navigate to Notifications, and verify notifications are enabled.',
-  });
-
-  console.log(result.text);
-} finally {
-  await mcpClient.close();
-}
-```
-
-This hands the model every command `agent-device mcp` exposes — dozens of tools, spanning device management and observability as well as interaction. For a smaller, curated default, use `agent-device/ai-sdk` below instead.
-
-## `agent-device/ai-sdk`: a typed tool set in-process
-
-`createAgentDeviceTools()` builds AI SDK tools from the same command registry the MCP server uses, in-process (no subprocess), pinned to one named session:
+Use `agent-device/ai-sdk` to give an [AI SDK](https://ai-sdk.dev/) agent a typed set of tools for navigating and inspecting an app. The tools run in-process, share one named session, and default to the focused perceive-and-act surface most agents need.
 
 ```bash
 pnpm add agent-device ai
@@ -56,23 +14,23 @@ pnpm add agent-device ai
 import { ToolLoopAgent } from 'ai';
 import { createAgentDeviceTools } from 'agent-device/ai-sdk';
 
-const { tools, client, toolApproval } = await createAgentDeviceTools({
+const { tools, client } = await createAgentDeviceTools({
   session: 'ai-sdk-agent',
   platform: 'ios',
-  approval: { close: 'user-approval' },
 });
 
 const agent = new ToolLoopAgent({
   model: process.env.AI_MODEL!,
   tools,
-  toolApproval,
 });
 
 try {
-  await client.apps.open({ app: 'com.example.app', platform: 'ios' });
-
   const result = await agent.generate({
-    prompt: 'Navigate to Notifications and verify that notifications are enabled.',
+    prompt: [
+      'Open Settings on the iOS device.',
+      'Navigate to Calendar notifications.',
+      'Report whether Allow Notifications is enabled.',
+    ].join(' '),
   });
 
   console.log(result.text);
@@ -81,73 +39,13 @@ try {
 }
 ```
 
-`set: 'core'` (the default) exposes the perceive/act loop most agents need — open, close, snapshot, click, press, fill, type, get, is, find, wait, back, scroll, swipe, alert, screenshot; pass `set: 'all'` for every command the MCP server exposes, matching the zero-code path above. `approval` maps command names to an [AI SDK tool approval status](https://ai-sdk.dev/docs/agents/tool-approvals) and is returned as `toolApproval`, ready to pass straight to `ToolLoopAgent`.
+Set `AI_MODEL` to a model available through your configured AI SDK provider. The agent sees the available device tools and chooses the calls needed to complete the prompt. The returned `client` targets the same session; keep cleanup in `finally` so the device is released even if generation fails.
 
-## Hand-written tools
+## Options
 
-Write tools by hand when you want a surface smaller than `core`, or application-specific input validation and result shaping. The example below gives the model two deliberately small tools: one for observing the current UI and one for pressing an element returned by that observation.
+`set: 'core'` is the default. It exposes the perceive-and-act loop: open, close, snapshot, click, press, fill, type, get, is, find, wait, back, scroll, swipe, alert, and screenshot.
 
-```bash
-pnpm add agent-device ai zod
-```
+- Pass `set: 'all'` when the agent also needs device-management or observability commands.
+- Pass `approval: { close: 'user-approval' }` to require approval for a command. `createAgentDeviceTools()` returns the map as `toolApproval`, ready to pass to [`ToolLoopAgent`](https://ai-sdk.dev/docs/agents/tool-approvals).
 
-```ts
-import { ToolLoopAgent, tool } from 'ai';
-import { createAgentDeviceClient } from 'agent-device';
-import { z } from 'zod';
-
-const client = createAgentDeviceClient({
-  session: 'ai-sdk-agent',
-  lockPolicy: 'reject',
-});
-
-const agent = new ToolLoopAgent({
-  model: process.env.AI_MODEL!,
-  instructions: [
-    'Inspect the current UI before acting.',
-    'Only press an element ref returned by the latest snapshot.',
-    'Stop and explain when the requested state cannot be verified.',
-  ].join('\n'),
-  tools: {
-    snapshot: tool({
-      description: 'Return the interactive elements in the current device UI.',
-      inputSchema: z.object({}),
-      execute: async () => await client.capture.snapshot({ interactiveOnly: true }),
-    }),
-    press: tool({
-      description: 'Press an element from the latest snapshot by its @e ref.',
-      inputSchema: z.object({
-        ref: z.string().regex(/^@e\d+$/),
-      }),
-      execute: async ({ ref }) => await client.interactions.press({ ref }),
-    }),
-  },
-});
-
-try {
-  await client.apps.open({
-    app: 'com.example.app',
-    platform: 'ios',
-  });
-
-  const result = await agent.generate({
-    prompt: 'Navigate to Notifications and verify that notifications are enabled.',
-  });
-
-  console.log(result.text);
-} finally {
-  await client.sessions.close();
-}
-```
-
-Set `AI_MODEL` to a model available through your configured AI SDK provider. See the AI SDK references for [`ToolLoopAgent`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent) and [`tool()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool).
-
-Guidance for hand-written tools:
-
-- Validate tool input with a schema. In particular, constrain element refs to values such as `@e12` and make the model observe before acting.
-- Keep the `agent-device` client outside tool execution so calls share one named session.
-- Return typed client results directly unless the result needs an application-specific projection.
-- Let the host application own session cleanup with `try`/`finally`; do not rely on the model to close the session.
-- Use AI SDK's [`toolApproval`](https://ai-sdk.dev/docs/agents/tool-approvals) option for actions that require human confirmation in your product — `tool()`'s own `needsApproval` is deprecated in its favor.
-
-See [Node.js API](/docs/client-api) for the complete client surface and runnable, typechecked `agent-device` examples.
+See the [Node.js API](/docs/client-api) when the host application needs deterministic setup or other direct device control outside the agent loop. See the AI SDK reference for [`ToolLoopAgent`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent).

--- a/website/docs/docs/ai-sdk.md
+++ b/website/docs/docs/ai-sdk.md
@@ -10,6 +10,15 @@ Use `agent-device/ai-sdk` to give an [AI SDK](https://ai-sdk.dev/) agent a typed
 pnpm add agent-device ai
 ```
 
+Make an iOS simulator or device [available to agent-device](/docs/agent-setup), then configure an AI SDK model. String model IDs use AI Gateway by default:
+
+```env
+AI_GATEWAY_API_KEY=your_api_key
+AI_MODEL=provider/model
+```
+
+Alternatively, pass a model from your configured AI SDK provider. See the AI SDK guide to [choosing a provider](https://ai-sdk.dev/docs/getting-started/choosing-a-provider).
+
 ```ts
 import { ToolLoopAgent } from 'ai';
 import { createAgentDeviceTools } from 'agent-device/ai-sdk';

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -4,9 +4,9 @@ title: Node.js API
 
 # Node.js API
 
-Use `createAgentDeviceClient()` to give a Node.js agent typed access to device automation instead of shelling out to the CLI. Its methods can be exposed as model tools, called from deterministic orchestration code, or combined with another Node.js agent framework.
+Use `createAgentDeviceClient()` for typed, deterministic device automation from Node.js instead of shelling out to the CLI.
 
-Start with the [AI SDK](/docs/ai-sdk) or [Eve](/docs/eve) integration guide for complete tool-calling examples. The client is framework-neutral, so the same pattern works with other solutions that accept JavaScript or TypeScript functions as tools.
+Building an agent? Start with the dedicated [AI SDK](/docs/ai-sdk) or [Eve](/docs/eve) integration.
 
 ## Runnable examples
 


### PR DESCRIPTION
## Summary

Recommend `agent-device/ai-sdk` as the single AI SDK integration path.

The guide now shows an agent choosing device tools from a realistic prompt, keeps the returned client for session cleanup, and moves advanced tool-set and approval configuration into a compact options section. The Node.js API introduction now directs agent builders to the dedicated integrations instead of suggesting manual tool wrapping.

Scope: 2 documentation files; no expansion beyond the AI SDK guide and its immediate Node.js API cross-link.

## Validation

Docs-only change; runtime and device validation do not apply. The committed-head affected check selected no local runtime gates and passed. A broader fail-open run triggered by an unrelated untracked environment file passed formatting, lint, typecheck, layering, package verification, Node integration, and other structural gates before an unrelated timing-sensitive Swift TMPDIR model test failed.