### PR TITLE
test: add web platform command coverage manifest

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -46,6 +46,7 @@ on:
       - 'test/integration/android-**'
       - 'test/integration/smoke-android-**'
       - 'test/integration/smoke-web-**'
+      - 'test/integration/web-e2e/**'
   push:
     branches:
       - main

--- a/test/integration/smoke-web-platform-coverage.test.ts
+++ b/test/integration/smoke-web-platform-coverage.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { WEB_DESKTOP_DEVICE, mkdtempForTest } from '../../src/__tests__/test-utils/index.ts';
+import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
+import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
+import {
+  WEB_COVERAGE_GAP_ISSUE,
+  WEB_PLATFORM_COVERAGE,
+  WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+  WEB_SMOKE_EVIDENCE,
+  WEB_SMOKE_TEST_NAME,
+  liveCommandsForWebSmoke,
+} from './web-e2e/coverage-manifest.ts';
+import { writeCoverageReport } from './web-e2e/coverage-report.ts';
+
+const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
+
+test('web coverage exhaustively classifies the public catalog', () => {
+  assert.deepEqual(Object.keys(WEB_PLATFORM_COVERAGE).sort(), publicCommands);
+
+  for (const command of publicCommands) {
+    const entry = WEB_PLATFORM_COVERAGE[command];
+    assert.ok(entry.assertion.trim().length > 0, `${command} needs an observable assertion`);
+    if (entry.level === 'live' || entry.level === 'command-contract') {
+      assert.ok(entry.owner.path.trim().length > 0, `${command} needs an evidence path`);
+      assert.ok(entry.owner.test.trim().length > 0, `${command} needs named evidence`);
+    }
+    if (entry.level === 'known-gap') {
+      assert.equal(
+        entry.trackingIssue,
+        WEB_COVERAGE_GAP_ISSUE,
+        `${command} has the wrong gap issue`,
+      );
+    }
+  }
+});
+
+test('web coverage report has the expected classification counts', () => {
+  assert.deepEqual(WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
+    capabilityDenial: 15,
+    contract: 12,
+    gap: 15,
+    live: 12,
+    total: 54,
+  });
+});
+
+test('web live claims reference commands in the existing smoke scenario', () => {
+  const smokeSource = fs.readFileSync(path.resolve(WEB_SMOKE_EVIDENCE.path), 'utf8');
+  assert.ok(smokeSource.includes(WEB_SMOKE_TEST_NAME));
+
+  const liveCommands = liveCommandsForWebSmoke();
+  assert.equal(liveCommands.length, 12);
+  for (const command of liveCommands) {
+    assert.equal(
+      smokeSource.includes(`'${command}',`),
+      true,
+      `${command} is not invoked by ${WEB_SMOKE_EVIDENCE.path}`,
+    );
+  }
+});
+
+test('web contract claims name existing executable evidence', () => {
+  for (const [command, entry] of Object.entries(WEB_PLATFORM_COVERAGE)) {
+    if (entry.level !== 'command-contract') continue;
+    const evidencePath = path.resolve(entry.owner.path);
+    assert.equal(fs.existsSync(evidencePath), true, `${command} owner does not exist`);
+    assert.equal(
+      fs.readFileSync(evidencePath, 'utf8').includes(entry.owner.test),
+      true,
+      `${command} owner does not contain named evidence`,
+    );
+  }
+});
+
+test('web capability denials match the mechanical capability matrix', () => {
+  const deniedByCapabilities = publicCommands.filter(
+    (command) => !isCommandSupportedOnDevice(command, WEB_DESKTOP_DEVICE),
+  );
+  const deniedByManifest = Object.entries(WEB_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'capability-denial')
+    .map(([command]) => command)
+    .sort();
+
+  assert.deepEqual(deniedByManifest, deniedByCapabilities);
+});
+
+test('web known gaps use one grouped tracking issue', () => {
+  const gapIssues = new Set(
+    Object.values(WEB_PLATFORM_COVERAGE)
+      .filter((entry) => entry.level === 'known-gap')
+      .map((entry) => entry.trackingIssue),
+  );
+  assert.deepEqual([...gapIssues], [WEB_COVERAGE_GAP_ISSUE]);
+});
+
+test('web coverage report persists the manifest rollup and live command list', async () => {
+  const artifactDir = await mkdtempForTest('agent-device-web-coverage-');
+  const steps = [{ command: 'agent-device open http://127.0.0.1 --platform web', status: 0 }];
+  const report = JSON.parse(readCoverageReport(artifactDir, steps)) as {
+    classificationSummary: typeof WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY;
+    liveCommands: string[];
+    steps: typeof steps;
+  };
+
+  assert.deepEqual(report.classificationSummary, WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY);
+  assert.deepEqual(report.liveCommands.sort(), liveCommandsForWebSmoke().sort());
+  assert.deepEqual(report.steps, steps);
+});
+
+function readCoverageReport(
+  artifactDir: string,
+  steps: readonly { command: string; status: number }[],
+) {
+  const reportPath = writeCoverageReport(artifactDir, steps);
+  return fs.readFileSync(reportPath, 'utf8');
+}

