### PR TITLE
perf: reduce cold iOS runner startup latency

### DIFF
--- a/packages/contracts/src/device-readiness-runtime.ts
+++ b/packages/contracts/src/device-readiness-runtime.ts
@@ -18,6 +18,8 @@ export type DeviceReadinessRuntimeHost = Readonly<{
   }>;
   appleAutomation: Readonly<{
     keepHot(device: DeviceInfo): void;
+    /** Reads the bounded memo populated only by a fresh native Booted observation. */
+    wasRecentlyObservedBooted(device: DeviceInfo): Promise<boolean>;
     /**
      * Publishes a FRESH Booted observation. `simctl list devices -j` costs ~0.7s per spawn and one
      * flow makes several boot checks, so the host memoizes what readiness just observed. Callers

--- a/packages/platform-android/src/network/runtime.test.ts
+++ b/packages/platform-android/src/network/runtime.test.ts
@@ -206,7 +206,11 @@ function unusedAppLogHost(): Omit<
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
     deviceShutdown: {

--- a/packages/platform-android/src/readiness/runtime.test.ts
+++ b/packages/platform-android/src/readiness/runtime.test.ts
@@ -23,7 +23,11 @@ test('cancellation interrupts Android boot polling and terminates the emulator l
     clock: { now: () => 1, sleep: async () => {} },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {}, markBooted: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: {
         discover: async () => {
           discoveries += 1;

--- a/packages/platform-android/src/runtime.test.ts
+++ b/packages/platform-android/src/runtime.test.ts
@@ -50,7 +50,11 @@ test.each([
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {}, markBooted: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
     localInteractors: { resolve: async () => ({}) },

--- a/packages/platform-apple/src/deployment/runtime.test.ts
+++ b/packages/platform-apple/src/deployment/runtime.test.ts
@@ -53,7 +53,11 @@ function deploymentHost(
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {}, markBooted: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
   } as unknown as PlatformRuntimeHost;

--- a/packages/platform-apple/src/network/runtime.test.ts
+++ b/packages/platform-apple/src/network/runtime.test.ts
@@ -170,7 +170,11 @@ function unusedAppLogHost(): Omit<
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
     deviceShutdown: {

--- a/packages/platform-apple/src/readiness/runtime.test.ts
+++ b/packages/platform-apple/src/readiness/runtime.test.ts
@@ -4,6 +4,93 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { platformRuntimeHostFixture } from '../runtime.fixtures.ts';
 import { ensureAppleReady } from './runtime.ts';
 
+test('recent native boot observation avoids a duplicate simulator listing', async () => {
+  const run = vi.fn(async () => ({
+    stdout: JSON.stringify({ devices: { ios: [{ udid: 'sim-1', state: 'Booted' }] } }),
+    stderr: '',
+    exitCode: 0,
+  }));
+  const markBooted = vi.fn();
+  const host = platformRuntimeHostFixture();
+
+  await ensureAppleReady(
+    {
+      ...host,
+      appleTools: { ...host.appleTools, run },
+      deviceReadiness: {
+        ...host.deviceReadiness,
+        appleAutomation: {
+          keepHot: vi.fn(),
+          markBooted,
+          wasRecentlyObservedBooted: vi.fn(async () => true),
+        },
+      },
+    },
+    simulator({ booted: true }),
+    new AbortController().signal,
+  );
+
+  expect(run).not.toHaveBeenCalled();
+  expect(markBooted).toHaveBeenCalledOnce();
+});
+
+test('plain device boot state does not bypass native readiness observation', async () => {
+  const run = vi.fn(async () => ({
+    stdout: JSON.stringify({ devices: { ios: [{ udid: 'sim-1', state: 'Booted' }] } }),
+    stderr: '',
+    exitCode: 0,
+  }));
+  const host = platformRuntimeHostFixture();
+
+  await ensureAppleReady(
+    {
+      ...host,
+      appleTools: { ...host.appleTools, run },
+      deviceReadiness: {
+        ...host.deviceReadiness,
+        appleAutomation: {
+          keepHot: vi.fn(),
+          markBooted: vi.fn(),
+          wasRecentlyObservedBooted: vi.fn(async () => false),
+        },
+      },
+    },
+    simulator({ booted: true }),
+    new AbortController().signal,
+  );
+
+  expect(run).toHaveBeenCalledOnce();
+});
+
+test('failed recent-observation lookup falls back to native simulator listing', async () => {
+  const run = vi.fn(async () => ({
+    stdout: JSON.stringify({ devices: { ios: [{ udid: 'sim-1', state: 'Booted' }] } }),
+    stderr: '',
+    exitCode: 0,
+  }));
+  const host = platformRuntimeHostFixture();
+
+  await ensureAppleReady(
+    {
+      ...host,
+      appleTools: { ...host.appleTools, run },
+      deviceReadiness: {
+        ...host.deviceReadiness,
+        appleAutomation: {
+          ...host.deviceReadiness.appleAutomation,
+          wasRecentlyObservedBooted: vi.fn(async () => {
+            throw new Error('memo unavailable');
+          }),
+        },
+      },
+    },
+    simulator({ booted: true }),
+    new AbortController().signal,
+  );
+
+  expect(run).toHaveBeenCalledOnce();
+});
+
 test('cancellation interrupts simulator bootstatus and schedules cleanup for the request boot', async () => {
   const controller = new AbortController();
   const keepHot = vi.fn();
@@ -34,7 +121,11 @@ test('cancellation interrupts simulator bootstatus and schedules cleanup for the
     },
     deviceReadiness: {
       ...platformRuntimeHostFixture().deviceReadiness,
-      appleAutomation: { keepHot, markBooted: vi.fn() },
+      appleAutomation: {
+        keepHot,
+        markBooted: vi.fn(),
+        wasRecentlyObservedBooted: vi.fn(async () => false),
+      },
     },
   } satisfies PlatformRuntimeHost;
 

--- a/packages/platform-apple/src/readiness/runtime.ts
+++ b/packages/platform-apple/src/readiness/runtime.ts
@@ -34,7 +34,8 @@ export async function ensureAppleReady(
   }
   if (device.kind !== 'simulator') return { ...device, booted: true };
 
-  const state = await simulatorState(host, device, signal);
+  const recentlyObservedBooted = await readRecentBootObservation(host, device);
+  const state = recentlyObservedBooted ? 'Booted' : await simulatorState(host, device, signal);
   if (state !== 'Booted') {
     options.onColdBootStart?.();
     host.deviceReadiness.appleAutomation.keepHot(device);
@@ -45,6 +46,17 @@ export async function ensureAppleReady(
   // Publish the fresh observation so the boot checks later in this flow skip their own listing.
   host.deviceReadiness.appleAutomation.markBooted(device);
   return { ...device, booted: true };
+}
+
+async function readRecentBootObservation(
+  host: AppleReadinessHost,
+  device: DeviceInfo,
+): Promise<boolean> {
+  try {
+    return await host.deviceReadiness.appleAutomation.wasRecentlyObservedBooted(device);
+  } catch {
+    return false;
+  }
 }
 
 async function bootSimulator(

--- a/packages/platform-apple/src/runtime.fixtures.ts
+++ b/packages/platform-apple/src/runtime.fixtures.ts
@@ -26,7 +26,11 @@ export function platformRuntimeHostFixture(): PlatformRuntimeHost {
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {}, markBooted: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: {
         discover: async () => [],
         launch: () => 1,

--- a/packages/platform-apple/src/runtime.test.ts
+++ b/packages/platform-apple/src/runtime.test.ts
@@ -206,7 +206,11 @@ test('readiness and boot keep the Apple automation helper warm inside the platfo
     },
     deviceReadiness: {
       ...host.deviceReadiness,
-      appleAutomation: { keepHot, markBooted: vi.fn() },
+      appleAutomation: {
+        keepHot,
+        markBooted: vi.fn(),
+        wasRecentlyObservedBooted: vi.fn(async () => false),
+      },
     },
   });
   const device = appleDevice({ booted: false });

--- a/packages/platform-web/src/runtime.test.ts
+++ b/packages/platform-web/src/runtime.test.ts
@@ -294,7 +294,11 @@ function host(
     },
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {}, markBooted: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
     localInteractors: { resolve: async () => ({}) as Interactor },

--- a/packages/provider-webdriver/src/platform-runtime.test.ts
+++ b/packages/provider-webdriver/src/platform-runtime.test.ts
@@ -313,7 +313,11 @@ function host(run: PlatformRuntimeHost['commands']['run']): PlatformRuntimeHost 
   return {
     deviceReadiness: {
       applePhysical: { ensureConnected: async () => {} },
-      appleAutomation: { keepHot: () => {} },
+      appleAutomation: {
+        keepHot: () => {},
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
       androidEmulator: { discover: async () => [], launch: () => 1, terminate: async () => {} },
     },
     appState: {

--- a/src/daemon/__tests__/application-lifecycle-runtime-fixture.ts
+++ b/src/daemon/__tests__/application-lifecycle-runtime-fixture.ts
@@ -142,7 +142,11 @@ function fixtureHost(
           signal.throwIfAborted();
         },
       }),
-      appleAutomation: Object.freeze({ keepHot: () => undefined, markBooted: () => {} }),
+      appleAutomation: Object.freeze({
+        keepHot: () => undefined,
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      }),
       androidEmulator: Object.freeze({
         discover: async (_request: unknown, signal: AbortSignal) => {
           signal.throwIfAborted();

--- a/src/platform-runtime-apple-automation-keep-hot.ts
+++ b/src/platform-runtime-apple-automation-keep-hot.ts
@@ -7,6 +7,11 @@ export function createAppleAutomationKeepHotHost(): DeviceReadinessRuntimeHost['
         .then(({ prewarmAppleRunnerCache }) => prewarmAppleRunnerCache(device, {}))
         .catch(() => {});
     },
+    wasRecentlyObservedBooted: async (device) => {
+      const { wasSimulatorRecentlyObservedBooted } =
+        await import('./platforms/apple/core/simulator.ts');
+      return wasSimulatorRecentlyObservedBooted(device);
+    },
     markBooted: (device) => {
       void import('./platforms/apple/core/simulator.ts')
         .then(({ markSimulatorBooted }) => markSimulatorBooted(device))

--- a/src/platforms/apple/core/__tests__/runner-listener-ready.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-listener-ready.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { createRunnerListenerReadySignal } from '../runner/runner-listener-ready.ts';
+
+test('runner listener readiness survives process-output chunk boundaries', async () => {
+  const signal = createRunnerListenerReadySignal();
+
+  signal.observe('stderr', 'noise AGENT_DEVICE_RUNNER_LISTENER_');
+  assert.equal(signal.wake.aborted, false);
+
+  signal.observe('stderr', 'READY more noise');
+  assert.equal(signal.wake.aborted, true);
+});
+
+test('runner listener readiness ignores unrelated output', async () => {
+  const signal = createRunnerListenerReadySignal();
+
+  signal.observe('stdout', 'AGENT_DEVICE_RUNNER_WAITING');
+  assert.equal(signal.wake.aborted, false);
+});
+
+test('runner listener readiness does not combine unrelated process streams', async () => {
+  const signal = createRunnerListenerReadySignal();
+
+  signal.observe('stdout', 'AGENT_DEVICE_RUNNER_LISTENER_');
+  signal.observe('stderr', 'READY');
+  assert.equal(signal.wake.aborted, false);
+});
+
+test('runner exit wakes startup probing when no listener marker arrives', () => {
+  const signal = createRunnerListenerReadySignal();
+
+  signal.finish();
+
+  assert.equal(signal.wake.aborted, true);
+});

--- a/src/platforms/apple/core/__tests__/runner-process-launch.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-process-launch.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/index.ts';
+import { makeBackgroundRunner } from './runner-session-fixtures.ts';
+
+const { mockRunCmdBackground } = vi.hoisted(() => ({
+  mockRunCmdBackground: vi.fn(),
+}));
+
+vi.mock('../../../../utils/exec.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../../../utils/exec.ts')>(
+    '../../../../utils/exec.ts',
+  );
+  return { ...actual, runCmdBackground: mockRunCmdBackground };
+});
+
+import { launchRunnerProcess } from '../runner/runner-process-launch.ts';
+
+test('runner process launch exposes the listener-ready marker from xcodebuild output', async () => {
+  const background = {
+    ...makeBackgroundRunner(4242),
+    wait: new Promise<{ stdout: string; stderr: string; exitCode: number }>(() => {}),
+  };
+  mockRunCmdBackground.mockReturnValue(background);
+
+  const launched = await launchRunnerProcess({
+    device: IOS_SIMULATOR,
+    port: 8123,
+    xctestrunPath: '/tmp/runner.xctestrun',
+    derivedPath: '/tmp/runner-derived',
+  });
+  background.child.stderr.emit('data', 'AGENT_DEVICE_RUNNER_LISTENER_');
+  background.child.stderr.emit('data', 'READY');
+  assert.equal(launched.startupRetryWake.aborted, true);
+
+  assert.equal(mockRunCmdBackground.mock.calls[0]?.[0], 'xcodebuild');
+  const args = mockRunCmdBackground.mock.calls[0]?.[1] as string[];
+  assert.equal(args[args.indexOf('-xctestrun') + 1], '/tmp/runner.xctestrun');
+  assert.equal(args[args.indexOf('-derivedDataPath') + 1], '/tmp/runner-derived');
+  assert.equal(mockRunCmdBackground.mock.calls[0]?.[2]?.env?.AGENT_DEVICE_RUNNER_PORT, '8123');
+});
+
+test('runner process exit wakes startup probing without a listener marker', async () => {
+  let rejectProcessExit: (reason?: unknown) => void = () => assert.fail('missing process wait');
+  const processExit = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    (_resolve, reject) => {
+      rejectProcessExit = reject;
+    },
+  );
+  mockRunCmdBackground.mockReturnValue({
+    ...makeBackgroundRunner(4242),
+    wait: processExit,
+  });
+
+  const launched = launchRunnerProcess({
+    device: IOS_SIMULATOR,
+    port: 8123,
+    xctestrunPath: '/tmp/runner.xctestrun',
+    derivedPath: '/tmp/runner-derived',
+  });
+  rejectProcessExit(new Error('xcodebuild exited'));
+  await Promise.resolve();
+
+  assert.equal(launched.startupRetryWake.aborted, true);
+});

--- a/src/platforms/apple/core/__tests__/runner-startup-transport.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-startup-transport.test.ts
@@ -134,6 +134,45 @@ test('waitForRunner uses simulator fallback within the attempt for ready session
   ]);
 });
 
+test('waitForRunner wakes a simulator startup retry when the listener reports ready', async () => {
+  vi.useFakeTimers();
+  const readiness = new AbortController();
+  const session: RunnerSession = {
+    ...makeReadyRunnerSession(),
+    ready: false,
+    startupRetryWake: readiness.signal,
+  };
+  let fetchAttempts = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      fetchAttempts += 1;
+      if (fetchAttempts === 1) throw new Error('ECONNREFUSED');
+      return new Response('{}');
+    }),
+  );
+
+  const response = waitForRunner(
+    iosSimulator,
+    8100,
+    { command: 'uptime' },
+    undefined,
+    5_000,
+    session,
+  );
+  try {
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(fetchAttempts, 1);
+    readiness.abort();
+    assert.equal((await response).status, 200);
+    assert.equal(fetchAttempts, 2);
+  } finally {
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+  }
+});
+
 test('waitForRunner invalidates cached tunnel IP when localhost fallback succeeds', async () => {
   mockUsbmuxPostCommand.mockRejectedValue(usbmuxDeviceUnattachedError());
   mockRunCmd.mockImplementation(makeTunnelIpLookupSequence(['fd00::123', 'fd00::456']));

--- a/src/platforms/apple/core/__tests__/simulator-booted-memo.test.ts
+++ b/src/platforms/apple/core/__tests__/simulator-booted-memo.test.ts
@@ -5,6 +5,7 @@ import {
   markSimulatorBooted,
   shutdownSimulator,
   SIMULATOR_BOOTED_MEMO_TTL_MS,
+  wasSimulatorRecentlyObservedBooted,
 } from '../simulator.ts';
 import { runXcrun } from '../tool-provider.ts';
 
@@ -83,6 +84,8 @@ test('shutdownSimulator forwards cancellation to the native simctl command', asy
 
 test('markSimulatorBooted seeds the memo so the first boot check skips the listing', async () => {
   markSimulatorBooted(simulator);
+
+  expect(wasSimulatorRecentlyObservedBooted(simulator)).toBe(true);
 
   await ensureBootedSimulator(simulator);
   expect(countSimctlListCalls()).toBe(0);

--- a/src/platforms/apple/core/runner/runner-listener-ready.ts
+++ b/src/platforms/apple/core/runner/runner-listener-ready.ts
@@ -1,0 +1,39 @@
+const RUNNER_LISTENER_READY_MARKER = 'AGENT_DEVICE_RUNNER_LISTENER_READY';
+
+export type RunnerListenerReadySignal = Readonly<{
+  wake: AbortSignal;
+  observe(source: 'stdout' | 'stderr', chunk: string): void;
+  finish(): void;
+}>;
+
+/**
+ * Turns the runner's authoritative NWListener-ready log marker into a one-shot host signal.
+ * xcodebuild may split one log line across process-output chunks, so the scanner retains only the
+ * shortest suffix that can complete the marker on the next chunk.
+ */
+export function createRunnerListenerReadySignal(): RunnerListenerReadySignal {
+  const wake = new AbortController();
+  let settled = false;
+  const tails = { stdout: '', stderr: '' };
+  return {
+    wake: wake.signal,
+    observe: (source, chunk) => {
+      if (settled) return;
+      const candidate = tails[source] + chunk;
+      if (candidate.includes(RUNNER_LISTENER_READY_MARKER)) {
+        settled = true;
+        tails.stdout = '';
+        tails.stderr = '';
+        wake.abort();
+        return;
+      }
+      tails[source] = candidate.slice(-(RUNNER_LISTENER_READY_MARKER.length - 1));
+    },
+    finish: () => {
+      settled = true;
+      tails.stdout = '';
+      tails.stderr = '';
+      wake.abort();
+    },
+  };
+}

--- a/src/platforms/apple/core/runner/runner-process-launch.ts
+++ b/src/platforms/apple/core/runner/runner-process-launch.ts
@@ -1,0 +1,65 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { runCmdBackground, type ExecBackgroundResult } from '../../../../utils/exec.ts';
+import { resolveRunnerDestination } from '../apple-runner-platform.ts';
+import { resolveRunnerMaxConcurrentDestinationsFlag } from './runner-cache-metadata.ts';
+import { logChunk } from './runner-io.ts';
+import { createRunnerListenerReadySignal } from './runner-listener-ready.ts';
+
+const RUNNER_DESTINATION_TIMEOUT_SECONDS = 20;
+
+type LaunchRunnerProcessInput = Readonly<{
+  device: DeviceInfo;
+  port: number;
+  xctestrunPath: string;
+  derivedPath: string;
+  signal?: AbortSignal;
+  logPath?: string;
+  traceLogPath?: string;
+  verbose?: boolean;
+}>;
+
+export type LaunchedRunnerProcess = ExecBackgroundResult &
+  Readonly<{ startupRetryWake: AbortSignal }>;
+
+/** Launches xcodebuild and projects its authoritative listener-ready marker as a host signal. */
+export function launchRunnerProcess(input: LaunchRunnerProcessInput): LaunchedRunnerProcess {
+  const listenerReady = createRunnerListenerReadySignal();
+  const launched = runCmdBackground(
+    'xcodebuild',
+    [
+      'test-without-building',
+      '-only-testing',
+      'AgentDeviceRunnerUITests/RunnerTests/testCommand',
+      '-parallel-testing-enabled',
+      'NO',
+      '-test-timeouts-enabled',
+      'NO',
+      '-collect-test-diagnostics',
+      'never',
+      resolveRunnerMaxConcurrentDestinationsFlag(input.device),
+      '1',
+      '-destination-timeout',
+      String(RUNNER_DESTINATION_TIMEOUT_SECONDS),
+      '-xctestrun',
+      input.xctestrunPath,
+      '-derivedDataPath',
+      input.derivedPath,
+      '-destination',
+      resolveRunnerDestination(input.device),
+    ],
+    {
+      allowFailure: true,
+      env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(input.port) },
+      detached: true,
+      signal: input.signal,
+    },
+  );
+  const observeOutput = (source: 'stdout' | 'stderr', chunk: string): void => {
+    listenerReady.observe(source, chunk);
+    logChunk(chunk, input.logPath, input.traceLogPath, input.verbose);
+  };
+  launched.child.stdout?.on('data', (chunk: string) => observeOutput('stdout', chunk));
+  launched.child.stderr?.on('data', (chunk: string) => observeOutput('stderr', chunk));
+  void launched.wait.then(listenerReady.finish, listenerReady.finish);
+  return { ...launched, startupRetryWake: listenerReady.wake };
+}

