### PR TITLE
refactor(recording): share the AVFoundation export pipeline between overlay and trim

### DIFF
--- a/apple/runner/AgentDeviceRunner/RecordingScripts/RecordingExportSupport.swift
+++ b/apple/runner/AgentDeviceRunner/RecordingScripts/RecordingExportSupport.swift
@@ -1,0 +1,111 @@
+import AVFoundation
+import Foundation
+
+/// Shared mechanics for the recording post-processing scripts (overlay burn-in, start trim).
+/// Each script keeps its own argument grammar and export-quality policy; this file owns the
+/// error vocabulary, flag-value reading, composition assembly, and the bounded export wait.
+
+enum RecordingScriptError: Error, CustomStringConvertible {
+  case invalidArgs(String)
+  case invalidTrimRange
+  case missingVideoTrack
+  case exportFailed(String)
+
+  var description: String {
+    switch self {
+    case .invalidArgs(let message):
+      return message
+    case .invalidTrimRange:
+      return "Trim start must be before the end of the recording."
+    case .missingVideoTrack:
+      return "Input video does not contain a video track."
+    case .exportFailed(let message):
+      return message
+    }
+  }
+}
+
+func recordingOptionValue(_ arguments: [String], _ nextIndex: Int, _ flag: String) throws -> String {
+  guard nextIndex < arguments.count else {
+    throw RecordingScriptError.invalidArgs("\(flag) requires a value")
+  }
+  return arguments[nextIndex]
+}
+
+func removeStaleOutput(_ outputURL: URL) throws {
+  if FileManager.default.fileExists(atPath: outputURL.path) {
+    try FileManager.default.removeItem(at: outputURL)
+  }
+}
+
+func sourceVideoTrack(of asset: AVURLAsset) throws -> AVAssetTrack {
+  guard let track = asset.tracks(withMediaType: .video).first else {
+    throw RecordingScriptError.missingVideoTrack
+  }
+  return track
+}
+
+/// Copies `videoTrack` for `timeRange` into a fresh composition, carrying the optional audio track
+/// along when present. The caller owns any `preferredTransform` policy: trim propagates the source
+/// transform directly, while overlay re-applies it through a video-composition layer instruction
+/// instead.
+func makeRecordingComposition(
+  asset: AVURLAsset,
+  videoTrack: AVAssetTrack,
+  timeRange: CMTimeRange
+) throws -> AVMutableComposition {
+  let composition = AVMutableComposition()
+  guard let compositionVideoTrack = composition.addMutableTrack(
+    withMediaType: .video,
+    preferredTrackID: kCMPersistentTrackID_Invalid
+  ) else {
+    throw RecordingScriptError.exportFailed("Failed to create composition video track.")
+  }
+  try compositionVideoTrack.insertTimeRange(timeRange, of: videoTrack, at: .zero)
+
+  if let sourceAudioTrack = asset.tracks(withMediaType: .audio).first,
+     let compositionAudioTrack = composition.addMutableTrack(
+       withMediaType: .audio,
+       preferredTrackID: kCMPersistentTrackID_Invalid
+     ) {
+    try? compositionAudioTrack.insertTimeRange(timeRange, of: sourceAudioTrack, at: .zero)
+  }
+  return composition
+}
+
+func makeRecordingExporter(
+  _ composition: AVAsset,
+  presetName: String,
+  outputURL: URL,
+  videoComposition: AVMutableVideoComposition? = nil
+) throws -> AVAssetExportSession {
+  guard let exporter = AVAssetExportSession(asset: composition, presetName: presetName) else {
+    throw RecordingScriptError.exportFailed("Failed to create export session.")
+  }
+  exporter.outputURL = outputURL
+  exporter.outputFileType = .mp4
+  exporter.videoComposition = videoComposition
+  exporter.shouldOptimizeForNetworkUse = true
+  return exporter
+}
+
+/// Bounded asynchronous export: signals completion through a semaphore and cancels after 120s so a
+/// wedged encoder cannot hang the recording pipeline past the caller's own timeout budget.
+func runRecordingExport(
+  _ exporter: AVAssetExportSession,
+  timeoutMessage: String,
+  failureMessage: String
+) throws {
+  let semaphore = DispatchSemaphore(value: 0)
+  exporter.exportAsynchronously {
+    semaphore.signal()
+  }
+  if semaphore.wait(timeout: .now() + 120) == .timedOut {
+    exporter.cancelExport()
+    throw RecordingScriptError.exportFailed(timeoutMessage)
+  }
+
+  if exporter.status != .completed {
+    throw RecordingScriptError.exportFailed(exporter.error?.localizedDescription ?? failureMessage)
+  }
+}

