### PR TITLE
test(bench): falsification fixtures for oracles + typed runner outcomes

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -42,7 +42,8 @@
     "scripts/maestro-conformance/corpus/**",
     "apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests.xctestplan",
     "scripts/write-xcuitest-cache-metadata.mjs",
-    "scripts/help-conformance-sample-outputs.d.mts"
+    "scripts/help-conformance-sample-outputs.d.mts",
+    "scripts/help-conformance-runner-output.d.mts"
   ],
   "ignoreDependencies": [
     "@theme",

--- a/scripts/__tests__/help-conformance-bench.test.ts
+++ b/scripts/__tests__/help-conformance-bench.test.ts
@@ -9,7 +9,8 @@ import { scoreExpectations } from '../help-conformance-case-checks.mjs';
 import { validateAgentDeviceCommand } from '../help-conformance-command-validator.ts';
 import { opensAndCloses, usesValidationPrep } from '../help-conformance-expectations.mjs';
 import { validatePlanCommands } from '../help-conformance-plan-validator.mjs';
-import { detectRunnerError, extractCommands } from '../help-conformance-runner-output.mjs';
+import { classifyRunnerOutput, extractCommands } from '../help-conformance-runner-output.mjs';
+import type { RunnerOutcome } from '../help-conformance-runner-output.mjs';
 import { summarizeResults } from '../help-conformance-summary.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -324,35 +325,52 @@ test('validation prep accepts intervening checks and the Android build path in o
   );
 });
 
