### PR TITLE
fix(maestro): make iOS presentation correspondence authoritative

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -300,9 +300,9 @@ task touches:
 
 ### Maestro compatibility
 
-- Maestro program: source-preserving typed representation of supported Maestro YAML. It is
-  interpreted directly through the compatibility runtime port and never lowered through generic
-  replay action strings. See ADR 0015.
+- Maestro program: source-preserving typed representation of the Maestro Flow syntax and behavior
+  supported by agent-device. The program is interpreted directly through the compatibility runtime
+  port and never lowered through generic replay action strings. See ADR 0015.
 - Maestro observation generation: explicit compatibility-engine state identifying evidence captured
   since the most recent mutation. Queries may share semantic evidence within one generation; every
   mutation attempt invalidates it before dispatch. Interaction geometry is action-local: unique exact

--- a/docs/adr/0015-direct-maestro-engine.md
+++ b/docs/adr/0015-direct-maestro-engine.md
@@ -190,6 +190,8 @@ two-pointer plans, executor selection, and app-observable effects must remain un
 
 - agent-device supports selected Maestro Flow syntax and behavior. Unsupported features return
   explicit errors, and intentional differences are declared in the conformance fixtures.
+- Shipping two production engines or a runtime fallback between them is rejected because it doubles
+  semantic and performance ownership.
 - Source provenance and runtime values stay typed through execution.
 - Compatibility policy remains local while device behavior stays in shared runtimes and backends.
 - Cross-platform correctness may require richer provider query evidence, but not additional round trips.

--- a/docs/adr/0015-direct-maestro-engine.md
+++ b/docs/adr/0015-direct-maestro-engine.md
@@ -167,8 +167,8 @@ vector).
 
 ## Performance Contract
 
-The migration cannot switch production routing until Android and iOS satisfy all of these on the pager
-and react-navigation corpora:
+The direct engine preserves these properties on Android and iOS across the pager and react-navigation
+corpora:
 
 - total wall time is no slower than the pre-migration compatibility engine;
 - an observation immediately after a mutation polls its authored condition directly; a later mutation uses
@@ -186,30 +186,10 @@ Android verification must prove the bundled helper backend and version. iOS veri
 runner startup from warm command latency. Both platforms rerun the non-Maestro gesture canaries; their
 two-pointer plans, executor selection, and app-observable effects must remain unchanged.
 
-## Migration
-
-Completed. Production Maestro YAML now uses the typed program, immutable replay plan, and direct
-runtime port exclusively. The `SessionAction` lowering path, private `__maestro*` commands,
-`replayControl`, hidden compatibility caches, positional decoders, and their fallback routing were
-deleted in the same change. Generic `.ad` replay remains independent.
-
-1. Add the typed program, runtime port, direct interpreter, and normalized upstream fixtures without
-   changing production routing.
-2. Differentially compare the old lowering path and direct engine at the typed operation boundary.
-3. Move lifecycle, input, screenshot, and keyboard commands.
-4. Move target queries and assertions, deleting unverified fast-path success and assertion-triggered
-   action replay.
-5. Move single-pointer swipes through ADR 0013's normalized input boundary.
-6. Move hooks, includes, conditions, repeat/retry, and trusted `runScript`.
-7. Switch `--maestro` atomically, then delete private Maestro commands, positional decoding, hidden
-   caches, and obsolete converter/runtime tests.
-
-The old and new engines may coexist only in tests during migration. Shipping two production engines or
-a runtime fallback between them is rejected because it doubles semantic and performance ownership.
-
 ## Consequences
 
-- Maestro remains a supported subset with explicit failures; this refactor does not expand parity.
+- agent-device supports selected Maestro Flow syntax and behavior. Unsupported features return
+  explicit errors, and intentional differences are declared in the conformance fixtures.
 - Source provenance and runtime values stay typed through execution.
 - Compatibility policy remains local while device behavior stays in shared runtimes and backends.
 - Cross-platform correctness may require richer provider query evidence, but not additional round trips.

--- a/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
@@ -313,48 +313,59 @@ test('iOS target resolution uses one presented candidate universe for geometry a
   });
 });
 
