### PR TITLE
fix(web): read enabled=false from the snapshot [disabled] annotation

### DIFF
--- a/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
+++ b/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeAgentBrowserSnapshot } from '../agent-browser-snapshot.ts';
+
+describe('normalizeAgentBrowserSnapshot', () => {
+  test('marks nodes disabled from the [disabled] text annotation', async () => {
+    const result = await normalizeAgentBrowserSnapshot({
+      snapshot: [
+        '- generic',
+        '  - button "Enabled Button" [ref=e1]',
+        '  - button "Disabled Button" [disabled, ref=e2]',
+        '  - link "Aria Disabled" [disabled, ref=e3]',
+      ].join('\n'),
+      refs: {
+        e1: { name: 'Enabled Button', role: 'button' },
+        e2: { name: 'Disabled Button', role: 'button' },
+        e3: { name: 'Aria Disabled', role: 'link' },
+      },
+    });
+
+    expect(result.nodes.map((node) => node.enabled)).toEqual([undefined, false, false]);
+  });
+
+  test('does not read disabled from bracket-like text inside labels', async () => {
+    const result = await normalizeAgentBrowserSnapshot({
+      snapshot: '  - button "Shows [disabled] in its label" [ref=e1]',
+      refs: { e1: { name: 'Shows [disabled] in its label', role: 'button' } },
+    });
+
+    expect(result.nodes[0]?.enabled).toBeUndefined();
+    expect(result.nodes[0]?.label).toBe('Shows [disabled] in its label');
+  });
+
+  test('metadata enabled still wins over the text annotation', async () => {
+    const result = await normalizeAgentBrowserSnapshot({
+      snapshot: '  - button "Odd" [disabled, ref=e1]',
+      refs: { e1: { name: 'Odd', role: 'button', enabled: true } },
+    });
+
+    expect(result.nodes[0]?.enabled).toBe(true);
+  });
+});

--- a/src/platforms/web/agent-browser-snapshot.ts
+++ b/src/platforms/web/agent-browser-snapshot.ts
@@ -95,7 +95,9 @@ function snapshotNodeFromLine(
     label: extractQuotedText(line) ?? readMetadataString(metadata, ['label', 'name', 'text']),
     value: extractValue(line) ?? readMetadataString(metadata, ['value']),
     depth,
-    enabled: readMetadataBoolean(metadata, ['enabled']),
+    enabled:
+      readMetadataBoolean(metadata, ['enabled']) ??
+      (isLineMarkedDisabled(line) ? false : undefined),
     focused: readMetadataBoolean(metadata, ['focused']),
   };
 }
@@ -164,6 +166,11 @@ function extractRole(line: string): string | undefined {
 
 function extractQuotedText(line: string): string | undefined {
   return line.match(/"([^"]+)"/)?.[1] ?? line.match(/'([^']+)'/)?.[1];
+}
+
+function isLineMarkedDisabled(line: string): boolean {
+  const withoutQuotedText = line.replace(/"[^"]*"/g, '').replace(/'[^']*'/g, '');
+  return /\[[^\]]*\bdisabled\b[^\]]*\]/i.test(withoutQuotedText);
 }
 
 function extractValue(line: string): string | undefined {


### PR DESCRIPTION
## Summary

Web snapshot nodes never reported `enabled: false`. The agent-browser refs payload carries only `role` + `name`, and the `[disabled]` bracket annotation in the snapshot text — emitted for both the `disabled` attribute and `aria-disabled` — went unparsed, so every node's `enabled`/`focused` was silently `undefined`.

The parser now reads `enabled: false` from the bracket annotation. Quoted label text is stripped before scanning, so a literal "[disabled]" inside a label does not flip the flag; explicit refs metadata still wins when present.

Focus state is not emitted anywhere by the pinned agent-browser backend (verified against the live binary — no marker appears even on a focused element), so `focused` remains metadata-only; recovering it needs an upstream change.

Before:
```
- button "Disabled Button" [disabled, ref=e2]   → enabled: undefined
```
After:
```
- button "Disabled Button" [disabled, ref=e2]   → enabled: false
```

## Validation

- Red-first test observed against pre-fix code (`[disabled, ref=e2]` yielded `undefined`), green after.
- Snapshot text format verified against the real pinned agent-browser binary with a fixture page covering `disabled`, `aria-disabled`, focused input, and label-containing-brackets cases.
- Full web platform suite green (29 tests); `check:affected` green at the pushed commit.