--- a/test/integration/smoke-web-platform-coverage.test.ts
+++ b/test/integration/smoke-web-platform-coverage.test.ts
@@ -14,7 +14,7 @@ import {
   WEB_SMOKE_TEST_NAME,
   liveCommandsForWebSmoke,
 } from './web-e2e/coverage-manifest.ts';
-import { writeCoverageReport } from './web-e2e/coverage-report.ts';
+import { runCleanupWithCoverageReport, writeCoverageReport } from './web-e2e/coverage-report.ts';
 
 const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
 
@@ -109,6 +109,41 @@ test('web coverage report persists the manifest rollup and live command list', a
   assert.deepEqual(report.classificationSummary, WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY);
   assert.deepEqual(report.liveCommands.sort(), liveCommandsForWebSmoke().sort());
   assert.deepEqual(report.steps, steps);
+});
+
+test('web coverage report survives a failed close cleanup', async () => {
+  const artifactDir = await mkdtempForTest('agent-device-web-close-failure-');
+  const steps = [{ command: 'agent-device close --platform web', status: 1 }];
+  const closeError = new Error('close failed');
+
+  await assert.rejects(
+    runCleanupWithCoverageReport(artifactDir, steps, async () => {
+      throw closeError;
+    }),
+    (error) => error === closeError,
+  );
+
+  const report = JSON.parse(
+    fs.readFileSync(path.join(artifactDir, 'coverage-report.json'), 'utf8'),
+  ) as { steps: typeof steps };
+  assert.deepEqual(report.steps, steps);
+});
+
+test('web cleanup error is preserved when report writing also fails', async () => {
+  const artifactDir = await mkdtempForTest('agent-device-web-report-failure-');
+  const cleanupError = new Error('close failed');
+
+  await assert.rejects(
+    runCleanupWithCoverageReport(path.join(artifactDir, 'missing-directory'), [], async () => {
+      throw cleanupError;
+    }),
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.errors[0], cleanupError);
+      assert.ok(error.errors[1] instanceof Error);
+      return true;
+    },
+  );
 });
 
 function readCoverageReport(

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { type CliJsonResult, formatResultDebug, runBuiltCliJson } from './cli-json.ts';
 import { assertPngDimensions, assertPngFile } from './provider-scenarios/assertions.ts';
+import { writeCoverageReport } from './web-e2e/coverage-report.ts';
 
 const TEST_NAME = 'live web platform e2e smoke';
 const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
@@ -57,6 +58,7 @@ async function runWebSmoke(context: WebSmokeContext): Promise<void> {
     await assertWebScreenshot(context);
   } finally {
     await cleanupWebSmoke(context, opened);
+    writeCoverageReport(context.artifactDir, context.stepHistory);
   }
 }
 

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { type CliJsonResult, formatResultDebug, runBuiltCliJson } from './cli-json.ts';
 import { assertPngDimensions, assertPngFile } from './provider-scenarios/assertions.ts';
-import { writeCoverageReport } from './web-e2e/coverage-report.ts';
+import { runCleanupWithCoverageReport } from './web-e2e/coverage-report.ts';
 
 const TEST_NAME = 'live web platform e2e smoke';
 const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
