### PR TITLE
perf(ios): build structural-identifier suppression child index once per pass

### DIFF
--- a/src/daemon/snapshot-presentation/ios/noise.test.ts
+++ b/src/daemon/snapshot-presentation/ios/noise.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+
+import { collectIosStructuralIdentifierSuppression } from './noise.ts';
+import type { SnapshotTreeRuleContext } from '../tree.ts';
+
+type ReadCounter = { reads: number };
+
+function countingNode(base: RawSnapshotNode, counter: ReadCounter): RawSnapshotNode {
+  return {
+    ...base,
+    get index() {
+      counter.reads += 1;
+      return base.index;
+    },
+    get parentIndex(): number | undefined {
+      counter.reads += 1;
+      return base.parentIndex;
+    },
+  };
+}
+
+function makeStructuralTree(
+  candidateCount: number,
+  descendantsPerCandidate: number,
+): {
+  nodes: RawSnapshotNode[];
+  counter: ReadCounter;
+} {
+  const counter: ReadCounter = { reads: 0 };
+  const plain: RawSnapshotNode[] = [{ index: 0, type: 'Application', label: 'App' }];
+  let nextIndex = 1;
+  for (let candidate = 0; candidate < candidateCount; candidate += 1) {
+    const candidateIndex = nextIndex;
+    plain.push({
+      index: candidateIndex,
+      parentIndex: 0,
+      type: 'Other',
+      identifier: `wrapper-${candidate}`,
+    });
+    nextIndex += 1;
+    for (let descendant = 0; descendant < descendantsPerCandidate; descendant += 1) {
+      plain.push({
+        index: nextIndex,
+        parentIndex: candidateIndex,
+        type: 'StaticText',
+        label: `content ${candidate}-${descendant}`,
+      });
+      nextIndex += 1;
+    }
+  }
+  return { nodes: plain.map((node) => countingNode(node, counter)), counter };
+}
+
+function makeRuleContext(nodes: RawSnapshotNode[]): SnapshotTreeRuleContext {
+  return {
+    replacements: new Map(),
+    semanticRepresentativeIndexes: new Set(),
+    sourceNodesByIndex: new Map(nodes.map((node) => [node.index, node])),
+    isSuppressed: () => false,
+    suppressNode: () => {},
+  };
+}
+
+describe('collectIosStructuralIdentifierSuppression', () => {
+  test('suppresses structural identifier wrappers, keeping their content published', () => {
+    const { nodes } = makeStructuralTree(3, 2);
+    const suppressed: number[] = [];
+    const context: SnapshotTreeRuleContext = {
+      ...makeRuleContext(nodes),
+      suppressNode: (source) => suppressed.push(source.index),
+    };
+
+    collectIosStructuralIdentifierSuppression(nodes, context);
+
+    expect(suppressed.sort((a, b) => a - b)).toEqual([1, 4, 7]);
+  });
+
+  test('builds the child index once instead of per structural candidate', () => {
+    const candidateCount = 40;
+    const descendantsPerCandidate = 25;
+    const { nodes, counter } = makeStructuralTree(candidateCount, descendantsPerCandidate);
+    const nodeCount = nodes.length;
+
+    collectIosStructuralIdentifierSuppression(nodes, makeRuleContext(nodes));
+
+    // The per-candidate implementation rebuilds a full node map and walks an
+    // ancestor chain for every node once per candidate (~candidates x n
+    // reads); the child-index implementation reads each node a constant
+    // number of times plus one subtree pass per candidate. The bound sits far
+    // above the healthy cost and far below the quadratic one.
+    expect(counter.reads).toBeLessThan(
+      4 * nodeCount + 8 * candidateCount * descendantsPerCandidate,
+    );
+  });
+});

