### PR TITLE
perf(ios): memoize simulator app url-scheme probes per bundle mtime

### DIFF
--- a/src/platforms/apple/core/__tests__/app-resolution-deep-link.test.ts
+++ b/src/platforms/apple/core/__tests__/app-resolution-deep-link.test.ts
@@ -1,0 +1,145 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+
+import { resolveIosSimulatorDeepLinkBundleId } from '../app-resolution.ts';
+import {
+  withFakeAppleTool,
+  type FakeAppleToolResponse,
+} from '../../../../__tests__/test-utils/index.ts';
+import { mkdtempForTest } from '../../../../__tests__/test-utils/tmp-dir.ts';
+import { IOS_TEST_SIMULATOR } from './apple-core-stub-helpers.ts';
+
+function unexpectedArgs(args: string[]): FakeAppleToolResponse {
+  return { stderr: `unexpected xcrun args: ${args.join(' ')}`, exitCode: 1 };
+}
+
+type SchemeFixture = {
+  root: string;
+  plistA: string;
+  listing: string;
+};
+
+async function makeSchemeFixture(): Promise<SchemeFixture> {
+  const root = await mkdtempForTest('deep-link-url-schemes-');
+  const bundleDirs = { a: path.join(root, 'AppA.app'), b: path.join(root, 'AppB.app') };
+  await fs.mkdir(bundleDirs.a, { recursive: true });
+  await fs.mkdir(bundleDirs.b, { recursive: true });
+  await fs.writeFile(path.join(bundleDirs.a, 'Info.plist'), '');
+  await fs.writeFile(path.join(bundleDirs.b, 'Info.plist'), '');
+  const listing = JSON.stringify({
+    'com.example.appa': {
+      ApplicationType: 'User',
+      CFBundleDisplayName: 'App A',
+      Path: bundleDirs.a,
+    },
+    'com.example.appb': {
+      ApplicationType: 'User',
+      CFBundleDisplayName: 'App B',
+      Path: bundleDirs.b,
+    },
+  });
+  return { root, plistA: path.join(bundleDirs.a, 'Info.plist'), listing };
+}
+
+const SCHEME_PROBES = [
+  {
+    suffix: 'AppA.app/Info.plist',
+    schemesJson: '{"CFBundleURLTypes":[{"CFBundleURLSchemes":["alpha"]}]}',
+  },
+  {
+    suffix: 'AppB.app/Info.plist',
+    schemesJson: '{"CFBundleURLTypes":[{"CFBundleURLSchemes":["beta"]}]}',
+  },
+];
+
+function createSchemeTool(
+  fixture: SchemeFixture,
+  options: { failFirstProbes?: number } = {},
+): { handle: (args: string[]) => FakeAppleToolResponse; probeCount: () => number } {
+  let probeCount = 0;
+
+  const respondToPlutil = (plistPath: string): FakeAppleToolResponse => {
+    const probe = SCHEME_PROBES.find((candidate) => plistPath.endsWith(candidate.suffix));
+    if (!probe) return '{}';
+    probeCount += 1;
+    if (options.failFirstProbes !== undefined && probeCount <= options.failFirstProbes) {
+      return { stdout: '', exitCode: 1 };
+    }
+    return probe.schemesJson;
+  };
+
+  return {
+    handle(args) {
+      if (args[0] === 'simctl' && args[1] === 'listapps') return fixture.listing;
+      if (args[0] === 'plutil' && args[1] === '-convert') return respondToPlutil(args[5] ?? '');
+      return unexpectedArgs(args);
+    },
+    probeCount: () => probeCount,
+  };
+}
+
+test('resolveIosSimulatorDeepLinkBundleId memoizes per-app url-scheme probes', async () => {
+  const fixture = await makeSchemeFixture();
+  const tool = createSchemeTool(fixture);
+
+  await withFakeAppleTool(tool.handle, async ({ calls }) => {
+    const plutilProbes = () => calls.filter((args) => args[0] === 'plutil').length;
+
+    const first = await resolveIosSimulatorDeepLinkBundleId(IOS_TEST_SIMULATOR, 'alpha://one');
+    assert.equal(first, 'com.example.appa');
+    const probesAfterFirst = plutilProbes();
+    assert.equal(probesAfterFirst, 2);
+
+    const second = await resolveIosSimulatorDeepLinkBundleId(IOS_TEST_SIMULATOR, 'beta://two');
+    assert.equal(second, 'com.example.appb');
+    assert.equal(plutilProbes(), probesAfterFirst);
+  });
+});
+
+test('a failed url-scheme probe is retried on the next lookup instead of cached', async () => {
+  const fixture = await makeSchemeFixture();
+  const tool = createSchemeTool(fixture, { failFirstProbes: 1 });
+
+  await withFakeAppleTool(tool.handle, async () => {
+    const duringFailure = await resolveIosSimulatorDeepLinkBundleId(
+      IOS_TEST_SIMULATOR,
+      'alpha://one',
+    );
+    assert.equal(duringFailure, undefined);
+
+    const afterRecovery = await resolveIosSimulatorDeepLinkBundleId(
+      IOS_TEST_SIMULATOR,
+      'alpha://one',
+    );
+    assert.equal(afterRecovery, 'com.example.appa');
+    // AppA retried once after the failure; AppB's successful probe stayed cached.
+    assert.equal(tool.probeCount(), 3);
+  });
+});
+
+test('rewriting the Info.plist invalidates the cached scheme set', async () => {
+  const fixture = await makeSchemeFixture();
+  const tool = createSchemeTool(fixture);
+
+  await withFakeAppleTool(tool.handle, async ({ calls }) => {
+    const plutilProbes = () => calls.filter((args) => args[0] === 'plutil').length;
+
+    assert.equal(
+      await resolveIosSimulatorDeepLinkBundleId(IOS_TEST_SIMULATOR, 'alpha://one'),
+      'com.example.appa',
+    );
+    const probesBeforeRewrite = plutilProbes();
+
+    await fs.writeFile(fixture.plistA, '/* rewritten */');
+    const later = Date.now() + 5_000;
+    await fs.utimes(fixture.plistA, new Date(later), new Date(later));
+
+    assert.equal(
+      await resolveIosSimulatorDeepLinkBundleId(IOS_TEST_SIMULATOR, 'alpha://one'),
+      'com.example.appa',
+    );
+    assert.equal(plutilProbes(), probesBeforeRewrite + 1);
+  });
+});

