### PR TITLE
test: add macOS platform command coverage manifest

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -47,7 +47,9 @@ on:
       - 'test/integration/smoke-android-**'
       - 'test/integration/smoke-linux-**'
       - 'test/integration/linux-e2e/**'
+      - 'test/integration/smoke-macos-**'
       - 'test/integration/smoke-web-**'
+      - 'test/integration/macos-e2e/**'
       - 'test/integration/web-e2e/**'
   push:
     branches:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Setup toolchain
         uses: ./.github/actions/setup-node-pnpm
 
+      - name: Run macOS command coverage contract
+        uses: ./.github/actions/run-gate
+        with: { gate: macos-coverage }
+
       - name: Restore and build macOS XCTest runner
         uses: ./.github/actions/setup-apple-runner-build
         with:

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
     "test:smoke:web": "pnpm build && node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-web-platform.test.ts",
     "test:smoke": "node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-*.test.ts",
     "test:integration:node": "node --experimental-strip-types scripts/node-test-tmpdir.ts --test --experimental-test-isolation=none test/integration/*.test.ts",
+    "test:integration:macos-coverage": "node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-macos-coverage.test.ts",
     "test:integration": "pnpm test:integration:node && pnpm test:integration:provider",
     "test:concurrency-torture": "node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/nightly/concurrency-torture.test.ts",
     "test:replay:ios": "node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator",

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -44,6 +44,7 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
   gate('build', 'Build (tsdown + declarations)', 'build'),
   gate('package', 'Published package (publint, attw, clean-install resolution)', 'check:package'),
   gate('integration-node', 'Node integration smoke', 'test:integration:node'),
+  gate('macos-coverage', 'macOS command coverage manifest', 'test:integration:macos-coverage'),
   {
     id: 'vitest-related',
     label: 'Tests related by Vitest module graph',

--- a/scripts/check-affected/device-lanes.test.ts
+++ b/scripts/check-affected/device-lanes.test.ts
@@ -56,6 +56,10 @@ test('an iOS replay script and the iOS smoke files own the iOS lanes', () => {
   }
 });
 
