### PR TITLE
test: complete boundary fault matrix

### DIFF
--- a/src/__tests__/contracts/boundary-fault-matrix.test.ts
+++ b/src/__tests__/contracts/boundary-fault-matrix.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+import {
+  BOUNDARY_COMMAND_CLASSES,
+  BOUNDARY_FAULTS,
+  BOUNDARY_FAULT_MATRIX,
+  type BoundaryCoverage,
+} from '../test-utils/boundary-fault-matrix.ts';
+
+test('boundary fault matrix is complete across both declared axes', () => {
+  assert.deepEqual(Object.keys(BOUNDARY_FAULT_MATRIX).sort(), [...BOUNDARY_FAULTS].sort());
+
+  for (const fault of BOUNDARY_FAULTS) {
+    const row = BOUNDARY_FAULT_MATRIX[fault];
+    assert.deepEqual(Object.keys(row).sort(), [...BOUNDARY_COMMAND_CLASSES].sort(), fault);
+    for (const commandClass of BOUNDARY_COMMAND_CLASSES) {
+      assertBoundaryCoverage(row[commandClass], `${fault}/${commandClass}`);
+    }
+  }
+});
+
+function assertBoundaryCoverage(cell: BoundaryCoverage, cellName: string): void {
+  if (cell.kind === 'not-applicable') {
+    assert.ok(cell.reason.trim(), `${cellName} must explain why it is not applicable`);
+    return;
+  }
+
+  assert.ok(cell.evidence.length > 0, `${cellName} must name executable evidence`);
+  assert.ok(cell.invariants.length > 0, `${cellName} must name asserted invariants`);
+  for (const evidence of cell.evidence) {
+    assert.ok(evidence.trim(), `${cellName} has empty evidence`);
+    const evidencePath = evidence.split(':', 1)[0];
+    if (!evidencePath) throw new Error(`${cellName} has no evidence path`);
+    assert.equal(
+      fs.existsSync(path.resolve(process.cwd(), evidencePath)),
+      true,
+      `${cellName} points at missing evidence ${evidencePath}`,
+    );
+  }
+}

--- a/src/__tests__/test-utils/boundary-fault-matrix.ts
+++ b/src/__tests__/test-utils/boundary-fault-matrix.ts
@@ -1,0 +1,215 @@
+export const BOUNDARY_FAULTS = [
+  'timeout',
+  'cancellation',
+  'response-framing',
+  'process-death',
+  'lost-response-after-mutation',
+  'filesystem-failure',
+  'optional-optimization-failure',
+] as const;
+
+export const BOUNDARY_COMMAND_CLASSES = [
+  'mutation',
+  'read',
+  'artifact-producing',
+  'session-lifecycle',
+] as const;
+
+export type BoundaryFault = (typeof BOUNDARY_FAULTS)[number];
+export type BoundaryCommandClass = (typeof BOUNDARY_COMMAND_CLASSES)[number];
+
+export type BoundaryInvariant =
+  | 'bounded-deadline'
+  | 'no-mutation-replay'
+  | 'typed-error-identity'
+  | 'request-scoped-cancellation'
+  | 'request-signal-cleanup'
+  | 'atomic-publication'
+  | 'publication-residue-free'
+  | 'claim-or-lease-state'
+  | 'best-effort-degradation';
+
+export type BoundaryCoverage =
+  | Readonly<{
+      kind: 'covered';
+      evidence: readonly [string, ...string[]];
+      invariants: readonly [BoundaryInvariant, ...BoundaryInvariant[]];
+    }>
+  | Readonly<{
+      kind: 'not-applicable';
+      reason: string;
+    }>;
+
+export type BoundaryFaultMatrix = {
+  readonly [fault in BoundaryFault]: {
+    readonly [commandClass in BoundaryCommandClass]: BoundaryCoverage;
+  };
+};
+
+/**
+ * The boundary-fault contract is deliberately nested by both axes. Adding a
+ * fault or command class makes this declaration fail to typecheck until every
+ * cell is classified and points at executable evidence (or explains why the
+ * fault has no meaning for that class).
+ */
+export const BOUNDARY_FAULT_MATRIX = {
+  timeout: {
+    mutation: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:timeout'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+    read: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/daemon-client-timeout-route.test.ts:http timeout'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:timeout'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:timeout'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+  },
+  cancellation: {
+    mutation: {
+      kind: 'covered',
+      evidence: ['test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts'],
+      invariants: ['request-scoped-cancellation', 'request-signal-cleanup'],
+    },
+    read: {
+      kind: 'covered',
+      evidence: ['test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts'],
+      invariants: ['request-scoped-cancellation', 'request-signal-cleanup'],
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: ['test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts'],
+      invariants: ['request-scoped-cancellation', 'request-signal-cleanup'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: ['test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts'],
+      invariants: ['request-scoped-cancellation', 'request-signal-cleanup'],
+    },
+  },
+  'response-framing': {
+    mutation: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:response framing'],
+      invariants: ['typed-error-identity', 'no-mutation-replay'],
+    },
+    read: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:response framing'],
+      invariants: ['typed-error-identity'],
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:response framing'],
+      invariants: ['typed-error-identity'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-transport.test.ts:response framing'],
+      invariants: ['typed-error-identity'],
+    },
+  },
+  'process-death': {
+    mutation: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
+      invariants: ['bounded-deadline', 'no-mutation-replay', 'typed-error-identity'],
+    },
+    read: {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
+      invariants: ['bounded-deadline', 'typed-error-identity'],
+    },
+  },
+  'lost-response-after-mutation': {
+    mutation: {
+      kind: 'covered',
+      evidence: ['src/platforms/apple/core/__tests__/runner-recovery-wiring.test.ts'],
+      invariants: ['no-mutation-replay', 'typed-error-identity'],
+    },
+    read: {
+      kind: 'not-applicable',
+      reason:
+        'The fault is defined after a mutation dispatch; read commands cannot satisfy that precondition.',
+    },
+    'artifact-producing': {
+      kind: 'not-applicable',
+      reason:
+        'The fault is defined after a mutation dispatch; artifact reads do not satisfy that precondition.',
+    },
+    'session-lifecycle': {
+      kind: 'not-applicable',
+      reason:
+        'Lifecycle commands use the separate process-death and response-framing rows; this fault requires a mutation.',
+    },
+  },
+  'filesystem-failure': {
+    mutation: {
+      kind: 'not-applicable',
+      reason:
+        'The scoped filesystem fault is an artifact-publication errno, not a command-dispatch fault.',
+    },
+    read: {
+      kind: 'not-applicable',
+      reason: 'Read commands do not publish the tmp-to-rename artifacts owned by this matrix.',
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: [
+        'src/daemon/__tests__/filesystem-boundary-faults.test.ts',
+        'src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts',
+      ],
+      invariants: ['atomic-publication', 'publication-residue-free'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: [
+        'src/daemon/__tests__/filesystem-boundary-faults.test.ts',
+        'src/platforms/apple/core/__tests__/runner-lease-filesystem-boundary-faults.test.ts',
+      ],
+      invariants: ['atomic-publication', 'publication-residue-free', 'claim-or-lease-state'],
+    },
+  },
+  'optional-optimization-failure': {
+    mutation: {
+      kind: 'covered',
+      evidence: ['src/daemon/handlers/__tests__/interaction-touch-direct-ios.test.ts'],
+      invariants: ['best-effort-degradation'],
+    },
+    read: {
+      kind: 'covered',
+      evidence: ['src/core/__tests__/dispatch-resolve.test.ts'],
+      invariants: ['best-effort-degradation'],
+    },
+    'artifact-producing': {
+      kind: 'covered',
+      evidence: ['src/platforms/apple/core/__tests__/screenshot.test.ts'],
+      invariants: ['best-effort-degradation'],
+    },
+    'session-lifecycle': {
+      kind: 'covered',
+      evidence: ['src/platforms/web/agent-browser-provider.test.ts'],
+      invariants: ['best-effort-degradation'],
+    },
+  },
+} as const satisfies BoundaryFaultMatrix;