-test('iOS target resolution uses presented bounds when the semantic match has none', () => {
-  const semanticSnapshot = makeSnapshot([
-    {
-      index: 0,
-      type: 'Application',
-      rect: { x: 0, y: 0, width: 393, height: 852 },
-    },
-    {
-      index: 1,
-      parentIndex: 0,
-      type: 'Other',
-      identifier: 'email-input',
-    },
-  ]);
-  const presentationSnapshot = makeSnapshot([
-    semanticSnapshot.nodes[0]!,
-    {
-      index: 1,
-      parentIndex: 0,
-      type: 'TextField',
-      rect: { x: 20, y: 100, width: 240, height: 44 },
-    },
-  ]);
-
-  expect(
-    resolveMaestroTargetFromSnapshot(semanticSnapshot, { selector: { id: 'email-input' } }, 'ios', {
-      interactiveBounds: true,
-      presentation: {
-        snapshot: presentationSnapshot,
-        presentedIndexesBySourceIndex: new Map([
-          [0, [0]],
-          [1, [1]],
-        ]),
+test.each([
+  { mode: 'interactive', interactiveBounds: true },
+  { mode: 'non-interactive', interactiveBounds: false },
+])(
+  'iOS $mode target resolution uses presented bounds when the semantic match has none',
+  (options) => {
+    const semanticSnapshot = makeSnapshot([
+      {
+        index: 0,
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 393, height: 852 },
       },
-    }),
-  ).toMatchObject({
-    ok: true,
-    node: { index: 1, identifier: 'email-input' },
-    rect: { x: 20, y: 100, width: 240, height: 44 },
-    matches: 1,
-  });
-});
+      {
+        index: 1,
+        parentIndex: 0,
+        type: 'Other',
+        identifier: 'email-input',
+      },
+    ]);
+    const presentationSnapshot = makeSnapshot([
+      semanticSnapshot.nodes[0]!,
+      {
+        index: 1,
+        parentIndex: 0,
+        type: 'TextField',
+        rect: { x: 20, y: 100, width: 240, height: 44 },
+      },
+    ]);
+
+    expect(
+      resolveMaestroTargetFromSnapshot(
+        semanticSnapshot,
+        { selector: { id: 'email-input' } },
+        'ios',
+        {
+          interactiveBounds: options.interactiveBounds,
+          presentation: {
+            snapshot: presentationSnapshot,
+            presentedIndexesBySourceIndex: new Map([
+              [0, [0]],
+              [1, [1]],
+            ]),
+          },
+        },
+      ),
+    ).toMatchObject({
+      ok: true,
+      node: { index: 1, identifier: 'email-input' },
+      rect: { x: 20, y: 100, width: 240, height: 44 },
+      matches: 1,
+    });
+  },
+);
 
 test('iOS target resolution takes geometry from the representative that proved visibility', () => {
   const semanticSnapshot = makeSnapshot([

--- a/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-targets-typed.test.ts
@@ -312,3 +312,96 @@ test('iOS target resolution uses one presented candidate universe for geometry a
     dispatchCandidates: 0,
   });
 });
+
+test('iOS target resolution uses presented bounds when the semantic match has none', () => {
+  const semanticSnapshot = makeSnapshot([
+    {
+      index: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 393, height: 852 },
+    },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'Other',
+      identifier: 'email-input',
+    },
+  ]);
+  const presentationSnapshot = makeSnapshot([
+    semanticSnapshot.nodes[0]!,
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'TextField',
+      rect: { x: 20, y: 100, width: 240, height: 44 },
+    },
+  ]);
+
+  expect(
+    resolveMaestroTargetFromSnapshot(semanticSnapshot, { selector: { id: 'email-input' } }, 'ios', {
+      interactiveBounds: true,
+      presentation: {
+        snapshot: presentationSnapshot,
+        presentedIndexesBySourceIndex: new Map([
+          [0, [0]],
+          [1, [1]],
+        ]),
+      },
+    }),
+  ).toMatchObject({
+    ok: true,
+    node: { index: 1, identifier: 'email-input' },
+    rect: { x: 20, y: 100, width: 240, height: 44 },
+    matches: 1,
+  });
+});
+
+test('iOS target resolution takes geometry from the representative that proved visibility', () => {
+  const semanticSnapshot = makeSnapshot([
+    {
+      index: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 393, height: 852 },
+    },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'Other',
+      identifier: 'email-input',
+      rect: { x: 20, y: 100, width: 240, height: 44 },
+    },
+  ]);
+  const presentationSnapshot = makeSnapshot([
+    semanticSnapshot.nodes[0]!,
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'StaticText',
+      rect: { x: 20, y: 900, width: 240, height: 44 },
+    },
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'TextField',
+      rect: { x: 20, y: 100, width: 240, height: 44 },
+    },
+  ]);
+
+  expect(
+    resolveMaestroTargetFromSnapshot(semanticSnapshot, { selector: { id: 'email-input' } }, 'ios', {
+      interactiveBounds: true,
+      presentation: {
+        snapshot: presentationSnapshot,
+        presentedIndexesBySourceIndex: new Map([
+          [0, [0]],
+          [1, [1, 2]],
+        ]),
+      },
+    }),
+  ).toMatchObject({
+    ok: true,
+    node: { index: 1, identifier: 'email-input' },
+    rect: { x: 20, y: 100, width: 240, height: 44 },
+    matches: 1,
+  });
+});

--- a/packages/maestro/src/internal/runtime-target-ranking.ts
+++ b/packages/maestro/src/internal/runtime-target-ranking.ts
@@ -84,6 +84,10 @@ export function selectMaestroSnapshotMatch(
   return { node: selected, rect: selected.rect };
 }
 
+export function usableRect(node: SnapshotNode): Rect | undefined {
+  return hasUsableRect(node) ? node.rect : undefined;
+}
+
 function hasUsableRect(node: SnapshotNode): node is SnapshotNode & { rect: Rect } {
   return isPositiveFiniteRect(node.rect);
 }

--- a/packages/maestro/src/internal/runtime-targets.ts
+++ b/packages/maestro/src/internal/runtime-targets.ts
@@ -43,6 +43,8 @@ export type MaestroTargetResolution =
     }
   | { ok: false; message: string; evidence: MaestroTargetEvidence };
 
