### PR TITLE
test: cover host runner tv remote and recording paths

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
@@ -1,4 +1,31 @@
+import CoreGraphics
+import Foundation
 import XCTest
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+private func makeRecordingTestImage() -> RunnerImage {
+  let context = CGContext(
+    data: nil,
+    width: 2,
+    height: 2,
+    bitsPerComponent: 8,
+    bytesPerRow: 0,
+    space: CGColorSpaceCreateDeviceRGB(),
+    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+  )!
+  context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 1))
+  context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+  let cgImage = context.makeImage()!
+#if canImport(AppKit)
+  return NSImage(cgImage: cgImage, size: NSSize(width: 2, height: 2))
+#else
+  return UIImage(cgImage: cgImage)
+#endif
+}
 
 extension RunnerTests {
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
@@ -14,6 +41,29 @@ extension RunnerTests {
       XCTAssertEqual(response.data?.message, "recording already stopped")
       XCTAssertNil(activeRecording)
     }
+  }
+
+  func testScreenRecorderClampsNonMonotonicFrameTimestamps() throws {
+    let outputPath = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("agent-device-screen-recorder-\(UUID().uuidString).mp4")
+      .path
+    defer { try? FileManager.default.removeItem(atPath: outputPath) }
+
+    let recorder = ScreenRecorder(outputPath: outputPath, fps: 30)
+    let image = makeRecordingTestImage()
+    try recorder.startForTesting(image: image)
+    defer { try? recorder.stop() }
+
+    XCTAssertEqual(
+      recorder.appendForTesting(image: image, timestampValue: 100),
+      100
+    )
+    // Non-vacuity: without the monotonicity guard, this append records 0 or fails instead of 101.
+    XCTAssertEqual(
+      recorder.appendForTesting(image: image, timestampValue: 0),
+      101
+    )
+    XCTAssertNoThrow(try recorder.stop())
   }
 #endif
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
@@ -1,31 +1,4 @@
-import CoreGraphics
-import Foundation
 import XCTest
-#if canImport(AppKit)
-import AppKit
-#elseif canImport(UIKit)
-import UIKit
-#endif
-
-private func makeRecordingTestImage() -> RunnerImage {
-  let context = CGContext(
-    data: nil,
-    width: 2,
-    height: 2,
-    bitsPerComponent: 8,
-    bytesPerRow: 0,
-    space: CGColorSpaceCreateDeviceRGB(),
-    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-  )!
-  context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 1))
-  context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
-  let cgImage = context.makeImage()!
-#if canImport(AppKit)
-  return NSImage(cgImage: cgImage, size: NSSize(width: 2, height: 2))
-#else
-  return UIImage(cgImage: cgImage)
-#endif
-}
 
 extension RunnerTests {
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
@@ -43,27 +16,12 @@ extension RunnerTests {
     }
   }
 
