### PR TITLE
perf(check-affected): stop running coverage locally, CI stays authoritative

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -224,11 +224,10 @@ docs-only short-circuit its path would otherwise take. If the matrix moves
 again, move that entry with it.
 The plan documents the rule and changed path behind every selected check.
 
-`coverage` (the changed-line coverage gate) is GitHub-authoritative and never runs locally:
-instrumenting Vitest is real overhead on top of an already-run suite, and the CI `coverage` job
-enforces this gate on every PR, so a local rerun only spends time without adding local-only
-signal. `--run` reports it as skipped; `vitest-related`, `unit`, and `provider-integration` run
-locally on their own, uninstrumented, instead of being folded into a coverage pass.
+Coverage is never instrumented by `check:affected --run`. The plan still reports the coverage
+obligation and its authoritative GitHub job, while the local path runs one capped, uninstrumented
+`vitest related` command and deduplicates full unit/provider aggregates. Run the dedicated coverage
+scripts explicitly when diagnosing a red CI result; do not make every pre-push loop pay for LCOV.
 
 Model and catalog live under `scripts/check-affected/`; the derivation is guarded
 by `pnpm check:affected:test` (the `Affected-check Selector` CI job).

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -224,11 +224,11 @@ docs-only short-circuit its path would otherwise take. If the matrix moves
 again, move that entry with it.
 The plan documents the rule and changed path behind every selected check.
 
-Local coverage reuses the affected Vitest run as its LCOV producer and applies the changed-line
-coverage gate to that report. It does not run the full instrumented suite; global coverage
-thresholds and full unit/provider matrices remain authoritative in GitHub CI. When coverage is
-selected, `vitest-related` is folded into this one affected coverage run, and full unit/provider
-aggregates are not repeated locally.
+`coverage` (the changed-line coverage gate) is GitHub-authoritative and never runs locally:
+instrumenting Vitest is real overhead on top of an already-run suite, and the CI `coverage` job
+enforces this gate on every PR, so a local rerun only spends time without adding local-only
+signal. `--run` reports it as skipped; `vitest-related`, `unit`, and `provider-integration` run
+locally on their own, uninstrumented, instead of being folded into a coverage pass.
 
 Model and catalog live under `scripts/check-affected/`; the derivation is guarded
 by `pnpm check:affected:test` (the `Affected-check Selector` CI job).

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -10,6 +10,7 @@
 // agent reads before skipping a check locally cannot go stale.
 
 import { ALL_CHECKS, type CheckId } from './model.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 
 export type CheckKind =
   | { readonly type: 'script'; readonly script: string }
@@ -50,10 +51,8 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
     localRunnable: true,
   },
   gate('unit', 'Unit + smoke suite', 'check:unit'),