+type MaestroRankedCandidates = ReturnType<typeof rankMaestroCandidates>;
+
 export function resolveMaestroTargetFromSnapshot(
   snapshot: SnapshotState,
   query: MaestroTargetQuery,
@@ -52,12 +54,29 @@ export function resolveMaestroTargetFromSnapshot(
     presentation?: MaestroInteractivePresentation;
   } = {},
 ): MaestroTargetResolution {
-  const presentedNodes = options.presentation
-    ? createPresentedNodeLookup(options.presentation)
-    : undefined;
+  const presentedNodes =
+    platform === 'ios' && options.presentation
+      ? createPresentedNodeLookup(options.presentation)
+      : undefined;
   const candidates = presentedNodes
-    ? rankPresentedMaestroCandidates(snapshot, query, platform, presentedNodes)
+    ? rankPresentedMaestroCandidates(snapshot, query, presentedNodes)
     : rankMaestroCandidates(snapshot, query.selector, platform, query.childOf);
+  return resolveRankedMaestroTarget(
+    query,
+    platform,
+    options.interactiveBounds === true,
+    candidates,
+    presentedNodes,
+  );
+}
+
+function resolveRankedMaestroTarget(
+  query: MaestroTargetQuery,
+  platform: MaestroPlatform,
+  interactiveBounds: boolean,
+  candidates: MaestroRankedCandidates,
+  presentedNodes: ReturnType<typeof createPresentedNodeLookup> | undefined,
+): MaestroTargetResolution {
   if (!candidates.parentMatched) {
     return {
       ok: false,
@@ -66,32 +85,93 @@ export function resolveMaestroTargetFromSnapshot(
     };
   }
   const { matches, ranked: rankedMatches } = candidates;
-  const target = selectMaestroSnapshotMatch(rankedMatches, query.index);
-  const evidence = buildMaestroTargetEvidence(query, matches, rankedMatches, target?.node);
-  if (!target) {
+  const sourceTarget = presentedNodes
+    ? selectMaestroCandidate(rankedMatches, query.index)
+    : selectMaestroSnapshotMatch(rankedMatches, query.index)?.node;
+  const evidence = buildMaestroTargetEvidence(query, matches, rankedMatches, sourceTarget);
+  if (!sourceTarget) {
     return failedTargetResolution(query, matches, rankedMatches, evidence);
   }
+  return resolveSelectedMaestroTarget({
+    query,
+    platform,
+    interactiveBounds,
+    candidates,
+    sourceTarget,
+    presentedNodes,
+    evidence,
+  });
+}
+
+function resolveSelectedMaestroTarget(params: {
+  query: MaestroTargetQuery;
+  platform: MaestroPlatform;
+  interactiveBounds: boolean;
+  candidates: MaestroRankedCandidates;
+  sourceTarget: SnapshotNode;
+  presentedNodes: ReturnType<typeof createPresentedNodeLookup> | undefined;
+  evidence: MaestroTargetEvidence;
+}): MaestroTargetResolution {
+  const { query, platform, candidates, sourceTarget, presentedNodes, evidence } = params;
   const presentedTarget = presentedNodes
-    ? selectMaestroSnapshotMatch(presentedNodes.forSource(target.node), undefined)
+    ? selectMaestroSnapshotMatch(presentedNodes.visibleForSource(sourceTarget), undefined)
     : null;
-  const rect =
-    options.interactiveBounds === true ? (presentedTarget?.rect ?? target.rect) : target.rect;
+  const semanticTarget = selectMaestroSnapshotMatch([sourceTarget], 0);
+  const rect = selectTargetRect(params.interactiveBounds, semanticTarget, presentedTarget);
+  if (!rect) return failedTargetResolution(query, candidates.matches, candidates.ranked, evidence);
   return {
     ok: true,
-    node: target.node,
+    node: sourceTarget,
     rect,
-    matches: rankedMatches.length,
-    dispatchCandidates:
-      platform === 'ios' && query.allowAtomicSelectorDispatch && !query.childOf && presentedNodes
-        ? countInteractionDispatchCandidates(target, rankedMatches, presentedTarget)
-        : 0,
+    matches: candidates.ranked.length,
+    dispatchCandidates: countAtomicDispatchCandidates({
+      platform,
+      query,
+      presentationUsed: presentedNodes !== undefined,
+      semanticTarget,
+      rankedCandidates: candidates.ranked,
+      presentedTarget,
+    }),
     evidence,
   };
 }
 
+function selectTargetRect(
+  interactiveBounds: boolean,
+  semanticTarget: { rect: Rect } | null,
+  presentedTarget: { rect: Rect } | null,
+): Rect | undefined {
+  return interactiveBounds
+    ? (presentedTarget?.rect ?? semanticTarget?.rect)
+    : (semanticTarget?.rect ?? presentedTarget?.rect);
+}
+
+function countAtomicDispatchCandidates(params: {
+  platform: MaestroPlatform;
+  query: MaestroTargetQuery;
+  presentationUsed: boolean;
+  semanticTarget: { node: SnapshotNode; rect: Rect } | null;
+  rankedCandidates: SnapshotNode[];
+  presentedTarget: { node: SnapshotNode; rect: Rect } | null;
+}): number {
+  if (
+    params.platform !== 'ios' ||
+    !params.query.allowAtomicSelectorDispatch ||
+    params.query.childOf ||
+    !params.presentationUsed
+  ) {
+    return 0;
+  }
+  return countInteractionDispatchCandidates(
+    params.semanticTarget,
+    params.rankedCandidates,
+    params.presentedTarget,
+  );
+}
+
 function createPresentedNodeLookup(presentation: MaestroInteractivePresentation): {
   isVisible: (node: SnapshotNode) => boolean;
-  forSource: (node: SnapshotNode) => SnapshotNode[];
+  visibleForSource: (node: SnapshotNode) => SnapshotNode[];
 } {
   const presentedByIndex = buildSnapshotNodeMap(presentation.snapshot.nodes);
   const forSource = (semanticNode: SnapshotNode): SnapshotNode[] => {
@@ -102,19 +182,16 @@ function createPresentedNodeLookup(presentation: MaestroInteractivePresentation)
       },
     );
   };
-  return {
-    forSource,
-    isVisible: (node) =>
-      forSource(node).some((presentedNode) =>
-        isMaestroNodeVisible(presentedNode, presentation.snapshot.nodes, 'ios'),
-      ),
-  };
+  const visibleForSource = (node: SnapshotNode): SnapshotNode[] =>
+    forSource(node).filter((presentedNode) =>
+      isMaestroNodeVisible(presentedNode, presentation.snapshot.nodes, 'ios'),
+    );
+  return { visibleForSource, isVisible: (node) => visibleForSource(node).length > 0 };
 }
 
 function rankPresentedMaestroCandidates(
   snapshot: SnapshotState,
   query: MaestroTargetQuery,
-  platform: MaestroPlatform,
   presentedNodes: ReturnType<typeof createPresentedNodeLookup>,
 ) {
   const scoped = matchMaestroCandidates(snapshot, query.selector, query.childOf);
@@ -122,8 +199,15 @@ function rankPresentedMaestroCandidates(
   return {
     ...scoped,
     visible,
-    ranked: rankVisibleMaestroMatches(snapshot.nodes, visible, query.selector, platform),
+    ranked: rankVisibleMaestroMatches(snapshot.nodes, visible, query.selector, 'ios'),
   };
+}
+
+function selectMaestroCandidate(
+  matches: SnapshotNode[],
+  index: number | undefined,
+): SnapshotNode | undefined {
+  return index === undefined ? matches[0] : matches[index];
 }
 
 function failedTargetResolution(
@@ -144,12 +228,13 @@ function failedTargetResolution(
 }
 
 function countInteractionDispatchCandidates(
-  target: { node: SnapshotNode; rect: Rect },
+  target: { node: SnapshotNode; rect: Rect } | null,
   rankedCandidates: SnapshotNode[],
   presentedTarget: { node: SnapshotNode; rect: Rect } | null,
 ): number {
   if (rankedCandidates.length !== 1) return rankedCandidates.length;
-  return presentedTarget &&
+  return target &&
+    presentedTarget &&
     presentedTarget.node.hittable !== false &&
     haveSameTapPoint(presentedTarget.rect, target.rect)
     ? 1

--- a/packages/maestro/src/internal/runtime-targets.ts
+++ b/packages/maestro/src/internal/runtime-targets.ts
@@ -6,6 +6,8 @@ import {
   rankMaestroCandidates,
   rankVisibleMaestroMatches,
   selectMaestroSnapshotMatch,
+  usableRect,
+  type MaestroRankedCandidates,
 } from './runtime-target-ranking.ts';
 import { pointInsideRect, stripUndefined } from './shared.ts';
 import { isMaestroNodeVisible } from './snapshot-policy.ts';
@@ -43,8 +45,6 @@ export type MaestroTargetResolution =
     }
   | { ok: false; message: string; evidence: MaestroTargetEvidence };
 
-type MaestroRankedCandidates = ReturnType<typeof rankMaestroCandidates>;
-
 export function resolveMaestroTargetFromSnapshot(
   snapshot: SnapshotState,
   query: MaestroTargetQuery,
@@ -58,115 +58,42 @@ export function resolveMaestroTargetFromSnapshot(
     platform === 'ios' && options.presentation
       ? createPresentedNodeLookup(options.presentation)
       : undefined;
-  const candidates = presentedNodes
+  const { matches, ranked, parentMatched } = presentedNodes
     ? rankPresentedMaestroCandidates(snapshot, query, presentedNodes)
     : rankMaestroCandidates(snapshot, query.selector, platform, query.childOf);
-  return resolveRankedMaestroTarget(
-    query,
-    platform,
-    options.interactiveBounds === true,
-    candidates,
-    presentedNodes,
-  );
-}
-
-function resolveRankedMaestroTarget(
-  query: MaestroTargetQuery,
-  platform: MaestroPlatform,
-  interactiveBounds: boolean,
-  candidates: MaestroRankedCandidates,
-  presentedNodes: ReturnType<typeof createPresentedNodeLookup> | undefined,
-): MaestroTargetResolution {
-  if (!candidates.parentMatched) {
+  if (!parentMatched) {
     return {
       ok: false,
       message: 'Maestro childOf parent did not match.',
-      evidence: buildMaestroTargetEvidence(query, candidates.matches, [], undefined),
+      evidence: buildMaestroTargetEvidence(query, matches, [], undefined),
     };
   }
-  const { matches, ranked: rankedMatches } = candidates;
-  const sourceTarget = presentedNodes
-    ? selectMaestroCandidate(rankedMatches, query.index)
-    : selectMaestroSnapshotMatch(rankedMatches, query.index)?.node;
-  const evidence = buildMaestroTargetEvidence(query, matches, rankedMatches, sourceTarget);
-  if (!sourceTarget) {
-    return failedTargetResolution(query, matches, rankedMatches, evidence);
-  }
-  return resolveSelectedMaestroTarget({
-    query,
-    platform,
-    interactiveBounds,
-    candidates,
-    sourceTarget,
-    presentedNodes,
-    evidence,
-  });
-}
+  const target = presentedNodes
+    ? selectMaestroCandidate(ranked, query.index)
+    : selectMaestroSnapshotMatch(ranked, query.index)?.node;
+  const evidence = buildMaestroTargetEvidence(query, matches, ranked, target);
+  if (!target) return failedTargetResolution(query, matches, ranked, evidence);
 
-function resolveSelectedMaestroTarget(params: {
-  query: MaestroTargetQuery;
-  platform: MaestroPlatform;
-  interactiveBounds: boolean;
-  candidates: MaestroRankedCandidates;
-  sourceTarget: SnapshotNode;
-  presentedNodes: ReturnType<typeof createPresentedNodeLookup> | undefined;
-  evidence: MaestroTargetEvidence;
-}): MaestroTargetResolution {
-  const { query, platform, candidates, sourceTarget, presentedNodes, evidence } = params;
   const presentedTarget = presentedNodes
-    ? selectMaestroSnapshotMatch(presentedNodes.visibleForSource(sourceTarget), undefined)
+    ? selectMaestroSnapshotMatch(presentedNodes.visibleForSource(target), undefined)
     : null;
-  const semanticTarget = selectMaestroSnapshotMatch([sourceTarget], 0);
-  const rect = selectTargetRect(params.interactiveBounds, semanticTarget, presentedTarget);
-  if (!rect) return failedTargetResolution(query, candidates.matches, candidates.ranked, evidence);
+  const semanticRect = usableRect(target);
+  const rect = options.interactiveBounds
+    ? (presentedTarget?.rect ?? semanticRect)
+    : (semanticRect ?? presentedTarget?.rect);
+  if (!rect) return failedTargetResolution(query, matches, ranked, evidence);
+
   return {
     ok: true,
-    node: sourceTarget,
+    node: target,
     rect,
-    matches: candidates.ranked.length,
-    dispatchCandidates: countAtomicDispatchCandidates({
-      platform,
-      query,
-      presentationUsed: presentedNodes !== undefined,
-      semanticTarget,
-      rankedCandidates: candidates.ranked,
-      presentedTarget,
-    }),
+    matches: ranked.length,
+    dispatchCandidates:
+      presentedNodes && query.allowAtomicSelectorDispatch && !query.childOf
+        ? countInteractionDispatchCandidates(semanticRect, ranked, presentedTarget)
+        : 0,
     evidence,
   };
-}
-
-function selectTargetRect(
-  interactiveBounds: boolean,
-  semanticTarget: { rect: Rect } | null,
-  presentedTarget: { rect: Rect } | null,
-): Rect | undefined {
-  return interactiveBounds
-    ? (presentedTarget?.rect ?? semanticTarget?.rect)
-    : (semanticTarget?.rect ?? presentedTarget?.rect);
-}
-
-function countAtomicDispatchCandidates(params: {
-  platform: MaestroPlatform;
-  query: MaestroTargetQuery;
-  presentationUsed: boolean;
-  semanticTarget: { node: SnapshotNode; rect: Rect } | null;
-  rankedCandidates: SnapshotNode[];
-  presentedTarget: { node: SnapshotNode; rect: Rect } | null;
-}): number {
-  if (
-    params.platform !== 'ios' ||
-    !params.query.allowAtomicSelectorDispatch ||
-    params.query.childOf ||
-    !params.presentationUsed
-  ) {
-    return 0;
-  }
-  return countInteractionDispatchCandidates(
-    params.semanticTarget,
-    params.rankedCandidates,
-    params.presentedTarget,
-  );
 }
 
 function createPresentedNodeLookup(presentation: MaestroInteractivePresentation): {
@@ -174,6 +101,7 @@ function createPresentedNodeLookup(presentation: MaestroInteractivePresentation)
   visibleForSource: (node: SnapshotNode) => SnapshotNode[];
 } {
   const presentedByIndex = buildSnapshotNodeMap(presentation.snapshot.nodes);
+  const visibleBySourceIndex = new Map<number, SnapshotNode[]>();
   const forSource = (semanticNode: SnapshotNode): SnapshotNode[] => {
     return (presentation.presentedIndexesBySourceIndex.get(semanticNode.index) ?? []).flatMap(
       (presentedIndex) => {
@@ -182,10 +110,15 @@ function createPresentedNodeLookup(presentation: MaestroInteractivePresentation)
       },
     );
   };
-  const visibleForSource = (node: SnapshotNode): SnapshotNode[] =>
-    forSource(node).filter((presentedNode) =>
+  const visibleForSource = (node: SnapshotNode): SnapshotNode[] => {
+    const cached = visibleBySourceIndex.get(node.index);
+    if (cached) return cached;
+    const visible = forSource(node).filter((presentedNode) =>
       isMaestroNodeVisible(presentedNode, presentation.snapshot.nodes, 'ios'),
     );
+    visibleBySourceIndex.set(node.index, visible);
+    return visible;
+  };
   return { visibleForSource, isVisible: (node) => visibleForSource(node).length > 0 };
 }
 
@@ -193,7 +126,7 @@ function rankPresentedMaestroCandidates(
   snapshot: SnapshotState,
   query: MaestroTargetQuery,
   presentedNodes: ReturnType<typeof createPresentedNodeLookup>,
-) {
+): MaestroRankedCandidates {
   const scoped = matchMaestroCandidates(snapshot, query.selector, query.childOf);
   const visible = scoped.matches.filter(presentedNodes.isVisible);
   return {
@@ -228,15 +161,15 @@ function failedTargetResolution(
 }
 
 function countInteractionDispatchCandidates(
-  target: { node: SnapshotNode; rect: Rect } | null,
+  semanticRect: Rect | undefined,
   rankedCandidates: SnapshotNode[],
   presentedTarget: { node: SnapshotNode; rect: Rect } | null,
 ): number {
   if (rankedCandidates.length !== 1) return rankedCandidates.length;
-  return target &&
+  return semanticRect &&
     presentedTarget &&
     presentedTarget.node.hittable !== false &&
-    haveSameTapPoint(presentedTarget.rect, target.rect)
+    haveSameTapPoint(presentedTarget.rect, semanticRect)
     ? 1
     : 0;
 }

--- a/src/daemon/snapshot-presentation/ios/action-shelf.ts
+++ b/src/daemon/snapshot-presentation/ios/action-shelf.ts
@@ -38,7 +38,7 @@ export function collectIosReplacedActionShelves(
     );
     if (!transition) continue;
 
-    suppressNodeAndDescendants(nodes, shelfPosition, context.suppressedIndexes);
+    suppressNodeAndDescendants(nodes, shelfPosition, context);
     const shelfBand = expandRect(transition.shelfRect, ACTION_SHELF_EDGE_TOLERANCE);
     for (const sibling of transition.intermediateSiblings) {
       if (
@@ -50,7 +50,7 @@ export function collectIosReplacedActionShelves(
       }
       const position = positions.get(sibling.index);
       if (position !== undefined) {
-        suppressNodeAndDescendants(nodes, position, context.suppressedIndexes);
+        suppressNodeAndDescendants(nodes, position, context);
       }
     }
   }
@@ -214,13 +214,13 @@ function isActionShelfReplacement(
 function suppressNodeAndDescendants(
   nodes: RawSnapshotNode[],
   position: number,
-  suppressedIndexes: Set<number>,
+  context: SnapshotTreeRuleContext,
 ): void {
   const node = nodes[position];
   if (!node) return;
-  suppressedIndexes.add(node.index);
+  context.suppressNode(node, []);
   for (const descendant of collectDescendants(nodes, position)) {
-    suppressedIndexes.add(descendant.index);
+    context.suppressNode(descendant, []);
   }
 }
 

--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -26,7 +26,7 @@ export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnap
 
 export type IosInteractiveSnapshotPresentation = {
   nodes: RawSnapshotNode[];
-  /** Canonical presented representatives for every semantic source index. */
+  /** Canonical presented representatives for every semantic source index; pure noise maps to []. */
   presentedIndexesBySourceIndex: ReadonlyMap<number, readonly number[]>;
 };
 
@@ -46,7 +46,7 @@ export function buildIosInteractiveSnapshotPresentation(
     replacements,
     semanticRepresentativeIndexes,
     sourceNodesByIndex,
-    suppressedIndexes,
+    isSuppressed: (node) => suppressedIndexes.has(node.index),
     suppressNode(source, representatives) {
       suppressedIndexes.add(source.index);
       if (representatives.length === 0) return;

--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -26,7 +26,7 @@ export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnap
 
 export type IosInteractiveSnapshotPresentation = {
   nodes: RawSnapshotNode[];
-  /** Presented node indexes for every source index; suppressed noise maps to an empty list. */
+  /** Canonical presented representatives for every semantic source index. */
   presentedIndexesBySourceIndex: ReadonlyMap<number, readonly number[]>;
 };
 
@@ -44,10 +44,17 @@ export function buildIosInteractiveSnapshotPresentation(
   const suppressedIndexes = new Set<number>();
   const ruleContext: SnapshotTreeRuleContext = {
     replacements,
-    representativeSourceIndexesBySourceIndex,
     semanticRepresentativeIndexes,
     sourceNodesByIndex,
     suppressedIndexes,
+    suppressNode(source, representatives) {
+      suppressedIndexes.add(source.index);
+      if (representatives.length === 0) return;
+      const indexes =
+        representativeSourceIndexesBySourceIndex.get(source.index) ?? new Set<number>();
+      for (const representative of representatives) indexes.add(representative.index);
+      representativeSourceIndexesBySourceIndex.set(source.index, indexes);
+    },
   };
 
   for (const rule of IOS_PRESENTATION_RULES) {

--- a/src/daemon/snapshot-presentation/ios/noise.ts
+++ b/src/daemon/snapshot-presentation/ios/noise.ts
@@ -137,7 +137,7 @@ function collectIosRepeatedStaticSuppression(
   for (let position = 0; position < nodes.length; position += 1) {
     const node = nodes[position];
     const nodeLabel = node?.label?.trim();
-    if (!node || context.suppressedIndexes.has(node.index) || !nodeLabel) {
+    if (!node || context.isSuppressed(node) || !nodeLabel) {
       continue;
     }
 

--- a/src/daemon/snapshot-presentation/ios/noise.ts
+++ b/src/daemon/snapshot-presentation/ios/noise.ts
@@ -10,7 +10,6 @@ import { normalizeType } from '@agent-device/contracts/snapshot';
 import { collectIosScrollIndicatorPresentation } from './scroll.ts';
 import {
   areRectsApproximatelyEqual,
-  associateSnapshotPresentation,
   collectDescendantsByParentIndex,
   findDescendant,
   findLargestViewportRect,
@@ -26,8 +25,7 @@ export function collectIosPresentationNoiseSuppression(
   nodes: RawSnapshotNode[],
   context: SnapshotTreeRuleContext,
 ): void {
-  const { suppressedIndexes } = context;
-  collectIosOffscreenKeyboardSuppression(nodes, context.sourceNodesByIndex, suppressedIndexes);
+  collectIosOffscreenKeyboardSuppression(nodes, context);
   collectIosStructuralIdentifierSuppression(nodes, context);
   collectIosScrollIndicatorPresentation(nodes, context);
   collectIosSearchToolbarSuppression(nodes, context);
@@ -119,10 +117,7 @@ function collectIosReactNativeOverlayWrapperSuppression(
         collectDescendantNodes(nodes, position),
       )
     ) {
-      context.suppressedIndexes.add(node.index);
-      for (const descendant of collectDescendantNodes(nodes, position)) {
-        associateSnapshotPresentation(context, node, descendant);
-      }
+      context.suppressNode(node, collectDescendantNodes(nodes, position));
     }
   });
 }
@@ -167,8 +162,7 @@ function collectRepeatedStaticSuppressionForNode(
   }
   const semanticDescendant = findEquivalentSemanticDescendant(nodes, position, nodeLabel);
   if (semanticDescendant) {
-    context.suppressedIndexes.add(node.index);
-    associateSnapshotPresentation(context, node, semanticDescendant);
+    context.suppressNode(node, [semanticDescendant]);
     return;
   }
   suppressRepeatedStaticDescendants(nodes, position, nodeLabel, node, context);
@@ -200,8 +194,7 @@ function suppressRepeatedStaticDescendants(
       !context.semanticRepresentativeIndexes.has(descendant.index) &&
       isRepeatedStaticNode(descendant, label)
     ) {
-      context.suppressedIndexes.add(descendant.index);
-      associateSnapshotPresentation(context, descendant, representative);
+      context.suppressNode(descendant, [representative]);
     }
   });
 }
@@ -220,8 +213,7 @@ function collectIosActionWrapperSuppression(
       );
     });
     if (semanticDescendant) {
-      context.suppressedIndexes.add(node.index);
-      associateSnapshotPresentation(context, node, semanticDescendant);
+      context.suppressNode(node, [semanticDescendant]);
     }
   });
 }
@@ -265,8 +257,7 @@ function isFullscreenActionLabelWrapper(
 
 function collectIosOffscreenKeyboardSuppression(
   nodes: RawSnapshotNode[],
-  sourceNodesByIndex: ReadonlyMap<number, RawSnapshotNode>,
-  suppressedIndexes: Set<number>,
+  context: SnapshotTreeRuleContext,
 ): void {
   const viewport = findLargestViewportRect(nodes);
   const screenBottom = viewport ? viewport.y + viewport.height : null;
@@ -278,10 +269,10 @@ function collectIosOffscreenKeyboardSuppression(
     if (!node || !isOffscreenKeyboardNode(node, screenBottom)) {
       continue;
     }
-    suppressedIndexes.add(node.index);
-    suppressOffscreenKeyboardAncestors(node, sourceNodesByIndex, suppressedIndexes, screenBottom);
+    context.suppressNode(node, []);
+    suppressOffscreenKeyboardAncestors(node, context, screenBottom);
     forEachDescendant(nodes, position, (descendant) => {
-      suppressedIndexes.add(descendant.index);
+      context.suppressNode(descendant, []);
     });
   }
 }
@@ -295,17 +286,18 @@ function isOffscreenKeyboardNode(node: RawSnapshotNode, screenBottom: number): b
 
 function suppressOffscreenKeyboardAncestors(
   node: RawSnapshotNode,
-  sourceNodesByIndex: ReadonlyMap<number, RawSnapshotNode>,
-  suppressedIndexes: Set<number>,
+  context: SnapshotTreeRuleContext,
   screenBottom: number,
 ): void {
   let current =
-    typeof node.parentIndex === 'number' ? sourceNodesByIndex.get(node.parentIndex) : undefined;
+    typeof node.parentIndex === 'number'
+      ? context.sourceNodesByIndex.get(node.parentIndex)
+      : undefined;
   while (current?.rect && current.rect.y >= screenBottom) {
-    suppressedIndexes.add(current.index);
+    context.suppressNode(current, []);
     current =
       typeof current.parentIndex === 'number'
-        ? sourceNodesByIndex.get(current.parentIndex)
+        ? context.sourceNodesByIndex.get(current.parentIndex)
         : undefined;
   }
 }
@@ -324,10 +316,7 @@ function collectIosStructuralIdentifierSuppression(
     if (!node.identifier?.trim()) {
       continue;
     }
-    context.suppressedIndexes.add(node.index);
-    for (const descendant of collectDescendantsByParentIndex(nodes, node.index)) {
-      associateSnapshotPresentation(context, node, descendant);
-    }
+    context.suppressNode(node, collectDescendantsByParentIndex(nodes, node.index));
   }
 }
 
@@ -354,8 +343,7 @@ function collectIosSearchToolbarSuppression(
       continue;
     }
 
-    context.suppressedIndexes.add(node.index);
-    associateSnapshotPresentation(context, node, innerSearch);
+    context.suppressNode(node, [innerSearch]);
     suppressToolbarAncestors(node, innerSearch, context);
     suppressSearchToolbarDescendants(nodes, position, innerSearch, context);
   }
@@ -381,8 +369,7 @@ function suppressSearchToolbarDescendants(
       return;
     }
     if (shouldSuppressIosSearchToolbarDescendant(descendant)) {
-      context.suppressedIndexes.add(descendant.index);
-      associateSnapshotPresentation(context, descendant, keptSearch);
+      context.suppressNode(descendant, [keptSearch]);
     }
   });
 }
@@ -398,8 +385,7 @@ function suppressToolbarAncestors(
     if (!parent || parent.label !== 'Toolbar') {
       return;
     }
-    context.suppressedIndexes.add(parent.index);
-    associateSnapshotPresentation(context, parent, representative);
+    context.suppressNode(parent, [representative]);
     current = parent;
   }
 }

