### PR TITLE
fix: calibrate iOS scroll execution

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1905,13 +1905,14 @@ extension RunnerTests {
       guard let x = command.x, let y = command.y, let x2 = command.x2, let y2 = command.y2 else {
         return Response(ok: false, error: ErrorPayload(message: "drag requires x, y, x2, and y2"))
       }
+      let defaults = runnerDragCommandDefaults(command)
       return executeDragGesture(
         activeApp: activeApp,
         x: x,
         y: y,
         x2: x2,
         y2: y2,
-        durationMs: command.durationMs,
+        durationMs: defaults.durationMs,
         synthesized: command.synthesized == true,
         message: "dragged",
         synthesizedPolicyKind: .synthesizedDrag
@@ -1948,9 +1949,10 @@ extension RunnerTests {
           error: ErrorPayload(message: "scroll could not resolve a usable interaction frame")
         )
       }
+      let defaults = runnerDragCommandDefaults(command)
       guard let plan = runnerScrollGesturePlan(
         direction: direction,
-        amount: command.amount,
+        amount: defaults.scrollAmount,
         pixels: command.pixels,
         referenceWidth: frame.width,
         referenceHeight: frame.height
@@ -1980,7 +1982,7 @@ extension RunnerTests {
         y: frame.minY + plan.y1,
         x2: frame.minX + plan.x2,
         y2: frame.minY + plan.y2,
-        durationMs: command.durationMs,
+        durationMs: defaults.durationMs,
         synthesized: shouldUseSynthesizedScrollPath(),
         message: "scrolled",
         synthesizedContext: scrollContext.withReferenceFrame(frame),
@@ -2297,6 +2299,7 @@ extension RunnerTests {
     synthesizedPolicyKind: SynthesizedGesturePolicyKind,
     synthesizedProfile: SynthesizedDragProfile = .continuous
   ) -> Response {
+    let durationMs = durationMs ?? runnerDefaultDragDurationMs
     let commandName = dragCommandName(message: message)
     guard x.isFinite, y.isFinite, x2.isFinite, y2.isFinite else {
       return Response(
@@ -2328,7 +2331,7 @@ extension RunnerTests {
     )
     var fallback: GestureFallback?
     if synthesized {
-      let durationMs = min(max(durationMs ?? 250, 16), 10000)
+      let durationMs = min(max(durationMs, 16), 10000)
       let context = synthesizedCoordinateContext(
         app: activeApp,
         policy: synthesizedGesturePolicy(synthesizedPolicyKind)
@@ -2351,7 +2354,7 @@ extension RunnerTests {
       fallback = gestureFallback(strategy: "xctest-coordinate-drag", from: outcome)
     }
     let holdDuration = synthesized
-      ? synthesizedSwipeFallbackHoldDuration(durationMs: durationMs ?? 250)
+      ? synthesizedSwipeFallbackHoldDuration(durationMs: durationMs)
       : coordinateDragHoldDuration()
     let (timing, outcome) = performGesture(activeApp) {
       dragAt(
@@ -2380,7 +2383,7 @@ extension RunnerTests {
     y: Double,
     x2: Double,
     y2: Double,
-    durationMs: Double?,
+    durationMs: Double,
     message: String,
     context: SynthesizedCoordinateContext?,
     policyKind: SynthesizedGesturePolicyKind,
@@ -2420,7 +2423,7 @@ extension RunnerTests {
         )
       )
     }
-    let durationMs = min(max(durationMs ?? 250, 16), 10000)
+    let durationMs = min(max(durationMs, 16), 10000)
     let dragFrame = axFreeDragVisualizationFrame(
       x: plan.points.x,
       y: plan.points.y,
@@ -2470,7 +2473,7 @@ extension RunnerTests {
     y: Double,
     x2: Double,
     y2: Double,
-    durationMs: Double?,
+    durationMs: Double,
     message: String,
     fallback: GestureFallback?
   ) -> Response {
@@ -2482,7 +2485,7 @@ extension RunnerTests {
       x2: dragPoints.x2,
       y2: dragPoints.y2
     )
-    let holdDuration = synthesizedSwipeFallbackHoldDuration(durationMs: durationMs ?? 250)
+    let holdDuration = synthesizedSwipeFallbackHoldDuration(durationMs: durationMs)
     let (timing, outcome) = performGesture(activeApp) {
       dragAt(
         app: activeApp,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScrollGesture.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+ScrollGesture.swift
@@ -20,9 +20,13 @@ struct RunnerScrollGesturePlan {
 }
 
 private let runnerDefaultScrollAmount = 0.6
-// Both constants are pinned by contracts/fixtures/scroll-gesture.json (`constants`). Scroll gestures
-// stay out of the outer 10% of each axis so a saturated scroll never touches down inside the status
-// bar / Dynamic Island band (#1781 A1).
+private let runnerDefaultIosScrollAmount = 0.35
+private let runnerDefaultMobileScrollDurationMs = 300.0
+let runnerDefaultDragDurationMs = 250.0
+// The platform scroll defaults and planner constants are pinned by
+// contracts/fixtures/scroll-gesture.json (`constants`). Scroll gestures stay out of the outer 10%
+// of each axis so a saturated scroll never touches down inside the status bar / Dynamic Island band
+// (#1781 A1).
 private let runnerDefaultEdgePaddingFraction = 0.1
 
 func runnerScrollGesturePlan(
@@ -66,9 +70,29 @@ func runnerScrollGesturePlan(
   }
 }
 
+struct RunnerDragCommandDefaults {
+  let scrollAmount: Double?
+  let durationMs: Double
+}
+
+func runnerDragCommandDefaults(_ command: Command) -> RunnerDragCommandDefaults {
+  if command.command == .scroll {
+    return RunnerDragCommandDefaults(
+      scrollAmount: command.pixels == nil ? (command.amount ?? runnerDefaultIosScrollAmount) : command.amount,
+      durationMs: command.durationMs ?? runnerDefaultMobileScrollDurationMs
+    )
+  }
+  return RunnerDragCommandDefaults(
+    scrollAmount: nil,
+    durationMs: command.durationMs ?? runnerDefaultDragDurationMs
+  )
+}
+
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
 private struct ScrollGestureFixture: Decodable {
   struct Constants: Decodable {
+    let defaultIosScrollAmount: Double
+    let defaultMobileScrollDurationMs: Double
     let defaultScrollAmount: Double
     let defaultEdgePaddingFraction: Double
   }
@@ -136,6 +160,11 @@ extension RunnerTests {
   // 1000px axis where every rounding step is exact.
   func testRunnerScrollGesturePlanUsesParityTableConstants() throws {
     let constants = try loadScrollGestureFixture().constants
+    let defaultScroll = try JSONDecoder().decode(
+      Command.self, from: Data(#"{"command":"scroll"}"#.utf8))
+    let defaults = runnerDragCommandDefaults(defaultScroll)
+    XCTAssertEqual(defaults.durationMs, constants.defaultMobileScrollDurationMs)
+    XCTAssertEqual(defaults.scrollAmount, constants.defaultIosScrollAmount)
     let defaulted = try XCTUnwrap(
       runnerScrollGesturePlan(
         direction: "down", amount: nil, pixels: nil, referenceWidth: 1000, referenceHeight: 1000
@@ -149,6 +178,30 @@ extension RunnerTests {
     )
     XCTAssertEqual(
       saturated.travelPixels, 1000 - 2 * 1000 * constants.defaultEdgePaddingFraction)
+  }
+
+  func testRunnerScrollAndDragCommandDefaultsStayDistinct() throws {
+    func command(_ json: String) throws -> Command {
+      try JSONDecoder().decode(Command.self, from: Data(json.utf8))
+    }
+
+    let pixelScroll = runnerDragCommandDefaults(
+      try command(#"{"command":"scroll","pixels":120}"#))
+    XCTAssertNil(pixelScroll.scrollAmount)
+    XCTAssertEqual(pixelScroll.durationMs, 300)
+
+    let drag = runnerDragCommandDefaults(try command(#"{"command":"drag"}"#))
+    XCTAssertNil(drag.scrollAmount)
+    XCTAssertEqual(drag.durationMs, 250)
+
+    let explicitScroll = runnerDragCommandDefaults(
+      try command(#"{"command":"scroll","amount":0.5,"durationMs":125}"#))
+    XCTAssertEqual(explicitScroll.scrollAmount, 0.5)
+    XCTAssertEqual(explicitScroll.durationMs, 125)
+
+    let explicitDrag = runnerDragCommandDefaults(
+      try command(#"{"command":"drag","durationMs":125}"#))
+    XCTAssertEqual(explicitDrag.durationMs, 125)
   }
 
   func testRunnerScrollGesturePlanRejectsUnknownDirection() {

--- a/contracts/fixtures/scroll-gesture.json
+++ b/contracts/fixtures/scroll-gesture.json
@@ -1,5 +1,7 @@
 {
   "constants": {
+    "defaultIosScrollAmount": 0.35,
+    "defaultMobileScrollDurationMs": 300,
     "defaultScrollAmount": 0.6,
     "defaultEdgePaddingFraction": 0.1
   },

--- a/packages/contracts/src/facades/interaction.ts
+++ b/packages/contracts/src/facades/interaction.ts
@@ -141,6 +141,8 @@ export type {
   TvRemoteCommandResult,
 } from '../navigation.ts';
 export {
+  DEFAULT_IOS_SCROLL_AMOUNT,
+  DEFAULT_MOBILE_SCROLL_DURATION_MS,
   SCROLL_DURATION_MAX_MS,
   assertExclusiveScrollDistanceInputs,
   honoredScrollDurationMs,

--- a/packages/contracts/src/scroll-command.ts
+++ b/packages/contracts/src/scroll-command.ts
@@ -1,6 +1,8 @@
 import { AppError } from '@agent-device/kernel/errors';
 
 export const SCROLL_DURATION_MAX_MS = 10_000;
+export const DEFAULT_MOBILE_SCROLL_DURATION_MS = 300;
+export const DEFAULT_IOS_SCROLL_AMOUNT = 0.35;
 
 export type ScrollDistanceOptions = {
   amount?: number;

--- a/packages/contracts/src/scroll-gesture.test.ts
+++ b/packages/contracts/src/scroll-gesture.test.ts
@@ -9,6 +9,7 @@ import {
   buildScrollGesturePlan,
   clampGestureCoordinate,
 } from './scroll-gesture.ts';
+import { DEFAULT_IOS_SCROLL_AMOUNT, DEFAULT_MOBILE_SCROLL_DURATION_MS } from './scroll-command.ts';
 
 test('buildInPageSwipeGesturePlan applies one inset lane policy in every direction', () => {
   const frame = { referenceWidth: 400, referenceHeight: 800 };
@@ -51,7 +52,12 @@ test('buildInPageSwipeGesturePlan truncates percentage coordinates on odd viewpo
 // XCTest in the same file). Add vectors to the table, never to one suite — drift on either side
 // turns CI red without a simulator.
 type ScrollGestureFixture = {
-  constants: { defaultScrollAmount: number; defaultEdgePaddingFraction: number };
+  constants: {
+    defaultIosScrollAmount: number;
+    defaultMobileScrollDurationMs: number;
+    defaultScrollAmount: number;
+    defaultEdgePaddingFraction: number;
+  };
   cases: Array<{
     name: string;
     direction: 'up' | 'down' | 'left' | 'right';
@@ -110,6 +116,12 @@ test('buildScrollGesturePlan uses the parity table default amount and edge paddi
   assert.equal(defaulted.pixels, 1000 * constants.defaultScrollAmount);
   const saturated = buildScrollGesturePlan({ direction: 'down', amount: 10, ...frame });
   assert.equal(saturated.pixels, 1000 - 2 * 1000 * constants.defaultEdgePaddingFraction);
+});
+
+test('mobile scroll duration agrees with the cross-platform parity table', () => {
+  const { constants } = readScrollGestureFixture();
+  assert.equal(DEFAULT_IOS_SCROLL_AMOUNT, constants.defaultIosScrollAmount);
+  assert.equal(DEFAULT_MOBILE_SCROLL_DURATION_MS, constants.defaultMobileScrollDurationMs);
 });
 
 test('buildScrollGesturePlan rejects invalid amounts', () => {

--- a/src/daemon/__tests__/recording-gestures.test.ts
+++ b/src/daemon/__tests__/recording-gestures.test.ts
@@ -4,10 +4,11 @@ import {
   augmentScrollVisualizationResult,
   recordTouchVisualizationEvent,
 } from '../recording-gestures.ts';
-import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import { makeIosSession, makeMacOsSession } from '../../__tests__/test-utils/session-factories.ts';
 import { makeSnapshotState } from '../../__tests__/test-utils/snapshot-builders.ts';
 import { makeTestScreenRecordingResource } from '../../__tests__/test-utils/screen-recording-live-handle.ts';
 import type { ScreenRecordingLiveSnapshot } from '@agent-device/contracts/platform';
+import { TVOS_SIMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
 
 function makeSession(recording: Partial<ScreenRecordingLiveSnapshot> = {}) {
   const session = makeIosSession('default', {
@@ -51,7 +52,7 @@ test('scroll records a semantic scroll gesture for visualization telemetry', () 
   assert.equal(event.y, 699);
   assert.equal(event.x2, 201);
   assert.equal(event.y2, 175);
-  assert.equal(event.durationMs, 250);
+  assert.equal(event.durationMs, 300);
   assert.equal(event.contentDirection, 'down');
 });
 
@@ -88,6 +89,17 @@ test('scroll augmentation preserves explicit duration for visualization', () => 
   const event = session.screenRecording?.handle.inspect().gestureEvents[0];
   assert.equal(event?.kind, 'scroll');
   assert.equal(event?.durationMs, 100);
+});
+
+test('scroll augmentation keeps non-mobile recording timing on macOS and tvOS', () => {
+  const sessions = [makeMacOsSession('macos'), makeIosSession('tvos', { device: TVOS_SIMULATOR })];
+
+  for (const session of sessions) {
+    const result = augmentScrollVisualizationResult(session, 'scroll', ['down'], {
+      direction: 'down',
+    });
+    assert.equal(result?.durationMs, 250);
+  }
 });
 
 test('scroll augmentation preserves explicit reference frame from platform result', () => {

--- a/src/daemon/recording-gestures.ts
+++ b/src/daemon/recording-gestures.ts
@@ -10,6 +10,7 @@ import {
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import {
   buildScrollGesturePlan,
+  DEFAULT_MOBILE_SCROLL_DURATION_MS,
   type ScrollDirection,
   type SwipePattern,
 } from '@agent-device/contracts/interaction';
@@ -108,7 +109,8 @@ export function augmentScrollVisualizationResult(
 
   const amountValue = readRecordingNumber(merged.amount) ?? readRecordingNumber(positionals[1]);
   const pixelValue = readRecordingNumber(merged.pixels);
-  const durationMs = readRecordingNumber(merged.durationMs) ?? DEFAULT_SWIPE_DURATION_MS;
+  const durationMs =
+    readRecordingNumber(merged.durationMs) ?? defaultRecordedScrollDurationMs(session);
   const explicitTravel = readTravelCoordinates(merged, []);
   const explicitReferenceWidth = readRecordingNumber(merged.referenceWidth);
   const explicitReferenceHeight = readRecordingNumber(merged.referenceHeight);
@@ -163,6 +165,12 @@ export function augmentScrollVisualizationResult(
     referenceHeight: fallbackReferenceFrame.referenceHeight,
     durationMs,
   };
+}
+
+function defaultRecordedScrollDurationMs(session: SessionState): number {
+  return session.device.target === 'desktop' || session.device.target === 'tv'
+    ? DEFAULT_SWIPE_DURATION_MS
+    : DEFAULT_MOBILE_SCROLL_DURATION_MS;
 }
 
 function buildGestureEvents(

--- a/src/platforms/android/input-actions.ts
+++ b/src/platforms/android/input-actions.ts
@@ -2,6 +2,7 @@ import { DEVICE_ROTATION_SURFACE_INDEX, type DeviceRotation } from '@agent-devic
 import {
   buildGesturePlan,
   buildScrollGesturePlan,
+  DEFAULT_MOBILE_SCROLL_DURATION_MS,
   GESTURE_DURATION_MIN_MS,
   toAndroidTvRemoteKeyevent,
   type FillUnconfirmedVerification,
@@ -290,7 +291,10 @@ export async function scrollAndroid(
     x2: viewport.x + relativePlan.x2,
     y2: viewport.y + relativePlan.y2,
   };
-  const durationMs = Math.max(options?.durationMs ?? 300, GESTURE_DURATION_MIN_MS);
+  const durationMs = Math.max(
+    options?.durationMs ?? DEFAULT_MOBILE_SCROLL_DURATION_MS,
+    GESTURE_DURATION_MIN_MS,
+  );
   const backend = await executeAndroidTouchPlan(
     device,
     buildGesturePlan(

--- a/src/platforms/apple/core/__tests__/interactions.test.ts
+++ b/src/platforms/apple/core/__tests__/interactions.test.ts
@@ -262,6 +262,7 @@ test('iosRunnerOverrides maps iOS scroll to a single fused scroll command', asyn
   assert.deepEqual(mockRunAppleRunnerCommand.mock.calls[0]?.[1], {
     command: 'scroll',
     direction: 'down',
+    amount: 0.35,
     durationMs: 50,
     appBundleId: 'com.example.App',
   });
@@ -272,12 +273,13 @@ test('iosRunnerOverrides maps iOS scroll to a single fused scroll command', asyn
     y2: 160,
     referenceWidth: 400,
     referenceHeight: 800,
-    pixels: 480,
+    amount: 0.35,
+    pixels: 280,
     durationMs: 50,
   });
 });
 
-test('iosRunnerOverrides maps iOS scroll without duration to a fused runner scroll', async () => {
+test('iosRunnerOverrides keeps explicit iOS scroll distance with the controlled default duration', async () => {
   mockRunAppleRunnerCommand.mockResolvedValueOnce({
     x: 200,
     y: 640,
@@ -297,7 +299,44 @@ test('iosRunnerOverrides maps iOS scroll without duration to a fused runner scro
     command: 'scroll',
     direction: 'down',
     pixels: 400,
+    durationMs: 300,
     appBundleId: 'com.example.App',
+  });
+});
+
+test('iosRunnerOverrides materializes the controlled iOS default scroll amount', async () => {
+  mockRunAppleRunnerCommand.mockResolvedValueOnce({
+    x: 200,
+    y: 540,
+    x2: 200,
+    y2: 260,
+    referenceWidth: 400,
+    referenceHeight: 800,
+  });
+
+  const { overrides } = iosRunnerOverrides(IOS_TEST_SIMULATOR, {
+    appBundleId: 'com.example.App',
+  });
+
+  const result = await overrides.scroll('down');
+
+  assert.deepEqual(mockRunAppleRunnerCommand.mock.calls[0]?.[1], {
+    command: 'scroll',
+    direction: 'down',
+    amount: 0.35,
+    durationMs: 300,
+    appBundleId: 'com.example.App',
+  });
+  assert.deepEqual(result, {
+    x1: 200,
+    y1: 540,
+    x2: 200,
+    y2: 260,
+    referenceWidth: 400,
+    referenceHeight: 800,
+    amount: 0.35,
+    pixels: 280,
+    durationMs: 300,
   });
 });
 

--- a/src/platforms/apple/core/scroll.ts
+++ b/src/platforms/apple/core/scroll.ts
@@ -1,4 +1,9 @@
-import { buildScrollGesturePlan, type ScrollDirection } from '@agent-device/contracts/interaction';
+import {
+  buildScrollGesturePlan,
+  DEFAULT_IOS_SCROLL_AMOUNT,
+  DEFAULT_MOBILE_SCROLL_DURATION_MS,
+  type ScrollDirection,
+} from '@agent-device/contracts/interaction';
 
 export type NormalizedScrollOptions = {
   amount?: number;
@@ -8,6 +13,17 @@ export type NormalizedScrollOptions = {
 };
 
 export type AppleScrollOptions = Omit<NormalizedScrollOptions, 'preferProvidedPixels'>;
+
+export function materializeIosScrollOptions(
+  options: AppleScrollOptions | undefined,
+): AppleScrollOptions {
+  const hasExplicitDistance = options?.amount !== undefined || options?.pixels !== undefined;
+  return {
+    ...options,
+    ...(!hasExplicitDistance ? { amount: DEFAULT_IOS_SCROLL_AMOUNT } : {}),
+    durationMs: options?.durationMs ?? DEFAULT_MOBILE_SCROLL_DURATION_MS,
+  };
+}
 
 export function normalizeAppleScrollResultWithResolvedFrame(
   runnerResult: Record<string, unknown>,

--- a/src/platforms/apple/interactions.ts
+++ b/src/platforms/apple/interactions.ts
@@ -23,6 +23,7 @@ import {
   parseRunnerSequenceResult,
 } from './core/runner/runner-sequence.ts';
 import {
+  materializeIosScrollOptions,
   normalizeAppleScrollResult,
   normalizeAppleScrollResultWithResolvedFrame,
   scrollRunnerFields,
@@ -331,17 +332,19 @@ async function runAppleScroll(
     );
   }
 
+  const iosOptions = materializeIosScrollOptions(options);
+
   // Single fused lifecycle command: the runner resolves the interaction frame and runs the drag.
   const runnerResult = await runRunnerCommand(
     device,
     {
       command: 'scroll',
       direction,
-      ...scrollRunnerFields(options),
+      ...scrollRunnerFields(iosOptions),
       appBundleId: ctx.appBundleId,
     },
     runnerOpts,
   );
 
-  return normalizeAppleScrollResultWithResolvedFrame(runnerResult, direction, options);
+  return normalizeAppleScrollResultWithResolvedFrame(runnerResult, direction, iosOptions);
 }

--- a/src/platforms/harmonyos/input-actions.ts
+++ b/src/platforms/harmonyos/input-actions.ts
@@ -1,6 +1,7 @@
 import type { DeviceRotation } from '@agent-device/contracts/device';
 import {
   buildScrollGesturePlan,
+  DEFAULT_MOBILE_SCROLL_DURATION_MS,
   type GesturePlan,
   type ScrollDirection,
 } from '@agent-device/contracts/interaction';
@@ -78,7 +79,7 @@ export async function scrollHarmony(
     String(plan.y1),
     String(plan.x2),
     String(plan.y2),
-    String(options?.durationMs ?? 300),
+    String(options?.durationMs ?? DEFAULT_MOBILE_SCROLL_DURATION_MS),
   ]);
   return plan;
 }

--- a/src/utils/__tests__/interactors.test.ts
+++ b/src/utils/__tests__/interactors.test.ts
@@ -123,7 +123,13 @@ test('ios scroll sends a single fused scroll command and reports planned pixels'
 
   // The common iOS scroll path issues exactly one lifecycle command and NO 'interactionFrame'.
   assert.deepEqual(commands, [
-    { command: 'scroll', direction: 'down', pixels: 120, appBundleId: 'com.example.app' },
+    {
+      command: 'scroll',
+      direction: 'down',
+      pixels: 120,
+      durationMs: 300,
+      appBundleId: 'com.example.app',
+    },
   ]);
   assert.deepEqual(result, {
     x1: 155,
@@ -133,6 +139,7 @@ test('ios scroll sends a single fused scroll command and reports planned pixels'
     referenceWidth: 300,
     referenceHeight: 600,
     pixels: 120,
+    durationMs: 300,
   });
 });
 
@@ -156,7 +163,13 @@ test('ios amount-based scroll recomputes pixels from the runner reference frame'
   const result = await interactor.scroll('down', { amount: 0.5 });
 
   assert.deepEqual(commands, [
-    { command: 'scroll', direction: 'down', amount: 0.5, appBundleId: 'com.example.app' },
+    {
+      command: 'scroll',
+      direction: 'down',
+      amount: 0.5,
+      durationMs: 300,
+      appBundleId: 'com.example.app',
+    },
   ]);
   // amount 0.5 against a 600px vertical axis -> 300 planned pixels.
   const amount =

--- a/src/utils/scroll-edge-state-broad-selection.test.ts
+++ b/src/utils/scroll-edge-state-broad-selection.test.ts
@@ -24,6 +24,27 @@ test('selectScrollContainer (broad): among containers with a hidden edge, the la
   assert.equal(state.scope, 'large-hidden');
 });
 
+test('selectScrollContainer (broad): edge verification follows the viewport-centered gesture instead of an off-center hidden-edge child', async () => {
+  const nodes = [
+    windowRoot(),
+    scrollNode(1, {
+      identifier: 'settings-table',
+      rect: { x: 0, y: 0, width: 400, height: 800 },
+    }),
+    scrollNode(2, {
+      identifier: 'profile-picture-scroll',
+      hiddenContentAbove: true,
+      hiddenContentBelow: true,
+      rect: { x: 300, y: 120, width: 80, height: 80 },
+    }),
+  ];
+
+  const state = await capture(nodes, 'top');
+
+  assert.equal(state.canScroll, false);
+  assert.equal(state.scope, 'settings-table');
+});
+
 test('selectScrollContainer (broad): with no hidden edge anywhere, the LARGEST visible-in-viewport container wins, not just the first visible one', async () => {
   // Declaration order deliberately disagrees with area order (visible-small is
   // declared first) so a sort-less "first visible" implementation would pick

--- a/src/utils/scroll-edge-state-target-resolution.test.ts
+++ b/src/utils/scroll-edge-state-target-resolution.test.ts
@@ -166,6 +166,24 @@ test('selectScrollContainer: target.point outside every scrollable rect falls ba
   assert.equal(state.scope, 'far-away');
 });
 
+test('selectScrollContainer: a point miss with no hidden edge keeps broad selection instead of adopting implicit viewport-center targeting', async () => {
+  const nodes = [
+    windowRoot(),
+    scrollNode(1, {
+      identifier: 'centered-small',
+      rect: { x: 150, y: 350, width: 100, height: 100 },
+    }),
+    scrollNode(2, {
+      identifier: 'broad-large',
+      rect: { x: 0, y: 0, width: 350, height: 300 },
+    }),
+  ];
+
+  const state = await capture(nodes, 'bottom', { point: { x: 999, y: 999 } });
+
+  assert.equal(state.scope, 'broad-large');
+});
+
 // ---------------------------------------------------------------------------
 // containsPoint boundary (inclusive edges, and-of-four rather than or-of-any)
 // ---------------------------------------------------------------------------

--- a/src/utils/scroll-edge-state.ts
+++ b/src/utils/scroll-edge-state.ts
@@ -2,6 +2,7 @@ import { deriveMobileSnapshotHiddenContentHints } from '../snapshot/mobile-snaps
 import {
   isNodeVisibleInEffectiveViewport,
   isScrollableNodeLike,
+  isViewportRootNode,
 } from '@agent-device/contracts/snapshot';
 import { AppError } from '@agent-device/kernel/errors';
 import type { ScrollDirection } from '@agent-device/contracts/interaction';
@@ -176,28 +177,61 @@ function selectScrollContainer(
 
   const targetPoint = target.point;
   if (targetPoint) {
-    const containing = scrollables
-      .filter((node) => node.rect && containsPoint(node.rect, targetPoint))
-      .sort(compareSpecificScrollContainer);
-    if (containing.length > 0) {
-      const withHiddenEdge = containing.find((node) =>
-        hasHiddenContentAtEdge(node, hiddenHints.get(node.index), edge),
-      );
-      return withHiddenEdge ?? containing[0] ?? null;
-    }
+    const containing = selectPointScrollContainer(scrollables, hiddenHints, edge, targetPoint);
+    if (containing) return containing;
+    return selectBroadScrollContainer(scrollables, hiddenHints, edge, nodes);
   }
 
+  const viewportCenter = inferViewportCenter(nodes);
+  if (viewportCenter) {
+    const centered = selectPointScrollContainer(scrollables, hiddenHints, edge, viewportCenter);
+    if (centered) return centered;
+  }
+
+  return selectBroadScrollContainer(scrollables, hiddenHints, edge, nodes);
+}
+
+function selectBroadScrollContainer(
+  scrollables: SnapshotNode[],
+  hiddenHints: Map<number, HiddenContentHint>,
+  edge: ScrollEdge,
+  nodes: SnapshotNode[],
+): SnapshotNode | null {
   const withHiddenEdge = scrollables
     .filter((node) => hasHiddenContentAtEdge(node, hiddenHints.get(node.index), edge))
     .sort(compareBroadScrollContainer);
-  if (withHiddenEdge.length > 0) {
-    return withHiddenEdge[0] ?? null;
-  }
+  if (withHiddenEdge.length > 0) return withHiddenEdge[0] ?? null;
 
   const visibleScrollables = scrollables
     .filter((node) => isNodeVisibleInEffectiveViewport(node, nodes))
     .sort(compareBroadScrollContainer);
   return visibleScrollables[0] ?? scrollables.sort(compareBroadScrollContainer)[0] ?? null;
+}
+
+function selectPointScrollContainer(
+  scrollables: SnapshotNode[],
+  hiddenHints: Map<number, HiddenContentHint>,
+  edge: ScrollEdge,
+  point: Point,
+): SnapshotNode | null {
+  const containing = scrollables
+    .filter((node) => node.rect && containsPoint(node.rect, point))
+    .sort(compareSpecificScrollContainer);
+  const withHiddenEdge = containing.find((node) =>
+    hasHiddenContentAtEdge(node, hiddenHints.get(node.index), edge),
+  );
+  return withHiddenEdge ?? containing[0] ?? null;
+}
+
+function inferViewportCenter(nodes: SnapshotNode[]): Point | undefined {
+  const viewport = nodes
+    .filter((node) => isViewportRootNode(node) && isUsableRect(node.rect))
+    .sort(compareBroadScrollContainer)[0]?.rect;
+  if (!viewport) return undefined;
+  return {
+    x: viewport.x + viewport.width / 2,
+    y: viewport.y + viewport.height / 2,
+  };
 }
 
 function findNearestScrollableAncestor(


### PR DESCRIPTION
## Summary

Calibrates default iOS scrolling for dense settings-style screens and makes edge verification follow the viewport-centered gesture instead of an unrelated nested scroll container.

The iOS amount and shared mobile duration now come from one cross-runtime parity contract, explicit distance/timing remains unchanged, Swift runner defaults are command-tested, and recording telemetry reflects each platform transport. Explicit point-target edge semantics are preserved. Scope is 17 files within the scroll command family.

## Validation

- Live iOS Simulator verification on a nested settings screen: the default scroll repeatedly reached the intended intermediate section, and target-less `scroll top --settle` correctly recognized the viewport was already at the edge without scrolling the nested control.
- `pnpm check:affected --run`: 4,562 tests passed; changed-line coverage 100%; formatting, lint, typecheck, layering, fallow, build, and XCTest selection passed.
- Exact iOS Simulator and macOS XCUITest runner builds passed.
- Regression tests were proven red against the prior default and prior broad-container selection, then green after the fix.
- Adversarial review completed with no remaining actionable findings.

Docs and skills are unchanged because command syntax and workflow guidance did not change.