--- a/src/__tests__/test-utils/boundary-fault-matrix.ts
+++ b/src/__tests__/test-utils/boundary-fault-matrix.ts
@@ -123,22 +123,22 @@ export const BOUNDARY_FAULT_MATRIX = {
     mutation: {
       kind: 'covered',
       evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
-      invariants: ['bounded-deadline', 'no-mutation-replay', 'typed-error-identity'],
+      invariants: ['bounded-deadline', 'no-mutation-replay'],
     },
     read: {
       kind: 'covered',
       evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
-      invariants: ['bounded-deadline', 'typed-error-identity'],
+      invariants: ['bounded-deadline'],
     },
     'artifact-producing': {
       kind: 'covered',
       evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
-      invariants: ['bounded-deadline', 'typed-error-identity'],
+      invariants: ['bounded-deadline'],
     },
     'session-lifecycle': {
       kind: 'covered',
       evidence: ['src/daemon/client/__tests__/boundary-fault-acceptance.test.ts'],
-      invariants: ['bounded-deadline', 'typed-error-identity'],
+      invariants: ['bounded-deadline'],
     },
   },
   'lost-response-after-mutation': {

--- a/src/__tests__/test-utils/exec-faults.ts
+++ b/src/__tests__/test-utils/exec-faults.ts
@@ -1,0 +1,44 @@
+import type { CommandExecutorOverride, ExecOptions, ExecResult } from '../../utils/exec.ts';
+
+export type RecordedCommand = Readonly<{
+  command: string;
+  args: readonly string[];
+  options: ExecOptions;
+}>;
+
+export type FailNthCommandExecutor = Readonly<{
+  override: CommandExecutorOverride;
+  calls: () => readonly RecordedCommand[];
+}>;
+
+/**
+ * Deterministic subprocess fault injection for provider tests. Every call is
+ * recorded, exactly one ordinal rejects, and later calls still reach the
+ * success result so a test can prove whether a caller replayed or stopped.
+ */
+export function createFailNthCommandExecutor(
+  nthCall: number,
+  failure: unknown = new Error('injected command failure'),
+): FailNthCommandExecutor {
+  if (!Number.isSafeInteger(nthCall) || nthCall < 1) {
+    throw new RangeError('nthCall must be a positive safe integer');
+  }
+
+  let callCount = 0;
+  const history: RecordedCommand[] = [];
+  const override: CommandExecutorOverride = async (command, args, options) => {
+    callCount += 1;
+    history.push({ command, args: [...args], options: { ...options } });
+    if (callCount === nthCall) throw failure;
+    return successfulJsonResult();
+  };
+
+  return {
+    override,
+    calls: () => history,
+  };
+}
+
+function successfulJsonResult(): ExecResult {
+  return { stdout: JSON.stringify({ success: true, data: {} }), stderr: '', exitCode: 0 };
+}

--- a/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-acceptance.test.ts
@@ -9,22 +9,26 @@ import type { DaemonPaths } from '../../config.ts';
 import type { DaemonRequest } from '../../types.ts';
 import { sendRequest } from '../daemon-client-transport.ts';
 
-type ProcessDeathCommand = 'open' | 'close';
+type ProcessDeathCommand = 'press' | 'fill' | 'snapshot' | 'screenshot' | 'open' | 'close';
 type ProcessDeathRow = Readonly<{
   command: ProcessDeathCommand;
   positionals: readonly string[];
 }>;
 
 const PROCESS_DEATH_ROWS = {
+  press: { command: 'press', positionals: ['enter'] },
+  fill: { command: 'fill', positionals: ['@e1', 'Ada'] },
+  snapshot: { command: 'snapshot', positionals: [] },
+  screenshot: { command: 'screenshot', positionals: ['/tmp/acceptance.png'] },
   open: { command: 'open', positionals: ['Demo'] },
   close: { command: 'close', positionals: [] },
 } as const satisfies Record<ProcessDeathCommand, ProcessDeathRow>;
 
 for (const row of Object.values(PROCESS_DEATH_ROWS)) {
   test(`acceptance row: process death after ${row.command} dispatch is bounded and non-replayed`, async () => {
-    // This acceptance row deliberately stops at the transport boundary: a
-    // dead daemon is observed as a closed response socket. Lifecycle teardown
-    // and process-tree cleanup belong to the deferred full fault matrix.
+    // A dead daemon is observed as a closed response socket. The command is
+    // sent exactly once because the transport cannot establish whether the
+    // daemon applied it before dying.
     const endpoint = await startEndpointThatDiesAfterRequest();
     const baseDir = mkdtempForTestSync(`agent-device-process-death-${row.command}-`);
     const statePaths = daemonPaths(baseDir);
@@ -83,8 +87,8 @@ async function startEndpointThatDiesAfterRequest(): Promise<DeadEndpoint> {
       const command = parsed.params?.command;
       if (typeof command === 'string') commands.push(command);
       // A daemon process death after dispatch is observed as the accepted
-      // socket closing. There is no response and no safe retry path for either
-      // lifecycle command.
+      // socket closing. There is no response and no safe retry path after any
+      // command has crossed the dispatch boundary.
       request.socket.destroy();
       closePromise ??= new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/src/daemon/client/__tests__/boundary-fault-transport.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-transport.test.ts
@@ -174,6 +174,35 @@ test('socket partial response fails at end-of-stream instead of waiting for the 
   assert.ok(Date.now() - startedAt < 500, 'EOF should reject before the injected deadline');
 });
 
+test('socket empty response fails at end-of-stream with request context', async () => {
+  const endpoint = await startNetServer((socket) => {
+    socket.once('data', () => {
+      socket.end();
+    });
+  });
+  const request = buildRequest(COMMAND_ROWS.read, 'socket-empty');
+  const startedAt = Date.now();
+
+  await assert.rejects(
+    sendRequest(
+      { port: endpoint.port, token: 'test-token', pid: process.pid },
+      request,
+      'socket',
+      daemonPaths(),
+      1_000,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'COMMAND_FAILED');
+      assert.equal(error.message, 'Invalid daemon response');
+      assert.equal(error.details?.requestId, request.meta?.requestId);
+      return true;
+    },
+  );
+
+  assert.ok(Date.now() - startedAt < 500, 'EOF should reject before the injected deadline');
+});
+
 test('socket malformed response stays typed at the daemon client seam', async () => {
   const endpoint = await startNetServer((socket) => {
     socket.once('data', () => {

--- a/src/daemon/client/__tests__/boundary-fault-transport.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-transport.test.ts
@@ -5,6 +5,11 @@ import path from 'node:path';
 import { afterEach, beforeEach, test, vi } from 'vitest';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  type LoopbackServer,
+} from '../../../__tests__/test-utils/loopback.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 import type { DaemonPaths } from '../../config.ts';
 import type { DaemonRequest } from '../../types.ts';
@@ -28,7 +33,7 @@ const COMMAND_ROWS = {
   'session-lifecycle': { command: PUBLIC_COMMANDS.open, positionals: ['Demo'] },
 } as const;
 
-const openServers: Array<http.Server | net.Server> = [];
+const openServers: LoopbackServer[] = [];
 
 beforeEach(() => {
   mockRunCmdSync.mockReset();
@@ -36,7 +41,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await Promise.all(openServers.splice(0).map(closeServer));
+  await Promise.all(openServers.splice(0).map(closeLoopbackServer));
 });
 
 for (const [commandClass, row] of Object.entries(COMMAND_ROWS)) {
@@ -225,43 +230,11 @@ function startHttpServer(
 ): Promise<{ port: number }> {
   const server = http.createServer(handler);
   openServers.push(server);
-  return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      if (!address || typeof address === 'string') {
-        reject(new Error('failed to bind boundary HTTP server'));
-        return;
-      }
-      resolve({ port: address.port });
-    });
-  });
+  return listenOnLoopback(server).then((port) => ({ port }));
 }
 
 function startNetServer(handler: (socket: net.Socket) => void): Promise<{ port: number }> {
   const server = net.createServer(handler);
   openServers.push(server);
-  return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      if (!address || typeof address === 'string') {
-        reject(new Error('failed to bind boundary socket server'));
-        return;
-      }
-      resolve({ port: address.port });
-    });
-  });
-}
-
-async function closeServer(server: http.Server | net.Server): Promise<void> {
-  const closableServer = server as http.Server & { closeAllConnections?: () => void };
-  closableServer.closeAllConnections?.();
-  await new Promise<void>((resolve) => {
-    if (!server.listening) {
-      resolve();
-      return;
-    }
-    server.close(() => resolve());
-  });
+  return listenOnLoopback(server).then((port) => ({ port }));
 }

--- a/src/daemon/client/__tests__/boundary-fault-transport.test.ts
+++ b/src/daemon/client/__tests__/boundary-fault-transport.test.ts
@@ -1,0 +1,267 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import path from 'node:path';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
+import { AppError, normalizeError } from '@agent-device/kernel/errors';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import type { DaemonPaths } from '../../config.ts';
+import type { DaemonRequest } from '../../types.ts';
+import { sendRequest } from '../daemon-client-transport.ts';
+
+const { mockRunCmdSync } = vi.hoisted(() => ({ mockRunCmdSync: vi.fn() }));
+
+vi.mock('../../../utils/exec.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/exec.ts')>('../../../utils/exec.ts');
+  return { ...actual, runCmdSync: mockRunCmdSync };
+});
+
+const COMMAND_ROWS = {
+  mutation: { command: PUBLIC_COMMANDS.press, positionals: ['enter'] },
+  read: { command: PUBLIC_COMMANDS.snapshot, positionals: [] },
+  'artifact-producing': {
+    command: PUBLIC_COMMANDS.screenshot,
+    positionals: ['/tmp/boundary-fault.png'],
+  },
+  'session-lifecycle': { command: PUBLIC_COMMANDS.open, positionals: ['Demo'] },
+} as const;
+
+const openServers: Array<http.Server | net.Server> = [];
+
+beforeEach(() => {
+  mockRunCmdSync.mockReset();
+  mockRunCmdSync.mockReturnValue({ exitCode: 1, stdout: '', stderr: '' });
+});
+
+afterEach(async () => {
+  await Promise.all(openServers.splice(0).map(closeServer));
+});
+
+for (const [commandClass, row] of Object.entries(COMMAND_ROWS)) {
+  test(`HTTP timeout stays bounded for the ${commandClass} command class`, async () => {
+    const endpoint = await startHttpServer((_request, _response) => {
+      // Keep the accepted request open so the client's own deadline is the
+      // only completion path.
+    });
+    const request = buildRequest(row, `timeout-${commandClass}`);
+
+    await assert.rejects(
+      sendRequest(
+        { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
+        request,
+        'http',
+        daemonPaths(),
+        60,
+      ),
+      (error: unknown) => {
+        assert.ok(error instanceof AppError);
+        assert.equal(error.message, 'Daemon request timed out');
+        assert.equal(error.details?.timeoutMs, 60);
+        assert.equal(error.details?.requestId, request.meta?.requestId);
+        assert.equal(typeof normalizeError(error).hint, 'string');
+        return true;
+      },
+    );
+    assert.equal(mockRunCmdSync.mock.calls.filter(([command]) => command === 'pkill').length, 3);
+  });
+
+  for (const responseShape of ['partial', 'malformed'] as const) {
+    test(`HTTP ${responseShape} response is typed for the ${commandClass} command class`, async () => {
+      const endpoint = await startHttpServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        if (responseShape === 'partial') {
+          response.end('{"jsonrpc":"2.0","result":');
+        } else {
+          response.end('{"jsonrpc":"2.0","result":null}');
+        }
+      });
+      const request = buildRequest(row, `${responseShape}-${commandClass}`);
+
+      await assert.rejects(
+        sendRequest(
+          { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
+          request,
+          'http',
+          daemonPaths(),
+          1_000,
+        ),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, 'COMMAND_FAILED');
+          assert.match(error.message, /Invalid daemon/);
+          assert.equal(error.details?.requestId, request.meta?.requestId);
+          return true;
+        },
+      );
+    });
+  }
+}
+
+test('HTTP RPC errors preserve typed identity through the client transport', async () => {
+  const endpoint = await startHttpServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          message: 'device disappeared',
+          data: {
+            code: 'DEVICE_NOT_FOUND',
+            message: 'device disappeared',
+            hint: 'Reconnect the device and retry.',
+            diagnosticId: 'diag-boundary-1',
+            logPath: '/tmp/boundary-daemon.ndjson',
+          },
+        },
+      }),
+    );
+  });
+  const request = buildRequest(COMMAND_ROWS.read, 'typed-error');
+
+  await assert.rejects(
+    sendRequest(
+      { httpPort: endpoint.port, token: 'test-token', pid: process.pid },
+      request,
+      'http',
+      daemonPaths(),
+      1_000,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'DEVICE_NOT_FOUND');
+      assert.equal(error.details?.hint, 'Reconnect the device and retry.');
+      assert.equal(error.details?.diagnosticId, 'diag-boundary-1');
+      assert.equal(error.details?.logPath, '/tmp/boundary-daemon.ndjson');
+      assert.equal(error.details?.requestId, request.meta?.requestId);
+      return true;
+    },
+  );
+});
+
+test('socket partial response fails at end-of-stream instead of waiting for the deadline', async () => {
+  const endpoint = await startNetServer((socket) => {
+    socket.once('data', () => {
+      socket.end('{"ok":');
+    });
+  });
+  const request = buildRequest(COMMAND_ROWS.read, 'socket-partial');
+  const startedAt = Date.now();
+
+  await assert.rejects(
+    sendRequest(
+      { port: endpoint.port, token: 'test-token', pid: process.pid },
+      request,
+      'socket',
+      daemonPaths(),
+      1_000,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'COMMAND_FAILED');
+      assert.equal(error.message, 'Invalid daemon response');
+      assert.equal(error.details?.requestId, request.meta?.requestId);
+      return true;
+    },
+  );
+
+  assert.ok(Date.now() - startedAt < 500, 'EOF should reject before the injected deadline');
+});
+
+test('socket malformed response stays typed at the daemon client seam', async () => {
+  const endpoint = await startNetServer((socket) => {
+    socket.once('data', () => {
+      socket.end('not-json\n');
+    });
+  });
+  const request = buildRequest(COMMAND_ROWS.mutation, 'socket-malformed');
+
+  await assert.rejects(
+    sendRequest(
+      { port: endpoint.port, token: 'test-token', pid: process.pid },
+      request,
+      'socket',
+      daemonPaths(),
+      1_000,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'COMMAND_FAILED');
+      assert.equal(error.message, 'Invalid daemon response');
+      assert.equal(error.details?.requestId, request.meta?.requestId);
+      return true;
+    },
+  );
+});
+
+function buildRequest(
+  row: { command: string; positionals: readonly string[] },
+  suffix: string,
+): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'boundary-faults',
+    command: row.command,
+    positionals: [...row.positionals],
+    flags: {},
+    meta: { requestId: `boundary-${suffix}` },
+  };
+}
+
+function daemonPaths(): DaemonPaths {
+  const baseDir = mkdtempForTestSync('agent-device-boundary-transport-');
+  return {
+    baseDir,
+    infoPath: path.join(baseDir, 'daemon.json'),
+    lockPath: path.join(baseDir, 'daemon.lock'),
+    logPath: path.join(baseDir, 'daemon.log'),
+    sessionsDir: path.join(baseDir, 'sessions'),
+  };
+}
+
+function startHttpServer(
+  handler: (request: http.IncomingMessage, response: http.ServerResponse) => void,
+): Promise<{ port: number }> {
+  const server = http.createServer(handler);
+  openServers.push(server);
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('failed to bind boundary HTTP server'));
+        return;
+      }
+      resolve({ port: address.port });
+    });
+  });
+}
+
+function startNetServer(handler: (socket: net.Socket) => void): Promise<{ port: number }> {
+  const server = net.createServer(handler);
+  openServers.push(server);
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('failed to bind boundary socket server'));
+        return;
+      }
+      resolve({ port: address.port });
+    });
+  });
+}
+
+async function closeServer(server: http.Server | net.Server): Promise<void> {
+  const closableServer = server as http.Server & { closeAllConnections?: () => void };
+  closableServer.closeAllConnections?.();
+  await new Promise<void>((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}

--- a/src/daemon/client/daemon-client-progress.ts
+++ b/src/daemon/client/daemon-client-progress.ts
@@ -155,6 +155,13 @@ export function readDaemonSocketProgressResponse(
       if (lineReader.handleLine(line)) return;
     }
   });
