### PR TITLE
refactor(web): drop duplicate viewport facts spread in webRuntimeFacts

### DIFF
--- a/packages/platform-web/src/runtime.ts
+++ b/packages/platform-web/src/runtime.ts
@@ -254,9 +254,6 @@ function webRuntimeFacts(
         findText: openTargetKindUnavailable,
         findSelector: openTargetKindUnavailable,
       }),
-      ...viewportRuntimeOperationFacts({
-        setViewport: device.kind === 'device' ? available : openTargetKindUnavailable,
-      }),
       ...screenshotRuntimeOperationFacts({ capture: browserDevice }),
       ...viewportRuntimeOperationFacts({ setViewport: browserDevice }),
       // The web backend has no point-addressed read: `get` answers from the captured DOM tree,


### PR DESCRIPTION
## What

`webRuntimeFacts` in `packages/platform-web/src/runtime.ts` spread `viewportRuntimeOperationFacts(...)` **twice** in the same object literal:

```ts
...viewportRuntimeOperationFacts({
  setViewport: device.kind === 'device' ? available : openTargetKindUnavailable,
}),
...screenshotRuntimeOperationFacts({ capture: browserDevice }),
...viewportRuntimeOperationFacts({ setViewport: browserDevice }),
```

`browserDevice` is defined a few lines above as exactly `device.kind === 'device' ? available : openTargetKindUnavailable`, so the two spreads declared an identical `setViewport` cell and the second one silently won. This PR deletes the first spread and keeps the `browserDevice` one, which sits next to the other cells reading that same value.

## Why

Behavior-neutral, but it reads as if two different cells are being declared. Whoever touches this next has to re-derive that `browserDevice` and the inlined ternary are the same expression before they can tell which spread is live.

This is pre-existing — not introduced by the focus migration in #1925.

## Reviewer notes

- The resulting facts object is byte-for-byte the same; only the dead first spread is gone.
- `pnpm check:affected --run` passes locally (144 files / 801 tests), confirming nothing depended on the spread ordering.