### PR TITLE
refactor: migrate focus to the request-bound device runtime

### DIFF
--- a/packages/contracts/src/facades/platform.ts
+++ b/packages/contracts/src/facades/platform.ts
@@ -221,6 +221,7 @@ export {
   selectorTextCaptureRuntimePlanUses,
   snapshotRuntimePlanUses,
   waitSelectorCaptureRuntimePlanUses,
+  focusRuntimeUse,
   viewportRuntimeUse,
 } from '../platform-runtime-operations.ts';
 export type {
@@ -288,6 +289,18 @@ export type {
   SnapshotRuntimeOperationFacts,
   SnapshotResult,
 } from '../snapshot-runtime.ts';
+export {
+  bindLocalFocusInteractor,
+  bindProviderFocusInteractor,
+  focusRuntimeOperationFacts,
+} from '../focus-runtime.ts';
+export type {
+  FocusPointInput,
+  FocusRuntimeOperationFacts,
+  FocusRuntimeOperations,
+  LocalFocusInteractorResolver,
+  ProviderFocusInteractorResolver,
+} from '../focus-runtime.ts';
 export { viewportRuntimeOperationFacts } from '../viewport-runtime.ts';
 export type {
   SetViewportInput,

--- a/packages/contracts/src/focus-runtime.test.ts
+++ b/packages/contracts/src/focus-runtime.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, vi } from 'vitest';
+import {
+  bindLocalFocusInteractor,
+  bindProviderFocusInteractor,
+  focusRuntimeOperationFacts,
+} from './focus-runtime.ts';
+import type { Interactor } from './interactor-types.ts';
+
+const device = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+} as const;
+
+test('builds the exact focus operation fact catalog', () => {
+  const focus = { available: true } as const;
+  expect(focusRuntimeOperationFacts({ focus })).toEqual({ focusPoint: focus });
+});
+
+test('a local binding drives the interactor at the resolved point', async () => {
+  const focus = vi.fn(async () => undefined);
+  const resolveInteractor = vi.fn(async () => ({ focus }) as unknown as Interactor);
+  const signal = new AbortController().signal;
+
+  const operations = bindLocalFocusInteractor({ device, signal, resolveInteractor });
+  await operations.focusPoint({
+    point: { x: 176, y: 132 },
+    options: { appBundleId: 'com.example.app' },
+    execution: { logPath: '/tmp/daemon.log', requestId: 'focus-1' },
+  });
+
+  expect(resolveInteractor).toHaveBeenCalledWith(device, {
+    logPath: '/tmp/daemon.log',
+    requestId: 'focus-1',
+    appBundleId: 'com.example.app',
+    signal,
+  });
+  // Positional (x, y), not an object: the `Interactor` seam takes two numbers, and swapping them
+  // is the one transposition a point-shaped assertion would not catch.
+  expect(focus).toHaveBeenCalledWith(176, 132);
+});
+
+test('a provider binding drives its own resolved interactor at the point', async () => {
+  const focus = vi.fn(async () => undefined);
+  const resolveInteractor = vi.fn(() => ({ focus }) as unknown as Interactor);
+  const signal = new AbortController().signal;
+
+  const operations = bindProviderFocusInteractor({ device, signal, resolveInteractor });
+  await operations.focusPoint({ point: { x: 12, y: 34 }, execution: { requestId: 'focus-2' } });
+
+  expect(resolveInteractor).toHaveBeenCalledWith({
+    requestId: 'focus-2',
+    appBundleId: undefined,
+    signal,
+  });
+  expect(focus).toHaveBeenCalledWith(12, 34);
+});
+
+test('a provider binding fails closed when its exact owner exposes no interactor', async () => {
+  const operations = bindProviderFocusInteractor({
+    device,
+    signal: new AbortController().signal,
+    resolveInteractor: () => undefined,
+  });
+
+  await expect(operations.focusPoint({ point: { x: 1, y: 2 } })).rejects.toMatchObject({
+    code: 'UNSUPPORTED_OPERATION',
+    details: { reason: 'provider-runtime-interactor-missing', deviceId: device.id },
+  });
+});
+
+test('an already-cancelled request never resolves an interactor', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const focus = vi.fn(async () => undefined);
+  const resolveInteractor = vi.fn(async () => ({ focus }) as unknown as Interactor);
+
+  const operations = bindLocalFocusInteractor({
+    device,
+    signal: controller.signal,
+    resolveInteractor,
+  });
+
+  await expect(operations.focusPoint({ point: { x: 1, y: 2 } })).rejects.toThrow();
+  expect(resolveInteractor).not.toHaveBeenCalled();
+  expect(focus).not.toHaveBeenCalled();
+});

--- a/packages/contracts/src/focus-runtime.ts
+++ b/packages/contracts/src/focus-runtime.ts
@@ -1,0 +1,98 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+import type { Point } from '@agent-device/kernel/snapshot';
+import type { Interactor, RunnerContext } from './interactor-types.ts';
+import type { RuntimeOperationFact } from './platform-runtime.ts';
+import type { SessionSurface } from './session-surface.ts';
+import type { SnapshotRuntimeExecution } from './snapshot-runtime.ts';
+
+/**
+ * Neutral intent for one point-addressed focus. The point is already resolved — from the
+ * positionals a caller parsed, or from the node a selector matched — so the operation names no
+ * command, request, session, or CLI flag.
+ */
+export type FocusPointInput = Readonly<{
+  point: Point;
+  options?: Readonly<{ appBundleId?: string; surface?: SessionSurface }>;
+  /** Same runner metadata a capture needs; reuses that type rather than restating it. */
+  execution?: SnapshotRuntimeExecution;
+}>;
+
+/**
+ * Focus returns nothing. The legacy leaf discarded whatever the interactor answered and reported
+ * only the point it addressed, so a result type here would be a surface the command never had.
+ */
+export type FocusRuntimeOperations = Readonly<{
+  focusPoint(input: FocusPointInput): Promise<void>;
+}>;
+
+export type FocusRuntimeOperationFacts = Readonly<{
+  focusPoint: RuntimeOperationFact;
+}>;
+
+export function focusRuntimeOperationFacts(
+  input: Readonly<{ focus: RuntimeOperationFact }>,
+): FocusRuntimeOperationFacts {
+  return Object.freeze({ focusPoint: input.focus });
+}
+
+/**
+ * Captures one selected owner's interactor authority for the lifetime of a request binding. The
+ * owner is already chosen by the time a binder is called, so each entry point supplies its own
+ * resolution and this holds only what both share: the runner context and the focus itself.
+ */
+function bindFocusPoint(
+  signal: AbortSignal,
+  resolveInteractor: (runner: RunnerContext) => Promise<Interactor>,
+): FocusRuntimeOperations {
+  return Object.freeze({
+    focusPoint: async (input: FocusPointInput) => {
+      signal.throwIfAborted();
+      const interactor = await resolveInteractor({
+        ...input.execution,
+        appBundleId: input.options?.appBundleId,
+        signal,
+      });
+      await interactor.focus(input.point.x, input.point.y);
+    },
+  });
+}
+
+export type LocalFocusInteractorResolver = (
+  device: DeviceInfo,
+  runner: RunnerContext,
+) => Promise<Interactor>;
+
+export function bindLocalFocusInteractor(
+  params: Readonly<{
+    device: DeviceInfo;
+    signal: AbortSignal;
+    resolveInteractor: LocalFocusInteractorResolver;
+  }>,
+): FocusRuntimeOperations {
+  return bindFocusPoint(
+    params.signal,
+    async (runner) => await params.resolveInteractor(params.device, runner),
+  );
+}
+
+export type ProviderFocusInteractorResolver = (runner: RunnerContext) => Interactor | undefined;
+
+/** Provider bindings fail closed when their exact owner no longer exposes its interactor. */
+export function bindProviderFocusInteractor(
+  params: Readonly<{
+    device: DeviceInfo;
+    signal: AbortSignal;
+    resolveInteractor: ProviderFocusInteractorResolver;
+  }>,
+): FocusRuntimeOperations {
+  return bindFocusPoint(params.signal, async (runner) => {
+    const interactor = params.resolveInteractor(runner);
+    if (interactor) return interactor;
+    throw new AppError(
+      'UNSUPPORTED_OPERATION',
+      'Provider-owned focus operation has no bound provider interactor.',
+      { reason: 'provider-runtime-interactor-missing', deviceId: params.device.id },
+    );
+  });
+}

--- a/packages/contracts/src/platform-runtime-operations.ts
+++ b/packages/contracts/src/platform-runtime-operations.ts
@@ -16,6 +16,7 @@ import type { ScreenshotRuntimeOperations } from './screenshot-runtime.ts';
 import type { SnapshotRuntimeHost, SnapshotRuntimeOperations } from './snapshot-runtime.ts';
 import type { SelectorObservationRuntimeOperations } from './selector-observation-runtime.ts';
 import type { ViewportRuntimeOperations } from './viewport-runtime.ts';
