### PR TITLE
refactor: reuse kernel uniqueStrings instead of local copies

### DIFF
--- a/packages/selectors/src/internal/build.ts
+++ b/packages/selectors/src/internal/build.ts
@@ -1,3 +1,4 @@
+import { uniqueStrings } from '@agent-device/kernel/collections';
 import type { Platform, PublicPlatform } from '@agent-device/kernel/device';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { isNodeVisible } from './node.ts';
@@ -99,10 +100,6 @@ function selectableId(
   const canonicalId = readNodeLocalIdentity(node).id;
   if (canonicalId === undefined) return id;
   return idMatchCountInTree(nodes, canonicalId) > 1 ? null : id;
-}
-
-function uniqueStrings(values: readonly string[]): string[] {
-  return Array.from(new Set(values));
 }
 
 function quoteSelectorValue(value: string): string {

--- a/src/platforms/apple/core/perf-frame.ts
+++ b/src/platforms/apple/core/perf-frame.ts
@@ -1,3 +1,4 @@
+import { uniqueStrings } from '@agent-device/kernel/collections';
 import { roundOneDecimal, roundPercent } from '../../perf-utils.ts';
 import { parseXmlDocumentSync, type XmlNode } from '@agent-device/xml';
 import {
@@ -274,8 +275,4 @@ function readDirectProcess(element: XmlNode | undefined): { pid?: number; name?:
     pid: pid ?? undefined,
     name: name.length > 0 ? name : undefined,
   };
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return [...new Set(values)];
 }

--- a/src/platforms/web/agent-browser-lifecycle.ts
+++ b/src/platforms/web/agent-browser-lifecycle.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { uniqueStrings } from '@agent-device/kernel/collections';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import {
   expandProcessTree,
@@ -116,7 +117,9 @@ export async function cleanupManagedAgentBrowserOrphans(
   reason: 'daemon-startup' | 'provider-startup',
   options: AgentBrowserCleanupOptions = {},
 ): Promise<AgentBrowserCleanupResult> {
-  const openWebSessionNames = uniqueStrings([...(options.openWebSessionNames ?? [])]);
+  const openWebSessionNames = uniqueStrings(
+    (options.openWebSessionNames ?? []).filter((value) => value.length > 0),
+  );
   if (openWebSessionNames.length > 0) {
     return skippedCleanupResult('open-web-session', { openWebSessionNames });
   }
@@ -200,10 +203,6 @@ function managedBrowserHomeMarkers(status: AgentBrowserToolStatus): string[] {
     path.join(status.homeDir, '.agent-browser', 'browsers'),
     path.join(status.runtimeHomeDir, '.agent-browser', 'browsers'),
   ]);
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return [...new Set(values.filter((value) => value.length > 0))];
 }
 
 function skippedCleanupResult(


### PR DESCRIPTION
## What

Replaces three hand-rolled local `uniqueStrings` helpers with imports of the canonical `@agent-device/kernel/collections` export, per the AGENTS.md reuse rule:

- `src/platforms/apple/core/perf-frame.ts` — identical semantics, direct swap.
- `src/platforms/web/agent-browser-lifecycle.ts` — the local copy also filtered empty strings; that filter is now composed at the one call site that receives caller input (`openWebSessionNames`). The other call site passes `path.join` results, which are never empty. The `[...]` spread is gone because the kernel helper accepts `readonly string[]`.
- `packages/selectors/src/internal/build.ts` — identical semantics, direct swap.

All three files' packages already depend on `@agent-device/kernel` and sibling modules import the same subpath.

## Why no gate caught this drift (evaluated as part of this task)

- **fallow duplication**: `fallow audit` does include duplication, but the repo floors are `minTokens: 50` / `minLines: 5` and these helpers are ~2 lines / ~15 tokens. Empirically (scratch run), mild-mode clone detection *does* group all three bodies at `--min-tokens 5 --min-lines 1`, but floors that low are unusable repo-wide (the 3-file toy already reports 66.7% duplication). The audit gate is also changed-files-only, so pre-existing drift is invisible until touched. Structural gap, not a config bug.
- **oxlint**: `no-restricted-syntax` and `id-denylist` are not implemented in oxlint 1.69 (checked the configuration schema), so a declaration-name ban is not expressible in the current lint config. oxlint 1.69 does support experimental custom `jsPlugins`, which could express "no local `uniqueStrings` declaration outside packages/kernel" in ~30 lines riding the existing `pnpm lint` gate.
- **fallow rule packs**: only `banned-call` / `banned-import` kinds — cannot ban a local declaration.

Notably, the other two helpers protected by the same AGENTS.md rule (`inferFillText`, `evaluateIsPredicate`) have exactly one definition each — only the trivially re-typeable one drifted. Whether that recurrence justifies a jsPlugin lane (per the Catches/Evidence/Cost/Kill-criterion bar) is left as a follow-up decision, not bundled here.

## Verification

`pnpm check:affected --run` — all runnable checks passed (lint, typecheck, affected units, changed-line coverage gate).