### PR TITLE
test(gesture): assert pan duration in the iOS gesture-lab replay

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -209,6 +209,17 @@ jobs:
           pnpm gate build
           node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-ios-simulator-coverage.test.ts test/integration/smoke-ios-simulator.test.ts
 
+      # #1584: isolated, cheap automatic guard for the #1562 class of regression (iOS silently
+      # ignoring a `gesture pan` duration). Split out of gesture-lab.ad, which stays full-tier
+      # (dispatch-only via replays-manual.yml) because its multi-touch commands are a separate,
+      # heavier concern. This is the only automatic lane this assertion runs in today.
+      - name: Run gesture pan-duration smoke replay
+        run: |
+          xcrun simctl install "${{ steps.ios-simulator.outputs.simulator-udid }}" "${{ steps.fixture-app.outputs.app-path }}"
+          pnpm clean:daemon
+          node --experimental-strip-types src/bin.ts test examples/test-app/replays/gesture-pan-duration.ad --udid "${{ steps.ios-simulator.outputs.simulator-udid }}" --retries 2 --artifacts-dir test/artifacts/replays-ios-gesture-pan-duration --report-junit test/artifacts/replays-ios-gesture-pan-duration.junit.xml
+          pnpm clean:daemon
+
       - name: Assert simulator automation preserved host focus
         if: ${{ always() }}
         run: |

--- a/examples/test-app/README.md
+++ b/examples/test-app/README.md
@@ -251,6 +251,13 @@ two-pointer gesture changes all three semantic states. On Android, these checks
 are intentionally qualitative because recognizers can report non-exact centroid,
 scale, and rotation values for one simultaneous two-finger gesture.
 
+`gesture-pan-duration.ad` is a separate, minimal iOS replay that asserts a single-pointer
+`gesture pan`'s requested duration is actually observed by the app (a bucketed
+`pan duration` status on the Home screen), rather than just that the gesture activated.
+It's split out of `gesture-lab.ad` so it can run as an automatic PR-tier check
+(`.github/workflows/ios.yml`) without depending on `gesture-lab.ad`'s multi-touch commands,
+which stay full-tier only.
+
 To target a specific iOS simulator or an installed Expo development build, run the
 underlying command directly so global flags stay before replay inputs:
 

--- a/examples/test-app/replays/gesture-lab.ad
+++ b/examples/test-app/replays/gesture-lab.ad
@@ -10,6 +10,7 @@ wait "two-pointer pan activations 0" 5000
 
 gesture pan 110 443 48 0 500
 wait "two-pointer pan activations 0" 5000
+wait text "pan duration >=400ms" 5000
 
 gesture pan 110 443 48 0 500 --pointer-count 2
 wait "two-pointer pan activations 1" 5000

--- a/examples/test-app/replays/gesture-pan-duration.ad
+++ b/examples/test-app/replays/gesture-pan-duration.ad
@@ -1,0 +1,17 @@
+# Isolated pan-duration canary (#1584), split out of gesture-lab.ad so the smoke tier gets a
+# cheap automatic regression guard for #1562 without depending on gesture-lab.ad's multi-touch
+# commands (pinch/rotate/transform/two-pointer pan), which are a separate, heavier full-tier
+# concern.
+context platform=ios kind=simulator timeout=60000
+
+env APP_TARGET="Agent Device Tester"
+env APP_URL=""
+
+open "${APP_TARGET}" --relaunch --launch-url "${APP_URL}"
+wait "Gesture lab" 30000
+wait "gesture canary ready" 5000
+
+gesture pan 110 443 48 0 500
+wait text "pan duration >=400ms" 5000
+
+close

--- a/examples/test-app/src/screens/GestureLab.tsx
+++ b/examples/test-app/src/screens/GestureLab.tsx
@@ -231,7 +231,9 @@ export function GestureLab() {
       if (start === undefined) return;
       const durationMs = Date.now() - start;
       const bucket =
-        durationMs >= panDurationBucketMs ? `>=${panDurationBucketMs}ms` : `<${panDurationBucketMs}ms`;
+        durationMs >= panDurationBucketMs
+          ? `>=${panDurationBucketMs}ms`
+          : `<${panDurationBucketMs}ms`;
       setPanDurationStatus(bucket);
     });
 

--- a/examples/test-app/src/screens/GestureLab.tsx
+++ b/examples/test-app/src/screens/GestureLab.tsx
@@ -37,6 +37,8 @@ type GestureCounts = {
   twoPointerPan: number;
 };
 