+import type { FocusRuntimeOperations } from './focus-runtime.ts';
 import type { ElementTextRuntimeOperations } from './element-text-runtime.ts';
 import type {
   DeviceReadinessRuntimeHost,
@@ -50,6 +51,7 @@ export type PlatformRuntimeOperations = AppLogRuntimeOperations &
   SnapshotRuntimeOperations &
   SelectorObservationRuntimeOperations &
   ViewportRuntimeOperations &
+  FocusRuntimeOperations &
   ElementTextRuntimeOperations &
   DeviceReadinessRuntimeOperations &
   DeviceShutdownRuntimeOperations &
@@ -70,6 +72,7 @@ export const bootTargetHeadlessUse = defineUse({
 export const appsRuntimeUse = defineUse({ required: ['ensureReady', 'listApps'] });
 export const captureSnapshotUse = defineUse({ required: ['captureSnapshot'] });
 export const viewportRuntimeUse = defineUse({ required: ['setViewport'] });
+export const focusRuntimeUse = defineUse({ required: ['focusPoint'] });
 const captureSnapshotWithCustomActionsUse = defineUse({
   required: ['captureSnapshot', 'captureSnapshotWithCustomActions'],
 });

--- a/packages/contracts/src/platform-runtime-unavailable.test.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.test.ts
@@ -31,6 +31,7 @@ test('generic unavailable binding preserves exact provider ownership and mode', 
     network: { available: false, reason: 'owner-capability-missing' },
     screenshot: { available: false, reason: 'unsupported-device-kind' },
     viewport: { available: false, reason: 'unsupported-platform-leaf' },
+    focus: { available: false, reason: 'unsupported-provider-mode' },
     elementText: { available: false, reason: 'unsupported-provider-mode' },
     lifecycle,
   });
@@ -40,6 +41,11 @@ test('generic unavailable binding preserves exact provider ownership and mode', 
   assert.deepEqual(binding.facts.operations.setViewport, {
     available: false,
     reason: 'unsupported-platform-leaf',
+  });
+  // Interaction is owner-stated too: it never inherits the transport gap's reason.
+  assert.deepEqual(binding.facts.operations.focusPoint, {
+    available: false,
+    reason: 'unsupported-provider-mode',
   });
   // Both capture cells are owner-stated, so neither inherits the network gap's reason.
   assert.deepEqual(binding.facts.operations.captureScreenshot, {

--- a/packages/contracts/src/platform-runtime-unavailable.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.ts
@@ -14,6 +14,7 @@ import { screenshotRuntimeOperationFacts } from './screenshot-runtime.ts';
 import { snapshotRuntimeOperationFacts } from './snapshot-runtime.ts';
 import { selectorObservationRuntimeOperationFacts } from './selector-observation-runtime.ts';
 import { viewportRuntimeOperationFacts } from './viewport-runtime.ts';
+import { focusRuntimeOperationFacts } from './focus-runtime.ts';
 import { elementTextRuntimeOperationFacts } from './element-text-runtime.ts';
 
 /**
@@ -30,6 +31,7 @@ export type UnavailablePlatformRuntimeFacts = Readonly<{
   screenshot: RuntimeOperationUnavailability;
   snapshot?: RuntimeOperationUnavailability;
   viewport: RuntimeOperationUnavailability;
+  focus: RuntimeOperationUnavailability;
   elementText: RuntimeOperationUnavailability;
   readiness?: RuntimeOperationUnavailability;
   shutdown?: RuntimeOperationUnavailability;
@@ -74,6 +76,7 @@ export function createUnavailablePlatformRuntimeFacts(
     screenshot,
     snapshot,
     viewport,
+    focus,
     elementText,
     readiness,
     shutdown,
@@ -114,6 +117,7 @@ export function createUnavailablePlatformRuntimeFacts(
         findSelector: snapshot,
       }),
       ...viewportRuntimeOperationFacts({ setViewport: viewport }),
+      ...focusRuntimeOperationFacts({ focus }),
       ...elementTextRuntimeOperationFacts({ readTextAtPoint: elementText }),
       ensureReady: readiness,
       bootTarget: readiness,
@@ -142,6 +146,9 @@ function freezeUnavailableFacts(
     screenshot: Object.freeze({ ...unavailable.screenshot }),
     snapshot: orNetwork(unavailable.snapshot),
     viewport: Object.freeze({ ...unavailable.viewport }),
+    // Interaction cells are stated by their owner: a family that can drive touch says so for its
+    // exact kinds, and one that cannot must say why rather than inherit a transport gap.
+    focus: Object.freeze({ ...unavailable.focus }),
     readiness: orNetwork(unavailable.readiness),
     shutdown: orNetwork(unavailable.shutdown),
     elementText: Object.freeze({ ...unavailable.elementText }),

--- a/packages/platform-android/src/runtime.ts
+++ b/packages/platform-android/src/runtime.ts
@@ -9,10 +9,12 @@ import type {
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindLocalFocusInteractor,
   bindLocalScreenshotInteractor,
   bindElementTextRuntime,
   bindLocalSnapshotInteractor,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   localRuntimeOwner,
   screenshotRuntimeOperationFacts,
   selectorObservationRuntimeOperationFacts,
@@ -36,6 +38,15 @@ const available = Object.freeze({ available: true } as const);
 const elementTextKindUnavailable = Object.freeze({
   available: false,
   reason: 'unsupported-device-kind',
+} as const);
+/**
+ * Parity with the retired `focus` capability bucket (`{ emulator, device, unknown }`): every
+ * Android kind drives touch through adb except the synthetic `simulator` row, which has no device.
+ */
+const focusKindUnavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-device-kind',
+  hint: 'focus is supported on Android emulators and physical devices.',
 } as const);
 const headlessUnavailable = Object.freeze({
   available: false,
@@ -160,6 +171,9 @@ export function createAndroidPlatformRuntime(host: PlatformRuntimeHost): Platfor
           findSelector: snapshotKindUnavailable,
         }),
         ...viewportRuntimeOperationFacts({ setViewport: viewportUnavailable }),
+        ...focusRuntimeOperationFacts({
+          focus: device.kind === 'simulator' ? focusKindUnavailable : available,
+        }),
         // uiautomator reads text at a point through the same adb path the snapshot uses, so the
         // synthetic `simulator` row is the only Android kind without a live read.
         ...elementTextRuntimeOperationFacts({
@@ -220,6 +234,13 @@ export function createAndroidPlatformRuntime(host: PlatformRuntimeHost): Platfor
             : {}),
           ...(facts.operations.captureScreenshot.available
             ? bindLocalScreenshotInteractor({
+                device: request.device,
+                signal: request.scope.signal,
+                resolveInteractor: host.localInteractors.resolve,
+              })
+            : {}),
+          ...(facts.operations.focusPoint.available
+            ? bindLocalFocusInteractor({
                 device: request.device,
                 signal: request.scope.signal,
                 resolveInteractor: host.localInteractors.resolve,

--- a/packages/platform-apple/src/runtime.ts
+++ b/packages/platform-apple/src/runtime.ts
@@ -9,9 +9,11 @@ import type {
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindLocalFocusInteractor,
   bindLocalScreenshotInteractor,
   bindElementTextRuntime,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   localRuntimeOwner,
   screenshotRuntimeOperationFacts,
   selectorObservationRuntimeOperationFacts,
@@ -52,6 +54,16 @@ const viewportUnavailable = Object.freeze({
   available: false,
   reason: 'unsupported-platform-leaf',
   hint: 'viewport resizes web targets only (--platform web). Apple screen geometry is fixed by the selected simulator or device type — open a different simulator to test another screen size.',
+} as const);
+/**
+ * Focus drives touch through the Apple interactor, which exists for the simulator and physical
+ * device kinds only. Parity with the retired `focus` capability bucket
+ * (`{ simulator: true, device: true }`), stated as one fact instead of an admission table.
+ */
+const focusKindUnavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-device-kind',
+  hint: 'focus is supported on Apple simulators and physical devices.',
 } as const);
 const appStateUnavailable = Object.freeze({
   available: false,
@@ -213,6 +225,10 @@ function appInventoryFacts(device: DeviceInfo) {
   return available;
 }
 
+function appleFocusFact(device: DeviceInfo): RuntimeOperationFact {
+  return device.kind === 'simulator' || device.kind === 'device' ? available : focusKindUnavailable;
+}
+
 export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformRuntimeOwner {
   const appLogs = createAppleAppLogRuntime(host);
   const inspectFacts = async (device: DeviceInfo) => {
@@ -250,6 +266,7 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
           findSelector: appleFindSelectorFact(device),
         }),
         ...viewportRuntimeOperationFacts({ setViewport: viewportUnavailable }),
+        ...focusRuntimeOperationFacts({ focus: appleFocusFact(device) }),
         ...elementTextRuntimeOperationFacts({ readTextAtPoint: appleElementTextFact(device) }),
         ensureReady: readiness,
         bootTarget: boot,
@@ -297,6 +314,13 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
           ),
           ...whenAdmitted(facts.operations.captureScreenshot, () =>
             bindLocalScreenshotInteractor({
+              device: request.device,
+              signal: request.scope.signal,
+              resolveInteractor: host.localInteractors.resolve,
+            }),
+          ),
+          ...whenAdmitted(facts.operations.focusPoint, () =>
+            bindLocalFocusInteractor({
               device: request.device,
               signal: request.scope.signal,
               resolveInteractor: host.localInteractors.resolve,

--- a/packages/platform-harmonyos/src/runtime.ts
+++ b/packages/platform-harmonyos/src/runtime.ts
@@ -3,13 +3,16 @@ import type {
   PlatformRuntimeHost,
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
+  RuntimeOperationFact,
 } from '@agent-device/contracts/platform';
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindLocalFocusInteractor,
   bindLocalScreenshotInteractor,
   bindLocalSnapshotInteractor,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   localRuntimeOwner,
   screenshotRuntimeOperationFacts,
   selectorObservationRuntimeOperationFacts,
@@ -34,6 +37,15 @@ const elementTextUnavailable = Object.freeze({
   available: false,
   reason: 'unsupported-platform-leaf',
   hint: 'HarmonyOS reads element text from the captured tree only.',
+} as const);
+/**
+ * Parity with the retired `focus` capability bucket, which the HarmonyOS overlay in
+ * `core/capabilities.ts` filled as `{ emulator, device }` — the two kinds hdc can drive.
+ */
+const focusKindUnavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-device-kind',
+  hint: 'focus is supported on HarmonyOS emulators and physical devices.',
 } as const);
 const available = Object.freeze({ available: true } as const);
 const unavailable = Object.freeze({
@@ -116,6 +128,10 @@ function harmonyCloseTargetFact(device: DeviceInfo) {
     : closeTargetKindUnavailable;
 }
 
+function harmonyFocusFact(device: DeviceInfo): RuntimeOperationFact {
+  return device.kind === 'emulator' || device.kind === 'device' ? available : focusKindUnavailable;
+}
+
 export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): PlatformRuntimeOwner {
   const appLogs = createHarmonyAppLogRuntime(host);
   const inspectFacts = async (device: Parameters<typeof appLogs.inspectFacts>[0]) => {
@@ -155,6 +171,7 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
           findSelector: snapshotKindUnavailable,
         }),
         ...viewportRuntimeOperationFacts({ setViewport: viewportUnavailable }),
+        ...focusRuntimeOperationFacts({ focus: harmonyFocusFact(device) }),
         // HarmonyOS has no point-read tool: `get` answers from the captured tree, which is what
         // the legacy dispatch already did after its Apple-runner attempt failed.
         ...elementTextRuntimeOperationFacts({ readTextAtPoint: elementTextUnavailable }),
@@ -214,6 +231,13 @@ export function createHarmonyPlatformRuntime(host: PlatformRuntimeHost): Platfor
             : {}),
           ...(facts.operations.captureScreenshot.available
             ? bindLocalScreenshotInteractor({
+                device: request.device,
+                signal: request.scope.signal,
+                resolveInteractor: host.localInteractors.resolve,
+              })
+            : {}),
+          ...(facts.operations.focusPoint.available
+            ? bindLocalFocusInteractor({
                 device: request.device,
                 signal: request.scope.signal,
                 resolveInteractor: host.localInteractors.resolve,

--- a/packages/platform-linux/src/runtime.ts
+++ b/packages/platform-linux/src/runtime.ts
@@ -10,11 +10,13 @@ import type {
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindLocalFocusInteractor,
   bindLocalScreenshotInteractor,
   bindElementTextRuntime,
   captureSnapshotSignal,
   createUnavailablePlatformRuntimeFacts,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   localRuntimeOwner,
   sameRuntimeOwner,
   screenshotRuntimeOperationFacts,
@@ -28,6 +30,10 @@ const supported = Object.freeze({ available: true } as const);
 const linuxOwner = localRuntimeOwner('linux');
 const unsupportedPlatformLeaf = unavailableLinuxRuntimeFact('unsupported-platform-leaf');
 const elementTextKindUnavailable = unavailableLinuxRuntimeFact('unsupported-device-kind');
+const focusKindUnavailable = unavailableLinuxRuntimeFact(
+  'unsupported-device-kind',
+  'focus is supported only for the Linux desktop device.',
+);
 const runtimeHintsUnavailable = unavailableLinuxRuntimeFact(
   'unsupported-platform-leaf',
   'Runtime hints are supported only for local iOS-family simulators and Android devices.',
@@ -97,6 +103,13 @@ export function createLinuxPlatformRuntime(host: PlatformRuntimeHost): PlatformR
                 resolveInteractor: host.localInteractors.resolve,
               })
             : {}),
+          ...(facts.operations.focusPoint.available
+            ? bindLocalFocusInteractor({
+                device: request.device,
+                signal: request.scope.signal,
+                resolveInteractor: host.localInteractors.resolve,
+              })
+            : {}),
           ...(facts.operations.readTextAtPoint.available
             ? bindElementTextRuntime({
                 device: request.device,
@@ -121,6 +134,7 @@ function linuxFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations>
     screenshot: screenshotKindUnavailable,
     snapshot: snapshotKindUnavailable,
     viewport: unsupportedPlatformLeaf,
+    focus: focusKindUnavailable,
     elementText: elementTextKindUnavailable,
     readiness: unsupportedPlatformLeaf,
     lifecycle: applicationLifecycleOperationFacts({
@@ -146,6 +160,11 @@ function linuxFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations>
       }),
       ...screenshotRuntimeOperationFacts({
         capture: device.kind === 'device' ? supported : screenshotKindUnavailable,
+      }),
+      // Parity with the retired `focus` capability bucket (`{ device: true }`): the desktop is
+      // the only Linux cell with a pointer to drive.
+      ...focusRuntimeOperationFacts({
+        focus: device.kind === 'device' ? supported : focusKindUnavailable,
       }),
       // The Linux read is value-first (AXValue/title/description) where the captured tree is
       // label-first, so the desktop row genuinely reads differently from its snapshot text.

--- a/packages/platform-vega/src/runtime.ts
+++ b/packages/platform-vega/src/runtime.ts
@@ -80,6 +80,11 @@ const screenshotUnavailable = vegaUnavailable(
   'screenshot is not supported on Vega OS: the Vega runtime exposes remote navigation only.',
 );
 
+const focusUnavailable = vegaUnavailable(
+  'unsupported-platform-leaf',
+  'focus is not supported on Vega OS: the Vega runtime exposes remote navigation only.',
+);
+
 function vegaFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations> {
   const supported = device.kind === 'emulator' && device.target === 'tv';
   const openTarget = supported ? lifecycleAvailable : openTargetUnavailable;
@@ -90,6 +95,8 @@ function vegaFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations> 
     screenshot: screenshotUnavailable,
     snapshot: unsupportedPlatformLeaf,
     viewport: unsupportedPlatformLeaf,
+    // Vega exposes remote navigation only; it never carried a `focus` capability bucket.
+    focus: focusUnavailable,
     elementText: unsupportedPlatformLeaf,
     readiness: unsupportedPlatformLeaf,
     lifecycle: applicationLifecycleOperationFacts({

--- a/packages/platform-web/src/runtime.ts
+++ b/packages/platform-web/src/runtime.ts
@@ -8,9 +8,11 @@ import type {
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindLocalFocusInteractor,
   bindLocalScreenshotInteractor,
   bindLocalSnapshotInteractor,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   localRuntimeOwner,
   screenshotRuntimeOperationFacts,
   selectorObservationRuntimeOperationFacts,
@@ -184,6 +186,13 @@ function bindWebRuntime(
           resolveInteractor: host.localInteractors.resolve,
         })
       : {}),
+    ...(facts.operations.focusPoint.available
+      ? bindLocalFocusInteractor({
+          device,
+          signal,
+          resolveInteractor: host.localInteractors.resolve,
+        })
+      : {}),
     ...(facts.operations.setViewport.available
       ? {
           setViewport: async (input) => {
@@ -258,6 +267,10 @@ function webRuntimeFacts(
         setViewport: device.kind === 'device' ? available : openTargetKindUnavailable,
       }),
       ...screenshotRuntimeOperationFacts({ capture: browserDevice }),
+      // Parity with the retired `focus` capability bucket, which the web overlay in
+      // `core/capabilities.ts` filled as `{ device: true }`: the browser device is the only
+      // web cell with an interactor to drive.
+      ...focusRuntimeOperationFacts({ focus: browserDevice }),
       ...viewportRuntimeOperationFacts({ setViewport: browserDevice }),
       // The web backend has no point-addressed read: `get` answers from the captured DOM tree,
       // which is what the legacy dispatch already did once its Apple-runner attempt failed.

--- a/packages/provider-limrun/src/app-log-runtime.ts
+++ b/packages/provider-limrun/src/app-log-runtime.ts
@@ -21,6 +21,7 @@ import {
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindProviderFocusInteractor,
   bindProviderScreenshotInteractor,
   bindProviderSnapshotInteractor,
   createUnavailablePlatformRuntimeFacts,
@@ -28,6 +29,7 @@ import {
   sameRuntimeOwner,
   screenshotRuntimeOperationFacts,
   elementTextRuntimeOperationFacts,
+  focusRuntimeOperationFacts,
   selectorObservationRuntimeOperationFacts,
   snapshotRuntimeOperationFacts,
   viewportRuntimeOperationFacts,
@@ -203,6 +205,7 @@ export function createLimrunPlatformRuntimeOwner(
             network: liveSessionUnavailable,
             screenshot: liveSessionUnavailable,
             viewport: liveSessionUnavailable,
+            focus: liveSessionUnavailable,
             elementText: liveSessionUnavailable,
             readiness: liveSessionUnavailable,
             shutdown: liveSessionUnavailable,
@@ -369,6 +372,11 @@ function bindLimrunAppLogs(
       signal,
       resolveInteractor: (runner) => options.getInteractor(device, runner),
     }),
+    ...bindProviderFocusInteractor({
+      device,
+      signal,
+      resolveInteractor: (runner) => options.getInteractor(device, runner),
+    }),
     ...bindProviderScreenshotInteractor({
       device,
       signal,
@@ -461,6 +469,9 @@ function facts(
         findSelector: customSnapshotUnavailable,
       }),
       ...viewportRuntimeOperationFacts({ setViewport: viewportUnavailable }),
+      // Focus rides the same provider interactor the captures do, and a live-session Limrun
+      // device always has one, so it is available wherever a capture is.
+      ...focusRuntimeOperationFacts({ focus: available }),
       ...elementTextRuntimeOperationFacts({ readTextAtPoint: elementTextUnavailable }),
       ensureReady: available,
       bootTarget: available,
@@ -506,6 +517,7 @@ function recoveryFacts(
         findSelector: liveSessionUnavailable,
       }),
       ...viewportRuntimeOperationFacts({ setViewport: liveSessionUnavailable }),
+      ...focusRuntimeOperationFacts({ focus: liveSessionUnavailable }),
       ensureReady: liveSessionUnavailable,
       bootTarget: liveSessionUnavailable,
       bootTargetHeadless: liveSessionUnavailable,

--- a/packages/provider-webdriver/src/platform-runtime.ts
+++ b/packages/provider-webdriver/src/platform-runtime.ts
@@ -1,10 +1,12 @@
 import {
   applicationLifecycleOperationFacts,
   availableApplicationLifecycleOperations,
+  bindProviderFocusInteractor,
   bindProviderScreenshotInteractor,
   bindProviderSnapshotInteractor,
   createUnavailablePlatformRuntimeFacts,
   sameRuntimeOwner,
+  focusRuntimeOperationFacts,
   screenshotRuntimeOperationFacts,
   snapshotRuntimeOperationFacts,
   viewportRuntimeOperationFacts,
@@ -93,6 +95,11 @@ const viewportUnavailable = Object.freeze({
  * read and `get` answers from the captured tree; provider ownership never borrows the local
  * family read.
  */
+const focusUnavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-provider-mode',
+  hint: 'This WebDriver provider runtime does not expose focus for this device.',
+} as const);
 const elementTextUnavailable = Object.freeze({
   available: false,
   reason: 'unsupported-provider-mode',
@@ -228,6 +235,13 @@ function bindWebDriverPlatformRuntime(
           resolveInteractor: (runner) => options.getInteractor?.(device, runner),
         })
       : {}),
+    ...(facts.operations.focusPoint.available
+      ? bindProviderFocusInteractor({
+          device,
+          signal,
+          resolveInteractor: (runner) => options.getInteractor?.(device, runner),
+        })
+      : {}),
     networkDump: async (input) => {
       const recent = await options.host.appLogs.readRecent(input.sessionId, input.maxScanLines);
       const dump = readRecentNetworkTrafficFromText(recent.text, {
@@ -280,6 +294,7 @@ function webDriverFacts(
       screenRecording: inactiveSession,
       screenshot: inactiveSession,
       viewport: inactiveSession,
+      focus: inactiveSession,
       elementText: inactiveSession,
       lifecycle: applicationLifecycleOperationFacts({
         resolveOpenTarget: inactiveSession,
@@ -302,6 +317,7 @@ function webDriverFacts(
     screenRecording: recordingUnavailable,
     screenshot: screenshotUnavailable,
     viewport: viewportUnavailable,
+    focus: focusUnavailable,
     elementText: elementTextUnavailable,
     lifecycle: webDriverLifecycleFacts(device),
   });
@@ -328,6 +344,9 @@ function webDriverFacts(
         withoutActiveApp: snapshotCell,
       }),
       ...screenshotRuntimeOperationFacts({ capture: screenshotCell }),
+      // Focus rides the same provider interactor the captures do, so it needs the same
+      // reachability and nothing more: this provider drives touch wherever it can drive a capture.
+      ...focusRuntimeOperationFacts({ focus: reachable ? available : focusUnavailable }),
       ...viewportRuntimeOperationFacts({ setViewport: viewportUnavailable }),
       ensureReady: available,
       bootTarget: available,

--- a/scripts/layering/runtime-command-cutover-table.ts
+++ b/scripts/layering/runtime-command-cutover-table.ts
@@ -25,8 +25,9 @@ import { retiredDispatchProjectionViolations } from './runtime-command-cutover-d
  * A row id is a report heading, so it must be unique across every stack that adds rows here.
  * `cutoverTableDefects` rejects a duplicate; lifecycle starts at R28 after the accepted
  * shutdown, install/deploy, and application-lifecycle allocations. Snapshot starts at R32;
- * diff follows at R33, viewport at R34, get at R36, and is at R37. R35 stays reserved for
- * find, whose cutover is deferred behind the Wave 5 `focus`/`type` surfaces.
+ * diff follows at R33, viewport at R34, get at R36, is at R37, screenshot at R39, wait at R38,
+ * and focus at R40. R35 stays reserved for find, whose cutover is deferred behind the Wave 5
+ * `type` surface — `focus`, its other blocker, landed at R40.
  */
 export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
   {
@@ -584,6 +585,29 @@ export const MIGRATED_COMMAND_CUTOVERS: readonly MigratedCommandCutover[] = [
         captureSnapshot: ['selectActiveAppSnapshot'],
         captureSnapshotWithoutActiveApp: ['selectSnapshotWithoutActiveApp'],
       },
+    },
+  },
+  {
+    rule: 'R40 focus-runtime-cutover',
+    command: 'focus',
+    subject: 'point focus',
+    tier: 'request-scoped',
+    execution: 'device-runtime',
+    legacyRetirement: {
+      // The interactor leaf and its dispatch-table arm. `find`'s focus leg keeps its helper
+      // name — what changed is what it calls: the same `resolveBoundFocusRuntime` the generic
+      // route binds, which is why `focusPoint` still has exactly one owner below.
+      routeNames: ['handleFocusCommand'],
+      // `focus` also leaves the two hand-maintained overlays that granted it a capability
+      // bucket on families the descriptor never listed.
+      staticCommandSets: ['HARMONYOS_SUPPORTED_COMMANDS', 'WEB_INTERACTION_COMMANDS'],
+    },
+    runtimeTypeNames: ['FocusRuntimeOperations'],
+    operations: { names: ['focusPoint'] },
+    singularExecution: {
+      routes: ['dispatchGenericCommand'],
+      operations: ['focusPoint'],
+      operationOwners: { focusPoint: ['resolveBoundFocusRuntime'] },
     },
   },
   {

--- a/src/__tests__/test-file-size-ratchet.test.ts
+++ b/src/__tests__/test-file-size-ratchet.test.ts
@@ -48,7 +48,7 @@ const PINNED_TEST_FILE_LINES: Readonly<Record<string, number>> = Object.freeze({
   'src/platforms/apple/core/__tests__/runner-command-retry.test.ts': 1327,
   'src/__tests__/cli-client-commands.test.ts': 1317,
   'src/__tests__/cli-config.test.ts': 1282,
-  'src/daemon/handlers/__tests__/find.test.ts': 1207,
+  'src/daemon/handlers/__tests__/find.test.ts': 1204,
   'src/platforms/apple/core/__tests__/perf.test.ts': 1222,
   'src/mcp/__tests__/command-tools.test.ts': 1218,
   'src/daemon/handlers/__tests__/session-replay-divergence.test.ts': 1215,

--- a/src/__tests__/test-utils/runtime-operation-facts.ts
+++ b/src/__tests__/test-utils/runtime-operation-facts.ts
@@ -36,6 +36,7 @@ export const unavailableDeploymentSnapshotAndShutdownOperationFacts = Object.fre
   findText: unavailable,
   findSelector: unavailable,
   setViewport: unavailable,
+  focusPoint: unavailable,
   ...elementTextRuntimeOperationFacts({ readTextAtPoint: unavailable }),
 });
 

--- a/src/core/__tests__/capability-plugin-routing-parity.test.ts
+++ b/src/core/__tests__/capability-plugin-routing-parity.test.ts
@@ -266,7 +266,6 @@ test('HarmonyOS static capabilities omit runtime-backed command admissions', () 
     'click',
     'fill',
     'find',
-    'focus',
     'gesture',
     'home',
     'keyboard',

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -43,7 +43,6 @@ const HARMONYOS_SUPPORTED_COMMANDS = new Set<string>([
   'click',
   'fill',
   'find',
-  'focus',
   'home',
   'gesture',
   'keyboard',
@@ -55,15 +54,7 @@ const HARMONYOS_SUPPORTED_COMMANDS = new Set<string>([
   'type',
 ]);
 const WEB_QUERY_COMMANDS = ['audio', 'find'] as const;
-const WEB_INTERACTION_COMMANDS = [
-  'click',
-  'fill',
-  'focus',
-  'hover',
-  'press',
-  'scroll',
-  'type',
-] as const;
+const WEB_INTERACTION_COMMANDS = ['click', 'fill', 'hover', 'press', 'scroll', 'type'] as const;
 const WEB_SUPPORTED_COMMANDS = new Set<string>([
   ...WEB_QUERY_COMMANDS,
   ...WEB_INTERACTION_COMMANDS,

--- a/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import { focusRuntimeUse } from '@agent-device/contracts/platform';
+import { commandDescriptors } from '../registry.ts';
+import {
+  BASE_COMMAND_CAPABILITY_MATRIX,
+  isCommandSupportedOnDevice,
+  listCapabilityCommands,
+} from '../../capabilities.ts';
+
+test('focus descriptor declares its complete runtime use with no legacy projection', () => {
+  const focus = commandDescriptors.find(({ name }) => name === 'focus');
+
+  expect(focus).not.toHaveProperty('capability');
+  expect(focus).not.toHaveProperty('dispatch');
+  expect(focus?.platformExecution).toEqual({
+    kind: 'device-runtime',
+    uses: [focusRuntimeUse],
+  });
+  expect(focusRuntimeUse).toEqual({
+    required: ['focusPoint'],
+    preferred: [],
+  });
+});
+
+test('focus keeps the traits its retired bucket did not own', () => {
+  const focus = commandDescriptors.find(({ name }) => name === 'focus');
+
+  // The Android blocking-dialog guard is admission-independent: it survived the cutover because
+  // it describes when the command may run, not which platform executes it.
+  expect(focus).toMatchObject({
+    daemon: {
+      route: 'generic',
+      refFrameEffect: 'may-invalidate',
+      androidBlockingDialogGuard: true,
+    },
+    recordsSessionAction: true,
+    recordingEffect: 'mutates-app',
+    deviceClaimPolicy: 'require-owner',
+    batchable: true,
+  });
+});
+
+test('focus leaves the capability matrix and is admitted by facts instead', () => {
+  expect(BASE_COMMAND_CAPABILITY_MATRIX).not.toHaveProperty('focus');
+  // A command with no capability row is no longer refused by the legacy bucket on any device:
+  // the exact owner's `focusPoint` fact is the only admission left.
+  expect(
+    isCommandSupportedOnDevice('focus', {
+      id: 'vega-1',
+      name: 'Vega',
+      platform: 'vega',
+      kind: 'emulator',
+      target: 'tv',
+      booted: true,
+    }),
+  ).toBe(true);
+  // It stays a projected capability command, because a migrated descriptor projects from facts.
+  expect(listCapabilityCommands()).toContain('focus');
+});

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -57,6 +57,7 @@ const NO_CAPABILITY_PUBLIC_COMMANDS = new Set<string>([
   PUBLIC_COMMANDS.diff,
   PUBLIC_COMMANDS.doctor,
   PUBLIC_COMMANDS.events,
+  PUBLIC_COMMANDS.focus,
   PUBLIC_COMMANDS.get,
   PUBLIC_COMMANDS.install,
   PUBLIC_COMMANDS.installFromSource,
@@ -210,6 +211,7 @@ test('platform dispatch command list is built from descriptor dispatch facets', 
 test('generic route commands that reach platform dispatch declare the dispatch facet', () => {
   const nonDispatchGenericCommands = new Set<string>([
     PUBLIC_COMMANDS.gesture,
+    PUBLIC_COMMANDS.focus,
     PUBLIC_COMMANDS.screenshot,
     PUBLIC_COMMANDS.viewport,
   ]);

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -35,6 +35,7 @@ import {
   screenRecordingRuntimePlanUses,
   screenshotRuntimePlanUses,
   shutdownTargetUse,
+  focusRuntimeUse,
   viewportRuntimeUse,
 } from '@agent-device/contracts/platform';
 import { readDeclaredPlatformExecution } from './platform-execution-entry.ts';
@@ -1348,8 +1349,20 @@ export const RAW_COMMAND_DESCRIPTORS = [
     ...(ownerFilesEnabled ? { ownerFiles: ['src/commands/interaction/index.ts'] as const } : {}),
     catalog: { group: 'public' },
     frameworkTier: 'extended',
-    ...GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS,
-    platformExecution: LEGACY_PLATFORM_EXECUTION,
+    // R40 retires this command's capability bucket and its `dispatch` leaf together: admission is
+    // the owner's `focusPoint` fact, and the only execution is the bound operation. The remaining
+    // traits are `GENERIC_MUTATING_LINUX_DEVICE_COMMAND_TRAITS` minus those two.
+    recordsSessionAction: true,
+    recordingEffect: 'mutates-app',
+    deviceClaimPolicy: 'require-owner',
+    daemon: {
+      route: 'generic',
+      refFrameEffect: 'may-invalidate',
+      androidBlockingDialogGuard: true,
+    },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: true,
+    platformExecution: { kind: 'device-runtime', uses: [focusRuntimeUse] },
   },
   {
     name: 'screenshot',

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -32,6 +32,7 @@ import {
   type ScrollEdgeState,
 } from '../utils/scroll-edge-state.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
+import { readPointPositionals } from '../utils/validation.ts';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import type { DispatchContext } from './dispatch-context.ts';
 import {
@@ -51,7 +52,7 @@ export async function handleLongPressCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
-  const { x, y } = readPoint(positionals, 'longpress requires x y [durationMs]', {
+  const { x, y } = readPointPositionals(positionals, 'longpress requires x y [durationMs]', {
     hint: 'Direct platform longpress requires coordinates. In an open daemon session, use agent-device longpress @ref|selector [durationMs]; otherwise run snapshot -i, use the target rect center as x y, then retry longpress x y durationMs.',
   });
   const durationMs = positionals[2] ? Number(positionals[2]) : undefined;
@@ -63,7 +64,7 @@ export async function handleHoverCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
-  const { x, y } = readPoint(positionals, 'hover requires x y', {
+  const { x, y } = readPointPositionals(positionals, 'hover requires x y', {
     hint: 'Direct platform hover requires coordinates. In an open daemon session, use agent-device hover @ref|selector; otherwise run snapshot -i, use the target rect center as x y, then retry hover x y.',
   });
   if (!interactor.hover) {
@@ -73,15 +74,6 @@ export async function handleHoverCommand(
   }
   await interactor.hover(x, y);
   return { x, y, ...successText(`Hovered (${x}, ${y})`) };
-}
-
-export async function handleFocusCommand(
-  interactor: Interactor,
-  positionals: string[],
-): Promise<Record<string, unknown>> {
-  const { x, y } = readPoint(positionals, 'focus requires x y');
-  await interactor.focus(x, y);
-  return { x, y, ...successText(`Focused (${x}, ${y})`) };
 }
 
 export async function handleTypeCommand(
@@ -181,7 +173,7 @@ export async function handlePressCommand(
     return await handleDirectElementSelectorPress(interactor, context.directElementSelector);
   }
 
-  const { x, y } = readPoint(positionals, 'press requires x y');
+  const { x, y } = readPointPositionals(positionals, 'press requires x y');
 
   if (isMacOs(device) && context?.surface && context.surface !== 'app') {
     return await handleMacOsSurfacePress(x, y, context);
@@ -222,8 +214,6 @@ async function handleDirectElementSelectorPress(
   };
 }
 
-type Point = { x: number; y: number };
-
 type PressSeriesOptions = {
   count: number;
   intervalMs: number;
@@ -231,19 +221,6 @@ type PressSeriesOptions = {
   jitterPx: number;
   doubleTap: boolean;
 };
-
-function readPoint(
-  positionals: string[],
-  errorMessage: string,
-  details?: Record<string, unknown>,
-): Point {
-  const x = Number(positionals[0]);
-  const y = Number(positionals[1]);
-  if (Number.isNaN(x) || Number.isNaN(y)) {
-    throw new AppError('INVALID_ARGS', errorMessage, details);
-  }
-  return { x, y };
-}
 
 async function handleMacOsSurfacePress(
   x: number,

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -14,7 +14,6 @@ import type { DescriptorDispatchCommandName } from './command-descriptor/registr
 import type { DispatchContext } from './dispatch-context.ts';
 import {
   handleFillCommand,
-  handleFocusCommand,
   handleHoverCommand,
   handleLongPressCommand,
   handlePressCommand,
@@ -145,7 +144,6 @@ const DISPATCH_HANDLERS: Record<DispatchCommand, DispatchHandler> = {
     handlePressCommand(device, interactor, positionals, context),
   longpress: ({ interactor, positionals }) => handleLongPressCommand(interactor, positionals),
   hover: ({ interactor, positionals }) => handleHoverCommand(interactor, positionals),
-  focus: ({ interactor, positionals }) => handleFocusCommand(interactor, positionals),
   type: ({ interactor, positionals, context }) =>
     handleTypeCommand(interactor, positionals, context),
   fill: ({ interactor, positionals, context }) =>

--- a/src/daemon/__tests__/focus-runtime.test.ts
+++ b/src/daemon/__tests__/focus-runtime.test.ts
@@ -1,0 +1,238 @@
+import { expect, test, vi } from 'vitest';
+import {
+  focusRuntimeOperationFacts,
+  focusRuntimeUse,
+  localRuntimeOwner,
+  narrowDeviceBinding,
+  type DeviceBinding,
+  type DeviceRuntimeGateway,
+  type PlatformRuntimeOperations,
+  type RuntimeFacts,
+  type RuntimeOperationFact,
+} from '@agent-device/contracts/platform';
+import { deviceShape } from '@agent-device/kernel/device';
+import { makeSession } from '../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { createTestDeviceInventoryGateways } from '../../__tests__/test-utils/device-inventory-gateways.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { activateCompleteRefFrame } from '../ref-frame.ts';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
+import type { GenericPlatformExecutionParams } from '../request-generic-dispatch.ts';
+import { readFocusPoint, resolveBoundFocusRuntime } from '../focus-runtime.ts';
+import { createRequestHandler } from './test-device-runtime-gateway.ts';
+
+const appleDevice = {
+  id: 'ios-simulator',
+  name: 'iPhone',
+  platform: 'apple',
+  appleOs: 'ios',
+  kind: 'simulator',
+  target: 'mobile',
+  booted: true,
+} as const;
+const available = Object.freeze({ available: true } as const);
+const unavailable = Object.freeze({
+  available: false,
+  reason: 'unsupported-device-kind' as const,
+  hint: 'focus is supported on Apple simulators and physical devices.',
+});
+
+function focusExecutionParams(
+  dispatchContext: GenericPlatformExecutionParams['dispatchContext'] = {},
+): GenericPlatformExecutionParams {
+  const session = makeSession('focus-runtime', { device: appleDevice });
+  return {
+    session,
+    sessionName: session.name,
+    logPath: '/tmp/daemon.log',
+    command: 'focus',
+    request: { command: 'focus', positionals: ['40', '90'], token: 't', session: session.name },
+    positionals: ['40', '90'],
+    out: undefined,
+    dispatchContext,
+  };
+}
+
+function runtimeHarness(fact: RuntimeOperationFact = available) {
+  const focusPoint = vi.fn(async () => undefined);
+  const facts: RuntimeFacts<PlatformRuntimeOperations> = {
+    device: { ...deviceShape(appleDevice), providerMode: 'local' },
+    operations: { focusPoint: fact } as RuntimeFacts<PlatformRuntimeOperations>['operations'],
+  };
+  const binding = {
+    device: appleDevice,
+    owner: localRuntimeOwner('apple'),
+    facts,
+    operations: { focusPoint },
+    [Symbol.asyncDispose]: async () => {},
+  } satisfies DeviceBinding<PlatformRuntimeOperations>;
+  const inspectFacts: InspectDeviceRuntimeFacts = vi.fn(async () => facts);
+  const bindDevice = vi.fn(async (_device, use) =>
+    narrowDeviceBinding(binding, use),
+  ) as unknown as BindDeviceRuntime;
+  const bind = vi.fn(async () => binding);
+  const gateway: DeviceRuntimeGateway<PlatformRuntimeOperations> = {
+    inspectFacts,
+    bind,
+    shutdown: async () => {},
+  };
+  return { focusPoint, inspectFacts, bindDevice, bind, gateway };
+}
+
+test('resolves one admitted binding and exposes one point focus', async () => {
+  const harness = runtimeHarness(focusRuntimeOperationFacts({ focus: available }).focusPoint);
+
+  const resolved = await resolveBoundFocusRuntime({
+    device: appleDevice,
+    positionals: ['40', '90'],
+    inspectFacts: harness.inspectFacts,
+    bindDevice: harness.bindDevice,
+  });
+
+  expect(resolved.ok).toBe(true);
+  if (!resolved.ok) return;
+  expect(harness.inspectFacts).toHaveBeenCalledTimes(1);
+  expect(harness.inspectFacts).toHaveBeenCalledWith(appleDevice);
+  expect(harness.bindDevice).toHaveBeenCalledTimes(1);
+  expect(harness.bindDevice).toHaveBeenCalledWith(appleDevice, focusRuntimeUse);
+  expect(await resolved.execute(focusExecutionParams())).toEqual({
+    x: 40,
+    y: 90,
+    message: 'Focused (40, 90)',
+  });
+  expect(harness.focusPoint).toHaveBeenCalledTimes(1);
+  expect(harness.focusPoint).toHaveBeenCalledWith({
+    point: { x: 40, y: 90 },
+    execution: {
+      requestId: undefined,
+      verbose: undefined,
+      logPath: undefined,
+      traceLogPath: undefined,
+      iosXctestrunFile: undefined,
+      iosXctestDerivedDataPath: undefined,
+      iosXctestEnvDir: undefined,
+      runnerLeaseContext: undefined,
+    },
+  });
+});
+
+test('forwards the request context the retired leaf passed through its runner context', async () => {
+  const harness = runtimeHarness();
+
+  const resolved = await resolveBoundFocusRuntime({
+    device: appleDevice,
+    positionals: ['40', '90'],
+    inspectFacts: harness.inspectFacts,
+    bindDevice: harness.bindDevice,
+  });
+  expect(resolved.ok).toBe(true);
+  if (!resolved.ok) return;
+  await resolved.execute(
+    focusExecutionParams({
+      appBundleId: 'com.example.app',
+      requestId: 'focus-context',
+      logPath: '/tmp/session.log',
+      traceLogPath: '/tmp/trace.log',
+      verbose: true,
+    }),
+  );
+
+  expect(harness.focusPoint).toHaveBeenCalledWith(
+    expect.objectContaining({
+      point: { x: 40, y: 90 },
+      options: { appBundleId: 'com.example.app' },
+      execution: expect.objectContaining({
+        requestId: 'focus-context',
+        logPath: '/tmp/session.log',
+        traceLogPath: '/tmp/trace.log',
+        verbose: true,
+      }),
+    }),
+  );
+});
+
+test('rejects a missing coordinate before inspection or binding', async () => {
+  const harness = runtimeHarness();
+
+  await expect(
+    resolveBoundFocusRuntime({
+      device: appleDevice,
+      positionals: ['40'],
+      inspectFacts: harness.inspectFacts,
+      bindDevice: harness.bindDevice,
+    }),
+  ).rejects.toMatchObject({ code: 'INVALID_ARGS', message: 'focus requires x y' });
+  expect(harness.inspectFacts).not.toHaveBeenCalled();
+  expect(harness.bindDevice).not.toHaveBeenCalled();
+});
+
+test('parses coordinates exactly as the retired leaf did', () => {
+  expect(readFocusPoint(['12', '34'])).toEqual({ x: 12, y: 34 });
+  // The leaf used `Number`, not an integer parse, so a fractional point stayed legal.
+  expect(readFocusPoint(['12.5', '34.25'])).toEqual({ x: 12.5, y: 34.25 });
+  expect(() => readFocusPoint(['left', '34'])).toThrowError(/focus requires x y/);
+});
+
+test('rejects an unavailable exact-owner fact before binding', async () => {
+  const harness = runtimeHarness(unavailable);
+
+  const resolved = await resolveBoundFocusRuntime({
+    device: appleDevice,
+    positionals: ['40', '90'],
+    inspectFacts: harness.inspectFacts,
+    bindDevice: harness.bindDevice,
+  });
+
+  expect(resolved).toEqual({
+    ok: false,
+    response: {
+      ok: false,
+      error: {
+        code: 'UNSUPPORTED_OPERATION',
+        message: 'focus is not supported on this device',
+        hint: unavailable.hint,
+      },
+    },
+  });
+  expect(harness.inspectFacts).toHaveBeenCalledTimes(1);
+  expect(harness.bindDevice).not.toHaveBeenCalled();
+});
+
+test('request router joins focus admission to execution, recording, and ref invalidation', async () => {
+  const harness = runtimeHarness();
+  const sessionStore = makeSessionStore('agent-device-focus-generic-');
+  const session = makeSession('focus-runtime', { device: appleDevice });
+  activateCompleteRefFrame(session);
+  sessionStore.set(session.name, session);
+  const handler = createRequestHandler({
+    logPath: '/tmp/daemon.log',
+    token: 't',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    deviceInventoryGateways: createTestDeviceInventoryGateways(),
+    deviceRuntimeGateway: harness.gateway,
+    trackDownloadableArtifact: () => 'artifact',
+  });
+
+  const response = await handler({
+    command: 'focus',
+    positionals: ['40', '90'],
+    token: 't',
+    session: session.name,
+    flags: {},
+    meta: { requestId: 'focus-router-join' },
+  });
+
+  expect(response).toMatchObject({
+    ok: true,
+    data: { x: 40, y: 90, message: 'Focused (40, 90)' },
+  });
+  expect(session.refFrameState).toBe('expired');
+  expect(session.actions.at(-1)).toMatchObject({
+    command: 'focus',
+    positionals: ['40', '90'],
+  });
+  expect(harness.inspectFacts).toHaveBeenCalledTimes(1);
+  expect(harness.bind).toHaveBeenCalledTimes(1);
+  expect(harness.focusPoint).toHaveBeenCalledTimes(1);
+});

--- a/src/daemon/focus-runtime.ts
+++ b/src/daemon/focus-runtime.ts
@@ -1,0 +1,52 @@
+import { focusRuntimeUse, type FocusPointInput } from '@agent-device/contracts/platform';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { Point } from '@agent-device/kernel/snapshot';
+import { successText } from '../utils/success-text.ts';
+import { readPointPositionals } from '../utils/validation.ts';
+import type { DaemonCommandContext } from './context.ts';
+import type { ResolvedGenericExecution } from './request-generic-dispatch.ts';
+import { admitRuntimeUse, type RuntimeAdmissionBindings } from './runtime-admission.ts';
+import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';
+
+/** `focus x y`, on the same positional parse its still-legacy touch siblings take. */
+export function readFocusPoint(positionals: readonly string[]): Point {
+  return readPointPositionals(positionals, 'focus requires x y');
+}
+
+/** The neutral intent one focus carries, projected from a resolved command context. */
+function focusPointInput(point: Point, context: DaemonCommandContext): FocusPointInput {
+  return {
+    point,
+    ...(context.appBundleId === undefined ? {} : { options: { appBundleId: context.appBundleId } }),
+    execution: runtimeExecutionFromContext(context),
+  };
+}
+
+/**
+ * The one place `focus` reaches a device (ADR 0019). Admission inspects the exact owner's
+ * `focusPoint` fact and binds once, before the dispatcher runs, so an owner that cannot drive
+ * touch is refused rather than discovered mid-execution.
+ */
+export async function resolveBoundFocusRuntime(
+  params: {
+    device: DeviceInfo;
+    positionals: readonly string[];
+  } & RuntimeAdmissionBindings,
+): Promise<ResolvedGenericExecution> {
+  const point = readFocusPoint(params.positionals);
+  const admission = await admitRuntimeUse({
+    command: 'focus',
+    device: params.device,
+    use: focusRuntimeUse,
+    inspectFacts: params.inspectFacts,
+    bindDevice: params.bindDevice,
+  });
+  if (admission.type === 'response') return { ok: false, response: admission.response };
+  return {
+    ok: true,
+    execute: async ({ dispatchContext }) => {
+      await admission.runtime.operations.focusPoint(focusPointInput(point, dispatchContext));
+      return { x: point.x, y: point.y, ...successText(`Focused (${point.x}, ${point.y})`) };
+    },
+  };
+}

--- a/src/daemon/generic-runtime-execution.ts
+++ b/src/daemon/generic-runtime-execution.ts
@@ -1,4 +1,5 @@
 import type { ResolvedGenericExecution } from './request-generic-dispatch.ts';
+import { resolveBoundFocusRuntime } from './focus-runtime.ts';
 import { resolveScreenshotGenericExecution } from './screenshot-runtime.ts';
 import type { ScreenshotRuntimeBindings } from './screenshot-runtime-binding.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
@@ -15,6 +16,13 @@ export async function resolveGenericRuntimeExecution(
   switch (params.req.command) {
     case 'screenshot':
       return await resolveScreenshotGenericExecution(params);
+    case 'focus':
+      return await resolveBoundFocusRuntime({
+        device: params.session.device,
+        positionals: params.req.positionals ?? [],
+        inspectFacts: params.inspectFacts,
+        bindDevice: params.bindDevice,
+      });
     case 'viewport':
       return await resolveBoundViewportRuntime({
         device: params.session.device,

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -28,7 +28,7 @@ vi.mock('../snapshot-interactor-capture.ts', async () => {
 
 import { dispatchCommand } from '../../../core/dispatch.ts';
 
-import { resetGetRuntimeFixture } from './interaction-get-runtime-fixture.ts';
+import { mockFocusPoint, resetGetRuntimeFixture } from './interaction-get-runtime-fixture.ts';
 import { invokeFindHandler } from './find-handler-fixture.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
@@ -742,12 +742,9 @@ test('handleFindCommands focus uses the promoted actionable node center', async 
   });
 
   expect(response.ok).toBe(true);
-  expect(mockDispatch).toHaveBeenLastCalledWith(
-    expect.anything(),
-    'focus',
-    ['176', '132'],
-    undefined,
-    expect.anything(),
+  // R40: find's focus leg reaches the device through the bound `focusPoint`, not a dispatch.
+  expect(mockFocusPoint).toHaveBeenLastCalledWith(
+    expect.objectContaining({ point: { x: 176, y: 132 } }),
   );
 });
 

--- a/src/daemon/handlers/__tests__/install-source.test.ts
+++ b/src/daemon/handlers/__tests__/install-source.test.ts
@@ -361,6 +361,7 @@ function sourceRuntimeFacts(
       findText: unavailable,
       findSelector: unavailable,
       setViewport: unavailable,
+      focusPoint: unavailable,
       readTextAtPoint: unavailable,
       deployApp: unavailable,
       materializeAppSource: materializationAvailable ? { available: true } : unavailable,

--- a/src/daemon/handlers/__tests__/interaction-get-runtime-fixture.ts
+++ b/src/daemon/handlers/__tests__/interaction-get-runtime-fixture.ts
@@ -8,6 +8,7 @@ import {
   type DeviceBinding,
   type PlatformRuntimeOperations,
   type ElementTextReadOutcome,
+  type FocusPointInput,
   type ReadTextAtPointInput,
   type RuntimeFacts,
 } from '@agent-device/contracts/platform';
@@ -29,12 +30,20 @@ export const mockReadTextAtPoint = vi.fn(
 );
 
 /**
- * Flip to model an exact owner cell: no live element read (web, HarmonyOS, provider), or no
- * capture at all (the watchOS sentinel, an inactive provider), which refuses admission outright.
+ * `find <q> focus` shares the `focus` unit's bound operation (R40), so this fixture owns it too:
+ * mutating find binds the same runtime the generic `focus` leaf does.
+ */
+export const mockFocusPoint = vi.fn(async (_input: FocusPointInput): Promise<void> => undefined);
+
+/**
+ * Flip to model an exact owner cell: no live element read (web, HarmonyOS, provider), no capture
+ * at all (the watchOS sentinel, an inactive provider), which refuses admission outright, or no
+ * touch (a device kind whose family cannot drive a point focus).
  */
 export const elementReadFixtureState = {
   readTextAtPointAvailable: true,
   captureSnapshotAvailable: true,
+  focusPointAvailable: true,
 };
 
 export function resetGetRuntimeFixture(): void {
@@ -42,8 +51,11 @@ export function resetGetRuntimeFixture(): void {
   mockReadTextAtPoint.mockResolvedValue(
     Object.freeze({ status: 'unreadable', reason: 'no-text-at-point' } as const),
   );
+  mockFocusPoint.mockReset();
+  mockFocusPoint.mockResolvedValue(undefined);
   elementReadFixtureState.readTextAtPointAvailable = true;
   elementReadFixtureState.captureSnapshotAvailable = true;
+  elementReadFixtureState.focusPointAvailable = true;
 }
 
 const available = Object.freeze({ available: true } as const);
@@ -57,6 +69,7 @@ function elementReadFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOpera
     appLog: unavailable,
     network: unavailable,
     viewport: unavailable,
+    focus: unavailable,
     elementText: unavailable,
     screenshot: unavailable,
     lifecycle: applicationLifecycleOperationFacts({
@@ -81,6 +94,7 @@ function elementReadFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOpera
         ? available
         : unavailable,
       readTextAtPoint: elementReadFixtureState.readTextAtPointAvailable ? available : unavailable,
+      focusPoint: elementReadFixtureState.focusPointAvailable ? available : unavailable,
     },
   });
 }
@@ -111,6 +125,7 @@ const mockBindElementReadRuntime: BindDeviceRuntime = vi.fn(async (device: Devic
       ...(elementReadFixtureState.readTextAtPointAvailable
         ? { readTextAtPoint: mockReadTextAtPoint }
         : {}),
+      ...(elementReadFixtureState.focusPointAvailable ? { focusPoint: mockFocusPoint } : {}),
     }),
     [Symbol.asyncDispose]: async () => undefined,
   }) as DeviceBinding<PlatformRuntimeOperations>;

--- a/src/daemon/handlers/__tests__/session-capabilities.fixtures.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.fixtures.ts
@@ -89,6 +89,7 @@ function createAdmissionFacts(
       findText: unavailable,
       findSelector: unavailable,
       setViewport: unavailable,
+      focusPoint: unavailable,
       deployApp: cell(options.deployAvailable),
       materializeAppSource: cell(options.sourceAvailable),
       deployMaterializedApp: cell(options.sourceAvailable),

--- a/src/daemon/handlers/__tests__/session-command-harness.ts
+++ b/src/daemon/handlers/__tests__/session-command-harness.ts
@@ -147,6 +147,7 @@ function readinessFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperati
       findText: unavailable,
       findSelector: unavailable,
       setViewport: unavailable,
+      focusPoint: unavailable,
       readTextAtPoint: unavailable,
       deployApp: operationAvailability(deployment.deploy),
       materializeAppSource: operationAvailability(deployment.source),

--- a/src/daemon/handlers/__tests__/session-state.test.ts
+++ b/src/daemon/handlers/__tests__/session-state.test.ts
@@ -46,6 +46,7 @@ test('boot rejects --headless outside Android directly', async () => {
             network: { available: false, reason: 'owner-capability-missing' },
             screenshot: { available: false, reason: 'owner-capability-missing' },
             viewport: { available: false, reason: 'owner-capability-missing' },
+            focus: { available: false, reason: 'owner-capability-missing' },
             elementText: { available: false, reason: 'owner-capability-missing' },
             readiness: { available: false, reason: 'unsupported-device-kind' },
             lifecycle: applicationLifecycleOperationFacts({
@@ -132,6 +133,7 @@ test('appstate rejects web before Android app-state backend dispatch', async () 
             network: { available: false, reason: 'unsupported-platform-leaf' },
             screenshot: { available: false, reason: 'unsupported-platform-leaf' },
             viewport: { available: false, reason: 'unsupported-platform-leaf' },
+            focus: { available: false, reason: 'unsupported-platform-leaf' },
             elementText: { available: false, reason: 'unsupported-platform-leaf' },
             readiness: { available: false, reason: 'unsupported-platform-leaf' },
             lifecycle: applicationLifecycleOperationFacts({

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -19,6 +19,7 @@ import { withSystemSurfaceDisclosure } from './system-surface-disclosure.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
 import { resolveFindMatch } from './find-match-resolution.ts';
+import { resolveBoundFocusRuntime } from '../focus-runtime.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { createFindTargetCapture, sparseFindSnapshotResponse } from './find-target-capture.ts';
@@ -36,6 +37,8 @@ type FindContext = {
   locator: FindLocator;
   query: string;
   publicFlags: Record<string, unknown>;
+  inspectFacts?: InspectDeviceRuntimeFacts;
+  bindDevice?: BindDeviceRuntime;
 };
 
 type ResolvedMatch = {
@@ -120,6 +123,8 @@ export async function handleFindCommands(params: {
     locator,
     query,
     publicFlags: publicFindFlags(req.flags),
+    inspectFacts: params.inspectFacts,
+    bindDevice: params.bindDevice,
   };
 
   const snapshotResult = await readTargetTree();
@@ -306,15 +311,30 @@ async function dispatchFocusForFindMatch(
   // command directly (they do not re-enter the interaction leaf), so expire the
   // frame here before the device op. Pre-seam guards above preserve the frame.
   expireRefFrame(session);
-  const response = await dispatchCommand(
+  // R40: find's focus leg shares `focus`'s bound runtime rather than dispatching the retired
+  // leaf, so `focus x y` and `find <q> focus` reach the device through one admitted operation.
+  const bound = await resolveBoundFocusRuntime({
     device,
-    'focus',
-    [String(coords.x), String(coords.y)],
-    req.flags?.out,
-    {
-      ...contextFromFlags(logPath, req.flags, session.appBundleId, session.trace?.outPath),
-    },
-  );
+    positionals: [String(coords.x), String(coords.y)],
+    inspectFacts: ctx.inspectFacts,
+    bindDevice: ctx.bindDevice,
+  });
+  if (!bound.ok) return bound.response;
+  const response = await bound.execute({
+    session,
+    sessionName: ctx.sessionName,
+    logPath,
+    command: 'focus',
+    request: req,
+    positionals: [String(coords.x), String(coords.y)],
+    out: req.flags?.out,
+    dispatchContext: contextFromFlags(
+      logPath,
+      req.flags,
+      session.appBundleId,
+      session.trace?.outPath,
+    ),
+  });
   return { ok: true, data: response ?? { ref: match.ref } };
 }
 

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -50,6 +50,7 @@ describe('composed platform runtime gateway', () => {
       screenshot: unavailable,
       elementText: unavailable,
       viewport: unavailable,
+      focus: unavailable,
       lifecycle: applicationLifecycleOperationFacts({
         resolveOpenTarget: unavailable,
         prepareApplicationOpen: unavailable,
@@ -126,6 +127,7 @@ describe('composed platform runtime gateway', () => {
       network: unavailable,
       screenshot: unavailable,
       viewport: unavailable,
+      focus: unavailable,
       elementText: unavailable,
       lifecycle: applicationLifecycleOperationFacts({
         resolveOpenTarget: unavailable,

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -305,6 +305,7 @@ function unavailableProviderBinding(
     network: unavailable,
     screenshot: unavailable,
     viewport: unavailable,
+    focus: unavailable,
     elementText: unavailable,
     lifecycle: unavailableProviderLifecycleFacts(unavailable),
   });
@@ -324,6 +325,7 @@ function unavailableProviderFacts(runtime: ProviderDeviceRuntime, device: Device
       network: unavailable,
       screenshot: unavailable,
       viewport: unavailable,
+      focus: unavailable,
       elementText: unavailable,
       readiness: unavailable,
       lifecycle: unavailableProviderLifecycleFacts(unavailable),

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,8 +1,29 @@
 import { AppError } from '@agent-device/kernel/errors';
+import type { Point } from '@agent-device/kernel/snapshot';
 
 export function requireIntInRange(value: number, name: string, min: number, max: number): number {
   if (!Number.isFinite(value) || !Number.isInteger(value) || value < min || value > max) {
     throw new AppError('INVALID_ARGS', `${name} must be an integer between ${min} and ${max}`);
   }
   return value;
+}
+
+/**
+ * The `x y` positional pair every point-addressed command takes. `Number`, not an integer parse:
+ * a fractional coordinate has always been legal, and only a non-numeric one is rejected.
+ *
+ * Shared rather than restated so a migrated command and its still-legacy siblings cannot drift
+ * apart on what "requires x y" means.
+ */
+export function readPointPositionals(
+  positionals: readonly string[],
+  errorMessage: string,
+  details?: Record<string, unknown>,
+): Point {
+  const x = Number(positionals[0]);
+  const y = Number(positionals[1]);
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    throw new AppError('INVALID_ARGS', errorMessage, details);
+  }
+  return { x, y };
 }

--- a/test/integration/linux-e2e/coverage-manifest.ts
+++ b/test/integration/linux-e2e/coverage-manifest.ts
@@ -218,11 +218,10 @@ export const LINUX_PLATFORM_COVERAGE = {
     'Linux scroll dispatch uses the Wayland ydotool wheel primitive',
   ),
   [C.swipe]: gap('No Linux-specific public swipe command evidence exists yet'),
-  [C.focus]: contract(
-    LINUX_PROVIDER_EVIDENCE.path,
-    LINUX_PROVIDER_EVIDENCE.test,
-    'Linux provider scenario focuses a coordinate target',
-  ),
+  // Promoted from command-contract to live by #1925: the desktop replay now runs a coordinate
+  // focus on real Linux hardware, so the migrated `focusPoint` path has live changed-path
+  // evidence rather than only the provider scenario at LINUX_PROVIDER_EVIDENCE.
+  [C.focus]: live('the Linux desktop replay focuses a coordinate on real hardware'),
   [C.screenshot]: live('the existing Linux replay creates a screenshot artifact'),
   [C.viewport]: contract(
     LINUX_RUNTIME_EVIDENCE.path,

--- a/test/integration/replays/linux/01-desktop-smoke.ad
+++ b/test/integration/replays/linux/01-desktop-smoke.ad
@@ -10,3 +10,9 @@ snapshot
 # or digit buttons that only a calculator app would expose.
 is exists "appname=gnome-calculator || windowtitle=Calculator || label=Calculator || label=0 || label=1 || label=5"
 snapshot -i
+# R40 (#1739): `focus` executes through the bound `focusPoint` operation rather than the retired
+# interactor leaf. A coordinate focus, not a selector one, so this step cannot fail on match
+# ambiguity or layout drift — it exists to prove the migrated path runs on real Linux hardware.
+focus 100 100
+# The session survives the focus: a crashed desktop would fail here, not silently pass above.
+is exists "appname=gnome-calculator || windowtitle=Calculator || label=Calculator || label=0 || label=1 || label=5"

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -40,9 +40,10 @@ test('Linux coverage exhaustively classifies the public catalog', () => {
 test('Linux coverage report has the expected classification counts', () => {
   assert.deepEqual(LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
     capabilityDenial: 11,
-    contract: 20,
+    // focus moved contract -> live in #1925: the replay now runs it on real hardware.
+    contract: 19,
     gap: 18,
-    live: 5,
+    live: 6,
     total: 54,
   });
 
@@ -59,7 +60,7 @@ test('Linux live claims reference commands in the existing smoke replay', () => 
     parseReplayScriptDetailed(replaySource).actions.map((action) => action.command),
   );
   const liveCommands = liveCommandsForLinuxReplay();
-  assert.deepEqual(liveCommands.length, 5);
+  assert.deepEqual(liveCommands.length, 6);
   for (const command of liveCommands) {
     assert.equal(
       replayCommands.has(command),


### PR DESCRIPTION
Wave 5's first unit for #1739 (ADR 0019). Migrates `focus` from the legacy interactor leaf onto a
request-bound device runtime.

## Unit record

- **Denominator cells:** one descriptor (`focus`), one operation (`focusPoint`), six platform
  families plus two provider runtimes.
- **Parity source:** `handleFocusCommand` in `src/core/dispatch-interactions.ts` and the `focus`
  arm of the `dispatchKnownCommand` table, at `06d27de4d`.
- **Facet owner:** `packages/contracts/src/focus-runtime.ts` — one contract owner for the
  operation, its facts, and both interactor binders.
- **Evidence tier:** request-scoped. `focus` binds no durable resource; its binding lives exactly
  as long as the request.
- **Expected deletions:** `handleFocusCommand`, the dispatch-table arm, the `focus` capability
  bucket, and `focus`'s membership in the two hand-maintained capability overlays.
- **Size budget:** move-dominated, no net production growth beyond the new contract. Actual below.

## What changed

**One execution path.** `focus x y` (generic route) and `find <q> focus` both resolve
`resolveBoundFocusRuntime`, admit the exact owner's `focusPoint` fact, and bind once. Previously
the leaf dispatched through `core/dispatch.ts` and find dispatched the `focus` command a second
time, independently.

**Facts replace the capability bucket.** The retired bucket was
`{ apple: sim+device, android: all, linux: device }`, widened at runtime by two hand-maintained
overlays in `core/capabilities.ts` that added `harmonyos` and `web`. Those five families plus vega
are now stated as facts by their owners:

| Owner | `focusPoint` |
| --- | --- |
| apple | `simulator` \| `device` |
| android | every kind except the synthetic `simulator` row |
| harmonyos | `emulator` \| `device` |
| linux | `device` |
| web | the browser `device` cell |
| vega | unavailable — remote navigation only, never had a bucket |
| webdriver / limrun | available wherever the provider interactor is reachable |

That is the retired bucket's exact cell table, so admission is unchanged; what changed is who
states it. `focus` leaves `BASE_COMMAND_CAPABILITY_MATRIX`, `HARMONYOS_SUPPORTED_COMMANDS` and
`WEB_INTERACTION_COMMANDS`.

**No second mechanism.** `bindLocalFocusInteractor` / `bindProviderFocusInteractor` ride the same
`Interactor` seam `bindLocalScreenshotInteractor` and `bindElementTextRuntime` already use, rather
than a bespoke host port for one more operation of the same class.

**Deduplicated the positional parse.** `readPoint` moves from `dispatch-interactions.ts` to
`utils/validation.ts` as `readPointPositionals`, shared by `focus` and by its still-legacy touch
siblings (`press`, `longpress`, `hover`). A migrated command and an unmigrated one cannot drift on
what "requires x y" means. `focus` accepts fractional coordinates exactly as the leaf did — a
`requireInt` here would have been a silent behavior change, and there is a test pinning it.

## Scope this unit does NOT claim

`find` stays `LEGACY_PLATFORM_EXECUTION` and claims no cutover row. This unit moves its **focus leg
only**; the `type` leg still dispatches, so R35 remains reserved for the Wave 5 `type` unit. Same
shape as #1877, which moved find's read leg while leaving the descriptor legacy.

`dispatchFocusForFindMatch` is deliberately not in the retirement claim: the helper survives, what
changed is what it calls. R40's `operationOwners` proves `focusPoint` has exactly one owner.

## Gate

- `pnpm check:affected --run`: **all runnable checks passed**.
- `pnpm check:layering`: OK — 24 migrated commands now keep exactly one platform-execution path,
  including `focus`. R40 is the new parametrized cutover row.
- Fail-close verified: adding `focusPoint` to `PlatformRuntimeOperations` broke every facts
  constructor that had not classified the cell, which is how the six platform packages, two
  provider runtimes and the composition root were found rather than guessed.
- 6 new daemon runtime tests, 3 new descriptor tests, plus the R40 row's gate coverage.

## Size

Authoritative CI Size (#1842) at `46ccce3d8`: JS raw **+4.5 kB**, gzip **+1.3 kB**, npm tarball
**+1.0 kB**, npm unpacked **+4.5 kB**. Unpacked exceeds #1842's ~3 kB escalation bar, so it is
itemized in [this comment](https://github.com/callstack/agent-device/pull/1925). Source movement:
root `src/` production **+131 / −49**, workspace packages **+260 / −0**.

Closes nothing on its own — #1739 stays open until the terminal gate.