--- a/apple/runner/AgentDeviceRunner/RecordingScripts/recording-overlay.swift
+++ b/apple/runner/AgentDeviceRunner/RecordingScripts/recording-overlay.swift
@@ -35,11 +35,18 @@ enum ExportQuality: String {
   case high
 }
 
-do {
-  try run()
-} catch {
-  fputs("recording-overlay: \(error)\n", stderr)
-  exit(1)
+/// Entry point: `@main` because multi-file swiftc compilation reserves top-level statements for
+/// `main.swift`, which cannot be shared per-script.
+@main
+enum RecordingOverlay {
+  static func main() {
+    do {
+      try run()
+    } catch {
+      fputs("recording-overlay: \(error)\n", stderr)
+      exit(1)
+    }
+  }
 }
 
 func run() throws {
@@ -123,32 +130,17 @@ func run() throws {
   // while avoiding very slow highest-quality exports. Pass --quality high to opt into
   // the slower highest-quality export.
   let presetName = exportPresetName(for: parsedArgs.exportQuality, compatibleWith: composition)
-  guard let exporter = AVAssetExportSession(asset: composition, presetName: presetName) else {
-    throw OverlayError.exportFailed("Failed to create export session.")
-  }
-
-  exporter.outputURL = outputURL
-  exporter.outputFileType = .mp4
-  exporter.videoComposition = videoComposition
-  exporter.shouldOptimizeForNetworkUse = true
-
-  let semaphore = DispatchSemaphore(value: 0)
-  exporter.exportAsynchronously {
-    semaphore.signal()
-  }
-  if semaphore.wait(timeout: .now() + 120) == .timedOut {
-    exporter.cancelExport()
-    throw OverlayError.exportFailed("Touch overlay export timed out.")
-  }
-
-  if exporter.status != .completed {
-    throw OverlayError.exportFailed(exporter.error?.localizedDescription ?? "Touch overlay export failed.")
-  }
-}
-
-enum ExportQuality: String {
-  case medium
-  case high
+  let exporter = try makeRecordingExporter(
+    composition,
+    presetName: presetName,
+    outputURL: outputURL,
+    videoComposition: videoComposition
+  )
+  try runRecordingExport(
+    exporter,
+    timeoutMessage: "Touch overlay export timed out.",
+    failureMessage: "Touch overlay export failed."
+  )
 }
 
 func parseArguments(

--- a/apple/runner/AgentDeviceRunner/RecordingScripts/recording-overlay.swift
+++ b/apple/runner/AgentDeviceRunner/RecordingScripts/recording-overlay.swift
@@ -30,21 +30,9 @@ struct GestureEvent: Decodable {
   let edge: String?
 }
 
-enum OverlayError: Error, CustomStringConvertible {
-  case invalidArgs(String)
-  case missingVideoTrack
-  case exportFailed(String)
-
-  var description: String {
-    switch self {
-    case .invalidArgs(let message):
-      return message
-    case .missingVideoTrack:
-      return "Input video does not contain a video track."
-    case .exportFailed(let message):
-      return message
-    }
-  }
+enum ExportQuality: String {
+  case medium
+  case high
 }
 
 do {
@@ -61,9 +49,7 @@ func run() throws {
   let outputURL = URL(fileURLWithPath: parsedArgs.outputPath)
   let eventsURL = URL(fileURLWithPath: parsedArgs.eventsPath)
 
-  if FileManager.default.fileExists(atPath: outputURL.path) {
-    try FileManager.default.removeItem(at: outputURL)
-  }
+  try removeStaleOutput(outputURL)
 
   let payload = try Data(contentsOf: eventsURL)
   let envelope = try JSONDecoder().decode(GestureEnvelope.self, from: payload)
@@ -74,27 +60,15 @@ func run() throws {
   }
 
   let asset = AVURLAsset(url: inputURL)
-  guard let sourceVideoTrack = asset.tracks(withMediaType: .video).first else {
-    throw OverlayError.missingVideoTrack
-  }
-
-  let composition = AVMutableComposition()
-  guard let compositionVideoTrack = composition.addMutableTrack(
-    withMediaType: .video,
-    preferredTrackID: kCMPersistentTrackID_Invalid
-  ) else {
-    throw OverlayError.exportFailed("Failed to create composition video track.")
-  }
-
+  let sourceVideoTrack = try sourceVideoTrack(of: asset)
   let fullRange = CMTimeRange(start: .zero, duration: asset.duration)
-  try compositionVideoTrack.insertTimeRange(fullRange, of: sourceVideoTrack, at: .zero)
-
-  if let sourceAudioTrack = asset.tracks(withMediaType: .audio).first,
-     let compositionAudioTrack = composition.addMutableTrack(
-       withMediaType: .audio,
-       preferredTrackID: kCMPersistentTrackID_Invalid
-     ) {
-    try? compositionAudioTrack.insertTimeRange(fullRange, of: sourceAudioTrack, at: .zero)
+  let composition = try makeRecordingComposition(
+    asset: asset,
+    videoTrack: sourceVideoTrack,
+    timeRange: fullRange
+  )
+  guard let compositionVideoTrack = composition.tracks(withMediaType: .video).first else {
+    throw RecordingScriptError.exportFailed("Failed to create composition video track.")
   }
 
   let renderSize = resolvedRenderSize(for: sourceVideoTrack)
@@ -193,33 +167,28 @@ func parseArguments(
     let nextIndex = index + 1
     switch argument {
     case "--input":
-      guard nextIndex < arguments.count else { throw OverlayError.invalidArgs("--input requires a value") }
-      inputPath = arguments[nextIndex]
+      inputPath = try recordingOptionValue(arguments, nextIndex, "--input")
       index += 2
     case "--output":
-      guard nextIndex < arguments.count else { throw OverlayError.invalidArgs("--output requires a value") }
-      outputPath = arguments[nextIndex]
+      outputPath = try recordingOptionValue(arguments, nextIndex, "--output")
       index += 2
     case "--events":
-      guard nextIndex < arguments.count else { throw OverlayError.invalidArgs("--events requires a value") }
-      eventsPath = arguments[nextIndex]
+      eventsPath = try recordingOptionValue(arguments, nextIndex, "--events")
       index += 2
     case "--quality":
-      guard nextIndex < arguments.count else {
-        throw OverlayError.invalidArgs("--quality requires a value")
-      }
-      guard let parsed = ExportQuality(rawValue: arguments[nextIndex]) else {
-        throw OverlayError.invalidArgs("--quality must be one of: medium, high")
+      let rawValue = try recordingOptionValue(arguments, nextIndex, "--quality")
+      guard let parsed = ExportQuality(rawValue: rawValue) else {
+        throw RecordingScriptError.invalidArgs("--quality must be one of: medium, high")
       }
       exportQuality = parsed
       index += 2
     default:
-      throw OverlayError.invalidArgs("Unknown argument: \(argument)")
+      throw RecordingScriptError.invalidArgs("Unknown argument: \(argument)")
     }
   }
 
   guard let inputPath, let outputPath, let eventsPath else {
-    throw OverlayError.invalidArgs(
+    throw RecordingScriptError.invalidArgs(
       "Usage: recording-overlay.swift --input <video> --output <video> --events <json> [--quality <medium|high>]"
     )
   }

--- a/apple/runner/AgentDeviceRunner/RecordingScripts/recording-trim.swift
+++ b/apple/runner/AgentDeviceRunner/RecordingScripts/recording-trim.swift
@@ -1,26 +1,6 @@
 import AVFoundation
 import Foundation
 
-enum TrimError: Error, CustomStringConvertible {
-  case invalidArgs(String)
-  case invalidTrimRange
-  case missingVideoTrack
-  case exportFailed(String)
-
-  var description: String {
-    switch self {
-    case .invalidArgs(let message):
-      return message
-    case .invalidTrimRange:
-      return "Trim start must be before the end of the recording."
-    case .missingVideoTrack:
-      return "Input video does not contain a video track."
-    case .exportFailed(let message):
-      return message
-    }
-  }
-}
-
 do {
   try run()
 } catch {
@@ -34,69 +14,39 @@ func run() throws {
   let inputURL = URL(fileURLWithPath: parsedArgs.inputPath)
   let outputURL = URL(fileURLWithPath: parsedArgs.outputPath)
 
-  if FileManager.default.fileExists(atPath: outputURL.path) {
-    try FileManager.default.removeItem(at: outputURL)
-  }
+  try removeStaleOutput(outputURL)
 
   let asset = AVURLAsset(url: inputURL)
-  guard let sourceVideoTrack = asset.tracks(withMediaType: .video).first else {
-    throw TrimError.missingVideoTrack
-  }
-
+  let videoTrack = try sourceVideoTrack(of: asset)
   let trimStart = CMTime(seconds: parsedArgs.trimStartMs / 1000.0, preferredTimescale: 600)
   guard CMTimeCompare(trimStart, asset.duration) < 0 else {
-    throw TrimError.invalidTrimRange
+    throw RecordingScriptError.invalidTrimRange
   }
 
   let trimmedDuration = CMTimeSubtract(asset.duration, trimStart)
   guard CMTimeCompare(trimmedDuration, .zero) > 0 else {
-    throw TrimError.invalidTrimRange
+    throw RecordingScriptError.invalidTrimRange
   }
 
-  let composition = AVMutableComposition()
-  let trimmedRange = CMTimeRange(start: trimStart, duration: trimmedDuration)
+  let composition = try makeRecordingComposition(
+    asset: asset,
+    videoTrack: videoTrack,
+    timeRange: CMTimeRange(start: trimStart, duration: trimmedDuration)
+  )
+  composition.tracks(withMediaType: .video).first?.preferredTransform = videoTrack.preferredTransform
 
-  guard let compositionVideoTrack = composition.addMutableTrack(
-    withMediaType: .video,
-    preferredTrackID: kCMPersistentTrackID_Invalid
-  ) else {
-    throw TrimError.exportFailed("Failed to create composition video track.")
-  }
-  try compositionVideoTrack.insertTimeRange(trimmedRange, of: sourceVideoTrack, at: .zero)
-  compositionVideoTrack.preferredTransform = sourceVideoTrack.preferredTransform
-
-  if let sourceAudioTrack = asset.tracks(withMediaType: .audio).first,
-     let compositionAudioTrack = composition.addMutableTrack(
-       withMediaType: .audio,
-       preferredTrackID: kCMPersistentTrackID_Invalid
-     ) {
-    try? compositionAudioTrack.insertTimeRange(trimmedRange, of: sourceAudioTrack, at: .zero)
-  }
-
+  // Passthrough keeps the trim lossless when the composition supports it; otherwise re-encode at
+  // highest quality.
   let presetName = AVAssetExportSession.exportPresets(compatibleWith: composition)
     .contains(AVAssetExportPresetPassthrough)
     ? AVAssetExportPresetPassthrough
     : AVAssetExportPresetHighestQuality
-  guard let exporter = AVAssetExportSession(asset: composition, presetName: presetName) else {
-    throw TrimError.exportFailed("Failed to create export session.")
-  }
-
-  exporter.outputURL = outputURL
-  exporter.outputFileType = .mp4
-  exporter.shouldOptimizeForNetworkUse = true
-
-  let semaphore = DispatchSemaphore(value: 0)
-  exporter.exportAsynchronously {
-    semaphore.signal()
-  }
-  if semaphore.wait(timeout: .now() + 120) == .timedOut {
-    exporter.cancelExport()
-    throw TrimError.exportFailed("Trim export timed out.")
-  }
-
-  if exporter.status != .completed {
-    throw TrimError.exportFailed(exporter.error?.localizedDescription ?? "Trim export failed.")
-  }
+  let exporter = try makeRecordingExporter(composition, presetName: presetName, outputURL: outputURL)
+  try runRecordingExport(
+    exporter,
+    timeoutMessage: "Trim export timed out.",
+    failureMessage: "Trim export failed."
+  )
 }
 
 func parseArguments(_ arguments: [String]) throws -> (inputPath: String, outputPath: String, trimStartMs: Double) {
@@ -110,29 +60,25 @@ func parseArguments(_ arguments: [String]) throws -> (inputPath: String, outputP
     let nextIndex = index + 1
     switch argument {
     case "--input":
-      guard nextIndex < arguments.count else { throw TrimError.invalidArgs("--input requires a value") }
-      inputPath = arguments[nextIndex]
+      inputPath = try recordingOptionValue(arguments, nextIndex, "--input")
       index += 2
     case "--output":
-      guard nextIndex < arguments.count else { throw TrimError.invalidArgs("--output requires a value") }
-      outputPath = arguments[nextIndex]
+      outputPath = try recordingOptionValue(arguments, nextIndex, "--output")
       index += 2
     case "--trim-start-ms":
-      guard nextIndex < arguments.count else {
-        throw TrimError.invalidArgs("--trim-start-ms requires a value")
-      }
-      guard let parsed = Double(arguments[nextIndex]), parsed >= 0 else {
-        throw TrimError.invalidArgs("--trim-start-ms must be a non-negative number")
+      let rawValue = try recordingOptionValue(arguments, nextIndex, "--trim-start-ms")
+      guard let parsed = Double(rawValue), parsed >= 0 else {
+        throw RecordingScriptError.invalidArgs("--trim-start-ms must be a non-negative number")
       }
       trimStartMs = parsed
       index += 2
     default:
-      throw TrimError.invalidArgs("Unknown argument: \(argument)")
+      throw RecordingScriptError.invalidArgs("Unknown argument: \(argument)")
     }
   }
 
   guard let inputPath, let outputPath, let trimStartMs else {
-    throw TrimError.invalidArgs(
+    throw RecordingScriptError.invalidArgs(
       "Usage: recording-trim.swift --input <video> --output <video> --trim-start-ms <ms>"
     )
   }

--- a/apple/runner/AgentDeviceRunner/RecordingScripts/recording-trim.swift
+++ b/apple/runner/AgentDeviceRunner/RecordingScripts/recording-trim.swift
@@ -1,11 +1,18 @@
 import AVFoundation
 import Foundation
 
-do {
-  try run()
-} catch {
-  fputs("recording-trim: \(error)\n", stderr)
-  exit(1)
+/// Entry point: `@main` because multi-file swiftc compilation reserves top-level statements for
+/// `main.swift`, which cannot be shared per-script.
+@main
+enum RecordingTrim {
+  static func main() {
+    do {
+      try run()
+    } catch {
+      fputs("recording-trim: \(error)\n", stderr)
+      exit(1)
+    }
+  }
 }
 
 func run() throws {

--- a/src/recording/__tests__/recording-scripts.test.ts
+++ b/src/recording/__tests__/recording-scripts.test.ts
@@ -15,10 +15,17 @@ const SWIFT_TYPECHECK_TIMEOUT_MS = 60_000;
 let swiftCompilerPath = 'swiftc';
 let swiftSdkPath = '';
 
-async function assertSwiftScriptTypechecks(scriptPath: string): Promise<void> {
-  const result = await runCmd(swiftCompilerPath, ['-sdk', swiftSdkPath, '-typecheck', scriptPath], {
-    allowFailure: true,
-  });
+async function assertSwiftScriptTypechecks(
+  scriptPath: string,
+  extraSourcePaths: string[] = [],
+): Promise<void> {
+  const result = await runCmd(
+    swiftCompilerPath,
+    ['-sdk', swiftSdkPath, '-typecheck', scriptPath, ...extraSourcePaths],
+    {
+      allowFailure: true,
+    },
+  );
   assert.equal(
     result.exitCode,
     0,
@@ -43,7 +50,9 @@ test(
       t.skip('Swift recording scripts are only validated on macOS');
     }
 
-    await assertSwiftScriptTypechecks(path.join(recordingScriptsDir, 'recording-trim.swift'));
+    await assertSwiftScriptTypechecks(path.join(recordingScriptsDir, 'recording-trim.swift'), [
+      path.join(recordingScriptsDir, 'RecordingExportSupport.swift'),
+    ]);
   },
   SWIFT_TYPECHECK_TIMEOUT_MS,
 );
@@ -69,7 +78,9 @@ test(
       t.skip('Swift recording scripts are only validated on macOS');
     }
 
-    await assertSwiftScriptTypechecks(path.join(recordingScriptsDir, 'recording-overlay.swift'));
+    await assertSwiftScriptTypechecks(path.join(recordingScriptsDir, 'recording-overlay.swift'), [
+      path.join(recordingScriptsDir, 'RecordingExportSupport.swift'),
+    ]);
   },
   SWIFT_TYPECHECK_TIMEOUT_MS,
 );

--- a/src/recording/overlay.ts
+++ b/src/recording/overlay.ts
@@ -54,6 +54,7 @@ function resolveRecordingScriptPath(scriptName: string): string {
 
 let overlayScriptPath: string | undefined;
 let trimScriptPath: string | undefined;
+let exportSupportScriptPath: string | undefined;
 
 export function getRecordingOverlaySupportWarning(
   hostPlatform: NodeJS.Platform = process.platform,
@@ -74,6 +75,11 @@ function getTrimScriptPath(): string {
   return trimScriptPath;
 }
 
+function getExportSupportScriptPath(): string {
+  exportSupportScriptPath ??= resolveRecordingScriptPath('RecordingExportSupport.swift');
+  return exportSupportScriptPath;
+}
+
 async function exportProcessedVideo(params: {
   videoPath: string;
   scriptPath: string;
@@ -86,7 +92,10 @@ async function exportProcessedVideo(params: {
 
   const outputPath = temporarySiblingVideoPath(videoPath);
   try {
-    const executablePath = await compileSwiftSourceFile({ sourcePath: scriptPath });
+    const executablePath = await compileSwiftSourceFile({
+      sourcePath: scriptPath,
+      extraSourcePaths: [getExportSupportScriptPath()],
+    });
     await runCmd(executablePath, ['--input', videoPath, '--output', outputPath, ...scriptArgs], {
       timeoutMs: 120_000,
       env: buildSwiftToolEnv(),

--- a/src/utils/__tests__/swift-cache.test.ts
+++ b/src/utils/__tests__/swift-cache.test.ts
@@ -59,6 +59,40 @@ test('concurrent file-backed helper compiles for the same cache key reuse the wi
   );
 });
 
+test('extra source paths participate in the cache key and reach the compiler', async () => {
+  const sourcePath = writeSourceFile();
+  const supportPath = path.join(tmpDir, 'RecordingExportSupport.swift');
+  fs.writeFileSync(supportPath, 'enum Support {}');
+  const changedSupportPath = path.join(tmpDir, 'OtherSupport.swift');
+  fs.writeFileSync(changedSupportPath, 'enum OtherSupport {}');
+
+  const [withSupport, withSupportAgain, withChangedSupport] = await Promise.all([
+    compileSwiftSourceFile({
+      sourcePath,
+      extraSourcePaths: [supportPath],
+      cacheName: 'recording-overlay',
+    }),
+    compileSwiftSourceFile({
+      sourcePath,
+      extraSourcePaths: [supportPath],
+      cacheName: 'recording-overlay',
+    }),
+    compileSwiftSourceFile({
+      sourcePath,
+      extraSourcePaths: [changedSupportPath],
+      cacheName: 'recording-overlay',
+    }),
+  ]);
+
+  expect(withSupportAgain).toBe(withSupport);
+  expect(withChangedSupport).not.toBe(withSupport);
+  const compiledPaths = mockRunCmd.mock.calls.map((call) =>
+    call[1].slice(0, call[1].indexOf('-o')),
+  );
+  expect(compiledPaths).toContainEqual(['swiftc', sourcePath, supportPath]);
+  expect(compiledPaths).toContainEqual(['swiftc', sourcePath, changedSupportPath]);
+});
+
 test('stale cache locks are removed before compiling', async () => {
   const { sourcePath, executablePath, lockDir } = await createBlockedCacheEntry();
   const staleTime = new Date(Date.now() - 1_000);

--- a/src/utils/swift-cache.ts
+++ b/src/utils/swift-cache.ts
@@ -25,11 +25,17 @@ export function buildSwiftToolEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.
 
 export async function compileSwiftSourceFile(params: {
   sourcePath: string;
+  /** Additional compilation units (shared helpers) compiled into the same executable. */
+  extraSourcePaths?: string[];
   cacheName?: string;
   timeoutMs?: number;
 }): Promise<string> {
-  const stat = fs.statSync(params.sourcePath);
-  const source = fs.readFileSync(params.sourcePath);
+  const sourcePaths = [params.sourcePath, ...(params.extraSourcePaths ?? [])];
+  const sources = sourcePaths.map((sourcePath) => ({
+    sourcePath,
+    stat: fs.statSync(sourcePath),
+    source: fs.readFileSync(sourcePath),
+  }));
   const cacheName = sanitizeCacheName(
     params.cacheName ?? path.basename(params.sourcePath, path.extname(params.sourcePath)),
   );
@@ -37,13 +43,15 @@ export async function compileSwiftSourceFile(params: {
     SWIFT_CACHE_VERSION,
     process.platform,
     process.arch,
-    path.resolve(params.sourcePath),
-    stat.size,
-    source,
+    ...sources.flatMap(({ sourcePath, stat, source }) => [
+      path.resolve(sourcePath),
+      stat.size,
+      source,
+    ]),
   ]);
   const executablePath = path.join(getSwiftCacheRoot(), 'bin', `${cacheName}-${key}`);
   await ensureSwiftExecutable({
-    sourcePath: params.sourcePath,
+    sourcePaths,
     executablePath,
     timeoutMs: params.timeoutMs,
   });
@@ -61,7 +69,7 @@ export async function compileSwiftSourceText(params: {
   const executablePath = path.join(getSwiftCacheRoot(), 'bin', `${cacheName}-${key}`);
 
   await ensureSwiftExecutable({
-    sourcePath,
+    sourcePaths: [sourcePath],
     executablePath,
     sourceText: params.source,
     timeoutMs: params.timeoutMs,
@@ -78,7 +86,7 @@ function getSwiftCacheRoot(): string {
 }
 
 async function ensureSwiftExecutable(params: {
-  sourcePath: string;
+  sourcePaths: string[];
   executablePath: string;
   sourceText?: string;
   timeoutMs?: number;
@@ -107,11 +115,12 @@ async function ensureSwiftExecutable(params: {
     if (isExecutableFile(params.executablePath)) {
       return;
     }
-    if (params.sourceText !== undefined && !fs.existsSync(params.sourcePath)) {
-      fs.mkdirSync(path.dirname(params.sourcePath), { recursive: true });
-      fs.writeFileSync(params.sourcePath, params.sourceText);
+    const [primarySourcePath] = params.sourcePaths;
+    if (params.sourceText !== undefined && primarySourcePath && !fs.existsSync(primarySourcePath)) {
+      fs.mkdirSync(path.dirname(primarySourcePath), { recursive: true });
+      fs.writeFileSync(primarySourcePath, params.sourceText);
     }
-    await runCmd('xcrun', ['swiftc', params.sourcePath, '-o', tempExecutablePath], {
+    await runCmd('xcrun', ['swiftc', ...params.sourcePaths, '-o', tempExecutablePath], {
       timeoutMs: params.timeoutMs ?? 120_000,
       env: buildSwiftToolEnv(),
     });


### PR DESCRIPTION
## Summary

Second of the two follow-ups from the #1936 size audit. `recording-overlay.swift` and `recording-trim.swift` each carried their own copy of the same three mechanics — error enum, flag parsing, and the composition/export pipeline (~90 duplicated lines). This extracts `RecordingExportSupport.swift` as the single owner of those mechanics; each script keeps only its own argument grammar and export-quality policy.

- `compileSwiftSourceFile` gains `extraSourcePaths`: extra units join the cache key (path + size + content) and are passed to `swiftc`. `overlay.ts` passes the shared support file for both scripts.
- Entry points move to `@main` because multi-file `swiftc` compilation reserves top-level statements for `main.swift`.
- Behavior preservation: error messages, per-script stderr prefixes (`recording-overlay:` / `recording-trim:`), trim's error precedence (missing video track before invalid range), and the transform policies (trim propagates `preferredTransform`; overlay re-applies it via layer instruction) are all unchanged.
- Size is roughly neutral by design — this is a maintainability consolidation: one export pipeline to fix instead of two drifting copies.

## Validation

At 309e730c4, in a clean worktree:
- End-to-end on real H264 video (generated via AVAssetWriter): trim cut 500 ms correctly; overlay burned tap/swipe/pinch layers into the output; both outputs written.
- Error paths byte-identical to pre-refactor: usage text, "Input video does not contain a video track.", "--trim-start-ms must be a non-negative number".
- Both scripts typecheck as pairs with the support file (updated `recording-scripts.test.ts`); new `swift-cache.test.ts` case pins that extra sources reach the compiler and participate in cache-key identity/reuse.
- `pnpm check:affected --run`: all runnable checks passed (829 unit tests green).

Scope: 6 files, recording module group. No CLI/help/docs changes — command behavior unchanged.