--- a/src/daemon/snapshot-presentation/ios/noise.ts
+++ b/src/daemon/snapshot-presentation/ios/noise.ts
@@ -10,7 +10,7 @@ import { normalizeType } from '@agent-device/contracts/snapshot';
 import { collectIosScrollIndicatorPresentation } from './scroll.ts';
 import {
   areRectsApproximatelyEqual,
-  collectDescendantsByParentIndex,
+  collectChildrenByParent,
   findDescendant,
   findLargestViewportRect,
   forEachDescendant,
@@ -302,10 +302,11 @@ function suppressOffscreenKeyboardAncestors(
   }
 }
 
-function collectIosStructuralIdentifierSuppression(
+export function collectIosStructuralIdentifierSuppression(
   nodes: RawSnapshotNode[],
   context: SnapshotTreeRuleContext,
 ): void {
+  const childrenByParent = collectChildrenByParent(nodes);
   for (const node of nodes) {
     if (normalizeType(node.type ?? '') !== 'other') {
       continue;
@@ -316,8 +317,26 @@ function collectIosStructuralIdentifierSuppression(
     if (!node.identifier?.trim()) {
       continue;
     }
-    context.suppressNode(node, collectDescendantsByParentIndex(nodes, node.index));
+    context.suppressNode(node, collectSubtreeByParentLinks(node, childrenByParent));
   }
+}
+
+function collectSubtreeByParentLinks(
+  root: RawSnapshotNode,
+  childrenByParent: ReadonlyMap<number, RawSnapshotNode[]>,
+): RawSnapshotNode[] {
+  const descendants: RawSnapshotNode[] = [];
+  const visited = new Set<number>([root.index]);
+  const pending = [...(childrenByParent.get(root.index) ?? [])];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || visited.has(current.index)) continue;
+    visited.add(current.index);
+    descendants.push(current);
+    const children = childrenByParent.get(current.index);
+    if (children) pending.push(...children);
+  }
+  return descendants;
 }
 
 function collectIosSearchToolbarSuppression(

--- a/src/daemon/snapshot-presentation/tree.ts
+++ b/src/daemon/snapshot-presentation/tree.ts
@@ -35,23 +35,6 @@ export function collectDescendants(
   return nodes.slice(startPosition + 1, endPosition);
 }
 
-export function collectDescendantsByParentIndex(
-  nodes: RawSnapshotNode[],
-  ancestorIndex: number,
-): RawSnapshotNode[] {
-  const byIndex = new Map(nodes.map((node) => [node.index, node]));
-  return nodes.filter((node) => {
-    let parentIndex = node.parentIndex;
-    const visited = new Set<number>();
-    while (typeof parentIndex === 'number' && !visited.has(parentIndex)) {
-      if (parentIndex === ancestorIndex) return true;
-      visited.add(parentIndex);
-      parentIndex = byIndex.get(parentIndex)?.parentIndex;
-    }
-    return false;
-  });
-}
-
 export function findDescendant(
   nodes: RawSnapshotNode[],
   startPosition: number,


### PR DESCRIPTION
## Summary

Every iOS snapshot paid an O(candidates × n × d) cost in structural-identifier suppression: for each identifier-only `Other` wrapper, `collectDescendantsByParentIndex` rebuilt a full node map and walked every node's ancestor chain. On large RN/XCUITest trees with many testID-shaped containers this is millions of visits per snapshot — pure CPU on the highest-frequency output path.

Suppression now collects descendants via one `childrenByParent` index built per pass (BFS from each candidate), preserving exact parent-link semantics — including trees whose nodes carry no `depth` field, where depth-order-based subtree slicing would be wrong. The single-caller helper `collectDescendantsByParentIndex` is removed.

No behavior change; snapshot output is byte-identical.

## Validation

- Property check: old vs new descendant collection agree on 2,000 random well-formed depth-ordered trees across all positions.
- Full unit bundle green at the pushed commit (`pnpm test:unit`, 7,417 tests), including the iOS presentation suite and the Maestro port-observation tests that pin suppression behavior for depth-less fixture trees.
- Residual risk: iOS snapshot presentation is a device-facing path and this run is fixture-backed only; no live simulator capture was taken for this refactor. The change is semantics-preserving by construction and the presentation suite pins the affected rule.