### PR TITLE
test: add filesystem boundary fault matrix

### DIFF
--- a/src/__tests__/test-utils/filesystem-boundary-faults.ts
+++ b/src/__tests__/test-utils/filesystem-boundary-faults.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, vi } from 'vitest';
+import { isAtomicPublishTemporaryPath } from '../../utils/atomic-file.ts';
+import { mkdtempForTestSync } from './tmp-dir.ts';
+
+export type FilesystemErrno = 'EIO' | 'ENOSPC' | 'EMFILE';
+export type FilesystemFaultPoint = 'write' | 'rename';
+
+export type FilesystemBoundaryFixture = {
+  targetPath: string;
+  run: () => unknown | Promise<unknown>;
+  expected: 'throw' | 'return';
+  verifyReturn?: (value: unknown, errno: FilesystemErrno) => void;
+};
+
+export type FilesystemBoundaryOwner = (root: string) => FilesystemBoundaryFixture;
+
+export const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
+export const FILESYSTEM_FAULT_POINTS: readonly FilesystemFaultPoint[] = ['write', 'rename'];
+
+/** Registers every fault row for a typed owner table. Missing required owners fail typechecking. */
+export function registerFilesystemBoundaryMatrix(
+  owners: Readonly<Record<string, FilesystemBoundaryOwner>>,
+  prefix: string,
+): void {
+  for (const [ownerName, createFixture] of Object.entries(owners)) {
+    for (const faultPoint of FILESYSTEM_FAULT_POINTS) {
+      for (const errno of FILESYSTEM_ERRNOS) {
+        test(`${prefix} ${ownerName} ${faultPoint} ${errno} leaves no unpublished temporary file`, async () => {
+          const root = mkdtempForTestSync(
+            `agent-device-${prefix}-${ownerName.replaceAll('/', '-')}-boundary-`,
+          );
+          const fixture = createFixture(root);
+          const fault = installFilesystemFault({
+            faultPoint,
+            errno,
+            targetPath: fixture.targetPath,
+          });
+
+          let value: unknown;
+          let thrown: unknown;
+          try {
+            value = await fixture.run();
+          } catch (error) {
+            thrown = error;
+          }
+
+          if (fixture.expected === 'throw') {
+            assert.ok(thrown, `${ownerName} should surface ${errno}`);
+            assert.equal((thrown as NodeJS.ErrnoException).code, errno);
+          } else {
+            assert.equal(thrown, undefined);
+            fixture.verifyReturn?.(value, errno);
+          }
+          assert.equal(fault.wasInjected(), true, `${ownerName} ${faultPoint} fault was injected`);
+          assert.equal(fs.existsSync(fixture.targetPath), false);
+          assert.deepEqual(listTemporaryFiles(root), []);
+        });
+      }
+    }
+  }
+}
+
+export function installFilesystemFault(options: {
+  faultPoint: FilesystemFaultPoint;
+  errno: FilesystemErrno;
+  targetPath: string;
+}): { wasInjected: () => boolean } {
+  const failure = createErrno(options.errno);
+  let injected = false;
+  const temporaryDescriptors = new Set<number>();
+  const isTargetOrTemporary = (value: unknown): boolean =>
+    value === options.targetPath || isAtomicPublishTemporaryPath(value, options.targetPath);
+
+  if (options.faultPoint === 'write') {
+    const originalOpenSync = fs.openSync;
+    vi.spyOn(fs, 'openSync').mockImplementation((...args) => {
+      const descriptor = Reflect.apply(originalOpenSync, fs, args);
+      if (isAtomicPublishTemporaryPath(args[0], options.targetPath)) {
+        temporaryDescriptors.add(descriptor);
+      }
+      return descriptor;
+    });
+
+    const originalWriteFileSync = fs.writeFileSync;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
+      const destination = args[0];
+      const writesPublishedTemporary =
+        isAtomicPublishTemporaryPath(destination, options.targetPath) ||
+        (typeof destination === 'number' && temporaryDescriptors.has(destination));
+      if (writesPublishedTemporary) {
+        injected = true;
+        Reflect.apply(originalWriteFileSync, fs, args);
+        throw failure;
+      }
+      return Reflect.apply(originalWriteFileSync, fs, args);
+    });
+  } else {
+    const originalRenameSync = fs.renameSync;
+    vi.spyOn(fs, 'renameSync').mockImplementation((...args) => {
+      if (isTargetOrTemporary(args[0]) || isTargetOrTemporary(args[1])) {
+        injected = true;
+        throw failure;
+      }
+      return Reflect.apply(originalRenameSync, fs, args);
+    });
+  }
+
+  return { wasInjected: () => injected };
+}
+
+function createErrno(errno: FilesystemErrno): NodeJS.ErrnoException {
+  const error = new Error(`injected filesystem ${errno}`) as NodeJS.ErrnoException;
+  error.code = errno;
+  return error;
+}
+
+function listTemporaryFiles(root: string): string[] {
+  const temporaryFiles: string[] = [];
+
+  function visit(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(entryPath);
+      else if (entry.name.endsWith('.tmp')) temporaryFiles.push(entryPath);
+    }
+  }
+
+  visit(root);
+  return temporaryFiles;
+}