--- a/src/platforms/apple/core/runner/runner-session-types.ts
+++ b/src/platforms/apple/core/runner/runner-session-types.ts
@@ -24,6 +24,8 @@ export type RunnerSession = {
   testPromise: Promise<ExecResult>;
   child: RunnerProcessHandle;
   ready: boolean;
+  /** Wakes one startup retry when the listener becomes ready or its process exits. */
+  startupRetryWake?: AbortSignal;
   startupTimeoutMs?: number;
   // Records the last allowlisted mutating interaction that the runner confirmed
   // healthy (parsed ok, non-runnerFatal) for a given app bundle. Lives only on

--- a/src/platforms/apple/core/runner/runner-session.ts
+++ b/src/platforms/apple/core/runner/runner-session.ts
@@ -1,9 +1,5 @@
 import { AppError, toAppErrorCode, createRequestCanceledError } from '@agent-device/kernel/errors';
-import {
-  runCmdBackground,
-  type ExecResult,
-  type ExecBackgroundResult,
-} from '../../../../utils/exec.ts';
+import { type ExecResult } from '../../../../utils/exec.ts';
 import { withKeyedLock } from '../../../../utils/keyed-lock.ts';
 import { Deadline } from '../../../../utils/retry.ts';
 import { isIosFamily, isApplePlatform, type DeviceInfo } from '@agent-device/kernel/device';
@@ -13,14 +9,8 @@ import { emitRequestProgress } from '../../../../request/progress.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../../../utils/diagnostics.ts';
 import { buildSimctlArgsForDevice } from '../simctl.ts';
 import { runAppleToolCommand, runXcrun } from '../tool-provider.ts';
-import { resolveRunnerDestination } from '../apple-runner-platform.ts';
-import { resolveRunnerMaxConcurrentDestinationsFlag } from './runner-cache-metadata.ts';
-import { getFreePort, logChunk } from './runner-io.ts';
-import {
-  waitForRunner,
-  RUNNER_STARTUP_TIMEOUT_MS,
-  RUNNER_DESTINATION_TIMEOUT_SECONDS,
-} from './runner-startup-transport.ts';
+import { getFreePort } from './runner-io.ts';
+import { waitForRunner, RUNNER_STARTUP_TIMEOUT_MS } from './runner-startup-transport.ts';
 import { sendRunnerCommandOnce } from './runner-transport.ts';
 import {
   acquireXcodebuildSimulatorSetRedirect,
@@ -66,6 +56,7 @@ import {
   normalizeRunnerStartupTimeoutMs,
   type RunnerSession,
 } from './runner-session-types.ts';
+import { launchRunnerProcess, type LaunchedRunnerProcess } from './runner-process-launch.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
 
@@ -211,29 +202,7 @@ async function startRunnerSessionWithLease(
     'simulator_set_redirect',
     async () => await acquireXcodebuildSimulatorSetRedirect(device),
   );
-  let child: ExecBackgroundResult['child'] | undefined;
-  let testPromise: Promise<ExecResult>;
-  const xcodebuildArgs = [
-    'test-without-building',
-    '-only-testing',
-    'AgentDeviceRunnerUITests/RunnerTests/testCommand',
-    '-parallel-testing-enabled',
-    'NO',
-    '-test-timeouts-enabled',
-    'NO',
-    '-collect-test-diagnostics',
-    'never',
-    resolveRunnerMaxConcurrentDestinationsFlag(device),
-    '1',
-    '-destination-timeout',
-    String(RUNNER_DESTINATION_TIMEOUT_SECONDS),
-    '-xctestrun',
-    xctestrunPath,
-    '-derivedDataPath',
-    xctestrunArtifact.derived,
-    '-destination',
-    resolveRunnerDestination(device),
-  ];
+  let runnerProcess: LaunchedRunnerProcess;
   try {
     if (xctestrunArtifact.buildMs > 0) {
       emitRequestProgress({
@@ -242,33 +211,27 @@ async function startRunnerSessionWithLease(
         message: 'Starting XCTest runner...',
       });
     }
-    ({ child, wait: testPromise } = await measureRunnerStartupStep(
-      startupTimings,
-      'launch_xcodebuild',
-      () =>
-        runCmdBackground('xcodebuild', xcodebuildArgs, {
-          allowFailure: true,
-          env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(port) },
-          detached: true,
-          signal,
-        }),
-    ));
+    runnerProcess = await measureRunnerStartupStep(startupTimings, 'launch_xcodebuild', () =>
+      launchRunnerProcess({
+        device,
+        port,
+        xctestrunPath,
+        derivedPath: xctestrunArtifact.derived,
+        signal,
+        logPath: options.logPath,
+        traceLogPath: options.traceLogPath,
+        verbose: options.verbose,
+      }),
+    );
   } catch (error) {
     await simulatorSetRedirect?.release();
     throw error;
   }
-  child.stdout?.on('data', (chunk: string) => {
-    logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
-  });
-  child.stderr?.on('data', (chunk: string) => {
-    logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
-  });
-
   const sessionId = buildRunnerSessionId(device.id, port);
   const lease = buildRunnerLease({
     deviceId: device.id,
     sessionId,
-    runnerPid: child.pid,
+    runnerPid: runnerProcess.child.pid,
     port,
     xctestrunPath,
     jsonPath,
@@ -281,9 +244,10 @@ async function startRunnerSessionWithLease(
     xctestrunPath,
     xctestrunArtifact,
     jsonPath,
-    testPromise,
-    child,
+    testPromise: runnerProcess.wait,
+    child: runnerProcess.child,
     ready: false,
+    startupRetryWake: runnerProcess.startupRetryWake,
     startupTimeoutMs: normalizeRunnerStartupTimeoutMs(options.startupTimeoutMs),
     startupTimings,
     logicalLeaseContext,

--- a/src/platforms/apple/core/runner/runner-startup-transport.ts
+++ b/src/platforms/apple/core/runner/runner-startup-transport.ts
@@ -34,7 +34,6 @@ const RUNNER_CONNECT_ATTEMPT_INTERVAL_MS = 250;
 const RUNNER_CONNECT_RETRY_BASE_DELAY_MS = 300;
 const RUNNER_CONNECT_RETRY_MAX_DELAY_MS = 2_000;
 const RUNNER_CONNECT_REQUEST_TIMEOUT_MS = 20_000;
-export const RUNNER_DESTINATION_TIMEOUT_SECONDS = 20;
 
 export async function waitForRunner(
   device: DeviceInfo,
@@ -87,7 +86,12 @@ export async function waitForRunner(
         jitter: 0.2,
         shouldRetry: shouldRetryRunnerConnectError,
       },
-      { deadline, phase: 'ios_runner_connect', signal },
+      {
+        deadline,
+        phase: 'ios_runner_connect',
+        signal,
+        retryWakeSignal: device.kind === 'simulator' ? session?.startupRetryWake : undefined,
+      },
     );
   } catch (error) {
     if (signal?.aborted || isRequestCanceledError(error)) {

--- a/src/platforms/apple/core/simulator.ts
+++ b/src/platforms/apple/core/simulator.ts
@@ -42,7 +42,7 @@ function simulatorBootedMemoKey(device: DeviceInfo): string {
   return `${device.id}|${device.simulatorSetPath ?? ''}`;
 }
 
-function readSimulatorBootedMemo(device: DeviceInfo): boolean {
+export function wasSimulatorRecentlyObservedBooted(device: DeviceInfo): boolean {
   return simulatorBootedMemo.get(simulatorBootedMemoKey(device)) === true;
 }
 
@@ -85,7 +85,7 @@ export async function ensureBootedSimulator(
   if (device.kind !== 'simulator') return;
   options.signal?.throwIfAborted();
 
-  const state = readSimulatorBootedMemo(device)
+  const state = wasSimulatorRecentlyObservedBooted(device)
     ? 'Booted'
     : await getSimulatorState(device, options.signal);
   if (state === 'Booted') {

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,6 +1,7 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { AppError } from '@agent-device/kernel/errors';
 import { retryWithPolicy } from '../retry.ts';
 import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../diagnostics.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
@@ -19,6 +20,58 @@ test('retryWithPolicy retries until success', async () => {
   );
   assert.equal(result, 'ok');
   assert.equal(attempts, 3);
+});
+
+test('retryWithPolicy can wake one scheduled retry from a readiness signal', async () => {
+  vi.useFakeTimers();
+  try {
+    const readiness = new AbortController();
+    let attempts = 0;
+    const result = retryWithPolicy(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('not ready');
+        return 'ok';
+      },
+      { maxAttempts: 2, baseDelayMs: 10_000, maxDelayMs: 10_000, jitter: 0 },
+      { retryWakeSignal: readiness.signal },
+    );
+
+    await Promise.resolve();
+    assert.equal(attempts, 1);
+    readiness.abort();
+    assert.equal(await result, 'ok');
+    assert.equal(attempts, 2);
+    assert.equal(vi.getTimerCount(), 0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('retryWithPolicy preserves cancellation while waiting for a retry wake', async () => {
+  vi.useFakeTimers();
+  try {
+    const cancellation = new AbortController();
+    const readiness = new AbortController();
+    const result = retryWithPolicy(
+      async () => {
+        throw new Error('not ready');
+      },
+      { maxAttempts: 2, baseDelayMs: 10_000, maxDelayMs: 10_000, jitter: 0 },
+      { signal: cancellation.signal, retryWakeSignal: readiness.signal },
+    );
+
+    await Promise.resolve();
+    cancellation.abort();
+    await assert.rejects(result, (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.details?.reason, 'request_canceled');
+      return true;
+    });
+    assert.equal(vi.getTimerCount(), 0);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('retryWithPolicy emits telemetry events', async () => {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -26,6 +26,20 @@ type RetryTelemetryEvent = {
   reason?: string;
 };
 
+type RetryOptions = {
+  deadline?: Deadline;
+  phase?: string;
+  signal?: AbortSignal;
+  classifyReason?: (error: unknown) => string | undefined;
+  onEvent?: (event: RetryTelemetryEvent) => void;
+  /**
+   * One-shot evidence that the dependency's startup state changed. It can wake the current retry
+   * delay, but never skips an attempt or changes the retry/deadline policy. The next attempt remains
+   * the authority on whether the dependency is usable.
+   */
+  retryWakeSignal?: AbortSignal;
+};
+
 export function isEnvTruthy(value: string | undefined): boolean {
   return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
 }
@@ -66,13 +80,7 @@ export class Deadline {
 export async function retryWithPolicy<T>(
   fn: (context: RetryAttemptContext) => Promise<T>,
   policy: Partial<RetryPolicy> = {},
-  options: {
-    deadline?: Deadline;
-    phase?: string;
-    signal?: AbortSignal;
-    classifyReason?: (error: unknown) => string | undefined;
-    onEvent?: (event: RetryTelemetryEvent) => void;
-  } = {},
+  options: RetryOptions = {},
 ): Promise<T> {
   const merged: RetryPolicy = {
     maxAttempts: policy.maxAttempts ?? defaultOptions.maxAttempts,
@@ -81,6 +89,7 @@ export async function retryWithPolicy<T>(
     jitter: policy.jitter ?? defaultOptions.jitter,
     shouldRetry: policy.shouldRetry,
   };
+  let retryWakeSignalConsumed = false;
   let lastError: unknown;
   for (let attempt = 1; attempt <= merged.maxAttempts; attempt += 1) {
     if (options.signal?.aborted) {
@@ -143,7 +152,16 @@ export async function retryWithPolicy<T>(
       };
       options.onEvent?.(retryEvent);
       publishRetryEvent(retryEvent);
-      await sleep(boundedDelay, options.signal);
+      if (options.retryWakeSignal && !retryWakeSignalConsumed) {
+        const wakeReason = await waitForRetryDelay(
+          boundedDelay,
+          options.signal,
+          options.retryWakeSignal,
+        );
+        retryWakeSignalConsumed = wakeReason === 'signaled';
+      } else {
+        await sleep(boundedDelay, options.signal);
+      }
     }
   }
   const exhaustedEvent: RetryTelemetryEvent = {
@@ -159,6 +177,34 @@ export async function retryWithPolicy<T>(
   publishRetryEvent(exhaustedEvent);
   if (lastError) throw lastError;
   throw new AppError('COMMAND_FAILED', 'retry failed');
+}
+
+function waitForRetryDelay(
+  ms: number,
+  signal: AbortSignal | undefined,
+  retryWakeSignal: AbortSignal,
+): Promise<'delay' | 'signaled'> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (reason: 'delay' | 'signaled') => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      retryWakeSignal.removeEventListener('abort', onRetryWake);
+      resolve(reason);
+    };
+    const timer = setTimeout(() => finish('delay'), ms);
+    const onAbort = () => finish('delay');
+    const onRetryWake = () => finish('signaled');
+    signal?.addEventListener('abort', onAbort, { once: true });
+    retryWakeSignal.addEventListener('abort', onRetryWake, { once: true });
+    if (signal?.aborted) {
+      finish('delay');
+      return;
+    }
+    if (retryWakeSignal.aborted) finish('signaled');
+  });
 }
 
 function computeDelay(base: number, max: number, jitter: number, attempt: number): number {


### PR DESCRIPTION
## Summary

Reduce cold iOS simulator startup latency without changing snapshot backends.

- reuse the existing bounded fresh-boot observation instead of immediately paying for a duplicate `simctl list devices -j`; stale booleans and memo failures still fall back to native discovery
- wake one runner connection retry from the runner's authoritative NWListener-ready marker, while keeping the HTTP probe authoritative
- extract xcodebuild process launch/output ownership from the oversized runner session module and make retry wakeups cancellation- and resource-safe

On the same existing iPhone 17 Pro simulator, cold `open` plus the first interactive snapshot improved from 5.45s to 3.83s. Retained runner preparation remained effectively instant (14ms internally), and a warm snapshot measured 185ms.

This does not make private AX the default. The current private-AX backend still runs inside XCTest, so it cannot remove XCTest startup.

## Validation

- `pnpm check:affected --run` — 342 files / 2,533 tests passed, plus format, lint, typecheck, layering, fallow, and build
- live isolated cold/retained/adopted startup matrix on the existing iPhone 17 Pro simulator
- verified no simulator was created or deleted and the isolated runner/daemon were stopped