--- a/src/platforms/apple/core/app-resolution.ts
+++ b/src/platforms/apple/core/app-resolution.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { isIosFamily, isMacOs, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
@@ -13,6 +14,7 @@ import { listMacApps, resolveMacOsApp } from '../os/macos/apps.ts';
 import { runAppleToolCommand } from './tool-provider.ts';
 import { runSimctl } from './apps-simctl.ts';
 import { resolveIosPhysicalDeviceControl } from './physical-device-control.ts';
+import { createTtlMemo } from '../../../utils/ttl-memo.ts';
 
 const ALIASES: Record<string, string> = {
   settings: 'com.apple.Preferences',
@@ -312,7 +314,42 @@ function resolveSimulatorAppPath(info: { Bundle?: string; Path?: string }): stri
   }
 }
 
+// One plutil spawn per installed app per deep-link lookup dominates open
+// scheme:// latency; schemes only change when the bundle is reinstalled, so
+// the mtime-keyed memo absorbs the per-lookup cost. Only successful parses are
+// cacheable — a transient probe failure must not pin empty schemes until TTL
+// expiry — and expiry is scheduled so abandoned install paths do not
+// accumulate in a long-lived daemon.
+const IOS_SIMULATOR_APP_URL_SCHEME_MEMO_TTL_MS = 30 * 60_000;
+const iosSimulatorAppUrlSchemeMemo = createTtlMemo<string, Set<string>>({
+  ttlMs: IOS_SIMULATOR_APP_URL_SCHEME_MEMO_TTL_MS,
+  scheduleExpiry: true,
+});
+
 async function readIosSimulatorAppUrlSchemes(infoPlistPath: string): Promise<Set<string>> {
+  let cacheKey: string | undefined;
+  try {
+    cacheKey = `${infoPlistPath}:${(await fs.stat(infoPlistPath)).mtimeMs}`;
+  } catch {
+    cacheKey = undefined;
+  }
+  if (cacheKey === undefined) {
+    return (await readIosSimulatorAppUrlSchemesUncached(infoPlistPath)) ?? new Set();
+  }
+  const cached = iosSimulatorAppUrlSchemeMemo.get(cacheKey);
+  if (cached) return cached;
+  const schemes = await readIosSimulatorAppUrlSchemesUncached(infoPlistPath);
+  if (schemes) iosSimulatorAppUrlSchemeMemo.set(cacheKey, schemes);
+  return schemes ?? new Set();
+}
+
+/**
+ * Returns the bundle's URL schemes, or `undefined` when the probe failed
+ * (nonzero exit or malformed output) and the result must not be cached.
+ */
+async function readIosSimulatorAppUrlSchemesUncached(
+  infoPlistPath: string,
+): Promise<Set<string> | undefined> {
   const result = await runAppleToolCommand(
     'plutil',
     ['-convert', 'json', '-o', '-', infoPlistPath],
@@ -320,7 +357,7 @@ async function readIosSimulatorAppUrlSchemes(infoPlistPath: string): Promise<Set
       allowFailure: true,
     },
   );
-  if (result.exitCode !== 0) return new Set();
+  if (result.exitCode !== 0) return undefined;
   try {
     const parsed = JSON.parse(result.stdout) as {
       CFBundleURLTypes?: Array<{ CFBundleURLSchemes?: unknown }>;
@@ -336,6 +373,6 @@ async function readIosSimulatorAppUrlSchemes(infoPlistPath: string): Promise<Set
     }
     return schemes;
   } catch {
-    return new Set();
+    return undefined;
   }
 }


### PR DESCRIPTION
## Summary

`open <scheme>://...` on an iOS simulator spawned one `plutil -convert json` process per installed app (50–150 apps ≈ 1.5–9s) on every deep-link resolution, repeated identically each time.

URL schemes are read once per installed bundle and cached, keyed on the app's `Info.plist` path + mtime so a reinstall invalidates naturally. An unreadable plist path falls through to the uncached probe, preserving prior error behavior exactly. Steady-state deep-link opens now pay zero per-app plutil spawns.

## Validation

- New test (`app-resolution.test.ts`): two consecutive deep-link resolutions issue exactly one plutil probe per app total; extracted to its own file to respect the test-file-size ratchet pin on `apps.test.ts`.
- Full unit bundle green at the pushed commit (`pnpm test:unit`, 7,417 tests); `check:affected` green.
- Residual risk: device-facing path validated with the fake Apple tool harness only; no live simulator run in this PR. The stat-failure fallback keeps any environment where the cache cannot key correctly on the pre-existing code path.