--- a/src/__tests__/test-utils/filesystem-boundary-faults.ts
+++ b/src/__tests__/test-utils/filesystem-boundary-faults.ts
@@ -17,8 +17,8 @@ export type FilesystemBoundaryFixture = {
 
 export type FilesystemBoundaryOwner = (root: string) => FilesystemBoundaryFixture;
 
-export const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
-export const FILESYSTEM_FAULT_POINTS: readonly FilesystemFaultPoint[] = ['write', 'rename'];
+const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
+const FILESYSTEM_FAULT_POINTS: readonly FilesystemFaultPoint[] = ['write', 'rename'];
 
 /** Registers every fault row for a typed owner table. Missing required owners fail typechecking. */
 export function registerFilesystemBoundaryMatrix(
@@ -63,7 +63,7 @@ export function registerFilesystemBoundaryMatrix(
   }
 }
 
-export function installFilesystemFault(options: {
+function installFilesystemFault(options: {
   faultPoint: FilesystemFaultPoint;
   errno: FilesystemErrno;
   targetPath: string;

--- a/src/daemon/__tests__/filesystem-boundary-faults.test.ts
+++ b/src/daemon/__tests__/filesystem-boundary-faults.test.ts
@@ -30,6 +30,23 @@ type FaultInjection = { wasInjected: () => boolean };
 
 const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
 const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
+const REQUIRED_DAEMON_MATRIX_MODULES = [
+  'durable-capture-resource-store/screen-recording',
+  'durable-capture-resource-store/app-log',
+  'device-claims',
+  'session-script-writer',
+  'daemon-shutdown-report',
+  'session-store',
+] as const;
+const DURABLE_RESOURCE_CONFIGS = [
+  {
+    resourceKind: 'screen-recording',
+    fileName: 'screen-recording.resource.json',
+    displayName: 'Screen recording',
+  },
+  { resourceKind: 'app-log', fileName: 'app-log.resource.json', displayName: 'App-log' },
+] as const;
+const registeredDaemonMatrixRows: string[] = [];
 
 type BoundaryFixture = {
   targetPath: string;
@@ -44,25 +61,23 @@ afterEach(() => {
   delete process.env.AGENT_DEVICE_CLAIMS_DIR;
 });
 
-registerFilesystemMatrix('durable-capture-resource-store', (root) => {
-  const store = createDurableCaptureResourceStore({
-    resourceKind: 'screen-recording',
-    fileName: 'screen-recording.resource.json',
-    displayName: 'Screen recording',
-  });
-  const targetPath = store.resolvePath(path.join(root, 'sessions', 'default'));
+for (const config of DURABLE_RESOURCE_CONFIGS) {
+  registerFilesystemMatrix(`durable-capture-resource-store/${config.resourceKind}`, (root) => {
+    const store = createDurableCaptureResourceStore(config);
+    const targetPath = store.resolvePath(path.join(root, 'sessions', 'default'));
 
-  return {
-    targetPath,
-    // The durable store opens the temporary path and writes through its file
-    // descriptor, so the write-side fault is identified by the descriptor.
-    // This fixture performs no other writes after the fault is installed.
-    matchesPublishPath: (value) =>
-      typeof value === 'number' || matchesTargetOrTemporary(value, targetPath),
-    run: async () => store.write(targetPath, resourceEnvelope('filesystem-fault')),
-    expected: 'throw',
-  };
-});
+    return {
+      targetPath,
+      // The durable store opens the temporary path and writes through its file
+      // descriptor, so the write-side fault is identified by the descriptor.
+      matchesPublishPath: (value) =>
+        typeof value === 'number' || matchesTargetOrTemporary(value, targetPath),
+      run: async () =>
+        store.write(targetPath, resourceEnvelope(config.resourceKind, 'filesystem-fault')),
+      expected: 'throw',
+    };
+  });
+}
 
 registerFilesystemMatrix('device-claims', (root) => {
   const device: DeviceInfo = {
@@ -153,14 +168,26 @@ registerFilesystemMatrix('session-store', (root) => {
   };
 });
 
+test('filesystem errno matrix declares every scoped daemon row', () => {
+  const expectedRows = REQUIRED_DAEMON_MATRIX_MODULES.flatMap((moduleName) =>
+    FAULT_POINTS.flatMap((faultPoint) =>
+      FILESYSTEM_ERRNOS.map((errno) => `${moduleName}:${faultPoint}:${errno}`),
+    ),
+  );
+  assert.deepEqual([...registeredDaemonMatrixRows].sort(), expectedRows.sort());
+});
+
 function registerFilesystemMatrix(
   moduleName: string,
   createFixture: (root: string) => BoundaryFixture,
 ): void {
   for (const faultPoint of FAULT_POINTS) {
     for (const errno of FILESYSTEM_ERRNOS) {
+      registeredDaemonMatrixRows.push(`${moduleName}:${faultPoint}:${errno}`);
       test(`${moduleName} ${faultPoint} ${errno} leaves no unpublished temporary file`, async () => {
-        const root = mkdtempForTestSync(`agent-device-${moduleName}-boundary-`);
+        const root = mkdtempForTestSync(
+          `agent-device-${moduleName.replaceAll('/', '-')}-boundary-`,
+        );
         const fixture = createFixture(root);
         const fault = installFilesystemFault(faultPoint, errno, fixture.matchesPublishPath);
 
@@ -199,6 +226,7 @@ function installFilesystemFault(
     vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
       if (matchesPublishPath(args[0])) {
         injected = true;
+        Reflect.apply(originalWriteFileSync, fs, args);
         throw failure;
       }
       return Reflect.apply(originalWriteFileSync, fs, args);
@@ -251,9 +279,12 @@ function listTemporaryFiles(root: string): string[] {
   }
 }
 
-function resourceEnvelope(sessionId: string) {
+function resourceEnvelope<ResourceKind extends 'screen-recording' | 'app-log'>(
+  resourceKind: ResourceKind,
+  sessionId: string,
+) {
   return createDurableResourceEnvelope({
-    resourceKind: 'screen-recording',
+    resourceKind,
     sessionId,
     device: { id: 'emulator-5554', family: 'android', kind: 'emulator' },
     owner: localRuntimeOwner('android'),

--- a/src/daemon/__tests__/filesystem-boundary-faults.test.ts
+++ b/src/daemon/__tests__/filesystem-boundary-faults.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import { localRuntimeOwner } from '@agent-device/contracts/platform';
+import { createDurableResourceEnvelope } from '@agent-device/capture-kit';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { acquireDeviceClaim } from '../device-claims.ts';
+import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
+import { createDurableCaptureResourceStore } from '../durable-capture-resource-store.ts';
+import { writeDaemonShutdownReport } from '../daemon-shutdown-report.ts';
+import { SessionScriptWriter } from '../session-script-writer.ts';
+import { SessionStore } from '../session-store.ts';
+import {
+  repairPublication,
+  makeRepairCompleteSession,
+} from '../../__tests__/test-utils/session-factories.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+
+vi.mock('../../utils/host-process.ts', async (importOriginal) =>
+  (await import('../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
+    importOriginal,
+  ),
+);
+
+type FilesystemErrno = 'EIO' | 'ENOSPC' | 'EMFILE';
+type FaultPoint = 'write' | 'rename';
+type FaultInjection = { wasInjected: () => boolean };
+
+const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
+const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
+
+type BoundaryFixture = {
+  targetPath: string;
+  matchesPublishPath: (value: unknown) => boolean;
+  run: () => Promise<unknown>;
+  expected: 'throw' | 'return';
+  verifyReturn?: (value: unknown, errno: FilesystemErrno) => void;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.AGENT_DEVICE_CLAIMS_DIR;
+});
+
+registerFilesystemMatrix('durable-capture-resource-store', (root) => {
+  const store = createDurableCaptureResourceStore({
+    resourceKind: 'screen-recording',
+    fileName: 'screen-recording.resource.json',
+    displayName: 'Screen recording',
+  });
+  const targetPath = store.resolvePath(path.join(root, 'sessions', 'default'));
+
+  return {
+    targetPath,
+    // The durable store opens the temporary path and writes through its file
+    // descriptor, so the write-side fault is identified by the descriptor.
+    // This fixture performs no other writes after the fault is installed.
+    matchesPublishPath: (value) =>
+      typeof value === 'number' || matchesTargetOrTemporary(value, targetPath),
+    run: async () => store.write(targetPath, resourceEnvelope('filesystem-fault')),
+    expected: 'throw',
+  };
+});
+
+registerFilesystemMatrix('device-claims', (root) => {
+  const device: DeviceInfo = {
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel',
+    kind: 'emulator',
+    booted: true,
+  };
+  process.env.AGENT_DEVICE_CLAIMS_DIR = root;
+  const deviceKey = canonicalLocalDeviceKey(device);
+  const claimPath = path.join(
+    root,
+    `${crypto.createHash('sha256').update(deviceKey).digest('hex')}.json`,
+  );
+
+  return {
+    targetPath: claimPath,
+    matchesPublishPath: (value) => matchesTargetOrTemporary(value, claimPath),
+    run: async () =>
+      acquireDeviceClaim({
+        device,
+        session: 'filesystem-fault',
+        workspace: process.cwd(),
+        stateDir: path.join(root, 'state'),
+        reconcileOrphanedDeviceClaim: async () => ({
+          status: 'retained' as const,
+          reason: 'test-no-recovery',
+        }),
+      }),
+    expected: 'throw',
+  };
+});
+
+registerFilesystemMatrix('session-script-writer', (root) => {
+  const targetPath = path.join(root, 'published.ad');
+  const writer = new SessionScriptWriter(path.join(root, 'sessions'));
+  const session = makeRepairCompleteSession('filesystem-fault', {
+    scriptPublication: repairPublication('complete', { path: targetPath, force: true }),
+    actions: [{ ts: 1, command: 'open', positionals: ['Demo'], flags: {} }],
+  });
+
+  return {
+    targetPath,
+    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
+    run: async () => writer.write(session, { force: true }),
+    expected: 'return',
+    verifyReturn: (value, errno) => {
+      const result = value as { written?: boolean; error?: { code?: string; message?: string } };
+      assert.equal(result.written, false);
+      assert.equal(result.error?.code, 'COMMAND_FAILED');
+      assert.match(result.error?.message ?? '', new RegExp(errno));
+    },
+  };
+});
+
+registerFilesystemMatrix('daemon-shutdown-report', (root) => {
+  const targetPath = path.join(root, 'daemon-shutdown.json');
+  return {
+    targetPath,
+    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
+    run: async () =>
+      writeDaemonShutdownReport(root, {
+        providerReleases: { released: [], pending: [] },
+        claims: { released: [], orphaned: [], superseded: [] },
+      }),
+    expected: 'return',
+  };
+});
+
+registerFilesystemMatrix('session-store', (root) => {
+  const targetPath = path.join(root, 'published-by-teardown.ad');
+  const store = new SessionStore(path.join(root, 'sessions'));
+  const session = makeRepairCompleteSession('filesystem-fault', {
+    scriptPublication: repairPublication('complete', { path: targetPath, force: true }),
+  });
+
+  return {
+    targetPath,
+    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
+    run: async () => store.finalizeRepairTeardown(session),
+    expected: 'return',
+    verifyReturn: (_value, errno) => {
+      const tombstone = store.readRepairTombstone(session.name);
+      assert.equal(tombstone?.commitFailure?.code, 'COMMAND_FAILED');
+      assert.match(tombstone?.commitFailure?.message ?? '', new RegExp(errno));
+    },
+  };
+});
+
+function registerFilesystemMatrix(
+  moduleName: string,
+  createFixture: (root: string) => BoundaryFixture,
+): void {
+  for (const faultPoint of FAULT_POINTS) {
+    for (const errno of FILESYSTEM_ERRNOS) {
+      test(`${moduleName} ${faultPoint} ${errno} leaves no unpublished temporary file`, async () => {
+        const root = mkdtempForTestSync(`agent-device-${moduleName}-boundary-`);
+        const fixture = createFixture(root);
+        const fault = installFilesystemFault(faultPoint, errno, fixture.matchesPublishPath);
+
+        let value: unknown;
+        let thrown: unknown;
+        try {
+          value = await fixture.run();
+        } catch (error) {
+          thrown = error;
+        }
+
+        if (fixture.expected === 'throw') {
+          assert.ok(thrown, `${moduleName} should surface ${errno}`);
+          assert.equal((thrown as NodeJS.ErrnoException).code, errno);
+        } else {
+          assert.equal(thrown, undefined);
+          fixture.verifyReturn?.(value, errno);
+        }
+        assert.equal(fault.wasInjected(), true, `${moduleName} ${faultPoint} fault was injected`);
+        assert.equal(fs.existsSync(fixture.targetPath), false);
+        assert.deepEqual(listTemporaryFiles(root), []);
+      });
+    }
+  }
+}
+
+function installFilesystemFault(
+  faultPoint: FaultPoint,
+  errno: FilesystemErrno,
+  matchesPublishPath: (value: unknown) => boolean,
+): FaultInjection {
+  const failure = createErrno(errno);
+  let injected = false;
+  if (faultPoint === 'write') {
+    const originalWriteFileSync = fs.writeFileSync;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
+      if (matchesPublishPath(args[0])) {
+        injected = true;
+        throw failure;
+      }
+      return Reflect.apply(originalWriteFileSync, fs, args);
+    });
+    return { wasInjected: () => injected };
+  }
+
+  const originalRenameSync = fs.renameSync;
+  vi.spyOn(fs, 'renameSync').mockImplementation((...args) => {
+    if (matchesPublishPath(args[0]) || matchesPublishPath(args[1])) {
+      injected = true;
+      throw failure;
+    }
+    return Reflect.apply(originalRenameSync, fs, args);
+  });
+  return { wasInjected: () => injected };
+}
+
+function createErrno(errno: FilesystemErrno): NodeJS.ErrnoException {
+  const error = new Error(`injected filesystem ${errno}`) as NodeJS.ErrnoException;
+  error.code = errno;
+  return error;
+}
+
+function matchesTargetOrTemporary(value: unknown, targetPath: string): boolean {
+  const candidate = String(value);
+  const targetName = path.basename(targetPath);
+  const candidateName = path.basename(candidate);
+  return (
+    candidate === targetPath ||
+    candidateName.startsWith(`.${targetName}.`) ||
+    candidateName.startsWith(`${targetName}.`)
+  );
+}
+
+function listTemporaryFiles(root: string): string[] {
+  const temporaryFiles: string[] = [];
+  visit(root);
+  return temporaryFiles;
+
+  function visit(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (entry.name.endsWith('.tmp')) {
+        temporaryFiles.push(entryPath);
+      }
+    }
+  }
+}
+
+function resourceEnvelope(sessionId: string) {
+  return createDurableResourceEnvelope({
+    resourceKind: 'screen-recording',
+    sessionId,
+    device: { id: 'emulator-5554', family: 'android', kind: 'emulator' },
+    owner: localRuntimeOwner('android'),
+    fence: { token: `fence-${sessionId}`, generation: 1 },
+    lifecycle: 'open',
+    descriptor: { version: 1, body: {} },
+  });
+}

--- a/src/daemon/__tests__/filesystem-boundary-faults.test.ts
+++ b/src/daemon/__tests__/filesystem-boundary-faults.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import fs from 'node:fs';
 import path from 'node:path';
-import { afterEach, test, vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { localRuntimeOwner } from '@agent-device/contracts/platform';
 import { createDurableResourceEnvelope } from '@agent-device/capture-kit';
 import type { DeviceInfo } from '@agent-device/kernel/device';
@@ -10,13 +9,17 @@ import { acquireDeviceClaim } from '../device-claims.ts';
 import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
 import { createDurableCaptureResourceStore } from '../durable-capture-resource-store.ts';
 import { writeDaemonShutdownReport } from '../daemon-shutdown-report.ts';
-import { SessionScriptWriter } from '../session-script-writer.ts';
+import { SessionScriptWriter, type SessionScriptWriteResult } from '../session-script-writer.ts';
 import { SessionStore } from '../session-store.ts';
 import {
   repairPublication,
   makeRepairCompleteSession,
 } from '../../__tests__/test-utils/session-factories.ts';
-import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import {
+  registerFilesystemBoundaryMatrix,
+  type FilesystemBoundaryOwner,
+  type FilesystemBoundaryFixture,
+} from '../../__tests__/test-utils/filesystem-boundary-faults.ts';
 
 vi.mock('../../utils/host-process.ts', async (importOriginal) =>
   (await import('../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
@@ -24,62 +27,58 @@ vi.mock('../../utils/host-process.ts', async (importOriginal) =>
   ),
 );
 
-type FilesystemErrno = 'EIO' | 'ENOSPC' | 'EMFILE';
-type FaultPoint = 'write' | 'rename';
-type FaultInjection = { wasInjected: () => boolean };
-
-const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
-const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
-const REQUIRED_DAEMON_MATRIX_MODULES = [
-  'durable-capture-resource-store/screen-recording',
-  'durable-capture-resource-store/app-log',
-  'device-claims',
-  'session-script-writer',
-  'daemon-shutdown-report',
-  'session-store',
-] as const;
-const DURABLE_RESOURCE_CONFIGS = [
-  {
-    resourceKind: 'screen-recording',
-    fileName: 'screen-recording.resource.json',
-    displayName: 'Screen recording',
-  },
-  { resourceKind: 'app-log', fileName: 'app-log.resource.json', displayName: 'App-log' },
-] as const;
-const registeredDaemonMatrixRows: string[] = [];
-
-type BoundaryFixture = {
-  targetPath: string;
-  matchesPublishPath: (value: unknown) => boolean;
-  run: () => Promise<unknown>;
-  expected: 'throw' | 'return';
-  verifyReturn?: (value: unknown, errno: FilesystemErrno) => void;
-};
+type DaemonFilesystemBoundaryOwner =
+  | 'durable-capture-resource-store/screen-recording'
+  | 'durable-capture-resource-store/app-log'
+  | 'device-claims'
+  | 'session-script-writer'
+  | 'daemon-shutdown-report'
+  | 'session-store';
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.AGENT_DEVICE_CLAIMS_DIR;
 });
 
-for (const config of DURABLE_RESOURCE_CONFIGS) {
-  registerFilesystemMatrix(`durable-capture-resource-store/${config.resourceKind}`, (root) => {
+const DAEMON_FILESYSTEM_BOUNDARY_OWNERS = {
+  'durable-capture-resource-store/screen-recording': createDurableResourceFixture({
+    resourceKind: 'screen-recording',
+    fileName: 'screen-recording.resource.json',
+    displayName: 'Screen recording',
+  }),
+  'durable-capture-resource-store/app-log': createDurableResourceFixture({
+    resourceKind: 'app-log',
+    fileName: 'app-log.resource.json',
+    displayName: 'App-log',
+  }),
+  'device-claims': createDeviceClaimFixture,
+  'session-script-writer': createSessionScriptFixture,
+  'daemon-shutdown-report': createShutdownReportFixture,
+  'session-store': createSessionStoreFixture,
+} as const satisfies Record<DaemonFilesystemBoundaryOwner, FilesystemBoundaryOwner>;
+
+registerFilesystemBoundaryMatrix(DAEMON_FILESYSTEM_BOUNDARY_OWNERS, 'daemon');
+
+function createDurableResourceFixture(
+  config: Readonly<{
+    resourceKind: 'screen-recording' | 'app-log';
+    fileName: string;
+    displayName: string;
+  }>,
+): FilesystemBoundaryOwner {
+  return (root) => {
     const store = createDurableCaptureResourceStore(config);
     const targetPath = store.resolvePath(path.join(root, 'sessions', 'default'));
-
     return {
       targetPath,
-      // The durable store opens the temporary path and writes through its file
-      // descriptor, so the write-side fault is identified by the descriptor.
-      matchesPublishPath: (value) =>
-        typeof value === 'number' || matchesTargetOrTemporary(value, targetPath),
       run: async () =>
         store.write(targetPath, resourceEnvelope(config.resourceKind, 'filesystem-fault')),
       expected: 'throw',
     };
-  });
+  };
 }
 
-registerFilesystemMatrix('device-claims', (root) => {
+function createDeviceClaimFixture(root: string): FilesystemBoundaryFixture {
   const device: DeviceInfo = {
     platform: 'android',
     id: 'emulator-5554',
@@ -96,7 +95,6 @@ registerFilesystemMatrix('device-claims', (root) => {
 
   return {
     targetPath: claimPath,
-    matchesPublishPath: (value) => matchesTargetOrTemporary(value, claimPath),
     run: async () =>
       acquireDeviceClaim({
         device,
@@ -110,9 +108,9 @@ registerFilesystemMatrix('device-claims', (root) => {
       }),
     expected: 'throw',
   };
-});
+}
 
-registerFilesystemMatrix('session-script-writer', (root) => {
+function createSessionScriptFixture(root: string): FilesystemBoundaryFixture {
   const targetPath = path.join(root, 'published.ad');
   const writer = new SessionScriptWriter(path.join(root, 'sessions'));
   const session = makeRepairCompleteSession('filesystem-fault', {
@@ -122,23 +120,21 @@ registerFilesystemMatrix('session-script-writer', (root) => {
 
   return {
     targetPath,
-    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
     run: async () => writer.write(session, { force: true }),
     expected: 'return',
     verifyReturn: (value, errno) => {
-      const result = value as { written?: boolean; error?: { code?: string; message?: string } };
-      assert.equal(result.written, false);
-      assert.equal(result.error?.code, 'COMMAND_FAILED');
-      assert.match(result.error?.message ?? '', new RegExp(errno));
+      assert.ok(isSessionScriptWriteFailure(value));
+      if (!isSessionScriptWriteFailure(value)) return;
+      assert.equal(value.written, false);
+      assert.equal(value.error?.code, 'COMMAND_FAILED');
+      assert.match(value.error?.message ?? '', new RegExp(errno));
     },
   };
-});
+}
 
-registerFilesystemMatrix('daemon-shutdown-report', (root) => {
-  const targetPath = path.join(root, 'daemon-shutdown.json');
+function createShutdownReportFixture(root: string): FilesystemBoundaryFixture {
   return {
-    targetPath,
-    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
+    targetPath: path.join(root, 'daemon-shutdown.json'),
     run: async () =>
       writeDaemonShutdownReport(root, {
         providerReleases: { released: [], pending: [] },
@@ -146,9 +142,9 @@ registerFilesystemMatrix('daemon-shutdown-report', (root) => {
       }),
     expected: 'return',
   };
-});
+}
 
-registerFilesystemMatrix('session-store', (root) => {
+function createSessionStoreFixture(root: string): FilesystemBoundaryFixture {
   const targetPath = path.join(root, 'published-by-teardown.ad');
   const store = new SessionStore(path.join(root, 'sessions'));
   const session = makeRepairCompleteSession('filesystem-fault', {
@@ -157,7 +153,6 @@ registerFilesystemMatrix('session-store', (root) => {
 
   return {
     targetPath,
-    matchesPublishPath: (value) => matchesTargetOrTemporary(value, targetPath),
     run: async () => store.finalizeRepairTeardown(session),
     expected: 'return',
     verifyReturn: (_value, errno) => {
@@ -166,117 +161,14 @@ registerFilesystemMatrix('session-store', (root) => {
       assert.match(tombstone?.commitFailure?.message ?? '', new RegExp(errno));
     },
   };
-});
-
-test('filesystem errno matrix declares every scoped daemon row', () => {
-  const expectedRows = REQUIRED_DAEMON_MATRIX_MODULES.flatMap((moduleName) =>
-    FAULT_POINTS.flatMap((faultPoint) =>
-      FILESYSTEM_ERRNOS.map((errno) => `${moduleName}:${faultPoint}:${errno}`),
-    ),
-  );
-  assert.deepEqual([...registeredDaemonMatrixRows].sort(), expectedRows.sort());
-});
-
-function registerFilesystemMatrix(
-  moduleName: string,
-  createFixture: (root: string) => BoundaryFixture,
-): void {
-  for (const faultPoint of FAULT_POINTS) {
-    for (const errno of FILESYSTEM_ERRNOS) {
-      registeredDaemonMatrixRows.push(`${moduleName}:${faultPoint}:${errno}`);
-      test(`${moduleName} ${faultPoint} ${errno} leaves no unpublished temporary file`, async () => {
-        const root = mkdtempForTestSync(
-          `agent-device-${moduleName.replaceAll('/', '-')}-boundary-`,
-        );
-        const fixture = createFixture(root);
-        const fault = installFilesystemFault(faultPoint, errno, fixture.matchesPublishPath);
-
-        let value: unknown;
-        let thrown: unknown;
-        try {
-          value = await fixture.run();
-        } catch (error) {
-          thrown = error;
-        }
-
-        if (fixture.expected === 'throw') {
-          assert.ok(thrown, `${moduleName} should surface ${errno}`);
-          assert.equal((thrown as NodeJS.ErrnoException).code, errno);
-        } else {
-          assert.equal(thrown, undefined);
-          fixture.verifyReturn?.(value, errno);
-        }
-        assert.equal(fault.wasInjected(), true, `${moduleName} ${faultPoint} fault was injected`);
-        assert.equal(fs.existsSync(fixture.targetPath), false);
-        assert.deepEqual(listTemporaryFiles(root), []);
-      });
-    }
-  }
 }
 
-function installFilesystemFault(
-  faultPoint: FaultPoint,
-  errno: FilesystemErrno,
-  matchesPublishPath: (value: unknown) => boolean,
-): FaultInjection {
-  const failure = createErrno(errno);
-  let injected = false;
-  if (faultPoint === 'write') {
-    const originalWriteFileSync = fs.writeFileSync;
-    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
-      if (matchesPublishPath(args[0])) {
-        injected = true;
-        Reflect.apply(originalWriteFileSync, fs, args);
-        throw failure;
-      }
-      return Reflect.apply(originalWriteFileSync, fs, args);
-    });
-    return { wasInjected: () => injected };
-  }
-
-  const originalRenameSync = fs.renameSync;
-  vi.spyOn(fs, 'renameSync').mockImplementation((...args) => {
-    if (matchesPublishPath(args[0]) || matchesPublishPath(args[1])) {
-      injected = true;
-      throw failure;
-    }
-    return Reflect.apply(originalRenameSync, fs, args);
-  });
-  return { wasInjected: () => injected };
-}
-
-function createErrno(errno: FilesystemErrno): NodeJS.ErrnoException {
-  const error = new Error(`injected filesystem ${errno}`) as NodeJS.ErrnoException;
-  error.code = errno;
-  return error;
-}
-
-function matchesTargetOrTemporary(value: unknown, targetPath: string): boolean {
-  const candidate = String(value);
-  const targetName = path.basename(targetPath);
-  const candidateName = path.basename(candidate);
+function isSessionScriptWriteFailure(
+  value: unknown,
+): value is Extract<SessionScriptWriteResult, { written: false }> {
   return (
-    candidate === targetPath ||
-    candidateName.startsWith(`.${targetName}.`) ||
-    candidateName.startsWith(`${targetName}.`)
+    typeof value === 'object' && value !== null && 'written' in value && value.written === false
   );
-}
-
-function listTemporaryFiles(root: string): string[] {
-  const temporaryFiles: string[] = [];
-  visit(root);
-  return temporaryFiles;
-
-  function visit(directory: string): void {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(entryPath);
-      } else if (entry.name.endsWith('.tmp')) {
-        temporaryFiles.push(entryPath);
-      }
-    }
-  }
 }
 
 function resourceEnvelope<ResourceKind extends 'screen-recording' | 'app-log'>(

--- a/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
@@ -9,10 +9,18 @@ import type { DaemonRequest } from '../../types.ts';
 import { sendRequest } from '../daemon-client-transport.ts';
 
 const PROCESS_DEATH_COMMANDS = ['open', 'close'] as const;
+const REQUIRED_PROCESS_DEATH_COMMANDS = ['open', 'close'] as const;
+
+test('acceptance matrix declares both process-death lifecycle commands', () => {
+  assert.deepEqual([...PROCESS_DEATH_COMMANDS].sort(), [...REQUIRED_PROCESS_DEATH_COMMANDS].sort());
+});
 
 test.each(PROCESS_DEATH_COMMANDS)(
   'acceptance row: process death after %s dispatch is a bounded, non-replayed request',
   async (command) => {
+    // This acceptance row deliberately stops at the transport boundary: a
+    // dead daemon is observed as a closed response socket. Lifecycle teardown
+    // and process-tree cleanup belong to the deferred full fault matrix.
     const endpoint = await startEndpointThatDiesAfterRequest();
     const baseDir = mkdtempForTestSync(`agent-device-process-death-${command}-`);
     const statePaths = daemonPaths(baseDir);
@@ -31,6 +39,8 @@ test.each(PROCESS_DEATH_COMMANDS)(
           assert.ok(error instanceof AppError);
           assert.equal(error.code, 'COMMAND_FAILED');
           assert.match(error.message, /communicate with daemon/i);
+          assert.equal(error.details?.requestId, request.meta?.requestId);
+          assert.match(String(error.details?.hint), /Retry command/i);
           return true;
         },
       );

--- a/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
@@ -3,54 +3,65 @@ import http from 'node:http';
 import path from 'node:path';
 import { test } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
+import { assertRejectsAppError } from '../../../__tests__/test-utils/index.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 import type { DaemonPaths } from '../../config.ts';
 import type { DaemonRequest } from '../../types.ts';
 import { sendRequest } from '../daemon-client-transport.ts';
 
-const PROCESS_DEATH_COMMANDS = ['open', 'close'] as const;
-const REQUIRED_PROCESS_DEATH_COMMANDS = ['open', 'close'] as const;
+type ProcessDeathCommand = 'open' | 'close';
+type ProcessDeathRow = Readonly<{
+  command: ProcessDeathCommand;
+  positionals: readonly string[];
+}>;
 
-test('acceptance matrix declares both process-death lifecycle commands', () => {
-  assert.deepEqual([...PROCESS_DEATH_COMMANDS].sort(), [...REQUIRED_PROCESS_DEATH_COMMANDS].sort());
-});
+const PROCESS_DEATH_ROWS = {
+  open: { command: 'open', positionals: ['Demo'] },
+  close: { command: 'close', positionals: [] },
+} as const satisfies Record<ProcessDeathCommand, ProcessDeathRow>;
 
-test.each(PROCESS_DEATH_COMMANDS)(
-  'acceptance row: process death after %s dispatch is a bounded, non-replayed request',
-  async (command) => {
+for (const row of Object.values(PROCESS_DEATH_ROWS)) {
+  test(`acceptance row: process death after ${row.command} dispatch is bounded and non-replayed`, async () => {
     // This acceptance row deliberately stops at the transport boundary: a
     // dead daemon is observed as a closed response socket. Lifecycle teardown
     // and process-tree cleanup belong to the deferred full fault matrix.
     const endpoint = await startEndpointThatDiesAfterRequest();
-    const baseDir = mkdtempForTestSync(`agent-device-process-death-${command}-`);
+    const baseDir = mkdtempForTestSync(`agent-device-process-death-${row.command}-`);
     const statePaths = daemonPaths(baseDir);
-    const request = buildRequest(command);
+    const request = buildRequest(row);
+    let observed: unknown;
 
     try {
-      await assert.rejects(
-        sendRequest(
-          { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
-          request,
-          'http',
-          statePaths,
-          1_000,
-        ),
-        (error: unknown) => {
-          assert.ok(error instanceof AppError);
-          assert.equal(error.code, 'COMMAND_FAILED');
-          assert.match(error.message, /communicate with daemon/i);
-          assert.equal(error.details?.requestId, request.meta?.requestId);
-          assert.match(String(error.details?.hint), /Retry command/i);
-          return true;
+      await assertRejectsAppError(
+        async () => {
+          try {
+            return await sendRequest(
+              { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
+              request,
+              'http',
+              statePaths,
+              1_000,
+            );
+          } catch (error) {
+            observed = error;
+            throw error;
+          }
+        },
+        {
+          code: 'COMMAND_FAILED',
+          message: /communicate with daemon/i,
+          hint: /Retry command/i,
         },
       );
     } finally {
       await endpoint.close();
     }
 
-    assert.deepEqual(endpoint.commands, [command]);
-  },
-);
+    assert.ok(observed instanceof AppError);
+    assert.equal(observed.details?.requestId, request.meta?.requestId);
+    assert.deepEqual(endpoint.commands, [row.command]);
+  });
+}
 
 type DeadEndpoint = {
   port: number;
@@ -100,14 +111,14 @@ async function startEndpointThatDiesAfterRequest(): Promise<DeadEndpoint> {
   };
 }
 
-function buildRequest(command: (typeof PROCESS_DEATH_COMMANDS)[number]): DaemonRequest {
+function buildRequest(row: ProcessDeathRow): DaemonRequest {
   return {
     token: 'test-token',
     session: 'acceptance',
-    command,
-    positionals: command === 'open' ? ['Demo'] : [],
+    command: row.command,
+    positionals: [...row.positionals],
     flags: {},
-    meta: { requestId: `acceptance-process-death-${command}` },
+    meta: { requestId: `acceptance-process-death-${row.command}` },
   };
 }
 

--- a/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import path from 'node:path';
+import { test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import type { DaemonPaths } from '../../config.ts';
+import type { DaemonRequest } from '../../types.ts';
+import { sendRequest } from '../daemon-client-transport.ts';
+
+const PROCESS_DEATH_COMMANDS = ['open', 'close'] as const;
+
+test.each(PROCESS_DEATH_COMMANDS)(
+  'acceptance row: process death after %s dispatch is a bounded, non-replayed request',
+  async (command) => {
+    const endpoint = await startEndpointThatDiesAfterRequest();
+    const baseDir = mkdtempForTestSync(`agent-device-process-death-${command}-`);
+    const statePaths = daemonPaths(baseDir);
+    const request = buildRequest(command);
+
+    try {
+      await assert.rejects(
+        sendRequest(
+          { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
+          request,
+          'http',
+          statePaths,
+          1_000,
+        ),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, 'COMMAND_FAILED');
+          assert.match(error.message, /communicate with daemon/i);
+          return true;
+        },
+      );
+    } finally {
+      await endpoint.close();
+    }
+
+    assert.deepEqual(endpoint.commands, [command]);
+  },
+);
+
+type DeadEndpoint = {
+  port: number;
+  commands: string[];
+  close: () => Promise<void>;
+};
+
+async function startEndpointThatDiesAfterRequest(): Promise<DeadEndpoint> {
+  const commands: string[] = [];
+  let closePromise: Promise<void> | undefined;
+  const server = http.createServer((request) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      const parsed = JSON.parse(body) as { params?: { command?: unknown } };
+      const command = parsed.params?.command;
+      if (typeof command === 'string') commands.push(command);
+      // A daemon process death after dispatch is observed as the accepted
+      // socket closing. There is no response and no safe retry path for either
+      // lifecycle command.
+      request.socket.destroy();
+      closePromise ??= new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+
+  return {
+    port: address.port,
+    commands,
+    close: async () => {
+      if (!closePromise) {
+        closePromise = new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+      await closePromise;
+    },
+  };
+}
+
+function buildRequest(command: (typeof PROCESS_DEATH_COMMANDS)[number]): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'acceptance',
+    command,
+    positionals: command === 'open' ? ['Demo'] : [],
+    flags: {},
+    meta: { requestId: `acceptance-process-death-${command}` },
+  };
+}
+
+function daemonPaths(baseDir: string): DaemonPaths {
+  return {
+    baseDir,
+    infoPath: path.join(baseDir, 'daemon.json'),
+    lockPath: path.join(baseDir, 'daemon.lock'),
+    logPath: path.join(baseDir, 'daemon.log'),
+    sessionsDir: path.join(baseDir, 'sessions'),
+  };
+}

--- a/src/daemon/daemon-shutdown-report.ts
+++ b/src/daemon/daemon-shutdown-report.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { DeviceLease } from '@agent-device/contracts/device';
+import { publishFileSync } from '../utils/atomic-file.ts';
 
 const SHUTDOWN_REPORT_FILE = 'daemon-shutdown.json';
 
@@ -59,15 +60,16 @@ export function writeDaemonShutdownReport(
     },
   };
   const filePath = shutdownReportPath(stateDir);
-  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   try {
-    fs.writeFileSync(temporaryPath, `${JSON.stringify(report)}\n`, { mode: 0o600 });
-    fs.renameSync(temporaryPath, filePath);
+    publishFileSync({
+      destination: filePath,
+      contents: `${JSON.stringify(report)}\n`,
+      mode: 0o600,
+    });
     fs.chmodSync(filePath, 0o600);
   } catch {
-    try {
-      fs.rmSync(temporaryPath, { force: true });
-    } catch {}
+    // Shutdown reporting is best effort; the atomic publisher has already
+    // preserved the primary filesystem failure and cleaned its temp sibling.
   }
 }
 

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -371,8 +371,14 @@ function writeClaim(claim: DeviceClaim): void {
   const claimPath = resolveDeviceClaimPath(claim.deviceKey);
   fs.mkdirSync(path.dirname(claimPath), { recursive: true, mode: 0o700 });
   const tmpPath = `${claimPath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, `${JSON.stringify(claim)}\n`, { encoding: 'utf8', mode: 0o600 });
-  fs.renameSync(tmpPath, claimPath);
+  try {
+    fs.writeFileSync(tmpPath, `${JSON.stringify(claim)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(tmpPath, claimPath);
+  } finally {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {}
+  }
 }
 
 async function withDeviceClaimLock<T>(deviceKey: string, task: () => Promise<T>): Promise<T> {

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -10,6 +10,7 @@ import {
 } from '@agent-device/kernel/device';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import type { RuntimeOwnerRef } from '@agent-device/contracts/platform';
+import { publishFileSync } from '../utils/atomic-file.ts';
 import { acquireProcessLock } from '../utils/process-lock.ts';
 import { ownerIdentityMatches, readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
 import { inspectDeviceClaimFile, type InspectedDeviceClaim } from './device-claim-inspection.ts';
@@ -370,15 +371,11 @@ async function settleVerifiedOrphanedClaim(
 function writeClaim(claim: DeviceClaim): void {
   const claimPath = resolveDeviceClaimPath(claim.deviceKey);
   fs.mkdirSync(path.dirname(claimPath), { recursive: true, mode: 0o700 });
-  const tmpPath = `${claimPath}.${process.pid}.${Date.now()}.tmp`;
-  try {
-    fs.writeFileSync(tmpPath, `${JSON.stringify(claim)}\n`, { encoding: 'utf8', mode: 0o600 });
-    fs.renameSync(tmpPath, claimPath);
-  } finally {
-    try {
-      fs.rmSync(tmpPath, { force: true });
-    } catch {}
-  }
+  publishFileSync({
+    destination: claimPath,
+    contents: `${JSON.stringify(claim)}\n`,
+    mode: 0o600,
+  });
 }
 
 async function withDeviceClaimLock<T>(deviceKey: string, task: () => Promise<T>): Promise<T> {

--- a/src/daemon/durable-capture-resource-store.ts
+++ b/src/daemon/durable-capture-resource-store.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import type {
@@ -6,6 +5,7 @@ import type {
   DurableResourceEnvelope,
 } from '@agent-device/contracts/platform';
 import { decodeDurableResourceEnvelope } from '@agent-device/capture-kit';
+import { withAtomicPublishTempPathSync } from '../utils/atomic-file.ts';
 import { openVerifiedFileForRead } from '../utils/verified-file.ts';
 
 export type DurableCaptureResourceRecord<K extends string> =
@@ -58,27 +58,22 @@ export function createDurableCaptureResourceStore<K extends string>(
     write(resourcePath: string, envelope: DurableResourceEnvelope<K>): void {
       const directory = path.dirname(resourcePath);
       fs.mkdirSync(directory, { recursive: true });
-      const temporaryPath = path.join(
-        directory,
-        `.${path.basename(resourcePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
-      );
-      let descriptor: number | undefined;
-      try {
-        assertSafeDestination(resourcePath, options.displayName);
-        descriptor = fs.openSync(temporaryPath, 'wx', 0o600);
-        fs.writeFileSync(descriptor, `${JSON.stringify(envelope)}\n`, 'utf8');
-        fs.fsyncSync(descriptor);
-        fs.closeSync(descriptor);
-        descriptor = undefined;
-        assertSafeDestination(resourcePath, options.displayName);
-        fs.renameSync(temporaryPath, resourcePath);
-        syncDirectoryBestEffort(directory);
-      } finally {
-        if (descriptor !== undefined) fs.closeSync(descriptor);
+      withAtomicPublishTempPathSync(resourcePath, (temporaryPath) => {
+        let descriptor: number | undefined;
         try {
-          fs.rmSync(temporaryPath, { force: true });
-        } catch {}
-      }
+          assertSafeDestination(resourcePath, options.displayName);
+          descriptor = fs.openSync(temporaryPath, 'wx', 0o600);
+          fs.writeFileSync(descriptor, `${JSON.stringify(envelope)}\n`, 'utf8');
+          fs.fsyncSync(descriptor);
+          fs.closeSync(descriptor);
+          descriptor = undefined;
+          assertSafeDestination(resourcePath, options.displayName);
+          fs.renameSync(temporaryPath, resourcePath);
+          syncDirectoryBestEffort(directory);
+        } finally {
+          if (descriptor !== undefined) fs.closeSync(descriptor);
+        }
+      });
     },
     list(sessionsDir: string): string[] {
       let entries: fs.Dirent[];

--- a/src/daemon/provider-lease-expiry.ts
+++ b/src/daemon/provider-lease-expiry.ts
@@ -5,6 +5,7 @@ import type {
   LeaseLifecycleProvider,
   ProviderExpiredLeaseRecovery,
 } from '@agent-device/contracts/device';
+import { publishFileSync } from '../utils/atomic-file.ts';
 import { releaseExpiredProviderLease } from './lease-lifecycle.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { sleep } from '../utils/timeouts.ts';
@@ -71,13 +72,15 @@ export function createExpiredProviderLeaseReleaser(options: {
         fs.rmSync(filePath, { force: true });
       } else {
         fs.mkdirSync(options.stateDir, { recursive: true, mode: 0o700 });
-        const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
         const record: PersistedExpiredProviderLeases = {
           version: PENDING_RELEASES_VERSION,
           leases: [...pendingRecoveryLeases.values()],
         };
-        fs.writeFileSync(temporaryPath, `${JSON.stringify(record)}\n`, { mode: 0o600 });
-        fs.renameSync(temporaryPath, filePath);
+        publishFileSync({
+          destination: filePath,
+          contents: `${JSON.stringify(record)}\n`,
+          mode: 0o600,
+        });
         fs.chmodSync(filePath, 0o600);
       }
       persistedRecoveryLeaseIds.clear();

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -286,27 +286,31 @@ function publishHealedScriptAtomically(params: {
     dir,
     `.${path.basename(scriptPath)}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
   );
-  fs.writeFileSync(tempPath, script);
   try {
-    if (force) {
-      fs.renameSync(tempPath, scriptPath);
-      return;
+    fs.writeFileSync(tempPath, script);
+    try {
+      if (force) {
+        fs.renameSync(tempPath, scriptPath);
+        return;
+      }
+      // Atomic create-exclusive: EEXIST iff a file already sits at scriptPath.
+      fs.linkSync(tempPath, scriptPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      throw new AppError(
+        'COMMAND_FAILED',
+        `A file already exists at ${scriptPath}; remove it, pass replay --save-script=<other-path>, or pass --force/--overwrite to replace it.`,
+        { reason: 'script_target_exists', path: scriptPath },
+      );
     }
-    // Atomic create-exclusive: EEXIST iff a file already sits at scriptPath.
-    fs.linkSync(tempPath, scriptPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-    throw new AppError(
-      'COMMAND_FAILED',
-      `A file already exists at ${scriptPath}; remove it, pass replay --save-script=<other-path>, or pass --force/--overwrite to replace it.`,
-      { reason: 'script_target_exists', path: scriptPath },
-    );
   } finally {
     // linkSync leaves the temp hard-link behind on success; an error leaves
     // it too — always clean up whatever of our own temp remains. A `force`
     // rename already consumed tempPath (it no longer exists at this path),
     // so this is a harmless no-op in that branch.
-    fs.rmSync(tempPath, { force: true });
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {}
   }
 }
 

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -17,6 +17,7 @@ import {
   stripRecordedRefGeneration,
 } from '@agent-device/ad-script';
 import { expandSessionPath, safeSessionName } from './session-paths.ts';
+import { publishFileSync } from '../utils/atomic-file.ts';
 import type { SessionState } from './types.ts';
 import {
   NO_SCRIPT_PUBLICATION,
@@ -281,36 +282,19 @@ function publishHealedScriptAtomically(params: {
   force?: boolean;
 }): void {
   const { scriptPath, script, force } = params;
-  const dir = path.dirname(scriptPath);
-  const tempPath = path.join(
-    dir,
-    `.${path.basename(scriptPath)}.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
-  );
   try {
-    fs.writeFileSync(tempPath, script);
-    try {
-      if (force) {
-        fs.renameSync(tempPath, scriptPath);
-        return;
-      }
-      // Atomic create-exclusive: EEXIST iff a file already sits at scriptPath.
-      fs.linkSync(tempPath, scriptPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-      throw new AppError(
-        'COMMAND_FAILED',
-        `A file already exists at ${scriptPath}; remove it, pass replay --save-script=<other-path>, or pass --force/--overwrite to replace it.`,
-        { reason: 'script_target_exists', path: scriptPath },
-      );
-    }
-  } finally {
-    // linkSync leaves the temp hard-link behind on success; an error leaves
-    // it too — always clean up whatever of our own temp remains. A `force`
-    // rename already consumed tempPath (it no longer exists at this path),
-    // so this is a harmless no-op in that branch.
-    try {
-      fs.rmSync(tempPath, { force: true });
-    } catch {}
+    publishFileSync({
+      destination: scriptPath,
+      contents: script,
+      publish: force ? 'replace' : 'link-exclusive',
+    });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    throw new AppError(
+      'COMMAND_FAILED',
+      `A file already exists at ${scriptPath}; remove it, pass replay --save-script=<other-path>, or pass --force/--overwrite to replace it.`,
+      { reason: 'script_target_exists', path: scriptPath },
+    );
   }
 }
 

--- a/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
@@ -12,9 +12,9 @@ type FaultInjection = { wasInjected: () => boolean };
 
 const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
 const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
+const REQUIRED_RUNNER_LEASE_MODULES = ['runner-lease'] as const;
 const DEVICE_ID = 'filesystem-fault-runner';
-
-let leaseRoot: string;
+const registeredRunnerLeaseRows: string[] = [];
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -23,8 +23,9 @@ afterEach(() => {
 
 for (const faultPoint of FAULT_POINTS) {
   for (const errno of FILESYSTEM_ERRNOS) {
+    registeredRunnerLeaseRows.push(`runner-lease:${faultPoint}:${errno}`);
     test(`runner lease ${faultPoint} ${errno} leaves no unpublished temporary file`, () => {
-      leaseRoot = mkdtempForTestSync(`agent-device-runner-lease-boundary-`);
+      const leaseRoot = mkdtempForTestSync(`agent-device-runner-lease-boundary-`);
       process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = leaseRoot;
       const targetPath = path.join(leaseRoot, `${DEVICE_ID}.json`);
       const lease = makeRunnerLease({
@@ -49,6 +50,15 @@ for (const faultPoint of FAULT_POINTS) {
   }
 }
 
+test('filesystem errno matrix declares every runner-lease row', () => {
+  const expectedRows = REQUIRED_RUNNER_LEASE_MODULES.flatMap((moduleName) =>
+    FAULT_POINTS.flatMap((faultPoint) =>
+      FILESYSTEM_ERRNOS.map((errno) => `${moduleName}:${faultPoint}:${errno}`),
+    ),
+  );
+  assert.deepEqual([...registeredRunnerLeaseRows].sort(), expectedRows.sort());
+});
+
 function installFilesystemFault(
   faultPoint: FaultPoint,
   errno: FilesystemErrno,
@@ -72,6 +82,7 @@ function installFilesystemFault(
     vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
       if (matchesTarget(args[0])) {
         injected = true;
+        Reflect.apply(originalWriteFileSync, fs, args);
         throw failure;
       }
       return Reflect.apply(originalWriteFileSync, fs, args);

--- a/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
+import { makeRunnerLease } from './runner-session-fixtures.ts';
+import { RUNNER_OWNER_TOKEN, writeRunnerLease } from '../runner/runner-lease.ts';
+
+type FilesystemErrno = 'EIO' | 'ENOSPC' | 'EMFILE';
+type FaultPoint = 'write' | 'rename';
+type FaultInjection = { wasInjected: () => boolean };
+
+const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
+const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
+const DEVICE_ID = 'filesystem-fault-runner';
+
+let leaseRoot: string;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR;
+});
+
+for (const faultPoint of FAULT_POINTS) {
+  for (const errno of FILESYSTEM_ERRNOS) {
+    test(`runner lease ${faultPoint} ${errno} leaves no unpublished temporary file`, () => {
+      leaseRoot = mkdtempForTestSync(`agent-device-runner-lease-boundary-`);
+      process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = leaseRoot;
+      const targetPath = path.join(leaseRoot, `${DEVICE_ID}.json`);
+      const lease = makeRunnerLease({
+        deviceId: DEVICE_ID,
+        ownerToken: RUNNER_OWNER_TOKEN,
+      });
+      const fault = installFilesystemFault(faultPoint, errno, targetPath);
+
+      let thrown: unknown;
+      try {
+        writeRunnerLease(lease);
+      } catch (error) {
+        thrown = error;
+      }
+
+      assert.ok(thrown, `runner lease should surface ${errno}`);
+      assert.equal((thrown as NodeJS.ErrnoException).code, errno);
+      assert.equal(fault.wasInjected(), true, `${faultPoint} fault was injected`);
+      assert.equal(fs.existsSync(targetPath), false);
+      assert.deepEqual(listTemporaryFiles(leaseRoot), []);
+    });
+  }
+}
+
+function installFilesystemFault(
+  faultPoint: FaultPoint,
+  errno: FilesystemErrno,
+  targetPath: string,
+): FaultInjection {
+  const failure = createErrno(errno);
+  let injected = false;
+  const matchesTarget = (value: unknown): boolean => {
+    const candidate = String(value);
+    const targetName = path.basename(targetPath);
+    const candidateName = path.basename(candidate);
+    return (
+      candidate === targetPath ||
+      candidateName.startsWith(`.${targetName}.`) ||
+      candidateName.startsWith(`${targetName}.`)
+    );
+  };
+
+  if (faultPoint === 'write') {
+    const originalWriteFileSync = fs.writeFileSync;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
+      if (matchesTarget(args[0])) {
+        injected = true;
+        throw failure;
+      }
+      return Reflect.apply(originalWriteFileSync, fs, args);
+    });
+    return { wasInjected: () => injected };
+  }
+
+  const originalRenameSync = fs.renameSync;
+  vi.spyOn(fs, 'renameSync').mockImplementation((...args) => {
+    if (matchesTarget(args[0]) || matchesTarget(args[1])) {
+      injected = true;
+      throw failure;
+    }
+    return Reflect.apply(originalRenameSync, fs, args);
+  });
+  return { wasInjected: () => injected };
+}
+
+function createErrno(errno: FilesystemErrno): NodeJS.ErrnoException {
+  const error = new Error(`injected filesystem ${errno}`) as NodeJS.ErrnoException;
+  error.code = errno;
+  return error;
+}
+
+function listTemporaryFiles(root: string): string[] {
+  const temporaryFiles: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.endsWith('.tmp')) temporaryFiles.push(path.join(root, entry.name));
+  }
+  return temporaryFiles;
+}

--- a/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts
@@ -1,116 +1,38 @@
-import assert from 'node:assert/strict';
-import fs from 'node:fs';
 import path from 'node:path';
-import { afterEach, test, vi } from 'vitest';
-import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
+import { afterEach, vi } from 'vitest';
+import {
+  registerFilesystemBoundaryMatrix,
+  type FilesystemBoundaryFixture,
+  type FilesystemBoundaryOwner,
+} from '../../../../__tests__/test-utils/filesystem-boundary-faults.ts';
 import { makeRunnerLease } from './runner-session-fixtures.ts';
 import { RUNNER_OWNER_TOKEN, writeRunnerLease } from '../runner/runner-lease.ts';
 
-type FilesystemErrno = 'EIO' | 'ENOSPC' | 'EMFILE';
-type FaultPoint = 'write' | 'rename';
-type FaultInjection = { wasInjected: () => boolean };
-
-const FILESYSTEM_ERRNOS: readonly FilesystemErrno[] = ['EIO', 'ENOSPC', 'EMFILE'];
-const FAULT_POINTS: readonly FaultPoint[] = ['write', 'rename'];
-const REQUIRED_RUNNER_LEASE_MODULES = ['runner-lease'] as const;
+type RunnerFilesystemBoundaryOwner = 'runner-lease';
 const DEVICE_ID = 'filesystem-fault-runner';
-const registeredRunnerLeaseRows: string[] = [];
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR;
 });
 
-for (const faultPoint of FAULT_POINTS) {
-  for (const errno of FILESYSTEM_ERRNOS) {
-    registeredRunnerLeaseRows.push(`runner-lease:${faultPoint}:${errno}`);
-    test(`runner lease ${faultPoint} ${errno} leaves no unpublished temporary file`, () => {
-      const leaseRoot = mkdtempForTestSync(`agent-device-runner-lease-boundary-`);
-      process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = leaseRoot;
-      const targetPath = path.join(leaseRoot, `${DEVICE_ID}.json`);
-      const lease = makeRunnerLease({
-        deviceId: DEVICE_ID,
-        ownerToken: RUNNER_OWNER_TOKEN,
-      });
-      const fault = installFilesystemFault(faultPoint, errno, targetPath);
+const RUNNER_FILESYSTEM_BOUNDARY_OWNERS = {
+  'runner-lease': createRunnerLeaseFixture,
+} as const satisfies Record<RunnerFilesystemBoundaryOwner, FilesystemBoundaryOwner>;
 
-      let thrown: unknown;
-      try {
-        writeRunnerLease(lease);
-      } catch (error) {
-        thrown = error;
-      }
+registerFilesystemBoundaryMatrix(RUNNER_FILESYSTEM_BOUNDARY_OWNERS, 'runner');
 
-      assert.ok(thrown, `runner lease should surface ${errno}`);
-      assert.equal((thrown as NodeJS.ErrnoException).code, errno);
-      assert.equal(fault.wasInjected(), true, `${faultPoint} fault was injected`);
-      assert.equal(fs.existsSync(targetPath), false);
-      assert.deepEqual(listTemporaryFiles(leaseRoot), []);
-    });
-  }
-}
-
-test('filesystem errno matrix declares every runner-lease row', () => {
-  const expectedRows = REQUIRED_RUNNER_LEASE_MODULES.flatMap((moduleName) =>
-    FAULT_POINTS.flatMap((faultPoint) =>
-      FILESYSTEM_ERRNOS.map((errno) => `${moduleName}:${faultPoint}:${errno}`),
-    ),
-  );
-  assert.deepEqual([...registeredRunnerLeaseRows].sort(), expectedRows.sort());
-});
-
-function installFilesystemFault(
-  faultPoint: FaultPoint,
-  errno: FilesystemErrno,
-  targetPath: string,
-): FaultInjection {
-  const failure = createErrno(errno);
-  let injected = false;
-  const matchesTarget = (value: unknown): boolean => {
-    const candidate = String(value);
-    const targetName = path.basename(targetPath);
-    const candidateName = path.basename(candidate);
-    return (
-      candidate === targetPath ||
-      candidateName.startsWith(`.${targetName}.`) ||
-      candidateName.startsWith(`${targetName}.`)
-    );
-  };
-
-  if (faultPoint === 'write') {
-    const originalWriteFileSync = fs.writeFileSync;
-    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
-      if (matchesTarget(args[0])) {
-        injected = true;
-        Reflect.apply(originalWriteFileSync, fs, args);
-        throw failure;
-      }
-      return Reflect.apply(originalWriteFileSync, fs, args);
-    });
-    return { wasInjected: () => injected };
-  }
-
-  const originalRenameSync = fs.renameSync;
-  vi.spyOn(fs, 'renameSync').mockImplementation((...args) => {
-    if (matchesTarget(args[0]) || matchesTarget(args[1])) {
-      injected = true;
-      throw failure;
-    }
-    return Reflect.apply(originalRenameSync, fs, args);
+function createRunnerLeaseFixture(root: string): FilesystemBoundaryFixture {
+  process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = root;
+  const targetPath = path.join(root, `${DEVICE_ID}.json`);
+  const lease = makeRunnerLease({
+    deviceId: DEVICE_ID,
+    ownerToken: RUNNER_OWNER_TOKEN,
   });
-  return { wasInjected: () => injected };
-}
 
-function createErrno(errno: FilesystemErrno): NodeJS.ErrnoException {
-  const error = new Error(`injected filesystem ${errno}`) as NodeJS.ErrnoException;
-  error.code = errno;
-  return error;
-}
-
-function listTemporaryFiles(root: string): string[] {
-  const temporaryFiles: string[] = [];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (entry.name.endsWith('.tmp')) temporaryFiles.push(path.join(root, entry.name));
-  }
-  return temporaryFiles;
+  return {
+    targetPath,
+    run: () => writeRunnerLease(lease),
+    expected: 'throw',
+  };
 }

--- a/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
@@ -53,6 +53,7 @@ const LOST_RESPONSE_MUTATION_ROWS = [
     request: { command: 'type', text: 'hello', textEntryMode: 'replace' },
   },
 ] as const;
+const REQUIRED_LOST_RESPONSE_ACCEPTANCE_COMMANDS = ['press', 'fill'] as const;
 
 afterEach(async () => {
   await server?.close();
@@ -75,6 +76,13 @@ function seedSession(port: number): RunnerSession {
   ensureRunnerSessionMock.mockResolvedValue(session);
   return session;
 }
+
+test('acceptance matrix declares both lost-response mutation commands', () => {
+  assert.deepEqual(
+    LOST_RESPONSE_MUTATION_ROWS.map((row) => row.acceptanceCommand).sort(),
+    [...REQUIRED_LOST_RESPONSE_ACCEPTANCE_COMMANDS].sort(),
+  );
+});
 
 test.each(LOST_RESPONSE_MUTATION_ROWS)(
   'acceptance row: lost-response-after-mutation for $acceptanceCommand does not replay the mutation',

--- a/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
@@ -41,19 +41,27 @@ vi.mock('../runner/runner-session.ts', async (importOriginal) => {
 
 const { runAppleRunnerCommand } = await import('../runner/runner-client.ts');
 
-const LOST_RESPONSE_MUTATION_ROWS = [
-  {
+type LostResponseAcceptanceCommand = 'press' | 'fill';
+
+const LOST_RESPONSE_MUTATION_ROWS = {
+  press: {
     acceptanceCommand: 'press',
     runnerCommand: 'tap',
     request: { command: 'tap', x: 5, y: 5 },
   },
-  {
+  fill: {
     acceptanceCommand: 'fill',
     runnerCommand: 'type',
     request: { command: 'type', text: 'hello', textEntryMode: 'replace' },
   },
-] as const;
-const REQUIRED_LOST_RESPONSE_ACCEPTANCE_COMMANDS = ['press', 'fill'] as const;
+} as const satisfies Record<
+  LostResponseAcceptanceCommand,
+  Readonly<{
+    acceptanceCommand: LostResponseAcceptanceCommand;
+    runnerCommand: 'tap' | 'type';
+    request: Readonly<Record<string, unknown>>;
+  }>
+>;
 
 afterEach(async () => {
   await server?.close();
@@ -77,14 +85,7 @@ function seedSession(port: number): RunnerSession {
   return session;
 }
 
-test('acceptance matrix declares both lost-response mutation commands', () => {
-  assert.deepEqual(
-    LOST_RESPONSE_MUTATION_ROWS.map((row) => row.acceptanceCommand).sort(),
-    [...REQUIRED_LOST_RESPONSE_ACCEPTANCE_COMMANDS].sort(),
-  );
-});
-
-test.each(LOST_RESPONSE_MUTATION_ROWS)(
+test.each(Object.values(LOST_RESPONSE_MUTATION_ROWS))(
   'acceptance row: lost-response-after-mutation for $acceptanceCommand does not replay the mutation',
   async ({ runnerCommand, request }) => {
     // 1st request: the mutation, answered by dropping the connection

--- a/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts
@@ -41,6 +41,19 @@ vi.mock('../runner/runner-session.ts', async (importOriginal) => {
 
 const { runAppleRunnerCommand } = await import('../runner/runner-client.ts');
 
+const LOST_RESPONSE_MUTATION_ROWS = [
+  {
+    acceptanceCommand: 'press',
+    runnerCommand: 'tap',
+    request: { command: 'tap', x: 5, y: 5 },
+  },
+  {
+    acceptanceCommand: 'fill',
+    runnerCommand: 'type',
+    request: { command: 'type', text: 'hello', textEntryMode: 'replace' },
+  },
+] as const;
+
 afterEach(async () => {
   await server?.close();
   server = undefined;
@@ -63,39 +76,47 @@ function seedSession(port: number): RunnerSession {
   return session;
 }
 
-test('a lost transport response is recovered through the production command path', async () => {
-  // 1st request: the tap, answered by dropping the connection mid-response
-  // (the real "lost response" shape). 2nd: the status probe recovery issues.
-  server = await startFakeRunnerServer({
-    // The tap's response is dropped mid-flight (the real "lost response"
-    // shape); the status probe recovery issues then returns the retained one.
-    tap: [{ kind: 'hangUp' }],
-    status: [
-      {
-        kind: 'ok',
-        data: {
-          lifecycleState: 'completed',
-          lifecycleResponseJson: JSON.stringify({ ok: true, data: { recovered: true } }),
+test.each(LOST_RESPONSE_MUTATION_ROWS)(
+  'acceptance row: lost-response-after-mutation for $acceptanceCommand does not replay the mutation',
+  async ({ runnerCommand, request }) => {
+    // 1st request: the mutation, answered by dropping the connection
+    // mid-response (the real "lost response" shape). 2nd: the status probe.
+    server = await startFakeRunnerServer({
+      // The mutation's response is dropped mid-flight (the real "lost
+      // response" shape); the status probe then returns the retained one.
+      [runnerCommand]: [{ kind: 'hangUp' }],
+      status: [
+        {
+          kind: 'ok',
+          data: {
+            lifecycleState: 'completed',
+            lifecycleResponseJson: JSON.stringify({ ok: true, data: { recovered: true } }),
+          },
         },
-      },
-    ],
-  });
-  seedSession(server.port);
+      ],
+    });
+    seedSession(server.port);
 
-  const result = await runAppleRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 5, y: 5 });
+    const result = await runAppleRunnerCommand(IOS_SIMULATOR, { ...request });
 
-  // The recovered payload proves the whole chain ran: classification said
-  // retryable, the callsite invoked recovery, recovery probed status, and the
-  // retained response replaced the lost one.
-  assert.deepEqual(result, { recovered: true });
-  const tap = server.requests.find((request) => request.command === 'tap');
-  const status = server.requests.find((request) => request.command === 'status');
-  assert.ok(tap, 'the tap reached the runner');
-  assert.ok(status, 'recovery probed status');
-  // The probe must reference the exact command id the send assigned.
-  assert.equal(typeof tap.body.commandId, 'string');
-  assert.equal(status.body.statusCommandId, tap.body.commandId);
-});
+    // The recovered payload proves the whole chain ran: classification said
+    // retryable, the callsite invoked recovery, recovery probed status, and
+    // the retained response replaced the lost one.
+    assert.deepEqual(result, { recovered: true });
+    const mutation = server.requests.find((entry) => entry.command === runnerCommand);
+    const status = server.requests.find((entry) => entry.command === 'status');
+    assert.ok(mutation, `${runnerCommand} reached the runner`);
+    assert.ok(status, 'recovery probed status');
+    // The probe must reference the exact command id the send assigned.
+    assert.equal(typeof mutation.body.commandId, 'string');
+    assert.equal(status.body.statusCommandId, mutation.body.commandId);
+    assert.equal(
+      server.requests.filter((entry) => entry.command === runnerCommand).length,
+      1,
+      `${runnerCommand} must not be silently replayed after the response is lost`,
+    );
+  },
+);
 
 test('a runner that reports the command failed surfaces that failure, not the transport error', async () => {
   server = await startFakeRunnerServer({

--- a/src/platforms/apple/core/runner/runner-lease.ts
+++ b/src/platforms/apple/core/runner/runner-lease.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { emitDiagnostic } from '../../../../utils/diagnostics.ts';
+import { publishFileSync } from '../../../../utils/atomic-file.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import { acquireProcessLock } from '../../../../utils/process-lock.ts';
 import {
@@ -309,15 +310,10 @@ export function releaseRunnerLease(lease: RunnerLease | undefined): void {
 export function writeRunnerLease(lease: RunnerLease): void {
   const leasePath = resolveRunnerLeasePath(lease.deviceId);
   fs.mkdirSync(path.dirname(leasePath), { recursive: true });
-  const tmpPath = `${leasePath}.${process.pid}.${Date.now()}.tmp`;
-  try {
-    fs.writeFileSync(tmpPath, JSON.stringify(lease, null, 2), 'utf8');
-    fs.renameSync(tmpPath, leasePath);
-  } finally {
-    try {
-      fs.rmSync(tmpPath, { force: true });
-    } catch {}
-  }
+  publishFileSync({
+    destination: leasePath,
+    contents: JSON.stringify(lease, null, 2),
+  });
 }
 
 function removeRunnerLease(params: {

--- a/src/platforms/apple/core/runner/runner-lease.ts
+++ b/src/platforms/apple/core/runner/runner-lease.ts
@@ -310,8 +310,14 @@ export function writeRunnerLease(lease: RunnerLease): void {
   const leasePath = resolveRunnerLeasePath(lease.deviceId);
   fs.mkdirSync(path.dirname(leasePath), { recursive: true });
   const tmpPath = `${leasePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, JSON.stringify(lease, null, 2), 'utf8');
-  fs.renameSync(tmpPath, leasePath);
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(lease, null, 2), 'utf8');
+    fs.renameSync(tmpPath, leasePath);
+  } finally {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {}
+  }
 }
 
 function removeRunnerLease(params: {

--- a/src/remote/remote-connection-state.ts
+++ b/src/remote/remote-connection-state.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { resolveRemoteConfigPath, resolveRemoteConfigProfile } from './remote-config-core.ts';
 import { AppError } from '@agent-device/kernel/errors';
+import { publishFileSync } from '../utils/atomic-file.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import type { CliFlags } from '@agent-device/contracts/command';
 import type { LeaseBackend, SessionRuntimeHints } from '@agent-device/kernel/contracts';
@@ -248,17 +249,11 @@ function resolveConnectionProfile(
 }
 
 function writeJsonFile(filePath: string, value: unknown): void {
-  const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
-  try {
-    fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
-      encoding: 'utf8',
-      mode: 0o600,
-    });
-    fs.renameSync(temporaryPath, filePath);
-  } catch (error) {
-    fs.rmSync(temporaryPath, { force: true });
-    throw error;
-  }
+  publishFileSync({
+    destination: filePath,
+    contents: `${JSON.stringify(value, null, 2)}\n`,
+    mode: 0o600,
+  });
 }
 
 function sanitizeDaemonBaseUrl(value: string | undefined): string | undefined {

--- a/src/utils/__tests__/atomic-publish-ownership.test.ts
+++ b/src/utils/__tests__/atomic-publish-ownership.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'vitest';
+
+const SIMPLE_PUBLISHERS = [
+  new URL('../../daemon/device-claims.ts', import.meta.url),
+  new URL('../../daemon/daemon-shutdown-report.ts', import.meta.url),
+  new URL('../../daemon/provider-lease-expiry.ts', import.meta.url),
+  new URL('../../daemon/session-script-writer.ts', import.meta.url),
+  new URL('../../platforms/apple/core/runner/runner-lease.ts', import.meta.url),
+  new URL('../../remote/remote-connection-state.ts', import.meta.url),
+  new URL('../process-lock.ts', import.meta.url),
+] as const;
+
+test('simple same-directory publishers use the shared atomic publish owner', () => {
+  for (const sourcePath of SIMPLE_PUBLISHERS) {
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    assert.match(source, /publishFileSync/);
+    assert.doesNotMatch(source, /fs\.(?:writeFileSync|renameSync)\s*\(/);
+  }
+});
+
+test('durable capture publication keeps its specialized fsync and destination checks', () => {
+  const source = fs.readFileSync(
+    new URL('../../daemon/durable-capture-resource-store.ts', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /withAtomicPublishTempPathSync/);
+  assert.match(source, /fs\.openSync\([^\n]+['"]wx['"]/);
+  assert.match(source, /fs\.fsyncSync/);
+  assert.match(source, /fs\.renameSync/);
+  assert.match(source, /assertSafeDestination/);
+});

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -64,7 +64,7 @@ export function withAtomicPublishTempPathSync<T>(
 }
 
 /** Returns the canonical same-directory temp path used by atomic publishers. */
-export function createAtomicPublishTempPath(destination: string): string {
+function createAtomicPublishTempPath(destination: string): string {
   return path.join(
     path.dirname(destination),
     `.${path.basename(destination)}.${process.pid}-${crypto.randomUUID()}.tmp`,

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { emitDiagnostic } from './diagnostics.ts';
+
+export type AtomicPublishMode = 'replace' | 'link-exclusive';
+
+/**
+ * Publishes a complete file from a same-directory temporary sibling.
+ *
+ * The temporary file is always removed after the publish attempt. Cleanup is
+ * best effort and never replaces the write or publish error; when a request
+ * diagnostics scope exists, a cleanup failure is retained as secondary evidence.
+ */
+export function publishFileSync(options: {
+  destination: string;
+  contents: string;
+  mode?: number;
+  publish?: AtomicPublishMode;
+}): void {
+  withAtomicPublishTempPathSync(options.destination, (temporaryPath) => {
+    if (options.mode === undefined) {
+      fs.writeFileSync(temporaryPath, options.contents, 'utf8');
+    } else {
+      fs.writeFileSync(temporaryPath, options.contents, {
+        encoding: 'utf8',
+        mode: options.mode,
+      });
+    }
+    if (options.publish === 'link-exclusive') {
+      fs.linkSync(temporaryPath, options.destination);
+    } else {
+      fs.renameSync(temporaryPath, options.destination);
+    }
+  });
+}
+
+/**
+ * Gives a specialized durable publisher a canonical temp path and cleanup
+ * ownership while it performs its own open/fsync/safety protocol.
+ */
+export function withAtomicPublishTempPathSync<T>(
+  destination: string,
+  publish: (temporaryPath: string) => T,
+): T {
+  const temporaryPath = createAtomicPublishTempPath(destination);
+  try {
+    return publish(temporaryPath);
+  } finally {
+    try {
+      fs.rmSync(temporaryPath, { force: true });
+    } catch (error) {
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'atomic_file_cleanup_failed',
+        data: {
+          destination,
+          temporaryPath,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+}
+
+/** Returns the canonical same-directory temp path used by atomic publishers. */
+export function createAtomicPublishTempPath(destination: string): string {
+  return path.join(
+    path.dirname(destination),
+    `.${path.basename(destination)}.${process.pid}-${crypto.randomUUID()}.tmp`,
+  );
+}
+
+/** Identifies a temp path produced for a particular destination. */
+export function isAtomicPublishTemporaryPath(value: unknown, destination: string): boolean {
+  if (typeof value !== 'string') return false;
+  if (path.dirname(value) !== path.dirname(destination)) return false;
+  const name = path.basename(value);
+  return name.startsWith(`.${path.basename(destination)}.`) && name.endsWith('.tmp');
+}

--- a/src/utils/process-lock.ts
+++ b/src/utils/process-lock.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
+import { publishFileSync } from './atomic-file.ts';
 import { classifyOwnerLiveness } from './owner-identity.ts';
 import { sleep } from './timeouts.ts';
 
@@ -60,9 +61,10 @@ export async function acquireProcessLock(params: {
 }
 
 function writeProcessLockOwner(ownerFilePath: string, owner: ProcessLockOwner): void {
-  const tmpOwnerFilePath = `${ownerFilePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpOwnerFilePath, JSON.stringify(owner), 'utf8');
-  fs.renameSync(tmpOwnerFilePath, ownerFilePath);
+  publishFileSync({
+    destination: ownerFilePath,
+    contents: JSON.stringify(owner),
+  });
 }
 
 function clearStaleProcessLock(


### PR DESCRIPTION
## Summary

- Add a shared synchronous atomic publisher that owns same-directory temp creation, replace or link-exclusive publication, cleanup, and primary-error preservation.
- Migrate the six issue-owned publish paths plus the adjacent process-lock, provider-lease, and remote-connection writers; durable capture keeps its wx, fsync, directory-sync, and symlink checks while sharing temp cleanup.
- Replace the duplicated filesystem fault drivers with one shared driver that tracks durable file descriptors explicitly and recursively checks for leftover temp files.
- Make filesystem owners and acceptance rows keyed typed records, so omitting a required row fails typechecking instead of comparing a registration list to itself.
- Assert process-death errors through the canonical AppError helper and add a structural ownership gate for simple publishers.
- The final diff touches 15 files. The scope expanded beyond the initial issue-owned modules only to migrate adjacent tmp→rename writers and centralize the shared test/ownership infrastructure; this does not add new fault axes or command-class coverage.

Part of #1431

This PR intentionally does not close #1431. The implemented scope is the filesystem errno matrix over the issue-owned tmp→rename modules plus the two acceptance-mandated rows. Remaining issue-owned work includes the socket and exec fault axes, lifecycle/process-tree cleanup assertions over those axes, the full fault-axis × command-class satisfies-cross, and the web-session SIGTERM candidate tracked in #1868.

## Validation

- pnpm install --frozen
- pnpm build
- pnpm check:quick
- Focused boundary and adjacent suites: 51 and 82 tests passed.
- Non-vacuous red proof: removing shared temp cleanup caused the session-script write/EIO row to fail with the exact leftover temp path; restoring it passes.
- pnpm check:affected --run passed all runnable checks: 448 related test files / 3,543 tests passed; changed-line coverage 35/36 (97.22%), changed-branch coverage 14/16 (87.50%).
- The restarted Android smoke run is currently in progress after the earlier retriable wait_capture_stalled failure: https://github.com/callstack/agent-device/actions/runs/32384140719
- Native, device, and web lanes remain GitHub-authoritative.

No CLI, docs, or skills changes were needed; this is internal fault handling and test ownership only.