--- a/src/daemon/snapshot-presentation/ios/rows.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.ts
@@ -3,7 +3,6 @@ import { normalizeType } from '@agent-device/contracts/snapshot';
 import { isSystemScrollIndicatorLabel } from '../../../utils/scroll-indicator.ts';
 import {
   areRectsApproximatelyEqual,
-  associateSnapshotPresentation,
   collectDescendants,
   isDisabledChevronButton,
   mergeReplacement,
@@ -47,8 +46,7 @@ function resolveIosRowLabel(
     return rowLabel;
   }
   mergeReplacement(context.replacements, row, { label: title });
-  context.suppressedIndexes.add(titleNode.index);
-  associateSnapshotPresentation(context, titleNode, row);
+  context.suppressNode(titleNode, [row]);
   return title;
 }
 
@@ -109,8 +107,7 @@ function collectSwitchRowPresentation(
   if (promotedIdentifier) {
     mergeReplacement(context.replacements, switchControl, { identifier: promotedIdentifier });
   }
-  context.suppressedIndexes.add(row.index);
-  associateSnapshotPresentation(context, row, switchControl);
+  context.suppressNode(row, [switchControl]);
   suppressSwitchRowDescendants(descendants, row, rowLabel, switchControl, context);
   return true;
 }
@@ -135,8 +132,7 @@ function collectButtonRowPresentation(
     mergeReplacement(context.replacements, row, { identifier: rowButton.identifier });
   }
 
