### PR TITLE
fix(maestro): align label metadata ownership

### DIFF
--- a/packages/maestro/package.json
+++ b/packages/maestro/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@agent-device/contracts": "workspace:*",
     "@agent-device/kernel": "workspace:*",
+    "@agent-device/selectors": "workspace:*",
     "yaml": "^2.9.0"
   },
   "exports": {

--- a/packages/maestro/src/internal/__tests__/conformance-selector-projection.test.ts
+++ b/packages/maestro/src/internal/__tests__/conformance-selector-projection.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest';
+import { canonicalizeAgentCommands, canonicalizeUpstreamFlow } from '../conformance-normalize.ts';
+import {
+  canonicalizeAgentSelector,
+  canonicalizeUpstreamSelector,
+} from '../conformance-selector-projection.ts';
+import { parseMaestroProgram } from '../program-ir-parser.ts';
+
+test('canonicalizes command labels separately from selector identity', () => {
+  const program = parseMaestroProgram(
+    ['---', '- tapOn:', '    text: Save', '    label: save action'].join('\n'),
+  );
+
+  expect(canonicalizeAgentCommands(program)).toEqual([
+    {
+      kind: 'tap',
+      longPress: false,
+      repeat: 1,
+      label: 'save action',
+      target: { selector: { text: 'Save' } },
+    },
+  ]);
+  expect(
+    canonicalizeUpstreamFlow([
+      {
+        type: 'TapOnElementCommand',
+        fields: {
+          label: 'save action',
+          selector: { textRegex: 'Save', label: 'must not match' },
+          longPress: false,
+          repeat: null,
+        },
+      },
+    ]),
+  ).toEqual([
+    {
+      kind: 'tap',
+      longPress: false,
+      repeat: 1,
+      label: 'save action',
+      target: { selector: { text: 'Save' } },
+    },
+  ]);
+});
+
+test('selector projection drops metadata-shaped label fields', () => {
+  expect(canonicalizeUpstreamSelector({ textRegex: 'Save', label: 'command metadata' })).toEqual({
+    text: 'Save',
+  });
+  expect(canonicalizeAgentSelector({ text: 'Save' })).toEqual({ text: 'Save' });
+});

--- a/packages/maestro/src/internal/__tests__/export-label-projection.test.ts
+++ b/packages/maestro/src/internal/__tests__/export-label-projection.test.ts
@@ -1,0 +1,45 @@
+import { parseAllDocuments } from 'yaml';
+import { expect, test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import type { SessionAction } from '@agent-device/contracts/session';
+import { exportReplayActionsToMaestro, inspectMaestroFlow } from '../../index.ts';
+import { MAESTRO_SELECTOR_PROJECTION } from '../selector-vocabulary.ts';
+import { projectSelectorExpression } from '@agent-device/selectors';
+
+test('projects native label selectors to text with a warning and self-parses', () => {
+  const result = exportReplayActionsToMaestro(
+    [action('open', ['com.example.app']), action('click', ['label="Save"'])],
+    {
+      actionLines: [1, 2],
+      resolveSelector: (expression) =>
+        projectSelectorExpression(expression, MAESTRO_SELECTOR_PROJECTION),
+    },
+  );
+
+  expect(parseAllDocuments(result.yaml).map((document) => document.toJSON())).toEqual([
+    { appId: 'com.example.app' },
+    ['launchApp', { tapOn: { text: 'Save' } }],
+  ]);
+  expect(result.warnings).toEqual([
+    {
+      line: 2,
+      action: 'click label="Save"',
+      message:
+        'label= selectors export as Maestro text; Maestro text matching is broader than agent-device label-only matching',
+    },
+  ]);
+  expect(() => inspectMaestroFlow(result.yaml, 'exported.yaml')).not.toThrow();
+});
+
+test('keeps compound selectors that include label as hard export errors', () => {
+  expect(() =>
+    exportReplayActionsToMaestro([action('click', ['role=button label="Save"'])], {
+      resolveSelector: (expression) =>
+        projectSelectorExpression(expression, MAESTRO_SELECTOR_PROJECTION),
+    }),
+  ).toThrow(AppError);
+});
+
+function action(command: string, positionals: string[]): SessionAction {
+  return { ts: 0, command, positionals, flags: {} };
+}

--- a/packages/maestro/src/internal/__tests__/program-ir-label-metadata.test.ts
+++ b/packages/maestro/src/internal/__tests__/program-ir-label-metadata.test.ts
@@ -39,6 +39,10 @@ test('keeps outer labels as command metadata across supported command forms', ()
       '- inputText:',
       '    text: value',
       '    label: field input',
+      '- runFlow:',
+      '    commands:',
+      '      - scroll',
+      '    label: nested flow',
     ].join('\n'),
   );
 
@@ -55,6 +59,7 @@ test('keeps outer labels as command metadata across supported command forms', ()
     'item scroll',
     'card swipe',
     'field input',
+    'nested flow',
   ]);
   expect(program.commands[0]).toMatchObject({
     target: { space: 'target', selector: { text: 'Save' } },

--- a/packages/maestro/src/internal/__tests__/program-ir-label-metadata.test.ts
+++ b/packages/maestro/src/internal/__tests__/program-ir-label-metadata.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+import { parseMaestroProgram } from '../program-ir-parser.ts';
+
+test('keeps outer labels as command metadata across supported command forms', () => {
+  const program = parseMaestroProgram(
+    [
+      '---',
+      '- tapOn:',
+      '    text: Save',
+      '    label: save tap',
+      '- tapOn:',
+      '    point: 20,30',
+      '    label: coordinate tap',
+      '- doubleTapOn:',
+      '    text: Save',
+      '    label: save twice',
+      '- longPressOn:',
+      '    text: Hold',
+      '    label: hold action',
+      '- assertVisible:',
+      '    text: Ready',
+      '    label: ready assertion',
+      '- assertNotVisible:',
+      '    text: Gone',
+      '    label: gone assertion',
+      '- extendedWaitUntil:',
+      '    visible:',
+      '      text: Loaded',
+      '    label: loaded wait',
+      '- scrollUntilVisible:',
+      '    element:',
+      '      text: Item',
+      '    label: item scroll',
+      '- swipe:',
+      '    from:',
+      '      text: Card',
+      '    direction: LEFT',
+      '    label: card swipe',
+      '- inputText:',
+      '    text: value',
+      '    label: field input',
+    ].join('\n'),
+  );
+
+  expect(
+    program.commands.map((command) => ('label' in command ? command.label : undefined)),
+  ).toEqual([
+    'save tap',
+    'coordinate tap',
+    'save twice',
+    'hold action',
+    'ready assertion',
+    'gone assertion',
+    'loaded wait',
+    'item scroll',
+    'card swipe',
+    'field input',
+  ]);
+  expect(program.commands[0]).toMatchObject({
+    target: { space: 'target', selector: { text: 'Save' } },
+  });
+  expect(program.commands[4]).toMatchObject({ target: { text: 'Ready' } });
+  expect(program.commands[6]).toMatchObject({ visible: { text: 'Loaded' } });
+  expect(program.commands[7]).toMatchObject({ element: { text: 'Item' } });
+  expect(program.commands[8]).toMatchObject({ gesture: { from: { text: 'Card' } } });
+});
+
+test('does not accept a label-only map as a selector', () => {
+  expect(() => parseMaestroProgram(['---', '- tapOn:', '    label: Save'].join('\n'))).toThrow(
+    /selector is empty|selector must contain a selector value/,
+  );
+});
+
+test('does not reinterpret a nested selector label as command metadata', () => {
+  expect(() =>
+    parseMaestroProgram(
+      [
+        '---',
+        '- extendedWaitUntil:',
+        '    visible:',
+        '      text: Loaded',
+        '      label: nested label',
+      ].join('\n'),
+    ),
+  ).toThrow(/visible field "label" is not supported/);
+});

--- a/packages/maestro/src/internal/__tests__/program-ir-parser.test.ts
+++ b/packages/maestro/src/internal/__tests__/program-ir-parser.test.ts
@@ -152,21 +152,6 @@ describe('parseMaestroProgram', () => {
     });
   });
 
-  test('keeps selector-map keys aligned with the supported command subset', () => {
-    const program = parseMaestroProgram(['---', '- tapOn:', '    label: Save'].join('\n'));
-    const tap = commandOfKind(program.commands[0], 'tapOn');
-    assert.deepEqual(tap.target, { space: 'target', selector: { label: 'Save' } });
-
-    assert.throws(
-      () => parseMaestroProgram(['---', '- doubleTapOn:', '    label: Save'].join('\n')),
-      /doubleTapOn field "label" is not supported.*line 3/i,
-    );
-    assert.throws(
-      () => parseMaestroProgram(['---', '- assertVisible:', '    label: Save'].join('\n')),
-      /assertVisible field "label" is not supported.*line 3/i,
-    );
-  });
-
   test('parses optional on assertion and target command maps', () => {
     const program = parseMaestroProgram(
       [

--- a/packages/maestro/src/internal/__tests__/progress.test.ts
+++ b/packages/maestro/src/internal/__tests__/progress.test.ts
@@ -29,3 +29,13 @@ test('redacts typed values from progress output', () => {
     { command: 'inputText', value: '<text>' },
   ]);
 });
+
+test('uses command labels for progress values without changing selector meaning', () => {
+  const program = parseMaestroProgram(
+    ['---', '- tapOn:', '    text: Save', '    label: save action'].join('\n'),
+  );
+
+  expect(program.commands.map(formatMaestroCommandProgress)).toEqual([
+    { command: 'tapOn', value: 'save action' },
+  ]);
+});

--- a/packages/maestro/src/internal/__tests__/runtime-target-policy.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-target-policy.test.ts
@@ -19,7 +19,7 @@ test('typed Maestro text selectors match visible text and state without expressi
   expect(matchesMaestroTypedSelector(node, { text: 'Subtotal', selected: false })).toBe(false);
 });
 
-test('typed Maestro id and label selectors keep their primary field semantics', () => {
+test('typed Maestro id and text selectors keep their primary field semantics', () => {
   const node = makeSnapshot([
     {
       index: 1,
@@ -30,8 +30,8 @@ test('typed Maestro id and label selectors keep their primary field semantics', 
   ]).nodes[0]!;
 
   expect(matchesMaestroTypedSelector(node, { id: 'checkout-submit' })).toBe(true);
-  expect(matchesMaestroTypedSelector(node, { label: 'Submit' })).toBe(false);
-  expect(matchesMaestroTypedSelector(node, { label: '^Submit.*' })).toBe(true);
+  expect(matchesMaestroTypedSelector(node, { text: 'Submit' })).toBe(false);
+  expect(matchesMaestroTypedSelector(node, { text: '^Submit.*' })).toBe(true);
 });
 
 test('intersects every field in a compound Maestro selector', () => {
@@ -49,7 +49,6 @@ test('intersects every field in a compound Maestro selector', () => {
     matchesMaestroTypedSelector(node, {
       id: 'checkout-submit',
       text: 'Submit order',
-      label: '^Submit.*',
       enabled: true,
     }),
   ).toBe(true);

--- a/packages/maestro/src/internal/conformance-normalize.ts
+++ b/packages/maestro/src/internal/conformance-normalize.ts
@@ -6,30 +6,25 @@
 // differences (regex-vs-literal selector storage, runScript path-vs-content,
 // nested runFlow expansion) that the two IR designs express differently.
 
-import type {
-  MaestroCommand,
-  MaestroGestureTarget,
-  MaestroProgram,
-  MaestroSelector,
-  MaestroSwipeGesture,
-} from './program-ir.ts';
+import type { MaestroCommand, MaestroProgram, MaestroSwipeGesture } from './program-ir.ts';
 import { MAESTRO_COMPATIBILITY_PRESETS } from './compatibility-policy.ts';
+import { asRecord, bool, dropUndefined, numLike, str } from './conformance-value-coercion.ts';
+import {
+  canonicalizeAgentSelector,
+  canonicalizeAgentPoint,
+  canonicalizeAgentTarget,
+  canonicalizeUpstreamPoint,
+  canonicalizeUpstreamSelector,
+  type CanonicalPoint,
+  type CanonicalSelector,
+  type CanonicalTarget,
+} from './conformance-selector-projection.ts';
 
-export type CanonicalSelector = {
-  text?: string;
-  id?: string;
-  index?: number | string;
-  enabled?: boolean;
-  selected?: boolean;
-  childOf?: CanonicalSelector;
-};
-
-export type CanonicalPoint = { x: number; y: number; unit: 'px' | 'percent'; expr?: string };
-
-export type CanonicalTarget = {
-  selector?: CanonicalSelector;
-  point?: CanonicalPoint;
-};
+export type {
+  CanonicalPoint,
+  CanonicalSelector,
+  CanonicalTarget,
+} from './conformance-selector-projection.ts';
 
 export type CanonicalGesture =
   | { mode: 'direction'; direction: string; duration?: number | string }
@@ -52,6 +47,7 @@ export type CanonicalCommand =
       longPress: boolean;
       repeat: number | string;
       delay?: number | string;
+      label?: string;
       target: CanonicalTarget;
     }
   | {
@@ -59,16 +55,18 @@ export type CanonicalCommand =
       mode: 'visible' | 'notVisible';
       timed: boolean;
       timeout?: number | string;
+      label?: string;
       selector?: CanonicalSelector;
     }
-  | { kind: 'swipe'; gesture: CanonicalGesture }
-  | { kind: 'inputText'; text?: string }
+  | { kind: 'swipe'; label?: string; gesture: CanonicalGesture }
+  | { kind: 'inputText'; label?: string; text?: string }
   | { kind: 'eraseText'; count?: number | string }
   | { kind: 'openLink'; link?: string }
   | { kind: 'scroll' }
   | {
       kind: 'scrollUntilVisible';
       direction?: string;
+      label?: string;
       selector?: CanonicalSelector;
       timeout?: number | string;
     }
@@ -80,7 +78,7 @@ export type CanonicalCommand =
   | { kind: 'stopApp' }
   | { kind: 'repeat'; times: string | number }
   | { kind: 'retry'; maxRetries?: string | number }
-  | { kind: 'runFlow'; source: 'file' | 'commands' }
+  | { kind: 'runFlow'; label?: string; source: 'file' | 'commands' }
   | { kind: 'runScript' }
   | { kind: 'unsupported'; command: string };
 
@@ -115,7 +113,8 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
         longPress: bool(f.longPress) ?? false,
         repeat: numLike(repeat?.repeat) ?? str(repeat?.repeat) ?? 1,
         delay: numLike(repeat?.delay) ?? str(repeat?.delay),
-        target: { selector: upstreamSelector(f.selector) },
+        label: str(f.label),
+        target: { selector: canonicalizeUpstreamSelector(f.selector) },
       });
     }
     case 'TapOnPointV2Command':
@@ -123,7 +122,8 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
       return canonicalTap({
         longPress: false,
         repeat: 1,
-        target: { point: upstreamPoint(f.point) },
+        label: str(f.label),
+        target: { point: canonicalizeUpstreamPoint(f.point) },
       });
     case 'AssertConditionCommand': {
       // Upstream serializes every condition slot; the active one is non-null.
@@ -135,7 +135,8 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
           mode: 'visible',
           timed: f.timeout != null,
           timeout,
-          selector: upstreamSelector(condition.visible),
+          label: str(f.label),
+          selector: canonicalizeUpstreamSelector(condition.visible),
         });
       }
       if (condition.notVisible != null) {
@@ -144,24 +145,26 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
           mode: 'notVisible',
           timed: f.timeout != null,
           timeout,
-          selector: upstreamSelector(condition.notVisible),
+          label: str(f.label),
+          selector: canonicalizeUpstreamSelector(condition.notVisible),
         });
       }
       return { kind: 'unsupported', command: 'assertTrue' };
     }
     case 'SwipeCommand':