-  func testScreenRecorderClampsNonMonotonicFrameTimestamps() throws {
-    let outputPath = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appendingPathComponent("agent-device-screen-recorder-\(UUID().uuidString).mp4")
-      .path
-    defer { try? FileManager.default.removeItem(atPath: outputPath) }
+  func testScreenRecorderClampsNonMonotonicFrameTimestamps() {
+    let recorder = ScreenRecorder(outputPath: "", fps: 30)
 
-    let recorder = ScreenRecorder(outputPath: outputPath, fps: 30)
-    let image = makeRecordingTestImage()
-    try recorder.startForTesting(image: image)
-    defer { try? recorder.stop() }
-
-    XCTAssertEqual(
-      recorder.appendForTesting(image: image, timestampValue: 100),
-      100
-    )
-    // Non-vacuity: without the monotonicity guard, this append records 0 or fails instead of 101.
-    XCTAssertEqual(
-      recorder.appendForTesting(image: image, timestampValue: 0),
-      101
-    )
-    XCTAssertNoThrow(try recorder.stop())
+    XCTAssertEqual(recorder.allocateTimestampForTesting(100), 100)
+    // Non-vacuity: the allocator must advance an accepted frame past the prior timestamp.
+    XCTAssertEqual(recorder.allocateTimestampForTesting(0), 101)
   }
 #endif
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+RecordingTests.swift
@@ -20,7 +20,7 @@ extension RunnerTests {
     let recorder = ScreenRecorder(outputPath: "", fps: 30)
 
     XCTAssertEqual(recorder.allocateTimestampForTesting(100), 100)
-    // Non-vacuity: the allocator must advance an accepted frame past the prior timestamp.
+    // The helper records each returned value as an accepted frame.
     XCTAssertEqual(recorder.allocateTimestampForTesting(0), 101)
   }
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
@@ -199,16 +199,8 @@ extension RunnerTests {
       }
       guard input.isReadyForMoreMediaData else { return }
       guard let pixelBuffer = makePixelBuffer(from: cgImage) else { return }
-      let nowUptime = ProcessInfo.processInfo.systemUptime
-      if recordingStartUptime == nil {
-        recordingStartUptime = nowUptime
-      }
-      let elapsed = max(0, nowUptime - (recordingStartUptime ?? nowUptime))
+      let timestampValue = timestampValue(for: ProcessInfo.processInfo.systemUptime)
       let timescale = effectiveFps
-      var timestampValue = Int64((elapsed * Double(timescale)).rounded(.down))
-      if timestampValue <= lastTimestampValue {
-        timestampValue = lastTimestampValue + 1
-      }
       let timestamp = CMTime(value: timestampValue, timescale: timescale)
       if !adaptor.append(pixelBuffer, withPresentationTime: timestamp) {
         startError = writer.error ?? NSError(
@@ -219,6 +211,18 @@ extension RunnerTests {
         return
       }
       lastTimestampValue = timestampValue
+    }
+
+    private func timestampValue(for nowUptime: TimeInterval) -> Int64 {
+      if recordingStartUptime == nil {
+        recordingStartUptime = nowUptime
+      }
+      let elapsed = max(0, nowUptime - (recordingStartUptime ?? nowUptime))
+      let timestampValue = Int64((elapsed * Double(effectiveFps)).rounded(.down))
+      if timestampValue <= lastTimestampValue {
+        return lastTimestampValue + 1
+      }
+      return timestampValue
     }
 
     private func shouldStop() -> Bool {
@@ -264,25 +268,16 @@ extension RunnerTests {
 
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
 extension RunnerTests.ScreenRecorder {
-  func startForTesting(image: RunnerImage) throws {
-    try start { image }
-    lock.lock()
-    timer?.cancel()
-    timer = nil
-    lock.unlock()
-  }
-
   @discardableResult
-  func appendForTesting(image: RunnerImage, timestampValue: Int64) -> Int64 {
+  func allocateTimestampForTesting(_ requestedTimestampValue: Int64) -> Int64 {
     lock.lock()
+    defer { lock.unlock() }
+    let nowUptime = ProcessInfo.processInfo.systemUptime
     recordingStartUptime =
-      ProcessInfo.processInfo.systemUptime - Double(timestampValue) / Double(effectiveFps)
-    lock.unlock()
-    append(image: image)
-    lock.lock()
-    let appendedTimestamp = lastTimestampValue
-    lock.unlock()
-    return appendedTimestamp
+      nowUptime - Double(requestedTimestampValue) / Double(effectiveFps)
+    let allocatedTimestamp = timestampValue(for: nowUptime)
+    lastTimestampValue = allocatedTimestamp
+    return allocatedTimestamp
   }
 }
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
@@ -261,3 +261,28 @@ extension RunnerTests {
 
   }
 }
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+extension RunnerTests.ScreenRecorder {
+  func startForTesting(image: RunnerImage) throws {
+    try start { image }
+    lock.lock()
+    timer?.cancel()
+    timer = nil
+    lock.unlock()
+  }
+
+  @discardableResult
+  func appendForTesting(image: RunnerImage, timestampValue: Int64) -> Int64 {
+    lock.lock()
+    recordingStartUptime =
+      ProcessInfo.processInfo.systemUptime - Double(timestampValue) / Double(effectiveFps)
+    lock.unlock()
+    append(image: image)
+    lock.lock()
+    let appendedTimestamp = lastTimestampValue
+    lock.unlock()
+    return appendedTimestamp
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScreenRecorder.swift
@@ -199,7 +199,8 @@ extension RunnerTests {
       }
       guard input.isReadyForMoreMediaData else { return }
       guard let pixelBuffer = makePixelBuffer(from: cgImage) else { return }
-      let timestampValue = timestampValue(for: ProcessInfo.processInfo.systemUptime)
+      let candidateTimestampValue = timestampCandidateValue(for: ProcessInfo.processInfo.systemUptime)
+      let timestampValue = monotonicTimestampValue(for: candidateTimestampValue)
       let timescale = effectiveFps
       let timestamp = CMTime(value: timestampValue, timescale: timescale)
       if !adaptor.append(pixelBuffer, withPresentationTime: timestamp) {
@@ -213,16 +214,18 @@ extension RunnerTests {
       lastTimestampValue = timestampValue
     }
 
-    private func timestampValue(for nowUptime: TimeInterval) -> Int64 {
-      if recordingStartUptime == nil {
-        recordingStartUptime = nowUptime
-      }
-      let elapsed = max(0, nowUptime - (recordingStartUptime ?? nowUptime))
-      let timestampValue = Int64((elapsed * Double(effectiveFps)).rounded(.down))
-      if timestampValue <= lastTimestampValue {
+    private func timestampCandidateValue(for nowUptime: TimeInterval) -> Int64 {
+      let startUptime = recordingStartUptime ?? nowUptime
+      recordingStartUptime = startUptime
+      let elapsed = max(0, nowUptime - startUptime)
+      return Int64((elapsed * Double(effectiveFps)).rounded(.down))
+    }
+
+    private func monotonicTimestampValue(for candidateTimestampValue: Int64) -> Int64 {
+      if candidateTimestampValue <= lastTimestampValue {
         return lastTimestampValue + 1
       }
-      return timestampValue
+      return candidateTimestampValue
     }
 
     private func shouldStop() -> Bool {
@@ -269,13 +272,10 @@ extension RunnerTests {
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
 extension RunnerTests.ScreenRecorder {
   @discardableResult
-  func allocateTimestampForTesting(_ requestedTimestampValue: Int64) -> Int64 {
+  func allocateTimestampForTesting(_ candidateTimestampValue: Int64) -> Int64 {
     lock.lock()
     defer { lock.unlock() }
-    let nowUptime = ProcessInfo.processInfo.systemUptime
-    recordingStartUptime =
-      nowUptime - Double(requestedTimestampValue) / Double(effectiveFps)
-    let allocatedTimestamp = timestampValue(for: nowUptime)
+    let allocatedTimestamp = monotonicTimestampValue(for: candidateTimestampValue)
     lastTimestampValue = allocatedTimestamp
     return allocatedTimestamp
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TvRemote.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TvRemote.swift
@@ -18,6 +18,40 @@ enum TvRemoteButton {
 }
 
 extension RunnerTests {
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+  func testTvRemoteButtonMappingAcceptsSupportedNamesAndRejectsUnknown() {
+    func buttonName(_ button: TvRemoteButton) -> String {
+      switch button {
+      case .select: return "select"
+      case .menu: return "menu"
+      case .home: return "home"
+      case .up: return "up"
+      case .down: return "down"
+      case .left: return "left"
+      case .right: return "right"
+      }
+    }
+
+    let supported = [
+      ("select", "select"),
+      ("SELECT", "select"),
+      ("menu", "menu"),
+      ("home", "home"),
+      ("up", "up"),
+      ("down", "down"),
+      ("left", "left"),
+      ("right", "right"),
+    ]
+    for (raw, expected) in supported {
+      XCTAssertEqual(tvRemoteButton(from: raw).map(buttonName), expected)
+    }
+
+    for raw in [String?(nil), "", "volumeUp", "select "] {
+      XCTAssertNil(tvRemoteButton(from: raw))
+    }
+  }
+#endif
+
   func resolveTvRemoteDoublePressDelay() -> TimeInterval {
     guard
       let raw = ProcessInfo.processInfo.environment["AGENT_DEVICE_TV_REMOTE_DOUBLE_PRESS_DELAY_MS"],


### PR DESCRIPTION
## Summary

- Add a host-runnable tvOS remote-button mapping regression covering supported names, case normalization, and invalid keys.
- Add a host-runnable ScreenRecorder regression for monotonic timestamps through a shared integer-candidate allocator, without AVAssetWriter output or readiness timing in the test.
- Keep the existing host-XCTest lane and scope the change to three Swift files.

Closes #1897

## Validation

- `pnpm check:xctest-selection`
- Signed macOS host XCTest: 2 passed, 0 failed.
- Mutation proof: removing the monotonic clamp made the focused recording test fail deterministically (`0` != `101`; 1 test, 1 failure), then the clamp was restored.
- `pnpm check:affected --run` passed; GitHub-authoritative native lanes remain for CI.