@@ -57,8 +57,9 @@ async function runWebSmoke(context: WebSmokeContext): Promise<void> {
     await assertWebInteractions(context);
     await assertWebScreenshot(context);
   } finally {
-    await cleanupWebSmoke(context, opened);
-    writeCoverageReport(context.artifactDir, context.stepHistory);
+    await runCleanupWithCoverageReport(context.artifactDir, context.stepHistory, () =>
+      cleanupWebSmoke(context, opened),
+    );
   }
 }
 

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -1,0 +1,213 @@
+import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+
+type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
+
+type RepositoryEvidence = {
+  path: string;
+  test: string;
+};
+
+export type WebPlatformCoverageEntry =
+  | {
+      assertion: string;
+      level: 'live' | 'command-contract';
+      owner: RepositoryEvidence;
+    }
+  | {
+      assertion: string;
+      level: 'capability-denial';
+    }
+  | {
+      assertion: string;
+      level: 'known-gap';
+      trackingIssue: number;
+    };
+
+export type WebPlatformCoverageClassificationSummary = {
+  capabilityDenial: number;
+  contract: number;
+  gap: number;
+  live: number;
+  total: number;
+};
+
+export const WEB_COVERAGE_GAP_ISSUE = 1900;
+export const WEB_SMOKE_TEST_NAME = 'live web platform e2e smoke';
+export const WEB_SMOKE_EVIDENCE: RepositoryEvidence = {
+  path: 'test/integration/smoke-web-platform.test.ts',
+  test: WEB_SMOKE_TEST_NAME,
+};
+
+const C = PUBLIC_COMMANDS;
+const live = (assertion: string): WebPlatformCoverageEntry => ({
+  assertion,
+  level: 'live',
+  owner: WEB_SMOKE_EVIDENCE,
+});
+const contract = (path: string, test: string, assertion: string): WebPlatformCoverageEntry => ({
+  assertion,
+  level: 'command-contract',
+  owner: { path, test },
+});
+const denial = (assertion: string): WebPlatformCoverageEntry => ({
+  assertion,
+  level: 'capability-denial',
+});
+const gap = (assertion: string): WebPlatformCoverageEntry => ({
+  assertion,
+  level: 'known-gap',
+  trackingIssue: WEB_COVERAGE_GAP_ISSUE,
+});
+
+/**
+ * One primary, observable owner for every public command on the managed web target.
+ *
+ * Live rows are limited to the existing web-smoke scenario. Contract rows cite
+ * existing web-specific unit/provider evidence; they do not turn fixture-backed
+ * tests into live E2E claims. Capability denials are derived from the web bucket
+ * in the command capability matrix. Known gaps are explicit follow-up work, not
+ * an implicit claim that a generic command works on web.
+ */
+export const WEB_PLATFORM_COVERAGE = {
+  [C.artifacts]: gap('No web-specific artifact inventory command evidence exists yet'),
+  [C.devices]: contract(
+    'test/integration/provider-scenarios/web-desktop.test.ts',
+    'Provider-backed integration web desktop flow uses semantic web provider calls',
+    'web inventory returns the established browser target',
+  ),
+  [C.capabilities]: contract(
+    'src/daemon/handlers/__tests__/session-capabilities.test.ts',
+    'capabilities omits apps when $label runtime facts deny the operation',
+    'web capability projection reflects runtime-owned unsupported operations',
+  ),
+  [C.doctor]: contract(
+    'src/daemon/handlers/__tests__/session-doctor-web.test.ts',
+    'web doctor lifecycle check reports live managed Chrome process count',
+    'web doctor reports managed browser lifecycle evidence',
+  ),
+  [C.apps]: contract(
+    'src/daemon/handlers/__tests__/session-capabilities.test.ts',
+    'capabilities omits apps when $label runtime facts deny the operation',
+    'web runtime facts keep native app inventory unavailable',
+  ),
+  [C.boot]: gap('Web boot has no command-level executable evidence'),
+  [C.shutdown]: gap('Web shutdown has no command-level executable evidence'),
+  [C.appState]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'preserves a narrow web provider dump including empty successful entries',
+    'web runtime facts keep app state unavailable',
+  ),
+  [C.perf]: denial('Web capability model rejects native performance inspection'),
+  [C.logs]: gap('Web app-log commands have no command-level executable evidence'),
+  [C.events]: gap('Web session event timeline has no command-level executable evidence'),
+  [C.network]: live('network dump returns the fixture GET request and requested headers'),
+  [C.audio]: contract(
+    'src/daemon/handlers/__tests__/session-audio.test.ts',
+    'audio probe forwards daemon millisecond timing to web provider',
+    'web audio probe forwards typed duration and bucket values',
+  ),
+  [C.replay]: gap('Web replay has no executable command evidence'),
+  [C.test]: gap('Web test-suite execution has no executable command evidence'),
+  [C.clipboard]: denial('Web capability model rejects native clipboard operations'),
+  [C.keyboard]: denial('Web capability model rejects native keyboard operations'),
+  [C.install]: gap('Web application installation has no command-level executable evidence'),
+  [C.reinstall]: gap('Web application reinstallation has no command-level executable evidence'),
+  [C.push]: gap('Web application push delivery has no command-level executable evidence'),
+  [C.triggerAppEvent]: denial('Web capability model rejects native app event delivery'),
+  [C.open]: live('the managed browser opens the local fixture page'),
+  [C.prepare]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'preserves a narrow web provider dump including empty successful entries',
+    'web runtime facts keep Apple runner preparation unavailable',
+  ),
+  [C.batch]: gap('Web batch execution has no command-level executable evidence'),
+  [C.close]: live('close releases the managed browser session during smoke cleanup'),
+  [C.snapshot]: live('interactive snapshot exposes the fixture ready marker and form controls'),
+  [C.diff]: gap('Web snapshot diff has no command-level executable evidence'),
+  [C.wait]: live('wait observes ready text and post-interaction fixture state'),
+  [C.alert]: denial('Web capability model rejects native alert operations'),
+  [C.settings]: denial('Web capability model rejects native device settings operations'),
+  [C.reactNative]: denial('Web capability model rejects React Native inspection'),
+  [C.record]: contract(
+    'test/integration/provider-scenarios/web-desktop.test.ts',
+    'start web recording',
+    'web recording starts and stops through the scoped provider',
+  ),
+  [C.trace]: gap('Web trace capture has no command-level executable evidence'),
+  [C.find]: live('find locates the ready marker through text and selector expressions'),
+  [C.click]: live('click changes the fixture status to Submitted'),
+  [C.fill]: live('fill updates the accessible email value and fixture status'),
+  [C.longPress]: denial('Web capability model rejects touch long-press input'),
+  [C.hover]: contract(
+    'test/integration/provider-scenarios/web-desktop.test.ts',
+    'hover submit ref',
+    'web hover moves the pointer through the provider element handle',
+  ),
+  [C.press]: gap('Web press has no direct command-level executable evidence'),
+  [C.type]: contract(
+    'test/integration/provider-scenarios/web-desktop.test.ts',
+    'type suffix',
+    'web type appends text to the focused field through the provider',
+  ),
+  [C.get]: live('get reads the ready marker text from the fixture'),
+  [C.is]: live('is visible passes for the Submit order control'),
+  [C.back]: denial('Web capability model rejects native back navigation'),
+  [C.gesture]: denial('Web capability model rejects touch gesture input'),
+  [C.home]: denial('Web capability model rejects native Home navigation'),
+  [C.tvRemote]: denial('Web capability model rejects TV remote input'),
+  [C.orientation]: denial('Web capability model rejects native orientation changes'),
+  [C.scroll]: contract(
+    'test/integration/provider-scenarios/web-desktop.test.ts',
+    'scroll by pixels',
+    'web scroll moves the provider-backed page by the requested pixels',
+  ),
+  [C.swipe]: denial('Web capability model rejects touch swipe input'),
+  [C.focus]: contract(
+    'src/core/__tests__/web-interactor.test.ts',
+    'web interactor delegates first-slice operations to the scoped provider',
+    'web focus delegates to the scoped provider click primitive',
+  ),
+  [C.screenshot]: live('screenshot creates a valid 640x480 PNG artifact'),
+  [C.viewport]: live('viewport resizes the browser and the PNG reports 640x480 dimensions'),
+  [C.appSwitcher]: denial('Web capability model rejects native app switcher navigation'),
+  [C.installFromSource]: gap('Web source installation has no command-level executable evidence'),
+} satisfies Record<PublicCommand, WebPlatformCoverageEntry>;
+
+export const WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClassificationSummary(
+  Object.values(WEB_PLATFORM_COVERAGE),
+);
+
+export function liveCommandsForWebSmoke(): PublicCommand[] {
+  return Object.entries(WEB_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'live')
+    .map(([command]) => command as PublicCommand);
+}
+
+function buildCoverageClassificationSummary(
+  entries: readonly WebPlatformCoverageEntry[],
+): WebPlatformCoverageClassificationSummary {
+  const summary: WebPlatformCoverageClassificationSummary = {
+    capabilityDenial: 0,
+    contract: 0,
+    gap: 0,
+    live: 0,
+    total: entries.length,
+  };
+  for (const entry of entries) {
+    switch (entry.level) {
+      case 'live':
+        summary.live += 1;
+        break;
+      case 'command-contract':
+        summary.contract += 1;
+        break;
+      case 'capability-denial':
+        summary.capabilityDenial += 1;
+        break;
+      case 'known-gap':
+        summary.gap += 1;
+        break;
+    }
+  }
+  return summary;
+}