-  context.suppressedIndexes.add(rowButton.index);
-  associateSnapshotPresentation(context, rowButton, row);
+  context.suppressNode(rowButton, [row]);
   suppressRepeatedRowDescendants(
     descendants.filter((descendant) => descendant.index !== rowButton.index),
     rowLabel,
@@ -162,8 +158,7 @@ function suppressSwitchRowDescendants(
       isIosSwitchValueDescendant(descendant, switchControl) ||
       shouldSuppressRepeatedTextDescendant(descendant, rowLabel)
     ) {
-      context.suppressedIndexes.add(descendant.index);
-      associateSnapshotPresentation(context, descendant, switchControl);
+      context.suppressNode(descendant, [switchControl]);
     }
   }
 }
@@ -179,8 +174,7 @@ function suppressRepeatedRowDescendants(
       shouldSuppressRepeatedTextDescendant(descendant, rowLabel) ||
       (row && isEmptyRowButtonWrapper(descendant, row))
     ) {
-      context.suppressedIndexes.add(descendant.index);
-      if (row) associateSnapshotPresentation(context, descendant, row);
+      context.suppressNode(descendant, row ? [row] : []);
     }
   }
 }

--- a/src/daemon/snapshot-presentation/ios/scroll.ts
+++ b/src/daemon/snapshot-presentation/ios/scroll.ts
@@ -4,7 +4,6 @@ import {
   isSystemScrollIndicatorLabel,
 } from '../../../utils/scroll-indicator.ts';
 import {
-  associateSnapshotPresentation,
   findNearestScrollableContainer,
   isScrollableSnapshotType,
   updateReplacement,
@@ -35,7 +34,7 @@ function collectIosScrollIndicatorNodePresentation(
   context: SnapshotTreeRuleContext,
 ): void {
   if (!isScrollableSnapshotType(node.type)) {
-    context.suppressedIndexes.add(node.index);
+    context.suppressNode(node, []);
   }
 
   const directions = inferVerticalScrollIndicatorDirections(node.label?.trim() ?? '', node.value);
@@ -49,7 +48,7 @@ function collectIosScrollIndicatorNodePresentation(
   }
 
   if (context.suppressedIndexes.has(node.index)) {
-    associateSnapshotPresentation(context, node, container);
+    context.suppressNode(node, [container]);
   }
 
   applyScrollIndicatorReplacement(context, container, node, directions);

--- a/src/daemon/snapshot-presentation/ios/scroll.ts
+++ b/src/daemon/snapshot-presentation/ios/scroll.ts
@@ -33,25 +33,14 @@ function collectIosScrollIndicatorNodePresentation(
   byIndex: ReadonlyMap<number, RawSnapshotNode>,
   context: SnapshotTreeRuleContext,
 ): void {
-  if (!isScrollableSnapshotType(node.type)) {
-    context.suppressNode(node, []);
-  }
-
+  const suppressed = !isScrollableSnapshotType(node.type) || context.isSuppressed(node);
   const directions = inferVerticalScrollIndicatorDirections(node.label?.trim() ?? '', node.value);
-  if (!directions) {
-    return;
-  }
-
-  const container = findNearestScrollableContainer(node, byIndex, { includeSelf: true });
-  if (!container) {
-    return;
-  }
-
-  if (context.suppressedIndexes.has(node.index)) {
-    context.suppressNode(node, [container]);
-  }
-
-  applyScrollIndicatorReplacement(context, container, node, directions);
+  const container = directions
+    ? findNearestScrollableContainer(node, byIndex, { includeSelf: true })
+    : undefined;
+  if (suppressed) context.suppressNode(node, container ? [container] : []);
+  if (container && directions)
+    applyScrollIndicatorReplacement(context, container, node, directions);
 }
 
 function applyScrollIndicatorReplacement(

--- a/src/daemon/snapshot-presentation/ios/transitions.ts
+++ b/src/daemon/snapshot-presentation/ios/transitions.ts
@@ -2,7 +2,6 @@ import type { RawSnapshotNode, Rect } from '@agent-device/kernel/snapshot';
 import { rectContains } from '@agent-device/kernel/rect';
 import { extractNodeText, normalizeType } from '@agent-device/contracts/snapshot';
 import {
-  associateSnapshotPresentation,
   collectChildrenByParent,
   mergeReplacement,
   type SnapshotTreeRuleContext,
@@ -40,10 +39,8 @@ function collectNavigationTitleAffordances(
       rect: unionRects([image.rect!, field.rect!, title.rect!]),
     });
     context.semanticRepresentativeIndexes.add(field.index);
-    context.suppressedIndexes.add(title.index);
-    context.suppressedIndexes.add(image.index);
-    associateSnapshotPresentation(context, title, field);
-    associateSnapshotPresentation(context, image, field);
+    context.suppressNode(title, [field]);
+    context.suppressNode(image, [field]);
   }
 }
 

--- a/src/daemon/snapshot-presentation/ios/web.ts
+++ b/src/daemon/snapshot-presentation/ios/web.ts
@@ -34,7 +34,7 @@ export function collectIosWebSemanticPresentation(
       childrenByParent,
     );
     if (presentation?.kind === 'suppress') {
-      context.suppressedIndexes.add(node.index);
+      context.suppressNode(node, []);
       continue;
     }
     if (presentation) {

--- a/src/daemon/snapshot-presentation/tree.ts
+++ b/src/daemon/snapshot-presentation/tree.ts
@@ -3,25 +3,14 @@ import { normalizeType } from '@agent-device/contracts/snapshot';
 export { areRectsApproximatelyEqual } from '../../utils/rect-center.ts';
 
 export type SnapshotTreeRuleContext = {
-  /** Exact semantic-source relationships declared by the presentation rule that owns them. */
-  representativeSourceIndexesBySourceIndex: Map<number, Set<number>>;
   replacements: Map<number, RawSnapshotNode>;
   /** Projected label owners that repeated-text suppression must retain. */
   semanticRepresentativeIndexes: Set<number>;
   sourceNodesByIndex: ReadonlyMap<number, RawSnapshotNode>;
-  suppressedIndexes: Set<number>;
+  suppressedIndexes: ReadonlySet<number>;
+  /** Suppress a source and declare every presented node that carries its semantic identity. */
+  suppressNode: (source: RawSnapshotNode, representatives: readonly RawSnapshotNode[]) => void;
 };
-
-export function associateSnapshotPresentation(
-  context: SnapshotTreeRuleContext,
-  source: RawSnapshotNode,
-  representative: RawSnapshotNode,
-): void {
-  const representatives =
-    context.representativeSourceIndexesBySourceIndex.get(source.index) ?? new Set<number>();
-  representatives.add(representative.index);
-  context.representativeSourceIndexesBySourceIndex.set(source.index, representatives);
-}
 
 export function collectChildrenByParent(nodes: RawSnapshotNode[]): Map<number, RawSnapshotNode[]> {
   const childrenByParent = new Map<number, RawSnapshotNode[]>();
@@ -273,7 +262,7 @@ function getRectArea(rect: RawSnapshotNode['rect']): number {
 
 export function reindexSnapshotNodesWithSuppressedParents(
   nodes: RawSnapshotNode[],
-  suppressedIndexes: Set<number>,
+  suppressedIndexes: ReadonlySet<number>,
   originalNodes: RawSnapshotNode[],
 ): RawSnapshotNode[] {
   const originalByIndex = new Map(originalNodes.map((node) => [node.index, node]));
@@ -302,7 +291,7 @@ export function reindexSnapshotNodesWithSuppressedParents(
 
 function findNearestKeptAncestorIndex(
   parentIndex: number,
-  suppressedIndexes: Set<number>,
+  suppressedIndexes: ReadonlySet<number>,
   originalByIndex: Map<number, RawSnapshotNode>,
   indexMap: Map<number, number>,
 ): number | undefined {

--- a/src/daemon/snapshot-presentation/tree.ts
+++ b/src/daemon/snapshot-presentation/tree.ts
@@ -7,7 +7,7 @@ export type SnapshotTreeRuleContext = {
   /** Projected label owners that repeated-text suppression must retain. */
   semanticRepresentativeIndexes: Set<number>;
   sourceNodesByIndex: ReadonlyMap<number, RawSnapshotNode>;
-  suppressedIndexes: ReadonlySet<number>;
+  isSuppressed: (node: RawSnapshotNode) => boolean;
   /** Suppress a source and declare every presented node that carries its semantic identity. */
   suppressNode: (source: RawSnapshotNode, representatives: readonly RawSnapshotNode[]) => void;
 };


### PR DESCRIPTION
## Summary

Make canonical iOS presentation correspondence authoritative for Maestro visibility and tap geometry.

- select semantic identity and authored index in provider snapshot space, even when the semantic node has no bounds
- take interactive geometry only from a visible canonical representative that established visibility
- make suppression and representative declaration one construction operation so the correspondence map cannot drift
- clarify ADR 0015 as a present-tense snapshot: agent-device supports selected Maestro Flow syntax and behavior

## Validation

Pre-fix focused tests failed in both targeted cases:

- `iOS target resolution uses presented bounds when the semantic match has none`: expected a successful resolution, received `{ ok: false }`
- `iOS target resolution takes geometry from the representative that proved visibility`: expected `y: 100`, received the off-screen representative at `y: 900`

Review-fix validation:

- focused Maestro and iOS presentation suite: 9 files / 73 tests passed
- `pnpm run check:fallow --base origin/main`: no issues
- `pnpm check:affected --run`: 2,382/2,383 tests passed; the unrelated Apple platform output guard timed out while the fake `record` harness was under full-suite load
- isolated `apple-platform-output-guard.test.ts`: 3/3 passed, including the timed-out iOS case

No manual device run: the fixture app does not expose a semantic-node-without-bounds or multi-representative hierarchy. GitHub iOS and conformance lanes remain authoritative for native/device coverage.