+test('the macOS coverage gate owns only the macOS replay lane', () => {
+  assert.deepEqual(lanes('test/integration/smoke-macos-coverage.test.ts'), ['replay-macos']);
+});
+
 test('shared runtime surface owns every device lane', () => {
   for (const file of [
     'src/daemon/handlers/session.ts',

--- a/scripts/check-affected/device-lanes.test.ts
+++ b/scripts/check-affected/device-lanes.test.ts
@@ -13,7 +13,9 @@ function lanes(file: string): CheckId[] {
   const plan = selectChecks({ changedFiles: [file] });
   assert.equal(plan.failOpen, false, `${file} must not fail open`);
   return plan.checks.filter((id) =>
-    /^replay-|^web-smoke$|^swift-runner-|^macos-helper$|^android-helpers$/.test(id),
+    /^macos-coverage$|^replay-|^web-smoke$|^swift-runner-|^macos-helper$|^android-helpers$/.test(
+      id,
+    ),
   );
 }
 
@@ -56,8 +58,15 @@ test('an iOS replay script and the iOS smoke files own the iOS lanes', () => {
   }
 });
 
-test('the macOS coverage gate owns only the macOS replay lane', () => {
-  assert.deepEqual(lanes('test/integration/smoke-macos-coverage.test.ts'), ['replay-macos']);
+test('the macOS coverage manifest selects its executable gate and macOS replay lane', () => {
+  assert.deepEqual(lanes('test/integration/smoke-macos-coverage.test.ts'), [
+    'macos-coverage',
+    'replay-macos',
+  ]);
+  assert.deepEqual(lanes('test/integration/macos-e2e/coverage-manifest.ts'), [
+    'macos-coverage',
+    'replay-macos',
+  ]);
 });
 
 test('shared runtime surface owns every device lane', () => {

--- a/scripts/check-affected/model.ts
+++ b/scripts/check-affected/model.ts
@@ -44,6 +44,7 @@ export type CheckId =
   | 'coverage'
   | 'provider-integration'
   | 'integration-node'
+  | 'macos-coverage'
   | 'integration-progress'
   | 'swift-runner-ios'
   | 'swift-runner-macos'
@@ -100,6 +101,7 @@ export const ALL_CHECKS: readonly CheckId[] = [
   // Real daemon/process integration owns host-global lifecycle state and must
   // run before the related-project workload heats the host.
   'integration-node',
+  'macos-coverage',
   'vitest-related',
   'unit',
   'unit-ci',
@@ -355,6 +357,19 @@ const nodeIntegrationOwnership: OwnershipRule = ({ file }) =>
     ? [reason('integration-node', file, 'node-integration', 'node --test integration smoke')]
     : [];
 
+const macosCoverageOwnership: OwnershipRule = ({ file }) =>
+  file === 'test/integration/smoke-macos-coverage.test.ts' ||
+  file.startsWith('test/integration/macos-e2e/')
+    ? [
+        reason(
+          'macos-coverage',
+          file,
+          'own:macos-coverage',
+          'the macOS lane executes the command coverage manifest contract',
+        ),
+      ]
+    : [];
+
 const testAppOwnership: OwnershipRule = ({ file }) => {
   if (!file.startsWith('examples/test-app/')) return [];
   if (!/\.(?:[cm]?[jt]sx?|json)$/.test(file)) return [];
@@ -558,6 +573,7 @@ const OWNERSHIP_RULES: readonly OwnershipRule[] = [
   workspacePackageOwnership,
   platformPackageScenarioOwnership,
   nodeIntegrationOwnership,
+  macosCoverageOwnership,
   testAppOwnership,
   replayCompatOwnership,
   daemonWireCompatOwnership,

--- a/test/integration/macos-e2e/coverage-manifest.ts
+++ b/test/integration/macos-e2e/coverage-manifest.ts
@@ -1,0 +1,299 @@
+import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import {
+  MACOS_LIVE_SCENARIOS,
+  type MacOsLiveScenario,
+  type MacOsLiveScenarioId,
+} from './live-scenarios.ts';
+
+export { MACOS_LIVE_SCENARIOS } from './live-scenarios.ts';
+export type { MacOsLiveScenario, MacOsLiveScenarioId } from './live-scenarios.ts';
+
+type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
+
+type RepositoryEvidence = {
+  path: string;
+  test: string;
+};
+
+export type MacOsPlatformCoverageEntry =
+  | {
+      assertion: string;
+      level: 'live';
+      owner: RepositoryEvidence;
+      scenario: MacOsLiveScenarioId;
+    }
+  | {
+      assertion: string;
+      level: 'command-contract' | 'capability-denial';
+      owner: RepositoryEvidence;
+    }
+  | {
+      assertion: string;
+      level: 'known-gap';
+      trackingIssue: number;
+    };
+
+export type MacOsPlatformCoverageClassificationSummary = {
+  capabilityDenial: number;
+  contract: number;
+  gap: number;
+  live: number;
+  total: number;
+};
+
+export const MACOS_COVERAGE_GAP_ISSUE = 1916;
+
+const C = PUBLIC_COMMANDS;
+const live = (scenario: MacOsLiveScenarioId, assertion: string): MacOsPlatformCoverageEntry => ({
+  assertion,
+  level: 'live',
+  owner: liveScenario(scenario).owner,
+  scenario,
+});
+const contract = (path: string, test: string, assertion: string): MacOsPlatformCoverageEntry => ({
+  assertion,
+  level: 'command-contract',
+  owner: { path, test },
+});
+const denial = (path: string, test: string, assertion: string): MacOsPlatformCoverageEntry => ({
+  assertion,
+  level: 'capability-denial',
+  owner: { path, test },
+});
+const gap = (assertion: string): MacOsPlatformCoverageEntry => ({
+  assertion,
+  level: 'known-gap',
+  trackingIssue: MACOS_COVERAGE_GAP_ISSUE,
+});
+
+/** One primary, observable owner for every public command on the local macOS host. */
+export const MACOS_PLATFORM_COVERAGE = {
+  [C.artifacts]: contract(
+    'src/daemon/__tests__/http-server-artifacts.test.ts',
+    'daemon artifact inventory lists artifacts and downloads consume them',
+    'daemon artifact inventory exposes downloadable files for the macOS session tooling',
+  ),
+  [C.devices]: contract(
+    'packages/platform-apple/src/inventory.test.ts',
+    'Apple inventory projects the host Mac without loading native tools',
+    'Apple inventory projects the local macOS host as a desktop device',
+  ),
+  [C.capabilities]: contract(
+    'src/core/__tests__/capabilities.test.ts',
+    'macOS supports the Apple runner interaction core but excludes mobile-only commands',
+    'the capability matrix admits the verified macOS interaction core',
+  ),
+  [C.doctor]: gap('No command-specific macOS doctor evidence exists yet'),
+  [C.apps]: live(
+    'provider:macos-desktop',
+    'provider-backed app inventory lists macOS applications',
+  ),
+  [C.boot]: contract(
+    'src/daemon/handlers/__tests__/session-boot-shutdown.test.ts',
+    'boot rejects the macOS host boot cell after one facts inspection and before binding',
+    'macOS boot is refused by the runtime fact before dispatch',
+  ),
+  [C.shutdown]: gap('No command-specific macOS shutdown evidence exists yet'),
+  [C.appState]: live('replay:system-settings', 'the System Settings replay reads macOS app state'),
+  [C.perf]: contract(
+    'src/daemon/handlers/__tests__/session-appstate-input-perf.test.ts',
+    'perf memory samples macOS app sessions',
+    'macOS app memory sampling returns typed performance data',
+  ),
+  [C.logs]: live('provider:macos-desktop', 'the provider scenario returns the macOS app log path'),
+  [C.events]: gap('No command-specific macOS event timeline evidence exists yet'),
+  [C.network]: contract(
+    'packages/platform-apple/src/network/runtime.test.ts',
+    'parses macOS session app-log traffic without loading simulator recovery',
+    'macOS network capture parses HTTP traffic from the session app log',
+  ),
+  [C.audio]: contract(
+    'src/daemon/handlers/__tests__/session-audio.test.ts',
+    'audio probe starts macOS ScreenCaptureKit helper and reads status',
+    'macOS audio probe starts the ScreenCaptureKit helper and reports its backend',
+  ),
+  [C.replay]: gap('No command-specific macOS replay evidence exists beyond the suite runner'),
+  [C.test]: gap('No command-specific macOS test-suite evidence exists yet'),
+  [C.clipboard]: live(
+    'provider:macos-desktop',
+    'the provider scenario round-trips desktop clipboard text',
+  ),
+  [C.keyboard]: denial(
+    'src/platforms/apple/capabilities.ts',
+    'readonly keyboard',
+    'macOS capability declarations reject hardware keyboard operations',
+  ),
+  [C.install]: contract(
+    'packages/platform-apple/src/deployment/runtime.test.ts',
+    'classifies deployment facts for the %s denominator cell',
+    'Apple deployment facts close application installation on the macOS host',
+  ),
+  [C.reinstall]: contract(
+    'packages/platform-apple/src/deployment/runtime.test.ts',
+    'classifies deployment facts for the %s denominator cell',
+    'Apple deployment facts close application reinstallation on the macOS host',
+  ),
+  [C.push]: contract(
+    'packages/platform-apple/src/deployment/runtime.test.ts',
+    'classifies deployment facts for the %s denominator cell',
+    'Apple deployment facts close push delivery on the macOS host',
+  ),
+  [C.triggerAppEvent]: contract(
+    'src/core/__tests__/dispatch-trigger-app-event.test.ts',
+    'trigger-app-event supports macOS and prefers macOS template',
+    'macOS app-event dispatch selects the macOS URL template',
+  ),
+  [C.open]: live('replay:system-settings', 'the System Settings replay opens the macOS target app'),
+  [C.prepare]: live(
+    'provider:macos-desktop',
+    'the provider scenario prepares the macOS XCTest runner through its lifecycle provider',
+  ),
+  [C.batch]: gap('No command-specific macOS batch evidence exists yet'),
+  [C.close]: contract(
+    'src/daemon/handlers/__tests__/session-relaunch-close.test.ts',
+    'close on macOS session stops runner and dismisses automation alert before delete',
+    'macOS close stops the runner, dismisses automation state, and deletes the session',
+  ),
+  [C.snapshot]: live(
+    'replay:system-settings',
+    'the System Settings replay captures interactive macOS accessibility snapshots',
+  ),
+  [C.diff]: gap('No command-specific macOS snapshot-diff evidence exists yet'),
+  [C.wait]: live(
+    'replay:system-settings',
+    'the System Settings replay waits for named macOS UI state',
+  ),
+  [C.alert]: live(
+    'provider:macos-desktop',
+    'the provider scenario reads, accepts, and dismisses the macOS automation alert',
+  ),
+  [C.settings]: live(
+    'provider:macos-desktop',
+    'the provider scenario changes macOS appearance and permissions through the helper',
+  ),
+  [C.reactNative]: gap('No command-specific macOS React Native inspection evidence exists yet'),
+  [C.record]: live(
+    'provider:macos-recording',
+    'the provider scenario records and finalizes a playable macOS MP4',
+  ),
+  [C.trace]: gap('No command-specific macOS trace evidence exists yet'),
+  [C.find]: gap('No command-specific macOS find evidence exists yet'),
+  [C.click]: live(
+    'replay:system-settings',
+    'the System Settings replay clicks a named macOS control',
+  ),
+  [C.fill]: gap('No command-specific macOS fill evidence exists yet'),
+  [C.longPress]: gap('No command-specific macOS long-press evidence exists yet'),
+  [C.hover]: denial(
+    'src/core/command-descriptor/registry.ts',
+    'capability: { apple: {}, android: {}, linux: LINUX_NONE }',
+    'the command capability declaration has no Apple hover bucket on macOS',
+  ),
+  [C.press]: live(
+    'provider:macos-desktop',
+    'the provider scenario presses a snapshot ref through the macOS helper',
+  ),
+  [C.type]: gap('No command-specific macOS type evidence exists yet'),
+  [C.get]: live(
+    'provider:macos-desktop',
+    'the provider scenario reads snapshot-ref text from the macOS helper',
+  ),
+  [C.is]: live(
+    'replay:system-settings',
+    'the System Settings replay asserts a named macOS control exists',
+  ),
+  [C.back]: live(
+    'replay:system-settings',
+    'the System Settings replay returns from the About pane',
+  ),
+  [C.gesture]: contract(
+    'src/platforms/apple/core/__tests__/interactions.test.ts',
+    'performGestureApple composes macOS one-contact plans with the drag executor',
+    'macOS gesture dispatch preserves the one-contact drag plan',
+  ),
+  [C.home]: denial(
+    'src/platforms/apple/capabilities.ts',
+    'appAndDeviceLifecycle',
+    'macOS capability declarations reject mobile Home navigation',
+  ),
+  [C.tvRemote]: denial(
+    'src/platforms/apple/plugin.ts',
+    'supportsTvRemote',
+    'the Apple plugin admits TV remote input only for tvOS or Android TV',
+  ),
+  [C.orientation]: denial(
+    'src/platforms/apple/capabilities.ts',
+    'readonly orientation',
+    'macOS capability declarations reject device orientation changes',
+  ),
+  [C.scroll]: live(
+    'provider:macos-desktop',
+    'the provider scenario maps desktop scrolling to the macOS wheel runner command',
+  ),
+  [C.swipe]: gap('No command-specific macOS swipe evidence exists yet'),
+  [C.focus]: gap('No command-specific macOS focus evidence exists yet'),
+  [C.screenshot]: live(
+    'replay:system-settings',
+    'the System Settings replay writes a macOS screenshot artifact',
+  ),
+  [C.viewport]: contract(
+    'packages/platform-apple/src/runtime.test.ts',
+    'classifies the %s leaf explicitly',
+    'Apple runtime facts reject viewport resizing on the macOS host',
+  ),
+  [C.appSwitcher]: denial(
+    'src/platforms/apple/capabilities.ts',
+    'appAndDeviceLifecycle',
+    'macOS capability declarations reject mobile app-switcher navigation',
+  ),
+  [C.installFromSource]: contract(
+    'packages/platform-apple/src/deployment/runtime.test.ts',
+    'classifies deployment facts for the %s denominator cell',
+    'Apple deployment facts close source installation on the macOS host',
+  ),
+} satisfies Record<PublicCommand, MacOsPlatformCoverageEntry>;
+
+export const MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClassificationSummary(
+  Object.values(MACOS_PLATFORM_COVERAGE),
+);
+
+export function liveCommandsForScenario(scenarioId: string): PublicCommand[] {
+  return Object.entries(MACOS_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'live' && entry.scenario === scenarioId)
+    .map(([command]) => command as PublicCommand);
+}
+
+function liveScenario(scenarioId: MacOsLiveScenarioId): MacOsLiveScenario {
+  const scenario = MACOS_LIVE_SCENARIOS.find((candidate) => candidate.id === scenarioId);
+  if (!scenario) throw new Error(`Unknown macOS coverage scenario: ${scenarioId}`);
+  return scenario;
+}
+
+function buildCoverageClassificationSummary(
+  entries: readonly MacOsPlatformCoverageEntry[],
+): MacOsPlatformCoverageClassificationSummary {
+  const summary: MacOsPlatformCoverageClassificationSummary = {
+    capabilityDenial: 0,
+    contract: 0,
+    gap: 0,
+    live: 0,
+    total: entries.length,
+  };
+  for (const entry of entries) {
+    switch (entry.level) {
+      case 'live':
+        summary.live += 1;
+        break;
+      case 'command-contract':
+        summary.contract += 1;
+        break;
+      case 'capability-denial':
+        summary.capabilityDenial += 1;
+        break;
+      case 'known-gap':
+        summary.gap += 1;
+        break;
+    }
+  }
+  return summary;
+}

--- a/test/integration/macos-e2e/coverage-manifest.ts
+++ b/test/integration/macos-e2e/coverage-manifest.ts
@@ -6,7 +6,6 @@ import {
 } from './live-scenarios.ts';
 
 export { MACOS_LIVE_SCENARIOS } from './live-scenarios.ts';
-export type { MacOsLiveScenario, MacOsLiveScenarioId } from './live-scenarios.ts';
 
 type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
 

--- a/test/integration/macos-e2e/coverage-report.ts
+++ b/test/integration/macos-e2e/coverage-report.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  MACOS_LIVE_SCENARIOS,
+  MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+  liveCommandsForScenario,
+} from './coverage-manifest.ts';
+
+export function writeCoverageReport(artifactDir: string): string {
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const reportPath = path.join(artifactDir, 'coverage-report.json');
+  fs.writeFileSync(
+    reportPath,
+    JSON.stringify(
+      {
+        classificationSummary: MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+        liveCommands: MACOS_LIVE_SCENARIOS.flatMap(({ id }) => liveCommandsForScenario(id)),
+        liveScenarios: MACOS_LIVE_SCENARIOS.map(({ id }) => id),
+      },
+      null,
+      2,
+    ),
+  );
+  return reportPath;
+}

--- a/test/integration/macos-e2e/live-scenarios.ts
+++ b/test/integration/macos-e2e/live-scenarios.ts
@@ -1,0 +1,37 @@
+export type MacOsLiveScenario = {
+  id: string;
+  owner: {
+    path: string;
+    test: string;
+  };
+  syntax: 'replay' | 'provider-command' | 'provider-call-command';
+};
+
+export const MACOS_LIVE_SCENARIOS = [
+  {
+    id: 'replay:system-settings',
+    owner: {
+      path: 'test/integration/replays/macos/01-system-settings.ad',
+      test: 'Dogfood macOS System Settings flow through the replay suite runner.',
+    },
+    syntax: 'replay',
+  },
+  {
+    id: 'provider:macos-desktop',
+    owner: {
+      path: 'test/integration/provider-scenarios/macos-desktop.test.ts',
+      test: 'Provider-backed integration macOS desktop flow uses semantic host and helper providers',
+    },
+    syntax: 'provider-command',
+  },
+  {
+    id: 'provider:macos-recording',
+    owner: {
+      path: 'test/integration/provider-scenarios/macos-recording.test.ts',
+      test: 'Provider-backed integration macOS recording uses focused exact runner authority',
+    },
+    syntax: 'provider-call-command',
+  },
+] as const satisfies readonly MacOsLiveScenario[];
+
+export type MacOsLiveScenarioId = (typeof MACOS_LIVE_SCENARIOS)[number]['id'];

--- a/test/integration/smoke-macos-coverage.test.ts
+++ b/test/integration/smoke-macos-coverage.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { mkdtempForTest } from '../../src/__tests__/test-utils/index.ts';
+import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
+import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
+import {
+  MACOS_COVERAGE_GAP_ISSUE,
+  MACOS_LIVE_SCENARIOS,
+  MACOS_PLATFORM_COVERAGE,
+  MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
+  liveCommandsForScenario,
+} from './macos-e2e/coverage-manifest.ts';
+import { writeCoverageReport } from './macos-e2e/coverage-report.ts';
+
+const MACOS_DEVICE = {
+  appleOs: 'macos' as const,
+  id: 'coverage-macos-host',
+  kind: 'device' as const,
+  name: 'Coverage Mac',
+  platform: 'apple' as const,
+  target: 'desktop' as const,
+};
+
+test('macOS coverage exhaustively classifies the public catalog', () => {
+  const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
+  assert.deepEqual(Object.keys(MACOS_PLATFORM_COVERAGE).sort(), publicCommands);
+
+  for (const command of publicCommands) {
+    const entry = MACOS_PLATFORM_COVERAGE[command];
+    assert.ok(entry.assertion.trim().length > 0, `${command} needs an observable assertion`);
+    if (entry.level === 'known-gap') {
+      assert.equal(
+        entry.trackingIssue,
+        MACOS_COVERAGE_GAP_ISSUE,
+        `${command} has the wrong gap issue`,
+      );
+      continue;
+    }
+    assert.ok(entry.owner.path.trim().length > 0, `${command} needs an evidence path`);
+    assert.ok(entry.owner.test.trim().length > 0, `${command} needs named evidence`);
+    if (entry.level === 'live') {
+      assert.ok(entry.scenario.trim().length > 0, `${command} needs a live scenario owner`);
+    }
+  }
+});
+
+test('macOS coverage report counts every manifest classification', () => {
+  assert.deepEqual(MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
+    capabilityDenial: 6,
+    contract: 15,
+    gap: 15,
+    live: 18,
+    total: 54,
+  });
+  assert.equal(
+    MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY.live +
+      MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY.contract +
+      MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY.capabilityDenial +
+      MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY.gap,
+    MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY.total,
+  );
+});
+
+test('macOS live claims reference commands in existing executable scenarios', () => {
+  const scenariosById = new Map(MACOS_LIVE_SCENARIOS.map((scenario) => [scenario.id, scenario]));
+  const claimedCommands: string[] = [];
+
+  for (const scenario of MACOS_LIVE_SCENARIOS) {
+    const source = readEvidence(scenario.owner);
+    for (const command of liveCommandsForScenario(scenario.id)) {
+      const entry = MACOS_PLATFORM_COVERAGE[command];
+      assert.equal(entry.level, 'live');
+      assert.deepEqual(entry.owner, scenario.owner, `${command} owner drifted from its scenario`);
+      assert.equal(
+        sourceContainsCommand(source, scenario.syntax, command),
+        true,
+        `${command} is not executed by ${scenario.owner.path}`,
+      );
+      claimedCommands.push(command);
+    }
+  }
+
+  assert.equal(new Set(scenariosById.keys()).size, MACOS_LIVE_SCENARIOS.length);
+  assert.equal(new Set(claimedCommands).size, claimedCommands.length);
+  assert.equal(
+    claimedCommands.length,
+    Object.values(MACOS_PLATFORM_COVERAGE).filter((entry) => entry.level === 'live').length,
+  );
+});
+
+test('macOS non-live evidence owners name existing executable repository evidence', () => {
+  for (const [command, entry] of Object.entries(MACOS_PLATFORM_COVERAGE)) {
+    if (entry.level === 'live' || entry.level === 'known-gap') continue;
+    const evidencePath = path.resolve(entry.owner.path);
+    assert.equal(fs.existsSync(evidencePath), true, `${command} owner does not exist`);
+    assert.equal(
+      fs.readFileSync(evidencePath, 'utf8').includes(entry.owner.test),
+      true,
+      `${command} owner does not contain named evidence: ${entry.owner.test}`,
+    );
+  }
+});
+
+test('macOS capability-denial rows match the owning capability matrix', () => {
+  const deniedByCapabilities = Object.values(PUBLIC_COMMANDS)
+    .filter((command) => !isCommandSupportedOnDevice(command, MACOS_DEVICE))
+    .sort();
+  const deniedByManifest = Object.entries(MACOS_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'capability-denial')
+    .map(([command]) => command)
+    .sort();
+
+  assert.deepEqual(deniedByManifest, deniedByCapabilities);
+});
+
+test('macOS known gaps use one grouped tracking issue', () => {
+  const gapIssues = new Set(
+    Object.values(MACOS_PLATFORM_COVERAGE)
+      .filter((entry) => entry.level === 'known-gap')
+      .map((entry) => entry.trackingIssue),
+  );
+  assert.deepEqual([...gapIssues], [MACOS_COVERAGE_GAP_ISSUE]);
+});
+
+test('macOS coverage report persists the manifest rollup and live command list', async () => {
+  const artifactDir = await mkdtempForTest('agent-device-macos-coverage-');
+  const report = JSON.parse(fs.readFileSync(writeCoverageReport(artifactDir), 'utf8')) as {
+    classificationSummary: typeof MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY;
+    liveCommands: string[];
+    liveScenarios: string[];
+  };
+
+  assert.deepEqual(report.classificationSummary, MACOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY);
+  assert.deepEqual(
+    report.liveCommands.sort(),
+    Object.entries(MACOS_PLATFORM_COVERAGE)
+      .filter(([, entry]) => entry.level === 'live')
+      .map(([command]) => command)
+      .sort(),
+  );
+  assert.deepEqual(
+    report.liveScenarios,
+    MACOS_LIVE_SCENARIOS.map(({ id }) => id),
+  );
+});
+
+function readEvidence(owner: { path: string; test: string }): string {
+  const evidencePath = path.resolve(owner.path);
+  assert.equal(fs.existsSync(evidencePath), true, `${owner.path} does not exist`);
+  const source = fs.readFileSync(evidencePath, 'utf8');
+  assert.equal(source.includes(owner.test), true, `${owner.path} lacks ${owner.test}`);
+  return source;
+}
+
+function sourceContainsCommand(
+  source: string,
+  syntax: (typeof MACOS_LIVE_SCENARIOS)[number]['syntax'],
+  command: string,
+): boolean {
+  switch (syntax) {
+    case 'replay':
+      return source.split(/\r?\n/).some((line) => {
+        const trimmed = line.trim();
+        return trimmed === command || trimmed.startsWith(`${command} `);
+      });
+    case 'provider-command':
+      return source.includes(`command: '${command}'`);
+    case 'provider-call-command':
+      return source.includes(`callCommand('${command}'`);
+  }
+}

--- a/test/integration/smoke-macos-coverage.test.ts
+++ b/test/integration/smoke-macos-coverage.test.ts
@@ -106,7 +106,17 @@ test('macOS non-live evidence owners name existing executable repository evidenc
 
 test('macOS capability-denial rows match the owning capability matrix', () => {
   const deniedByCapabilities = Object.values(PUBLIC_COMMANDS)
-    .filter((command) => !isCommandSupportedOnDevice(command, MACOS_DEVICE))
+    .filter((command) => {
+      if (command === PUBLIC_COMMANDS.audio) {
+        assert.equal(
+          isCommandSupportedOnDevice(command, MACOS_DEVICE),
+          process.platform === 'darwin',
+          'macOS audio admission follows host ScreenCaptureKit availability',
+        );
+        return false;
+      }
+      return !isCommandSupportedOnDevice(command, MACOS_DEVICE);
+    })
     .sort();
   const deniedByManifest = Object.entries(MACOS_PLATFORM_COVERAGE)
     .filter(([, entry]) => entry.level === 'capability-denial')


### PR DESCRIPTION
## Summary

Add an exhaustive macOS host command-coverage manifest for all 54 `PUBLIC_COMMANDS` using a hand-rolled row union and `Record<PublicCommand, ...>`.

- 18 live rows cite existing System Settings replay/provider scenarios; no live scenarios changed.
- 15 command-contract rows cite current Apple/runtime tests, 6 mechanical denials cite owning capability/guarantee declarations, and 15 known gaps point to grouped #1916.
- Add live/contract/denial/gap counts, report persistence, source-backed completeness, denial parity, gap grouping, and affected routing assertions.
- Register `macos-coverage` in the check catalog and package scripts; route the manifest and its `macos-e2e` support files to that executable gate, and run it in the macOS workflow through `run-gate`.
- Host-dependent `audio` availability is explicitly checked against Darwin ScreenCaptureKit availability and remains command-contract evidence, following the existing iOS pattern.
- The parent checklist in #1426 is intentionally unchanged.
- Docs/help/metadata and skills unchanged; this is test evidence and routing only.

Part of #1426.

## Validation

- `pnpm install --frozen-lockfile && pnpm build`
- `pnpm format` / `pnpm format:check`
- `pnpm check:quick`
- Focused macOS manifest gate: 7 passed.
- Affected selector and gate-manifest suites: 49 and 49 tests passed; the macOS manifest selects `macos-coverage` and `replay-macos`.
- Planted-red proof: temporarily omitting `artifacts` failed catalog completeness and the count invariant; the row was restored and the gate returned to 7 passed.
- After rebasing onto `origin/main` at `46eff36f8`, `pnpm check:affected --base origin/main --head HEAD --run` completed with all runnable checks passing; native/device/provider checks remain GitHub-authoritative.
- Exact CI coverage command: `pnpm test:coverage:ci` passed with 1,055 files and 7,688 tests (8 skipped), including `scripts/fuzz/corpus-replay.test.ts`; exit 0. Coverage totals were 88.22% statements, 80.03% branches, 91.84% functions, and 90.21% lines.
- Rebased and pushed as `781400d84`.

## CI note

The historical Coverage job [96683519618](https://github.com/callstack/agent-device/actions/runs/32452529072/job/96683519618) passed all assertions before a Vitest worker-timeout while terminating `scripts/fuzz/corpus-replay.test.ts`. The exact coverage command now passes locally after the executable macOS-gate fix; fresh CI checks for `781400d84` are pending.