### PR TITLE
ci: attribute native package size and trim Apple runner

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -41,7 +41,9 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
 
       - name: Preserve report scripts
-        run: cp scripts/size-report*.mjs /tmp/
+        run: |
+          mkdir -p /tmp/agent-device-size-report
+          cp scripts/size-report*.mjs /tmp/agent-device-size-report/
 
       # dist is fully determined by the base commit, so reuse it across PR runs
       # against the same base. Startup medians are still measured fresh on this
@@ -60,7 +62,7 @@ jobs:
           if [ "${{ steps.base-dist-cache.outputs.cache-hit }}" != "true" ]; then
             pnpm build
           fi
-          node /tmp/agent-device-size-report.mjs \
+          node /tmp/agent-device-size-report/size-report.mjs \
             --startup-runs 7 \
             --json /tmp/agent-device-size-base.json
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Setup toolchain
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Preserve report script
-        run: cp scripts/size-report.mjs /tmp/agent-device-size-report.mjs
+      - name: Preserve report scripts
+        run: cp scripts/size-report*.mjs /tmp/
 
       # dist is fully determined by the base commit, so reuse it across PR runs
       # against the same base. Startup medians are still measured fresh on this

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -238,7 +238,6 @@ extension RunnerTests {
     }
     do {
       let viewport = try runMainThreadWork(
-        command: nil,
         timeout: 1,
         timeoutError: snapshotMainThreadTimeoutError("reading private AX viewport")
       ) {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -845,7 +845,6 @@ extension RunnerTests {
     DispatchQueue(label: "agent-device.runner.tests.off-main").async {
       do {
         box.observedMainThread = try self.runMainThreadWork(
-          command: nil,
           timeout: 1,
           timeoutError: self.mainThreadExecutionTimeoutError
         ) {
@@ -879,7 +878,6 @@ extension RunnerTests {
     DispatchQueue(label: "agent-device.runner.tests.timeout").async {
       do {
         _ = try self.runMainThreadWork(
-          command: nil,
           timeout: 0,
           timeoutError: self.mainThreadExecutionTimeoutError,
           onAbandoned: {
@@ -938,6 +936,7 @@ extension RunnerTests {
   }
 #endif
 
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
   func execute(command: Command) throws -> Response {
     if command.command == .status {
       return executeStatus(command: command)
@@ -948,6 +947,7 @@ extension RunnerTests {
     commandJournal.accept(command: command)
     return try executeAccepted(command: command)
   }
+#endif
 
   func executeAccepted(command: Command) throws -> Response {
     commandJournal.start(command: command)
@@ -1107,7 +1107,6 @@ extension RunnerTests {
     }
     if command.command == .alert, let deadline = alertDeadline {
       return try runMainThreadWork(
-        command: command,
         timeout: max(0.001, deadline.timeIntervalSinceNow),
         timeoutError: mainThreadExecutionTimeoutError
       ) {
@@ -1119,7 +1118,6 @@ extension RunnerTests {
       }
     }
     return try runMainThreadWork(
-      command: command,
       timeout: mainThreadExecutionTimeout,
       timeoutError: mainThreadExecutionTimeoutError
     ) {
@@ -1128,7 +1126,6 @@ extension RunnerTests {
   }
 
   func runMainThreadWork<T>(
-    command: Command?,
     timeout: TimeInterval,
     timeoutError: @escaping () -> Error,
     onAbandoned: (() -> Void)? = nil,
@@ -1300,7 +1297,6 @@ extension RunnerTests {
     var hasRetried = false
     while true {
       let failureCountBefore = try runMainThreadWork(
-        command: command,
         timeout: mainThreadExecutionTimeout,
         timeoutError: mainThreadExecutionTimeoutError
       ) {
@@ -1317,7 +1313,6 @@ extension RunnerTests {
         return response
       }
       let recordedFailureResponse = try runMainThreadWork(
-        command: command,
         timeout: mainThreadExecutionTimeout,
         timeoutError: mainThreadExecutionTimeoutError
       ) {
@@ -1327,7 +1322,6 @@ extension RunnerTests {
       }
       if let recordedFailureResponse {
         try runMainThreadWork(
-          command: command,
           timeout: mainThreadExecutionTimeout,
           timeoutError: mainThreadExecutionTimeoutError
         ) {
@@ -1342,7 +1336,6 @@ extension RunnerTests {
         )
         hasRetried = true
         try runMainThreadWork(
-          command: command,
           timeout: mainThreadExecutionTimeout,
           timeoutError: mainThreadExecutionTimeoutError
         ) {
@@ -1357,7 +1350,6 @@ extension RunnerTests {
 
   private func executeSnapshotDispatchedOnce(command: Command) throws -> Response {
     let preparation = try runMainThreadWork(
-      command: command,
       timeout: mainThreadExecutionTimeout,
       timeoutError: mainThreadExecutionTimeoutError
     ) {
@@ -1424,7 +1416,6 @@ extension RunnerTests {
     }
     do {
       try runMainThreadWork(
-        command: nil,
         timeout: 1,
         timeoutError: mainThreadExecutionTimeoutError
       ) {
@@ -1442,7 +1433,6 @@ extension RunnerTests {
     }
     do {
       try runMainThreadWork(
-        command: nil,
         timeout: 1,
         timeoutError: mainThreadExecutionTimeoutError
       ) {
@@ -2583,9 +2573,11 @@ extension RunnerTests {
     )
   }
 
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
   func runnerCommandFixture(_ json: String) throws -> Command {
     try JSONDecoder().decode(Command.self, from: Data(json.utf8))
   }
+#endif
 
   private func shouldSkipAppActivationPreflight(_ command: Command) -> Bool {
 #if os(iOS)

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -5,7 +5,9 @@ import CoreGraphics
 #endif
 
 private enum RunnerInterfaceOrientation {
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
   static let unknown = 0
+#endif
   static let portrait = 1
   static let portraitUpsideDown = 2
   static let landscapeRight = 3

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -294,7 +294,6 @@ extension RunnerTests {
     let startedAt = Date()
     do {
       return try runMainThreadWork(
-        command: nil,
         timeout: slice,
         timeoutError: {
           SnapshotCaptureFailure(
@@ -813,7 +812,6 @@ extension RunnerTests {
     treeCaptureSliceBudgetOverride: TimeInterval? = nil
   ) throws -> SnapshotTraversalContext? {
     let viewport = try runMainThreadWork(
-      command: nil,
       timeout: min(1.0, max(0.1, captureDeadline.timeIntervalSinceNow)),
       timeoutError: snapshotMainThreadTimeoutError("preparing tree snapshot")
     ) {
@@ -869,7 +867,6 @@ extension RunnerTests {
       return try captureSnapshotRoot(element)
     }
     return try runMainThreadWork(
-      command: nil,
       timeout: sliceSeconds,
       timeoutError: treeCaptureTimeoutError(sliceSeconds: sliceSeconds),
       onAbandoned: {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -490,7 +490,6 @@ extension RunnerTests {
         return nil
       }
       acquisition = try runMainThreadWork(
-        command: nil,
         timeout: min(treeCaptureSliceBudget, max(0.5, deadline.timeIntervalSinceNow)),
         timeoutError: snapshotMainThreadTimeoutError("processing tree snapshot")
       ) {
@@ -500,7 +499,6 @@ extension RunnerTests {
       }
     case .querySweep:
       acquisition = try runMainThreadWork(
-        command: nil,
         timeout: min(Self.flatInteractiveFallbackBudget, max(0.1, deadline.timeIntervalSinceNow)),
         timeoutError: snapshotMainThreadTimeoutError("running query-sweep snapshot")
       ) {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationModels.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationModels.swift
@@ -112,16 +112,6 @@ struct PresentedNode: Codable {
     )
   }
 
-  init(presenting raw: RawAXNode, index: Int, depth: Int, parentIndex: Int?) {
-    self.init(
-      presenting: raw,
-      rect: raw.rect,
-      index: index,
-      depth: depth,
-      parentIndex: parentIndex
-    )
-  }
-
   init(
     presenting raw: RawAXNode,
     rect: SnapshotRect,

--- a/scripts/__tests__/fixtures/size-report-npm-pack.json
+++ b/scripts/__tests__/fixtures/size-report-npm-pack.json
@@ -1,0 +1,12 @@
+{
+  "unpackedSize": 1701,
+  "files": [
+    { "path": "dist/src/index.js", "size": 401 },
+    { "path": "dist/src/index.d.ts", "size": 102 },
+    { "path": "dist/apple/runner/RunnerTests.swift", "size": 503 },
+    { "path": "apple/macos-helper/Sources/main.swift", "size": 211 },
+    { "path": "android/snapshot-helper/dist/helper.apk", "size": 307 },
+    { "path": "package.json", "size": 99 },
+    { "path": "vendor/unknown.bin", "size": 78 }
+  ]
+}

--- a/scripts/__tests__/size-report-package.test.ts
+++ b/scripts/__tests__/size-report-package.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { test } from 'vitest';
+import { formatMarkdown } from '../size-report.mjs';
+import { classifyNpmPackEntry, summarizeNpmPackComponents } from '../size-report-package.mjs';
+
+const fixturePack = JSON.parse(
+  await readFile(join(import.meta.dirname, 'fixtures', 'size-report-npm-pack.json'), 'utf8'),
+);
+
+test('classifies every shipped entry into one named component', () => {
+  const classified = fixturePack.files.map(classifyNpmPackEntry);
+
+  assert.deepEqual(
+    classified.map((entry) => [entry.path, entry.component]),
+    [
+      ['dist/src/index.js', 'js'],
+      ['dist/src/index.d.ts', 'js'],
+      ['dist/apple/runner/RunnerTests.swift', 'apple-runner'],
+      ['apple/macos-helper/Sources/main.swift', 'macos-helper'],
+      ['android/snapshot-helper/dist/helper.apk', 'android-helpers'],
+      ['package.json', 'other'],
+      ['vendor/unknown.bin', 'other'],
+    ],
+  );
+});
+
+test('unknown package paths fall into other', () => {
+  assert.equal(
+    classifyNpmPackEntry({ path: 'new/future-package-file', size: 13 }).component,
+    'other',
+  );
+});
+
+test('component bytes sum exactly to npm pack unpackedSize', () => {
+  const components = summarizeNpmPackComponents(fixturePack);
+
+  assert.equal(
+    components.reduce((total, component) => total + component.unpackedBytes, 0),
+    fixturePack.unpackedSize,
+  );
+  assert.deepEqual(
+    Object.fromEntries(components.map((component) => [component.id, component.unpackedBytes])),
+    {
+      js: 503,
+      'apple-runner': 503,
+      'macos-helper': 211,
+      'android-helpers': 307,
+      other: 177,
+    },
+  );
+  assert.throws(
+    () => summarizeNpmPackComponents({ ...fixturePack, unpackedSize: 1700 }),
+    /does not match npm pack unpackedSize/,
+  );
+});
+
+test('Markdown reports component diffs and changed packed files', () => {
+  const current = {
+    js: { rawBytes: 10, gzipBytes: 8 },
+    npmPack: {
+      tarballBytes: 100,
+      unpackedBytes: 1701,
+      components: summarizeNpmPackComponents(fixturePack),
+      entries: fixturePack.files,
+    },
+    chunks: [],
+  };
+  const baseEntries = fixturePack.files.map((entry) =>
+    entry.path === 'dist/src/index.js' ? { ...entry, size: 300 } : entry,
+  );
+  const base = {
+    js: { rawBytes: 10, gzipBytes: 8 },
+    npmPack: {
+      tarballBytes: 100,
+      unpackedBytes: 1600,
+      components: summarizeNpmPackComponents({
+        ...fixturePack,
+        unpackedSize: 1600,
+        files: baseEntries,
+      }),
+      entries: baseEntries,
+    },
+    chunks: [],
+  };
+
+  const markdown = formatMarkdown(current, base);
+
+  assert.match(markdown, /### npm unpacked components/);
+  assert.match(markdown, /\| JS \/ dist source \| 402 B \| 503 B \| \+101 B \|/);
+  assert.match(markdown, /\| Other package files \| 177 B \| 177 B \| 0 B \|/);
+  assert.match(markdown, /### Top changed packed files/);
+  assert.match(markdown, /`dist\/src\/index\.js` \| 300 B \| 401 B \| \+101 B/);
+});

--- a/scripts/__tests__/size-report-post-comment.test.ts
+++ b/scripts/__tests__/size-report-post-comment.test.ts
@@ -5,21 +5,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { test } from 'vitest';
-import {
-  classifyNpmPackEntry,
-  formatMarkdown,
-  summarizeNpmPackComponents,
-} from '../size-report.mjs';
 
 const execFileAsync = promisify(execFile);
 const ROOT = join(import.meta.dirname, '..', '..');
 const SCRIPT = join(ROOT, 'scripts', 'size-report.mjs');
 const MARKER = '<!-- agent-device-size-report -->';
-const SIZE_FIXTURE = join(
-  import.meta.dirname,
-  'fixtures',
-  'size-report-npm-pack.json',
-);
 
 // Each entry answers one fetch call, in order. `net` rejects the fetch (a
 // dropped connection); a number is the HTTP status; `body` is the response
@@ -121,93 +111,4 @@ test('a non-transient 4xx is fatal and is not retried', async () => {
   assert.match(result.stderr, /Failed to create PR comment: 401/);
   assert.doesNotMatch(result.stdout, /::warning::/);
   assert.equal(result.calls.length, 2, 'no retry after a fatal status');
-});
-
-const fixturePack = JSON.parse(await readFile(SIZE_FIXTURE, 'utf8'));
-
-test('classifies every shipped entry into one named component', () => {
-  const classified = fixturePack.files.map(classifyNpmPackEntry);
-
-  assert.deepEqual(
-    classified.map((entry) => [entry.path, entry.component]),
-    [
-      ['dist/src/index.js', 'js'],
-      ['dist/src/index.d.ts', 'js'],
-      ['dist/apple/runner/RunnerTests.swift', 'apple-runner'],
-      ['apple/macos-helper/Sources/main.swift', 'macos-helper'],
-      ['android/snapshot-helper/dist/helper.apk', 'android-helpers'],
-      ['package.json', 'other'],
-      ['vendor/unknown.bin', 'other'],
-    ],
-  );
-});
-
-test('unknown package paths fall into other', () => {
-  assert.equal(
-    classifyNpmPackEntry({ path: 'new/future-package-file', size: 13 }).component,
-    'other',
-  );
-});
-
-test('component bytes sum exactly to npm pack unpackedSize', () => {
-  const components = summarizeNpmPackComponents(fixturePack);
-
-  assert.equal(
-    components.reduce((total, component) => total + component.unpackedBytes, 0),
-    fixturePack.unpackedSize,
-  );
-  assert.deepEqual(
-    Object.fromEntries(
-      components.map((component) => [component.id, component.unpackedBytes]),
-    ),
-    {
-      js: 503,
-      'apple-runner': 503,
-      'macos-helper': 211,
-      'android-helpers': 307,
-      other: 177,
-    },
-  );
-  assert.throws(
-    () => summarizeNpmPackComponents({ ...fixturePack, unpackedSize: 1700 }),
-    /does not match npm pack unpackedSize/,
-  );
-});
-
-test('Markdown reports component diffs and changed packed files', () => {
-  const current = {
-    js: { rawBytes: 10, gzipBytes: 8 },
-    npmPack: {
-      tarballBytes: 100,
-      unpackedBytes: 1701,
-      components: summarizeNpmPackComponents(fixturePack),
-      entries: fixturePack.files,
-    },
-    chunks: [],
-  };
-  const baseEntries = fixturePack.files.map((entry) =>
-    entry.path === 'dist/src/index.js' ? { ...entry, size: 300 } : entry,
-  );
-  const base = {
-    js: { rawBytes: 10, gzipBytes: 8 },
-    npmPack: {
-      tarballBytes: 100,
-      unpackedBytes: 1600,
-      components: summarizeNpmPackComponents({
-        ...fixturePack,
-        unpackedSize: 1600,
-        files: baseEntries,
-      }),
-      entries: baseEntries,
-    },
-    chunks: [],
-  };
-
-  const markdown = formatMarkdown(current, base);
-
-  assert.match(markdown, /### npm unpacked components/);
-  assert.match(markdown, /\| JS \/ dist source \| 402 B \| 503 B \| \+101 B \|/);
-  assert.match(markdown, /\| Other package files \| 177 B \| 177 B \| 0 B \|/);
-  assert.match(markdown, /### Top changed packed files/);
-  assert.match(markdown, /`dist\/src\/index\.js` \| 300 B \| 401 B \| \+101 B/);
 });

--- a/scripts/__tests__/size-report-post-comment.test.ts
+++ b/scripts/__tests__/size-report-post-comment.test.ts
@@ -5,11 +5,21 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { test } from 'vitest';
+import {
+  classifyNpmPackEntry,
+  formatMarkdown,
+  summarizeNpmPackComponents,
+} from '../size-report.mjs';
 
 const execFileAsync = promisify(execFile);
 const ROOT = join(import.meta.dirname, '..', '..');
 const SCRIPT = join(ROOT, 'scripts', 'size-report.mjs');
 const MARKER = '<!-- agent-device-size-report -->';
+const SIZE_FIXTURE = join(
+  import.meta.dirname,
+  'fixtures',
+  'size-report-npm-pack.json',
+);
 
 // Each entry answers one fetch call, in order. `net` rejects the fetch (a
 // dropped connection); a number is the HTTP status; `body` is the response
@@ -111,4 +121,93 @@ test('a non-transient 4xx is fatal and is not retried', async () => {
   assert.match(result.stderr, /Failed to create PR comment: 401/);
   assert.doesNotMatch(result.stdout, /::warning::/);
   assert.equal(result.calls.length, 2, 'no retry after a fatal status');
+});
+
+const fixturePack = JSON.parse(await readFile(SIZE_FIXTURE, 'utf8'));
+
+test('classifies every shipped entry into one named component', () => {
+  const classified = fixturePack.files.map(classifyNpmPackEntry);
+
+  assert.deepEqual(
+    classified.map((entry) => [entry.path, entry.component]),
+    [
+      ['dist/src/index.js', 'js'],
+      ['dist/src/index.d.ts', 'js'],
+      ['dist/apple/runner/RunnerTests.swift', 'apple-runner'],
+      ['apple/macos-helper/Sources/main.swift', 'macos-helper'],
+      ['android/snapshot-helper/dist/helper.apk', 'android-helpers'],
+      ['package.json', 'other'],
+      ['vendor/unknown.bin', 'other'],
+    ],
+  );
+});
+
+test('unknown package paths fall into other', () => {
+  assert.equal(
+    classifyNpmPackEntry({ path: 'new/future-package-file', size: 13 }).component,
+    'other',
+  );
+});
+
+test('component bytes sum exactly to npm pack unpackedSize', () => {
+  const components = summarizeNpmPackComponents(fixturePack);
+
+  assert.equal(
+    components.reduce((total, component) => total + component.unpackedBytes, 0),
+    fixturePack.unpackedSize,
+  );
+  assert.deepEqual(
+    Object.fromEntries(
+      components.map((component) => [component.id, component.unpackedBytes]),
+    ),
+    {
+      js: 503,
+      'apple-runner': 503,
+      'macos-helper': 211,
+      'android-helpers': 307,
+      other: 177,
+    },
+  );
+  assert.throws(
+    () => summarizeNpmPackComponents({ ...fixturePack, unpackedSize: 1700 }),
+    /does not match npm pack unpackedSize/,
+  );
+});
+
+test('Markdown reports component diffs and changed packed files', () => {
+  const current = {
+    js: { rawBytes: 10, gzipBytes: 8 },
+    npmPack: {
+      tarballBytes: 100,
+      unpackedBytes: 1701,
+      components: summarizeNpmPackComponents(fixturePack),
+      entries: fixturePack.files,
+    },
+    chunks: [],
+  };
+  const baseEntries = fixturePack.files.map((entry) =>
+    entry.path === 'dist/src/index.js' ? { ...entry, size: 300 } : entry,
+  );
+  const base = {
+    js: { rawBytes: 10, gzipBytes: 8 },
+    npmPack: {
+      tarballBytes: 100,
+      unpackedBytes: 1600,
+      components: summarizeNpmPackComponents({
+        ...fixturePack,
+        unpackedSize: 1600,
+        files: baseEntries,
+      }),
+      entries: baseEntries,
+    },
+    chunks: [],
+  };
+
+  const markdown = formatMarkdown(current, base);
+
+  assert.match(markdown, /### npm unpacked components/);
+  assert.match(markdown, /\| JS \/ dist source \| 402 B \| 503 B \| \+101 B \|/);
+  assert.match(markdown, /\| Other package files \| 177 B \| 177 B \| 0 B \|/);
+  assert.match(markdown, /### Top changed packed files/);
+  assert.match(markdown, /`dist\/src\/index\.js` \| 300 B \| 401 B \| \+101 B/);
 });

--- a/scripts/size-report-format.mjs
+++ b/scripts/size-report-format.mjs
@@ -1,0 +1,20 @@
+export function formatMaybeBytes(value) {
+  return typeof value === 'number' ? formatBytes(value) : '-';
+}
+
+export function formatDiff(base, current) {
+  return typeof base === 'number' ? formatSignedBytes(current - base) : '-';
+}
+
+export function formatBytes(value) {
+  const absoluteValue = Math.abs(value);
+  if (absoluteValue < 1000) return `${value} B`;
+  if (absoluteValue < 1000 * 1000) return `${(value / 1000).toFixed(1)} kB`;
+  return `${(value / (1000 * 1000)).toFixed(2)} MB`;
+}
+
+export function formatSignedBytes(value) {
+  if (value === 0) return '0 B';
+  const sign = value > 0 ? '+' : '-';
+  return `${sign}${formatBytes(Math.abs(value))}`;
+}

--- a/scripts/size-report-package.mjs
+++ b/scripts/size-report-package.mjs
@@ -1,0 +1,183 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  formatBytes,
+  formatDiff,
+  formatMaybeBytes,
+  formatSignedBytes,
+} from './size-report-format.mjs';
+
+const PACKAGE_COMPONENTS = [
+  {
+    id: 'js',
+    label: 'JS / dist source',
+    matches: (entryPath) => entryPath === 'dist/src' || entryPath.startsWith('dist/src/'),
+  },
+  {
+    id: 'apple-runner',
+    label: 'Apple runner source/project',
+    matches: (entryPath) =>
+      entryPath === 'dist/apple/runner' || entryPath.startsWith('dist/apple/runner/'),
+  },
+  {
+    id: 'macos-helper',
+    label: 'macOS helper source',
+    matches: (entryPath) =>
+      entryPath === 'apple/macos-helper' || entryPath.startsWith('apple/macos-helper/'),
+  },
+  {
+    id: 'android-helpers',
+    label: 'Android helper artifacts',
+    matches: (entryPath) =>
+      /^android\/(?:snapshot-helper|ime-helper)\/dist(?:\/|$)/.test(entryPath),
+  },
+  { id: 'other', label: 'Other package files' },
+];
+
+export function collectNpmPack(root) {
+  const cachePath = path.join(root, '.tmp', 'npm-cache');
+  fs.mkdirSync(cachePath, { recursive: true });
+  const stdout = execFileSync(
+    'npm',
+    ['pack', '--dry-run', '--ignore-scripts', '--json', '--cache', cachePath],
+    { cwd: root, encoding: 'utf8' },
+  );
+  const pack = parseNpmPackOutput(stdout);
+  const entries = normalizeNpmPackEntries(pack);
+  return {
+    filename: pack.filename,
+    tarballBytes: pack.size,
+    unpackedBytes: pack.unpackedSize,
+    files: entries.length,
+    entries,
+    components: summarizeEntries(pack.unpackedSize, entries),
+  };
+}
+
+function parseNpmPackOutput(stdout) {
+  const parsed = JSON.parse(stdout);
+  return Array.isArray(parsed) ? parsed[0] : parsed;
+}
+
+function normalizeNpmPackEntries(pack) {
+  if (!Array.isArray(pack.files)) {
+    throw new Error('npm pack did not return per-file path/size data in files[]');
+  }
+  return pack.files.map((entry) => {
+    if (
+      !entry ||
+      typeof entry.path !== 'string' ||
+      !Number.isSafeInteger(entry.size) ||
+      entry.size < 0
+    ) {
+      throw new Error(`npm pack returned an invalid file entry: ${JSON.stringify(entry)}`);
+    }
+    return { path: entry.path, size: entry.size };
+  });
+}
+
+export function classifyNpmPackEntry(entry) {
+  const matches = PACKAGE_COMPONENTS.filter((component) => component.matches?.(entry.path));
+  if (matches.length > 1) {
+    throw new Error(
+      `Package entry ${JSON.stringify(entry.path)} matched ${matches.length} size components`,
+    );
+  }
+  return { ...entry, component: matches[0]?.id ?? 'other' };
+}
+
+export function summarizeNpmPackComponents(pack) {
+  return summarizeEntries(pack.unpackedSize, normalizeNpmPackEntries(pack));
+}
+
+function summarizeEntries(unpackedSize, entries) {
+  if (!Number.isSafeInteger(unpackedSize) || unpackedSize < 0) {
+    throw new Error(`npm pack returned an invalid unpackedSize: ${unpackedSize}`);
+  }
+  const totals = new Map(
+    PACKAGE_COMPONENTS.map((component) => [component.id, { files: 0, unpackedBytes: 0 }]),
+  );
+  for (const entry of entries.map(classifyNpmPackEntry)) {
+    const total = totals.get(entry.component);
+    total.files += 1;
+    total.unpackedBytes += entry.size;
+  }
+  const components = PACKAGE_COMPONENTS.map((component) => ({
+    id: component.id,
+    label: component.label,
+    ...totals.get(component.id),
+  }));
+  const componentBytes = components.reduce(
+    (total, component) => total + component.unpackedBytes,
+    0,
+  );
+  if (componentBytes !== unpackedSize) {
+    throw new Error(
+      `Package component byte sum ${componentBytes} does not match npm pack unpackedSize ${unpackedSize}`,
+    );
+  }
+  return components;
+}
+
+export function formatPackageComponents(currentPack, basePack) {
+  const currentById = new Map(
+    (currentPack.components ?? []).map((component) => [component.id, component]),
+  );
+  const baseById = new Map(
+    (basePack?.components ?? []).map((component) => [component.id, component]),
+  );
+  const rows = PACKAGE_COMPONENTS.map((component) => {
+    const current = currentById.get(component.id)?.unpackedBytes ?? 0;
+    const base = baseById.get(component.id)?.unpackedBytes;
+    return `| ${component.label} | ${formatMaybeBytes(base)} | ${formatBytes(current)} | ${formatDiff(base, current)} |`;
+  });
+  return `### npm unpacked components
+
+| Component | Base | Current | Diff |
+|---|---:|---:|---:|
+${rows.join('\n')}
+`;
+}
+
+export function formatPackedFiles(currentEntries, baseEntries) {
+  if (!baseEntries) return formatTopPackedFiles(currentEntries);
+  const currentByPath = new Map(currentEntries.map((entry) => [entry.path, entry.size]));
+  const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry.size]));
+  const paths = new Set([...currentByPath.keys(), ...baseByPath.keys()]);
+  const rows = [...paths]
+    .map((filePath) => {
+      const current = currentByPath.get(filePath) ?? 0;
+      const base = baseByPath.get(filePath) ?? 0;
+      return { path: filePath, base, current, diff: current - base };
+    })
+    .filter((entry) => entry.diff !== 0)
+    .sort((left, right) => Math.abs(right.diff) - Math.abs(left.diff))
+    .slice(0, 10)
+    .map(
+      (entry) =>
+        `| \`${entry.path}\` | ${formatBytes(entry.base)} | ${formatBytes(entry.current)} | ${formatSignedBytes(entry.diff)} |`,
+    );
+  if (rows.length === 0) {
+    return '### Top changed packed files\n\nNo changed packed files.\n';
+  }
+  return `### Top changed packed files
+
+| Packed file | Base | Current | Diff |
+|---|---:|---:|---:|
+${rows.join('\n')}
+`;
+}
+
+function formatTopPackedFiles(entries) {
+  const rows = [...entries]
+    .sort((left, right) => right.size - left.size)
+    .slice(0, 10)
+    .map((entry) => `| \`${entry.path}\` | ${formatBytes(entry.size)} |`);
+  return `### Top packed files
+
+| Packed file | Unpacked |
+|---|---:|
+${rows.join('\n')}
+`;
+}

--- a/scripts/size-report.mjs
+++ b/scripts/size-report.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
 import { gzipSync } from 'node:zlib';
 
 const COMMENT_MARKER = '<!-- agent-device-size-report -->';
@@ -25,29 +26,70 @@ const STARTUP_BENCHMARKS = [
   { name: 'CLI --help', args: ['--help'] },
 ];
 
-const args = parseArgs(process.argv.slice(2));
-const cwd = path.resolve(args.cwd ?? process.cwd());
+const PACKAGE_COMPONENTS = [
+  {
+    id: 'js',
+    label: 'JS / dist source',
+    matches: (entryPath) => entryPath === 'dist/src' || entryPath.startsWith('dist/src/'),
+  },
+  {
+    id: 'apple-runner',
+    label: 'Apple runner source/project',
+    matches: (entryPath) =>
+      entryPath === 'dist/apple/runner' || entryPath.startsWith('dist/apple/runner/'),
+  },
+  {
+    id: 'macos-helper',
+    label: 'macOS helper source',
+    matches: (entryPath) =>
+      entryPath === 'apple/macos-helper' || entryPath.startsWith('apple/macos-helper/'),
+  },
+  {
+    id: 'android-helpers',
+    label: 'Android helper artifacts',
+    matches: (entryPath) =>
+      /^android\/(?:snapshot-helper|ime-helper)\/dist(?:\/|$)/.test(entryPath),
+  },
+  {
+    id: 'other',
+    label: 'Other package files',
+    matches: () => true,
+  },
+];
 
-if (args.postComment) {
-  await postGitHubCommentBestEffort(args.postComment, args.pr);
-  process.exit(0);
+if (isMainModule()) {
+  await run();
 }
 
-const report = collectReport(cwd, {
-  startupRuns: parseNonNegativeInteger(args.startupRuns ?? '0', '--startup-runs'),
-});
-const baseReport = args.compare ? JSON.parse(fs.readFileSync(args.compare, 'utf8')) : null;
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const cwd = path.resolve(args.cwd ?? process.cwd());
 
-if (args.json) {
-  writeFile(args.json, `${JSON.stringify(report, null, 2)}\n`);
+  if (args.postComment) {
+    await postGitHubCommentBestEffort(args.postComment, args.pr);
+    return;
+  }
+
+  const report = collectReport(cwd, {
+    startupRuns: parseNonNegativeInteger(args.startupRuns ?? '0', '--startup-runs'),
+  });
+  const baseReport = args.compare ? JSON.parse(fs.readFileSync(args.compare, 'utf8')) : null;
+
+  if (args.json) {
+    writeFile(args.json, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  const markdown = formatMarkdown(report, baseReport);
+
+  if (args.markdown) {
+    writeFile(args.markdown, markdown);
+  } else {
+    process.stdout.write(markdown);
+  }
 }
 
-const markdown = formatMarkdown(report, baseReport);
-
-if (args.markdown) {
-  writeFile(args.markdown, markdown);
-} else {
-  process.stdout.write(markdown);
+function isMainModule() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 }
 
 function parseArgs(argv) {
@@ -216,11 +258,14 @@ function collectNpmPack(root) {
     { cwd: root, encoding: 'utf8' },
   );
   const pack = parseNpmPackOutput(stdout);
+  const entries = normalizeNpmPackEntries(pack);
   return {
     filename: pack.filename,
     tarballBytes: pack.size,
     unpackedBytes: pack.unpackedSize,
-    files: countNpmPackEntries(pack),
+    files: entries.length,
+    entries,
+    components: summarizeNpmPackComponents({ ...pack, files: entries }),
   };
 }
 
@@ -229,9 +274,70 @@ function parseNpmPackOutput(stdout) {
   return Array.isArray(parsed) ? parsed[0] : parsed;
 }
 
-function countNpmPackEntries(pack) {
-  if (typeof pack.entryCount === 'number') return pack.entryCount;
-  return Array.isArray(pack.files) ? pack.files.length : 0;
+function normalizeNpmPackEntries(pack) {
+  if (!Array.isArray(pack.files)) {
+    throw new Error('npm pack did not return per-file path/size data in files[]');
+  }
+  return pack.files.map((entry) => {
+    if (
+      !entry ||
+      typeof entry.path !== 'string' ||
+      !Number.isSafeInteger(entry.size) ||
+      entry.size < 0
+    ) {
+      throw new Error(`npm pack returned an invalid file entry: ${JSON.stringify(entry)}`);
+    }
+    return { path: entry.path, size: entry.size };
+  });
+}
+
+function classifyNpmPackEntry(entry) {
+  const matches = PACKAGE_COMPONENTS.filter(
+    (component) => component.id !== 'other' && component.matches(entry.path),
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Package entry ${JSON.stringify(entry.path)} matched ${matches.length} size components`,
+    );
+  }
+  return { ...entry, component: matches[0]?.id ?? 'other' };
+}
+
+function summarizeNpmPackComponents(pack) {
+  if (!Number.isSafeInteger(pack.unpackedSize) || pack.unpackedSize < 0) {
+    throw new Error(`npm pack returned an invalid unpackedSize: ${pack.unpackedSize}`);
+  }
+  const entries = normalizeNpmPackEntries(pack).map(classifyNpmPackEntry);
+  const bytesByComponent = new Map(PACKAGE_COMPONENTS.map((component) => [component.id, 0]));
+  const filesByComponent = new Map(PACKAGE_COMPONENTS.map((component) => [component.id, 0]));
+
+  for (const entry of entries) {
+    bytesByComponent.set(
+      entry.component,
+      bytesByComponent.get(entry.component) + entry.size,
+    );
+    filesByComponent.set(
+      entry.component,
+      filesByComponent.get(entry.component) + 1,
+    );
+  }
+
+  const components = PACKAGE_COMPONENTS.map((component) => ({
+    id: component.id,
+    label: component.label,
+    files: filesByComponent.get(component.id),
+    unpackedBytes: bytesByComponent.get(component.id),
+  }));
+  const componentBytes = components.reduce(
+    (total, component) => total + component.unpackedBytes,
+    0,
+  );
+  if (componentBytes !== pack.unpackedSize) {
+    throw new Error(
+      `Package component byte sum ${componentBytes} does not match npm pack unpackedSize ${pack.unpackedSize}`,
+    );
+  }
+  return components;
 }
 
 function formatMarkdown(report, baseReport) {
@@ -245,7 +351,11 @@ function formatMarkdown(report, baseReport) {
   const changedChunks = baseReport
     ? formatChangedChunks(report.chunks, baseReport.chunks ?? [])
     : formatTopChunks(report.chunks);
+  const components = formatPackageComponents(report.npmPack, baseReport?.npmPack);
   const startup = formatStartupBenchmarks(report.startup, baseReport?.startup);
+  const packedFiles = baseReport
+    ? formatChangedPackedFiles(report.npmPack.entries, baseReport.npmPack?.entries ?? [])
+    : formatTopPackedFiles(report.npmPack.entries);
 
   return `${COMMENT_MARKER}
 ## Size Report
@@ -254,8 +364,10 @@ function formatMarkdown(report, baseReport) {
 |---|---:|---:|---:|
 ${rows.join('\n')}
 
+${components}
 ${startup}
 ${changedChunks}
+${packedFiles}
 `;
 }
 
@@ -301,6 +413,68 @@ function formatChangedChunks(currentChunks, baseChunks) {
 
 | Chunk | Raw diff | Gzip diff |
 |---|---:|---:|
+${rows.join('\n')}
+`;
+}
+
+function formatPackageComponents(currentPack, basePack) {
+  const currentById = new Map(
+    (currentPack.components ?? []).map((component) => [component.id, component]),
+  );
+  const baseById = new Map(
+    (basePack?.components ?? []).map((component) => [component.id, component]),
+  );
+  const rows = PACKAGE_COMPONENTS.map((component) => {
+    const current = currentById.get(component.id)?.unpackedBytes ?? 0;
+    const base = baseById.get(component.id)?.unpackedBytes;
+    return `| ${component.label} | ${formatMaybeBytes(base)} | ${formatBytes(current)} | ${formatDiff(base, current)} |`;
+  });
+  return `### npm unpacked components
+
+| Component | Base | Current | Diff |
+|---|---:|---:|---:|
+${rows.join('\n')}
+`;
+}
+
+function formatTopPackedFiles(entries) {
+  const rows = [...entries]
+    .sort((left, right) => right.size - left.size)
+    .slice(0, 10)
+    .map((entry) => `| \`${entry.path}\` | ${formatBytes(entry.size)} |`);
+  return `### Top packed files
+
+| Packed file | Unpacked |
+|---|---:|
+${rows.join('\n')}
+`;
+}
+
+function formatChangedPackedFiles(currentEntries, baseEntries) {
+  const currentByPath = new Map(currentEntries.map((entry) => [entry.path, entry.size]));
+  const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry.size]));
+  const paths = new Set([...currentByPath.keys(), ...baseByPath.keys()]);
+  const rows = [...paths]
+    .map((filePath) => {
+      const current = currentByPath.get(filePath) ?? 0;
+      const base = baseByPath.get(filePath) ?? 0;
+      return { path: filePath, base, current, diff: current - base };
+    })
+    .filter((entry) => entry.diff !== 0)
+    .sort((left, right) => Math.abs(right.diff) - Math.abs(left.diff))
+    .slice(0, 10)
+    .map(
+      (entry) =>
+        `| \`${entry.path}\` | ${formatBytes(entry.base)} | ${formatBytes(entry.current)} | ${formatSignedBytes(entry.diff)} |`,
+    );
+
+  if (rows.length === 0) {
+    return '### Top changed packed files\n\nNo changed packed files.\n';
+  }
+  return `### Top changed packed files
+
+| Packed file | Base | Current | Diff |
+|---|---:|---:|---:|
 ${rows.join('\n')}
 `;
 }
@@ -510,3 +684,5 @@ async function githubStatusError(response, action) {
 function isTransientGitHubStatus(status) {
   return status === 429 || status >= 500;
 }
+
+export { classifyNpmPackEntry, formatMarkdown, summarizeNpmPackComponents };

--- a/scripts/size-report.mjs
+++ b/scripts/size-report.mjs
@@ -5,6 +5,17 @@ import { execFileSync } from 'node:child_process';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { gzipSync } from 'node:zlib';
+import {
+  formatBytes,
+  formatDiff,
+  formatMaybeBytes,
+  formatSignedBytes,
+} from './size-report-format.mjs';
+import {
+  collectNpmPack,
+  formatPackageComponents,
+  formatPackedFiles,
+} from './size-report-package.mjs';
 
 const COMMENT_MARKER = '<!-- agent-device-size-report -->';
 const GITHUB_REQUEST_ATTEMPTS = 4;
@@ -24,37 +35,6 @@ const VALUE_ARGS = new Map([
 const STARTUP_BENCHMARKS = [
   { name: 'CLI --version', args: ['--version'] },
   { name: 'CLI --help', args: ['--help'] },
-];
-
-const PACKAGE_COMPONENTS = [
-  {
-    id: 'js',
-    label: 'JS / dist source',
-    matches: (entryPath) => entryPath === 'dist/src' || entryPath.startsWith('dist/src/'),
-  },
-  {
-    id: 'apple-runner',
-    label: 'Apple runner source/project',
-    matches: (entryPath) =>
-      entryPath === 'dist/apple/runner' || entryPath.startsWith('dist/apple/runner/'),
-  },
-  {
-    id: 'macos-helper',
-    label: 'macOS helper source',
-    matches: (entryPath) =>
-      entryPath === 'apple/macos-helper' || entryPath.startsWith('apple/macos-helper/'),
-  },
-  {
-    id: 'android-helpers',
-    label: 'Android helper artifacts',
-    matches: (entryPath) =>
-      /^android\/(?:snapshot-helper|ime-helper)\/dist(?:\/|$)/.test(entryPath),
-  },
-  {
-    id: 'other',
-    label: 'Other package files',
-    matches: () => true,
-  },
 ];
 
 if (isMainModule()) {
@@ -249,97 +229,6 @@ function walk(root) {
   });
 }
 
-function collectNpmPack(root) {
-  const cachePath = path.join(root, '.tmp', 'npm-cache');
-  fs.mkdirSync(cachePath, { recursive: true });
-  const stdout = execFileSync(
-    'npm',
-    ['pack', '--dry-run', '--ignore-scripts', '--json', '--cache', cachePath],
-    { cwd: root, encoding: 'utf8' },
-  );
-  const pack = parseNpmPackOutput(stdout);
-  const entries = normalizeNpmPackEntries(pack);
-  return {
-    filename: pack.filename,
-    tarballBytes: pack.size,
-    unpackedBytes: pack.unpackedSize,
-    files: entries.length,
-    entries,
-    components: summarizeNpmPackComponents({ ...pack, files: entries }),
-  };
-}
-
-function parseNpmPackOutput(stdout) {
-  const parsed = JSON.parse(stdout);
-  return Array.isArray(parsed) ? parsed[0] : parsed;
-}
-
-function normalizeNpmPackEntries(pack) {
-  if (!Array.isArray(pack.files)) {
-    throw new Error('npm pack did not return per-file path/size data in files[]');
-  }
-  return pack.files.map((entry) => {
-    if (
-      !entry ||
-      typeof entry.path !== 'string' ||
-      !Number.isSafeInteger(entry.size) ||
-      entry.size < 0
-    ) {
-      throw new Error(`npm pack returned an invalid file entry: ${JSON.stringify(entry)}`);
-    }
-    return { path: entry.path, size: entry.size };
-  });
-}
-
-function classifyNpmPackEntry(entry) {
-  const matches = PACKAGE_COMPONENTS.filter(
-    (component) => component.id !== 'other' && component.matches(entry.path),
-  );
-  if (matches.length > 1) {
-    throw new Error(
-      `Package entry ${JSON.stringify(entry.path)} matched ${matches.length} size components`,
-    );
-  }
-  return { ...entry, component: matches[0]?.id ?? 'other' };
-}
-
-function summarizeNpmPackComponents(pack) {
-  if (!Number.isSafeInteger(pack.unpackedSize) || pack.unpackedSize < 0) {
-    throw new Error(`npm pack returned an invalid unpackedSize: ${pack.unpackedSize}`);
-  }
-  const entries = normalizeNpmPackEntries(pack).map(classifyNpmPackEntry);
-  const bytesByComponent = new Map(PACKAGE_COMPONENTS.map((component) => [component.id, 0]));
-  const filesByComponent = new Map(PACKAGE_COMPONENTS.map((component) => [component.id, 0]));
-
-  for (const entry of entries) {
-    bytesByComponent.set(
-      entry.component,
-      bytesByComponent.get(entry.component) + entry.size,
-    );
-    filesByComponent.set(
-      entry.component,
-      filesByComponent.get(entry.component) + 1,
-    );
-  }
-
-  const components = PACKAGE_COMPONENTS.map((component) => ({
-    id: component.id,
-    label: component.label,
-    files: filesByComponent.get(component.id),
-    unpackedBytes: bytesByComponent.get(component.id),
-  }));
-  const componentBytes = components.reduce(
-    (total, component) => total + component.unpackedBytes,
-    0,
-  );
-  if (componentBytes !== pack.unpackedSize) {
-    throw new Error(
-      `Package component byte sum ${componentBytes} does not match npm pack unpackedSize ${pack.unpackedSize}`,
-    );
-  }
-  return components;
-}
-
 function formatMarkdown(report, baseReport) {
   const rows = [
     metricRow('JS raw', baseReport?.js.rawBytes, report.js.rawBytes),
@@ -353,9 +242,10 @@ function formatMarkdown(report, baseReport) {
     : formatTopChunks(report.chunks);
   const components = formatPackageComponents(report.npmPack, baseReport?.npmPack);
   const startup = formatStartupBenchmarks(report.startup, baseReport?.startup);
-  const packedFiles = baseReport
-    ? formatChangedPackedFiles(report.npmPack.entries, baseReport.npmPack?.entries ?? [])
-    : formatTopPackedFiles(report.npmPack.entries);
+  const packedFiles = formatPackedFiles(
+    report.npmPack.entries,
+    baseReport ? (baseReport.npmPack?.entries ?? []) : undefined,
+  );
 
   return `${COMMENT_MARKER}
 ## Size Report
@@ -417,76 +307,6 @@ ${rows.join('\n')}
 `;
 }
 
-function formatPackageComponents(currentPack, basePack) {
-  const currentById = new Map(
-    (currentPack.components ?? []).map((component) => [component.id, component]),
-  );
-  const baseById = new Map(
-    (basePack?.components ?? []).map((component) => [component.id, component]),
-  );
-  const rows = PACKAGE_COMPONENTS.map((component) => {
-    const current = currentById.get(component.id)?.unpackedBytes ?? 0;
-    const base = baseById.get(component.id)?.unpackedBytes;
-    return `| ${component.label} | ${formatMaybeBytes(base)} | ${formatBytes(current)} | ${formatDiff(base, current)} |`;
-  });
-  return `### npm unpacked components
-
-| Component | Base | Current | Diff |
-|---|---:|---:|---:|
-${rows.join('\n')}
-`;
-}
-
-function formatTopPackedFiles(entries) {
-  const rows = [...entries]
-    .sort((left, right) => right.size - left.size)
-    .slice(0, 10)
-    .map((entry) => `| \`${entry.path}\` | ${formatBytes(entry.size)} |`);
-  return `### Top packed files
-
-| Packed file | Unpacked |
-|---|---:|
-${rows.join('\n')}
-`;
-}
-
-function formatChangedPackedFiles(currentEntries, baseEntries) {
-  const currentByPath = new Map(currentEntries.map((entry) => [entry.path, entry.size]));
-  const baseByPath = new Map(baseEntries.map((entry) => [entry.path, entry.size]));
-  const paths = new Set([...currentByPath.keys(), ...baseByPath.keys()]);
-  const rows = [...paths]
-    .map((filePath) => {
-      const current = currentByPath.get(filePath) ?? 0;
-      const base = baseByPath.get(filePath) ?? 0;
-      return { path: filePath, base, current, diff: current - base };
-    })
-    .filter((entry) => entry.diff !== 0)
-    .sort((left, right) => Math.abs(right.diff) - Math.abs(left.diff))
-    .slice(0, 10)
-    .map(
-      (entry) =>
-        `| \`${entry.path}\` | ${formatBytes(entry.base)} | ${formatBytes(entry.current)} | ${formatSignedBytes(entry.diff)} |`,
-    );
-
-  if (rows.length === 0) {
-    return '### Top changed packed files\n\nNo changed packed files.\n';
-  }
-  return `### Top changed packed files
-
-| Packed file | Base | Current | Diff |
-|---|---:|---:|---:|
-${rows.join('\n')}
-`;
-}
-
-function formatMaybeBytes(value) {
-  return typeof value === 'number' ? formatBytes(value) : '-';
-}
-
-function formatDiff(base, current) {
-  return typeof base === 'number' ? formatSignedBytes(current - base) : '-';
-}
-
 function formatStartupBenchmarks(startup, baseStartup) {
   if (!startup) return '';
   const baseByName = new Map(
@@ -519,19 +339,6 @@ function formatMsDiff(base, current) {
 
 function formatMs(value) {
   return value < 1000 ? `${value.toFixed(1)} ms` : `${(value / 1000).toFixed(2)} s`;
-}
-
-function formatBytes(value) {
-  const absoluteValue = Math.abs(value);
-  if (absoluteValue < 1000) return `${value} B`;
-  if (absoluteValue < 1000 * 1000) return `${(value / 1000).toFixed(1)} kB`;
-  return `${(value / (1000 * 1000)).toFixed(2)} MB`;
-}
-
-function formatSignedBytes(value) {
-  if (value === 0) return '0 B';
-  const sign = value > 0 ? '+' : '-';
-  return `${sign}${formatBytes(Math.abs(value))}`;
 }
 
 function writeFile(filePath, contents) {
@@ -685,4 +492,4 @@ function isTransientGitHubStatus(status) {
   return status === 429 || status >= 500;
 }
 
-export { classifyNpmPackEntry, formatMarkdown, summarizeNpmPackComponents };
+export { formatMarkdown };

--- a/test/ci/size-workflow.test.ts
+++ b/test/ci/size-workflow.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const preservedReportDir = '/tmp/agent-device-size-report';
+
+type WorkflowStep = { name?: string; run?: string };
+type WorkflowDoc = {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+};
+
+function workflowStep(name: string): WorkflowStep {
+  const workflow = parse(
+    fs.readFileSync(path.join(repoRoot, '.github/workflows/size.yml'), 'utf8'),
+  ) as WorkflowDoc;
+  const step = workflow.jobs?.['bundle-size']?.steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    throw new Error(`size.yml must declare the ${JSON.stringify(name)} step`);
+  }
+  return step;
+}
+
+test('the preserved size reporter keeps its entrypoint and relative modules together', () => {
+  const preserve = workflowStep('Preserve report scripts').run ?? '';
+  const measureBase = workflowStep('Measure base size').run ?? '';
+
+  expect(preserve).toContain(`mkdir -p ${preservedReportDir}`);
+  expect(preserve).toContain(`cp scripts/size-report*.mjs ${preservedReportDir}/`);
+  expect(measureBase).toContain(`node ${preservedReportDir}/size-report.mjs`);
+
+  const reportSource = fs.readFileSync(path.join(repoRoot, 'scripts/size-report.mjs'), 'utf8');
+  const relativeModules = [...reportSource.matchAll(/from '\.\/(size-report-[^']+\.mjs)'/g)].map(
+    (match) => match[1],
+  );
+  expect(relativeModules.length).toBeGreaterThan(0);
+  for (const moduleName of relativeModules) {
+    if (!moduleName) throw new Error('relative size-report import has no module name');
+    expect(fs.existsSync(path.join(repoRoot, 'scripts', moduleName)), moduleName).toBe(true);
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,6 +97,9 @@ export default defineConfig({
             'scripts/__tests__/size-report-package.test.ts',
             // Parses CI configuration only, so this action guard needs no device or subprocess lane.
             'test/ci/upload-agent-device-artifacts.test.ts',
+            // The size reporter is preserved across a base checkout; its entrypoint and imported
+            // modules must move as one directory or the Bundle Size lane fails before measuring.
+            'test/ci/size-workflow.test.ts',
             // #1781 A9: pins the root-doc paths-ignore entries directly against the
             // real workflow YAML, parse-only like its sibling above.
             'test/ci/root-docs-paths-ignore.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -92,6 +92,9 @@ export default defineConfig({
             // The Bundle Size lane's PR-comment path: spawns the real script against a
             // stubbed fetch, so it needs no network; pins retry/reconcile/fatal outcomes.
             'scripts/__tests__/size-report-post-comment.test.ts',
+            // Package attribution is a pure npm-pack manifest model. Keep it in the fast lane so
+            // every new package path remains accounted for without building an archive.
+            'scripts/__tests__/size-report-package.test.ts',
             // Parses CI configuration only, so this action guard needs no device or subprocess lane.
             'test/ci/upload-agent-device-artifacts.test.ts',
             // #1781 A9: pins the root-doc paths-ignore entries directly against the


### PR DESCRIPTION
## Summary

- Attribute every byte from `npm pack --json` to JS/dist, the Apple runner, the macOS helper, Android helpers, or other package files. The report now fails if those components do not sum exactly to npm's unpacked size and shows the largest changed packed files.
- Keep the size workflow's base-commit comparison working with the extracted report modules, while keeping each reporting module below the repository's context-size threshold.
- Remove five declarations/parameters that clean Periphery builds identified as unused on iOS, macOS, tvOS, and visionOS. Test-only conveniences remain available to runner unit tests but are stripped from the shipped source package.

This is the tightening follow-up to the package-growth review around #1930. It does not change snapshot behavior or backend contracts. Scope is Apple runner source plus its package-size CI evidence.

## Validation

- Clean Periphery scans after packaging: iOS 8 platform-specific findings, macOS 89, tvOS 90, visionOS 78; the cross-platform intersection is now empty. Before the cleanup, the intersection contained the five declarations removed here.
- The real release-shaped local pack contained 388 files and 3,187,049 unpacked bytes: 2,503,862 JS/dist, 543,510 Apple runner, 54,545 macOS helper, 43,196 Android helpers, and 41,936 other. The component sum matched npm exactly.
- Focused reporting/package tests: 12 passed. XCTest selection reaches every declared test lane.
- iOS Simulator and macOS XCTest runner builds both completed with `TEST BUILD SUCCEEDED`.
- The size workflow's base-checkout reporter path has a red-first regression test and was also exercised through its exact copy-and-run shell entry point.
- `pnpm check:affected --run` passed on commit 5b014496f; GitHub-only lanes remain authoritative on this pushed head.

No docs or skills changed: this affects CI reporting and removes unreachable implementation surface without changing user-facing commands or guidance.