+  socket.on('end', () => {
+    if (isSettled()) return;
+    const line = buffer.trim();
+    if (line && lineReader.handleLine(line)) return;
+    clearTimeout();
+    reject(createInvalidDaemonResponseError(req, line));
+  });
 }
 
 export function readDaemonHttpProgressResponse(

--- a/src/platforms/apple/core/__tests__/runner-usbmux-boundary-faults.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-usbmux-boundary-faults.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import type { Server } from 'node:net';
+import { afterEach, test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { createUsbmuxRunnerTransport } from '../runner/runner-usbmux.ts';
+import {
+  buildPacket,
+  cleanupUsbmuxFixtures,
+  createFakeUsbmuxd,
+  createSocketPath,
+  readHttpRequestBody,
+  readPacket,
+} from './runner-usbmux-fixtures.ts';
+
+const DEVICE_UDID = '00008020-001C2D2234567890';
+const RUNNER_PORT = 51_234;
+const openServers: Server[] = [];
+const socketDirectories: string[] = [];
+
+afterEach(async () => {
+  await cleanupUsbmuxFixtures(openServers, socketDirectories);
+});
+
+test('usbmux read timeout is bounded at the packet seam', async () => {
+  const socketPath = await createSocketPath(socketDirectories);
+  await createFakeUsbmuxd(openServers, socketPath, async (socket) => {
+    await readPacket(socket);
+    await waitForClose(socket);
+  });
+
+  const error = await post(socketPath, 60).catch((value: unknown) => value);
+  assert.ok(error instanceof AppError);
+  assert.equal(error.code, 'COMMAND_FAILED');
+  assert.match(error.message, /Timed out reading usbmuxd response/);
+});
+
+test('usbmux cancellation interrupts an in-flight packet read', async () => {
+  const socketPath = await createSocketPath(socketDirectories);
+  let markRequestReceived: () => void = () => {};
+  const requestReceived = new Promise<void>((resolve) => {
+    markRequestReceived = resolve;
+  });
+  await createFakeUsbmuxd(openServers, socketPath, async (socket) => {
+    await readPacket(socket);
+    markRequestReceived();
+    await waitForClose(socket);
+  });
+
+  const controller = new AbortController();
+  const request = post(socketPath, 1_000, controller.signal);
+  await requestReceived;
+  controller.abort();
+
+  await assert.rejects(request, (error: unknown) => {
+    assert.ok(error instanceof AppError);
+    assert.equal(error.code, 'COMMAND_FAILED');
+    assert.equal(error.message, 'request canceled');
+    assert.equal(error.details?.reason, 'request_canceled');
+    return true;
+  });
+});
+
+test('usbmux partial packets fail as a closed response, not as a successful device lookup', async () => {
+  const socketPath = await createSocketPath(socketDirectories);
+  await createFakeUsbmuxd(openServers, socketPath, async (socket) => {
+    await readPacket(socket);
+    const header = Buffer.alloc(16);
+    header.writeUInt32LE(32, 0);
+    socket.end(header);
+  });
+
+  const error = await post(socketPath, 1_000).catch((value: unknown) => value);
+  assert.ok(error instanceof AppError);
+  assert.equal(error.code, 'COMMAND_FAILED');
+  assert.equal(error.message, 'usbmuxd closed the connection unexpectedly');
+});
+
+test('usbmux malformed packet lengths stay typed at the protocol seam', async () => {
+  const socketPath = await createSocketPath(socketDirectories);
+  await createFakeUsbmuxd(openServers, socketPath, async (socket) => {
+    await readPacket(socket);
+    const header = Buffer.alloc(16);
+    header.writeUInt32LE(8, 0);
+    socket.end(header);
+  });
+
+  const error = await post(socketPath, 1_000).catch((value: unknown) => value);
+  assert.ok(error instanceof AppError);
+  assert.equal(error.code, 'COMMAND_FAILED');
+  assert.equal(error.message, 'Invalid usbmuxd response length');
+});
+
+test('usbmux process death after runner request is never replayed', async () => {
+  const socketPath = await createSocketPath(socketDirectories);
+  let runnerRequests = 0;
+  const { done } = await createFakeUsbmuxd(openServers, socketPath, async (socket, index) => {
+    if (index === 0) {
+      await readPacket(socket);
+      socket.end(
+        buildPacket(
+          '<plist><dict><key>DeviceList</key><array><dict><key>DeviceID</key><integer>42</integer><key>Properties</key><dict><key>SerialNumber</key><string>00008020-001C2D2234567890</string></dict></dict></array></dict></plist>',
+        ),
+      );
+      return;
+    }
+    await readPacket(socket);
+    socket.write(
+      buildPacket(
+        '<plist><dict><key>MessageType</key><string>Result</string><key>Number</key><integer>0</integer></dict></plist>',
+      ),
+    );
+    await readHttpRequestBody(socket);
+    runnerRequests += 1;
+    socket.destroy();
+  });
+
+  await assert.rejects(post(socketPath, 1_000));
+  await done;
+  assert.equal(runnerRequests, 1);
+});
+
+async function post(
+  socketPath: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<Response> {
+  return await createUsbmuxRunnerTransport(socketPath).postCommand(
+    DEVICE_UDID,
+    RUNNER_PORT,
+    { command: 'uptime' },
+    timeoutMs,
+    signal,
+  );
+}
+
+async function waitForClose(socket: { once: (event: 'close', listener: () => void) => void }) {
+  await new Promise<void>((resolve) => socket.once('close', resolve));
+}

--- a/src/platforms/apple/core/__tests__/runner-usbmux-fixtures.ts
+++ b/src/platforms/apple/core/__tests__/runner-usbmux-fixtures.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from 'node:fs';
+import net, { type Server, type Socket } from 'node:net';
+import path from 'node:path';
+import { mkdtempForTest } from '../../../../__tests__/test-utils/tmp-dir.ts';
+
+export type FakeDevice = { deviceId: number; udid: string; connectionType?: string };
+
+export async function createSocketPath(socketDirectories: string[]): Promise<string> {
+  const directory = await mkdtempForTest('agent-device-usbmux-test-');
+  const socketPath = path.join(directory, 'usbmuxd.sock');
+  socketDirectories.push(directory);
+  return socketPath;
+}
+
+export async function createFakeUsbmuxd(
+  openServers: Server[],
+  socketPath: string,
+  handleConnection: (socket: Socket, connectionIndex: number) => Promise<void>,
+): Promise<{ done: Promise<void> }> {
+  let connectionIndex = 0;
+  let resolveDone!: () => void;
+  let rejectDone!: (error: unknown) => void;
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+  const server = net.createServer((socket) => {
+    const currentIndex = connectionIndex++;
+    handleConnection(socket, currentIndex).then(() => {
+      if (currentIndex === 1) resolveDone();
+    }, rejectDone);
+  });
+  server.on('error', rejectDone);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, resolve);
+  });
+  openServers.push(server);
+  return { done };
+}
+
+export async function readPacket(socket: Socket): Promise<string> {
+  const packet = await readUntil(socket, (buffer) => {
+    if (buffer.length < 16) return undefined;
+    const length = buffer.readUInt32LE(0);
+    return buffer.length >= length ? buffer.subarray(16, length) : undefined;
+  });
+  return packet.toString('utf8');
+}
+
+export function buildPacket(xml: string): Buffer {
+  const payload = Buffer.from(xml, 'utf8');
+  const packet = Buffer.alloc(16 + payload.length);
+  packet.writeUInt32LE(packet.length, 0);
+  packet.writeUInt32LE(1, 4);
+  packet.writeUInt32LE(8, 8);
+  packet.writeUInt32LE(1, 12);
+  payload.copy(packet, 16);
+  return packet;
+}
+
+export async function readHttpRequestBody(socket: Socket): Promise<string> {
+  const body = await readUntil(socket, (buffer) => {
+    const headerEnd = buffer.indexOf('\r\n\r\n');
+    if (headerEnd < 0) return undefined;
+    const headers = buffer.subarray(0, headerEnd).toString('utf8');
+    const contentLength = Number(/^content-length:\s*(\d+)$/im.exec(headers)?.[1]);
+    const bodyStart = headerEnd + 4;
+    return buffer.length >= bodyStart + contentLength
+      ? buffer.subarray(bodyStart, bodyStart + contentLength)
+      : undefined;
+  });
+  return body.toString('utf8');
+}
+
+async function readUntil(
+  socket: Socket,
+  select: (buffer: Buffer) => Buffer | undefined,
+): Promise<Buffer> {
+  return await new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    const onData = (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const selected = select(buffer);
+      if (!selected) return;
+      cleanup();
+      resolve(selected);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      socket.off('data', onData);
+      socket.off('error', onError);
+    };
+    socket.on('data', onData);
+    socket.once('error', onError);
+  });
+}
+
+export function hostToNetworkPort(port: number): number {
+  return ((port & 0xff) << 8) | ((port >>> 8) & 0xff);
+}
+
+export async function cleanupUsbmuxFixtures(
+  openServers: Server[],
+  socketDirectories: string[],
+): Promise<void> {
+  await Promise.all(
+    openServers.splice(0).map(async (server) => {
+      const closableServer = server as Server & { closeAllConnections?: () => void };
+      closableServer.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }),
+  );
+  await Promise.all(
+    socketDirectories
+      .splice(0)
+      .map(async (directory) => await fs.rm(directory, { force: true, recursive: true })),
+  );
+}