-      return { kind: 'swipe', gesture: upstreamGesture(f) };
+      return dropUndefined({ kind: 'swipe', label: str(f.label), gesture: upstreamGesture(f) });
     case 'ScrollCommand':
       return { kind: 'scroll' };
     case 'ScrollUntilVisibleCommand':
       return dropUndefined({
         kind: 'scrollUntilVisible',
         direction: lower(str(f.direction)),
-        selector: upstreamSelector(f.selector),
+        label: str(f.label),
+        selector: canonicalizeUpstreamSelector(f.selector),
         timeout: numLike(f.timeout) ?? str(f.timeout),
       });
     case 'InputTextCommand':
-      return dropUndefined({ kind: 'inputText', text: str(f.text) });
+      return dropUndefined({ kind: 'inputText', label: str(f.label), text: str(f.text) });
     case 'EraseTextCommand':
       return dropUndefined({
         kind: 'eraseText',
@@ -192,7 +195,11 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
         maxRetries: numLike(f.maxRetries) ?? str(f.maxRetries),
       });
     case 'RunFlowCommand':
-      return { kind: 'runFlow', source: f.sourceDescription != null ? 'file' : 'commands' };
+      return dropUndefined({
+        kind: 'runFlow',
+        label: str(f.label),
+        source: f.sourceDescription != null ? 'file' : 'commands',
+      });
     case 'RunScriptCommand':
       return { kind: 'runScript' };
     default:
@@ -210,6 +217,7 @@ function canonicalTap(tap: {
   longPress: boolean;
   repeat: number | string;
   delay?: number | string;
+  label?: string;
   target: CanonicalTarget;
 }): CanonicalCommand {
   return dropUndefined({
@@ -217,40 +225,9 @@ function canonicalTap(tap: {
     longPress: tap.longPress,
     repeat: tap.repeat,
     delay: typeof tap.repeat === 'number' && tap.repeat <= 1 ? undefined : tap.delay,
+    label: tap.label,
     target: tap.target,
   });
-}
-
-function upstreamSelector(value: unknown): CanonicalSelector | undefined {
-  const record = asRecord(value);
-  if (!record) return undefined;
-  return dropUndefined({
-    text: str(record.textRegex),
-    id: str(record.idRegex),
-    index: numLike(record.index) ?? str(record.index),
-    enabled: bool(record.enabled),
-    selected: bool(record.selected),
-    childOf: upstreamSelector(record.childOf),
-  });
-}
-
-/**
- * A point the upstream parser accepted but we cannot canonicalize is a hole in
- * the oracle, not a value to drop: silently returning undefined would erase the
- * point from BOTH sides of the comparison and make an unequal pair compare equal.
- * Fail loudly so the projection gets fixed instead.
- */
-function upstreamPoint(value: unknown): CanonicalPoint | undefined {
-  const text = str(value);
-  if (!text) return undefined;
-  const match = /^\s*(-?\d+)(%?)\s*,\s*(-?\d+)(%?)\s*$/.exec(text);
-  if (!match) {
-    throw new Error(
-      `Cannot canonicalize upstream point ${JSON.stringify(text)}; extend upstreamPoint() in normalize.ts.`,
-    );
-  }
-  const unit = match[2] === '%' || match[4] === '%' ? 'percent' : 'px';
-  return { x: Number(match[1]), y: Number(match[3]), unit };
 }
 
 function upstreamGesture(f: Record<string, unknown>): CanonicalGesture {
@@ -258,7 +235,7 @@ function upstreamGesture(f: Record<string, unknown>): CanonicalGesture {
   if (f.elementSelector != null) {
     return dropUndefined({
       mode: 'element',
-      from: upstreamSelector(f.elementSelector) ?? {},
+      from: canonicalizeUpstreamSelector(f.elementSelector) ?? {},
       direction: lower(str(f.direction)),
       duration,
     });
@@ -294,42 +271,8 @@ function unsupportedName(type: string): string {
   return base.charAt(0).toLowerCase() + base.slice(1);
 }
 
-// ---------------------------------------------------------------------------
-// Small coercion helpers (upstream stores several fields as strings)
-// ---------------------------------------------------------------------------
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-function str(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-function bool(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
 function lower(value: string | undefined): string | undefined {
   return value?.toLowerCase();
-}
-const VARIABLE_PATTERN = /^\$\{[A-Za-z_][A-Za-z0-9_.]*\}$/;
-
-/** Coerce a literal numeric-or-string field to a number, preserving unresolved ${VAR} tokens. */
-function numLike(value: unknown): number | string | undefined {
-  if (typeof value === 'number') return value;
-  if (typeof value === 'string') {
-    if (VARIABLE_PATTERN.test(value)) return value;
-    const trimmed = value.trim();
-    if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
-  }
-  return undefined;
-}
-
-function dropUndefined<T extends Record<string, unknown>>(value: T): T {
-  for (const key of Object.keys(value)) {
-    if (value[key] === undefined) delete value[key];
-  }
-  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -369,7 +312,8 @@ function canonicalizeAgentCommand(
         delay: repeatIsNumber
           ? (numLike(command.delay) ?? AGENT_REPEAT_DELAY_MS)
           : numLike(command.delay),
-        target: agentTarget(command.target, numLike(command.index), command.childOf),
+        label: command.label,
+        target: canonicalizeAgentTarget(command.target, numLike(command.index), command.childOf),
       });
     }
     case 'doubleTapOn':
@@ -378,23 +322,31 @@ function canonicalizeAgentCommand(
         longPress: false,
         repeat: 2,
         delay: numLike(command.delay) ?? AGENT_REPEAT_DELAY_MS,
-        target: agentTarget(command.target),
+        label: command.label,
+        target: canonicalizeAgentTarget(command.target),
       });
     case 'longPressOn':
-      return canonicalTap({ longPress: true, repeat: 1, target: agentTarget(command.target) });
+      return canonicalTap({
+        longPress: true,
+        repeat: 1,
+        label: command.label,
+        target: canonicalizeAgentTarget(command.target),
+      });
     case 'assertVisible':
       return dropUndefined({
         kind: 'assert',
         mode: 'visible',
         timed: false,
-        selector: agentSelector(command.target, command.childOf),
+        label: command.label,
+        selector: canonicalizeAgentSelector(command.target, command.childOf),
       });
     case 'assertNotVisible':
       return dropUndefined({
         kind: 'assert',
         mode: 'notVisible',
         timed: false,
-        selector: agentSelector(command.target, command.childOf),
+        label: command.label,
+        selector: canonicalizeAgentSelector(command.target, command.childOf),
       });
     case 'extendedWaitUntil':
       return dropUndefined({
@@ -402,12 +354,13 @@ function canonicalizeAgentCommand(
         mode: command.notVisible ? 'notVisible' : 'visible',
         timed: command.timeout != null,
         timeout: numLike(command.timeout),
-        selector: agentSelector(command.notVisible ?? command.visible),
+        label: command.label,
+        selector: canonicalizeAgentSelector(command.notVisible ?? command.visible),
       });
     case 'swipe':
-      return { kind: 'swipe', gesture: agentGesture(command.gesture) };
+      return { kind: 'swipe', label: command.label, gesture: agentGesture(command.gesture) };
     case 'inputText':
-      return dropUndefined({ kind: 'inputText', text: command.text });
+      return dropUndefined({ kind: 'inputText', label: command.label, text: command.text });
     case 'eraseText':
       return dropUndefined({ kind: 'eraseText', count: numLike(command.charactersToErase) });
     case 'openLink':
@@ -418,7 +371,8 @@ function canonicalizeAgentCommand(
       return dropUndefined({
         kind: 'scrollUntilVisible',
         direction: command.direction,
-        selector: agentSelector(command.element),
+        label: command.label,
+        selector: canonicalizeAgentSelector(command.element),
         timeout: numLike(command.timeout),
       });
     case 'pressKey':
@@ -441,7 +395,11 @@ function canonicalizeAgentCommand(
         maxRetries: numLike(command.maxRetries) ?? str(command.maxRetries),
       });
     case 'runFlow':
-      return { kind: 'runFlow', source: command.include.kind === 'file' ? 'file' : 'commands' };
+      return dropUndefined({
+        kind: 'runFlow',
+        label: command.label,
+        source: command.include.kind === 'file' ? 'file' : 'commands',
+      });
     case 'runScript':
       return { kind: 'runScript' };
     default: {
@@ -449,39 +407,6 @@ function canonicalizeAgentCommand(
       throw new Error(`Unhandled agent command: ${JSON.stringify(exhaustive)}`);
     }
   }
-}
-
-function agentTarget(
-  target: MaestroGestureTarget,
-  index?: number | string,
-  childOf?: MaestroSelector,
-): CanonicalTarget {
-  if (target.space === 'target') {
-    return {
-      selector: dropUndefined({
-        ...agentSelector(target.selector),
-        index,
-        childOf: childOf ? agentSelector(childOf) : undefined,
-      }),
-    };
-  }
-  return {
-    point: { x: target.x, y: target.y, unit: target.space === 'percent' ? 'percent' : 'px' },
-  };
-}
-
-function agentSelector(
-  selector: MaestroSelector | undefined,
-  childOf?: MaestroSelector,
-): CanonicalSelector | undefined {
-  if (!selector) return undefined;
-  return dropUndefined({
-    text: selector.text,
-    id: selector.id,
-    enabled: selector.enabled,
-    selected: selector.selected,
-    childOf: childOf ? agentSelector(childOf) : undefined,
-  });
 }
 
 function agentGesture(gesture: MaestroSwipeGesture): CanonicalGesture {
@@ -492,28 +417,16 @@ function agentGesture(gesture: MaestroSwipeGesture): CanonicalGesture {
     case 'coordinates':
       return dropUndefined({
         mode: 'coordinates',
-        start: agentPoint(gesture.start),
-        end: agentPoint(gesture.end),
+        start: canonicalizeAgentPoint(gesture.start),
+        end: canonicalizeAgentPoint(gesture.end),
         duration,
       });
     case 'target':
       return dropUndefined({
         mode: 'element',
-        from: agentSelector(gesture.from) ?? {},
+        from: canonicalizeAgentSelector(gesture.from) ?? {},
         direction: gesture.direction,
         duration,
       });
   }
-}
-
-function agentPoint(coordinate: {
-  space: 'absolute' | 'percent';
-  x: number;
-  y: number;
-}): CanonicalPoint {
-  return {
-    x: coordinate.x,
-    y: coordinate.y,
-    unit: coordinate.space === 'percent' ? 'percent' : 'px',
-  };
 }

--- a/packages/maestro/src/internal/conformance-selector-projection.ts
+++ b/packages/maestro/src/internal/conformance-selector-projection.ts
@@ -1,0 +1,93 @@
+import type { MaestroGestureTarget, MaestroSelector } from './program-ir.ts';
+import { asRecord, bool, dropUndefined, numLike, str } from './conformance-value-coercion.ts';
+
+export type CanonicalSelector = {
+  text?: string;
+  id?: string;
+  index?: number | string;
+  enabled?: boolean;
+  selected?: boolean;
+  childOf?: CanonicalSelector;
+};
+
+export type CanonicalTarget = {
+  selector?: CanonicalSelector;
+  point?: CanonicalPoint;
+};
+
+export type CanonicalPoint = { x: number; y: number; unit: 'px' | 'percent'; expr?: string };
+
+/** Project an upstream point string without letting an unhandled shape disappear. */
+export function canonicalizeUpstreamPoint(value: unknown): CanonicalPoint | undefined {
+  const text = str(value);
+  if (!text) return undefined;
+  const match = /^\s*(-?\d+)(%?)\s*,\s*(-?\d+)(%?)\s*$/.exec(text);
+  if (!match) {
+    throw new Error(
+      `Cannot canonicalize upstream point ${JSON.stringify(text)}; extend the conformance projection.`,
+    );
+  }
+  const unit = match[2] === '%' || match[4] === '%' ? 'percent' : 'px';
+  return { x: Number(match[1]), y: Number(match[3]), unit };
+}
+
+export function canonicalizeAgentPoint(coordinate: {
+  space: 'absolute' | 'percent';
+  x: number;
+  y: number;
+}): CanonicalPoint {
+  return {
+    x: coordinate.x,
+    y: coordinate.y,
+    unit: coordinate.space === 'percent' ? 'percent' : 'px',
+  };
+}
+
+/** Project an upstream selector model without importing its command model. */
+export function canonicalizeUpstreamSelector(value: unknown): CanonicalSelector | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  return dropUndefined({
+    text: str(record.textRegex),
+    id: str(record.idRegex),
+    index: numLike(record.index) ?? str(record.index),
+    enabled: bool(record.enabled),
+    selected: bool(record.selected),
+    childOf: canonicalizeUpstreamSelector(record.childOf),
+  });
+}
+
+/** Project an agent-device gesture target while keeping selector identity separate from metadata. */
+export function canonicalizeAgentTarget(
+  target: MaestroGestureTarget,
+  index?: number | string,
+  childOf?: MaestroSelector,
+): CanonicalTarget {
+  if (target.space === 'target') {
+    return {
+      selector: dropUndefined({
+        ...canonicalizeAgentSelector(target.selector),
+        index,
+        childOf: childOf ? canonicalizeAgentSelector(childOf) : undefined,
+      }),
+    };
+  }
+  return {
+    point: { x: target.x, y: target.y, unit: target.space === 'percent' ? 'percent' : 'px' },
+  };
+}
+
+/** Project an agent-device selector and its optional child relation. */
+export function canonicalizeAgentSelector(
+  selector: MaestroSelector | undefined,
+  childOf?: MaestroSelector,
+): CanonicalSelector | undefined {
+  if (!selector) return undefined;
+  return dropUndefined({
+    text: selector.text,
+    id: selector.id,
+    enabled: selector.enabled,
+    selected: selector.selected,
+    childOf: childOf ? canonicalizeAgentSelector(childOf) : undefined,
+  });
+}

--- a/packages/maestro/src/internal/conformance-value-coercion.ts
+++ b/packages/maestro/src/internal/conformance-value-coercion.ts
@@ -1,0 +1,33 @@
+const VARIABLE_PATTERN = /^\$\{[A-Za-z_][A-Za-z0-9_.]*\}$/;
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function str(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function bool(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+/** Coerce a literal numeric-or-string field to a number, preserving unresolved ${VAR} tokens. */
+export function numLike(value: unknown): number | string | undefined {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    if (VARIABLE_PATTERN.test(value)) return value;
+    const trimmed = value.trim();
+    if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  }
+  return undefined;
+}
+
+export function dropUndefined<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) delete value[key];
+  }
+  return value;
+}

--- a/packages/maestro/src/internal/export-flow.ts
+++ b/packages/maestro/src/internal/export-flow.ts
@@ -1,6 +1,7 @@
 import type { SessionAction } from '@agent-device/contracts/session';
 import { GESTURE_FLING_DURATION_MS } from '@agent-device/contracts/interaction';
 import { AppError } from '@agent-device/kernel/errors';
+import { selectorContainsKey } from '@agent-device/selectors';
 import { formatMaestroPoint } from './export-points.ts';
 import { DEFAULT_MAESTRO_COMPATIBILITY_TIMING_POLICY } from './compatibility-policy.ts';
 import type { MaestroExportCommand, MaestroExportConfig } from './export-types.ts';
@@ -48,6 +49,8 @@ type SwipeGeometry = {
 
 const LONG_PRESS_DURATION_WARNING =
   'long-press duration exports as Maestro longPressOn; Maestro uses its default long-press duration';
+const LABEL_SELECTOR_EXPORT_WARNING =
+  'label= selectors export as Maestro text; Maestro text matching is broader than agent-device label-only matching';
 
 export function exportReplayActionsToMaestro(
   actions: SessionAction[],
@@ -181,7 +184,10 @@ function convertClickAction(
     return {
       kind: 'commands',
       commands: [{ doubleTapOn: tapTarget }],
-      warnings: readIgnoredRepeatedTapOptionWarnings(action, 'doubleTapOn'),
+      warnings: [
+        ...readLabelSelectorWarnings(first),
+        ...readIgnoredRepeatedTapOptionWarnings(action, 'doubleTapOn'),
+      ],
     };
   }
   if (typeof action.flags?.holdMs === 'number') {
@@ -189,13 +195,18 @@ function convertClickAction(
       kind: 'commands',
       commands: [{ longPressOn: tapTarget }],
       warnings: [
+        ...readLabelSelectorWarnings(first),
         formatLongPressDurationWarning(action.flags.holdMs),
         ...readIgnoredRepeatedTapOptionWarnings(action, 'longPressOn'),
       ],
     };
   }
 
-  return { kind: 'commands', commands: [withTapOptions(tapTarget, tapOptions.options)] };
+  return {
+    kind: 'commands',
+    commands: [withTapOptions(tapTarget, tapOptions.options)],
+    warnings: readLabelSelectorWarnings(first),
+  };
 }
 
 function convertLongPressAction(
@@ -210,7 +221,10 @@ function convertLongPressAction(
   return {
     kind: 'commands',
     commands: [{ longPressOn: target }],
-    warnings: readLongPressDuration(action).map(formatLongPressDurationWarning),
+    warnings: [
+      ...readLabelSelectorWarnings(first),
+      ...readLongPressDuration(action).map(formatLongPressDurationWarning),
+    ],
   };
 }
 
@@ -256,6 +270,7 @@ function convertFillAction(
     kind: 'commands',
     commands: [{ tapOn: tapTarget }, { inputText: text }],
     warnings: [
+      ...readLabelSelectorWarnings(target),
       'fill exports as tapOn + inputText; Maestro may append text instead of replacing existing field contents',
     ],
   };
@@ -324,7 +339,12 @@ function convertWaitAction(
         },
       },
     ],
+    warnings: readLabelSelectorWarnings(first),
   };
+}
+
+function readLabelSelectorWarnings(expression: string): string[] {
+  return selectorContainsKey(expression, 'label') ? [LABEL_SELECTOR_EXPORT_WARNING] : [];
 }
 
 function convertFindAction(action: SessionAction): ConvertedAction {

--- a/packages/maestro/src/internal/facade-execution.ts
+++ b/packages/maestro/src/internal/facade-execution.ts
@@ -308,5 +308,5 @@ function suggestionBasis(
   ) {
     return 'id';
   }
-  return selector.text !== undefined || selector.label !== undefined ? 'label' : 'other';
+  return selector.text !== undefined ? 'label' : 'other';
 }