-  // Coverage instrumentation adds real overhead on top of an already-run test suite, and the
-  // `coverage` CI job enforces this gate on every PR — so a local rerun only spends time without
-  // adding local-only signal. Report it as GitHub-authoritative instead of running it here.
-  gate('coverage', 'Affected LCOV + changed-line coverage', 'check:coverage-changed', false),
+  // CI owns the default coverage run; the scripts remain available for explicit local diagnosis.
+  gate('coverage', 'Changed-line coverage', 'check:coverage-changed', false),
   gate('provider-integration', 'Provider-backed integration suite', 'test:integration:provider'),
   gate(
     'integration-progress',
@@ -82,9 +81,8 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
   // steps; before the registry became canonical, nothing in the repo could name
   // them, so nothing could ask whether they still ran.
   //
-  // `unit-ci` is the CI form of the unit suite, run under coverage instrumentation. Locally you
-  // run `unit` (and `provider-integration`) uninstrumented; the `coverage` job is what actually
-  // repeats this one, on GitHub.
+  // `unit-ci` is the CI form of the unit suite under coverage. Local affected checks use Vitest's
+  // related graph without instrumentation; CI owns the full coverage run and changed-line verdict.
   gate('unit-ci', 'CI unit suite under coverage', 'test:coverage:ci', false),
   gate('affected-selector', 'Affected-check selector model', 'check:affected:test'),
   gate('gate-manifest', 'Gate manifest — every gate owned and wired', 'check:gate-manifest'),
@@ -164,7 +162,16 @@ export function resolveCommand(
   changedFiles: readonly string[] = [],
 ): string[] {
   if (spec.kind.type === 'vitest-related') {
-    return ['pnpm', 'exec', 'vitest', 'related', '--run', '--passWithNoTests', ...changedFiles];
+    return [
+      'pnpm',
+      'exec',
+      'vitest',
+      'related',
+      '--run',
+      '--passWithNoTests',
+      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
+      ...changedFiles,
+    ];
   }
   const { script } = spec.kind;
   if (!(script in scripts)) {

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -20,8 +20,9 @@ export type CheckSpec = {
   readonly label: string;
   readonly kind: CheckKind;
   // Whether `--run` should attempt the check locally. Device/emulator lanes,
-  // network/toolchain-gated lanes, and long scheduled sweeps (mutation, fuzz,
-  // torture) stay authoritative on GitHub CI.
+  // network/toolchain-gated lanes, long scheduled sweeps (mutation, fuzz,
+  // torture), and the instrumented coverage run stay authoritative on
+  // GitHub CI.
   readonly localRunnable: boolean;
 };
 
@@ -49,7 +50,10 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
     localRunnable: true,
   },
   gate('unit', 'Unit + smoke suite', 'check:unit'),
-  gate('coverage', 'Affected LCOV + changed-line coverage', 'check:coverage-changed'),
+  // Coverage instrumentation adds real overhead on top of an already-run test suite, and the
+  // `coverage` CI job enforces this gate on every PR — so a local rerun only spends time without
+  // adding local-only signal. Report it as GitHub-authoritative instead of running it here.
+  gate('coverage', 'Affected LCOV + changed-line coverage', 'check:coverage-changed', false),
   gate('provider-integration', 'Provider-backed integration suite', 'test:integration:provider'),
   gate(
     'integration-progress',
@@ -78,8 +82,9 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
   // steps; before the registry became canonical, nothing in the repo could name
   // them, so nothing could ask whether they still ran.
   //
-  // `unit-ci` is the CI form of the unit suite. Locally you run `unit` and
-  // `coverage`, which together repeat it.
+  // `unit-ci` is the CI form of the unit suite, run under coverage instrumentation. Locally you
+  // run `unit` (and `provider-integration`) uninstrumented; the `coverage` job is what actually
+  // repeats this one, on GitHub.
   gate('unit-ci', 'CI unit suite under coverage', 'test:coverage:ci', false),
   gate('affected-selector', 'Affected-check selector model', 'check:affected:test'),
   gate('gate-manifest', 'Gate manifest — every gate owned and wired', 'check:gate-manifest'),

--- a/scripts/check-affected/model.test.ts
+++ b/scripts/check-affected/model.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { assertCatalogComplete, CHECK_CATALOG, resolveCommand } from './checks.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { ALL_CHECKS, selectChecks, type CheckId, type SelectInput } from './model.ts';
 
 function plan(changedFiles: string[], extra: Partial<SelectInput> = {}) {
@@ -296,6 +297,7 @@ test('vitest-related delegates changed paths to Vitest instead of modeling proje
     'related',
     '--run',
     '--passWithNoTests',
+    `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
     'src/a.ts',
     'test/fixture.ts',
   ]);

--- a/scripts/check-affected/model.ts
+++ b/scripts/check-affected/model.ts
@@ -97,7 +97,7 @@ export const ALL_CHECKS: readonly CheckId[] = [
   'build',
   'package',
   // Real daemon/process integration owns host-global lifecycle state and must
-  // run before the high-parallelism coverage workload heats the host.
+  // run before the related-project workload heats the host.
   'integration-node',
   'vitest-related',
   'unit',

--- a/scripts/check-affected/run.test.ts
+++ b/scripts/check-affected/run.test.ts
@@ -10,7 +10,6 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { runCmdSync } from '../../src/utils/exec.ts';
 import { CHECK_CATALOG } from './checks.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { selectChecks } from './model.ts';
 import { type CommandExecutor, readChangedFiles, runChecks } from './run.ts';
 
@@ -171,7 +170,7 @@ test('runChecks skips GitHub-authoritative checks and passes when locals succeed
   }
 });
 
-test('runChecks combines related tests with lightweight changed-line coverage', async () => {
+test('runChecks runs related tests, unit, and provider-integration uninstrumented and leaves coverage to CI', async () => {
   const executed: string[][] = [];
   const execute: CommandExecutor = async (command) => {
     executed.push(command);
@@ -184,13 +183,14 @@ test('runChecks combines related tests with lightweight changed-line coverage', 
   assert.equal(code, 0);
   const related = executed.filter((command) => command.includes('related'));
   assert.equal(related.length, 1);
-  assert.ok(related[0]?.includes('--coverage'));
-  assert.ok(related[0]?.includes('--coverage.reporter=lcov'));
-  assert.ok(related[0]?.includes(`--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`));
+  assert.ok(
+    !related[0]?.includes('--coverage'),
+    'coverage instrumentation stays GitHub-authoritative; the local run must not add it',
+  );
   assert.ok(
     executed.findIndex((command) => command.includes('test:integration:node')) <
       executed.findIndex((command) => command.includes('related')),
-    'process-lifecycle integration must run before high-parallelism affected coverage',
+    'process-lifecycle integration must run before the high-parallelism related-test run',
   );
   assert.equal(
     executed.some((command) => command.includes('test:coverage')),
@@ -198,14 +198,17 @@ test('runChecks combines related tests with lightweight changed-line coverage', 
   );
   assert.equal(
     executed.some((command) => command.includes('check:unit')),
-    false,
+    true,
+    'unit must run locally on its own — it is no longer folded into a coverage run',
   );
   assert.equal(
     executed.some((command) => command.includes('test:integration:provider')),
-    false,
+    true,
+    'provider-integration must run locally on its own — it is no longer folded into a coverage run',
   );
   assert.equal(
     executed.some((command) => command.includes('check:coverage-changed')),
-    true,
+    false,
+    'the coverage gate is GitHub-authoritative and must not run locally',
   );
 });

--- a/scripts/check-affected/run.test.ts
+++ b/scripts/check-affected/run.test.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { runCmdSync } from '../../src/utils/exec.ts';
 import { CHECK_CATALOG } from './checks.ts';
+import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { selectChecks } from './model.ts';
 import { type CommandExecutor, readChangedFiles, runChecks } from './run.ts';
 
@@ -135,7 +136,16 @@ test('runChecks passes the selector change set to Vitest related', async () => {
   assert.equal(code, 0);
   assert.deepEqual(
     executed.find((command) => command.includes('related')),
-    ['pnpm', 'exec', 'vitest', 'related', '--run', '--passWithNoTests', ...changedFiles],
+    [
+      'pnpm',
+      'exec',
+      'vitest',
+      'related',
+      '--run',
+      '--passWithNoTests',
+      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
+      ...changedFiles,
+    ],
   );
 });
 
@@ -170,7 +180,7 @@ test('runChecks skips GitHub-authoritative checks and passes when locals succeed
   }
 });
 
-test('runChecks runs related tests, unit, and provider-integration uninstrumented and leaves coverage to CI', async () => {
+test('runChecks leaves coverage to CI and runs capped related tests once', async () => {
   const executed: string[][] = [];
   const execute: CommandExecutor = async (command) => {
     executed.push(command);
@@ -187,10 +197,11 @@ test('runChecks runs related tests, unit, and provider-integration uninstrumente
     !related[0]?.includes('--coverage'),
     'coverage instrumentation stays GitHub-authoritative; the local run must not add it',
   );
+  assert.ok(related[0]?.includes(`--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`));
   assert.ok(
     executed.findIndex((command) => command.includes('test:integration:node')) <
       executed.findIndex((command) => command.includes('related')),
-    'process-lifecycle integration must run before the high-parallelism related-test run',
+    'process-lifecycle integration must run before the related-project workload',
   );
   assert.equal(
     executed.some((command) => command.includes('test:coverage')),
@@ -198,13 +209,13 @@ test('runChecks runs related tests, unit, and provider-integration uninstrumente
   );
   assert.equal(
     executed.some((command) => command.includes('check:unit')),
-    true,
-    'unit must run locally on its own — it is no longer folded into a coverage run',
+    false,
+    'related tests cover the selected unit graph without repeating the full suite',
   );
   assert.equal(
     executed.some((command) => command.includes('test:integration:provider')),
-    true,
-    'provider-integration must run locally on its own — it is no longer folded into a coverage run',
+    false,
+    'related tests cover the selected provider graph without repeating the full suite',
   );
   assert.equal(
     executed.some((command) => command.includes('check:coverage-changed')),

--- a/scripts/check-affected/run.ts
+++ b/scripts/check-affected/run.ts
@@ -11,7 +11,6 @@ import { pathToFileURL } from 'node:url';
 import { runCmdStreaming, runCmdSync } from '../../src/utils/exec.ts';
 import { parseScriptArgs } from '../lib/cli-args.ts';
 import { runEntrypoint } from '../lib/cli-entrypoint.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import {
   assertCatalogComplete,
   CHECK_CATALOG,
@@ -191,24 +190,17 @@ export async function runChecks(
   const execute = options.execute ?? streamingExecutor;
   const runnable = plan.checks.map(getCheckSpec).filter((spec: CheckSpec) => spec.localRunnable);
   const skipped = plan.checks.map(getCheckSpec).filter((spec: CheckSpec) => !spec.localRunnable);
-  const coverageSelected = plan.checks.includes('coverage');
   const ciJobs = skipped.length > 0 ? ciJobsByCheck() : new Map<CheckId, string[]>();
   for (const spec of skipped) {
     process.stdout.write(`\n[skip] ${spec.id} — ${describeOwner(spec.id, ciJobs)}\n`);
   }
   for (const spec of runnable) {
-    if (isCoveredByAffectedCoverage(spec, coverageSelected)) {
-      process.stdout.write(`\n[dedupe] ${spec.id} — covered by affected LCOV or GitHub CI\n`);
-      continue;
-    }
-    const commands = resolveCheckCommands(spec, pkg, args, options.changedFiles ?? []);
-    for (const command of commands) {
-      process.stdout.write(`\n[run] ${spec.id}: ${command.join(' ')}\n`);
-      const exitCode = await execute(command, cwd);
-      if (exitCode !== 0) {
-        process.stderr.write(`\ncheck:affected: ${spec.id} failed.\n`);
-        return 1;
-      }
+    const command = resolveCommand(spec, pkg.scripts, args.base, options.changedFiles ?? []);
+    process.stdout.write(`\n[run] ${spec.id}: ${command.join(' ')}\n`);
+    const exitCode = await execute(command, cwd);
+    if (exitCode !== 0) {
+      process.stderr.write(`\ncheck:affected: ${spec.id} failed.\n`);
+      return 1;
     }
   }
   process.stdout.write('\ncheck:affected: all runnable checks passed.\n');
@@ -221,56 +213,6 @@ function describeOwner(id: CheckId, ciJobs: ReadonlyMap<CheckId, string[]>): str
   const parked = MANUAL_ONLY_OWNERS[id];
   if (parked) return `parked, workflow_dispatch only (${parked.lane})`;
   return `GitHub-authoritative (jobs: ${(ciJobs.get(id) ?? []).join(', ')})`;
-}
-
-function isCoveredByAffectedCoverage(spec: CheckSpec, coverageSelected: boolean): boolean {
-  return (
-    coverageSelected &&
-    (spec.id === 'vitest-related' || spec.id === 'unit' || spec.id === 'provider-integration')
-  );
-}
-
-function resolveCheckCommands(
-  spec: CheckSpec,
-  pkg: PackageJson,
-  args: Args,
-  changedFiles: readonly string[],
-): string[][] {
-  return spec.id === 'coverage'
-    ? resolveAffectedCoverageCommands(pkg.scripts, args.base, changedFiles)
-    : [resolveCommand(spec, pkg.scripts, args.base, changedFiles)];
-}
-
-function resolveAffectedCoverageCommands(
-  scripts: Readonly<Record<string, string>>,
-  base: string,
-  changedFiles: readonly string[],
-): string[][] {
-  if (!('check:coverage-changed' in scripts)) {
-    throw new Error('Required package.json script "check:coverage-changed" does not exist.');
-  }
-  return [
-    [
-      'pnpm',
-      'exec',
-      'vitest',
-      'related',
-      '--run',
-      '--passWithNoTests',
-      // `related` spans every configured Vitest project for broad diffs. The
-      // machine-derived default can start enough projects concurrently to
-      // starve otherwise-green subprocess/provider tests past their exact
-      // timeout budgets. Bound this aggregate feedback lane without changing
-      // the suites' own timeout or serialization contracts.
-      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
-      '--coverage',
-      '--coverage.reporter=lcov',
-      '--coverage.thresholds.statements=0',
-      '--coverage.thresholds.lines=0',
-      ...changedFiles,
-    ],
-    ['pnpm', 'run', 'check:coverage-changed', '--base', base],
-  ];
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {

--- a/scripts/check-affected/run.ts
+++ b/scripts/check-affected/run.ts
@@ -190,11 +190,16 @@ export async function runChecks(
   const execute = options.execute ?? streamingExecutor;
   const runnable = plan.checks.map(getCheckSpec).filter((spec: CheckSpec) => spec.localRunnable);
   const skipped = plan.checks.map(getCheckSpec).filter((spec: CheckSpec) => !spec.localRunnable);
+  const relatedSelected = plan.checks.includes('vitest-related');
   const ciJobs = skipped.length > 0 ? ciJobsByCheck() : new Map<CheckId, string[]>();
   for (const spec of skipped) {
     process.stdout.write(`\n[skip] ${spec.id} — ${describeOwner(spec.id, ciJobs)}\n`);
   }
   for (const spec of runnable) {
+    if (isCoveredByRelatedTests(spec, relatedSelected)) {
+      process.stdout.write(`\n[dedupe] ${spec.id} — covered by related tests or GitHub CI\n`);
+      continue;
+    }
     const command = resolveCommand(spec, pkg.scripts, args.base, options.changedFiles ?? []);
     process.stdout.write(`\n[run] ${spec.id}: ${command.join(' ')}\n`);
     const exitCode = await execute(command, cwd);
@@ -213,6 +218,10 @@ function describeOwner(id: CheckId, ciJobs: ReadonlyMap<CheckId, string[]>): str
   const parked = MANUAL_ONLY_OWNERS[id];
   if (parked) return `parked, workflow_dispatch only (${parked.lane})`;
   return `GitHub-authoritative (jobs: ${(ciJobs.get(id) ?? []).join(', ')})`;
+}
+
+function isCoveredByRelatedTests(spec: CheckSpec, relatedSelected: boolean): boolean {
+  return relatedSelected && (spec.id === 'unit' || spec.id === 'provider-integration');
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {


### PR DESCRIPTION
## Summary

- Keep coverage out of the default local `check:affected --run` loop; the plan reports the authoritative GitHub `Coverage` job, while the dedicated coverage scripts remain available for explicit diagnosis.
- Run affected tests once through capped, uninstrumented `vitest related`, preserving the shared `--maxWorkers=2` contention bound and deduplicating the full unit/provider aggregates.
- Update the affected-gate model, regression tests, and testing guidance. Scope is 6 files with no expansion beyond the local affected-check workflow.

## Validation

- Exact head `3a1cc99413b751d565fd0071e379c711e3a58d10`
- `pnpm check:affected:test` — 47/47 pass
- Planted red: removing the shared Vitest worker cap fails three affected-gate assertions; restoring it returns 47/47 green
- `pnpm check:gate-manifest` — 46 checks wired across 33 lanes; coverage remains owned by GitHub CI
- `pnpm check:affected --json` — coverage reports `localRunnable: false` and the `Coverage` CI job
- `pnpm check:affected --run` — full fail-open local gate passes; coverage is skipped, related tests run once with `--maxWorkers=2`, and unit/provider aggregates are deduplicated