--- a/test/integration/web-e2e/coverage-report.ts
+++ b/test/integration/web-e2e/coverage-report.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+  liveCommandsForWebSmoke,
+} from './coverage-manifest.ts';
+
+export type WebSmokeStep = {
+  command: string;
+  status: number;
+};
+
+export function writeCoverageReport(artifactDir: string, steps: readonly WebSmokeStep[]): string {
+  const reportPath = path.join(artifactDir, 'coverage-report.json');
+  fs.writeFileSync(
+    reportPath,
+    JSON.stringify(
+      {
+        classificationSummary: WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+        liveCommands: liveCommandsForWebSmoke(),
+        steps,
+      },
+      null,
+      2,
+    ),
+  );
+  return reportPath;
+}

--- a/test/integration/web-e2e/coverage-report.ts
+++ b/test/integration/web-e2e/coverage-report.ts
@@ -11,6 +11,40 @@ export type WebSmokeStep = {
   status: number;
 };
 
+export async function runCleanupWithCoverageReport(
+  artifactDir: string,
+  steps: readonly WebSmokeStep[],
+  cleanup: () => Promise<void>,
+): Promise<void> {
+  let cleanupFailed = false;
+  let cleanupError: unknown;
+  let reportFailed = false;
+  let reportError: unknown;
+  try {
+    try {
+      await cleanup();
+    } catch (error) {
+      cleanupFailed = true;
+      cleanupError = error;
+    }
+  } finally {
+    try {
+      writeCoverageReport(artifactDir, steps);
+    } catch (error) {
+      reportFailed = true;
+      reportError = error;
+    }
+  }
+  if (cleanupFailed && reportFailed) {
+    throw new AggregateError(
+      [cleanupError, reportError],
+      'web smoke cleanup and coverage reporting failed',
+    );
+  }
+  if (cleanupFailed) throw cleanupError;
+  if (reportFailed) throw reportError;
+}
+
 export function writeCoverageReport(artifactDir: string, steps: readonly WebSmokeStep[]): string {
   const reportPath = path.join(artifactDir, 'coverage-report.json');
   fs.writeFileSync(


### PR DESCRIPTION
## Summary

- Add an exhaustive `satisfies Record<PublicCommand, ...>` web manifest for all 54 public commands.
- Credit 12 commands to the existing live web smoke, 12 to existing web-specific contract evidence, 15 to mechanical capability denials, and 15 to explicit known gaps.
- Persist the manifest rollup and executed command steps in the existing smoke artifact.
- Add the grouped follow-up issue #1900 for web gaps and route `test/integration/web-e2e/**` away from the iOS workflow.
- This PR is web-only and adds no live scenarios; macOS, Linux, and tvOS are not included. Part of #1426.

## Validation

- `pnpm install --frozen-lockfile && pnpm build`
- `pnpm format`
- `pnpm check:quick`
- Focused web coverage gate: 7 tests passed.
- Planted-red proof: removing only the `artifacts` row failed catalog completeness and the expected 54-command count; restoring it passed.
- `AGENT_DEVICE_WEB_E2E=1 pnpm test:smoke:web`: 1 live test passed, covering 12 public commands. Artifact: `test/artifacts/web/live-web-platform-e2e-smoke/2026-08-20T11-48-29.572Z/`.
- `pnpm check:affected --run`: all runnable checks passed; GitHub-authoritative web/native lanes remain for CI.

Touched files are limited to the web manifest/report, existing web smoke integration, and the iOS workflow routing metadata needed by the affected-check gate.