--- a/packages/maestro/src/internal/program-ir-command-options.ts
+++ b/packages/maestro/src/internal/program-ir-command-options.ts
@@ -1,0 +1,17 @@
+import {
+  readOptionalEntry,
+  readOptionalString,
+  type MaestroMapEntry,
+  type MaestroProgramParseContext,
+} from './program-ir-values.ts';
+
+/** Read Maestro's outer command description without giving it selector meaning. */
+export function readMaestroCommandLabel(
+  entries: readonly MaestroMapEntry[],
+  commandName: string,
+  context: MaestroProgramParseContext,
+): string | undefined {
+  return readOptionalEntry(entries, 'label', (entry) =>
+    readOptionalString(entry, `${commandName}.label`, context),
+  );
+}

--- a/packages/maestro/src/internal/program-ir-command-parser.ts
+++ b/packages/maestro/src/internal/program-ir-command-parser.ts
@@ -1,8 +1,6 @@
 import { isMap, isScalar, isSeq, type Node } from 'yaml';
 import { stripUndefined } from './shared.ts';
 import type {
-  MaestroAssertNotVisibleCommand,
-  MaestroAssertVisibleCommand,
   MaestroBackCommand,
   MaestroCommand,
   MaestroEraseTextCommand,
@@ -15,7 +13,6 @@ import type {
   MaestroPressKeyCommand,
   MaestroScrollCommand,
   MaestroScrollUntilVisibleCommand,
-  MaestroSelector,
   MaestroStopAppCommand,
   MaestroTakeScreenshotCommand,
   MaestroWaitForAnimationToEndCommand,
@@ -24,12 +21,16 @@ import {
   parseMaestroDirection,
   parseMaestroDoubleTapOnCommand,
   parseMaestroLongPressOnCommand,
-  parseMaestroSelector,
-  parseMaestroSelectorMapEntries,
   parseMaestroSwipeCommand,
   parseMaestroTapOnCommand,
 } from './program-ir-gesture-parser.ts';
-import { MAESTRO_BASE_SELECTOR_KEYS } from './selector-vocabulary.ts';
+import { parseMaestroSelector } from './program-ir-selector-parser.ts';
+import {
+  parseMaestroAssertion,
+  parseMaestroExtendedWaitUntilCondition,
+  parseMaestroOptionalSelector,
+} from './program-ir-selector-options.ts';
+import { readMaestroCommandLabel } from './program-ir-command-options.ts';
 import {
   parseMaestroRepeatCommand,
   parseMaestroRetryCommand,
@@ -54,7 +55,6 @@ import {
   readScalarValue,
   readSequenceItems,
   sourceAt,
-  type MaestroMapEntry,
   type MaestroProgramParseContext,
 } from './program-ir-values.ts';
 
@@ -105,9 +105,10 @@ const COMMAND_VALUE_PARSERS: Readonly<Record<string, CommandValueParser>> = {
   inputText: parseInputText,
   eraseText: parseEraseText,
   openLink: parseOpenLink,
-  assertVisible: (value, node, context) => parseAssertion('assertVisible', value, node, context),
+  assertVisible: (value, node, context) =>
+    parseMaestroAssertion('assertVisible', value, node, context),
   assertNotVisible: (value, node, context) =>
-    parseAssertion('assertNotVisible', value, node, context),
+    parseMaestroAssertion('assertNotVisible', value, node, context),
   extendedWaitUntil: parseExtendedWaitUntil,
   takeScreenshot: parseTakeScreenshot,
   scroll: parseScroll,
@@ -255,89 +256,6 @@ function parseOpenLink(
   };
 }
 
-function parseAssertion(
-  kind: 'assertVisible' | 'assertNotVisible',
-  value: Node | null,
-  commandNode: Node,
-  context: MaestroProgramParseContext,
-): MaestroAssertVisibleCommand | MaestroAssertNotVisibleCommand {
-  const source = sourceAt(commandNode, context);
-  if (isScalar(value)) {
-    return { kind, source, target: parseMaestroSelector(value, kind, context) };
-  }
-  const entries = readMapEntries(value, kind, context);
-  assertOnlyKeys(
-    entries,
-    kind,
-    ['id', 'text', 'enabled', 'selected', 'optional', 'childOf'],
-    context,
-  );
-  const options = readOptionalCommandOption(entries, kind, context);
-  const childOf = hasEntry(entries, 'childOf')
-    ? parseMaestroSelector(entryValue(entries, 'childOf'), `${kind}.childOf`, context)
-    : undefined;
-  return stripUndefined({
-    kind,
-    source,
-    target: parseMaestroSelectorMapEntries(
-      entries.filter((entry) => entry.key !== 'optional' && entry.key !== 'childOf'),
-      kind,
-      context,
-    ),
-    ...options,
-    childOf,
-  });
-}
-
-const OPTIONAL_SELECTOR_KEYS = [...MAESTRO_BASE_SELECTOR_KEYS, 'optional'] as const;
-
-type ParsedOptionalSelector = {
-  selector: MaestroSelector;
-  optional: boolean | undefined;
-};
-
-function parseOptionalSelector(
-  entries: readonly MaestroMapEntry[],
-  key: string,
-  name: string,
-  context: MaestroProgramParseContext,
-): ParsedOptionalSelector | undefined {
-  if (!hasEntry(entries, key)) return undefined;
-  const parsed = parseMaestroSelector(
-    entryValue(entries, key),
-    name,
-    context,
-    OPTIONAL_SELECTOR_KEYS,
-  );
-  const { optional: selectorOptional, ...selector } = parsed;
-  return { selector, optional: selectorOptional };
-}
-
-function parseExtendedWaitUntilCondition(
-  entries: readonly MaestroMapEntry[],
-  commandNode: Node,
-  context: MaestroProgramParseContext,
-): { key: 'visible' | 'notVisible'; selector: MaestroSelector; optional?: boolean } {
-  const visible = parseOptionalSelector(entries, 'visible', 'extendedWaitUntil.visible', context);
-  const notVisible = parseOptionalSelector(
-    entries,
-    'notVisible',
-    'extendedWaitUntil.notVisible',
-    context,
-  );
-  if (visible && notVisible)
-    invalidAt(
-      'Maestro extendedWaitUntil cannot specify both visible and notVisible.',
-      commandNode,
-      context,
-    );
-  if (!visible && !notVisible)
-    invalidAt('Maestro extendedWaitUntil requires visible or notVisible.', commandNode, context);
-  return visible
-    ? { key: 'visible', selector: visible.selector, optional: visible.optional }
-    : { key: 'notVisible', selector: notVisible!.selector, optional: notVisible!.optional };
-}
-
 function parseExtendedWaitUntil(
   value: Node | null,
   commandNode: Node,
@@ -347,11 +265,12 @@ function parseExtendedWaitUntil(
   assertOnlyKeys(
     entries,
     'extendedWaitUntil',
-    ['visible', 'notVisible', 'timeout', 'optional'],
+    ['visible', 'notVisible', 'timeout', 'optional', 'label'],
     context,
   );
   const options = readOptionalCommandOption(entries, 'extendedWaitUntil', context);
-  const condition = parseExtendedWaitUntilCondition(entries, commandNode, context);
+  const label = readMaestroCommandLabel(entries, 'extendedWaitUntil', context);
+  const condition = parseMaestroExtendedWaitUntilCondition(entries, commandNode, context);
   const timeout = hasEntry(entries, 'timeout')
     ? readOptionalNumeric(entryValue(entries, 'timeout'), 'extendedWaitUntil.timeout', context)
     : undefined;
@@ -361,6 +280,7 @@ function parseExtendedWaitUntil(
     source: sourceAt(commandNode, context),
     timeout,
     optional,
+    label,
   };
   command[condition.key] = condition.selector;
   return stripUndefined(command);
@@ -404,11 +324,12 @@ function parseScrollUntilVisible(
   assertOnlyKeys(
     entries,
     'scrollUntilVisible',
-    ['element', 'direction', 'timeout', 'optional'],
+    ['element', 'direction', 'timeout', 'optional', 'label'],
     context,
   );
   const options = readOptionalCommandOption(entries, 'scrollUntilVisible', context);
-  const parsedElement = parseOptionalSelector(
+  const label = readMaestroCommandLabel(entries, 'scrollUntilVisible', context);
+  const parsedElement = parseMaestroOptionalSelector(
     entries,
     'element',
     'scrollUntilVisible.element',
@@ -434,6 +355,7 @@ function parseScrollUntilVisible(
     direction,
     timeout,
     optional,
+    label,
   });
 }
 

--- a/packages/maestro/src/internal/program-ir-command-parser.ts
+++ b/packages/maestro/src/internal/program-ir-command-parser.ts
@@ -204,9 +204,7 @@ function parseInputText(
   if (!hasEntry(entries, 'text'))
     invalidAt('Maestro inputText requires text.', commandNode, context);
   const text = readRequiredString(entryValue(entries, 'text'), 'inputText.text', context);
-  const label = hasEntry(entries, 'label')
-    ? readOptionalString(entryValue(entries, 'label'), 'inputText.label', context)
-    : undefined;
+  const label = readMaestroCommandLabel(entries, 'inputText', context);
   return stripUndefined({ kind: 'inputText' as const, source, text, label });
 }
 

--- a/packages/maestro/src/internal/program-ir-flow-parser.ts
+++ b/packages/maestro/src/internal/program-ir-flow-parser.ts
@@ -15,7 +15,6 @@ import {
   invalidAt,
   readMapEntries,
   readRequiredNumeric,
-  readOptionalString,
   readOptionalEntry,
   readRequiredString,
   readScalarMap,
@@ -23,6 +22,7 @@ import {
   sourceAt,
   type MaestroProgramParseContext,
 } from './program-ir-values.ts';
+import { readMaestroCommandLabel } from './program-ir-command-options.ts';
 import { parseMaestroSelector } from './program-ir-selector-parser.ts';
 import { stripUndefined } from './shared.ts';
 
@@ -101,9 +101,7 @@ export function parseMaestroRunFlowCommand(
   const when = hasEntry(entries, 'when')
     ? parseMaestroRunFlowCondition(entryValue(entries, 'when'), context)
     : undefined;
-  const label = hasEntry(entries, 'label')
-    ? readOptionalString(entryValue(entries, 'label'), 'runFlow.label', context)
-    : undefined;
+  const label = readMaestroCommandLabel(entries, 'runFlow', context);
   return stripUndefined({
     kind: 'runFlow' as const,
     source,

--- a/packages/maestro/src/internal/program-ir-flow-parser.ts
+++ b/packages/maestro/src/internal/program-ir-flow-parser.ts
@@ -23,7 +23,7 @@ import {
   sourceAt,
   type MaestroProgramParseContext,
 } from './program-ir-values.ts';
-import { parseMaestroSelector } from './program-ir-gesture-parser.ts';
+import { parseMaestroSelector } from './program-ir-selector-parser.ts';
 import { stripUndefined } from './shared.ts';
 
 export type MaestroCommandListParser = (

--- a/packages/maestro/src/internal/program-ir-gesture-parser.ts
+++ b/packages/maestro/src/internal/program-ir-gesture-parser.ts
@@ -18,7 +18,6 @@ import {
   readOptionalBoolean,
   readOptionalEntry,
   readOptionalNumeric,
-  readOptionalString,
   readRequiredNumeric,
   readRequiredString,
   sourceAt,
@@ -146,9 +145,7 @@ export function parseMaestroSwipeCommand(
     context,
   );
   const options = readOptionalCommandOption(entries, 'swipe', context);
-  const label = readOptionalEntry(entries, 'label', (entry) =>
-    readOptionalString(entry, 'swipe.label', context),
-  );
+  const label = readMaestroCommandLabel(entries, 'swipe', context);
   const duration = hasEntry(entries, 'duration')
     ? readOptionalNumeric(entryValue(entries, 'duration'), 'swipe.duration', context)
     : undefined;
@@ -269,9 +266,7 @@ function tapOptions(
     readOptionalNumeric(entry, 'tapOn.delay', context),
   );
   const optional = readOptionalCommandOption(entries, 'tapOn', context).optional;
-  const label = readOptionalEntry(entries, 'label', (entry) =>
-    readOptionalString(entry, 'tapOn.label', context),
-  );
+  const label = readMaestroCommandLabel(entries, 'tapOn', context);
   return stripUndefined({ retryTapIfNoChange, repeat, delay, optional, label });
 }
 

--- a/packages/maestro/src/internal/program-ir-gesture-parser.ts
+++ b/packages/maestro/src/internal/program-ir-gesture-parser.ts
@@ -1,13 +1,9 @@
-import { isScalar, type Node } from 'yaml';
+import { type Node } from 'yaml';
 import { stripUndefined } from './shared.ts';
 import type {
-  MaestroCoordinate,
   MaestroDirection,
   MaestroDoubleTapOnCommand,
-  MaestroGestureTarget,
   MaestroLongPressOnCommand,
-  MaestroSelector,
-  MaestroSelectorMap,
   MaestroSourceLocation,
   MaestroSwipeCommand,
   MaestroTapOnCommand,
@@ -29,80 +25,14 @@ import {
   type MaestroMapEntry,
   type MaestroProgramParseContext,
 } from './program-ir-values.ts';
+import { readMaestroCommandLabel } from './program-ir-command-options.ts';
 import {
-  MAESTRO_BASE_SELECTOR_KEYS,
-  MAESTRO_TAP_SELECTOR_KEYS,
-  type MaestroSelectorKey,
-} from './selector-vocabulary.ts';
-
-type SelectorFieldReader = (
-  selector: MaestroSelectorMap,
-  entry: MaestroMapEntry,
-  name: string,
-  context: MaestroProgramParseContext,
-) => void;
-
-type ParsedPointOrSelectorTarget = {
-  readonly source: MaestroSourceLocation;
-  readonly entries: readonly MaestroMapEntry[];
-  readonly target: MaestroGestureTarget;
-};
-
-const SELECTOR_FIELD_READERS: Readonly<Record<string, SelectorFieldReader>> = {
-  id: (selector, entry, name, context) =>
-    assignStringSelector(selector, 'id', entry, name, context),
-  text: (selector, entry, name, context) =>
-    assignStringSelector(selector, 'text', entry, name, context),
-  label: (selector, entry, name, context) =>
-    assignStringSelector(selector, 'label', entry, name, context),
-  enabled: (selector, entry, name, context) =>
-    assignBooleanSelector(selector, 'enabled', entry, name, context),
-  selected: (selector, entry, name, context) =>
-    assignBooleanSelector(selector, 'selected', entry, name, context),
-  optional: (selector, entry, name, context) =>
-    assignBooleanSelector(selector, 'optional', entry, name, context),
-};
-
-export function parseMaestroSelector(
-  node: Node | null | undefined,
-  name: string,
-  context: MaestroProgramParseContext,
-  selectorKeys: readonly MaestroSelectorKey[] = MAESTRO_BASE_SELECTOR_KEYS,
-): MaestroSelector {
-  if (isScalar(node)) return { text: readRequiredString(node, name, context) };
-  const entries = readMapEntries(node, name, context);
-  assertOnlyKeys(entries, name, selectorKeys, context);
-  return parseMaestroSelectorMapEntries(entries, name, context);
-}
-
-export function parseMaestroSelectorMapEntries(
-  entries: readonly MaestroMapEntry[],
-  name: string,
-  context: MaestroProgramParseContext,
-): MaestroSelector {
-  if (entries.length === 0) invalidAt(`Maestro ${name} selector is empty.`, undefined, context);
-  const selector: MaestroSelectorMap = {};
-  for (const entry of entries) {
-    const read = SELECTOR_FIELD_READERS[entry.key];
-    if (!read) {
-      invalidAt(
-        `Maestro ${name} selector field "${entry.key}" is not supported.`,
-        entry.keyNode,
-        context,
-      );
-    }
-    read(selector, entry, name, context);
-  }
-  const matchingKeys = Object.keys(selector).filter((key) => key !== 'optional');
-  if (matchingKeys.length === 0) {
-    invalidAt(
-      `Maestro ${name} selector must contain a selector value.`,
-      entries[0]?.keyNode,
-      context,
-    );
-  }
-  return selector;
-}
+  parseMaestroAbsolutePoint,
+  parseMaestroPoint,
+  parseMaestroSelector,
+  parsePointOrSelectorTarget,
+} from './program-ir-selector-parser.ts';
+import { MAESTRO_BASE_SELECTOR_KEYS } from './selector-vocabulary.ts';
 
 export function parseMaestroTapOnCommand(
   value: Node | null,
@@ -111,19 +41,20 @@ export function parseMaestroTapOnCommand(
 ): MaestroTapOnCommand {
   const parsed = parsePointOrSelectorTarget(value, commandNode, context, {
     name: 'tapOn',
-    selectorKeys: MAESTRO_TAP_SELECTOR_KEYS,
+    selectorKeys: MAESTRO_BASE_SELECTOR_KEYS,
     pointConflictingSelectorKeys: MAESTRO_BASE_SELECTOR_KEYS,
     pointAllowedKeys: ['point', 'retryTapIfNoChange', 'repeat', 'delay', 'optional', 'label'],
     selectorAllowedKeys: [
-      ...MAESTRO_TAP_SELECTOR_KEYS,
+      ...MAESTRO_BASE_SELECTOR_KEYS,
       'retryTapIfNoChange',
       'repeat',
       'delay',
       'optional',
+      'label',
       'index',
       'childOf',
     ],
-    parsePoint,
+    parsePoint: parseMaestroPoint,
   });
   if (parsed.entries.length === 0) {
     return { kind: 'tapOn', source: parsed.source, target: parsed.target };
@@ -133,13 +64,13 @@ export function parseMaestroTapOnCommand(
       kind: 'tapOn',
       source: parsed.source,
       target: parsed.target,
-      ...tapOptions(parsed.entries, context, true),
+      ...tapOptions(parsed.entries, context),
     };
   }
   const childOf = hasEntry(parsed.entries, 'childOf')
     ? parseMaestroSelector(entryValue(parsed.entries, 'childOf'), 'tapOn.childOf', context)
     : undefined;
-  const options = tapOptions(parsed.entries, context, false);
+  const options = tapOptions(parsed.entries, context);
   const index = hasEntry(parsed.entries, 'index')
     ? readOptionalNumeric(entryValue(parsed.entries, 'index'), 'tapOn.index', context)
     : undefined;
@@ -161,20 +92,22 @@ export function parseMaestroDoubleTapOnCommand(
   const parsed = parsePointOrSelectorTarget(value, commandNode, context, {
     name: 'doubleTapOn',
     selectorKeys: MAESTRO_BASE_SELECTOR_KEYS,
-    pointAllowedKeys: ['point', 'delay', 'optional'],
-    selectorAllowedKeys: [...MAESTRO_BASE_SELECTOR_KEYS, 'delay', 'optional'],
-    parsePoint: parseAbsolutePoint,
+    pointAllowedKeys: ['point', 'delay', 'optional', 'label'],
+    selectorAllowedKeys: [...MAESTRO_BASE_SELECTOR_KEYS, 'delay', 'optional', 'label'],
+    parsePoint: parseMaestroAbsolutePoint,
   });
   const options = readOptionalCommandOption(parsed.entries, 'doubleTapOn', context);
   const delay = hasEntry(parsed.entries, 'delay')
     ? readOptionalNumeric(entryValue(parsed.entries, 'delay'), 'doubleTapOn.delay', context)
     : undefined;
+  const label = readMaestroCommandLabel(parsed.entries, 'doubleTapOn', context);
   return stripUndefined({
     kind: 'doubleTapOn' as const,
     source: parsed.source,
     target: parsed.target,
     ...options,
     delay,
+    label,
   });
 }
 
@@ -186,74 +119,17 @@ export function parseMaestroLongPressOnCommand(
   const parsed = parsePointOrSelectorTarget(value, commandNode, context, {
     name: 'longPressOn',
     selectorKeys: MAESTRO_BASE_SELECTOR_KEYS,
-    pointAllowedKeys: ['point', 'optional'],
-    selectorAllowedKeys: [...MAESTRO_BASE_SELECTOR_KEYS, 'optional'],
-    parsePoint: parseAbsolutePoint,
+    pointAllowedKeys: ['point', 'optional', 'label'],
+    selectorAllowedKeys: [...MAESTRO_BASE_SELECTOR_KEYS, 'optional', 'label'],
+    parsePoint: parseMaestroAbsolutePoint,
   });
-  return {
+  return stripUndefined({
     kind: 'longPressOn',
     source: parsed.source,
     target: parsed.target,
     ...readOptionalCommandOption(parsed.entries, 'longPressOn', context),
-  };
-}
-
-function parsePointOrSelectorTarget(
-  value: Node | null,
-  commandNode: Node,
-  context: MaestroProgramParseContext,
-  options: {
-    readonly name: string;
-    readonly selectorKeys: readonly MaestroSelectorKey[];
-    readonly pointConflictingSelectorKeys?: readonly MaestroSelectorKey[];
-    readonly pointAllowedKeys: readonly string[];
-    readonly selectorAllowedKeys: readonly string[];
-    readonly parsePoint: (
-      node: Node | null | undefined,
-      name: string,
-      context: MaestroProgramParseContext,
-    ) => MaestroCoordinate;
-  },
-): ParsedPointOrSelectorTarget {
-  const source = sourceAt(commandNode, context);
-  if (isScalar(value)) {
-    return {
-      source,
-      entries: [],
-      target: selectorTarget(
-        parseMaestroSelector(value, options.name, context, options.selectorKeys),
-      ),
-    };
-  }
-  const entries = readMapEntries(value, options.name, context);
-  const hasPoint = hasEntry(entries, 'point');
-  assertOnlyKeys(
-    entries,
-    options.name,
-    hasPoint ? options.pointAllowedKeys : options.selectorAllowedKeys,
-    context,
-  );
-  if (hasPoint) {
-    const conflictingKeys = options.pointConflictingSelectorKeys ?? options.selectorKeys;
-    if (entries.some((entry) => isSelectorKey(entry.key, conflictingKeys))) {
-      invalidAt(
-        `Maestro ${options.name}.point cannot be combined with a selector.`,
-        commandNode,
-        context,
-      );
-    }
-    return {
-      source,
-      entries,
-      target: options.parsePoint(entryValue(entries, 'point'), `${options.name}.point`, context),
-    };
-  }
-  const selectorEntries = entries.filter((entry) => isSelectorKey(entry.key, options.selectorKeys));
-  return {
-    source,
-    entries,
-    target: selectorTarget(parseMaestroSelectorMapEntries(selectorEntries, options.name, context)),
-  };
+    label: readMaestroCommandLabel(parsed.entries, 'longPressOn', context),
+  });
 }
 
 export function parseMaestroSwipeCommand(
@@ -270,22 +146,34 @@ export function parseMaestroSwipeCommand(
     context,
   );
   const options = readOptionalCommandOption(entries, 'swipe', context);
+  const label = readOptionalEntry(entries, 'label', (entry) =>
+    readOptionalString(entry, 'swipe.label', context),
+  );
   const duration = hasEntry(entries, 'duration')
     ? readOptionalNumeric(entryValue(entries, 'duration'), 'swipe.duration', context)
     : undefined;
   if (hasEntry(entries, 'start') || hasEntry(entries, 'end')) {
-    return { ...parseCoordinateSwipe(entries, source, duration, commandNode, context), ...options };
+    return {
+      ...parseCoordinateSwipe(entries, source, duration, commandNode, context),
+      ...options,
+      label,
+    };
   }
   const direction = hasEntry(entries, 'direction')
     ? parseMaestroDirection(entryValue(entries, 'direction'), 'swipe.direction', context)
     : undefined;
-  if (hasEntry(entries, 'from') || hasEntry(entries, 'label')) {
+  if (hasEntry(entries, 'from')) {
     return {
       ...parseTargetSwipe(entries, source, direction, duration, commandNode, context),
       ...options,
+      label,
     };
   }
-  return { ...parseScreenSwipe(source, direction, duration, commandNode, context), ...options };
+  return {
+    ...parseScreenSwipe(source, direction, duration, commandNode, context),
+    ...options,
+    label,
+  };
 }
 
 function parseCoordinateSwipe(
@@ -305,8 +193,8 @@ function parseCoordinateSwipe(
   if (!hasEntry(entries, 'start') || !hasEntry(entries, 'end')) {
     invalidAt('Maestro swipe requires both start and end coordinates.', commandNode, context);
   }
-  const start = parsePoint(entryValue(entries, 'start'), 'swipe.start', context);
-  const end = parsePoint(entryValue(entries, 'end'), 'swipe.end', context);
+  const start = parseMaestroPoint(entryValue(entries, 'start'), 'swipe.start', context);
+  const end = parseMaestroPoint(entryValue(entries, 'end'), 'swipe.end', context);
   if (start.space !== end.space) {
     invalidAt('Maestro swipe start/end must use the same coordinate space.', commandNode, context);
   }
@@ -333,12 +221,7 @@ function parseTargetSwipe(
   if (direction === undefined) {
     invalidAt('Maestro target swipe requires direction.', commandNode, context);
   }
-  const label = hasEntry(entries, 'label')
-    ? readOptionalString(entryValue(entries, 'label'), 'swipe.label', context)
-    : undefined;
-  const from = hasEntry(entries, 'from')
-    ? parseMaestroSelector(entryValue(entries, 'from'), 'swipe.from', context)
-    : { text: label ?? '' };
+  const from = parseMaestroSelector(entryValue(entries, 'from'), 'swipe.from', context);
   return {
     kind: 'swipe',
     source,
@@ -347,7 +230,6 @@ function parseTargetSwipe(
       from,
       direction,
       duration,
-      label,
     }),
   };
 }
@@ -376,7 +258,6 @@ function parseScreenSwipe(
 function tapOptions(
   entries: readonly MaestroMapEntry[],
   context: MaestroProgramParseContext,
-  includeLabel: boolean,
 ): Pick<MaestroTapOnCommand, 'retryTapIfNoChange' | 'repeat' | 'delay' | 'optional' | 'label'> {
   const retryTapIfNoChange = readOptionalEntry(entries, 'retryTapIfNoChange', (entry) =>
     readOptionalBoolean(entry, 'tapOn.retryTapIfNoChange', context),
@@ -388,79 +269,10 @@ function tapOptions(
     readOptionalNumeric(entry, 'tapOn.delay', context),
   );
   const optional = readOptionalCommandOption(entries, 'tapOn', context).optional;
-  const label = includeLabel
-    ? readOptionalEntry(entries, 'label', (entry) =>
-        readOptionalString(entry, 'tapOn.label', context),
-      )
-    : undefined;
+  const label = readOptionalEntry(entries, 'label', (entry) =>
+    readOptionalString(entry, 'tapOn.label', context),
+  );
   return stripUndefined({ retryTapIfNoChange, repeat, delay, optional, label });
-}
-
-function assignStringSelector(
-  selector: MaestroSelectorMap,
-  key: 'id' | 'text' | 'label',
-  entry: MaestroMapEntry,
-  name: string,
-  context: MaestroProgramParseContext,
-): void {
-  const value = readOptionalString(entry.value, `${name}.${key}`, context);
-  if (value !== undefined) selector[key] = value;
-}
-
-function assignBooleanSelector(
-  selector: MaestroSelectorMap,
-  key: 'enabled' | 'selected' | 'optional',
-  entry: MaestroMapEntry,
-  name: string,
-  context: MaestroProgramParseContext,
-): void {
-  const value = readOptionalBoolean(entry.value, `${name}.${key}`, context);
-  if (value !== undefined) selector[key] = value;
-}
-
-function isSelectorKey(
-  key: string,
-  selectorKeys: readonly MaestroSelectorKey[],
-): key is MaestroSelectorKey {
-  return selectorKeys.includes(key as MaestroSelectorKey);
-}
-
-function parsePoint(
-  node: Node | null | undefined,
-  name: string,
-  context: MaestroProgramParseContext,
-): MaestroCoordinate {
-  const value = readRequiredString(node, name, context);
-  const absolute = /^\s*(\d+)\s*,\s*(\d+)\s*$/.exec(value);
-  if (absolute) return { space: 'absolute', x: Number(absolute[1]), y: Number(absolute[2]) };
-  const percent = /^\s*(\d+)%\s*,\s*(\d+)%\s*$/.exec(value);
-  if (percent) {
-    const x = Number(percent[1]);
-    const y = Number(percent[2]);
-    if (x > 100 || y > 100) {
-      invalidAt(
-        `Maestro ${name} percentage coordinates must be between 0% and 100%.`,
-        node,
-        context,
-      );
-    }
-    return { space: 'percent', x, y };
-  }
-  if (/^\s*\d+(?:\.\d+)?%\s*,\s*\d+(?:\.\d+)?%\s*$/.test(value)) {
-    invalidAt(`Maestro ${name} percentage coordinates must be whole numbers.`, node, context);
-  }
-  invalidAt(`Maestro ${name} expects absolute or percentage coordinates.`, node, context);
-}
-
-function parseAbsolutePoint(
-  node: Node | null | undefined,
-  name: string,
-  context: MaestroProgramParseContext,
-): MaestroCoordinate {
-  const point = parsePoint(node, name, context);
-  if (point.space !== 'absolute')
-    invalidAt(`Maestro ${name} only supports absolute coordinates.`, node, context);
-  return point;
 }
 
 export function parseMaestroDirection(
@@ -471,8 +283,4 @@ export function parseMaestroDirection(
   const value = readRequiredString(node, name, context).toLowerCase();
   if (value === 'up' || value === 'down' || value === 'left' || value === 'right') return value;
   invalidAt(`Maestro ${name} must be UP, DOWN, LEFT, or RIGHT.`, node, context);
-}
-
-function selectorTarget(selector: MaestroSelector): MaestroGestureTarget {
-  return { space: 'target', selector };
 }

--- a/packages/maestro/src/internal/program-ir-selector-options.ts
+++ b/packages/maestro/src/internal/program-ir-selector-options.ts
@@ -1,0 +1,115 @@
+import { isScalar, type Node } from 'yaml';
+import type {
+  MaestroAssertNotVisibleCommand,
+  MaestroAssertVisibleCommand,
+  MaestroSelector,
+} from './program-ir.ts';
+import {
+  assertOnlyKeys,
+  entryValue,
+  hasEntry,
+  invalidAt,
+  readMapEntries,
+  readOptionalCommandOption,
+  sourceAt,
+  type MaestroMapEntry,
+  type MaestroProgramParseContext,
+} from './program-ir-values.ts';
+import {
+  parseMaestroSelector,
+  parseMaestroSelectorMapEntries,
+} from './program-ir-selector-parser.ts';
+import { readMaestroCommandLabel } from './program-ir-command-options.ts';
+import { stripUndefined } from './shared.ts';
+
+export function parseMaestroAssertion(
+  kind: 'assertVisible' | 'assertNotVisible',
+  value: Node | null,
+  commandNode: Node,
+  context: MaestroProgramParseContext,
+): MaestroAssertVisibleCommand | MaestroAssertNotVisibleCommand {
+  const source = sourceAt(commandNode, context);
+  if (isScalar(value)) {
+    return { kind, source, target: parseMaestroSelector(value, kind, context) };
+  }
+  const entries = readMapEntries(value, kind, context);
+  assertOnlyKeys(
+    entries,
+    kind,
+    ['id', 'text', 'enabled', 'selected', 'optional', 'childOf', 'label'],
+    context,
+  );
+  const options = readOptionalCommandOption(entries, kind, context);
+  const childOf = hasEntry(entries, 'childOf')
+    ? parseMaestroSelector(entryValue(entries, 'childOf'), `${kind}.childOf`, context)
+    : undefined;
+  const label = readMaestroCommandLabel(entries, kind, context);
+  return stripUndefined({
+    kind,
+    source,
+    target: parseMaestroSelectorMapEntries(
+      entries.filter(
+        (entry) => entry.key !== 'optional' && entry.key !== 'childOf' && entry.key !== 'label',
+      ),
+      kind,
+      context,
+    ),
+    ...options,
+    childOf,
+    label,
+  });
+}
+
+const OPTIONAL_SELECTOR_KEYS = ['id', 'text', 'enabled', 'selected', 'optional'] as const;
+
+type ParsedOptionalSelector = {
+  selector: MaestroSelector;
+  optional: boolean | undefined;
+};
+
+export function parseMaestroOptionalSelector(
+  entries: readonly MaestroMapEntry[],
+  key: string,
+  name: string,
+  context: MaestroProgramParseContext,
+): ParsedOptionalSelector | undefined {
+  if (!hasEntry(entries, key)) return undefined;
+  const parsed = parseMaestroSelector(
+    entryValue(entries, key),
+    name,
+    context,
+    OPTIONAL_SELECTOR_KEYS,
+  );
+  const { optional: selectorOptional, ...selector } = parsed;
+  return { selector, optional: selectorOptional };
+}
+
+export function parseMaestroExtendedWaitUntilCondition(
+  entries: readonly MaestroMapEntry[],
+  commandNode: Node,
+  context: MaestroProgramParseContext,
+): { key: 'visible' | 'notVisible'; selector: MaestroSelector; optional?: boolean } {
+  const visible = parseMaestroOptionalSelector(
+    entries,
+    'visible',
+    'extendedWaitUntil.visible',
+    context,
+  );
+  const notVisible = parseMaestroOptionalSelector(
+    entries,
+    'notVisible',
+    'extendedWaitUntil.notVisible',
+    context,
+  );
+  if (visible && notVisible)
+    invalidAt(
+      'Maestro extendedWaitUntil cannot specify both visible and notVisible.',
+      commandNode,
+      context,
+    );
+  if (!visible && !notVisible)
+    invalidAt('Maestro extendedWaitUntil requires visible or notVisible.', commandNode, context);
+  return visible
+    ? { key: 'visible', selector: visible.selector, optional: visible.optional }
+    : { key: 'notVisible', selector: notVisible!.selector, optional: notVisible!.optional };
+}

--- a/packages/maestro/src/internal/program-ir-selector-parser.ts
+++ b/packages/maestro/src/internal/program-ir-selector-parser.ts
@@ -1,0 +1,218 @@
+import { isScalar, type Node } from 'yaml';
+import type {
+  MaestroCoordinate,
+  MaestroGestureTarget,
+  MaestroSelector,
+  MaestroSelectorMap,
+  MaestroSourceLocation,
+} from './program-ir.ts';
+import {
+  assertOnlyKeys,
+  entryValue,
+  hasEntry,
+  invalidAt,
+  readMapEntries,
+  readOptionalBoolean,
+  readOptionalString,
+  readRequiredString,
+  sourceAt,
+  type MaestroMapEntry,
+  type MaestroProgramParseContext,
+} from './program-ir-values.ts';
+import { MAESTRO_BASE_SELECTOR_KEYS, type MaestroSelectorKey } from './selector-vocabulary.ts';
+
+type SelectorFieldReader = (
+  selector: MaestroSelectorMap,
+  entry: MaestroMapEntry,
+  name: string,
+  context: MaestroProgramParseContext,
+) => void;
+
+export type ParsedPointOrSelectorTarget = {
+  readonly source: MaestroSourceLocation;
+  readonly entries: readonly MaestroMapEntry[];
+  readonly target: MaestroGestureTarget;
+};
+
+const SELECTOR_FIELD_READERS: Readonly<Record<string, SelectorFieldReader>> = {
+  id: (selector, entry, name, context) =>
+    assignStringSelector(selector, 'id', entry, name, context),
+  text: (selector, entry, name, context) =>
+    assignStringSelector(selector, 'text', entry, name, context),
+  enabled: (selector, entry, name, context) =>
+    assignBooleanSelector(selector, 'enabled', entry, name, context),
+  selected: (selector, entry, name, context) =>
+    assignBooleanSelector(selector, 'selected', entry, name, context),
+  optional: (selector, entry, name, context) =>
+    assignBooleanSelector(selector, 'optional', entry, name, context),
+};
+
+export function parseMaestroSelector(
+  node: Node | null | undefined,
+  name: string,
+  context: MaestroProgramParseContext,
+  selectorKeys: readonly MaestroSelectorKey[] = MAESTRO_BASE_SELECTOR_KEYS,
+): MaestroSelector {
+  if (isScalar(node)) return { text: readRequiredString(node, name, context) };
+  const entries = readMapEntries(node, name, context);
+  assertOnlyKeys(entries, name, selectorKeys, context);
+  return parseMaestroSelectorMapEntries(entries, name, context);
+}
+
+export function parseMaestroSelectorMapEntries(
+  entries: readonly MaestroMapEntry[],
+  name: string,
+  context: MaestroProgramParseContext,
+): MaestroSelector {
+  if (entries.length === 0) invalidAt(`Maestro ${name} selector is empty.`, undefined, context);
+  const selector: MaestroSelectorMap = {};
+  for (const entry of entries) {
+    const read = SELECTOR_FIELD_READERS[entry.key];
+    if (!read) {
+      invalidAt(
+        `Maestro ${name} selector field "${entry.key}" is not supported.`,
+        entry.keyNode,
+        context,
+      );
+    }
+    read(selector, entry, name, context);
+  }
+  const matchingKeys = Object.keys(selector).filter((key) => key !== 'optional');
+  if (matchingKeys.length === 0) {
+    invalidAt(
+      `Maestro ${name} selector must contain a selector value.`,
+      entries[0]?.keyNode,
+      context,
+    );
+  }
+  return selector;
+}
+
+export function parsePointOrSelectorTarget(
+  value: Node | null,
+  commandNode: Node,
+  context: MaestroProgramParseContext,
+  options: {
+    readonly name: string;
+    readonly selectorKeys: readonly MaestroSelectorKey[];
+    readonly pointConflictingSelectorKeys?: readonly MaestroSelectorKey[];
+    readonly pointAllowedKeys: readonly string[];
+    readonly selectorAllowedKeys: readonly string[];
+    readonly parsePoint: (
+      node: Node | null | undefined,
+      name: string,
+      context: MaestroProgramParseContext,
+    ) => MaestroCoordinate;
+  },
+): ParsedPointOrSelectorTarget {
+  const source = sourceAt(commandNode, context);
+  if (isScalar(value)) {
+    return {
+      source,
+      entries: [],
+      target: selectorTarget(
+        parseMaestroSelector(value, options.name, context, options.selectorKeys),
+      ),
+    };
+  }
+  const entries = readMapEntries(value, options.name, context);
+  const hasPoint = hasEntry(entries, 'point');
+  assertOnlyKeys(
+    entries,
+    options.name,
+    hasPoint ? options.pointAllowedKeys : options.selectorAllowedKeys,
+    context,
+  );
+  if (hasPoint) {
+    const conflictingKeys = options.pointConflictingSelectorKeys ?? options.selectorKeys;
+    if (entries.some((entry) => isSelectorKey(entry.key, conflictingKeys))) {
+      invalidAt(
+        `Maestro ${options.name}.point cannot be combined with a selector.`,
+        commandNode,
+        context,
+      );
+    }
+    return {
+      source,
+      entries,
+      target: options.parsePoint(entryValue(entries, 'point'), `${options.name}.point`, context),
+    };
+  }
+  const selectorEntries = entries.filter((entry) => isSelectorKey(entry.key, options.selectorKeys));
+  return {
+    source,
+    entries,
+    target: selectorTarget(parseMaestroSelectorMapEntries(selectorEntries, options.name, context)),
+  };
+}
+
+export function parseMaestroPoint(
+  node: Node | null | undefined,
+  name: string,
+  context: MaestroProgramParseContext,
+): MaestroCoordinate {
+  const value = readRequiredString(node, name, context);
+  const absolute = /^\s*(\d+)\s*,\s*(\d+)\s*$/.exec(value);
+  if (absolute) return { space: 'absolute', x: Number(absolute[1]), y: Number(absolute[2]) };
+  const percent = /^\s*(\d+)%\s*,\s*(\d+)%\s*$/.exec(value);
+  if (percent) {
+    const x = Number(percent[1]);
+    const y = Number(percent[2]);
+    if (x > 100 || y > 100) {
+      invalidAt(
+        `Maestro ${name} percentage coordinates must be between 0% and 100%.`,
+        node,
+        context,
+      );
+    }
+    return { space: 'percent', x, y };
+  }
+  if (/^\s*\d+(?:\.\d+)?%\s*,\s*\d+(?:\.\d+)?%\s*$/.test(value)) {
+    invalidAt(`Maestro ${name} percentage coordinates must be whole numbers.`, node, context);
+  }
+  invalidAt(`Maestro ${name} expects absolute or percentage coordinates.`, node, context);
+}
+
+export function parseMaestroAbsolutePoint(
+  node: Node | null | undefined,
+  name: string,
+  context: MaestroProgramParseContext,
+): MaestroCoordinate {
+  const point = parseMaestroPoint(node, name, context);
+  if (point.space !== 'absolute')
+    invalidAt(`Maestro ${name} only supports absolute coordinates.`, node, context);
+  return point;
+}
+
+function assignStringSelector(
+  selector: MaestroSelectorMap,
+  key: 'id' | 'text',
+  entry: MaestroMapEntry,
+  name: string,
+  context: MaestroProgramParseContext,
+): void {
+  const value = readOptionalString(entry.value, `${name}.${key}`, context);
+  if (value !== undefined) selector[key] = value;
+}
+
+function assignBooleanSelector(
+  selector: MaestroSelectorMap,
+  key: 'enabled' | 'selected' | 'optional',
+  entry: MaestroMapEntry,
+  name: string,
+  context: MaestroProgramParseContext,
+): void {
+  const value = readOptionalBoolean(entry.value, `${name}.${key}`, context);
+  if (value !== undefined) selector[key] = value;
+}
+
+function isSelectorKey(
+  key: string,
+  selectorKeys: readonly MaestroSelectorKey[],
+): key is MaestroSelectorKey {
+  return selectorKeys.includes(key as MaestroSelectorKey);
+}
+
+function selectorTarget(selector: MaestroSelector): MaestroGestureTarget {
+  return { space: 'target', selector };
+}

--- a/packages/maestro/src/internal/program-ir.ts
+++ b/packages/maestro/src/internal/program-ir.ts
@@ -16,7 +16,6 @@ export type MaestroCoordinate =
 export type MaestroSelectorMap = {
   text?: string;
   id?: string;
-  label?: string;
   enabled?: boolean;
   selected?: boolean;
   optional?: boolean;
@@ -64,12 +63,14 @@ export type MaestroDoubleTapOnCommand = MaestroOptionalCommand & {
   source: MaestroSourceLocation;
   target: MaestroGestureTarget;
   delay?: number | string;
+  label?: string;
 };
 
 export type MaestroLongPressOnCommand = MaestroOptionalCommand & {
   kind: 'longPressOn';
   source: MaestroSourceLocation;
   target: MaestroGestureTarget;
+  label?: string;
 };
 
 export type MaestroSwipeGesture =
@@ -89,13 +90,13 @@ export type MaestroSwipeGesture =
       from: MaestroSelector;
       direction: MaestroDirection;
       duration?: number | string;
-      label?: string;
     };
 
 export type MaestroSwipeCommand = MaestroOptionalCommand & {
   kind: 'swipe';
   source: MaestroSourceLocation;
   gesture: MaestroSwipeGesture;
+  label?: string;
 };
 
 export type MaestroInputTextCommand = {
@@ -122,6 +123,7 @@ export type MaestroAssertVisibleCommand = MaestroOptionalCommand & {
   source: MaestroSourceLocation;
   target: MaestroSelector;
   childOf?: MaestroSelector;
+  label?: string;
 };
 
 export type MaestroAssertNotVisibleCommand = MaestroOptionalCommand & {
@@ -129,6 +131,7 @@ export type MaestroAssertNotVisibleCommand = MaestroOptionalCommand & {
   source: MaestroSourceLocation;
   target: MaestroSelector;
   childOf?: MaestroSelector;
+  label?: string;
 };
 
 export type MaestroExtendedWaitUntilCommand = MaestroOptionalCommand & {
@@ -137,6 +140,7 @@ export type MaestroExtendedWaitUntilCommand = MaestroOptionalCommand & {
   visible?: MaestroSelector;
   notVisible?: MaestroSelector;
   timeout?: number | string;
+  label?: string;
 };
 
 export type MaestroTakeScreenshotCommand = {
@@ -156,6 +160,7 @@ export type MaestroScrollUntilVisibleCommand = MaestroOptionalCommand & {
   element: MaestroSelector;
   direction?: MaestroDirection;
   timeout?: number | string;
+  label?: string;
 };
 
 export type MaestroHideKeyboardCommand = {

--- a/packages/maestro/src/internal/progress.ts
+++ b/packages/maestro/src/internal/progress.ts
@@ -22,6 +22,7 @@ export function formatMaestroCommandProgress(
 }
 
 function progressValue(command: MaestroCommand): Pick<MaestroCommandProgress, 'value'> {
+  if ('label' in command && command.label) return valueOf(command.label);
   if (isGestureTargetCommand(command)) return valueOf(formatGestureTarget(command.target));
   if (isSelectorProgressCommand(command)) return selectorProgressValue(command);
   if (command.kind === 'inputText') return valueOf('<text>');
@@ -124,7 +125,7 @@ function formatGestureTarget(target: MaestroGestureTarget): string | undefined {
 }
 
 function formatSelector(selector: MaestroSelector | undefined): string | undefined {
-  return selector?.id ?? selector?.text ?? selector?.label;
+  return selector?.id ?? selector?.text;
 }
 
 function formatCoordinate(coordinate: { space: 'absolute' | 'percent'; x: number; y: number }) {

--- a/packages/maestro/src/internal/runtime-target-policy.ts
+++ b/packages/maestro/src/internal/runtime-target-policy.ts
@@ -13,7 +13,8 @@ export type MaestroPlatform = 'ios' | 'android';
  * Maestro intersects every authored selector field. String values are
  * full-match regular expressions. Text is the visible-text form used by
  * scalar selectors, so it checks label, readable node text, and identifier
- * values. Enabled and selected are independent state constraints.
+ * values; `label` itself is command metadata, never a selector field. Enabled
+ * and selected are independent state constraints.
  */
 export function matchesMaestroTypedSelector(
   node: SnapshotNode,
@@ -24,9 +25,6 @@ export function matchesMaestroTypedSelector(
       ? undefined
       : matchesMaestroSelectorValue(node.identifier, selector.id),
     selector.text === undefined ? undefined : matchesMaestroVisibleText(node, selector.text),
-    selector.label === undefined
-      ? undefined
-      : matchesMaestroSelectorValue(node.label, selector.label),
   ].filter((matched): matched is boolean => matched !== undefined);
   if (textTerms.length === 0 && selector.enabled === undefined && selector.selected === undefined) {
     return false;

--- a/packages/maestro/src/internal/runtime-target-ranking.ts
+++ b/packages/maestro/src/internal/runtime-target-ranking.ts
@@ -93,7 +93,7 @@ function hasUsableRect(node: SnapshotNode): node is SnapshotNode & { rect: Rect 
 }
 
 function hasTextualSelector(selector: MaestroSelector): boolean {
-  return selector.id !== undefined || selector.label !== undefined || selector.text !== undefined;
+  return selector.id !== undefined || selector.text !== undefined;
 }
 
 function haveSameSelectorIdentity(
@@ -102,9 +102,6 @@ function haveSameSelectorIdentity(
   selector: MaestroSelector,
 ): boolean {
   if (selector.id !== undefined && normalize(left.identifier) !== normalize(right.identifier)) {
-    return false;
-  }
-  if (selector.label !== undefined && normalize(left.label) !== normalize(right.label)) {
     return false;
   }
   if (selector.text !== undefined) {

--- a/packages/maestro/src/internal/selector-vocabulary.ts
+++ b/packages/maestro/src/internal/selector-vocabulary.ts
@@ -1,8 +1,7 @@
 import type { MaestroSelectorMap } from './program-ir.ts';
 
 export const MAESTRO_BASE_SELECTOR_KEYS = ['id', 'text', 'enabled', 'selected'] as const;
-export const MAESTRO_TAP_SELECTOR_KEYS = [...MAESTRO_BASE_SELECTOR_KEYS, 'label'] as const;
-const MAESTRO_TEXT_SELECTOR_KEYS = ['id', 'text', 'label'] as const;
+const MAESTRO_TEXT_SELECTOR_KEYS = ['id', 'text'] as const;
 const MAESTRO_STATE_SELECTOR_KEYS = ['enabled', 'selected'] as const;
 
 /**
@@ -15,6 +14,7 @@ const MAESTRO_STATE_SELECTOR_KEYS = ['enabled', 'selected'] as const;
 export const MAESTRO_SELECTOR_PROJECTION = {
   textKeys: MAESTRO_TEXT_SELECTOR_KEYS,
   booleanKeys: MAESTRO_STATE_SELECTOR_KEYS,
+  textAliases: { label: 'text' },
 } as const;
 
 export type MaestroSelectorKey = keyof MaestroSelectorMap;

--- a/packages/maestro/src/internal/support-matrix.ts
+++ b/packages/maestro/src/internal/support-matrix.ts
@@ -1,6 +1,6 @@
 export const MAESTRO_COMPAT_SUPPORTED_CAPABILITIES = [
   'Flows: launchApp; runFlow file/inline with platform, visibility, and limited boolean conditions; onFlowStart/onFlowComplete; repeat.times and retry.',
-  'Interactions: tapOn, doubleTapOn, longPressOn, inputText on the focused element, eraseText, openLink, hideKeyboard, basic pressKey, and back; tap targets poll until available and support index, childOf, label, points, and optional.',
+  'Interactions: tapOn, doubleTapOn, longPressOn, inputText on the focused element, eraseText, openLink, hideKeyboard, basic pressKey, and back; tap targets poll until available and support index, childOf, points, and optional; outer command labels are metadata, not target selectors.',
   'Assertions and navigation: assertVisible, assertNotVisible, extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
   'Scripts: ordered runScript file/env scripts with http.post, json, and output variables.',
 ] as const;

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -83,6 +83,7 @@ export {
   resolveReplaySuggestionCandidate,
   selectorFailureHint,
   selectorContainsValue,
+  selectorContainsKey,
   splitSelectorFromArgs,
   validateSelectorExpression,
 };
@@ -114,16 +115,26 @@ export type SelectorProjection = string | Readonly<Record<string, string | boole
  */
 function projectSelectorExpression(
   expression: string,
-  vocabulary: { textKeys: readonly string[]; booleanKeys: readonly string[] },
+  vocabulary: {
+    textKeys: readonly string[];
+    booleanKeys: readonly string[];
+    textAliases?: Readonly<Record<string, string>>;
+  },
 ): SelectorProjection {
   const parsed = tryParseSelectorChain(expression);
   // Not selector-shaped at all: pass plain text through, refuse anything that
   // tried to be a selector and failed.
   if (!parsed) return expression.includes('=') || expression.includes('||') ? null : expression;
   const textKeys = new Set(vocabulary.textKeys);
+  const textAliases = vocabulary.textAliases ?? {};
   return parsed.selectors.length > 1
-    ? readAgreedTextValue(parsed.selectors, textKeys)
-    : projectSelectorTerms(parsed.selectors[0], textKeys, new Set(vocabulary.booleanKeys));
+    ? readAgreedTextValue(parsed.selectors, textKeys, textAliases)
+    : projectSelectorTerms(
+        parsed.selectors[0],
+        textKeys,
+        new Set(vocabulary.booleanKeys),
+        textAliases,
+      );
 }
 
 /**
@@ -134,10 +145,11 @@ function projectSelectorExpression(
 function readAgreedTextValue(
   selectors: readonly Selector[],
   textKeys: ReadonlySet<string>,
+  textAliases: Readonly<Record<string, string>>,
 ): SelectorProjection {
   const values = selectors.map((selector) => {
     const term = selector.terms.length === 1 ? selector.terms[0] : undefined;
-    return term && textKeys.has(term.key) && typeof term.value === 'string'
+    return term && isTextKey(term.key, textKeys, textAliases) && typeof term.value === 'string'
       ? term.value
       : undefined;
   });
@@ -150,16 +162,26 @@ function projectSelectorTerms(
   selector: Selector | undefined,
   textKeys: ReadonlySet<string>,
   booleanKeys: ReadonlySet<string>,
+  textAliases: Readonly<Record<string, string>>,
 ): SelectorProjection {
   if (!selector) return null;
   const result: Record<string, string | boolean> = {};
   let textTerms = 0;
   for (const term of selector.terms) {
-    if (termMatches(term, textKeys, 'string')) textTerms += 1;
+    if (isTextKey(term.key, textKeys, textAliases) && typeof term.value === 'string')
+      textTerms += 1;
     else if (!termMatches(term, booleanKeys, 'boolean')) return null;
-    result[term.key] = term.value;
+    result[textAliases[term.key] ?? term.key] = term.value;
   }
   return textTerms <= 1 && Object.keys(result).length > 0 ? result : null;
+}
+
+function isTextKey(
+  key: string,
+  textKeys: ReadonlySet<string>,
+  textAliases: Readonly<Record<string, string>>,
+): boolean {
+  return textKeys.has(key) || textAliases[key] !== undefined;
 }
 
 function termMatches(
@@ -196,6 +218,14 @@ function selectorContainsValue(expression: string, literal: string): boolean {
         typeof term.value === 'string' &&
         term.value.includes(literal),
     ),
+  );
+}
+
+/** Whether a parsed selector expression contains a term with `key`. */
+function selectorContainsKey(expression: string, key: string): boolean {
+  const parsed = tryParseSelectorChain(expression);
+  return (
+    parsed?.selectors.some((selector) => selector.terms.some((term) => term.key === key)) ?? false
   );
 }
 

--- a/packages/selectors/src/projection.test.ts
+++ b/packages/selectors/src/projection.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { projectSelectorExpression } from './index.ts';
+
+test('projects configured text aliases into the consumer vocabulary', () => {
+  expect(
+    projectSelectorExpression('label="Save"', {
+      textKeys: ['id', 'text'],
+      booleanKeys: ['enabled'],
+      textAliases: { label: 'text' },
+    }),
+  ).toEqual({ text: 'Save' });
+  expect(
+    projectSelectorExpression('label="Save" enabled=true', {
+      textKeys: ['id', 'text'],
+      booleanKeys: ['enabled'],
+      textAliases: { label: 'text' },
+    }),
+  ).toEqual({ text: 'Save', enabled: true });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@agent-device/kernel':
         specifier: workspace:*
         version: link:../kernel
+      '@agent-device/selectors':
+        specifier: workspace:*
+        version: link:../selectors
       yaml:
         specifier: ^2.9.0
         version: 2.9.0

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -322,6 +322,7 @@ test('the real tree parses, declares, and passes R11', () => {
   assert.deepEqual([...maestroPackage.workspaceDependencies].sort(), [
     '@agent-device/contracts',
     '@agent-device/kernel',
+    '@agent-device/selectors',
   ]);
   const adScriptPackage = packages.find((pkg) => pkg.name === '@agent-device/ad-script');
   assert.ok(adScriptPackage, 'ad-script package must exist');

--- a/scripts/maestro-conformance/README.md
+++ b/scripts/maestro-conformance/README.md
@@ -97,7 +97,8 @@ failure, not a pass.
   teeth (`invalid/`). To add a flow: drop the `.yaml` in, add a note to `NOTES`
   in `build-manifest.mjs`, and regenerate.
 - [`fixtures/`](./fixtures) — the generated, checked-in layer-1/layer-2 captures.
-- `packages/maestro/src/internal/conformance-normalize.ts` — package-private canonical projection.
+- `packages/maestro/src/internal/conformance-normalize.ts` and
+  `conformance-selector-projection.ts` — package-private canonical projection and selector model.
 - `packages/maestro/test/conformance/` — the deterministic verifier, declared divergences,
   package-private harness, shared fixture seal, and layer-3 differential scenarios. Keeping this
   code under package tests prevents parser/canonicalization tooling from widening the production
@@ -118,7 +119,7 @@ command/option in `packages/maestro/test/conformance/expected-divergence.ts` —
 list is the mechanical parity record. A focused issue is attached only when
 implementation work is planned.
 
-## Regenerate (only on an upstream-pin bump)
+## Regenerate (on an upstream-pin bump or intentional corpus/harness change)
 
 Heavy, manual, needs JDK 17+ (Gradle is provided by the committed wrapper):
 
@@ -128,7 +129,9 @@ pnpm maestro:conformance:regenerate
 
 This resolves the pinned jars, **verifies their SHA-256 against
 `pinned-upstream.json`**, runs the harness over the corpus, and rewrites
-`fixtures/`. Review the diff, then run the verifier. To bump the pin: update
+`fixtures/`. Review the diff, then run the verifier. A pin bump is not required
+when a corpus flow or harness behavior intentionally changes; regenerate from
+the unchanged pin and review the generated diff. To bump the pin: update
 `pinned-upstream.json` (version/tag/commit + the jar SHA-256s from Maven Central),
 refresh the vendored corpus flows and their `manifest.json` `sha256`s, regenerate,
 and reconcile any new divergences.

--- a/scripts/maestro-conformance/build-manifest.mjs
+++ b/scripts/maestro-conformance/build-manifest.mjs
@@ -28,6 +28,8 @@ const NOTES = {
   'authored/runflow-child': 'Include target for runflow-main (not parsed as a top-level flow).',
   'authored/doubletap':
     'Coverage: doubleTapOn (upstream 101 uses the unsupported retryTapIfNoChange option).',
+  'authored/label-metadata':
+    'Coverage: outer command labels stay metadata across selector, point, assertion, wait, scroll, swipe, and input commands.',
   'authored/scroll-until-visible':
     'Coverage: scrollUntilVisible (upstream 079 uses unsupported speed/visibilityPercentage).',
   'authored/extended-wait':

--- a/scripts/maestro-conformance/corpus/authored/label-metadata.yaml
+++ b/scripts/maestro-conformance/corpus/authored/label-metadata.yaml
@@ -1,0 +1,39 @@
+appId: com.example.app
+---
+- tapOn:
+    text: "Login"
+    label: "login tap"
+- tapOn:
+    point: "20,30"
+    label: "coordinate tap"
+- doubleTapOn:
+    text: "Save"
+    label: "save twice"
+- longPressOn:
+    text: "Hold"
+    label: "hold action"
+- assertVisible:
+    text: "Ready"
+    label: "ready assertion"
+- assertNotVisible:
+    text: "Gone"
+    label: "gone assertion"
+- extendedWaitUntil:
+    visible:
+      text: "Loaded"
+    timeout: 1000
+    label: "loaded wait"
+- scrollUntilVisible:
+    element:
+      text: "Item"
+    direction: DOWN
+    timeout: 20000
+    label: "item scroll"
+- swipe:
+    from:
+      text: "Card"
+    direction: LEFT
+    label: "card swipe"
+- inputText:
+    text: "value"
+    label: "field input"

--- a/scripts/maestro-conformance/corpus/manifest.json
+++ b/scripts/maestro-conformance/corpus/manifest.json
@@ -481,6 +481,14 @@
       }
     },
     {
+      "id": "authored/label-metadata",
+      "file": "authored/label-metadata.yaml",
+      "origin": {
+        "kind": "authored",
+        "note": "Coverage: outer command labels stay metadata across selector, point, assertion, wait, scroll, swipe, and input commands."
+      }
+    },
+    {
       "id": "authored/numeric-variable-doubletap",
       "file": "authored/numeric-variable-doubletap.yaml",
       "origin": {

--- a/scripts/maestro-conformance/fixtures/layer1-parser.json
+++ b/scripts/maestro-conformance/fixtures/layer1-parser.json
@@ -3370,6 +3370,322 @@
       ]
     },
     {
+      "id": "authored/label-metadata",
+      "file": "authored/label-metadata.yaml",
+      "status": "parsed",
+      "commands": [
+        {
+          "type": "ApplyConfigurationCommand",
+          "fields": {
+            "config": {
+              "appId": "com.example.app",
+              "name": null,
+              "tags": [],
+              "ext": {},
+              "onFlowStart": null,
+              "onFlowComplete": null,
+              "properties": {}
+            },
+            "label": null,
+            "optional": false
+          }
+        },
+        {
+          "type": "TapOnElementCommand",
+          "fields": {
+            "selector": {
+              "textRegex": "Login",
+              "idRegex": null,
+              "size": null,
+              "below": null,
+              "above": null,
+              "leftOf": null,
+              "rightOf": null,
+              "containsChild": null,
+              "containsDescendants": null,
+              "traits": null,
+              "index": null,
+              "enabled": null,
+              "optional": false,
+              "selected": null,
+              "checked": null,
+              "focused": null,
+              "childOf": null,
+              "css": null
+            },
+            "retryIfNoChange": false,
+            "waitUntilVisible": false,
+            "longPress": false,
+            "repeat": null,
+            "waitToSettleTimeoutMs": null,
+            "relativePoint": null,
+            "label": "login tap",
+            "optional": false
+          }
+        },
+        {
+          "type": "TapOnPointV2Command",
+          "fields": {
+            "point": "20,30",
+            "retryIfNoChange": false,
+            "longPress": false,
+            "repeat": null,
+            "waitToSettleTimeoutMs": null,
+            "label": "coordinate tap",
+            "optional": false
+          }
+        },
+        {
+          "type": "TapOnElementCommand",
+          "fields": {
+            "selector": {
+              "textRegex": "Save",
+              "idRegex": null,
+              "size": null,
+              "below": null,
+              "above": null,
+              "leftOf": null,
+              "rightOf": null,
+              "containsChild": null,
+              "containsDescendants": null,
+              "traits": null,
+              "index": null,
+              "enabled": null,
+              "optional": false,
+              "selected": null,
+              "checked": null,
+              "focused": null,
+              "childOf": null,
+              "css": null
+            },
+            "retryIfNoChange": false,
+            "waitUntilVisible": false,
+            "longPress": false,
+            "repeat": {
+              "repeat": 2,
+              "delay": 100
+            },
+            "waitToSettleTimeoutMs": null,
+            "relativePoint": null,
+            "label": "save twice",
+            "optional": false
+          }
+        },
+        {
+          "type": "TapOnElementCommand",
+          "fields": {
+            "selector": {
+              "textRegex": "Hold",
+              "idRegex": null,
+              "size": null,
+              "below": null,
+              "above": null,
+              "leftOf": null,
+              "rightOf": null,
+              "containsChild": null,
+              "containsDescendants": null,
+              "traits": null,
+              "index": null,
+              "enabled": null,
+              "optional": false,
+              "selected": null,
+              "checked": null,
+              "focused": null,
+              "childOf": null,
+              "css": null
+            },
+            "retryIfNoChange": false,
+            "waitUntilVisible": false,
+            "longPress": true,
+            "repeat": null,
+            "waitToSettleTimeoutMs": null,
+            "relativePoint": null,
+            "label": "hold action",
+            "optional": false
+          }
+        },
+        {
+          "type": "AssertConditionCommand",
+          "fields": {
+            "condition": {
+              "platform": null,
+              "visible": {
+                "textRegex": "Ready",
+                "idRegex": null,
+                "size": null,
+                "below": null,
+                "above": null,
+                "leftOf": null,
+                "rightOf": null,
+                "containsChild": null,
+                "containsDescendants": null,
+                "traits": null,
+                "index": null,
+                "enabled": null,
+                "optional": false,
+                "selected": null,
+                "checked": null,
+                "focused": null,
+                "childOf": null,
+                "css": null
+              },
+              "notVisible": null,
+              "scriptCondition": null,
+              "label": null
+            },
+            "timeout": null,
+            "label": "ready assertion",
+            "optional": false
+          }
+        },
+        {
+          "type": "AssertConditionCommand",
+          "fields": {
+            "condition": {
+              "platform": null,
+              "visible": null,
+              "notVisible": {
+                "textRegex": "Gone",
+                "idRegex": null,
+                "size": null,
+                "below": null,
+                "above": null,
+                "leftOf": null,
+                "rightOf": null,
+                "containsChild": null,
+                "containsDescendants": null,
+                "traits": null,
+                "index": null,
+                "enabled": null,
+                "optional": false,
+                "selected": null,
+                "checked": null,
+                "focused": null,
+                "childOf": null,
+                "css": null
+              },
+              "scriptCondition": null,
+              "label": null
+            },
+            "timeout": null,
+            "label": "gone assertion",
+            "optional": false
+          }
+        },
+        {
+          "type": "AssertConditionCommand",
+          "fields": {
+            "condition": {
+              "platform": null,
+              "visible": {
+                "textRegex": "Loaded",
+                "idRegex": null,
+                "size": null,
+                "below": null,
+                "above": null,
+                "leftOf": null,
+                "rightOf": null,
+                "containsChild": null,
+                "containsDescendants": null,
+                "traits": null,
+                "index": null,
+                "enabled": null,
+                "optional": false,
+                "selected": null,
+                "checked": null,
+                "focused": null,
+                "childOf": null,
+                "css": null
+              },
+              "notVisible": null,
+              "scriptCondition": null,
+              "label": null
+            },
+            "timeout": "1000",
+            "label": "loaded wait",
+            "optional": false
+          }
+        },
+        {
+          "type": "ScrollUntilVisibleCommand",
+          "fields": {
+            "selector": {
+              "textRegex": "Item",
+              "idRegex": null,
+              "size": null,
+              "below": null,
+              "above": null,
+              "leftOf": null,
+              "rightOf": null,
+              "containsChild": null,
+              "containsDescendants": null,
+              "traits": null,
+              "index": null,
+              "enabled": null,
+              "optional": false,
+              "selected": null,
+              "checked": null,
+              "focused": null,
+              "childOf": null,
+              "css": null
+            },
+            "direction": "DOWN",
+            "scrollDuration": "40",
+            "visibilityPercentage": 100,
+            "timeout": "20000",
+            "waitToSettleTimeoutMs": null,
+            "centerElement": false,
+            "originalSpeedValue": "40",
+            "label": "item scroll",
+            "optional": false,
+            "visibilityPercentageNormalized": 1
+          }
+        },
+        {
+          "type": "SwipeCommand",
+          "fields": {
+            "direction": "LEFT",
+            "startPoint": null,
+            "endPoint": null,
+            "elementSelector": {
+              "textRegex": "Card",
+              "idRegex": null,
+              "size": null,
+              "below": null,
+              "above": null,
+              "leftOf": null,
+              "rightOf": null,
+              "containsChild": null,
+              "containsDescendants": null,
+              "traits": null,
+              "index": null,
+              "enabled": null,
+              "optional": false,
+              "selected": null,
+              "checked": null,
+              "focused": null,
+              "childOf": null,
+              "css": null
+            },
+            "startRelative": null,
+            "endRelative": null,
+            "duration": 400,
+            "waitToSettleTimeoutMs": null,
+            "label": "card swipe",
+            "optional": false
+          }
+        },
+        {
+          "type": "InputTextCommand",
+          "fields": {
+            "text": "value",
+            "label": "field input",
+            "optional": false
+          }
+        }
+      ]
+    },
+    {
       "id": "authored/numeric-variable-doubletap",
       "file": "authored/numeric-variable-doubletap.yaml",
       "status": "rejected",
@@ -4042,5 +4358,5 @@
       ]
     }
   ],
-  "contentHash": "b81dbe35d8b2b95c6c0c0b9f49514c00a0729f618da693574ef84b6feb05a5b4"
+  "contentHash": "5dd6cb659c4a5c55e53ae9f6170abfdfd32b1a6bc423839cb4f49f7454109e49"
 }

--- a/src/cli/commands/__tests__/replay-maestro-export.test.ts
+++ b/src/cli/commands/__tests__/replay-maestro-export.test.ts
@@ -83,12 +83,18 @@ press text="Retry" --hold-ms 1500
       { appId: 'com.example.app' },
       [
         'launchApp',
-        { longPressOn: { label: 'Last message' } },
+        { longPressOn: { text: 'Last message' } },
         { longPressOn: { id: 'hold-button' } },
         { longPressOn: { text: 'Retry' } },
       ],
     ]);
     expect(result.warnings).toEqual([
+      {
+        line: 2,
+        action: 'longpress label="Last message" 800',
+        message:
+          'label= selectors export as Maestro text; Maestro text matching is broader than agent-device label-only matching',
+      },
       {
         line: 2,
         action: 'longpress label="Last message" 800',

--- a/src/daemon/handlers/__tests__/session-replay-maestro-failure.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-failure.test.ts
@@ -338,7 +338,7 @@ test('typed Maestro failure publishes exactly the refs exposed by its divergence
   const command = {
     kind: 'tapOn' as const,
     source: { path: '/flows/actions.yaml', line: 4 },
-    target: { space: 'target' as const, selector: { label: 'Missing' } },
+    target: { space: 'target' as const, selector: { text: 'Missing' } },
   } satisfies Extract<MaestroRuntimeCommand, { kind: 'tapOn' }>;
   const scenario = await buildFailureScenario(command, [
     {
@@ -478,7 +478,7 @@ test('typed Maestro suggestions retain total count before the five-entry cap', a
   const command = {
     kind: 'tapOn' as const,
     source: { path: '/flows/actions.yaml', line: 4 },
-    target: { space: 'target' as const, selector: { label: 'Save' } },
+    target: { space: 'target' as const, selector: { text: 'Save' } },
   } satisfies Extract<MaestroRuntimeCommand, { kind: 'tapOn' }>;
   const response = await buildFailureResponse(command, [
     {

--- a/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test, vi } from 'vitest';
+import type { MaestroActionEvent } from '@agent-device/maestro';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import { createMaestroReplayObserver } from '../session-replay-maestro-observer.ts';
+
+test('forwards command labels to progress and replay trace projection', () => {
+  const root = mkdtempForTestSync('agent-device-maestro-label-trace-');
+  const tracePath = path.join(root, 'replay-timing.ndjson');
+  const replayPath = path.join(root, 'flow.yaml');
+  const onStep = vi.fn();
+  const event: MaestroActionEvent = {
+    action: 'tapOn',
+    value: 'save action',
+    source: { path: replayPath, line: 3 },
+    generation: 0,
+    stepIndex: 1,
+    stepTotal: 1,
+  };
+
+  const observer = createMaestroReplayObserver({ tracePath, filePath: replayPath, onStep });
+  observer.actionStarted?.(event);
+  observer.actionCompleted?.({
+    ...event,
+    durationMs: 5,
+    runtimeMetrics: { hierarchyCaptures: 1, screenshotCaptures: 0, tapRetries: 0 },
+  });
+
+  expect(onStep).toHaveBeenCalledWith({
+    index: 1,
+    total: 1,
+    command: 'tapOn',
+    value: 'save action',
+  });
+  const traceStart = JSON.parse(fs.readFileSync(tracePath, 'utf8').split('\n')[0]!) as Record<
+    string,
+    unknown
+  >;
+  expect(traceStart).toMatchObject({
+    type: 'replay_action_start',
+    command: 'tapOn',
+    positionals: ['save action'],
+  });
+});

--- a/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime-maestro.test.ts
@@ -1293,7 +1293,7 @@ test('runReplayScriptSource resolves a text-entry target once before typing', as
   );
 });
 
-test('runReplayScriptSource resolves Maestro swipe.label from a labeled element rect', async () => {
+test('runReplayScriptSource resolves scalar Maestro swipe.from to an element rect', async () => {
   const calls: CapturedInvocation[] = [];
   const { response } = await runReplayFixture({
     label: 'maestro-swipe-label',
@@ -1301,7 +1301,7 @@ test('runReplayScriptSource resolves Maestro swipe.label from a labeled element 
       'appId: demo.app',
       '---',
       '- swipe:',
-      '    label: Thread body',
+      '    from: Thread body',
       '    direction: UP',
       '    duration: 400',
       '',
@@ -1350,7 +1350,7 @@ test('runReplayScriptSource resolves Maestro swipe.label from a labeled element 
   );
 });
 
-test('runReplayScriptSource keeps Maestro swipe.label anchored to the matched label rect', async () => {
+test('runReplayScriptSource anchors scalar Maestro swipe.from to the matched element rect', async () => {
   const calls: CapturedInvocation[] = [];
   const { response } = await runReplayFixture({
     label: 'maestro-swipe-label-child-rect',
@@ -1358,7 +1358,7 @@ test('runReplayScriptSource keeps Maestro swipe.label anchored to the matched la
       'appId: demo.app',
       '---',
       '- swipe:',
-      '    label: Article',
+      '    from: Article',
       '    direction: UP',
       '    duration: 400',
       '',

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -71,7 +71,7 @@ agent-device test ./maestro-flows --maestro --platform android --artifacts-dir .
 Supported subset:
 
 - Flows: `launchApp`; `runFlow` file/inline with platform, visibility, and limited boolean conditions; `onFlowStart`/`onFlowComplete`; `repeat.times` and retry.
-- Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText` on the focused element, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; tap targets poll until available and support `index`, `childOf`, `label`, points, and `optional`.
+- Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText` on the focused element, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; tap targets poll until available and support `index`, `childOf`, points, and `optional`; outer command labels are metadata, not target selectors.
 - Assertions and navigation: `assertVisible`, `assertNotVisible`, `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
 - Scripts: ordered `runScript` file/env scripts with `http.post`, `json`, and `output` variables.
 
@@ -97,7 +97,7 @@ agent-device replay export ./workflows/checkout.ad --out ./maestro/checkout.yaml
 
 `replay export` is a local file transform. It does not start the daemon or contact a device. If `--out` is omitted, the YAML is printed to stdout.
 
-The exporter is intentionally strict. It writes Maestro YAML for compatible flow actions such as app launch, taps, long press, text input, keyboard dismiss/enter, back, text visibility assertions, coordinate swipes, basic scroll, screenshots, and `.ad` `env` directives. Agent-only inspection or maintenance actions such as `snapshot`, `get`, `record`, `trace`, `settings`, and unsupported selector shapes fail with the source line and action instead of being silently dropped. Known semantic differences are reported as warnings; for example, `.ad` `fill` exports as `tapOn` plus `inputText`, which may append text in Maestro rather than replacing existing field contents.
+The exporter is intentionally strict. It writes Maestro YAML for compatible flow actions such as app launch, taps, long press, text input, keyboard dismiss/enter, back, text visibility assertions, coordinate swipes, basic scroll, screenshots, and `.ad` `env` directives. Agent-only inspection or maintenance actions such as `snapshot`, `get`, `record`, `trace`, `settings`, and unsupported selector shapes fail with the source line and action instead of being silently dropped. Known semantic differences are reported as warnings; for example, `.ad` `fill` exports as `tapOn` plus `inputText`, which may append text in Maestro rather than replacing existing field contents. Native `.ad` `label=` selectors export as Maestro `text:` selectors and warn because Maestro text matching is broader than label-only matching.
 
 ## Run a lightweight `.ad` suite
 


### PR DESCRIPTION
## Summary

Part of #1894. This is the first PR in a three-PR stack; followed by #1910 and #1911.

- Treat Maestro `label` consistently as outer command metadata instead of an element selector.
- Keep native `.ad` replay export round-trippable by projecting `label=` to Maestro `text:` with an explicit broader-match warning.
- Extend the canonical conformance projection, supported-capability declaration, authored corpus, help, and replay docs so this breaking ownership decision is visible and mechanically checked.
- Extract parser and conformance responsibilities before adding behavior to files already over the repository size tripwire.

This PR changes 38 files across the Maestro parser/export/conformance and replay integration surfaces. That cross-module scope is intentional: landing only parser acceptance or only export behavior would create the silent/invalid round trip described in #1894.

## Validation

The cumulative stack head `3d7208a07` passed `pnpm check:affected --run`: 4,273 affected tests, changed-line coverage at 90.60%, package/build/layering/fallow checks, and Maestro conformance at 47/47. The label-focused parser, export, replay, support-matrix, and conformance tests are included in that run.

GitHub CI on this PR head remains authoritative for independent-layer readiness. No live device run was performed for this parser/export ownership slice; it does not change a platform interaction path.