--- a/src/platforms/apple/core/__tests__/runner-usbmux.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-usbmux.test.ts
@@ -1,11 +1,18 @@
 import assert from 'node:assert/strict';
-import { promises as fs } from 'node:fs';
-import net, { type Server, type Socket } from 'node:net';
-import path from 'node:path';
+import type { Server } from 'node:net';
 import { afterEach, test } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
 import { createUsbmuxRunnerTransport } from '../runner/runner-usbmux.ts';
-import { mkdtempForTest } from '../../../../__tests__/test-utils/tmp-dir.ts';
+import {
+  buildPacket,
+  cleanupUsbmuxFixtures,
+  createFakeUsbmuxd,
+  createSocketPath,
+  hostToNetworkPort,
+  type FakeDevice,
+  readHttpRequestBody,
+  readPacket,
+} from './runner-usbmux-fixtures.ts';
 
 const DEVICE_UDID = '00008020-001C2D2234567890';
 const USBMUX_DEVICE_ID = 42;
@@ -14,24 +21,13 @@ const openServers: Server[] = [];
 const socketDirectories: string[] = [];
 
 afterEach(async () => {
-  await Promise.all(
-    openServers.splice(0).map(
-      async (server) =>
-        await new Promise<void>((resolve) => {
-          server.close(() => resolve());
-        }),
-    ),
-  );
-  await Promise.all(
-    socketDirectories
-      .splice(0)
-      .map(async (directory) => await fs.rm(directory, { force: true, recursive: true })),
-  );
+  await cleanupUsbmuxFixtures(openServers, socketDirectories);
 });
 
 test('xctest runner commands use usbmux device lookup and port transport', async () => {
-  const socketPath = await createSocketPath();
+  const socketPath = await createSocketPath(socketDirectories);
   const { done: serverDone } = await createFakeUsbmuxd(
+    openServers,
     socketPath,
     async (socket, connectionIndex) => {
       if (connectionIndex === 0) {
@@ -97,8 +93,6 @@ test('xctest runner commands use usbmux device lookup and port transport', async
   await serverDone;
 });
 
-type FakeDevice = { deviceId: number; udid: string; connectionType?: string };
-
 /**
  * Serves ListDevices from `devices`, then answers Connect with `connectResult`.
  * Records the DeviceID the client asked to connect to, which is what proves
@@ -110,7 +104,7 @@ async function serveUsbmuxDevices(
   connectResult = 0,
 ): Promise<{ connectedDeviceId: () => number | undefined }> {
   let connectedDeviceId: number | undefined;
-  await createFakeUsbmuxd(socketPath, async (socket, connectionIndex) => {
+  await createFakeUsbmuxd(openServers, socketPath, async (socket, connectionIndex) => {
     if (connectionIndex === 0) {
       await readPacket(socket);
       const entries = devices
@@ -160,7 +154,7 @@ test('selects the requested device by UDID regardless of its position in the lis
     [...others, target],
     [others[0]!, target, others[1]!],
   ]) {
-    const socketPath = await createSocketPath();
+    const socketPath = await createSocketPath(socketDirectories);
     const server = await serveUsbmuxDevices(socketPath, devices);
     await postThroughFakeUsbmux(socketPath, DEVICE_UDID);
     assert.equal(server.connectedDeviceId(), 77);
@@ -168,7 +162,7 @@ test('selects the requested device by UDID regardless of its position in the lis
 });
 
 test('never matches a different device whose UDID merely shares a prefix', async () => {
-  const socketPath = await createSocketPath();
+  const socketPath = await createSocketPath(socketDirectories);
   const server = await serveUsbmuxDevices(socketPath, [
     { deviceId: 5, udid: `${DEVICE_UDID}0` },
     { deviceId: 6, udid: DEVICE_UDID.slice(0, -1) },
@@ -181,7 +175,7 @@ test('never matches a different device whose UDID merely shares a prefix', async
 });
 
 test('treats a device usbmuxd no longer knows as unattached so a tunnel fallback can run', async () => {
-  const socketPath = await createSocketPath();
+  const socketPath = await createSocketPath(socketDirectories);
   // Result 2 is what the real daemon answers for an unknown DeviceID.
   await serveUsbmuxDevices(socketPath, [{ deviceId: 42, udid: DEVICE_UDID }], 2);
 
@@ -194,7 +188,7 @@ test('treats a device usbmuxd no longer knows as unattached so a tunnel fallback
 });
 
 test('reports a refused runner port as the runner not listening, not a cable problem', async () => {
-  const socketPath = await createSocketPath();
+  const socketPath = await createSocketPath(socketDirectories);
   // Result 3 is what the real daemon answers for a closed port on a live device.
   await serveUsbmuxDevices(socketPath, [{ deviceId: 42, udid: DEVICE_UDID }], 3);
 
@@ -206,100 +200,3 @@ test('reports a refused runner port as the runner not listening, not a cable pro
   assert.match(appError.message, /not listening on the device port/);
   assert.doesNotMatch(String(appError.details?.hint), /cable/);
 });
-
-async function createSocketPath(): Promise<string> {
-  const directory = await mkdtempForTest('agent-device-usbmux-test-');
-  const socketPath = path.join(directory, 'usbmuxd.sock');
-  socketDirectories.push(directory);
-  return socketPath;
-}
-
-async function createFakeUsbmuxd(
-  socketPath: string,
-  handleConnection: (socket: Socket, connectionIndex: number) => Promise<void>,
-): Promise<{ done: Promise<void> }> {
-  let connectionIndex = 0;
-  let resolveDone!: () => void;
-  let rejectDone!: (error: unknown) => void;
-  const done = new Promise<void>((resolve, reject) => {
-    resolveDone = resolve;
-    rejectDone = reject;
-  });
-  const server = net.createServer((socket) => {
-    const currentIndex = connectionIndex++;
-    handleConnection(socket, currentIndex).then(() => {
-      if (currentIndex === 1) resolveDone();
-    }, rejectDone);
-  });
-  server.on('error', rejectDone);
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(socketPath, resolve);
-  });
-  openServers.push(server);
-  return { done };
-}
-
-async function readPacket(socket: Socket): Promise<string> {
-  const packet = await readUntil(socket, (buffer) => {
-    if (buffer.length < 16) return undefined;
-    const length = buffer.readUInt32LE(0);
-    return buffer.length >= length ? buffer.subarray(16, length) : undefined;
-  });
-  return packet.toString('utf8');
-}
-
-function buildPacket(xml: string): Buffer {
-  const payload = Buffer.from(xml, 'utf8');
-  const packet = Buffer.alloc(16 + payload.length);
-  packet.writeUInt32LE(packet.length, 0);
-  packet.writeUInt32LE(1, 4);
-  packet.writeUInt32LE(8, 8);
-  packet.writeUInt32LE(1, 12);
-  payload.copy(packet, 16);
-  return packet;
-}
-
-async function readHttpRequestBody(socket: Socket): Promise<string> {
-  const body = await readUntil(socket, (buffer) => {
-    const headerEnd = buffer.indexOf('\r\n\r\n');
-    if (headerEnd < 0) return undefined;
-    const headers = buffer.subarray(0, headerEnd).toString('utf8');
-    const contentLength = Number(/^content-length:\s*(\d+)$/im.exec(headers)?.[1]);
-    const bodyStart = headerEnd + 4;
-    return buffer.length >= bodyStart + contentLength
-      ? buffer.subarray(bodyStart, bodyStart + contentLength)
-      : undefined;
-  });
-  return body.toString('utf8');
-}
-
-async function readUntil(
-  socket: Socket,
-  select: (buffer: Buffer) => Buffer | undefined,
-): Promise<Buffer> {
-  return await new Promise((resolve, reject) => {
-    let buffer = Buffer.alloc(0);
-    const onData = (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      const selected = select(buffer);
-      if (!selected) return;
-      cleanup();
-      resolve(selected);
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      socket.off('data', onData);
-      socket.off('error', onError);
-    };
-    socket.on('data', onData);
-    socket.once('error', onError);
-  });
-}
-
-function hostToNetworkPort(port: number): number {
-  return ((port & 0xff) << 8) | ((port >>> 8) & 0xff);
-}

--- a/src/platforms/web/__tests__/agent-browser-boundary-faults.test.ts
+++ b/src/platforms/web/__tests__/agent-browser-boundary-faults.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import { createFailNthCommandExecutor } from '../../../__tests__/test-utils/exec-faults.ts';
+import { withCommandExecutorOverride } from '../../../utils/exec.ts';
+import { createAgentBrowserWebProvider } from '../agent-browser-provider.ts';
+import { installFakeManagedAgentBrowser } from './test-utils.ts';
+
+const COMMAND_CLASS_OPERATIONS = {
+  mutation: (provider: ReturnType<typeof createAgentBrowserWebProvider>) => provider.click(10, 20),
+  read: async (provider: ReturnType<typeof createAgentBrowserWebProvider>) => {
+    await provider.snapshot();
+  },
+  'artifact-producing': (provider: ReturnType<typeof createAgentBrowserWebProvider>) =>
+    provider.screenshot('/tmp/boundary-fault.png'),
+  'session-lifecycle': (provider: ReturnType<typeof createAgentBrowserWebProvider>) =>
+    provider.open('https://example.test'),
+} as const;
+
+for (const [commandClass, runOperation] of Object.entries(COMMAND_CLASS_OPERATIONS)) {
+  test(`agent-browser fail-Nth subprocess fault is not replayed for ${commandClass}`, async () => {
+    const stateDir = mkdtempForTestSync(`agent-device-exec-boundary-${commandClass}-`);
+    try {
+      installFakeManagedAgentBrowser(stateDir);
+      const provider = createAgentBrowserWebProvider({ stateDir, session: 'boundary' });
+      const failure = new AppError('COMMAND_FAILED', 'injected command failure', {
+        hint: 'retry the boundary test',
+        diagnosticId: `diag-${commandClass}`,
+        logPath: `/tmp/${commandClass}.ndjson`,
+      });
+      const driver = createFailNthCommandExecutor(1, failure);
+
+      await assert.rejects(
+        withCommandExecutorOverride(driver.override, async () => await runOperation(provider)),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, 'COMMAND_FAILED');
+          assert.equal(error.message, 'injected command failure');
+          assert.equal(error.details?.hint, 'retry the boundary test');
+          assert.equal(error.details?.diagnosticId, `diag-${commandClass}`);
+          assert.equal(error.details?.logPath, `/tmp/${commandClass}.ndjson`);
+          return true;
+        },
+      );
+      assert.equal(driver.calls().length, 1, 'the failed command must not be replayed');
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+}

--- a/src/utils/__tests__/exec-boundary-faults.test.ts
+++ b/src/utils/__tests__/exec-boundary-faults.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { createFailNthCommandExecutor } from '../../__tests__/test-utils/exec-faults.ts';
+import { runCmd, withCommandExecutorOverride } from '../exec.ts';
+
+test('fail-Nth executor drives one deterministic command failure without hiding later calls', async () => {
+  const failure = new AppError('COMMAND_FAILED', 'injected command failure', {
+    hint: 'retry the boundary test',
+  });
+  const driver = createFailNthCommandExecutor(2, failure);
+
+  await withCommandExecutorOverride(driver.override, async () => {
+    assert.equal((await runCmd('fake-tool', ['first'])).exitCode, 0);
+    await assert.rejects(runCmd('fake-tool', ['second']), (error: unknown) => error === failure);
+    assert.equal((await runCmd('fake-tool', ['third'])).exitCode, 0);
+  });
+
+  assert.deepEqual(
+    driver.calls().map((call) => call.args),
+    [['first'], ['second'], ['third']],
+  );
+});

--- a/test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts
+++ b/test/integration/provider-scenarios/daemon-http-boundary-cancellation.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { test } from 'vitest';
+import { getRequestSignal } from '../../../src/request/cancel.ts';
+import { createDaemonHttpServer } from '../../../src/daemon/server/http-server.ts';
+import type { DaemonRequest, DaemonResponse } from '../../../src/daemon/types.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../../src/__tests__/test-utils/loopback.ts';
+
+const CANCELLATION_ROWS = {
+  mutation: { command: 'press', positionals: ['enter'] },
+  read: { command: 'snapshot', positionals: [] },
+  'artifact-producing': { command: 'screenshot', positionals: ['/tmp/boundary.png'] },
+  'session-lifecycle': { command: 'open', positionals: ['Demo'] },
+} as const satisfies Record<string, Readonly<{ command: string; positionals: readonly string[] }>>;
+
+for (const [commandClass, row] of Object.entries(CANCELLATION_ROWS)) {
+  test(`HTTP cancellation mid-request is scoped for the ${commandClass} command class`, async (t) => {
+    if (await skipWhenLoopbackUnavailable(t, 'daemon HTTP boundary cancellation coverage')) return;
+
+    const requestId = `boundary-cancellation-${commandClass}`;
+    let markHandlerStarted: () => void = () => {};
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    let markAbortObserved: () => void = () => {};
+    const abortObserved = new Promise<void>((resolve) => {
+      markAbortObserved = resolve;
+    });
+
+    const server = await createDaemonHttpServer({
+      token: 'boundary-cancellation-token',
+      handleRequest: async (request: DaemonRequest): Promise<DaemonResponse> => {
+        assert.equal(request.command, row.command);
+        const signal = getRequestSignal(requestId);
+        assert.ok(signal, 'request signal should be registered before the handler runs');
+        markHandlerStarted();
+        await waitForAbort(signal);
+        assert.equal(signal.aborted, true);
+        markAbortObserved();
+        return { ok: true, data: { canceled: signal.aborted } };
+      },
+    });
+
+    try {
+      const port = await listenOnLoopback(server);
+      const requestClosed = sendRpcAndDisconnectOnceStarted(port, handlerStarted, {
+        jsonrpc: '2.0',
+        id: `rpc-${requestId}`,
+        method: 'agent_device.command',
+        params: {
+          command: row.command,
+          positionals: [...row.positionals],
+          meta: { requestId },
+        },
+      });
+      await Promise.all([requestClosed, abortObserved]);
+      assert.equal(
+        getRequestSignal(requestId),
+        undefined,
+        'canceled request signal must be cleaned',
+      );
+    } finally {
+      await closeLoopbackServer(server);
+    }
+  });
+}
+
+function sendRpcAndDisconnectOnceStarted(
+  port: number,
+  handlerStarted: Promise<void>,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload);
+    const request = http.request({
+      host: '127.0.0.1',
+      port,
+      path: '/rpc',
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer boundary-cancellation-token',
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(body),
+      },
+    });
+    request.on('error', () => {
+      // The intentional disconnect is reported as a client-side socket error;
+      // the server-side AbortSignal is the contract under test.
+    });
+    void handlerStarted.then(() => {
+      request.destroy();
+      resolve();
+    }, reject);
+    request.end(body);
+  });
+}
+
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}


### PR DESCRIPTION
## Summary

Completes #1431's deterministic boundary-fault matrix across timeout, cancellation, partial or malformed response, process death, lost response after mutation, filesystem publication failure, and optional optimization failure for mutation, read, artifact-producing, and session-lifecycle command classes.

Adds a `satisfies`-enforced 7×4 matrix with executable evidence and explicit applicability rows; extends process-death acceptance to `press`, `fill`, `snapshot`, `screenshot`, `open`, and `close`; adds daemon HTTP/socket framing and cancellation coverage; adds usbmux timeout, cancellation, partial, malformed, and process-death coverage; adds a fail-Nth command executor; and fixes partial final daemon socket responses to fail at EOF instead of waiting for the request timeout.

The web-session SIGTERM issue (#1868) and durable process-identity redesign (#1882) remain separate follow-ups; this PR does not claim to solve them.

Closes #1431

## Validation

`pnpm check:affected --run` passed all runnable local checks. Native/device, coverage, mutation, replay, and other GitHub-authoritative lanes remain for CI.
