### PR TITLE
fix: preserve Maestro clickable-first ordering

### DIFF
--- a/examples/test-app/README.md
+++ b/examples/test-app/README.md
@@ -88,7 +88,9 @@ The `/automation` route is intentionally JavaScript-only and can be opened from
 **Settings → Open automation lab** or with the
 `agent-device-test-app:///automation` scheme. Its stable `automation-*` ids expose durable
 outcomes for long press, native alert actions, app-event name/payload, app state, appearance,
-window orientation, and microphone permission recovery. CI repacks JavaScript-only changes into the
+window orientation, and microphone permission recovery; the
+`maestro-clickable-first-target` duplicate pair exercises Android Maestro clickable-first
+ordering. CI repacks JavaScript-only changes into the
 cached Release app without starting Metro; native configuration changes intentionally produce one
 new fingerprinted build that all simulator consumers share.
 

--- a/examples/test-app/src/screens/AutomationLabScreen.tsx
+++ b/examples/test-app/src/screens/AutomationLabScreen.tsx
@@ -161,26 +161,28 @@ export function AutomationLabScreen(props: {
         />
       </SectionCard>
 
-      <SectionCard
-        subtitle="The first duplicate is inert; the second duplicate is clickable."
-        title="Maestro clickable ordering"
-      >
-        <View style={styles.maestroTarget} testID="maestro-clickable-first-target">
-          <Text style={styles.maestroTargetLabel}>Inert duplicate target</Text>
-        </View>
-        <Pressable
-          accessibilityLabel="Clickable duplicate target"
-          accessibilityRole="button"
-          onPress={() => setMaestroSelection('clickable')}
-          style={({ pressed }) => [styles.maestroTarget, pressed ? styles.pressed : null]}
-          testID="maestro-clickable-first-target"
+      {Platform.OS === 'android' ? (
+        <SectionCard
+          subtitle="The first duplicate is inert; the second duplicate is clickable."
+          title="Maestro clickable ordering"
         >
-          <Text style={styles.maestroTargetLabel}>Clickable duplicate target</Text>
-        </Pressable>
-        <Text style={styles.value} testID="maestro-clickable-first-result">
-          Maestro selection: {maestroSelection}
-        </Text>
-      </SectionCard>
+          <View style={styles.maestroTarget} testID="maestro-clickable-first-target">
+            <Text style={styles.maestroTargetLabel}>Inert duplicate target</Text>
+          </View>
+          <Pressable
+            accessibilityLabel="Clickable duplicate target"
+            accessibilityRole="button"
+            onPress={() => setMaestroSelection('clickable')}
+            style={({ pressed }) => [styles.maestroTarget, pressed ? styles.pressed : null]}
+            testID="maestro-clickable-first-target"
+          >
+            <Text style={styles.maestroTargetLabel}>Clickable duplicate target</Text>
+          </Pressable>
+          <Text style={styles.value} testID="maestro-clickable-first-result">
+            Maestro selection: {maestroSelection}
+          </Text>
+        </SectionCard>
+      ) : null}
 
       <SectionCard title="Input canaries">
         <ActionButton

--- a/examples/test-app/src/screens/AutomationLabScreen.tsx
+++ b/examples/test-app/src/screens/AutomationLabScreen.tsx
@@ -41,6 +41,7 @@ export function AutomationLabScreen(props: {
   const [alertResult, setAlertResult] = useState('none');
   const [lastInput, setLastInput] = useState('none');
   const [longPressCount, setLongPressCount] = useState(0);
+  const [maestroSelection, setMaestroSelection] = useState('none');
   const [microphonePermission, setMicrophonePermission] = useState('checking');
   const [lastPushBroadcast, setLastPushBroadcast] = useState('none');
   const [sheetVisible, setSheetVisible] = useState(false);
@@ -158,6 +159,27 @@ export function AutomationLabScreen(props: {
           onPress={() => setSheetVisible(true)}
           testID="automation-open-sheet"
         />
+      </SectionCard>
+
+      <SectionCard
+        subtitle="The first duplicate is inert; the second duplicate is clickable."
+        title="Maestro clickable ordering"
+      >
+        <View style={styles.maestroTarget} testID="maestro-clickable-first-target">
+          <Text style={styles.maestroTargetLabel}>Inert duplicate target</Text>
+        </View>
+        <Pressable
+          accessibilityLabel="Clickable duplicate target"
+          accessibilityRole="button"
+          onPress={() => setMaestroSelection('clickable')}
+          style={({ pressed }) => [styles.maestroTarget, pressed ? styles.pressed : null]}
+          testID="maestro-clickable-first-target"
+        >
+          <Text style={styles.maestroTargetLabel}>Clickable duplicate target</Text>
+        </Pressable>
+        <Text style={styles.value} testID="maestro-clickable-first-result">
+          Maestro selection: {maestroSelection}
+        </Text>
       </SectionCard>
 
       <SectionCard title="Input canaries">
@@ -282,6 +304,19 @@ function createStyles(colors: AppColors) {
       borderWidth: StyleSheet.hairlineWidth,
       paddingHorizontal: 16,
       paddingVertical: 16,
+    },
+    maestroTarget: {
+      alignItems: 'center',
+      borderColor: colors.lineStrong,
+      borderRadius: 4,
+      borderWidth: StyleSheet.hairlineWidth,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+    },
+    maestroTargetLabel: {
+      color: colors.text,
+      fontSize: 15,
+      fontWeight: '700',
     },
     pressed: {
       opacity: 0.8,

--- a/packages/contracts/src/facades/capture.ts
+++ b/packages/contracts/src/facades/capture.ts
@@ -52,5 +52,11 @@ export type {
   FindLocator,
   ScreenshotResultData,
 } from '../snapshot-types.ts';
+export {
+  attachSnapshotClickabilityEvidence,
+  copySnapshotClickabilityEvidence,
+  readSnapshotClickabilityEvidence,
+} from '../snapshot-clickability.ts';
+export type { SnapshotClickabilityEvidence } from '../snapshot-clickability.ts';
 export { readViewportDimensions } from '../viewport.ts';
 export type { ViewportCommandResult } from '../viewport.ts';

--- a/packages/contracts/src/snapshot-clickability.test.ts
+++ b/packages/contracts/src/snapshot-clickability.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  attachSnapshotClickabilityEvidence,
+  copySnapshotClickabilityEvidence,
+  readSnapshotClickabilityEvidence,
+} from './snapshot-clickability.ts';
+
+test('retains exact evidence without adding enumerable snapshot or node fields', () => {
+  const node = { index: 0, identifier: 'save' };
+  const snapshot = { createdAt: 0, nodes: [node] };
+  const evidence = {
+    kind: 'exact' as const,
+    provider: 'android-helper' as const,
+    clickableByNodeIndex: new Map<number, boolean | undefined>([[0, true]]),
+  };
+
+  attachSnapshotClickabilityEvidence(snapshot, evidence);
+
+  assert.deepEqual(readSnapshotClickabilityEvidence(snapshot), evidence);
+  assert.deepEqual(Object.keys(node), ['index', 'identifier']);
+  assert.equal(JSON.stringify(snapshot).includes('clickable'), false);
+});
+
+test('copies evidence across internal snapshot construction without serializing the sidecar', () => {
+  const source = {};
+  const target = { nodes: [] };
+  const evidence = {
+    kind: 'divergence' as const,
+    provider: 'apple-xctest' as const,
+    reason: 'maestro-clickable-not-exposed-by-provider' as const,
+  };
+
+  attachSnapshotClickabilityEvidence(source, evidence);
+  copySnapshotClickabilityEvidence(source, target);
+
+  assert.deepEqual(readSnapshotClickabilityEvidence(target), evidence);
+  assert.deepEqual(JSON.parse(JSON.stringify(target)), { nodes: [] });
+});

--- a/packages/contracts/src/snapshot-clickability.ts
+++ b/packages/contracts/src/snapshot-clickability.ts
@@ -1,0 +1,40 @@
+/**
+ * Capture-local clickability facts for consumers that reproduce Maestro's private
+ * TreeNode semantics. This is deliberately kept outside SnapshotNode: the fact
+ * is retained by object identity, never serialized into the snapshot contract.
+ */
+export type SnapshotClickabilityEvidence =
+  | {
+      kind: 'exact';
+      provider: 'android-helper';
+      clickableByNodeIndex: ReadonlyMap<number, boolean | undefined>;
+    }
+  | {
+      kind: 'divergence';
+      provider: 'apple-xctest';
+      reason: 'maestro-clickable-not-exposed-by-provider';
+    };
+
+const evidenceBySnapshotObject = new WeakMap<object, SnapshotClickabilityEvidence>();
+
+export function attachSnapshotClickabilityEvidence<T extends object>(
+  owner: T,
+  evidence: SnapshotClickabilityEvidence,
+): T {
+  evidenceBySnapshotObject.set(owner, evidence);
+  return owner;
+}
+
+export function readSnapshotClickabilityEvidence(
+  owner: object | null | undefined,
+): SnapshotClickabilityEvidence | undefined {
+  return owner ? evidenceBySnapshotObject.get(owner) : undefined;
+}
+
+export function copySnapshotClickabilityEvidence<T extends object>(
+  source: object | null | undefined,
+  target: T,
+): T {
+  const evidence = readSnapshotClickabilityEvidence(source);
+  return evidence ? attachSnapshotClickabilityEvidence(target, evidence) : target;
+}

--- a/packages/maestro/src/internal/__tests__/runtime-target-ranking.test.ts
+++ b/packages/maestro/src/internal/__tests__/runtime-target-ranking.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { attachSnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
 import {
   rankMaestroCandidates,
   selectMaestroSnapshotMatch,
@@ -15,6 +16,94 @@ test('typed target matching preserves snapshot read order', () => {
   expect(
     rankMaestroCandidates(snapshot, { text: 'Save' }, 'ios').matches.map((node) => node.index),
   ).toEqual([1, 2]);
+});
+
+test('supported Android evidence applies stable clickableFirst ordering across all groups', () => {
+  const snapshot = attachSnapshotClickabilityEvidence(
+    makeSnapshot([
+      { index: 0, identifier: 'candidate', rect: { x: 0, y: 0, width: 20, height: 20 } },
+      { index: 1, identifier: 'candidate', rect: { x: 0, y: 20, width: 20, height: 20 } },
+      { index: 2, identifier: 'candidate', rect: { x: 0, y: 40, width: 20, height: 20 } },
+      { index: 3, identifier: 'candidate', rect: { x: 0, y: 60, width: 20, height: 20 } },
+      { index: 4, identifier: 'candidate', rect: { x: 0, y: 80, width: 20, height: 20 } },
+    ]),
+    {
+      kind: 'exact',
+      provider: 'android-helper',
+      clickableByNodeIndex: new Map([
+        [0, false],
+        [1, true],
+        [2, undefined],
+        [3, true],
+        [4, false],
+      ]),
+    },
+  );
+
+  const ranked = rankMaestroCandidates(snapshot, { id: 'candidate' }, 'android');
+
+  expect(ranked.matches.map((node) => node.index)).toEqual([0, 1, 2, 3, 4]);
+  expect(ranked.ranked.map((node) => node.index)).toEqual([1, 3, 0, 4, 2]);
+  expect(ranked.clickability).toMatchObject({ kind: 'exact', provider: 'android-helper' });
+});
+
+test('authored index bypasses clickableFirst and keeps y/x ordering', () => {
+  const snapshot = attachSnapshotClickabilityEvidence(
+    makeSnapshot([
+      {
+        index: 0,
+        identifier: 'candidate',
+        rect: { x: 0, y: 200, width: 20, height: 20 },
+      },
+      {
+        index: 1,
+        identifier: 'candidate',
+        rect: { x: 10, y: 20, width: 20, height: 20 },
+      },
+    ]),
+    {
+      kind: 'exact',
+      provider: 'android-helper',
+      clickableByNodeIndex: new Map([
+        [0, true],
+        [1, false],
+      ]),
+    },
+  );
+
+  const ranked = rankMaestroCandidates(snapshot, { id: 'candidate', index: 0 }, 'android');
+  const resolution = selectMaestroSnapshotMatch(ranked.ranked, 0);
+
+  expect(ranked.ranked.map((node) => node.index)).toEqual([0, 1]);
+  expect(resolution).toMatchObject({ node: { index: 1 } });
+});
+
+test('unsupported iOS evidence is classified and never inferred from hittable or type', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 0,
+      identifier: 'candidate',
+      type: 'Button',
+      hittable: false,
+      rect: { x: 0, y: 0, width: 20, height: 20 },
+    },
+    {
+      index: 1,
+      identifier: 'candidate',
+      type: 'StaticText',
+      hittable: true,
+      rect: { x: 0, y: 20, width: 20, height: 20 },
+    },
+  ]);
+
+  const ranked = rankMaestroCandidates(snapshot, { id: 'candidate' }, 'ios');
+
+  expect(ranked.ranked.map((node) => node.index)).toEqual([0, 1]);
+  expect(ranked.clickability).toEqual({
+    kind: 'divergence',
+    provider: 'apple-xctest',
+    reason: 'maestro-clickable-not-exposed-by-provider',
+  });
 });
 
 test('target selection preserves snapshot aggregate order when no index is authored', () => {

--- a/packages/maestro/src/internal/runtime-clickability.ts
+++ b/packages/maestro/src/internal/runtime-clickability.ts
@@ -1,0 +1,83 @@
+import { readSnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
+import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
+
+type MaestroClickabilityPlatform = 'android' | 'ios';
+
+type MaestroClickabilityProviderDeclaration =
+  | { kind: 'exact'; provider: 'android-helper' }
+  | {
+      kind: 'divergence';
+      provider: 'apple-xctest';
+      reason: 'maestro-clickable-not-exposed-by-provider';
+    };
+
+/** The admitted Maestro providers and the evidence contract each one owns. */
+const MAESTRO_CLICKABILITY_PROVIDER_REGISTRY = {
+  android: { kind: 'exact', provider: 'android-helper' },
+  ios: {
+    kind: 'divergence',
+    provider: 'apple-xctest',
+    reason: 'maestro-clickable-not-exposed-by-provider',
+  },
+} as const satisfies Record<MaestroClickabilityPlatform, MaestroClickabilityProviderDeclaration>;
+
+export type MaestroClickabilityDecision =
+  | {
+      kind: 'exact';
+      provider: 'android-helper';
+      clickableByNodeIndex: ReadonlyMap<number, boolean | undefined>;
+    }
+  | {
+      kind: 'divergence';
+      provider: 'android-helper' | 'apple-xctest';
+      reason:
+        | 'exact-evidence-not-retained'
+        | 'maestro-clickable-not-exposed-by-provider'
+        | 'unregistered-provider-evidence';
+    };
+
+/** Resolve provider evidence once per selector operation; missing exact evidence is explicit. */
+export function resolveMaestroClickability(
+  snapshot: SnapshotState,
+  platform: MaestroClickabilityPlatform,
+): MaestroClickabilityDecision {
+  const declaration = MAESTRO_CLICKABILITY_PROVIDER_REGISTRY[platform];
+  if (declaration.kind === 'divergence') return declaration;
+
+  const evidence = readSnapshotClickabilityEvidence(snapshot);
+  if (!evidence) {
+    return {
+      kind: 'divergence',
+      provider: declaration.provider,
+      reason: 'exact-evidence-not-retained',
+    };
+  }
+  if (evidence.kind !== 'exact' || evidence.provider !== declaration.provider) {
+    return {
+      kind: 'divergence',
+      provider: declaration.provider,
+      reason: 'unregistered-provider-evidence',
+    };
+  }
+  return evidence;
+}
+
+/** Apply pinned `Filters.clickableFirst()` ordering, preserving stable equal groups. */
+export function orderMaestroClickableFirst(
+  matches: readonly SnapshotNode[],
+  decision: MaestroClickabilityDecision,
+): SnapshotNode[] {
+  if (decision.kind !== 'exact') return [...matches];
+  return matches
+    .map((node, order) => ({
+      node,
+      order,
+      rank: clickableRank(decision.clickableByNodeIndex.get(node.index)),
+    }))
+    .sort((left, right) => right.rank - left.rank || left.order - right.order)
+    .map(({ node }) => node);
+}
+
+function clickableRank(value: boolean | undefined): number {
+  return value === true ? 2 : value === false ? 1 : 0;
+}

--- a/packages/maestro/src/internal/runtime-port-geometry.ts
+++ b/packages/maestro/src/internal/runtime-port-geometry.ts
@@ -84,7 +84,7 @@ function selectMaestroScrollableViewport(
   const candidateByIndex = new Map(
     candidates.map((candidate) => [candidate.node.index, candidate]),
   );
-  for (const target of selectMaestroSnapshotMatches(snapshot, selector)) {
+  for (const target of selectMaestroSnapshotMatches(snapshot, selector, platform)) {
     const container = findScrollContainer(target, byIndex);
     const candidate = container ? candidateByIndex.get(container.index) : undefined;
     if (candidate) return candidate.viewport;

--- a/packages/maestro/src/internal/runtime-selector-resolution.ts
+++ b/packages/maestro/src/internal/runtime-selector-resolution.ts
@@ -12,7 +12,7 @@ import { matchesMaestroTypedSelector } from './runtime-target-policy.ts';
 export type MaestroSelectorResolution = {
   /** Relation-composed matches in snapshot order, before this selector's own index. */
   readonly matches: SnapshotNode[];
-  /** Matches after applying this selector's own y/x-ordered index. */
+  /** Matches after applying this selector's own index or no-index ordering policy. */
   readonly indexed: SnapshotNode[];
 };
 
@@ -20,6 +20,10 @@ export type MaestroResolutionProbe = {
   onNodeMapBuilt?: () => void;
   onSelectorComputed?: (selector: MaestroSelector) => void;
   onPositionComputed?: (relation: MaestroPositionRelation, anchor: MaestroSelector) => void;
+};
+
+export type MaestroResolutionOptions = {
+  orderUnindexed?: (matches: readonly SnapshotNode[]) => SnapshotNode[];
 };
 
 export type MaestroSnapshotResolver = {
@@ -37,6 +41,7 @@ type MaestroPositionResolution = {
 export function createMaestroSnapshotResolver(
   snapshot: SnapshotState,
   probe: MaestroResolutionProbe = {},
+  options: MaestroResolutionOptions = {},
 ): MaestroSnapshotResolver {
   const nodeByIndex = buildSnapshotNodeMap(snapshot.nodes);
   probe.onNodeMapBuilt?.();
@@ -117,7 +122,7 @@ export function createMaestroSnapshotResolver(
       );
       const resolution = {
         matches,
-        indexed: selectMaestroIndexedMatches(matches, selector.index),
+        indexed: selectMaestroIndexedMatches(matches, selector.index, options.orderUnindexed),
       };
       selectorCache.set(selector, resolution);
       return resolution;
@@ -216,8 +221,9 @@ function positionalSelectors(
 function selectMaestroIndexedMatches(
   matches: readonly SnapshotNode[],
   index: number | string | undefined,
+  orderUnindexed: MaestroResolutionOptions['orderUnindexed'],
 ): SnapshotNode[] {
-  if (index === undefined) return [...matches];
+  if (index === undefined) return orderUnindexed ? orderUnindexed(matches) : [...matches];
   const selected = sortMaestroMatchesForIndex(matches)[resolveMaestroSelectorIndex(index)];
   return selected ? [selected] : [];
 }

--- a/packages/maestro/src/internal/runtime-target-ranking.ts
+++ b/packages/maestro/src/internal/runtime-target-ranking.ts
@@ -11,12 +11,18 @@ import {
 } from './runtime-selector-resolution.ts';
 import { type MaestroPositionRelation } from './runtime-target-position.ts';
 import { filterVisibleMaestroMatches, type MaestroPlatform } from './runtime-target-policy.ts';
+import {
+  orderMaestroClickableFirst,
+  resolveMaestroClickability,
+  type MaestroClickabilityDecision,
+} from './runtime-clickability.ts';
 
 export type MaestroRankedCandidates = {
   readonly matches: SnapshotNode[];
   readonly visible: SnapshotNode[];
   readonly ranked: SnapshotNode[];
   readonly parentMatched: boolean;
+  readonly clickability: MaestroClickabilityDecision;
 };
 
 export type MaestroCandidateMatches = Pick<MaestroRankedCandidates, 'matches' | 'parentMatched'>;
@@ -26,7 +32,8 @@ export function rankMaestroCandidates(
   selector: MaestroSelector,
   platform: MaestroPlatform,
 ): MaestroRankedCandidates {
-  const resolver = createMaestroSnapshotResolver(snapshot);
+  const clickability = resolveMaestroClickability(snapshot, platform);
+  const resolver = createMaestroResolver(snapshot, clickability);
   const scoped = matchMaestroCandidatesWithResolver(selector, resolver);
   const visible = filterVisibleMaestroMatches({
     nodes: snapshot.nodes,
@@ -36,12 +43,14 @@ export function rankMaestroCandidates(
   return {
     ...scoped,
     visible,
+    clickability,
     ranked: rankVisibleMaestroMatches(
       snapshot.nodes,
       visible,
       selector,
       platform,
       resolver.nodeByIndex,
+      clickability,
     ),
   };
 }
@@ -59,43 +68,67 @@ export function matchMaestroCandidatesWithResolver(
 export function selectMaestroSnapshotMatches(
   snapshot: SnapshotState,
   selector: MaestroSelector,
+  platform?: MaestroPlatform,
 ): SnapshotNode[] {
-  return createMaestroSnapshotResolver(snapshot).resolve(selector).indexed;
+  const clickability = platform ? resolveMaestroClickability(snapshot, platform) : undefined;
+  return createMaestroResolver(snapshot, clickability).resolve(selector).indexed;
 }
 
 export function selectMaestroPositionMatches(
   snapshot: SnapshotState,
   relation: MaestroPositionRelation,
   anchor: MaestroSelector,
+  platform?: MaestroPlatform,
 ): SnapshotNode[] {
-  return createMaestroSnapshotResolver(snapshot).resolvePosition(relation, anchor);
+  const clickability = platform ? resolveMaestroClickability(snapshot, platform) : undefined;
+  return createMaestroResolver(snapshot, clickability).resolvePosition(relation, anchor);
 }
+
+function createMaestroResolver(
+  snapshot: SnapshotState,
+  clickability: MaestroClickabilityDecision | undefined,
+): MaestroSnapshotResolver {
+  return createMaestroSnapshotResolver(
+    snapshot,
+    {},
+    clickability
+      ? { orderUnindexed: (matches) => orderMaestroClickableFirst(matches, clickability) }
+      : {},
+  );
+}
+
 export function rankVisibleMaestroMatches(
   nodes: SnapshotNode[],
   matches: SnapshotNode[],
   selector: MaestroSelector,
   platform: MaestroPlatform,
   nodeByIndex: ReadonlyMap<number, SnapshotNode> = buildSnapshotNodeMap(nodes),
+  clickability?: MaestroClickabilityDecision,
 ): SnapshotNode[] {
-  if (platform !== 'ios' || !hasTextualSelector(selector)) return matches;
-  return matches.filter((candidate) => {
-    if (isInteractiveControl(candidate)) return true;
-    const equivalentMatches = matches.filter(
-      (other) => other !== candidate && haveSameSelectorIdentity(candidate, other, selector),
-    );
-    if (
-      equivalentMatches.some(
-        (other) =>
-          isInteractiveControl(other) &&
-          isDescendantOfSnapshotNode(nodes, candidate, other, nodeByIndex),
-      )
-    ) {
-      return false;
-    }
-    return !equivalentMatches.some((other) =>
-      isDescendantOfSnapshotNode(nodes, other, candidate, nodeByIndex),
-    );
-  });
+  const ranked =
+    platform !== 'ios' || !hasTextualSelector(selector)
+      ? matches
+      : matches.filter((candidate) => {
+          if (isInteractiveControl(candidate)) return true;
+          const equivalentMatches = matches.filter(
+            (other) => other !== candidate && haveSameSelectorIdentity(candidate, other, selector),
+          );
+          if (
+            equivalentMatches.some(
+              (other) =>
+                isInteractiveControl(other) &&
+                isDescendantOfSnapshotNode(nodes, candidate, other, nodeByIndex),
+            )
+          ) {
+            return false;
+          }
+          return !equivalentMatches.some((other) =>
+            isDescendantOfSnapshotNode(nodes, other, candidate, nodeByIndex),
+          );
+        });
+  return selector.index === undefined && clickability
+    ? orderMaestroClickableFirst(ranked, clickability)
+    : ranked;
 }
 
 export function selectMaestroSnapshotMatch(

--- a/packages/maestro/src/internal/runtime-targets.ts
+++ b/packages/maestro/src/internal/runtime-targets.ts
@@ -15,6 +15,7 @@ import { pointInsideRect, stripUndefined } from './shared.ts';
 import { isMaestroNodeVisible } from './snapshot-policy.ts';
 import { buildSnapshotNodeMap } from '@agent-device/contracts/snapshot';
 import { hasMaestroRecursiveRelations as hasRecursiveRelations } from './selector-relations.ts';
+import { orderMaestroClickableFirst, resolveMaestroClickability } from './runtime-clickability.ts';
 
 export type MaestroTargetQuery = {
   selector: MaestroSelector;
@@ -134,18 +135,25 @@ function rankPresentedMaestroCandidates(
   query: MaestroTargetQuery,
   presentedNodes: ReturnType<typeof createPresentedNodeLookup>,
 ): MaestroRankedCandidates {
-  const resolver = createMaestroSnapshotResolver(snapshot);
+  const clickability = resolveMaestroClickability(snapshot, 'ios');
+  const resolver = createMaestroSnapshotResolver(
+    snapshot,
+    {},
+    { orderUnindexed: (matches) => orderMaestroClickableFirst(matches, clickability) },
+  );
   const scoped = matchMaestroCandidatesWithResolver(query.selector, resolver);
   const visible = scoped.matches.filter(presentedNodes.isVisible);
   return {
     ...scoped,
     visible,
+    clickability,
     ranked: rankVisibleMaestroMatches(
       snapshot.nodes,
       visible,
       query.selector,
       'ios',
       resolver.nodeByIndex,
+      clickability,
     ),
   };
 }

--- a/packages/maestro/test/conformance/layer2-tree.ts
+++ b/packages/maestro/test/conformance/layer2-tree.ts
@@ -1,4 +1,5 @@
 import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
+import { attachSnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
 import type { MaestroSelector } from '../../src/internal/program-ir.ts';
 import { resolveMaestroTargetFromSnapshot } from '../../src/internal/runtime-targets.ts';
 import {
@@ -16,11 +17,13 @@ export type Layer2TreeVector = {
     identifier: string;
     label: string | null;
     rect: { x: number; y: number; width: number; height: number } | null;
+    clickable?: boolean;
   }>;
   matches: string[];
   selected?: string;
   intermediateRelation?: 'below' | 'above' | 'leftOf' | 'rightOf';
   intermediate?: string[];
+  clickableFirstMatches?: string[];
 };
 
 export type Layer2TreeResult = {
@@ -34,6 +37,7 @@ export function checkLayer2TreeVector(vector: Layer2TreeVector): Layer2TreeResul
   const snapshot = snapshotFromTreeVector(vector);
   const ranked = rankMaestroCandidates(snapshot, vector.selector, 'android');
   const actualMatches = ranked.matches.map((node) => vector.nodes[node.index]?.key ?? '');
+  const actualOrderedMatches = ranked.ranked.map((node) => vector.nodes[node.index]?.key ?? '');
   const resolution = resolveMaestroTargetFromSnapshot(
     snapshot,
     { selector: vector.selector },
@@ -53,6 +57,8 @@ export function checkLayer2TreeVector(vector: Layer2TreeVector): Layer2TreeResul
     agent: actualMatches.length,
     status:
       JSON.stringify(actualMatches) === JSON.stringify(vector.matches) &&
+      (vector.clickableFirstMatches === undefined ||
+        JSON.stringify(actualOrderedMatches) === JSON.stringify(vector.clickableFirstMatches)) &&
       JSON.stringify(actualSelected) === JSON.stringify(expectedSelected) &&
       JSON.stringify(actualIntermediate) === JSON.stringify(vector.intermediate)
         ? 'match'
@@ -73,5 +79,13 @@ function snapshotFromTreeVector(vector: Layer2TreeVector): SnapshotState {
       ...(node.rect ? { rect: node.rect } : {}),
     };
   });
-  return { createdAt: 0, nodes };
+  const snapshot = { createdAt: 0, nodes };
+  const hasClickabilityEvidence = vector.nodes.some((node) => 'clickable' in node);
+  return hasClickabilityEvidence
+    ? attachSnapshotClickabilityEvidence(snapshot, {
+        kind: 'exact',
+        provider: 'android-helper',
+        clickableByNodeIndex: new Map(vector.nodes.map((node, index) => [index, node.clickable])),
+      })
+    : snapshot;
 }

--- a/scripts/maestro-conformance/fixtures/layer2-semantics.json
+++ b/scripts/maestro-conformance/fixtures/layer2-semantics.json
@@ -291,6 +291,112 @@
       "selected": "complete-card"
     },
     {
+      "id": "clickable-first-tristate-stable",
+      "operation": "compose(intersect(id=candidate), clickableFirst()) preserves true/false/absent groups",
+      "selector": {
+        "id": "candidate"
+      },
+      "nodes": [
+        {
+          "key": "false-first",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": false
+        },
+        {
+          "key": "true-first",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": true
+        },
+        {
+          "key": "absent",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 30
+          }
+        },
+        {
+          "key": "true-second",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": true
+        },
+        {
+          "key": "false-second",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": false
+        }
+      ],
+      "matches": ["false-first", "true-first", "absent", "true-second", "false-second"],
+      "selected": "true-first",
+      "clickableFirstMatches": [
+        "true-first",
+        "true-second",
+        "false-first",
+        "false-second",
+        "absent"
+      ]
+    },
+    {
+      "id": "clickable-first-index-bypass",
+      "operation": "compose(intersect(id=candidate), index=0) keeps y/x ordering and bypasses clickableFirst",
+      "selector": {
+        "id": "candidate",
+        "index": 0
+      },
+      "nodes": [
+        {
+          "key": "clickable-later",
+          "identifier": "candidate",
+          "rect": {
+            "x": 0,
+            "y": 200,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": true
+        },
+        {
+          "key": "nonclickable-top",
+          "identifier": "candidate",
+          "rect": {
+            "x": 10,
+            "y": 20,
+            "width": 40,
+            "height": 30
+          },
+          "clickable": false
+        }
+      ],
+      "matches": ["clickable-later", "nonclickable-top"],
+      "selected": "nonclickable-top"
+    },
+    {
       "id": "nested-tree-relations",
       "operation": "intersect(id=card, containsChild(intersect(id=panel, containsChild(id=title), containsDescendants(id=icon))))",
       "selector": {
@@ -1037,5 +1143,5 @@
       "selected": "card"
     }
   ],
-  "contentHash": "6c2fdcdab374ca1ca26d2d7932adff911561ad2c8f9daa2f84eabfe9b0643638"
+  "contentHash": "7061897332fd8ae7c6af126af620dfaf875ebfaa3c3f13df87dee638c4c41bb7"
 }

--- a/scripts/maestro-conformance/jvm-harness/src/main/kotlin/dev/agentdevice/conformance/Layer2TreeVectors.kt
+++ b/scripts/maestro-conformance/jvm-harness/src/main/kotlin/dev/agentdevice/conformance/Layer2TreeVectors.kt
@@ -28,6 +28,7 @@ private data class FixtureNode(
     val identifier: String,
     val label: String?,
     val rect: FixtureRect?,
+    val clickable: Boolean?,
 )
 
 private data class FixtureRect(
@@ -46,6 +47,7 @@ private data class TreeVector(
     val selected: String?,
     val intermediateRelation: String? = null,
     val intermediate: List<String>? = null,
+    val clickableFirstMatches: List<String>? = null,
 )
 
 private data class NodeSpec(
@@ -58,6 +60,7 @@ private data class NodeSpec(
     val hasBounds: Boolean = true,
     val width: Int = 40,
     val height: Int = 30,
+    val clickable: Boolean? = null,
 )
 
 /** Emit vectors from the pinned Filters implementation, never hand-written answers. */
@@ -73,6 +76,9 @@ fun emitTreeVectors(target: ArrayNode) {
         vector.intermediateRelation?.let { node.put("intermediateRelation", it) }
         vector.intermediate?.let { values ->
             node.putArray("intermediate").also { values.forEach(it::add) }
+        }
+        vector.clickableFirstMatches?.let { values ->
+            node.putArray("clickableFirstMatches").also { values.forEach(it::add) }
         }
     }
 }
@@ -130,6 +136,31 @@ private val TREE_VECTORS: List<TreeVector> = listOf(
         ),
         TreeSelector(id = "card", containsDescendants = listOf(TreeSelector(id = "title"), TreeSelector(text = "Badge"))),
         intersect(id("card"), descendants(id("title"), text("Badge"))),
+    ),
+    treeVector(
+        "clickable-first-tristate-stable",
+        "compose(intersect(id=candidate), clickableFirst()) preserves true/false/absent groups",
+        listOf(
+            node("false-first", resourceId = "candidate", clickable = false),
+            node("true-first", resourceId = "candidate", clickable = true),
+            node("absent", resourceId = "candidate"),
+            node("true-second", resourceId = "candidate", clickable = true),
+            node("false-second", resourceId = "candidate", clickable = false),
+        ),
+        TreeSelector(id = "candidate"),
+        id("candidate"),
+        emitClickableOrder = true,
+    ),
+    treeVector(
+        "clickable-first-index-bypass",
+        "compose(intersect(id=candidate), index=0) keeps y/x ordering and bypasses clickableFirst",
+        listOf(
+            node("clickable-later", resourceId = "candidate", x = 0, y = 200, clickable = true),
+            node("nonclickable-top", resourceId = "candidate", x = 10, y = 20, clickable = false),
+        ),
+        TreeSelector(id = "candidate", index = 0),
+        id("candidate"),
+        Filters.compose(id("candidate"), Filters.index(0)),
     ),
     treeVector(
         "nested-tree-relations",
@@ -357,23 +388,22 @@ private fun treeVector(
     selectionFilter: ElementFilter? = null,
     intermediateRelation: String? = null,
     intermediate: List<String>? = null,
+    emitClickableOrder: Boolean = false,
 ): TreeVector {
     val flattened = roots.flatMap { it.toTreeNode().aggregate() }
     val matches = filter(flattened).map { it.attributes.getValue("key") }
-    // RawSnapshotNode has no exact clickable field, so these fixtures leave
-    // TreeNode.clickable null rather than guessing from hittable. Maestro's
-    // clickableFirst therefore preserves fixture order for this Layer2 oracle.
     val finalSelectionFilter = selectionFilter ?: Filters.compose(filter, Filters.clickableFirst())
-    val selected = finalSelectionFilter(flattened).firstOrNull()?.attributes?.get("key")
+    val finalSelection = finalSelectionFilter(flattened).map { it.attributes.getValue("key") }
     return TreeVector(
         id,
         operation,
         selector,
         roots.flatMap { it.toFixtureNodes() },
         matches,
-        selected,
+        finalSelection.firstOrNull(),
         intermediateRelation,
         intermediate,
+        if (emitClickableOrder) finalSelection else null,
     )
 }
 
@@ -400,15 +430,27 @@ private fun node(
     hasBounds: Boolean = true,
     width: Int = 40,
     height: Int = 30,
-): NodeSpec = NodeSpec(key, resourceId, x, y, text, children, hasBounds, width, height)
+    clickable: Boolean? = null,
+): NodeSpec = NodeSpec(key, resourceId, x, y, text, children, hasBounds, width, height, clickable)
 
 private fun NodeSpec.toTreeNode(): TreeNode {
     val attributes = mutableMapOf("key" to key, "resource-id" to resourceId)
     if (hasBounds) attributes["bounds"] = "[$x,$y][${x + width},${y + height}]"
     text?.let { attributes["text"] = it }
-    return TreeNode(attributes = attributes, children = children.map { it.toTreeNode() })
+    return TreeNode(
+        attributes = attributes,
+        children = children.map { it.toTreeNode() },
+        clickable = clickable,
+    )
 }
 
 private fun NodeSpec.toFixtureNodes(parentKey: String? = null): List<FixtureNode> = listOf(
-    FixtureNode(key, parentKey, resourceId, text, if (hasBounds) FixtureRect(x, y, width, height) else null),
+    FixtureNode(
+        key,
+        parentKey,
+        resourceId,
+        text,
+        if (hasBounds) FixtureRect(x, y, width, height) else null,
+        clickable,
+    ),
 ) + children.flatMap { it.toFixtureNodes(key) }

--- a/src/commands/capture/runtime/snapshot.ts
+++ b/src/commands/capture/runtime/snapshot.ts
@@ -1,4 +1,5 @@
 import {
+  copySnapshotClickabilityEvidence,
   publicSnapshotCaptureAnnotations,
   snapshotCaptureAnnotationsFrom,
   type DiffSnapshotCommandResult,
@@ -67,7 +68,7 @@ export const snapshotCommand: RuntimeCommand<
     },
   });
   await runtime.sessions.set(nextSnapshotSession(options.session, capture));
-  return {
+  return copySnapshotClickabilityEvidence(capture.snapshot, {
     nodes: capture.snapshot.nodes,
     truncated: capture.snapshot.truncated ?? false,
     visibility: buildSnapshotVisibility({
@@ -84,7 +85,7 @@ export const snapshotCommand: RuntimeCommand<
       ? { snapshotDiagnostics: capture.result.snapshotDiagnostics }
       : {}),
     ...snapshotAppFields(capture),
-  };
+  });
 };
 
 export const diffSnapshotCommand: RuntimeCommand<
@@ -154,9 +155,10 @@ async function captureRuntimeSnapshot(
       customActions: options.customActions,
     },
   );
-  const snapshot = ensureSnapshotPresentationKey(
-    normalizeBackendSnapshot(result, runtime),
-    options,
+  const normalizedSnapshot = normalizeBackendSnapshot(result, runtime);
+  const snapshot = copySnapshotClickabilityEvidence(
+    normalizedSnapshot,
+    ensureSnapshotPresentationKey(normalizedSnapshot, options),
   );
   const annotations = snapshotCaptureAnnotationsFrom(result);
   const warningTime = now(runtime);

--- a/src/core/interactors/android.test.ts
+++ b/src/core/interactors/android.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import {
+  attachSnapshotClickabilityEvidence,
+  readSnapshotClickabilityEvidence,
+} from '@agent-device/contracts/capture';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { createAndroidInteractor } from './android.ts';
+import { snapshotAndroid } from '../../platforms/android/snapshot.ts';
+
+vi.mock('../../platforms/android/snapshot.ts', () => ({
+  snapshotAndroid: vi.fn(),
+}));
+
+const snapshotAndroidMock = vi.mocked(snapshotAndroid);
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test('preserves Android clickability evidence through the interactor snapshot adapter', async () => {
+  const captured = {
+    nodes: [{ index: 0, identifier: 'target', rect: { x: 0, y: 0, width: 20, height: 20 } }],
+    analysis: { rawNodeCount: 1, maxDepth: 0 },
+    androidSnapshot: { backend: 'android-helper' as const },
+  };
+  const evidence = {
+    kind: 'exact' as const,
+    provider: 'android-helper' as const,
+    clickableByNodeIndex: new Map<number, boolean | undefined>([[0, true]]),
+  };
+  attachSnapshotClickabilityEvidence(captured, evidence);
+  snapshotAndroidMock.mockResolvedValue(captured);
+
+  const result = await createAndroidInteractor(device).snapshot({});
+
+  expect(readSnapshotClickabilityEvidence(result)).toEqual(evidence);
+  expect(JSON.stringify(result)).not.toContain('clickable');
+});

--- a/src/core/interactors/android.ts
+++ b/src/core/interactors/android.ts
@@ -35,7 +35,10 @@ import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { withMethodScope } from '../../utils/method-scope.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { Interactor, RunnerContext } from '@agent-device/contracts/interaction';
-import { snapshotCaptureAnnotationsFrom } from '@agent-device/contracts/capture';
+import {
+  copySnapshotClickabilityEvidence,
+  snapshotCaptureAnnotationsFrom,
+} from '@agent-device/contracts/capture';
 
 export function createAndroidInteractor(
   device: DeviceInfo,
@@ -89,12 +92,12 @@ export function createAndroidInteractor(
           }),
         { backend: 'android' },
       );
-      return {
+      return copySnapshotClickabilityEvidence(result, {
         nodes: result.nodes ?? [],
         truncated: result.truncated ?? false,
         backend: 'android',
         ...snapshotCaptureAnnotationsFrom(result),
-      };
+      });
     },
     back: (_mode) => backAndroid(device),
     home: () => homeAndroid(device),

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-snapshot-source.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-snapshot-source.test.ts
@@ -1,8 +1,40 @@
 import { expect, test } from 'vitest';
+import {
+  attachSnapshotClickabilityEvidence,
+  readSnapshotClickabilityEvidence,
+} from '@agent-device/contracts/capture';
 import type { DaemonRequest } from '../../../types.ts';
 import { MAESTRO_OBSERVATION_POLL_MS } from '../daemon-runtime-port-observation.ts';
 import { createDaemonMaestroSnapshotSource } from '../daemon-runtime-port-snapshot-source.ts';
 import { makeBaseRequest, makeDependencies } from './daemon-runtime-port-fixtures.ts';
+
+test('carries clickability sidecar through one public snapshot capture without wire fields', async () => {
+  const requests: DaemonRequest[] = [];
+  const data = {
+    nodes: [{ index: 0, identifier: 'save', rect: { x: 0, y: 0, width: 20, height: 20 } }],
+  };
+  const evidence = {
+    kind: 'exact' as const,
+    provider: 'android-helper' as const,
+    clickableByNodeIndex: new Map<number, boolean | undefined>([[0, true]]),
+  };
+  attachSnapshotClickabilityEvidence(data, evidence);
+  const source = createDaemonMaestroSnapshotSource({
+    baseReq: makeBaseRequest({ flags: { platform: 'android', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      requests.push(request);
+      return { ok: true, data };
+    },
+    dependencies: makeDependencies(),
+    platform: 'android',
+  });
+
+  const snapshot = await source.capture({ generation: 0, env: {} });
+
+  expect(requests).toHaveLength(1);
+  expect(readSnapshotClickabilityEvidence(snapshot)).toEqual(evidence);
+  expect(JSON.stringify(snapshot)).not.toContain('clickable');
+});
 
 test('reuses bound observations and seeds a pending stability comparison', async () => {
   const requests: DaemonRequest[] = [];

--- a/src/daemon/adapters/maestro/daemon-runtime-port-snapshot-source.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-snapshot-source.ts
@@ -1,5 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';
+import { copySnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
 import {
   MAESTRO_RUNTIME_ADAPTER_POLICY,
   type MaestroObservationIdentity,
@@ -35,7 +36,7 @@ export function createDaemonMaestroSnapshotSource(
     if (!data || !Array.isArray(data.nodes)) {
       throw new AppError('COMMAND_FAILED', 'Maestro snapshot did not return node data.');
     }
-    const snapshot = data as SnapshotState;
+    const snapshot = copySnapshotClickabilityEvidence(data, data as SnapshotState);
     cached = { generation: context.generation, snapshot };
     return snapshot;
   };

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -1,5 +1,6 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import {
+  copySnapshotClickabilityEvidence,
   recordSnapshotTiming,
   snapshotCaptureAnnotationsFrom,
   type SnapshotCaptureAnnotations,
@@ -129,7 +130,10 @@ async function captureSnapshotAttempt(params: CaptureSnapshotParams): Promise<Sn
     platform: publicPlatformString(params.device),
   });
   const annotations = snapshotCaptureAnnotationsFrom(data);
-  const snapshot = buildSnapshotState(data, resolveSnapshotStateFlags(params));
+  const snapshot = copySnapshotClickabilityEvidence(
+    data,
+    buildSnapshotState(data, resolveSnapshotStateFlags(params)),
+  );
   // The one seam where snapshot state and capture annotations meet: consumers that only keep the
   // SnapshotState (selector-backed find/wait, session-stored snapshots) must still learn that the
   // capture is an occluding system surface, so the disclosure is not lost with the annotations.

--- a/src/daemon/snapshot-command-runtime.ts
+++ b/src/daemon/snapshot-command-runtime.ts
@@ -1,4 +1,5 @@
 import {
+  copySnapshotClickabilityEvidence,
   snapshotCaptureAnnotationsFrom,
   summarizeSnapshotDiagnostics,
   type SnapshotDiffSummary,
@@ -91,14 +92,15 @@ export async function dispatchSnapshotRuntimeCommand(
       sessionStore,
       result: result.record,
     });
+    const data = applyRecoveredWarningLatch({
+      session: sessionStore.get(sessionName),
+      data: result.data,
+      verdict: capturedQuality.value,
+      internalObservation: req.internal?.observationOnly === true,
+    });
     return {
       ok: true,
-      data: applyRecoveredWarningLatch({
-        session: sessionStore.get(sessionName),
-        data: result.data,
-        verdict: capturedQuality.value,
-        internalObservation: req.internal?.observationOnly === true,
-      }),
+      data: copySnapshotClickabilityEvidence(result.data, data),
     };
   });
 }

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,4 +1,5 @@
 import { stripAndroidSystemChromeProvenance } from '@agent-device/contracts/platform';
+import { copySnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
 import { dispatchSnapshotRuntimeCommand } from './snapshot-command-runtime.ts';
 import { captureSparseFallbackScreenshot } from './sparse-fallback-screenshot.ts';
 import type { SnapshotRuntimeRouteParams } from './snapshot-runtime-binding.ts';
@@ -30,8 +31,10 @@ export async function dispatchSnapshotViaRuntime(
         params.sessionStore.get(resolvedSessionName),
       );
       const publicNodes = stripAndroidSystemChromeProvenance(result.nodes);
-      const publicResult =
-        publicNodes === result.nodes ? result : { ...result, nodes: publicNodes };
+      const publicResult = copySnapshotClickabilityEvidence(
+        result,
+        publicNodes === result.nodes ? result : { ...result, nodes: publicNodes },
+      );
       const session = params.sessionStore.get(resolvedSessionName);
       const fallbackScreenshot = await captureSparseFallbackScreenshot({
         req: request,
@@ -42,15 +45,22 @@ export async function dispatchSnapshotViaRuntime(
         inspectFacts: params.inspectFacts,
         bindDevice: params.bindDevice,
       });
-      const published = fallbackScreenshot
-        ? {
-            ...publicResult,
-            fallbackScreenshotPath: fallbackScreenshot.path,
-            artifacts: [fallbackScreenshot.artifact],
-          }
-        : publicResult;
+      const published = copySnapshotClickabilityEvidence(
+        publicResult,
+        fallbackScreenshot
+          ? {
+              ...publicResult,
+              fallbackScreenshotPath: fallbackScreenshot.path,
+              artifacts: [fallbackScreenshot.artifact],
+            }
+          : publicResult,
+      );
+      const data =
+        refsGeneration === undefined
+          ? published
+          : copySnapshotClickabilityEvidence(published, { ...published, refsGeneration });
       return {
-        data: refsGeneration === undefined ? published : { ...published, refsGeneration },
+        data,
         record: {
           kind: 'snapshot',
           nodes: result.nodes.length,

--- a/src/platforms/android/__tests__/snapshot-clickability.test.ts
+++ b/src/platforms/android/__tests__/snapshot-clickability.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { afterEach, test, vi } from 'vitest';
+import {
+  readSnapshotClickabilityEvidence,
+  type SnapshotClickabilityEvidence,
+} from '@agent-device/contracts/capture';
+import { snapshotAndroid } from '../snapshot.ts';
+import { buildUiHierarchySnapshot, parseUiHierarchyTree } from '../ui-hierarchy.ts';
+import { buildAndroidSnapshotClickabilityEvidence } from '../snapshot-clickability.ts';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { AndroidAdbExecutor } from '../snapshot-helper.ts';
+import { ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT } from '../../../__tests__/test-utils/index.ts';
+import { resetAndroidSnapshotHelperInstallCache } from '../snapshot-helper-install.ts';
+import { resetAndroidSnapshotHelperSessions } from '../snapshot-helper-session.ts';
+
+vi.mock('../../../utils/exec.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/exec.ts')>();
+  return { ...actual, runCmd: vi.fn() };
+});
+vi.mock('../adb.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../adb.ts')>();
+  return { ...actual, sleep: vi.fn() };
+});
+
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+afterEach(() => {
+  resetAndroidSnapshotHelperInstallCache();
+  resetAndroidSnapshotHelperSessions();
+});
+
+test('retains Android helper clickable facts from the same hierarchy projection', () => {
+  const built = buildUiHierarchySnapshot(
+    parseUiHierarchyTree(`<hierarchy>
+      <node resource-id="true-node" bounds="[0,0][20,20]" clickable="true" />
+      <node resource-id="false-node" bounds="[0,20][20,40]" clickable="false" focusable="true" />
+      <node resource-id="absent-node" bounds="[0,40][20,60]" />
+    </hierarchy>`),
+    undefined,
+    { raw: true },
+  );
+  const evidence = buildAndroidSnapshotClickabilityEvidence(built);
+  const publicSnapshot = { nodes: built.nodes };
+  assert.equal(evidence.kind, 'exact');
+  if (evidence.kind !== 'exact') throw new Error('Android evidence must be exact');
+
+  assert.deepEqual(
+    [...evidence.clickableByNodeIndex.entries()],
+    [
+      [0, true],
+      [1, false],
+      [2, false],
+    ],
+  );
+  assert.equal(publicSnapshot.nodes[1]?.hittable, true);
+  assert.equal('clickable' in (publicSnapshot.nodes[1] ?? {}), false);
+  assert.equal(readSnapshotClickabilityEvidence(publicSnapshot), undefined);
+});
+
+test('snapshotAndroid captures the hierarchy once and retains clickability off-wire', async () => {
+  let hierarchyCaptures = 0;
+  const helperAdb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      return {
+        exitCode: 0,
+        stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode=13004',
+        stderr: '',
+      };
+    }
+    if (args[0] === 'shell' && args[1] === 'am' && args[2] === 'force-stop') {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (args[0] === 'install') {
+      return { exitCode: 0, stdout: 'Success', stderr: '' };
+    }
+    if (args.includes('instrument')) {
+      hierarchyCaptures += 1;
+      return { exitCode: 0, stdout: helperOutput(), stderr: '' };
+    }
+    throw new Error(`unexpected helper adb args: ${args.join(' ')}`);
+  };
+
+  const result = await snapshotAndroid(device, {
+    helperAdb,
+    helperArtifact: ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT,
+    raw: true,
+  });
+  const evidence = readSnapshotClickabilityEvidence(result);
+
+  assert.equal(hierarchyCaptures, 1);
+  assert.equal(evidence?.kind, 'exact');
+  assert.deepEqual(
+    [
+      ...(
+        evidence as Extract<SnapshotClickabilityEvidence, { kind: 'exact' }>
+      ).clickableByNodeIndex.values(),
+    ],
+    [false, true, false],
+  );
+  assert.equal(JSON.stringify(result).includes('clickable'), false);
+});
+
+function helperOutput(): string {
+  const xml = `<hierarchy>
+    <node class="android.widget.FrameLayout" bounds="[0,0][390,844]" clickable="false">
+      <node class="android.widget.Button" text="Save" bounds="[20,120][200,180]" clickable="true" />
+      <node class="android.widget.TextView" text="Read only" bounds="[20,200][200,260]" clickable="false" />
+    </node>
+  </hierarchy>`;
+  return [
+    'INSTRUMENTATION_STATUS: agentDeviceProtocol=android-snapshot-helper-v1',
+    'INSTRUMENTATION_STATUS: helperApiVersion=1',
+    'INSTRUMENTATION_STATUS: outputFormat=uiautomator-xml',
+    'INSTRUMENTATION_STATUS: chunkIndex=0',
+    'INSTRUMENTATION_STATUS: chunkCount=1',
+    `INSTRUMENTATION_STATUS: payloadBase64=${Buffer.from(xml, 'utf8').toString('base64')}`,
+    'INSTRUMENTATION_STATUS_CODE: 1',
+    'INSTRUMENTATION_RESULT: agentDeviceProtocol=android-snapshot-helper-v1',
+    'INSTRUMENTATION_RESULT: helperApiVersion=1',
+    'INSTRUMENTATION_RESULT: ok=true',
+    'INSTRUMENTATION_RESULT: outputFormat=uiautomator-xml',
+    'INSTRUMENTATION_RESULT: waitForIdleTimeoutMs=0',
+    'INSTRUMENTATION_RESULT: timeoutMs=8000',
+    'INSTRUMENTATION_RESULT: maxDepth=128',
+    'INSTRUMENTATION_RESULT: maxNodes=5000',
+    'INSTRUMENTATION_RESULT: rootPresent=true',
+    'INSTRUMENTATION_RESULT: captureMode=interactive-windows',
+    'INSTRUMENTATION_RESULT: windowCount=1',
+    'INSTRUMENTATION_RESULT: nodeCount=3',
+    'INSTRUMENTATION_RESULT: truncated=false',
+    'INSTRUMENTATION_RESULT: elapsedMs=12',
+    'INSTRUMENTATION_CODE: 0',
+  ].join('\n');
+}

--- a/src/platforms/android/snapshot-clickability.ts
+++ b/src/platforms/android/snapshot-clickability.ts
@@ -1,0 +1,17 @@
+import type { SnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
+import type { AndroidBuiltSnapshot } from './ui-hierarchy.ts';
+
+/** Preserve the helper's reported clickable fact across Android presentation. */
+export function buildAndroidSnapshotClickabilityEvidence(
+  snapshot: Pick<AndroidBuiltSnapshot, 'nodes' | 'sourceNodes'>,
+): SnapshotClickabilityEvidence {
+  const clickableByNodeIndex = new Map<number, boolean | undefined>();
+  snapshot.nodes.forEach((node, position) => {
+    clickableByNodeIndex.set(node.index, snapshot.sourceNodes[position]?.clickable);
+  });
+  return {
+    kind: 'exact',
+    provider: 'android-helper',
+    clickableByNodeIndex,
+  };
+}

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -15,6 +15,7 @@ import {
   type RawSnapshotNode,
   type SnapshotOptions,
 } from '@agent-device/kernel/snapshot';
+import { attachSnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
 import { deriveMobileSnapshotHiddenContentHints } from '../../snapshot/mobile-snapshot-semantics.ts';
 import {
   buildUiHierarchySnapshot,
@@ -23,6 +24,7 @@ import {
   type AndroidSnapshotAnalysis,
   type AndroidUiHierarchy,
 } from './ui-hierarchy.ts';
+import { buildAndroidSnapshotClickabilityEvidence } from './snapshot-clickability.ts';
 import { resolveAndroidAdbProvider, type AndroidAdbProvider } from './adb-executor.ts';
 import { sleep } from './adb.ts';
 import {
@@ -105,11 +107,15 @@ export async function snapshotAndroid(
     });
   }
   const { sourceNodes: _sourceNodes, ...snapshot } = built;
-  return {
+  const result = {
     ...snapshot,
     ...androidSnapshotTruncationFields(truncated),
     androidSnapshot: withOcclusionScanDisclosure(capture.metadata, tree),
   };
+  return attachSnapshotClickabilityEvidence(
+    result,
+    buildAndroidSnapshotClickabilityEvidence(built),
+  );
 }
 
 /**

--- a/test/integration/android-emulator-e2e/behavior-coverage.ts
+++ b/test/integration/android-emulator-e2e/behavior-coverage.ts
@@ -5,6 +5,7 @@ export type AndroidEmulatorBehaviorId =
   | 'home-recents-restoration'
   | 'ime-owned-input-recovery'
   | 'long-list-scroll-recovery'
+  | 'maestro-clickable-first-selection'
   | 'orientation-fixture-state'
   | 'push-broadcast-delivery'
   | 'runtime-permission-recovery'
@@ -62,6 +63,11 @@ export const ANDROID_EMULATOR_BEHAVIOR_COVERAGE = {
     assertion:
       'fixture traversal reaches the footer, returns to the top, and rediscovers the catalog landmark',
     owner: 'full:fixture-replays',
+  },
+  'maestro-clickable-first-selection': {
+    assertion:
+      'one Android helper snapshot exposes two duplicate resource-id nodes and a no-index Maestro tap selects the clickable duplicate first',
+    owner: 'smoke:maestro-clickable-first',
   },
   'safe-back-navigation': {
     assertion: 'Back leaves the fixture automation route through normal in-app navigation',

--- a/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
@@ -8,7 +8,7 @@ import { type LiveContext, runStep, verifyBehavior } from './live-harness.ts';
 const TARGET_ID = 'maestro-clickable-first-target';
 
 export async function assertMaestroClickableFirst(context: LiveContext): Promise<void> {
-  await runStep(context, 'reveal duplicate Maestro targets', ['scroll', 'down', '0.7']);
+  await runStep(context, 'reveal duplicate Maestro targets', ['scroll', 'down', '0.3']);
   const snapshot = await runStep(
     context,
     'capture duplicate Maestro targets through Android helper',

--- a/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
@@ -45,7 +45,7 @@ name: Android clickable-first selector
 - tapOn:
     id: ${TARGET_ID}
 - assertVisible:
-    text: Maestro selection: clickable
+    text: "Maestro selection: clickable"
 `,
   );
   const replay = await runStep(context, 'resolve duplicate target through no-index Maestro tapOn', [

--- a/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-maestro-clickable-first-scenario.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { assertPersistentAndroidHelper, assertWaitText } from './live-assertions.ts';
+import { type LiveContext, runStep, verifyBehavior } from './live-harness.ts';
+
+const TARGET_ID = 'maestro-clickable-first-target';
+
+export async function assertMaestroClickableFirst(context: LiveContext): Promise<void> {
+  await runStep(context, 'reveal duplicate Maestro targets', ['scroll', 'down', '0.7']);
+  const snapshot = await runStep(
+    context,
+    'capture duplicate Maestro targets through Android helper',
+    ['snapshot', '-i'],
+  );
+  assertPersistentAndroidHelper(snapshot);
+
+  const nodes = snapshot.json?.data?.nodes;
+  assert.ok(Array.isArray(nodes), JSON.stringify(snapshot.json));
+  const matchingNodes = nodes.filter(
+    (node: unknown) =>
+      isSnapshotNode(node) &&
+      (node.identifier === TARGET_ID || node.identifier.endsWith(`:id/${TARGET_ID}`)),
+  );
+  assert.equal(
+    matchingNodes.length,
+    2,
+    `expected two ${TARGET_ID} nodes from one helper snapshot: ${JSON.stringify(snapshot.json)}`,
+  );
+  for (const node of matchingNodes) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(node, 'clickable'),
+      false,
+      `clickability must stay off the public snapshot wire: ${JSON.stringify(node)}`,
+    );
+  }
+
+  const flowPath = path.join(context.artifactDir, 'maestro-clickable-first.yaml');
+  fs.writeFileSync(
+    flowPath,
+    `appId: ${JSON.stringify(context.appId)}
+name: Android clickable-first selector
+---
+- tapOn:
+    id: ${TARGET_ID}
+- assertVisible:
+    text: Maestro selection: clickable
+`,
+  );
+  const replay = await runStep(context, 'resolve duplicate target through no-index Maestro tapOn', [
+    'replay',
+    flowPath,
+    '--maestro',
+  ]);
+  assert.equal(replay.json?.data?.replayed, 2, JSON.stringify(replay.json));
+  await assertWaitText(context, 'Maestro selection: clickable');
+  verifyBehavior(
+    context,
+    'maestro-clickable-first-selection',
+    'one Android helper snapshot exposed two identical resource-id nodes and a no-index Maestro tapOn selected the clickable duplicate first',
+  );
+}
+
+function isSnapshotNode(value: unknown): value is { identifier: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { identifier?: unknown }).identifier === 'string'
+  );
+}

--- a/test/integration/android-emulator-e2e/scenarios.ts
+++ b/test/integration/android-emulator-e2e/scenarios.ts
@@ -7,6 +7,7 @@ import { assertFormInput, assertKeyboardIme } from './live-form-scenario.ts';
 import type { LiveContext } from './live-harness.ts';
 import { assertInventoryAndInstall } from './live-inventory-scenario.ts';
 import { assertLifecycleAndSystem } from './live-lifecycle-scenario.ts';
+import { assertMaestroClickableFirst } from './live-maestro-clickable-first-scenario.ts';
 import { assertObservabilityAndArtifacts } from './live-observability-scenario.ts';
 import { assertFixtureReplays } from './live-replay-scenarios.ts';
 import type { AndroidEmulatorScenarioStart } from './scenario-start.ts';
@@ -70,6 +71,17 @@ export const ANDROID_EMULATOR_LIVE_SCENARIOS = [
       ime: 'system',
       landmark: 'Automation lab',
       url: AUTOMATION_DEEP_LINK,
+    },
+  },
+  {
+    behaviors: ['maestro-clickable-first-selection'],
+    commands: [],
+    id: 'smoke:maestro-clickable-first',
+    run: assertMaestroClickableFirst,
+    start: {
+      ime: 'system',
+      landmark: 'Automation lab',
+      url: 'agent-device-test-app:///automation',
     },
   },
   {

--- a/test/integration/smoke-android-emulator-coverage.test.ts
+++ b/test/integration/smoke-android-emulator-coverage.test.ts
@@ -107,6 +107,14 @@ test('Android app scenarios declare deterministic starting surfaces and IME mode
         },
       },
       {
+        id: 'smoke:maestro-clickable-first',
+        start: {
+          ime: 'system',
+          landmark: 'Automation lab',
+          url: 'agent-device-test-app:///automation',
+        },
+      },
+      {
         id: 'smoke:form-input',
         start: {
           ime: 'test',


### PR DESCRIPTION
## Summary

Preserve pinned Maestro v2.5.1 clickableFirst ordering for Android selector resolution without adding clickability to the public snapshot wire shape.

- Retain exact Android helper clickability in an internal snapshot sidecar from the single hierarchy capture.
- Apply stable true, false, absent ordering only when no selector index is authored.
- Preserve the existing y/x comparator for authored indices.
- Classify iOS XCTest/private AX as an explicit unsupported divergence instead of inferring clickability.
- Add generated Layer 2 vectors, runtime parity tests, transport/public-shape tests, and one-capture evidence.

Closes #1907

## Validation

- pnpm check:affected --run passed; all runnable checks passed.
- pnpm maestro:conformance passed 47/47.
- Related Vitest passed 4,620 tests across 563 files.
- Red proofs observed for reversed ordering, public enumerable clickability, and a second hierarchy capture; all were restored green.
- Native/device, coverage, differential, fuzz, mutation, concurrency, and replay lanes remain GitHub-authoritative.

Scope: 21 files across contracts, Android capture propagation, Maestro resolution, and generated conformance coverage.