### PR TITLE
docs: record visionOS/watchOS support decision

### DIFF
--- a/docs/adr/0009-apple-platform-consolidation.md
+++ b/docs/adr/0009-apple-platform-consolidation.md
@@ -72,9 +72,10 @@ Implementation status as of 2026-08:
   plus simulator-deployment evidence.
 - Decision-only support boundary: visionOS discovery and simulator deployment are supported and
   unit-tested (`packages/platform-apple/src/inventory-classification.ts` and
-  `packages/platform-apple/src/deployment/runtime.test.ts`); physical-device deployment is
-  unsupported, and no public-command coverage is claimed for visionOS or watchOS. This boundary is
-  recorded here without creating a command-coverage manifest for either leaf.
+  `packages/platform-apple/src/deployment/runtime.test.ts`); app deployment is also admitted for
+  CoreDevice-backed physical devices, while XCTest-backed physical deployment is unsupported and
+  push remains simulator-only. No public-command coverage is claimed for visionOS or watchOS. This
+  boundary is recorded here without creating a command-coverage manifest for either leaf.
 - Retained compatibility: the public wire still emits `ios`/`macos` leaves through
   `PUBLIC_PLATFORMS`; internal family ownership must not leak into that projection.
 - Deferred: net-new visionOS spatial-input QA.

--- a/docs/adr/0009-apple-platform-consolidation.md
+++ b/docs/adr/0009-apple-platform-consolidation.md
@@ -67,8 +67,14 @@ Implementation status as of 2026-08:
   direct internal imports to the Apple modules; the per-`AppleOS` capability table
   (`APPLE_OS_CAPABILITIES`, `src/platforms/apple/capabilities.ts`, parity-pinned against the pre-table
   predicates); the watchOS **unsupported sentinel** (reserved in the `AppleOS` type and interactor-rejected —
-  XCUITest cannot drive watchOS UI — never produced by discovery); and visionOS profile/build/discovery
-  groundwork.
+  XCUITest cannot drive watchOS UI — `isSupportedAppleDeploymentLeaf`, the Apple interactor, and
+  gesture admission reject it — never produced by discovery); and visionOS profile/build/discovery
+  plus simulator-deployment evidence.
+- Decision-only support boundary: visionOS discovery and simulator deployment are supported and
+  unit-tested (`packages/platform-apple/src/inventory-classification.ts` and
+  `packages/platform-apple/src/deployment/runtime.test.ts`); physical-device deployment is
+  unsupported, and no public-command coverage is claimed for visionOS or watchOS. This boundary is
+  recorded here without creating a command-coverage manifest for either leaf.
 - Retained compatibility: the public wire still emits `ios`/`macos` leaves through
   `PUBLIC_PLATFORMS`; internal family ownership must not leak into that projection.
 - Deferred: net-new visionOS spatial-input QA.


### PR DESCRIPTION
## Summary

- Record the visionOS/watchOS support decision in the existing Apple consolidation ADR, which owns the Apple family/leaf boundary.
- Document visionOS discovery and simulator app deployment as existing unit-tested support.
- Document the precise deployment boundary: app deployment is admitted for CoreDevice-backed physical devices, XCTest-backed physical deployment is unsupported, and push remains simulator-only.
- Document watchOS as uniformly unsupported through the deployment leaf guard, Apple interactor admission, and gesture admission.
- Keep this decision-only: no platform manifest, live scenario, grouped gap issue, or #1426 checklist edit. Part of #1426.

## Validation

- `pnpm install --frozen-lockfile && pnpm build`
- `pnpm check:affected --run` — all runnable checks passed after the review correction; GitHub-authoritative/native/device lanes were skipped by design.
- Existing evidence reviewed: `packages/platform-apple/src/inventory-classification.ts`, `packages/platform-apple/src/deployment/runtime.test.ts`, `packages/platform-apple/src/deployment/runtime.ts`, `src/core/capabilities.ts`, and `src/platforms/apple/interactor.ts`.
- Docs-only change: no live-device validation is required.
- Evidence is current at commit `3bb6cca90`; CI on the updated PR head remains authoritative. This is published and reported, not merge-ready until required checks pass.

Touched files: 1. Scope stayed within the Apple support decision. Docs changed; skills unchanged.