### PR TITLE
test: add Linux platform command coverage manifest

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -45,6 +45,8 @@ on:
       - 'test/integration/replays/macos/**'
       - 'test/integration/android-**'
       - 'test/integration/smoke-android-**'
+      - 'test/integration/smoke-linux-**'
+      - 'test/integration/linux-e2e/**'
       - 'test/integration/smoke-web-**'
       - 'test/integration/web-e2e/**'
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Setup toolchain
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Run Linux desktop catalog coverage contract
-        run: node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-linux-coverage.test.ts
-
       - name: Start Xvfb and D-Bus
         run: |
           # Start virtual framebuffer (1280x1024, 24-bit color)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Setup toolchain
         uses: ./.github/actions/setup-node-pnpm
 
+      - name: Run Linux desktop catalog coverage contract
+        run: node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-linux-coverage.test.ts
+
       - name: Start Xvfb and D-Bus
         run: |
           # Start virtual framebuffer (1280x1024, 24-bit color)

--- a/test/integration/android-emulator-e2e/coverage-manifest.ts
+++ b/test/integration/android-emulator-e2e/coverage-manifest.ts
@@ -2,6 +2,7 @@ import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 import { ANDROID_AUDIO_CONTRACT_EVIDENCE } from '../../../src/daemon/handlers/__tests__/session-audio.coverage.ts';
 import { ANDROID_INSTALL_SOURCE_CONTRACT_EVIDENCE } from '../../../src/platforms/__tests__/install-source.coverage.ts';
 import { ANDROID_LIFECYCLE_CONTRACT_EVIDENCE } from '../provider-scenarios/android-lifecycle.coverage.ts';
+import { buildCoverageClassificationSummary } from '../support/coverage-classification.ts';
 import {
   defineAndroidContractEvidence,
   type AndroidContractEvidence,
@@ -17,14 +18,6 @@ export type AndroidEmulatorCoverageEntry =
       level: 'command-contract';
     }
   | { assertion: string; level: 'capability-denial' };
