### PR TITLE
refactor(maestro): remove obsolete presentation mapping

### DIFF
--- a/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
@@ -249,10 +249,6 @@ test('iOS target resolution keeps semantic identity bound to presented geometry'
         interactiveBounds: true,
         presentation: {
           snapshot: presentationSnapshot,
-          sourceIndexes: new Map([
-            [0, 0],
-            [1, 2],
-          ]),
           presentedIndexesBySourceIndex: new Map([
             [0, [0]],
             [1, []],
@@ -301,7 +297,6 @@ test('iOS target resolution uses one presented candidate universe for geometry a
         interactiveBounds: true,
         presentation: {
           snapshot: presentationSnapshot,
-          sourceIndexes: new Map([[0, 1]]),
           presentedIndexesBySourceIndex: new Map([
             [0, []],
             [1, [0]],

--- a/packages/maestro/src/internal/runtime-targets.ts
+++ b/packages/maestro/src/internal/runtime-targets.ts
@@ -29,8 +29,7 @@ export type MaestroTargetEvidence = {
 
 type MaestroInteractivePresentation = {
   snapshot: SnapshotState;
-  presentedIndexesBySourceIndex: ReadonlyMap<number, number[]>;
-  sourceIndexes: ReadonlyMap<number, number>;
+  presentedIndexesBySourceIndex: ReadonlyMap<number, readonly number[]>;
 };
 
 export type MaestroTargetResolution =

--- a/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
@@ -116,7 +116,6 @@ function resolveTargetFromSnapshot(params: {
       presentation: presentation
         ? {
             snapshot: interactiveSnapshot,
-            sourceIndexes: presentation.sourceIndexes,
             presentedIndexesBySourceIndex: presentation.presentedIndexesBySourceIndex,
           }
         : undefined,

--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -27,18 +27,16 @@ export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnap
 export type IosInteractiveSnapshotPresentation = {
   nodes: RawSnapshotNode[];
   /** Presented node indexes for every source index; suppressed noise maps to an empty list. */
-  presentedIndexesBySourceIndex: ReadonlyMap<number, number[]>;
-  sourceIndexes: ReadonlyMap<number, number>;
+  presentedIndexesBySourceIndex: ReadonlyMap<number, readonly number[]>;
 };
 
 export function buildIosInteractiveSnapshotPresentation(
   nodes: RawSnapshotNode[],
 ): IosInteractiveSnapshotPresentation {
   if (nodes.length === 0) {
-    return { nodes, presentedIndexesBySourceIndex: new Map(), sourceIndexes: new Map() };
+    return { nodes, presentedIndexesBySourceIndex: new Map() };
   }
 
-  const sourceIndexes = new Map(nodes.map((node) => [node.index, node.index]));
   const replacements = new Map<number, RawSnapshotNode>();
   const representativeSourceIndexesBySourceIndex = new Map<number, Set<number>>();
   const semanticRepresentativeIndexes = new Set<number>();
@@ -60,7 +58,6 @@ export function buildIosInteractiveSnapshotPresentation(
     return {
       nodes,
       presentedIndexesBySourceIndex: new Map(nodes.map((node) => [node.index, [node.index]])),
-      sourceIndexes,
     };
   }
 
@@ -86,9 +83,6 @@ export function buildIosInteractiveSnapshotPresentation(
           representativeSourceIndexesBySourceIndex,
         ),
       ]),
-    ),
-    sourceIndexes: new Map(
-      presentedNodes.map((node, position) => [node.index, presentedSourceNodes[position]!.index]),
     ),
   };
 }

--- a/src/daemon/snapshot-presentation/ios/mapping.test.ts
+++ b/src/daemon/snapshot-presentation/ios/mapping.test.ts
@@ -58,12 +58,4 @@ test('publishes an exact representative for every semantic source index', () => 
     [4, [3]],
     [5, []],
   ]);
-  expect(presentation.sourceIndexes).toEqual(
-    new Map([
-      [0, 0],
-      [1, 2],
-      [2, 3],
-      [3, 4],
-    ]),
-  );
 });


### PR DESCRIPTION
## Summary

Remove the unused presented-to-source index map introduced by #1889. Keep the source-to-presented mapping as the single presentation authority and make its values readonly.

Scope: 5 files, 3 additions, 24 deletions. No public behavior or documentation changes.

## Validation

`pnpm check:affected --run` passed on e74debd5d (289 test files, 2,284 tests). Focused iOS presentation and Maestro target tests passed (22 tests).