-test('runner output distinguishes model commands from infrastructure errors', () => {
+test('runner output classifies model commands as success and infrastructure noise as runner-error', () => {
   const successEnvelope = JSON.stringify({
     is_error: false,
     result: JSON.stringify({ commands: ['agent-device snapshot -i'] }),
   });
   assert.deepEqual(extractCommands(successEnvelope), ['agent-device snapshot -i']);
-  assert.equal(detectRunnerError(successEnvelope), undefined);
+  assert.deepEqual(classifyRunnerOutput(successEnvelope), {
+    kind: 'success',
+    raw: successEnvelope,
+    commands: ['agent-device snapshot -i'],
+  });
 
   const claudeError = JSON.stringify({
     is_error: true,
     result: 'API Error: Unable to connect to API',
   });
-  assert.equal(detectRunnerError(claudeError), 'API Error: Unable to connect to API');
+  assert.deepEqual(classifyRunnerOutput(claudeError), {
+    kind: 'runner-error',
+    raw: claudeError,
+    message: 'API Error: Unable to connect to API',
+    reason: 'error-envelope',
+  });
   assert.deepEqual(extractCommands(claudeError), []);
 
-  assert.equal(
-    detectRunnerError(JSON.stringify({ type: 'error', message: 'rate limit exceeded' })),
-    'rate limit exceeded',
-  );
-  assert.equal(
-    detectRunnerError(
-      JSON.stringify({
-        status: 'failed',
-        commands: ['agent-device snapshot -i'],
-      }),
-    ),
-    undefined,
-  );
-  assert.equal(detectRunnerError(''), 'Runner returned empty output.');
+  const rateLimited = JSON.stringify({ type: 'error', message: 'rate limit exceeded' });
+  const rateLimitedOutcome: RunnerOutcome = classifyRunnerOutput(rateLimited);
+  if (rateLimitedOutcome.kind !== 'runner-error') {
+    throw new Error('expected a runner-error outcome');
+  }
+  assert.equal(rateLimitedOutcome.reason, 'error-envelope');
+  assert.equal(rateLimitedOutcome.message, 'rate limit exceeded');
+
+  // status: 'failed' alone does not shadow a real commands payload.
+  const statusFailedWithCommands = JSON.stringify({
+    status: 'failed',
+    commands: ['agent-device snapshot -i'],
+  });
+  assert.equal(classifyRunnerOutput(statusFailedWithCommands).kind, 'success');
+
+  const empty = classifyRunnerOutput('');
+  assert.deepEqual(empty, {
+    kind: 'runner-error',
+    raw: '',
+    message: 'Runner returned empty output.',
+    reason: 'empty-output',
+  });
 });
 
 test('plan validator rejects shell projection and non-permitted executables', async () => {
@@ -601,20 +619,16 @@ test('aggregate summary exposes stability and failure taxonomy per runner x case
       checks: { validPlanCommands: true, usesSettle: true },
       commandValidation: [],
     },
+    // A runner-error result (see runCase in help-conformance-bench.mjs)
+    // never carries checks/commandValidation alongside runnerError: an
+    // infrastructure failure must not also read as a model validation
+    // failure in the aggregate taxonomy.
     {
       runner: 'claude:haiku',
       caseId: 'metamorphic',
       passed: false,
-      checks: { validPlanCommands: false, usesSettle: true },
-      commandValidation: [
-        {
-          issues: [
-            { kind: 'pseudo-ref', error: 'bad ref' },
-            { kind: 'shell-projection', error: 'bad shell' },
-          ],
-        },
-      ],
       runnerError: 'failed',
+      runnerErrorReason: 'process-failure',
     },
     {
       runner: 'claude:haiku',
@@ -639,6 +653,38 @@ test('aggregate summary exposes stability and failure taxonomy per runner x case
       validationIssues: { 'pseudo-ref': 1 },
       runnerErrors: 1,
       passRate: 0.5,
+    },
+  ]);
+});
+
+test('a group with only runner-error trials reports passRate: null, not 0/0', () => {
+  const summary = summarizeResults([
+    {
+      runner: 'codex:gpt',
+      caseId: 'metamorphic',
+      passed: false,
+      runnerError: 'timed out',
+      runnerErrorReason: 'process-failure',
+    },
+    {
+      runner: 'codex:gpt',
+      caseId: 'metamorphic',
+      passed: false,
+      runnerError: 'Runner returned empty output.',
+      runnerErrorReason: 'empty-output',
+    },
+  ]);
+  assert.deepEqual(summary, [
+    {
+      runner: 'codex:gpt',
+      caseId: 'metamorphic',
+      trials: 2,
+      evaluatedTrials: 0,
+      passed: 0,
+      failedChecks: {},
+      validationIssues: {},
+      runnerErrors: 2,
+      passRate: null,
     },
   ]);
 });

--- a/scripts/__tests__/help-conformance-bench.test.ts
+++ b/scripts/__tests__/help-conformance-bench.test.ts
@@ -10,7 +10,6 @@ import { validateAgentDeviceCommand } from '../help-conformance-command-validato
 import { opensAndCloses, usesValidationPrep } from '../help-conformance-expectations.mjs';
 import { validatePlanCommands } from '../help-conformance-plan-validator.mjs';
 import { classifyRunnerOutput, extractCommands } from '../help-conformance-runner-output.mjs';
-import type { RunnerOutcome } from '../help-conformance-runner-output.mjs';
 import { summarizeResults } from '../help-conformance-summary.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -350,12 +349,12 @@ test('runner output classifies model commands as success and infrastructure nois
   assert.deepEqual(extractCommands(claudeError), []);
 
   const rateLimited = JSON.stringify({ type: 'error', message: 'rate limit exceeded' });
-  const rateLimitedOutcome: RunnerOutcome = classifyRunnerOutput(rateLimited);
-  if (rateLimitedOutcome.kind !== 'runner-error') {
-    throw new Error('expected a runner-error outcome');
-  }
-  assert.equal(rateLimitedOutcome.reason, 'error-envelope');
-  assert.equal(rateLimitedOutcome.message, 'rate limit exceeded');
+  assert.deepEqual(classifyRunnerOutput(rateLimited), {
+    kind: 'runner-error',
+    raw: rateLimited,
+    message: 'rate limit exceeded',
+    reason: 'error-envelope',
+  });
 
   // status: 'failed' alone does not shadow a real commands payload.
   const statusFailedWithCommands = JSON.stringify({

--- a/scripts/__tests__/help-conformance-expectation-falsification.test.ts
+++ b/scripts/__tests__/help-conformance-expectation-falsification.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { KNOWN_EXPECTATIONS, scoreExpectations } from '../help-conformance-case-checks.mjs';
+import { validatePlanCommands } from '../help-conformance-plan-validator.mjs';
+import {
+  EXPECTATION_FIXTURES,
+  type ExpectationWitness,
+} from './help-conformance-expectation-fixtures.ts';
+
+// "What enumerates N" for the expectation surface (see the analogous gates
+// for help topics and error-recovery quizzes): KNOWN_EXPECTATIONS is the
+// scorer registry itself (help-conformance-case-checks.mjs
+// EXPECTATION_SCORERS), so a new named expectation with no falsification
+// fixture fails this gate instead of silently shipping unfalsifiable. An
+// oracle nobody has proven can fail is not an oracle — it is decoration that
+// reports every plan as passing whether or not its regex or predicate still
+// matches anything.
+
+test('every named expectation has a falsification fixture', () => {
+  const missing = KNOWN_EXPECTATIONS.filter((id) => !(id in EXPECTATION_FIXTURES));
+  assert.deepEqual(
+    missing,
+    [],
+    `add a scripts/__tests__/help-conformance-expectation-fixtures.ts entry for: ${missing.join(', ')}`,
+  );
+});
+
+test('the fixture registry names only real, current expectations', () => {
+  const known = new Set<string>(KNOWN_EXPECTATIONS);
+  const stale = Object.keys(EXPECTATION_FIXTURES).filter((id) => !known.has(id));
+  assert.deepEqual(
+    stale,
+    [],
+    `fixture(s) for a retired/renamed expectation: ${stale.join(', ')} — remove them`,
+  );
+});
+
+test('every fixture set declares a passing witness and at least one counterexample', () => {
+  for (const [id, fixture] of Object.entries(EXPECTATION_FIXTURES)) {
+    assert.ok(fixture.passing, `expectation "${id}" needs a passing witness`);
+    assert.ok(
+      fixture.counterexamples.length > 0,
+      `expectation "${id}" needs at least one known-bad counterexample`,
+    );
+    for (const counter of fixture.counterexamples) {
+      assert.ok(
+        counter.id.trim().length > 0,
+        `expectation "${id}" has a counterexample with no id`,
+      );
+    }
+  }
+});
+
+/** Runs a witness through the real production scorer pipeline, not a reimplementation. */
+async function score(id: string, witness: ExpectationWitness): Promise<boolean> {
+  const commandValidation = await validatePlanCommands(witness.commands, {
+    allowedExternalCommands: witness.allowedExternalCommands,
+  });
+  const raw = witness.commands.join('\n');
+  const checks = scoreExpectations(
+    { expectations: [id] },
+    witness.commands,
+    raw,
+    commandValidation,
+  );
+  return checks[id] === true;
+}
+
+// One vitest test per witness/counterexample (rather than one loop inside a
+// single test) so a failure names the exact fixture that broke, and so the
+// many real validatePlanCommands subprocess calls this drives don't compound
+// into one test's timeout budget.
+for (const [id, fixture] of Object.entries(EXPECTATION_FIXTURES)) {
+  test(`${id}: passing witness scores true`, async () => {
+    assert.equal(
+      await score(id, fixture.passing),
+      true,
+      `expectation "${id}" passing witness must score true: ${JSON.stringify(fixture.passing.commands)}`,
+    );
+  });
+
+  for (const counter of fixture.counterexamples) {
+    test(`${id}: counterexample "${counter.id}" scores false`, async () => {
+      assert.equal(
+        await score(id, counter),
+        false,
+        `expectation "${id}" counterexample "${counter.id}" must score false: ${JSON.stringify(counter.commands)}`,
+      );
+    });
+  }
+
+  if (fixture.metamorphic) {
+    const metamorphic = fixture.metamorphic;
+    test(`${id}: metamorphic variant differs from the witness and still scores true`, async () => {
+      assert.notDeepEqual(
+        metamorphic.commands,
+        fixture.passing.commands,
+        `expectation "${id}" metamorphic variant must actually differ from the passing witness`,
+      );
+      assert.equal(
+        await score(id, metamorphic),
+        true,
+        `expectation "${id}" metamorphic variant must still score true: ${JSON.stringify(metamorphic.commands)}`,
+      );
+    });
+  }
+}

--- a/scripts/__tests__/help-conformance-expectation-fixtures.ts
+++ b/scripts/__tests__/help-conformance-expectation-fixtures.ts
@@ -1,0 +1,218 @@
+// Falsification fixtures for every named benchmark expectation (the
+// EXPECTATION_SCORERS registry in ../help-conformance-case-checks.mjs, keyed
+// by scripts/__tests__/help-conformance-expectation-falsification.test.ts via
+// KNOWN_EXPECTATIONS). "An oracle nobody has seen fail" is exactly what a
+// benchmark check can silently rot into — a scorer whose regex or predicate
+// stopped matching anything still reports every plan as passing. Each entry
+// here proves the opposite: a minimal plan the scorer must accept, and at
+// least one plan it must reject. `metamorphic`, where present, is a second
+// passing plan built from different domain nouns/values, proving the scorer
+// keys on plan shape rather than memorizing the witness's specific content.
+//
+// Fixtures are plain `commands` arrays — the same shape `extractCommands`
+// hands to the scorer pipeline — run through the REAL
+// validatePlanCommands/scoreExpectations production path so a fixture cannot
+// drift from what the bench itself does with a model's plan.
+
+export type ExpectationWitness = {
+  commands: string[];
+  allowedExternalCommands?: string[];
+};
+
+export type ExpectationCounterexample = ExpectationWitness & {
+  id: string;
+};
+
+export type ExpectationFixture = {
+  passing: ExpectationWitness;
+  counterexamples: ExpectationCounterexample[];
+  metamorphic?: ExpectationWitness;
+};
+
+export const EXPECTATION_FIXTURES: Record<string, ExpectationFixture> = {
+  validPlanCommands: {
+    passing: {
+      commands: [
+        'agent-device open com.example.app',
+        'agent-device get text @e5',
+        'agent-device close',
+      ],
+    },
+    counterexamples: [
+      {
+        // The @ref/@id-prefix contract is the whole point of "agent-device
+        // <verb>"; a bare lifecycle verb silently drops the prefix instead of
+        // failing the command, so the plan runs nothing.
+        id: 'swallowedLifecyclePrefix',
+        commands: ['open com.example.app', 'agent-device close'],
+      },
+      {
+        id: 'unsupportedFlag',
+        commands: ['agent-device wait --selector role=button'],
+      },
+      {
+        id: 'unsupportedSelectorCombination',
+        commands: ['agent-device is role=button label=Following'],
+      },
+      {
+        id: 'pseudoRef',
+        commands: ['agent-device press @<search-ref> --settle'],
+      },
+      {
+        id: 'shellOperator',
+        commands: ['agent-device snapshot -i | tee evidence.txt'],
+      },
+      {
+        // get's grammar is (format, ref) in that order; swapping them feeds
+        // the ref where "text"/"attrs" is expected.
+        id: 'invalidPositionalOrdering',
+        commands: ['agent-device get @e5 text'],
+      },
+    ],
+    metamorphic: {
+      commands: [
+        'agent-device open com.example.other',
+        'agent-device get text @e9',
+        'agent-device close',
+      ],
+    },
+  },
+  fullPrefix: {
+    passing: {
+      commands: ['agent-device open com.example.app', 'agent-device close'],
+    },
+    counterexamples: [
+      {
+        id: 'bareOpenPrefix',
+        commands: ['open com.example.app', 'agent-device close'],
+      },
+      {
+        id: 'barePressPrefix',
+        commands: ['agent-device open com.example.app', 'press @e5 --settle'],
+      },
+    ],
+    metamorphic: {
+      commands: [
+        'agent-device open com.example.other',
+        'agent-device press @e9 --settle',
+        'agent-device close',
+      ],
+    },
+  },
+  usesSnapshotI: {
+    passing: { commands: ['agent-device snapshot -i'] },
+    counterexamples: [
+      { id: 'snapshotMissingInteractiveFlag', commands: ['agent-device snapshot'] },
+      {
+        id: 'noSnapshotCommandAtAll',
+        commands: ['agent-device open com.example.app', 'agent-device close'],
+      },
+    ],
+    metamorphic: {
+      commands: ['agent-device open com.example.other --foreground', 'agent-device snapshot -i'],
+    },
+  },
+  usesSettleOnMutations: {
+    passing: { commands: ['agent-device press @e5 --settle'] },
+    counterexamples: [
+      { id: 'mutationMissingSettle', commands: ['agent-device press @e5'] },
+      // No mutation command present at all is also a fail: the scorer
+      // requires evidence of settling, not just the absence of an unsettled
+      // mutation.
+      {
+        id: 'noMutationCommandsPresent',
+        commands: ['agent-device snapshot -i', 'agent-device close'],
+      },
+    ],
+    metamorphic: {
+      commands: ['agent-device fill label="Email" "qa@example.com" --settle'],
+    },
+  },
+  usesConfidentChaining: {
+    passing: {
+      commands: [
+        'agent-device press label="Search" --settle && agent-device fill label="Search" "query" --settle',
+      ],
+    },
+    counterexamples: [
+      {
+        id: 'sameStepsWithoutChain',
+        commands: [
+          'agent-device press label="Search" --settle',
+          'agent-device fill label="Search" "query" --settle',
+        ],
+      },
+    ],
+    metamorphic: {
+      commands: [
+        'agent-device press label="Continue" --settle && agent-device fill label="Notes" "groceries" --settle',
+      ],
+    },
+  },
+  noWaitStable: {
+    passing: { commands: ['agent-device wait text "Sent"'] },
+    counterexamples: [{ id: 'usesWaitStable', commands: ['agent-device wait stable'] }],
+    metamorphic: { commands: ['agent-device wait text "Welcome back"'] },
+  },
+  verifiesNamedExpectation: {
+    passing: { commands: ['agent-device wait text "Sent"'] },
+    counterexamples: [
+      {
+        id: 'noVerificationCommand',
+        commands: ['agent-device press @e5 --settle', 'agent-device close'],
+      },
+    ],
+    metamorphic: { commands: ['agent-device is visible label="Welcome back"'] },
+  },
+  usesDogfoodEvidence: {
+    passing: {
+      commands: ['agent-device screenshot --overlay-refs ./dogfood-output/issue.png'],
+    },
+    counterexamples: [
+      {
+        id: 'noEvidenceCaptured',
+        commands: ['agent-device open com.example.shop', 'agent-device close'],
+      },
+    ],
+    metamorphic: { commands: ['agent-device record start'] },
+  },
+  usesValidationPrep: {
+    passing: {
+      commands: ['agent-device doctor', 'pnpm build', 'pnpm clean:daemon'],
+      allowedExternalCommands: ['pnpm'],
+    },
+    counterexamples: [
+      {
+        // Build after the clean it was supposed to precede proves nothing:
+        // clean:daemon must follow the build it validates.
+        id: 'cleanBeforeBuild',
+        commands: ['pnpm clean:daemon', 'pnpm build'],
+        allowedExternalCommands: ['pnpm'],
+      },
+    ],
+    metamorphic: {
+      commands: ['pnpm run build:android', 'agent-device doctor', 'pnpm clean:daemon'],
+      allowedExternalCommands: ['pnpm'],
+    },
+  },
+  opensAndCloses: {
+    passing: {
+      commands: ['agent-device open com.example.community', 'agent-device close'],
+    },
+    counterexamples: [
+      {
+        // Both verbs present, but merged onto one command line: close is
+        // swallowed as an argument to open rather than a separate command.
+        id: 'mergedIntoOneCommandLine',
+        commands: ['agent-device open com.example.community close'],
+      },
+    ],
+    metamorphic: {
+      commands: [
+        'agent-device open com.example.other --relaunch',
+        'agent-device press @e9 --settle',
+        'agent-device close',
+      ],
+    },
+  },
+};

--- a/scripts/help-conformance-bench.mjs
+++ b/scripts/help-conformance-bench.mjs
@@ -11,7 +11,7 @@ import {
 } from './help-conformance-case-checks.mjs';
 import { CASES } from './help-conformance-cases.mjs';
 import { validatePlanCommands } from './help-conformance-plan-validator.mjs';
-import { detectRunnerError, extractCommands } from './help-conformance-runner-output.mjs';
+import { classifyRunnerOutput } from './help-conformance-runner-output.mjs';
 import { summarizeResults } from './help-conformance-summary.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -256,18 +256,30 @@ function printResult(result, dryRun, repeat) {
   if (dryRun) return;
   const trial = repeat > 1 ? ` trial=${result.trial}/${repeat}` : '';
   console.log(
-    `${result.passed ? 'PASS' : 'FAIL'} ${result.runner} ${result.caseId}${trial} ${result.score}/${result.total}`,
+    `${resultStatus(result)} ${result.runner} ${result.caseId}${trial} ${resultDetail(result)}`,
   );
+}
+
+function resultStatus(result) {
+  if (result.runnerError) return 'ERROR';
+  return result.passed ? 'PASS' : 'FAIL';
+}
+
+function resultDetail(result) {
+  return result.runnerError
+    ? `${result.runnerErrorReason}: ${result.runnerError}`
+    : `${result.score}/${result.total}`;
 }
 
 function printSummary(summary) {
   console.log('Aggregate stability:');
   for (const group of summary) {
-    const percent = Math.round(group.passRate * 100);
+    const rate =
+      group.passRate === null
+        ? 'N/A'
+        : `${group.passed}/${group.evaluatedTrials} (${Math.round(group.passRate * 100)}%)`;
     const details = summaryDetails(group);
-    console.log(
-      `  ${group.runner} ${group.caseId}: ${group.passed}/${group.evaluatedTrials} (${percent}%)${details ? `; ${details}` : ''}`,
-    );
+    console.log(`  ${group.runner} ${group.caseId}: ${rate}${details ? `; ${details}` : ''}`);
   }
 }
 
@@ -350,40 +362,59 @@ function buildPrompt(testCase, docs) {
   ].join('\n');
 }
 
+// Only a 'success' RunnerOutcome ever reaches validatePlanCommands/
+// scoreExpectations: a runner-error result carries runnerError/
+// runnerErrorReason and nothing else, so infrastructure noise (an empty
+// payload, a codex timeout, a Claude is_error envelope) can never masquerade
+// as a model's failed command plan in the report or the aggregate summary.
 async function runCase(runner, testCase, prompt, outDir, trial, repeat) {
-  const { raw, runnerError } = await runCaseRawOutput(runner, prompt, outDir);
+  const outcome = await runOutcome(runner, prompt, outDir);
   const trialSuffix = repeat > 1 ? `-trial-${trial}` : '';
   const outputPath = join(outDir, `${safeName(runner)}-${testCase.id}${trialSuffix}.txt`);
-  await writeFile(outputPath, raw);
-  const commands = extractCommands(raw);
-  const commandValidation = await validatePlanCommands(commands, {
+  await writeFile(outputPath, outcome.raw);
+  if (outcome.kind === 'runner-error') {
+    return {
+      runner,
+      caseId: testCase.id,
+      trial,
+      passed: false,
+      runnerError: outcome.message,
+      runnerErrorReason: outcome.reason,
+      outputPath,
+    };
+  }
+  const commandValidation = await validatePlanCommands(outcome.commands, {
     allowedExternalCommands: testCase.allowedExternalCommands,
   });
-  const checks = scoreExpectations(testCase, commands, raw, commandValidation);
+  const checks = scoreExpectations(testCase, outcome.commands, outcome.raw, commandValidation);
   const score = countPassingChecks(checks);
   const total = countChecks(testCase);
   return {
     runner,
     caseId: testCase.id,
     trial,
-    commands,
+    commands: outcome.commands,
     commandValidation,
     checks,
     score,
     total,
-    passed: runnerError === undefined && score === total,
-    ...(runnerError ? { runnerError } : {}),
+    passed: score === total,
     outputPath,
   };
 }
 
-async function runCaseRawOutput(runner, prompt, outDir) {
+async function runOutcome(runner, prompt, outDir) {
   const [kind, model] = runner.split(':');
   try {
     const raw = await runModel(kind, model, prompt, outDir);
-    return { raw, runnerError: detectRunnerError(raw) };
+    return classifyRunnerOutput(raw);
   } catch (error) {
-    return { raw: errorOutput(error), runnerError: errorMessage(error) };
+    return {
+      kind: 'runner-error',
+      raw: errorOutput(error),
+      message: errorMessage(error),
+      reason: 'process-failure',
+    };
   }
 }
 

--- a/scripts/help-conformance-bench.mjs
+++ b/scripts/help-conformance-bench.mjs
@@ -11,7 +11,7 @@ import {
 } from './help-conformance-case-checks.mjs';
 import { CASES } from './help-conformance-cases.mjs';
 import { validatePlanCommands } from './help-conformance-plan-validator.mjs';
-import { classifyRunnerOutput } from './help-conformance-runner-output.mjs';
+import { classifyRunnerOutput, runnerErrorOutcome } from './help-conformance-runner-output.mjs';
 import { summarizeResults } from './help-conformance-summary.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -372,15 +372,13 @@ async function runCase(runner, testCase, prompt, outDir, trial, repeat) {
   const trialSuffix = repeat > 1 ? `-trial-${trial}` : '';
   const outputPath = join(outDir, `${safeName(runner)}-${testCase.id}${trialSuffix}.txt`);
   await writeFile(outputPath, outcome.raw);
+  const base = { runner, caseId: testCase.id, trial, outputPath };
   if (outcome.kind === 'runner-error') {
     return {
-      runner,
-      caseId: testCase.id,
-      trial,
+      ...base,
       passed: false,
       runnerError: outcome.message,
       runnerErrorReason: outcome.reason,
-      outputPath,
     };
   }
   const commandValidation = await validatePlanCommands(outcome.commands, {
@@ -390,16 +388,13 @@ async function runCase(runner, testCase, prompt, outDir, trial, repeat) {
   const score = countPassingChecks(checks);
   const total = countChecks(testCase);
   return {
-    runner,
-    caseId: testCase.id,
-    trial,
+    ...base,
     commands: outcome.commands,
     commandValidation,
     checks,
     score,
     total,
     passed: score === total,
-    outputPath,
   };
 }
 
@@ -409,12 +404,7 @@ async function runOutcome(runner, prompt, outDir) {
     const raw = await runModel(kind, model, prompt, outDir);
     return classifyRunnerOutput(raw);
   } catch (error) {
-    return {
-      kind: 'runner-error',
-      raw: errorOutput(error),
-      message: errorMessage(error),
-      reason: 'process-failure',
-    };
+    return runnerErrorOutcome(errorOutput(error), errorMessage(error), 'process-failure');
   }
 }
 

--- a/scripts/help-conformance-case-checks.mjs
+++ b/scripts/help-conformance-case-checks.mjs
@@ -26,6 +26,12 @@ const EXPECTATION_SCORERS = {
   opensAndCloses,
 };
 
+// The scorer registry itself, so a falsification-fixture completeness gate
+// (scripts/__tests__/help-conformance-expectation-falsification.test.ts) can
+// enumerate every named expectation instead of hand-maintaining a second list
+// that silently drifts from EXPECTATION_SCORERS.
+export const KNOWN_EXPECTATIONS = Object.keys(EXPECTATION_SCORERS);
+
 export function assertCaseDefinitions(cases) {
   assertUniqueIds(
     cases.map(({ id }) => id),

--- a/scripts/help-conformance-runner-output.d.mts
+++ b/scripts/help-conformance-runner-output.d.mts
@@ -1,0 +1,8 @@
+export type RunnerErrorReason = 'process-failure' | 'empty-output' | 'error-envelope';
+
+export type RunnerOutcome =
+  | { kind: 'success'; raw: string; commands: string[] }
+  | { kind: 'runner-error'; raw: string; message: string; reason: RunnerErrorReason };
+
+export declare function classifyRunnerOutput(raw: string): RunnerOutcome;
+export declare function extractCommands(raw: string): string[];

--- a/scripts/help-conformance-runner-output.d.mts
+++ b/scripts/help-conformance-runner-output.d.mts
@@ -6,3 +6,8 @@ export type RunnerOutcome =
 
 export declare function classifyRunnerOutput(raw: string): RunnerOutcome;
 export declare function extractCommands(raw: string): string[];
+export declare function runnerErrorOutcome(
+  raw: string,
+  message: string,
+  reason: RunnerErrorReason,
+): Extract<RunnerOutcome, { kind: 'runner-error' }>;

--- a/scripts/help-conformance-runner-output.mjs
+++ b/scripts/help-conformance-runner-output.mjs
@@ -1,3 +1,20 @@
+// Discriminated runner outcome (see the companion .d.mts): a raw-string
+// success/error split let infrastructure noise (an empty codex payload, a
+// Claude is_error envelope) parse as if it were a command plan. Only a
+// 'success' outcome carries `commands`, so a caller cannot accidentally score
+// a runner-error's raw text against the command validator or expectations.
+
+export function classifyRunnerOutput(raw) {
+  if (raw.trim().length === 0) {
+    return runnerError(raw, 'empty-output', 'Runner returned empty output.');
+  }
+  const payload = parseJsonEnvelope(raw);
+  if (isErrorPayload(payload)) {
+    return runnerError(raw, 'error-envelope', errorPayloadMessage(payload));
+  }
+  return { kind: 'success', raw, commands: extractCommands(raw) };
+}
+
 export function extractCommands(raw) {
   const json = parseJsonPayload(raw);
   if (json && Array.isArray(json.commands)) {
@@ -12,11 +29,8 @@ export function extractCommands(raw) {
     );
 }
 
-export function detectRunnerError(raw) {
-  if (raw.trim().length === 0) return 'Runner returned empty output.';
-  const payload = parseJsonEnvelope(raw);
-  if (!isErrorPayload(payload)) return undefined;
-  return errorPayloadMessage(payload);
+function runnerError(raw, reason, message) {
+  return { kind: 'runner-error', raw, message, reason };
 }
 
 function isErrorPayload(payload) {

--- a/scripts/help-conformance-runner-output.mjs
+++ b/scripts/help-conformance-runner-output.mjs
@@ -6,11 +6,11 @@
 
 export function classifyRunnerOutput(raw) {
   if (raw.trim().length === 0) {
-    return runnerError(raw, 'empty-output', 'Runner returned empty output.');
+    return runnerErrorOutcome(raw, 'Runner returned empty output.', 'empty-output');
   }
   const payload = parseJsonEnvelope(raw);
   if (isErrorPayload(payload)) {
-    return runnerError(raw, 'error-envelope', errorPayloadMessage(payload));
+    return runnerErrorOutcome(raw, errorPayloadMessage(payload), 'error-envelope');
   }
   return { kind: 'success', raw, commands: extractCommands(raw) };
 }
@@ -29,7 +29,11 @@ export function extractCommands(raw) {
     );
 }
 
-function runnerError(raw, reason, message) {
+// The RunnerOutcome union's only 'runner-error' constructor: every caller
+// that classifies a runner failure (a bad envelope here, a spawn/timeout
+// failure in help-conformance-bench.mjs) builds the outcome through this one
+// function, so the shape can't drift between the two error sources.
+export function runnerErrorOutcome(raw, message, reason) {
   return { kind: 'runner-error', raw, message, reason };
 }
 

--- a/scripts/help-conformance-summary.mjs
+++ b/scripts/help-conformance-summary.mjs
@@ -23,9 +23,12 @@ export function summarizeResults(results) {
     }
     groups.set(key, group);
   }
+  // A group with zero evaluated trials (every trial was a runner error) has
+  // no pass rate to report — 0 would silently read as "0% correct" instead
+  // of "the model was never actually graded".
   return [...groups.values()].map((group) => ({
     ...group,
-    passRate: group.evaluatedTrials === 0 ? 0 : group.passed / group.evaluatedTrials,
+    passRate: group.evaluatedTrials === 0 ? null : group.passed / group.evaluatedTrials,
   }));
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
             'scripts/fuzz/envelope.test.ts',
             'scripts/__tests__/help-conformance-bench.test.ts',
             'scripts/__tests__/help-conformance-error-recovery-coverage.test.ts',
+            'scripts/__tests__/help-conformance-expectation-falsification.test.ts',
             'scripts/__tests__/help-conformance-sample-outputs.test.ts',
             'scripts/__tests__/help-conformance-topic-coverage.test.ts',
             'scripts/__tests__/agent-setup-startup-contract.test.ts',


### PR DESCRIPTION
## Summary

Implements #1481 — the two surviving deterministic PR-time quality items carved out of #1406 for the help-conformance bench (the repo's single non-gating small-model planning oracle):

**1. Falsification fixtures for benchmark oracles**
- Every named expectation in `EXPECTATION_SCORERS` (`scripts/help-conformance-case-checks.mjs`, exported as `KNOWN_EXPECTATIONS`) now has a fixture entry in the new `scripts/__tests__/help-conformance-expectation-fixtures.ts`: a minimal passing witness, at least one known-bad counterexample, and a metamorphic variant where useful (a second passing plan built from different domain nouns, proving the scorer keys on plan shape rather than memorizing content).
- `scripts/__tests__/help-conformance-expectation-falsification.test.ts` is the completeness gate (same "what enumerates N" shape as the existing topic-coverage/error-recovery-coverage gates): a new named expectation with no fixture fails it, and a stale fixture for a removed expectation also fails.
- Fixtures run through the *real* `validatePlanCommands`/`scoreExpectations` production pipeline, not a reimplementation, so they can't drift from what the bench actually does with a model's plan.
- Regressions included per the issue: swallowed lifecycle command prefixes (bare `open`/`press` instead of `agent-device open`/`agent-device press`), unsupported flags (`wait --selector`) and selector combinations (`is role=... label=...`), pseudo refs (`@<search-ref>`), shell operators (`| tee`), and invalid positional ordering (`get @e5 text` instead of `get text @e5`).

**2. Typed runner outcomes**
- `scripts/help-conformance-runner-output.mjs` now exports `classifyRunnerOutput`, returning a discriminated `RunnerOutcome` (declared in the new companion `scripts/help-conformance-runner-output.d.mts`, following the same `.mjs`+`.d.mts` pairing already used for `help-conformance-sample-outputs.mjs`):
  ```ts
  type RunnerOutcome =
    | { kind: 'success'; raw: string; commands: string[] }
    | { kind: 'runner-error'; raw: string; message: string; reason: RunnerErrorReason };
  ```
  instead of the old raw-string `detectRunnerError(): string | undefined` inference.
- `runCase` in `help-conformance-bench.mjs` now only calls `validatePlanCommands`/`scoreExpectations` for a `'success'` outcome; a `'runner-error'` result carries `runnerError`/`runnerErrorReason` and nothing else — a result can no longer carry both `runnerError` and model-validation checks.
- `summarizeResults` (`help-conformance-summary.mjs`) now reports `passRate: null` for a group with zero evaluated trials (every trial was a runner error), and the CLI's aggregate-stability print renders that as `N/A` instead of the misleading `0/0 (0%)`.
- Single-trial mode is unchanged (the `Aggregate stability` summary already only prints when `--repeat > 1`), so it still isn't mislabeled as stability evidence.

No paid model calls in either gate — everything runs through the local command-validator subprocess deterministically.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (oxlint --deny-warnings) — clean
- [x] `pnpm check:fallow` (fallow audit) — clean (0 issues in changed files)
- [x] `pnpm format:check` — clean
- [x] `npx vitest run scripts/__tests__/help-conformance-*` — 100/100 passing (bench, sample-outputs, topic-coverage, error-recovery-coverage, and the new expectation-falsification suite)
- [x] Full `pnpm test:unit` (unit-core + subprocess-stub, ~7200 tests) — all green; two pre-existing `&&`-chain plan-validator tests hit the 5s timeout only under full-suite CPU contention and pass cleanly in isolation (unrelated to this change)
- [x] `node scripts/help-conformance-bench.mjs --dry-run` smoke-tested end to end with an override doc