-
-export type AndroidEmulatorCoverageClassificationSummary = {
-  capabilityDenial: number;
-  contract: number;
-  gap: number;
-  live: number;
-  total: number;
-};
 
 const C = PUBLIC_COMMANDS;
 const live = (scenario: string, assertion: string): AndroidEmulatorCoverageEntry => ({
@@ -219,30 +212,4 @@ export function liveCommandsForScenario(scenarioId: string): PublicCommand[] {
   return Object.entries(ANDROID_EMULATOR_E2E_COVERAGE)
     .filter(([, entry]) => entry.level === 'live' && entry.scenario === scenarioId)
     .map(([command]) => command as PublicCommand);
-}
-
-function buildCoverageClassificationSummary(
-  entries: readonly AndroidEmulatorCoverageEntry[],
-): AndroidEmulatorCoverageClassificationSummary {
-  const summary: AndroidEmulatorCoverageClassificationSummary = {
-    capabilityDenial: 0,
-    contract: 0,
-    gap: 0,
-    live: 0,
-    total: entries.length,
-  };
-  for (const entry of entries) {
-    switch (entry.level) {
-      case 'live':
-        summary.live += 1;
-        break;
-      case 'command-contract':
-        summary.contract += 1;
-        break;
-      case 'capability-denial':
-        summary.capabilityDenial += 1;
-        break;
-    }
-  }
-  return summary;
 }

--- a/test/integration/linux-e2e/coverage-manifest.ts
+++ b/test/integration/linux-e2e/coverage-manifest.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import { buildCoverageClassificationSummary } from '../support/coverage-classification.ts';
 
 type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
 
@@ -27,14 +28,6 @@ export type LinuxPlatformCoverageEntry =
       level: 'known-gap';
       trackingIssue: number;
     };
-
-export type LinuxPlatformCoverageClassificationSummary = {
-  capabilityDenial: number;
-  contract: number;
-  gap: number;
-  live: number;
-  total: number;
-};
 
 export const LINUX_COVERAGE_GAP_ISSUE = 1915;
 
@@ -251,33 +244,4 @@ export function liveCommandsForLinuxReplay(): PublicCommand[] {
   return Object.entries(LINUX_PLATFORM_COVERAGE)
     .filter(([, entry]) => entry.level === 'live')
     .map(([command]) => command as PublicCommand);
-}
-
-function buildCoverageClassificationSummary(
-  entries: readonly LinuxPlatformCoverageEntry[],
-): LinuxPlatformCoverageClassificationSummary {
-  const summary: LinuxPlatformCoverageClassificationSummary = {
-    capabilityDenial: 0,
-    contract: 0,
-    gap: 0,
-    live: 0,
-    total: entries.length,
-  };
-  for (const entry of entries) {
-    switch (entry.level) {
-      case 'live':
-        summary.live += 1;
-        break;
-      case 'command-contract':
-        summary.contract += 1;
-        break;
-      case 'capability-denial':
-        summary.capabilityDenial += 1;
-        break;
-      case 'known-gap':
-        summary.gap += 1;
-        break;
-    }
-  }
-  return summary;
 }

--- a/test/integration/linux-e2e/coverage-manifest.ts
+++ b/test/integration/linux-e2e/coverage-manifest.ts
@@ -1,0 +1,283 @@
+import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+
+type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
+
+type RepositoryEvidence = {
+  path: string;
+  test: string;
+};
+
+type CapabilityDeclarationEvidence = RepositoryEvidence & {
+  declaration: string;
+};
+
+export type LinuxPlatformCoverageEntry =
+  | {
+      assertion: string;
+      level: 'live' | 'command-contract';
+      owner: RepositoryEvidence;
+    }
+  | {
+      assertion: string;
+      level: 'capability-denial';
+      owner: CapabilityDeclarationEvidence;
+    }
+  | {
+      assertion: string;
+      level: 'known-gap';
+      trackingIssue: number;
+    };
+
+export type LinuxPlatformCoverageClassificationSummary = {
+  capabilityDenial: number;
+  contract: number;
+  gap: number;
+  live: number;
+  total: number;
+};
+
+export const LINUX_COVERAGE_GAP_ISSUE = 1915;
+
+export const LINUX_REPLAY_EVIDENCE: RepositoryEvidence = {
+  path: 'test/integration/replays/linux/01-desktop-smoke.ad',
+  test: '# Smoke test for Linux desktop automation on CI.',
+};
+
+const LINUX_PROVIDER_EVIDENCE: RepositoryEvidence = {
+  path: 'test/integration/provider-scenarios/linux-desktop.test.ts',
+  test: 'Provider-backed integration Linux desktop flow uses semantic desktop and input providers',
+};
+
+const LINUX_RUNTIME_EVIDENCE: RepositoryEvidence = {
+  path: 'packages/platform-linux/src/runtime.test.ts',
+  test: 'classifies the Linux $name lifecycle denominator against the legacy dispatch cell',
+};
+
+const LINUX_CAPABILITY_DECLARATION_PATH = 'src/core/command-descriptor/registry.ts';
+const LINUX_CAPABILITY_DECLARATION = 'linux: LINUX_NONE';
+
+const C = PUBLIC_COMMANDS;
+const live = (assertion: string): LinuxPlatformCoverageEntry => ({
+  assertion,
+  level: 'live',
+  owner: LINUX_REPLAY_EVIDENCE,
+});
+const contract = (path: string, test: string, assertion: string): LinuxPlatformCoverageEntry => ({
+  assertion,
+  level: 'command-contract',
+  owner: { path, test },
+});
+const denial = (command: string, assertion: string): LinuxPlatformCoverageEntry => ({
+  assertion,
+  level: 'capability-denial',
+  owner: {
+    path: LINUX_CAPABILITY_DECLARATION_PATH,
+    test: `name: '${command}'`,
+    declaration: LINUX_CAPABILITY_DECLARATION,
+  },
+});
+const gap = (assertion: string): LinuxPlatformCoverageEntry => ({
+  assertion,
+  level: 'known-gap',
+  trackingIssue: LINUX_COVERAGE_GAP_ISSUE,
+});
+
+/**
+ * One primary, observable owner for every public command on the Linux desktop.
+ *
+ * Live rows are limited to the existing Linux replay. Contract rows cite the
+ * existing provider scenario or dedicated Linux unit/runtime evidence; they do
+ * not turn mocked provider calls into live desktop claims. Capability denials
+ * are derived from the owning command-descriptor matrix. Known gaps are
+ * explicit follow-up work, not an implicit claim that a generic command works.
+ */
+export const LINUX_PLATFORM_COVERAGE = {
+  [C.artifacts]: gap('No Linux-specific artifact inventory command evidence exists yet'),
+  [C.devices]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario inventories the selected desktop device through the daemon client',
+  ),
+  [C.capabilities]: gap('No Linux-specific capabilities command evidence exists yet'),
+  [C.doctor]: gap('No Linux-specific doctor command evidence exists yet'),
+  [C.apps]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report native app inventory unavailable',
+  ),
+  [C.boot]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report boot unavailable for the desktop owner',
+  ),
+  [C.shutdown]: gap('No Linux-specific shutdown command evidence exists yet'),
+  [C.appState]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report app state unavailable',
+  ),
+  [C.perf]: denial('perf', 'Linux capability declaration rejects native performance inspection'),
+  [C.logs]: gap('No Linux-specific app-log command evidence exists yet'),
+  [C.events]: gap('No Linux-specific session event command evidence exists yet'),
+  [C.network]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report network capture unavailable',
+  ),
+  [C.audio]: denial('audio', 'Linux capability declaration rejects native audio probing'),
+  [C.replay]: gap('No Linux-specific replay command evidence exists yet'),
+  [C.test]: gap('No Linux-specific test-suite command evidence exists yet'),
+  [C.clipboard]: contract(
+    'src/platforms/linux/__tests__/clipboard.test.ts',
+    'writeLinuxClipboard uses xclip with stdin on X11',
+    'Linux clipboard writes through the supported X11 host-tool seam',
+  ),
+  [C.keyboard]: denial('keyboard', 'Linux capability declaration rejects native keyboard control'),
+  [C.install]: gap('No Linux-specific application installation command evidence exists yet'),
+  [C.reinstall]: gap('No Linux-specific application reinstallation command evidence exists yet'),
+  [C.push]: gap('No Linux-specific push delivery command evidence exists yet'),
+  [C.triggerAppEvent]: denial(
+    'trigger-app-event',
+    'Linux capability declaration rejects native application event delivery',
+  ),
+  [C.open]: live('the existing Linux replay opens gnome-calculator'),
+  [C.prepare]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report Apple runner preparation unavailable',
+  ),
+  [C.batch]: gap('No Linux-specific batch command evidence exists yet'),
+  [C.close]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario closes the calculator and observes the desktop close call',
+  ),
+  [C.snapshot]: live('the existing Linux replay captures the calculator accessibility tree'),
+  [C.diff]: gap('No Linux-specific snapshot diff command evidence exists yet'),
+  [C.wait]: live('the existing Linux replay waits for an observable calculator landmark'),
+  [C.alert]: denial('alert', 'Linux capability declaration rejects native alert operations'),
+  [C.settings]: denial(
+    'settings',
+    'Linux capability declaration rejects native device settings operations',
+  ),
+  [C.reactNative]: denial(
+    'react-native',
+    'Linux capability declaration rejects React Native inspection',
+  ),
+  [C.record]: gap('No Linux-specific recording command evidence exists yet'),
+  [C.trace]: gap('No Linux-specific trace command evidence exists yet'),
+  [C.find]: gap('No Linux-specific find command evidence exists yet'),
+  [C.click]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario executes primary, secondary, middle, and double clicks',
+  ),
+  [C.fill]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario fills both a snapshot ref and coordinate target',
+  ),
+  [C.longPress]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario executes a coordinate long press',
+  ),
+  [C.hover]: denial('hover', 'Linux capability declaration rejects pointer-only hover input'),
+  [C.press]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario presses a snapshot ref and coordinate target',
+  ),
+  [C.type]: contract(
+    'src/platforms/linux/__tests__/input-actions.test.ts',
+    'typeLinux uses ydotool type',
+    'Linux type dispatch uses the Wayland ydotool type primitive',
+  ),
+  [C.get]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario reads the pressed snapshot ref text',
+  ),
+  [C.is]: live('the existing Linux replay verifies a calculator landmark exists'),
+  [C.back]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario dispatches Alt+Left through the semantic input provider',
+  ),
+  [C.gesture]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario executes a single-pointer pan through the semantic drag provider',
+  ),
+  [C.home]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario dispatches Super+D through the semantic input provider',
+  ),
+  [C.tvRemote]: denial('tv-remote', 'Linux capability declaration rejects TV remote input'),
+  [C.orientation]: denial(
+    'orientation',
+    'Linux capability declaration rejects native orientation changes',
+  ),
+  [C.scroll]: contract(
+    'src/platforms/linux/__tests__/input-actions.test.ts',
+    'scrollLinux uses ydotool mousemove --wheel for vertical scroll',
+    'Linux scroll dispatch uses the Wayland ydotool wheel primitive',
+  ),
+  [C.swipe]: gap('No Linux-specific public swipe command evidence exists yet'),
+  [C.focus]: contract(
+    LINUX_PROVIDER_EVIDENCE.path,
+    LINUX_PROVIDER_EVIDENCE.test,
+    'Linux provider scenario focuses a coordinate target',
+  ),
+  [C.screenshot]: live('the existing Linux replay creates a screenshot artifact'),
+  [C.viewport]: contract(
+    LINUX_RUNTIME_EVIDENCE.path,
+    LINUX_RUNTIME_EVIDENCE.test,
+    'Linux runtime facts explicitly report viewport changes unavailable',
+  ),
+  [C.appSwitcher]: denial(
+    'app-switcher',
+    'Linux capability declaration rejects native app-switcher navigation',
+  ),
+  [C.installFromSource]: gap('No Linux-specific source-install command evidence exists yet'),
+} satisfies Record<PublicCommand, LinuxPlatformCoverageEntry>;
+
+export const LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClassificationSummary(
+  Object.values(LINUX_PLATFORM_COVERAGE),
+);
+
+export function liveCommandsForLinuxReplay(): PublicCommand[] {
+  return Object.entries(LINUX_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'live')
+    .map(([command]) => command as PublicCommand);
+}
+
+function buildCoverageClassificationSummary(
+  entries: readonly LinuxPlatformCoverageEntry[],
+): LinuxPlatformCoverageClassificationSummary {
+  const summary: LinuxPlatformCoverageClassificationSummary = {
+    capabilityDenial: 0,
+    contract: 0,
+    gap: 0,
+    live: 0,
+    total: entries.length,
+  };
+  for (const entry of entries) {
+    switch (entry.level) {
+      case 'live':
+        summary.live += 1;
+        break;
+      case 'command-contract':
+        summary.contract += 1;
+        break;
+      case 'capability-denial':
+        summary.capabilityDenial += 1;
+        break;
+      case 'known-gap':
+        summary.gap += 1;
+        break;
+    }
+  }
+  return summary;
+}

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { parseReplayScriptDetailed } from '@agent-device/ad-script';
+import { LINUX_DEVICE } from '../../src/__tests__/test-utils/device-fixtures.ts';
 import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
 import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
 import {
@@ -14,13 +15,6 @@ import {
   liveCommandsForLinuxReplay,
 } from './linux-e2e/coverage-manifest.ts';
 
-const LINUX_DESKTOP = {
-  id: 'ci-linux-desktop',
-  kind: 'device' as const,
-  name: 'CI Linux desktop',
-  platform: 'linux' as const,
-  target: 'desktop' as const,
-};
 const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
 
 test('Linux coverage exhaustively classifies the public catalog', () => {
@@ -90,7 +84,7 @@ test('Linux contract claims name existing executable evidence', () => {
 
 test('Linux capability denials match the owning descriptor matrix', () => {
   const deniedByCapabilities = publicCommands.filter(
-    (command) => !isCommandSupportedOnDevice(command, LINUX_DESKTOP),
+    (command) => !isCommandSupportedOnDevice(command, LINUX_DEVICE),
   );
   const deniedByManifest = Object.entries(LINUX_PLATFORM_COVERAGE)
     .filter(([, entry]) => entry.level === 'capability-denial')

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { parseReplayScriptDetailed } from '@agent-device/ad-script';
+import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
+import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
+import {
+  LINUX_COVERAGE_GAP_ISSUE,
+  LINUX_PLATFORM_COVERAGE,
+  LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+  LINUX_REPLAY_EVIDENCE,
+  liveCommandsForLinuxReplay,
+} from './linux-e2e/coverage-manifest.ts';
+
+const LINUX_DESKTOP = {
+  id: 'ci-linux-desktop',
+  kind: 'device' as const,
+  name: 'CI Linux desktop',
+  platform: 'linux' as const,
+  target: 'desktop' as const,
+};
+const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
+
+test('Linux coverage exhaustively classifies the public catalog', () => {
+  assert.deepEqual(Object.keys(LINUX_PLATFORM_COVERAGE).sort(), publicCommands);
+
+  for (const command of publicCommands) {
+    const entry = LINUX_PLATFORM_COVERAGE[command];
+    assert.ok(entry.assertion.trim().length > 0, `${command} needs an observable assertion`);
+    if (entry.level === 'live' || entry.level === 'command-contract') {
+      assert.ok(entry.owner.path.trim().length > 0, `${command} needs an evidence path`);
+      assert.ok(entry.owner.test.trim().length > 0, `${command} needs named evidence`);
+    }
+    if (entry.level === 'known-gap') {
+      assert.equal(
+        entry.trackingIssue,
+        LINUX_COVERAGE_GAP_ISSUE,
+        `${command} has the wrong Linux gap issue`,
+      );
+    }
+  }
+});
+
+test('Linux coverage report has the expected classification counts', () => {
+  assert.deepEqual(LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
+    capabilityDenial: 11,
+    contract: 20,
+    gap: 18,
+    live: 5,
+    total: 54,
+  });
+
+  const { capabilityDenial, contract, gap, live, total } =
+    LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY;
+  assert.equal(capabilityDenial + contract + gap + live, total);
+});
+
+test('Linux live claims reference commands in the existing smoke replay', () => {
+  const replaySource = fs.readFileSync(path.resolve(LINUX_REPLAY_EVIDENCE.path), 'utf8');
+  assert.ok(replaySource.includes(LINUX_REPLAY_EVIDENCE.test));
+
+  const replayCommands = new Set(
+    parseReplayScriptDetailed(replaySource).actions.map((action) => action.command),
+  );
+  const liveCommands = liveCommandsForLinuxReplay();
+  assert.deepEqual(liveCommands.length, 5);
+  for (const command of liveCommands) {
+    assert.equal(
+      replayCommands.has(command),
+      true,
+      `${command} is not invoked by ${LINUX_REPLAY_EVIDENCE.path}`,
+    );
+  }
+});
+
+test('Linux contract claims name existing executable evidence', () => {
+  for (const [command, entry] of Object.entries(LINUX_PLATFORM_COVERAGE)) {
+    if (entry.level !== 'command-contract') continue;
+    const evidencePath = path.resolve(entry.owner.path);
+    assert.equal(fs.existsSync(evidencePath), true, `${command} owner does not exist`);
+    assert.equal(
+      fs.readFileSync(evidencePath, 'utf8').includes(entry.owner.test),
+      true,
+      `${command} owner does not contain named evidence`,
+    );
+  }
+});
+
+test('Linux capability denials match the owning descriptor matrix', () => {
+  const deniedByCapabilities = publicCommands.filter(
+    (command) => !isCommandSupportedOnDevice(command, LINUX_DESKTOP),
+  );
+  const deniedByManifest = Object.entries(LINUX_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'capability-denial')
+    .map(([command]) => command)
+    .sort();
+
+  assert.deepEqual(deniedByManifest, deniedByCapabilities);
+
+  for (const [command, entry] of Object.entries(LINUX_PLATFORM_COVERAGE)) {
+    if (entry.level !== 'capability-denial') continue;
+    const declarationPath = path.resolve(entry.owner.path);
+    const declarationSource = fs.readFileSync(declarationPath, 'utf8');
+    assert.equal(
+      declarationSource.includes(entry.owner.test),
+      true,
+      `${command} capability owner does not name its descriptor`,
+    );
+    assert.equal(
+      declarationSource.includes(entry.owner.declaration),
+      true,
+      `${command} capability owner does not cite its Linux declaration`,
+    );
+  }
+});
+
+test('Linux known gaps use one grouped tracking issue', () => {
+  const gapIssues = new Set(
+    Object.values(LINUX_PLATFORM_COVERAGE)
+      .filter((entry) => entry.level === 'known-gap')
+      .map((entry) => entry.trackingIssue),
+  );
+  assert.deepEqual([...gapIssues], [LINUX_COVERAGE_GAP_ISSUE]);
+});

--- a/test/integration/support/coverage-classification.ts
+++ b/test/integration/support/coverage-classification.ts
@@ -1,0 +1,42 @@
+export type CoverageClassificationLevel =
+  | 'live'
+  | 'command-contract'
+  | 'capability-denial'
+  | 'known-gap';
+
+export type CoverageClassificationSummary = {
+  capabilityDenial: number;
+  contract: number;
+  gap: number;
+  live: number;
+  total: number;
+};
+
+export function buildCoverageClassificationSummary(
+  entries: readonly { level: CoverageClassificationLevel }[],
+): CoverageClassificationSummary {
+  const summary: CoverageClassificationSummary = {
+    capabilityDenial: 0,
+    contract: 0,
+    gap: 0,
+    live: 0,
+    total: entries.length,
+  };
+  for (const entry of entries) {
+    switch (entry.level) {
+      case 'live':
+        summary.live += 1;
+        break;
+      case 'command-contract':
+        summary.contract += 1;
+        break;
+      case 'capability-denial':
+        summary.capabilityDenial += 1;
+        break;
+      case 'known-gap':
+        summary.gap += 1;
+        break;
+    }
+  }
+  return summary;
+}

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import { buildCoverageClassificationSummary } from '../support/coverage-classification.ts';
 
 type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
 
@@ -22,14 +23,6 @@ export type WebPlatformCoverageEntry =
       level: 'known-gap';
       trackingIssue: number;
     };
-
-export type WebPlatformCoverageClassificationSummary = {
-  capabilityDenial: number;
-  contract: number;
-  gap: number;
-  live: number;
-  total: number;
-};
 
 export const WEB_COVERAGE_GAP_ISSUE = 1900;
 export const WEB_SMOKE_TEST_NAME = 'live web platform e2e smoke';
@@ -181,33 +174,4 @@ export function liveCommandsForWebSmoke(): PublicCommand[] {
   return Object.entries(WEB_PLATFORM_COVERAGE)
     .filter(([, entry]) => entry.level === 'live')
     .map(([command]) => command as PublicCommand);
-}
-
-function buildCoverageClassificationSummary(
-  entries: readonly WebPlatformCoverageEntry[],
-): WebPlatformCoverageClassificationSummary {
-  const summary: WebPlatformCoverageClassificationSummary = {
-    capabilityDenial: 0,
-    contract: 0,
-    gap: 0,
-    live: 0,
-    total: entries.length,
-  };
-  for (const entry of entries) {
-    switch (entry.level) {
-      case 'live':
-        summary.live += 1;
-        break;
-      case 'command-contract':
-        summary.contract += 1;
-        break;
-      case 'capability-denial':
-        summary.capabilityDenial += 1;
-        break;
-      case 'known-gap':
-        summary.gap += 1;
-        break;
-    }
-  }
-  return summary;
 }


### PR DESCRIPTION
## Summary

Add an exhaustive Linux desktop command-coverage manifest over all 54 public commands. It records 5 existing replay-live commands, 20 command-contract citations from the existing Linux provider/runtime/unit evidence, 11 descriptor capability denials, and 18 explicit known gaps grouped in #1915. The static catalog, denial, evidence, and report gate runs in the existing Node integration PR lane. The pure classification summary helper is shared by the Android, web, and Linux manifests while each platform keeps its hand-rolled row union; Linux also reuses the canonical `LINUX_DEVICE` fixture. No live scenarios were added and no macOS manifest files were changed. Part of #1426.

## Validation

- `pnpm install --frozen-lockfile && pnpm build`
- `pnpm format`
- `pnpm check:quick`
- Android, web, and Linux coverage gates: 25 tests passed.
- Linux unit evidence: 6 files / 36 tests passed.
- Linux provider scenario: 1 test passed.
- Planted-red proof: removing only `install-from-source` failed the catalog completeness invariant and changed expected counts from 54 total / 18 gaps to 53 total / 17 gaps; restoring it passed.
- `pnpm check:gate-manifest` passed.
- `pnpm check:affected --run`: all runnable checks passed; Linux replay and other device/native/coverage lanes remain GitHub-authoritative.

Review follow-up is committed at `5db8b0e78`: the redundant Linux workflow rerun was removed because the existing Node integration PR lane already executes the gate. The open tvOS PR should adopt the shared helper before its separate platform branch merges.
