### PR TITLE
fix(ios): separate snapshot actionability from occlusion

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -164,6 +164,8 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testEffectiveGeometryIntersectsViewportAndAncestorClip \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testEffectiveGeometryKeepsReportedOriginWhenFullyClipped \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRegularPresentationRoutesThroughVisibilityFold \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRegularPresentationPublishesGeometricActionabilityWithoutOcclusionOrTypeGate \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotAcquisitionDoesNotReintroduceRunnerOcclusionScan \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotScopePolicyMatchesGoldenParityTable \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollContainerTypeNamesMatchElementTypeSet \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXDepthLimitedRequiresEveryFrontierResolved \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXElementTypes.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXElementTypes.swift
@@ -1,13 +1,6 @@
 import XCTest
 
 extension RunnerTests {
-  func privateAXInteractiveCandidate(rawElementType: Int) -> Bool {
-    guard let type = privateAXElementType(rawElementType: rawElementType) else {
-      return false
-    }
-    return interactiveTypes.contains(type) || Self.scrollContainerTypes.contains(type)
-  }
-
   func privateAXElementType(rawElementType: Int) -> XCUIElement.ElementType? {
     guard let raw = UInt(exactly: rawElementType),
       let type = XCUIElement.ElementType(rawValue: raw)
@@ -16,13 +9,4 @@ extension RunnerTests {
     }
     return type
   }
-
-#if AGENT_DEVICE_RUNNER_UNIT_TESTS
-  func testPrivateAXInteractiveCandidatesPreserveBackendInputs() {
-    XCTAssertTrue(
-      privateAXInteractiveCandidate(rawElementType: Int(XCUIElement.ElementType.scrollView.rawValue)),
-      "private AX marks scroll containers as interactive candidates"
-    )
-  }
-#endif
 }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -14,8 +14,6 @@ struct PrivateAXFields {
   let selected: Bool?
   let actions: [String]?
   let children: [[String: Any]]
-
-  var hasFrame: Bool { !rect.isNull && !rect.isEmpty }
 }
 
 extension RunnerTests {
@@ -23,7 +21,7 @@ extension RunnerTests {
   /// depth -- membership, the clip fold, scroll hints, and collapsed depth are
   /// `SnapshotPresentation`'s alone (#1797). The traversal-depth cut is the backend's one
   /// narrowing, complete for raw (raw depth *is* traversal depth) and a declared residue for
-  /// regular; `hittable` is the pre-clip geometric fact the fold narrows per projection.
+  /// regular; `hittable` is the shared geometric fact the fold recomputes for effective geometry.
   func privateAXAcquisition(rawRoot: [String: Any], hint: CaptureHint, viewport: CGRect)
     -> [RawAXNode]
   {
@@ -38,10 +36,15 @@ extension RunnerTests {
   {
     if let limit = hint.depth, depth > limit { return }
     let fields = privateAXFields(raw)
-    let onScreen = fields.hasFrame && Self.isVisibleInViewport(fields.rect, viewport)
     let index = nodes.count
     nodes.append(
-      privateAXNode(fields, index: index, depth: depth, parentIndex: parentIndex, onScreen: onScreen)
+      privateAXNode(
+        fields,
+        index: index,
+        depth: depth,
+        parentIndex: parentIndex,
+        viewport: viewport
+      )
     )
     for child in fields.children {
       appendPrivateAXNode(child, to: &nodes, hint: hint, viewport: viewport,
@@ -67,7 +70,7 @@ extension RunnerTests {
   }
 
   private func privateAXNode(_ fields: PrivateAXFields, index: Int, depth: Int, parentIndex: Int?,
-    onScreen: Bool) -> RawAXNode
+    viewport: CGRect) -> RawAXNode
   {
     RawAXNode(index: index,
       type: fields.elementType.map(elementTypeName) ?? "Element(\(fields.rawType))",
@@ -76,8 +79,11 @@ extension RunnerTests {
       value: fields.value.isEmpty ? nil : fields.value,
       rect: snapshotRect(from: fields.rect), enabled: fields.enabled,
       focused: fields.focused, selected: fields.selected,
-      hittable: onScreen && fields.enabled
-        && privateAXInteractiveCandidate(rawElementType: fields.rawType),
+      hittable: parentIndex != nil && SnapshotGeometry.isGeometricallyActionable(
+        enabled: fields.enabled,
+        frame: fields.rect,
+        viewport: viewport
+      ),
       depth: depth, parentIndex: parentIndex, hiddenContentAbove: nil, hiddenContentBelow: nil,
       actions: fields.actions)
   }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -15,8 +15,6 @@ extension RunnerTests {
     let queryRoot: XCUIElement
     let rootSnapshot: XCUIElementSnapshot
     let viewport: CGRect
-    let flatSnapshots: [XCUIElementSnapshot]
-    let snapshotRanges: [ObjectIdentifier: (Int, Int)]
     let maxDepth: Int
   }
 
@@ -24,7 +22,6 @@ extension RunnerTests {
     let label: String
     let identifier: String
     let valueText: String?
-    let hittable: Bool
     let focused: Bool
     let selected: Bool
   }
@@ -149,14 +146,15 @@ extension RunnerTests {
     // cut (declared residue -- regular presentation emits collapsed depth) and the collapsed-tab
     // expansion, which needs live element handles.
     var nodes: [RawAXNode] = []
-    let rootEvaluation = evaluateSnapshot(context.rootSnapshot, in: context)
+    let rootEvaluation = evaluateSnapshot(context.rootSnapshot)
     nodes.append(
       makeSnapshotNode(
         snapshot: context.rootSnapshot,
         evaluation: rootEvaluation,
         depth: 0,
         index: 0,
-        parentIndex: nil
+        parentIndex: nil,
+        viewport: context.viewport
       )
     )
     if context.maxDepth > 0 {
@@ -165,7 +163,8 @@ extension RunnerTests {
         containerSnapshot: context.rootSnapshot,
         resolveElements: collapsedTabDescendants,
         depth: 1,
-        parentIndex: 0
+        parentIndex: 0,
+        viewport: context.viewport
       )
     }
 
@@ -184,7 +183,7 @@ extension RunnerTests {
       let parentIndex = entry.parentIndex
       if let limit = hint.depth, depth > limit { continue }
 
-      let evaluation = evaluateSnapshot(snapshot, in: context)
+      let evaluation = evaluateSnapshot(snapshot)
       let key = Self.snapshotTraversalIdentity(
         elementType: snapshot.elementType,
         label: evaluation.label,
@@ -218,7 +217,8 @@ extension RunnerTests {
           evaluation: evaluation,
           depth: depth,
           index: index,
-          parentIndex: parentIndex
+          parentIndex: parentIndex,
+          viewport: context.viewport
         )
       )
       if depth < context.maxDepth {
@@ -227,7 +227,8 @@ extension RunnerTests {
           containerSnapshot: snapshot,
           resolveElements: collapsedTabDescendants,
           depth: depth + 1,
-          parentIndex: index
+          parentIndex: index,
+          viewport: context.viewport
         )
       }
     }
@@ -347,7 +348,7 @@ extension RunnerTests {
     func walk(_ snapshot: XCUIElementSnapshot, depth: Int, parentIndex: Int?) throws {
       if let limit = hint.depth, depth > limit { return }
 
-      let evaluation = evaluateSnapshot(snapshot, in: context)
+      let evaluation = evaluateSnapshot(snapshot)
       if nodes.count >= Self.rawSnapshotMaxNodes {
         throw rawSnapshotTooLargeFailure(nodeCount: nodes.count + 1)
       }
@@ -358,7 +359,8 @@ extension RunnerTests {
           evaluation: evaluation,
           depth: depth,
           index: currentIndex,
-          parentIndex: parentIndex
+          parentIndex: parentIndex,
+          viewport: context.viewport
         )
       )
 
@@ -804,25 +806,6 @@ extension RunnerTests {
 
   // MARK: - Snapshot Filtering
 
-  private func computedSnapshotHittable(
-    _ snapshot: XCUIElementSnapshot,
-    viewport: CGRect,
-    laterNodes: ArraySlice<XCUIElementSnapshot>
-  ) -> Bool {
-    guard snapshot.isEnabled else { return false }
-    let frame = snapshot.frame
-    if frame.isNull || frame.isEmpty { return false }
-    let center = CGPoint(x: frame.midX, y: frame.midY)
-    if !viewport.contains(center) { return false }
-    for node in laterNodes {
-      if !isOccludingType(node.elementType) { continue }
-      let nodeFrame = node.frame
-      if nodeFrame.isNull || nodeFrame.isEmpty { continue }
-      if nodeFrame.contains(center) { return false }
-    }
-    return true
-  }
-
   func makeSnapshotTraversalContext(
     app: XCUIApplication,
     hint: CaptureHint,
@@ -843,13 +826,10 @@ extension RunnerTests {
       return nil
     }
 
-    let (flatSnapshots, snapshotRanges) = flattenedSnapshots(rootSnapshot)
     return SnapshotTraversalContext(
       queryRoot: app,
       rootSnapshot: rootSnapshot,
       viewport: viewport,
-      flatSnapshots: flatSnapshots,
-      snapshotRanges: snapshotRanges,
       maxDepth: hint.depth ?? Int.max
     )
   }
@@ -987,23 +967,14 @@ extension RunnerTests {
     failure.code == Self.axSnapshotErrorCode || isAxIllegalArgument(failure.message)
   }
 
-  private func evaluateSnapshot(
-    _ snapshot: XCUIElementSnapshot,
-    in context: SnapshotTraversalContext
-  ) -> SnapshotEvaluation {
+  private func evaluateSnapshot(_ snapshot: XCUIElementSnapshot) -> SnapshotEvaluation {
     let label = aggregatedLabel(for: snapshot) ?? snapshot.label.trimmingCharacters(in: .whitespacesAndNewlines)
     let identifier = snapshot.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
     let valueText = snapshotValueText(snapshot)
-    let laterNodes = laterSnapshots(
-      for: snapshot,
-      in: context.flatSnapshots,
-      ranges: context.snapshotRanges
-    )
     return SnapshotEvaluation(
       label: label,
       identifier: identifier,
       valueText: valueText,
-      hittable: computedSnapshotHittable(snapshot, viewport: context.viewport, laterNodes: laterNodes),
       focused: snapshotHasFocus(snapshot),
       selected: snapshotIsSelected(snapshot)
     )
@@ -1014,7 +985,8 @@ extension RunnerTests {
     evaluation: SnapshotEvaluation,
     depth: Int,
     index: Int,
-    parentIndex: Int?
+    parentIndex: Int?,
+    viewport: CGRect
   ) -> RawAXNode {
     return RawAXNode(
       index: index,
@@ -1026,58 +998,16 @@ extension RunnerTests {
       enabled: snapshot.isEnabled,
       focused: evaluation.focused ? true : nil,
       selected: evaluation.selected ? true : nil,
-      hittable: evaluation.hittable,
+      hittable: parentIndex != nil && SnapshotGeometry.isGeometricallyActionable(
+        enabled: snapshot.isEnabled,
+        frame: snapshot.frame,
+        viewport: viewport
+      ),
       depth: depth,
       parentIndex: parentIndex,
       hiddenContentAbove: nil,
       hiddenContentBelow: nil
     )
-  }
-
-  private func isOccludingType(_ type: XCUIElement.ElementType) -> Bool {
-    switch type {
-    case .application, .window:
-      return false
-    default:
-      return true
-    }
-  }
-
-  private func flattenedSnapshots(
-    _ root: XCUIElementSnapshot
-  ) -> ([XCUIElementSnapshot], [ObjectIdentifier: (Int, Int)]) {
-    var ordered: [XCUIElementSnapshot] = []
-    var ranges: [ObjectIdentifier: (Int, Int)] = [:]
-
-    @discardableResult
-    func visit(_ snapshot: XCUIElementSnapshot) -> Int {
-      let start = ordered.count
-      ordered.append(snapshot)
-      var end = start
-      for child in snapshot.children {
-        end = max(end, visit(child))
-      }
-      ranges[ObjectIdentifier(snapshot)] = (start, end)
-      return end
-    }
-
-    _ = visit(root)
-    return (ordered, ranges)
-  }
-
-  private func laterSnapshots(
-    for snapshot: XCUIElementSnapshot,
-    in ordered: [XCUIElementSnapshot],
-    ranges: [ObjectIdentifier: (Int, Int)]
-  ) -> ArraySlice<XCUIElementSnapshot> {
-    guard let (_, subtreeEnd) = ranges[ObjectIdentifier(snapshot)] else {
-      return ordered.suffix(from: ordered.count)
-    }
-    let nextIndex = subtreeEnd + 1
-    if nextIndex >= ordered.count {
-      return ordered.suffix(from: ordered.count)
-    }
-    return ordered.suffix(from: nextIndex)
   }
 
   private func snapshotValueText(_ snapshot: XCUIElementSnapshot) -> String? {
@@ -1120,24 +1050,21 @@ extension RunnerTests {
     return nil
   }
 
-  static func isVisibleInViewport(_ rect: CGRect, _ viewport: CGRect) -> Bool {
-    if rect.isNull || rect.isEmpty { return false }
-    return rect.intersects(viewport)
-  }
-
   private func appendCollapsedTabFallbackNodes(
     to nodes: inout [RawAXNode],
     containerSnapshot: XCUIElementSnapshot,
     resolveElements: () -> [XCUIElement],
     depth: Int,
-    parentIndex: Int
+    parentIndex: Int,
+    viewport: CGRect
   ) {
     let fallbackNodes = collapsedTabFallbackNodes(
       for: containerSnapshot,
       resolveElements: resolveElements,
       startingIndex: nodes.count,
       depth: depth,
-      parentIndex: parentIndex
+      parentIndex: parentIndex,
+      viewport: viewport
     )
     nodes.append(contentsOf: fallbackNodes)
   }
@@ -1147,7 +1074,8 @@ extension RunnerTests {
     resolveElements: () -> [XCUIElement],
     startingIndex: Int,
     depth: Int,
-    parentIndex: Int
+    parentIndex: Int,
+    viewport: CGRect
   ) -> [RawAXNode] {
     if !containerSnapshot.children.isEmpty { return [] }
     guard shouldExpandCollapsedTabContainer(containerSnapshot) else { return [] }
@@ -1161,7 +1089,8 @@ extension RunnerTests {
       collapsedTabCandidateNode(
         element: element,
         containerSnapshot: containerSnapshot,
-        containerFrame: containerFrame
+        containerFrame: containerFrame,
+        viewport: viewport
       )
     }
     .sorted { left, right in
@@ -1209,7 +1138,8 @@ extension RunnerTests {
   private func collapsedTabCandidateNode(
     element: XCUIElement,
     containerSnapshot: XCUIElementSnapshot,
-    containerFrame: CGRect
+    containerFrame: CGRect,
+    viewport: CGRect
   ) -> RawAXNode? {
     var node: RawAXNode?
     let exceptionMessage = RunnerObjCExceptionCatcher.catchException({
@@ -1249,7 +1179,11 @@ extension RunnerTests {
         enabled: element.isEnabled,
         focused: elementHasFocus(element) ? true : nil,
         selected: element.isSelected ? true : nil,
-        hittable: element.isHittable,
+        hittable: SnapshotGeometry.isGeometricallyActionable(
+          enabled: element.isEnabled,
+          frame: frame,
+          viewport: viewport
+        ),
         depth: 0,
         parentIndex: nil,
         hiddenContentAbove: nil,
@@ -1384,13 +1318,16 @@ extension RunnerTests {
       // attach to, so frameless elements are dropped at acquisition rather than presented.
       let frame = element.frame
       if frame.isNull || frame.isEmpty { return }
-      let visible = Self.isVisibleInViewport(frame, viewport)
       let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
       let identifier = element.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
       let valueText = snapshotValueText(element)
       let elementType = element.elementType
       let enabled = element.isEnabled
-      let hittable = visible && enabled && element.isHittable
+      let hittable = SnapshotGeometry.isGeometricallyActionable(
+        enabled: enabled,
+        frame: frame,
+        viewport: viewport
+      )
 
       node = RawAXNode(
         index: index,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotActionability.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotActionability.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension SnapshotGeometry {
+  /// Geometric actionability shared by every iOS snapshot acquisition path. Native hit-testing
+  /// and occlusion are separate facts owned by their respective layers.
+  static func isGeometricallyActionable(
+    enabled: Bool,
+    frame: CGRect,
+    viewport: CGRect
+  ) -> Bool {
+    guard enabled, !frame.isNull, !frame.isEmpty else { return false }
+    if viewport.isInfinite { return true }
+    let center = CGPoint(x: frame.midX, y: frame.midY)
+    return viewport.contains(center)
+  }
+}

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotHittabilityTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotHittabilityTests.swift
@@ -1,0 +1,128 @@
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+import Foundation
+import XCTest
+
+extension RunnerTests {
+  func testRegularPresentationPublishesGeometricActionabilityWithoutOcclusionOrTypeGate() throws {
+    // Non-vacuity: restoring the old raw `hittable` copy would make the covered button and the
+    // labeled image false, while dropping the enabled check would make the disabled button true.
+    let nodes = [
+      RawAXNode(
+        index: 0,
+        type: "Application",
+        label: "Example",
+        identifier: nil,
+        value: nil,
+        rect: SnapshotRect(x: 0, y: 0, width: 100, height: 100),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: false,
+        depth: 0,
+        parentIndex: nil,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      ),
+      RawAXNode(
+        index: 1,
+        type: "Button",
+        label: "Covered button",
+        identifier: nil,
+        value: nil,
+        rect: SnapshotRect(x: 10, y: 10, width: 30, height: 30),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: false,
+        depth: 1,
+        parentIndex: 0,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      ),
+      RawAXNode(
+        index: 2,
+        type: "TabBar",
+        label: "Overlay",
+        identifier: nil,
+        value: nil,
+        rect: SnapshotRect(x: 10, y: 10, width: 30, height: 30),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: true,
+        depth: 1,
+        parentIndex: 0,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      ),
+      RawAXNode(
+        index: 3,
+        type: "Image",
+        label: "Labeled image",
+        identifier: nil,
+        value: nil,
+        rect: SnapshotRect(x: 60, y: 10, width: 30, height: 30),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: false,
+        depth: 1,
+        parentIndex: 0,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      ),
+      RawAXNode(
+        index: 4,
+        type: "Button",
+        label: "Disabled button",
+        identifier: nil,
+        value: nil,
+        rect: SnapshotRect(x: 10, y: 60, width: 30, height: 30),
+        enabled: false,
+        focused: nil,
+        selected: nil,
+        hittable: true,
+        depth: 1,
+        parentIndex: 0,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      ),
+    ]
+    let options = PresentationOptions(
+      interactiveOnly: false, depth: nil, scope: nil, raw: false)
+    let capture = SnapshotPresentation.presentRegular(
+      SnapshotAcquisition(
+        hint: SnapshotPresentation.captureHint(for: options),
+        nodes: nodes,
+        truncated: false,
+        effectiveDepth: nil,
+        viewport: CGRect(x: 0, y: 0, width: 100, height: 100)
+      ),
+      options: options
+    )
+    let presented = try XCTUnwrap(capture.payload.nodes)
+
+    XCTAssertEqual(presented.first { $0.label == "Covered button" }?.hittable, true)
+    XCTAssertEqual(presented.first { $0.label == "Labeled image" }?.hittable, true)
+    XCTAssertEqual(presented.first { $0.label == "Disabled button" }?.hittable, false)
+  }
+
+  func testSnapshotAcquisitionDoesNotReintroduceRunnerOcclusionScan() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .appendingPathComponent("RunnerTests+Snapshot.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    for obsoleteSymbol in [
+      "computedSnapshotHittable", "flattenedSnapshots", "snapshotRanges", "laterSnapshots",
+      "isOccludingType", "isVisibleInViewport", "ArraySlice<XCUIElementSnapshot>",
+      "element.isHittable",
+    ] {
+      XCTAssertFalse(
+        source.contains(obsoleteSymbol),
+        "Runner snapshot acquisition must not restore the retired occlusion helper: \(obsoleteSymbol)"
+      )
+    }
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotVisibilityFold.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotVisibilityFold.swift
@@ -152,7 +152,11 @@ enum SnapshotVisibilityFold {
               enabled: node.enabled,
               focused: node.focused,
               selected: node.selected,
-              hittable: node.hittable && intersects,
+              hittable: node.parentIndex != nil && SnapshotGeometry.isGeometricallyActionable(
+                enabled: node.enabled,
+                frame: effectiveFrame,
+                viewport: viewport
+              ),
               depth: outDepth,
               parentIndex: keptIndex,
               hiddenContentAbove: node.hiddenContentAbove,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotVisibilityFoldTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotVisibilityFoldTests.swift
@@ -7,13 +7,12 @@ extension RunnerTests {
     type: String,
     label: String? = nil,
     rect: SnapshotRect,
-    hittable: Bool = false,
     depth: Int,
     parentIndex: Int?
   ) -> RawAXNode {
     RawAXNode(
       index: index, type: type, label: label, identifier: nil, value: nil, rect: rect,
-      enabled: true, focused: nil, selected: nil, hittable: hittable, depth: depth,
+      enabled: true, focused: nil, selected: nil, hittable: false, depth: depth,
       parentIndex: parentIndex, hiddenContentAbove: nil, hiddenContentBelow: nil
     )
   }
@@ -35,12 +34,12 @@ extension RunnerTests {
       Self.foldNode(1, type: "ScrollView",
         rect: SnapshotRect(x: 0, y: 96, width: 402, height: 700), depth: 1, parentIndex: 0),
       Self.foldNode(2, type: "Cell", label: "Visible row",
-        rect: SnapshotRect(x: 0, y: 120, width: 402, height: 52), hittable: true,
+        rect: SnapshotRect(x: 0, y: 120, width: 402, height: 52),
         depth: 2, parentIndex: 1),
       Self.foldNode(3, type: "StaticText", label: "Detail",
         rect: SnapshotRect(x: 16, y: 130, width: 200, height: 20), depth: 3, parentIndex: 2),
       Self.foldNode(4, type: "Cell", label: "Offscreen row",
-        rect: SnapshotRect(x: 0, y: 900, width: 402, height: 52), hittable: true,
+        rect: SnapshotRect(x: 0, y: 900, width: 402, height: 52),
         depth: 2, parentIndex: 1),
       Self.foldNode(5, type: "StaticText", label: "Clamped child",
         rect: SnapshotRect(x: 16, y: 96, width: 100, height: 20), depth: 3, parentIndex: 4),
@@ -69,10 +68,10 @@ extension RunnerTests {
       Self.foldNode(0, type: "Application", label: "App",
         rect: SnapshotRect(x: 0, y: 0, width: 402, height: 874), depth: 0, parentIndex: nil),
       Self.foldNode(1, type: "Window", label: "Second screen",
-        rect: SnapshotRect(x: 402, y: 0, width: 402, height: 874), hittable: true,
+        rect: SnapshotRect(x: 402, y: 0, width: 402, height: 874),
         depth: 1, parentIndex: 0),
       Self.foldNode(2, type: "Button", label: "Gone",
-        rect: SnapshotRect(x: 500, y: 100, width: 100, height: 44), hittable: true,
+        rect: SnapshotRect(x: 500, y: 100, width: 100, height: 44),
         depth: 2, parentIndex: 1),
     ]
     let folded = Self.folded(nodes, viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
@@ -91,12 +90,12 @@ extension RunnerTests {
       Self.foldNode(0, type: "Application", label: "App",
         rect: SnapshotRect(x: 0, y: 0, width: 402, height: 874), depth: 0, parentIndex: nil),
       Self.foldNode(1, type: "Button",
-        rect: SnapshotRect(x: 0, y: 100, width: 402, height: 1), hittable: true,
+        rect: SnapshotRect(x: 0, y: 100, width: 402, height: 1),
         depth: 1, parentIndex: 0),
       Self.foldNode(2, type: "StaticText", label: "Hairline caption",
         rect: SnapshotRect(x: 0, y: 200, width: 402, height: 1), depth: 1, parentIndex: 0),
       Self.foldNode(3, type: "StaticText", label: "Frameless semantics",
-        rect: SnapshotRect(x: 0, y: 0, width: 0, height: 0), hittable: true,
+        rect: SnapshotRect(x: 0, y: 0, width: 0, height: 0),
         depth: 1, parentIndex: 0),
     ]
     let folded = Self.folded(nodes, viewport: CGRect(x: 0, y: 0, width: 402, height: 874))

--- a/test/integration/ios-simulator-e2e/live-full-scenarios.ts
+++ b/test/integration/ios-simulator-e2e/live-full-scenarios.ts
@@ -150,18 +150,40 @@ export async function assertLifecycleAndSystem(context: LiveContext): Promise<vo
   const switcherNodes = Array.isArray(switcherSurface.json?.data?.nodes)
     ? switcherSurface.json.data.nodes
     : [];
-  const coveredFixtureControl = switcherNodes.find(
+  const fixtureControl = switcherNodes.find(
     (node: { identifier?: unknown }) => node.identifier === 'automation-press',
   );
-  assert.ok(coveredFixtureControl, JSON.stringify(switcherSurface.json));
-  assert.equal(coveredFixtureControl.hittable, false, JSON.stringify(coveredFixtureControl));
+  assert.ok(fixtureControl, JSON.stringify(switcherSurface.json));
+  // The system app switcher is outside the app accessibility tree. Its screenshot proves the
+  // visual cover, while this tree must retain geometric actionability and must not invent a
+  // structured daemon occlusion reason for an overlay the runner never captured.
+  assert.equal(fixtureControl.hittable, true, JSON.stringify(fixtureControl));
+  assert.equal(fixtureControl.interactionBlocked, undefined, JSON.stringify(fixtureControl));
   assert.equal(
     switcherNodes.some(
       (node: { hittable?: unknown; type?: unknown }) =>
         node.type === 'Button' && node.hittable === true,
     ),
-    false,
-    'app switcher should cover every fixture button',
+    true,
+    'app switcher must not turn geometric actionability into runner-side occlusion',
+  );
+  const rawSwitcherSurface = await runStep(context, 'inspect raw fixture in app switcher', [
+    'snapshot',
+    '--raw',
+  ]);
+  const rawSwitcherNodes = Array.isArray(rawSwitcherSurface.json?.data?.nodes)
+    ? rawSwitcherSurface.json.data.nodes
+    : [];
+  const rawFixtureControl = rawSwitcherNodes.find(
+    (node: { identifier?: unknown }) => node.identifier === 'automation-press',
+  );
+  assert.ok(rawFixtureControl, JSON.stringify(rawSwitcherSurface.json));
+  assert.equal(rawFixtureControl.hittable, true, JSON.stringify(rawFixtureControl));
+  assert.equal(rawFixtureControl.interactionBlocked, undefined, JSON.stringify(rawFixtureControl));
+  assert.equal(rawSwitcherSurface.json?.data?.snapshotQuality?.backend, 'tree');
+  assert.ok(
+    Number(rawSwitcherSurface.json?.data?.snapshotDiagnostics?.stats?.backends?.xctest) > 0,
+    JSON.stringify(rawSwitcherSurface.json),
   );
   const switcherPath = path.join(context.artifactDir, 'system-app-switcher.png');
   await capturePng(context, 'capture app switcher', switcherPath);
@@ -174,7 +196,7 @@ export async function assertLifecycleAndSystem(context: LiveContext): Promise<vo
   verifyCommand(
     context,
     C.appSwitcher,
-    'app switcher covers fixture controls and differs from Home and foreground pixels',
+    'app switcher visibly covers the app while regular/raw trees retain geometric actionability',
   );
   verifyBehavior(
     context,


### PR DESCRIPTION
## Summary

- Make iOS snapshot geometric actionability one backend-independent predicate across recursive tree, query sweep, private AX, and collapsed-tab acquisition.
- Remove the XCTest runner later-node occlusion scan and its obsolete flatten/range/type-gate helpers while preserving intentional direct/raw interaction paths.
- Keep daemon snapshot occlusion as the sole owner of structured covered state and retain interactionBlocked: "covered" consumer behavior.
- Add focused regression coverage and changed-path live evidence for the distinction between geometric hittable and daemon occlusion.

## Validation

- Red before the fix: the focused regular-presentation XCTest selected one test and failed three assertions for a covered button, labeled image, and disabled button.
- Green: iOS XCTest build succeeded; focused runner tests 2/2, snapshot/presentation tests 18/18, private-AX tests 5/5; daemon occlusion/state/response/find Vitest files passed with 97 tests; xctest selection passed.
- Live on existing booted iPhone 17 Pro F7D6F9A4-4FCC-4DD7-AC0B-3280C9319CB9: regular and raw direct payloads both reported automation-press as hittable true with no interactionBlocked, snapshotQuality.backend tree, and XCTest backend diagnostics present (4/5). The changed lifecycle route passed its regular/raw app-switcher assertions and screenshot evidence. All scoped sessions were closed and isolated daemons cleaned.
- Final pnpm check:affected --run passed all runnable checks; native/device and coverage lanes remain GitHub-authoritative. The broad lifecycle run later reached the existing simulator observability check and stopped because CPU sampling is unavailable on simulators; that unrelated failure was not pursued.