+const panDurationBucketMs = 400;
+
 type AndroidTouchStart = TransformState & {
   angle: number;
   centroidX: number;
@@ -65,8 +67,10 @@ export function GestureLab() {
   const [transform, setTransform] = useState<TransformState>(initialTransform);
   const [counts, setCounts] = useState<GestureCounts>(initialCounts);
   const [dragCompleted, setDragCompleted] = useState(false);
+  const [panDurationStatus, setPanDurationStatus] = useState('pending');
   const transformRef = useRef<TransformState>(initialTransform);
   const gestureStartRef = useRef<TransformState>(initialTransform);
+  const panDurationStartRef = useRef<number | undefined>(undefined);
   const androidTouchStartRef = useRef<AndroidTouchStart | undefined>(undefined);
   const legacyFlingDownRef = useRef(null);
   const legacyFlingLeftRef = useRef(null);
@@ -207,6 +211,29 @@ export function GestureLab() {
     legacyFlingUpRef,
     legacyFlingDownRef,
   ];
+  const panDurationGesture = Gesture.Pan()
+    .minPointers(1)
+    .maxPointers(1)
+    .runOnJS(true)
+    .simultaneousWithExternalGesture(
+      twoPointerPanGesture,
+      legacyPanRef,
+      legacyPinchRef,
+      legacyRotationRef,
+      ...legacyFlingRefs,
+    )
+    .onBegin(() => {
+      panDurationStartRef.current = Date.now();
+    })
+    .onFinalize(() => {
+      const start = panDurationStartRef.current;
+      panDurationStartRef.current = undefined;
+      if (start === undefined) return;
+      const durationMs = Date.now() - start;
+      const bucket =
+        durationMs >= panDurationBucketMs ? `>=${panDurationBucketMs}ms` : `<${panDurationBucketMs}ms`;
+      setPanDurationStatus(bucket);
+    });
 
   const androidTransformTarget = (
     <FlingGestureHandler
@@ -286,6 +313,46 @@ export function GestureLab() {
     pinchChanged ? 'yes' : 'no'
   }, rotate changed ${rotateChanged ? 'yes' : 'no'}`;
 
+  const targetView = (
+    <View
+      accessibilityLabel="Gesture test image"
+      onTouchEnd={
+        Platform.OS === 'android' ? () => (androidTouchStartRef.current = undefined) : undefined
+      }
+      onTouchMove={Platform.OS === 'android' ? handleAndroidTouchMove : undefined}
+      onTouchStart={Platform.OS === 'android' ? handleAndroidTouchStart : undefined}
+      style={styles.target}
+      testID="gesture-target"
+    >
+      <Image
+        accessibilityIgnoresInvertColors
+        accessibilityLabel="Gesture test image"
+        resizeMode="cover"
+        source={{ uri: gestureImageUri }}
+        style={[
+          styles.image,
+          {
+            transform: [
+              { translateX: transform.offsetX },
+              { translateY: transform.offsetY },
+              { scale: transform.scale },
+              { rotate: `${rotationDegrees}deg` },
+            ],
+          },
+        ]}
+        testID="gesture-target-image"
+      />
+      {androidTransformTarget}
+      <GestureDetector gesture={twoPointerPanGesture}>
+        <View
+          accessibilityLabel="Exact two-pointer pan target"
+          style={styles.twoPointerTarget}
+          testID="two-pointer-pan-target"
+        />
+      </GestureDetector>
+    </View>
+  );
+
   return (
     <SectionCard
       subtitle={`Image target for pan, pinch, rotate, and fling. ${changeStatusLabel}`}
@@ -318,43 +385,11 @@ export function GestureLab() {
         drag completed {dragCompleted ? 'yes' : 'no'}
       </Text>
 
-      <View
-        accessibilityLabel="Gesture test image"
-        onTouchEnd={
-          Platform.OS === 'android' ? () => (androidTouchStartRef.current = undefined) : undefined
-        }
-        onTouchMove={Platform.OS === 'android' ? handleAndroidTouchMove : undefined}
-        onTouchStart={Platform.OS === 'android' ? handleAndroidTouchStart : undefined}
-        style={styles.target}
-        testID="gesture-target"
-      >
-        <Image
-          accessibilityIgnoresInvertColors
-          accessibilityLabel="Gesture test image"
-          resizeMode="cover"
-          source={{ uri: gestureImageUri }}
-          style={[
-            styles.image,
-            {
-              transform: [
-                { translateX: transform.offsetX },
-                { translateY: transform.offsetY },
-                { scale: transform.scale },
-                { rotate: `${rotationDegrees}deg` },
-              ],
-            },
-          ]}
-          testID="gesture-target-image"
-        />
-        {androidTransformTarget}
-        <GestureDetector gesture={twoPointerPanGesture}>
-          <View
-            accessibilityLabel="Exact two-pointer pan target"
-            style={styles.twoPointerTarget}
-            testID="two-pointer-pan-target"
-          />
-        </GestureDetector>
-      </View>
+      {Platform.OS === 'ios' ? (
+        <GestureDetector gesture={panDurationGesture}>{targetView}</GestureDetector>
+      ) : (
+        targetView
+      )}
 
       <View style={styles.metrics} testID="gesture-metrics">
         <Text style={styles.metric} testID="gesture-canary-ready">
@@ -368,6 +403,9 @@ export function GestureLab() {
         </Text>
         <Text style={styles.metric} testID="gesture-two-pointer-pan-status">
           two-pointer pan activations {counts.twoPointerPan}
+        </Text>
+        <Text style={styles.metric} testID="gesture-pan-duration-status">
+          pan duration {panDurationStatus}
         </Text>
         <Text style={styles.metric} testID="gesture-change-status">
           {changeStatusLabel}

--- a/examples/test-app/src/screens/GestureLab.tsx
+++ b/examples/test-app/src/screens/GestureLab.tsx
@@ -225,7 +225,9 @@ export function GestureLab() {
     .onBegin(() => {
       panDurationStartRef.current = Date.now();
     })
-    .onFinalize(() => {
+    // `onEnd` only fires after the recognizer reached ACTIVE. `onFinalize` would also run for a
+    // failed or cancelled pan, allowing a long-lived non-gesture to satisfy the duration canary.
+    .onEnd(() => {
       const start = panDurationStartRef.current;
       panDurationStartRef.current = undefined;
       if (start === undefined) return;


### PR DESCRIPTION
## Summary

Closes #1584.

Adds an automatic iOS regression canary for the timed-pan bug fixed by #1572. The existing `gesture-lab.ad` replay exercised `gesture pan`, but only asserted an activation counter, so it stayed green when iOS collapsed a requested 500 ms pan to roughly 100 ms.

- The fixture app measures a recognized single-pointer pan and exposes only a bucketed result: `pan duration >=400ms` or `<400ms`.
- The measurement finishes in `onEnd`, which only fires after the recognizer reached `ACTIVE`; failed or cancelled recognizers cannot publish a passing bucket.
- A minimal `gesture-pan-duration.ad` replay asserts the bucket without depending on the fixture's unrelated multi-touch gestures.
- The iOS PR smoke lane runs this replay automatically with its standard retry policy.
- The broader `gesture-lab.ad` replay keeps the same assertion after its existing 500 ms pan.

Scope: 5 files, limited to the fixture app, replay coverage, and iOS CI wiring. No runner, runtime, protocol, Android, or public response behavior changes.

### Why a fixture canary

The runner's internal gesture timestamps are deliberately absent from public JSON responses. Exposing them solely for a regression test would expand the protocol for test infrastructure. The fixture instead observes the user-visible duration while keeping the assertion coarse enough to tolerate scheduling jitter.

### Red-before / green-after evidence

The same canary was tested against the parent of the timed-pan fix (`80feff42d6e788f597bf4e2e777f41a3e3b885d9`): the replay timed out waiting for `pan duration >=400ms`, and the live fixture reported `pan duration <400ms`. This confirms the test detects the original regression rather than an incidental launch or selector failure.

On the fixed implementation, the isolated replay passed twice locally:

```text
Run 1: passed 1, failed 0, duration 17.4s
Run 2: passed 1, failed 0, duration 6.4s
```

The previous PR head (`ca0b4026d`) also passed the new iOS smoke step in CI on its first attempt (`gesture-pan-duration.ad`, 33.7s; run `32378738304`, job `96456403877`). The current head strengthens the fixture observer so only an activated pan can satisfy the assertion; current-head CI is the final confirmation.

The pre-existing multi-touch portion of `gesture-lab.ad` was investigated separately. Its local iOS 26.2 failures reproduced on unmodified code and remain outside this PR. Android behavior is unchanged and `gesture-lab-android.ad` is untouched.

## Validation

- [x] Regression test proven red against pre-#1572 code, including the rendered `<400ms` result
- [x] Isolated duration replay passed twice locally on the fixed implementation
- [x] Previous exact head passed the new automatic iOS smoke step on its first attempt
- [x] `pnpm check:affected --run`
- [ ] Current-head GitHub CI
