### PR TITLE
fix(ios): make snapshot presentation construction private

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
@@ -1,6 +1,73 @@
 import Foundation
 
 enum SnapshotPresentation {
+  /// The only snapshot node shape accepted by response payload assembly.
+  ///
+  /// The encoded shape intentionally remains byte-for-byte compatible with the former
+  /// `SnapshotNode` wire model. Construction stays file-private to this presentation module:
+  /// acquisition backends can return `RawAXNode` values, but cannot recreate a presented node.
+  struct PresentedNode: Codable {
+    let index: Int
+    let type: String
+    let label: String?
+    let identifier: String?
+    let value: String?
+    let rect: SnapshotRect
+    let enabled: Bool
+    let focused: Bool?
+    let selected: Bool?
+    let hittable: Bool
+    let depth: Int
+    let parentIndex: Int?
+    let hiddenContentAbove: Bool?
+    let hiddenContentBelow: Bool?
+    let actions: [String]?
+
+    fileprivate init(presenting raw: RawAXNode) {
+      self.init(
+        presenting: raw,
+        rect: raw.rect,
+        index: raw.index,
+        depth: raw.depth,
+        parentIndex: raw.parentIndex
+      )
+    }
+
+    fileprivate init(presenting node: SnapshotPresentationNode) {
+      self.init(
+        presenting: node.raw,
+        rect: node.effectiveRect,
+        index: node.raw.index,
+        depth: node.raw.depth,
+        parentIndex: node.raw.parentIndex
+      )
+    }
+
+    fileprivate init(
+      presenting raw: RawAXNode,
+      rect: SnapshotRect,
+      index: Int,
+      depth: Int,
+      parentIndex: Int?
+    ) {
+      self.index = index
+      type = raw.type
+      label = raw.label
+      identifier = raw.identifier
+      value = raw.value
+      self.rect = rect
+      enabled = raw.enabled
+      focused = raw.focused
+      selected = raw.selected
+      hittable = raw.hittable
+      self.depth = depth
+      self.parentIndex = parentIndex
+      hiddenContentAbove = raw.hiddenContentAbove
+      hiddenContentBelow = raw.hiddenContentBelow
+      actions = raw.actions
+    }
+  }
+
   private static let eligibleInteractiveTypes: Set<String> = [
     "Button",
     "Cell",

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationModels.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationModels.swift
@@ -70,69 +70,7 @@ struct SnapshotAcquisition {
   let viewport: CGRect
 }
 
-/// The only snapshot node shape accepted by response payload assembly.
-///
-/// It has no memberwise initializer, so response assembly has to choose one of the explicit
-/// presentation constructors. The encoded shape intentionally remains byte-for-byte compatible
-/// with the former `SnapshotNode` wire model.
-struct PresentedNode: Codable {
-  let index: Int
-  let type: String
-  let label: String?
-  let identifier: String?
-  let value: String?
-  let rect: SnapshotRect
-  let enabled: Bool
-  let focused: Bool?
-  let selected: Bool?
-  let hittable: Bool
-  let depth: Int
-  let parentIndex: Int?
-  let hiddenContentAbove: Bool?
-  let hiddenContentBelow: Bool?
-  let actions: [String]?
-
-  init(presenting raw: RawAXNode) {
-    self.init(
-      presenting: raw,
-      rect: raw.rect,
-      index: raw.index,
-      depth: raw.depth,
-      parentIndex: raw.parentIndex
-    )
-  }
-
-  init(presenting node: SnapshotPresentationNode) {
-    self.init(
-      presenting: node.raw,
-      rect: node.effectiveRect,
-      index: node.raw.index,
-      depth: node.raw.depth,
-      parentIndex: node.raw.parentIndex
-    )
-  }
-
-  init(
-    presenting raw: RawAXNode,
-    rect: SnapshotRect,
-    index: Int,
-    depth: Int,
-    parentIndex: Int?
-  ) {
-    self.index = index
-    type = raw.type
-    label = raw.label
-    identifier = raw.identifier
-    value = raw.value
-    self.rect = rect
-    enabled = raw.enabled
-    focused = raw.focused
-    selected = raw.selected
-    hittable = raw.hittable
-    self.depth = depth
-    self.parentIndex = parentIndex
-    hiddenContentAbove = raw.hiddenContentAbove
-    hiddenContentBelow = raw.hiddenContentBelow
-    actions = raw.actions
-  }
-}
+/// Keep the wire payload's existing spelling while making the presented-node type owned by the
+/// presentation module. Its constructors live in `RunnerTests+SnapshotPresentation.swift` and are
+/// file-private there, so acquisition backends can carry a `PresentedNode` but cannot construct one.
+typealias PresentedNode = SnapshotPresentation.PresentedNode


### PR DESCRIPTION
## Summary

Related to #1797.

The merged #1930, #1931, and #1933 prerequisites establish backend conformance, effective geometry, and daemon-owned occlusion. This focused slice closes the remaining construction-boundary gap:

- Moves PresentedNode under SnapshotPresentation.
- Preserves the existing PresentedNode spelling at the payload boundary with a typealias.
- Makes all interpretation initializers fileprivate in RunnerTests+SnapshotPresentation.swift, so backend files can carry presentation output but cannot recreate it.

This PR does not touch the #1936 scanner or package-boundary files.

The broader #1797 obligations remain intentionally separate: the cumulative-clip choke and named quality downgrade, deterministic differential fixtures and multidimensional ratchets, nightly live differential wiring, cross-runtime golden conformance, and the visible-depth frontier.

## Validation

- Planted-red compiler proof: a temporary direct PresentedNode(presenting:) call in RunnerTests+PrivateAXPresentation.swift failed the macOS XCTest build at the backend source with the inaccessible-constructor diagnostic; removing that violation restored the build.
- Unit-enabled direct macOS XCTest build passed after the violation was removed.
- pnpm check:xctest-selection passed.
- pnpm check:affected --run passed with exit 0. The pre-existing untracked .codex/environments/ path caused the selector to fail open to the full runnable set; the rerun used process-table access required by the sandbox.
- pnpm build:xcuitest:macos passed.
- pnpm build:xcuitest:ios passed.