### PR TITLE
refactor: derive every --settle surface from the descriptor trait (#1652)

### DIFF
--- a/packages/contracts/src/facades/interaction.ts
+++ b/packages/contracts/src/facades/interaction.ts
@@ -152,6 +152,7 @@ export {
 } from '../scroll-command.ts';
 export type {
   ScrollCommandOptions,
+  ScrollCommandResult,
   ScrollDistanceOptions,
   ScrollExecutionOptions,
   ResolvedScrollExecutionOptions,

--- a/packages/contracts/src/scroll-command.ts
+++ b/packages/contracts/src/scroll-command.ts
@@ -1,4 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
+import type { SettleObservation } from './interaction.ts';
+import type { ScrollDirection } from './scroll-gesture.ts';
 
 export const SCROLL_DURATION_MAX_MS = 10_000;
 export const DEFAULT_MOBILE_SCROLL_DURATION_MS = 300;
@@ -67,3 +69,26 @@ export function honoredScrollDurationMs(
 ): number | undefined {
   return typeof result?.durationMs === 'number' ? result.durationMs : undefined;
 }
+
+/**
+ * `scroll` — the generic-route result built by `buildDispatchedScrollResult`
+ * (src/core/dispatch-interactions.ts): the resolved direction, the edge-pass
+ * bookkeeping for `top`/`bottom` scrolls, the honored distance/timing echo,
+ * and the success message. Platform leaves add gesture-plan coordinates
+ * (`x1`/`y1`/`x2`/`y2`, reference frame) on top; the output schema stays
+ * non-strict so those additive fields validate. The one field the dispatcher
+ * itself may add: `settle`, the opt-in `--settle` observation (#1638),
+ * attached after the command — same shape as `BackCommandResult`.
+ */
+export type ScrollCommandResult = {
+  direction: ScrollDirection;
+  /** Set for `top`/`bottom` requests: the extreme being scrolled to. */
+  edge?: 'top' | 'bottom';
+  /** Edge scrolls only: how many scroll-and-check passes ran. */
+  passes?: number;
+  amount?: number;
+  pixels?: number;
+  durationMs?: number;
+  message?: string;
+  settle?: SettleObservation;
+};

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -521,10 +521,8 @@ test('usageForCommand resolves dogfood help topic', async () => {
   assert.match(help, /direct Android localhost URL opens with a port auto-configure/);
   assert.match(help, /Keep stateful commands serial within the same session/);
   assert.match(help, /agent-device wait 'role=tab' 10000/);
-  assert.match(
-    help,
-    /scroll takes direction then amount and does not support a selector or --settle/,
-  );
+  assert.match(help, /scroll takes a selector-less direction\+amount form/);
+  assert.match(help, /Use --settle to wait for the UI to go quiet/);
   assert.match(help, /prefer agent-device open "Expo Go" <url>/);
   assert.match(help, /dogfood-output\/report\.md/);
   assert.match(help, /ID, severity, category, title, affected flow\/screen/);

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -970,7 +970,7 @@ Rules:
   Findings must come from observed runtime behavior, not source reads.
   After each mutation, use the --settle diff as evidence when available; otherwise re-snapshot.
   Wait timeouts are integer milliseconds in the trailing positional: agent-device wait 'role=tab' 10000. Do not write duration suffixes such as 10s.
-  scroll takes direction then amount and does not support a selector or --settle: agent-device scroll down 3.
+  scroll takes a selector-less direction+amount form: agent-device scroll down 3. Use --settle to wait for the UI to go quiet and get the settled diff.
   Keep commands in the report reproducible; use selectors or refs from fresh snapshots, not guessed coordinates.
   Prefer refs for exploration and selectors for deterministic replay.
   Use logs, network, screenshot --overlay-refs, trace, perf frames, perf memory, native profiles, or react-devtools only when they add evidence to a specific issue.

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -140,6 +140,8 @@ export function selectorSnapshotOptionsFromFlags(flags: CliFlags): SelectorSnaps
 // Descriptor post-action observation commands use --settle (#1101).
 // --timeout doubles as the settle deadline only when --settle is present; a
 // bare --timeout stays compatible and is ignored by touch commands.
+// #1652: readers do NOT spread this themselves — `readInputFromCli` merges
+// `settleInputForCommand` at the one seam every reader passes through.
 export function settleInputFromFlags(flags: CliFlags): Record<string, unknown> {
   return compactRecord({
     settle: flags.settle,

--- a/src/commands/cli-grammar/registry.ts
+++ b/src/commands/cli-grammar/registry.ts
@@ -1,6 +1,7 @@
 import type { CliFlags } from '@agent-device/contracts/command';
 import type { CommandName } from '../command-metadata.ts';
 import { listCommandFamilyCliReaders } from '../family/registry.ts';
+import { settleInputForCommand } from '../post-action-observation-grammar.ts';
 
 const cliReaders = listCommandFamilyCliReaders();
 
@@ -13,5 +14,8 @@ export function readInputFromCli(
   if (!reader) {
     throw new Error(`Missing CLI reader for command: ${command}`);
   }
-  return reader(positionals, flags);
+  // #1652: the `--settle` triple merges here, at the one seam every reader
+  // passes through, instead of being hand-spread per settle-capable reader —
+  // a drop at any one of those silently disabled the flag.
+  return { ...reader(positionals, flags), ...settleInputForCommand(command, flags) };
 }

--- a/src/commands/interaction/interactions.ts
+++ b/src/commands/interaction/interactions.ts
@@ -30,7 +30,6 @@ import {
   request,
   requiredDaemonString,
   selectorSnapshotInputFromFlags,
-  settleInputFromFlags,
   targetInputFromClientTarget,
 } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
@@ -41,7 +40,6 @@ export const interactionCliReaders = {
     ...commonInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
     ...repeatedInputFromFlags(flags),
-    ...settleInputFromFlags(flags),
     target: targetInputFromClientTarget(readInteractionTargetFromPositionals(positionals)),
     button: flags.clickButton,
     verify: flags.verify,
@@ -50,7 +48,6 @@ export const interactionCliReaders = {
     ...commonInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
     ...repeatedInputFromFlags(flags),
-    ...settleInputFromFlags(flags),
     target: targetInputFromClientTarget(readInteractionTargetFromPositionals(positionals)),
     verify: flags.verify,
   }),
@@ -59,7 +56,6 @@ export const interactionCliReaders = {
     return {
       ...commonInputFromFlags(flags),
       ...selectorSnapshotInputFromFlags(flags),
-      ...settleInputFromFlags(flags),
       target: targetInputFromClientTarget(decoded),
       durationMs: decoded.durationMs,
     };
@@ -67,7 +63,6 @@ export const interactionCliReaders = {
   hover: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
     ...selectorSnapshotInputFromFlags(flags),
-    ...settleInputFromFlags(flags),
     target: targetInputFromClientTarget(readInteractionTargetFromPositionals(positionals)),
   }),
   swipe: (positionals, flags) => ({
@@ -93,7 +88,6 @@ export const interactionCliReaders = {
     return {
       ...commonInputFromFlags(flags),
       ...selectorSnapshotInputFromFlags(flags),
-      ...settleInputFromFlags(flags),
       target: targetInputFromClientTarget(decoded.target),
       text: decoded.text,
       delayMs: flags.delayMs,
@@ -103,7 +97,6 @@ export const interactionCliReaders = {
   },
   scroll: (positionals, flags) => ({
     ...commonInputFromFlags(flags),
-    ...settleInputFromFlags(flags),
     direction: readScrollDirection(positionals[0]),
     amount: optionalCliNumber(positionals[1]),
     pixels: flags.pixels,

--- a/src/commands/interaction/output.ts
+++ b/src/commands/interaction/output.ts
@@ -5,11 +5,12 @@ import { displayLabel, formatRole } from '../../snapshot/snapshot-lines.ts';
 import { readCommandMessage } from '../../utils/success-text.ts';
 import {
   messageCliOutput,
+  messageOutput,
   pinnedRefText,
   resultOutput,
   type CliOutputFormatter,
 } from '../output-common.ts';
-import { appendResponseNotes, messageWithSettleOutput } from '../settle-output.ts';
+import { withSettleCapableNotes } from '../settle-output.ts';
 
 function getCliOutput(params: { result: CommandRequestResult; format?: string }): CliOutput {
   const data = params.result as Record<string, unknown>;
@@ -73,19 +74,21 @@ function tapCliOutput(result: CommandRequestResult): CliOutput {
   const x = data.x;
   const y = data.y;
   if (!ref || typeof x !== 'number' || typeof y !== 'number') {
-    const output = defaultCommandCliOutput(data);
-    return { data: output.data, text: appendResponseNotes(output.text, data) };
+    return defaultCommandCliOutput(data);
   }
-  return { data, text: appendResponseNotes(`Tapped @${ref} (${x}, ${y})`, data) };
+  return { data, text: `Tapped @${ref} (${x}, ${y})` };
 }
 
-export const interactionCliOutputFormatters = {
+// #1652: settle-capable entries (click, press, fill, longpress, hover, scroll)
+// get the warning/settle notes appended by the trait-derived wrapper; the rest
+// of the map is returned untouched.
+export const interactionCliOutputFormatters = withSettleCapableNotes({
   click: resultOutput(tapCliOutput),
   press: resultOutput(tapCliOutput),
-  fill: messageWithSettleOutput,
-  longpress: messageWithSettleOutput,
-  hover: messageWithSettleOutput,
-  scroll: messageWithSettleOutput,
+  fill: messageOutput,
+  longpress: messageOutput,
+  hover: messageOutput,
+  scroll: messageOutput,
   get: ({ input, result }) =>
     getCliOutput({
       result: result as CommandRequestResult,
@@ -93,7 +96,7 @@ export const interactionCliOutputFormatters = {
     }),
   is: resultOutput(isCliOutput),
   find: resultOutput(findCliOutput),
-} as const satisfies Record<string, CliOutputFormatter>;
+} satisfies Record<string, CliOutputFormatter>);
 
 function defaultCommandCliOutput(result: CommandRequestResult): CliOutput {
   return messageCliOutput(result as Record<string, unknown>);

--- a/src/commands/post-action-observation-client-options.ts
+++ b/src/commands/post-action-observation-client-options.ts
@@ -1,0 +1,35 @@
+import type {
+  ClickOptions,
+  FillOptions,
+  HoverOptions,
+  LongPressOptions,
+  PressOptions,
+  ScrollOptions,
+  SettleCommandOptions,
+} from '@agent-device/contracts/client';
+import type { PostActionObservationCommandName } from '../core/command-descriptor/post-action-observation.ts';
+import type { NavigationCommandOptions } from './system/navigation-projection.ts';
+
+/**
+ * Compile-time completeness for the contracts half of the `--settle` surface
+ * (#1652): every client options type whose command carries the descriptor
+ * post-action observation trait must intersect `SettleCommandOptions`.
+ *
+ * The `Record` over the trait command union makes a missing or extra cell a
+ * compile error, and the `satisfies` assignability check fails when any listed
+ * option type drops its `& SettleCommandOptions` intersection — the same
+ * strategy `packages/contracts/src/interaction-guarantees.ts` uses to make
+ * guarantee completeness a compile error instead of a runtime assertion.
+ */
+const SETTLE_CAPABLE_CLIENT_OPTION_TYPES = {
+  click: {} as ClickOptions,
+  press: {} as PressOptions,
+  longpress: {} as LongPressOptions,
+  hover: {} as HoverOptions,
+  fill: {} as FillOptions,
+  scroll: {} as ScrollOptions,
+  back: {} as NavigationCommandOptions<'back'>,
+} as const satisfies Record<PostActionObservationCommandName, SettleCommandOptions>;
+
+export type SettleCapableClientOptionCommands =
+  readonly (keyof typeof SETTLE_CAPABLE_CLIENT_OPTION_TYPES)[];

--- a/src/commands/post-action-observation-grammar.ts
+++ b/src/commands/post-action-observation-grammar.ts
@@ -1,20 +1,22 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import type { PostActionObservationSupportFor } from '../core/command-descriptor/post-action-observation.ts';
 import {
   commandSupportsSettleObservation,
   commandSupportsVerifyEvidence,
 } from '../core/command-descriptor/registry.ts';
+import { settleInputFromFlags } from './cli-grammar/common.ts';
 import { SETTLE_FLAGS } from './cli-grammar/flag-groups.ts';
 import type { FlagKey } from './cli-grammar/flag-types.ts';
 import { booleanField, integerField } from './command-input.ts';
 
 /**
- * The two caller-facing surfaces a command's post-action observation trait
+ * The caller-facing surfaces a command's post-action observation trait
  * entitles it to (`--verify` / `--settle`, #1047/#1101): the metadata input
- * fields (Node SDK options + MCP tool schema) and the CLI allowed flags. Both
- * are materialized from the descriptor registry rather than hand-listed per
- * command. This lives outside the interaction family because the trait does
- * too: `scroll` and `back` carry it on the generic daemon route (#1638), and
- * `back` is a system command.
+ * fields (Node SDK options + MCP tool schema), the CLI allowed flags, and the
+ * CLI reader input (#1652). All are materialized from the descriptor registry
+ * rather than hand-listed per command. This lives outside the interaction
+ * family because the trait does too: `scroll` and `back` carry it on the
+ * generic daemon route (#1638), and `back` is a system command.
  *
  * A descriptor gate (`post-action-observation.test.ts`) asserts, over every
  * descriptor, that both surfaces are present exactly when the trait is — so a
@@ -59,4 +61,15 @@ export function postActionObservationCliFlags(command: string): readonly FlagKey
   if (commandSupportsVerifyEvidence(command)) flags.push('verify');
   if (commandSupportsSettleObservation(command)) flags.push(...SETTLE_FLAGS);
   return flags;
+}
+
+/**
+ * #1652: the settle triple a command's reader owes the daemon, merged at the
+ * `readInputFromCli` seam so no reader can forget it (the pre-seam per-reader
+ * spreads silently no-op'd when dropped). Non-settle commands get `{}` — and
+ * their parsers refuse `--settle` anyway via `postActionObservationCliFlags`.
+ */
+export function settleInputForCommand(command: string, flags: CliFlags): Record<string, unknown> {
+  if (!commandSupportsSettleObservation(command)) return {};
+  return settleInputFromFlags(flags);
 }

--- a/src/commands/settle-output.ts
+++ b/src/commands/settle-output.ts
@@ -1,10 +1,5 @@
-import type { CliOutput } from './command-contract.ts';
-import {
-  messageCliOutput,
-  pinnedRefText,
-  resultOutput,
-  type CliOutputFormatter,
-} from './output-common.ts';
+import { commandSupportsSettleObservation } from '../core/command-descriptor/registry.ts';
+import { pinnedRefText, type CliOutputFormatter } from './output-common.ts';
 
 /**
  * Compact `--settle` (#1101) rendering appended to a command's own success
@@ -30,15 +25,37 @@ type SettleTextView = {
   refsGeneration?: number;
 };
 
-/** `messageCliOutput` plus the response's warning and settle notes. */
-export const messageWithSettleOutput: CliOutputFormatter = resultOutput(
-  (result: Record<string, unknown>): CliOutput => {
-    const output = messageCliOutput(result);
-    return { data: output.data, text: appendResponseNotes(output.text, result) };
-  },
-);
+/** A formatter's own success line plus the response's warning and settle notes. */
+function messageWithSettledNotes(formatter: CliOutputFormatter): CliOutputFormatter {
+  return ({ input, result }) => {
+    const output = formatter({ input, result });
+    return {
+      data: output.data,
+      text: appendResponseNotes(output.text, output.data as Record<string, unknown>),
+    };
+  };
+}
 
-export function appendResponseNotes(
+/**
+ * #1652: whether a formatter renders the settle notes derives from the
+ * command's descriptor post-action observation trait instead of hand-picking
+ * the note-appending wrapper per entry. Wrap a whole family map; settle-capable
+ * entries come back with the notes appended, everything else is returned
+ * untouched — deliberately, because appending notes to outputs like
+ * `get --format attrs` JSON would corrupt them.
+ */
+export function withSettleCapableNotes<Formatters extends Record<string, CliOutputFormatter>>(
+  formatters: Formatters,
+): Formatters {
+  const derived: Record<string, CliOutputFormatter> = { ...formatters };
+  for (const [command, formatter] of Object.entries(formatters)) {
+    if (!commandSupportsSettleObservation(command)) continue;
+    derived[command] = messageWithSettledNotes(formatter);
+  }
+  return derived as Formatters;
+}
+
+function appendResponseNotes(
   text: string | null | undefined,
   data: Record<string, unknown>,
 ): string {

--- a/src/commands/system/index.test.ts
+++ b/src/commands/system/index.test.ts
@@ -7,6 +7,7 @@ import type {
   TvRemoteCommandOptions,
 } from '../../client/client-types.ts';
 import type { CommandResult } from '../../core/command-descriptor/command-result.ts';
+import { readInputFromCli } from '../cli-grammar/registry.ts';
 import type { CliFlags } from '@agent-device/contracts/command';
 import {
   appStateCliReader,
@@ -119,17 +120,23 @@ describe('system command interface', () => {
     ).toBeUndefined();
   });
 
-  // #1638: --settle has to survive BOTH back seams — the reader that builds the
-  // input and the writer that turns it into daemon request options.
+  // #1638: --settle has to survive BOTH back seams — the reader seam that
+  // builds the input (`readInputFromCli`, which merges the trait-derived
+  // settle triple since #1652) and the writer that turns it into daemon
+  // request options.
   test('back reader and writer carry the settle request through to daemon flags', () => {
-    const input = backCliReader([], flags({ settle: true, settleQuietMs: 250, timeoutMs: 8_000 }));
+    const input = readInputFromCli(
+      'back',
+      [],
+      flags({ settle: true, settleQuietMs: 250, timeoutMs: 8_000 }),
+    );
     expect(input).toMatchObject({ settle: true, settleQuietMs: 250, timeoutMs: 8_000 });
     expect(backDaemonWriter(input).options).toMatchObject({
       settle: true,
       settleQuietMs: 250,
       timeoutMs: 8_000,
     });
-    expect(backCliReader([], flags()).settle).toBeUndefined();
+    expect(readInputFromCli('back', [], flags()).settle).toBeUndefined();
   });
 
   test('back CLI output renders the settled observation', () => {

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -16,7 +16,6 @@ import {
   optionalString,
   request,
   requiredDaemonString,
-  settleInputFromFlags,
 } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineExecutableCommand } from '../command-contract.ts';
@@ -216,7 +215,6 @@ export const appSwitcherCliReader: CliReader = (_positionals, flags) => commonIn
 
 export const backCliReader: CliReader = (_positionals, flags) => ({
   ...commonInputFromFlags(flags),
-  ...settleInputFromFlags(flags),
   mode: flags.backMode,
 });
 

--- a/src/commands/system/output.ts
+++ b/src/commands/system/output.ts
@@ -10,7 +10,7 @@ import {
   resultOutput,
   type CliOutputFormatter,
 } from '../output-common.ts';
-import { messageWithSettleOutput } from '../settle-output.ts';
+import { withSettleCapableNotes } from '../settle-output.ts';
 
 function appStateCliOutput(result: AppStateCommandResult): CliOutput {
   return {
@@ -41,17 +41,18 @@ function clipboardCliOutput(result: ClipboardCommandResult): CliOutput {
   return messageCliOutput(result);
 }
 
-export const systemCliOutputFormatters = {
+// #1652: back is settle-capable, so the trait-derived wrapper appends the
+// settled diff to its line; the rest of the map is returned untouched.
+export const systemCliOutputFormatters = withSettleCapableNotes({
   appstate: resultOutput(appStateCliOutput),
-  // #1638: back is settle-capable, so its line carries the settled diff.
-  back: messageWithSettleOutput,
+  back: messageOutput,
   home: messageOutput,
   orientation: messageOutput,
   'app-switcher': messageOutput,
   keyboard: resultOutput(keyboardCliOutput),
   clipboard: resultOutput(clipboardCliOutput),
   'tv-remote': messageOutput,
-} as const satisfies Record<string, CliOutputFormatter>;
+} satisfies Record<string, CliOutputFormatter>);
 
 function formatAppState(data: AppStateCommandResult): string | null {
   if (data.platform === 'ios') {

--- a/src/core/command-descriptor/__tests__/command-result.test.ts
+++ b/src/core/command-descriptor/__tests__/command-result.test.ts
@@ -153,6 +153,7 @@ test('CommandResultMap is seeded only from already-existing contract result type
     | 'keyboard'
     | 'tv-remote'
     | 'wait'
+    | 'scroll'
     | 'prepare'
     | 'push'
     | 'trigger-app-event'

--- a/src/core/command-descriptor/__tests__/post-action-observation.test.ts
+++ b/src/core/command-descriptor/__tests__/post-action-observation.test.ts
@@ -1,14 +1,44 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import type { CliFlags } from '@agent-device/contracts/command';
+import type { SessionAction } from '@agent-device/contracts/session';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
-import { findCommandMetadata } from '../../../commands/command-metadata.ts';
+import type { AgentDeviceClient } from '../../../agent-device-client.ts';
+import { findCommandMetadata, type CommandName } from '../../../commands/command-metadata.ts';
+import { readInputFromCli } from '../../../commands/cli-grammar/registry.ts';
+import {
+  listCommandFamilyCliOutputFormatters,
+  listCommandFamilyDefinitions,
+} from '../../../commands/family/registry.ts';
+import type { SettleCapableClientOptionCommands } from '../../../commands/post-action-observation-client-options.ts';
 import { getCliCommandSchema } from '../../../cli-schema/command-schema.ts';
+import { buildActionDetails } from '../../../daemon/session-event-action.ts';
+import { COMMAND_OUTPUT_SCHEMAS } from '../../../mcp/command-output-schemas.ts';
 import {
   commandDescriptors,
   commandSupportsSettleObservation,
   commandSupportsVerifyEvidence,
   resolveCommandPostActionObservationSupport,
 } from '../registry.ts';
+
+/**
+ * The descriptor gate for the `--settle` / `--verify` surfaces (#1652). Every
+ * caller-facing surface derives from `postActionObservation`; these tests pin
+ * each one to the trait so a forgotten cell fails here instead of silently
+ * no-op'ing the flag:
+ *
+ * | Surface                    | Enforcement                                            |
+ * | -------------------------- | ------------------------------------------------------ |
+ * | CLI allowed flags          | below (+ timeout policy in timeout-policy.test.ts)     |
+ * | Metadata / MCP input fields| below                                                  |
+ * | CLI reader input           | below — merged at the `readInputFromCli` seam          |
+ * | Client option projections  | below — end to end through `definition.invoke`         |
+ * | Contracts option types     | compile error (`post-action-observation-client-options`)|
+ * | Session safe-flag specs    | below                                                  |
+ * | MCP output schemas         | below — grafted in `command-output-schemas.ts`         |
+ * | CLI output formatters      | below — wrapped in `settle-output.ts`                  |
+ * | MCP ref-pinning            | derived in `mcp/tool-ref-pins.ts`                      |
+ */
 
 const SETTLE_OBSERVATION_COMMANDS = [
   PUBLIC_COMMANDS.click,
@@ -19,6 +49,24 @@ const SETTLE_OBSERVATION_COMMANDS = [
   PUBLIC_COMMANDS.scroll,
   PUBLIC_COMMANDS.back,
 ] as const;
+
+const SETTLE_FLAGS_SNAPSHOT = {
+  settle: true,
+  settleQuietMs: 250,
+  timeoutMs: 4000,
+} as CliFlags;
+
+// Minimal valid positionals per settle-capable reader; coverage against the
+// trait set is asserted so a new trait command cannot skip its fixture.
+const SETTLE_READER_POSITIONALS: Record<string, string[]> = {
+  [PUBLIC_COMMANDS.click]: ['10', '20'],
+  [PUBLIC_COMMANDS.press]: ['10', '20'],
+  [PUBLIC_COMMANDS.longPress]: ['10', '20'],
+  [PUBLIC_COMMANDS.hover]: ['10', '20'],
+  [PUBLIC_COMMANDS.fill]: ['10', '20', 'hello'],
+  [PUBLIC_COMMANDS.scroll]: ['down'],
+  [PUBLIC_COMMANDS.back]: [],
+};
 
 test('post-action observation descriptor traits are the source for settle command support', () => {
   const descriptorCommands = commandDescriptors
@@ -77,4 +125,184 @@ test('post-action observation metadata fields follow descriptor traits', () => {
       `${descriptor.name}: verify field must match descriptor trait`,
     );
   }
+});
+
+test('post-action observation CLI reader input follows descriptor traits', () => {
+  assert.deepEqual(
+    Object.keys(SETTLE_READER_POSITIONALS).sort(),
+    [...SETTLE_OBSERVATION_COMMANDS].sort(),
+  );
+  for (const [command, positionals] of Object.entries(SETTLE_READER_POSITIONALS)) {
+    const input = readInputFromCli(command as CommandName, positionals, SETTLE_FLAGS_SNAPSHOT);
+    assert.equal(input.settle, true, `${command}: --settle must reach daemon input`);
+    assert.equal(input.settleQuietMs, 250, `${command}: --settle-quiet must reach daemon input`);
+    assert.equal(input.timeoutMs, 4000, `${command}: settle --timeout must reach daemon input`);
+  }
+  // Readers outside the trait must not leak the triple even when raw flags
+  // carry it — including `type`, which shares fill's text-entry spec family.
+  const nonSettleReaders: Array<[CommandName, string[]]> = [
+    [PUBLIC_COMMANDS.home, []],
+    [PUBLIC_COMMANDS.type, ['hi']],
+    [PUBLIC_COMMANDS.swipe, ['30', '40', '50', '60']],
+  ];
+  for (const [command, positionals] of nonSettleReaders) {
+    const input = readInputFromCli(command, positionals, SETTLE_FLAGS_SNAPSHOT);
+    assert.equal('settle' in input, false, `${command}: non-settle reader must ignore --settle`);
+    assert.equal(
+      'settleQuietMs' in input,
+      false,
+      `${command}: non-settle reader must ignore --settle-quiet`,
+    );
+  }
+});
+
+/** A client proxy that records the options of every method call at any depth. */
+function recordingClient(calls: Array<Record<string, unknown>>): AgentDeviceClient {
+  const surface: unknown = new Proxy(function () {}, {
+    apply: (_target, _thisArg, args) => {
+      calls.push(args[0] as Record<string, unknown>);
+      return undefined;
+    },
+    get: () => surface,
+  });
+  return surface as AgentDeviceClient;
+}
+
+test('post-action observation client options follow descriptor traits', async () => {
+  const definitions = listCommandFamilyDefinitions();
+  for (const [command, positionals] of Object.entries(SETTLE_READER_POSITIONALS)) {
+    const definition = definitions.find((entry) => entry.name === command);
+    assert.ok(definition, `${command}: missing executable definition`);
+    const calls: Array<Record<string, unknown>> = [];
+    await definition.invoke(
+      recordingClient(calls),
+      readInputFromCli(command as CommandName, positionals, SETTLE_FLAGS_SNAPSHOT),
+    );
+    assert.equal(calls.length, 1, `${command}: expected exactly one client call`);
+    assert.equal(calls[0]?.settle, true, `${command}: settle option must survive projection`);
+    assert.equal(
+      calls[0]?.settleQuietMs,
+      250,
+      `${command}: settle quiet window must survive projection`,
+    );
+    assert.equal(calls[0]?.timeoutMs, 4000, `${command}: settle deadline must survive projection`);
+  }
+});
+
+function actionWithSettleFlags(command: string): SessionAction {
+  return {
+    ts: 0,
+    command,
+    positionals: [],
+    flags: { settle: true, settleQuietMs: 250 },
+    result: {},
+  };
+}
+
+test('post-action observation session-event safe flags follow descriptor traits', () => {
+  for (const command of SETTLE_OBSERVATION_COMMANDS) {
+    const details = buildActionDetails(actionWithSettleFlags(command));
+    const flags = (details.flags ?? {}) as Record<string, unknown>;
+    assert.equal(flags.settle, true, `${command}: session event must disclose settle`);
+    assert.equal(
+      flags.settleQuietMs,
+      250,
+      `${command}: session event must disclose the settle quiet window`,
+    );
+  }
+  for (const command of [PUBLIC_COMMANDS.type, PUBLIC_COMMANDS.swipe]) {
+    const details = buildActionDetails(actionWithSettleFlags(command));
+    const flags = (details.flags ?? {}) as Record<string, unknown>;
+    assert.equal(
+      'settle' in flags,
+      false,
+      `${command}: non-settle session event must not disclose settle`,
+    );
+  }
+});
+
+type SchemaView = {
+  properties?: Record<string, unknown>;
+  oneOf?: readonly SchemaView[];
+};
+
+function* settlePropertyGroups(schema: SchemaView): Generator<Record<string, unknown>> {
+  for (const branch of schema.oneOf ?? []) yield* settlePropertyGroups(branch);
+  if (schema.properties) yield schema.properties;
+}
+
+test('post-action observation MCP output schemas follow descriptor traits', () => {
+  // The trait denominator must be covered by the schema keys: a settle-capable
+  // command with no entry at all (the pre-#1652 scroll gap) is drift too.
+  for (const command of SETTLE_OBSERVATION_COMMANDS) {
+    assert.ok(
+      Object.hasOwn(COMMAND_OUTPUT_SCHEMAS, command),
+      `${command}: settle-capable command must have an output schema entry`,
+    );
+  }
+  for (const [command, schema] of Object.entries(COMMAND_OUTPUT_SCHEMAS)) {
+    const expected = commandSupportsSettleObservation(command);
+    let groups = 0;
+    for (const properties of settlePropertyGroups(schema as SchemaView)) {
+      groups += 1;
+      assert.equal(
+        Object.hasOwn(properties, 'settle'),
+        expected,
+        `${command}: settle advertisement must match descriptor trait`,
+      );
+    }
+    if (expected) {
+      assert.ok(groups > 0, `${command}: settle-capable schema must have object groups`);
+    }
+  }
+});
+
+test('post-action observation CLI output formatters follow descriptor traits', () => {
+  const formatters = listCommandFamilyCliOutputFormatters();
+  for (const command of SETTLE_OBSERVATION_COMMANDS) {
+    assert.ok(formatters[command], `${command}: missing CLI output formatter`);
+  }
+  const settledResult = { message: 'ok', settle: { settled: true, waitedMs: 12 } };
+  for (const [command, format] of Object.entries(formatters)) {
+    let text: string;
+    try {
+      text = String(format({ input: {}, result: settledResult }).text ?? '');
+    } catch {
+      // Formatters expecting a differently-shaped result (device lists) are
+      // orthogonal to settle rendering — but a settle-capable formatter must
+      // cope with a settled response.
+      assert.equal(
+        commandSupportsSettleObservation(command),
+        false,
+        `${command}: settle-capable formatter must render the settled result`,
+      );
+      continue;
+    }
+    assert.equal(
+      text.includes('settled after'),
+      commandSupportsSettleObservation(command),
+      `${command}: settle rendering must match descriptor trait`,
+    );
+  }
+});
+
+// The compile-time cells live in post-action-observation-client-options.ts:
+// a missing or extra cell, or a dropped `& SettleCommandOptions` intersection,
+// fails the build. Pin the declared set to the descriptor trait here so the
+// module cannot be gutted without this gate noticing.
+const COMPILE_TIME_CLIENT_OPTION_COVERAGE: SettleCapableClientOptionCommands = [
+  'click',
+  'press',
+  'longpress',
+  'hover',
+  'fill',
+  'scroll',
+  'back',
+];
+
+test('post-action observation contracts option types cover the trait', () => {
+  assert.deepEqual(
+    [...COMPILE_TIME_CLIENT_OPTION_COVERAGE].sort(),
+    [...SETTLE_OBSERVATION_COMMANDS].sort(),
+  );
 });

--- a/src/core/command-descriptor/command-result.ts
+++ b/src/core/command-descriptor/command-result.ts
@@ -22,6 +22,7 @@ import type {
   LongPressCommandResponseData,
   OrientationCommandResult,
   PressCommandResponseData,
+  ScrollCommandResult,
   TvRemoteCommandResult,
   WaitCommandResult,
 } from '@agent-device/contracts/interaction';
@@ -45,7 +46,11 @@ import type { ReplayCommandResult, ReplaySuiteResult } from '@agent-device/contr
  * `appstate` (a closed `platform` union — Apple session state with the iOS-only
  * device locators, or Android package/activity). Batch 4 adds `keyboard` (a
  * closed flat shape). Batch 5 adds the compact daemon projections for `wait`,
- * `prepare`, `push`, and `trigger-app-event`. Each entry is grounded in a
+ * `prepare`, `push`, and `trigger-app-event`. #1652 adds `scroll`
+ * (ScrollCommandResult): the shared dispatch vocabulary plus the opt-in
+ * settle observation, so the settle-capable generic-route pair (`back`,
+ * `scroll`) is fully typed and its MCP output schema derives from the trait.
+ * Each entry is grounded in a
  * re-read of the handler's literal return; see the per-type docstrings.
  */
 export interface CommandResultMap {
@@ -67,6 +72,7 @@ export interface CommandResultMap {
   keyboard: KeyboardCommandResult;
   'tv-remote': TvRemoteCommandResult;
   wait: WaitCommandResult;
+  scroll: ScrollCommandResult;
   prepare: PrepareCommandResult;
   push: PushCommandResult;
   'trigger-app-event': TriggerAppEventCommandResult;

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -3,6 +3,7 @@ import { RECORDING_SCOPE_VALUES } from '@agent-device/contracts/recording';
 import { SESSION_SURFACES, type SessionAction } from '@agent-device/contracts/session';
 import { DEVICE_TARGETS, PLATFORM_SELECTORS, PUBLIC_PLATFORMS } from '@agent-device/kernel/device';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
+import { commandSupportsSettleObservation } from '../core/command-descriptor/registry.ts';
 import {
   buildInstallActionSummary,
   buildStructuredActionDetails,
@@ -288,6 +289,15 @@ const COMMON_SAFE_FLAG_SPEC = {
   ],
 } as const satisfies SafeFlagSpec;
 
+// #1652: the settle triple's safe projection derives from the descriptor
+// post-action observation trait instead of being re-listed inside every
+// per-command spec — a settle-capable command that forgot its entries would
+// otherwise record the flag but never display it.
+const SETTLE_SAFE_FLAG_SPEC = {
+  booleans: [{ source: 'settle' }],
+  numbers: [{ source: 'settleQuietMs' }],
+} as const satisfies SafeFlagSpec;
+
 const SAFE_ACTION_FLAG_SPECS: Record<string, SafeFlagSpec> = {
   [PUBLIC_COMMANDS.open]: {
     booleans: [{ source: 'relaunch' }, { source: 'testIme' }],
@@ -300,8 +310,7 @@ const SAFE_ACTION_FLAG_SPECS: Record<string, SafeFlagSpec> = {
   [PUBLIC_COMMANDS.fill]: textEntrySafeFlagSpec(),
   [PUBLIC_COMMANDS.type]: textEntrySafeFlagSpec(),
   [PUBLIC_COMMANDS.scroll]: {
-    booleans: [{ source: 'settle' }],
-    numbers: [{ source: 'pixels' }, { source: 'durationMs' }, { source: 'settleQuietMs' }],
+    numbers: [{ source: 'pixels' }, { source: 'durationMs' }],
   },
   [PUBLIC_COMMANDS.gesture]: gestureSafeFlagSpec(),
   [PUBLIC_COMMANDS.swipe]: gestureSafeFlagSpec(),
@@ -328,8 +337,6 @@ const SAFE_ACTION_FLAG_SPECS: Record<string, SafeFlagSpec> = {
     numbers: [{ source: 'snapshotDepth', output: 'depth' }],
   },
   [PUBLIC_COMMANDS.back]: {
-    booleans: [{ source: 'settle' }],
-    numbers: [{ source: 'settleQuietMs' }],
     enums: [{ source: 'backMode', output: 'mode', values: BACK_MODES }],
   },
   [PUBLIC_COMMANDS.record]: {
@@ -356,18 +363,22 @@ function buildSafeActionFlags(action: SessionAction): Record<string, unknown> | 
     : undefined;
   projectSafeFlags(safeFlags, flags, COMMON_SAFE_FLAG_SPEC);
   projectSafeFlags(safeFlags, flags, commandFlagSpec);
+  projectSafeFlags(safeFlags, flags, settleSafeFlagSpec(action.command));
   return Object.keys(safeFlags).length > 0 ? safeFlags : undefined;
+}
+
+function settleSafeFlagSpec(command: string): SafeFlagSpec | undefined {
+  return commandSupportsSettleObservation(command) ? SETTLE_SAFE_FLAG_SPEC : undefined;
 }
 
 function touchSafeFlagSpec(): SafeFlagSpec {
   return {
-    booleans: [{ source: 'doubleTap' }, { source: 'settle' }],
+    booleans: [{ source: 'doubleTap' }],
     numbers: [
       { source: 'count' },
       { source: 'intervalMs' },
       { source: 'holdMs' },
       { source: 'jitterPx' },
-      { source: 'settleQuietMs' },
     ],
     enums: [{ source: 'clickButton', values: CLICK_BUTTONS }],
   };
@@ -375,8 +386,7 @@ function touchSafeFlagSpec(): SafeFlagSpec {
 
 function textEntrySafeFlagSpec(): SafeFlagSpec {
   return {
-    booleans: [{ source: 'settle' }],
-    numbers: [{ source: 'delayMs' }, { source: 'settleQuietMs' }],
+    numbers: [{ source: 'delayMs' }],
   };
 }
 

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -1,6 +1,7 @@
 import type { JsonSchema } from '../commands/command-contract.ts';
 import { projectedSystemCommandOutputSchemas } from '../commands/system/index.ts';
 import type { CommandResultMap } from '../core/command-descriptor/command-result.ts';
+import { commandSupportsSettleObservation } from '../core/command-descriptor/registry.ts';
 import { booleanSchema, looseObjectSchema, stringSchema } from '../commands/command-input.ts';
 import { SESSION_SURFACES } from '@agent-device/contracts/session';
 import { DEVICE_TARGETS, PUBLIC_PLATFORMS } from '@agent-device/kernel/device';
@@ -25,6 +26,11 @@ import { DEVICE_TARGETS, PUBLIC_PLATFORMS } from '@agent-device/kernel/device';
  *    fields ride into `structuredContent` and still validate.
  *  - Accurate, never invented: required-vs-optional, enums, `const` discriminants
  *    and discriminated-union branches mirror the source contract types.
+ *
+ * The opt-in `--settle` observation (#1101) is not hand-listed per entry: the
+ * base map carries none and `deriveSettleObservationSchemas` grafts it onto
+ * exactly the entries whose descriptor declares the post-action observation
+ * trait (#1652).
  */
 
 export const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
@@ -308,18 +314,42 @@ const targetShutdownResultSchema: JsonSchema = objectSchema(
   ['success', 'exitCode', 'stdout', 'stderr'],
 );
 
-/** Grafts the opt-in `--settle` observation onto an otherwise closed schema. */
+/** Grafts the opt-in `--settle` observation onto a closed schema or union branch. */
 function withSettleObservation(schema: JsonSchema): JsonSchema {
+  // Union-shaped results (fill) carry the observation in EACH branch, never
+  // next to the oneOf.
+  if (schema.oneOf) {
+    return { ...schema, oneOf: schema.oneOf.map(withSettleObservation) };
+  }
   return {
     ...schema,
     properties: { ...(schema.properties ?? {}), settle: settleObservationSchema },
   };
 }
 
+/**
+ * #1652: whether a command's output schema advertises `settle` derives from
+ * its descriptor post-action observation trait instead of hand-listed
+ * properties per schema. The base map below carries no settle property
+ * anywhere; this pass grafts it onto exactly the trait-capable entries.
+ * Copies only — press and click share one base schema object, so an in-place
+ * graft would leak across them, and non-trait entries must stay the SAME
+ * object identity their projection tests pin.
+ */
+function deriveSettleObservationSchemas(
+  schemas: Record<keyof CommandResultMap, JsonSchema>,
+): Record<keyof CommandResultMap, JsonSchema> {
+  const derived: Record<keyof CommandResultMap, JsonSchema> = { ...schemas };
+  for (const command of Object.keys(derived) as Array<keyof CommandResultMap>) {
+    if (!commandSupportsSettleObservation(command)) continue;
+    derived[command] = withSettleObservation(derived[command]);
+  }
+  return derived;
+}
+
 const tapInteractionResponseDataSchema = interactionResponseDataSchema({
   properties: {
     evidence: interactionEvidenceSchema,
-    settle: settleObservationSchema,
     button: enumSchema(['secondary', 'middle']),
     count: numberSchema('Number of press/click repetitions.'),
     intervalMs: numberSchema('Delay between repeated press/click actions.'),
@@ -333,7 +363,6 @@ const fillResponseProperties = {
   text: stringSchema('Text submitted to the field.'),
   delayMs: numberSchema('Delay between typed characters in milliseconds.'),
   evidence: interactionEvidenceSchema,
-  settle: settleObservationSchema,
 };
 
 const fillVerificationTargetSchema = objectSchema(
@@ -379,8 +408,10 @@ const unconfirmedFillResponseSchema = interactionResponseDataSchema({
   required: ['text', 'verification', 'requested', 'before', 'after', 'target'],
 });
 
-export const COMMAND_OUTPUT_SCHEMAS = {
+const BASE_COMMAND_OUTPUT_SCHEMAS = {
   // buildInteractionResponseData public payloads for interaction commands.
+  // #1652: the opt-in `settle` observation is NOT listed here — the trait
+  // derivation pass grafts it onto settle-capable entries below.
   press: tapInteractionResponseDataSchema,
   click: tapInteractionResponseDataSchema,
   fill: {
@@ -392,13 +423,11 @@ export const COMMAND_OUTPUT_SCHEMAS = {
   longpress: interactionResponseDataSchema({
     properties: {
       durationMs: numberSchema(),
-      settle: settleObservationSchema,
       gesture: constSchema('longpress'),
     },
   }),
   hover: interactionResponseDataSchema({
     properties: {
-      settle: settleObservationSchema,
       gesture: constSchema('hover'),
     },
   }),
@@ -420,7 +449,6 @@ export const COMMAND_OUTPUT_SCHEMAS = {
       x: numberSchema('Resolved x coordinate for mutating find actions.'),
       y: numberSchema('Resolved y coordinate for mutating find actions.'),
       message: stringSchema('Diagnostic message for mutating find actions.'),
-      settle: settleObservationSchema,
       cost: responseCostSchema,
     },
     [],
@@ -444,12 +472,8 @@ export const COMMAND_OUTPUT_SCHEMAS = {
   ),
 
   // packages/contracts/src/navigation.ts, projected from executable command contracts.
+  // The `back` settle observation is grafted by the derivation pass below.
   ...projectedSystemCommandOutputSchemas,
-  // #1638: the projected navigation schema is the closed dispatch shape. `back`
-  // is settle-capable on the generic route, so the opt-in observation is added
-  // here — the projection layer sits below this module and cannot reach
-  // `settleObservationSchema`.
-  back: withSettleObservation(projectedSystemCommandOutputSchemas.back),
 
   // packages/contracts/src/wait.ts — compact public daemon projection.
   wait: objectSchema(
@@ -464,6 +488,23 @@ export const COMMAND_OUTPUT_SCHEMAS = {
       warning: stringSchema(),
     },
     ['waitedMs'],
+  ),
+
+  // packages/contracts/src/scroll-command.ts — ScrollCommandResult. The
+  // settle-capable generic-route pair must both be typed so the trait
+  // derivation grafts the observation onto each (#1652); platform leaves add
+  // gesture-plan coordinates on top, which the non-strict schema admits.
+  scroll: objectSchema(
+    {
+      direction: enumSchema(['up', 'down', 'left', 'right']),
+      edge: enumSchema(['top', 'bottom']),
+      passes: numberSchema('Edge scrolls only: how many scroll-and-check passes ran.'),
+      amount: numberSchema(),
+      pixels: numberSchema(),
+      durationMs: numberSchema(),
+      message: stringSchema(),
+    },
+    ['direction'],
   ),
 
   // packages/contracts/src/prepare.ts — prepare is not MCP-exposed, but the schema stays
@@ -772,3 +813,5 @@ export const COMMAND_OUTPUT_SCHEMAS = {
     ],
   },
 } satisfies Record<keyof CommandResultMap, JsonSchema>;
+
+export const COMMAND_OUTPUT_SCHEMAS = deriveSettleObservationSchemas(BASE_COMMAND_OUTPUT_SCHEMAS);


### PR DESCRIPTION
## Summary

Closes #1652. Every caller-facing `--settle` surface now derives from the descriptor `postActionObservation` trait instead of being hand-spread per command, and the descriptor gate pins all of them — a forgotten cell now fails a gate instead of silently no-op'ing the flag.

- **CLI reader input**: `readInputFromCli` merges `settleInputForCommand(command, flags)` at the one seam every reader passes through; the seven per-reader `settleInputFromFlags` spreads are deleted. A new settle-capable command inherits the triple for free.
- **MCP output schemas**: the base map carries no `settle` property anywhere; `deriveSettleObservationSchemas` grafts the observation onto exactly the trait-capable entries (into each `oneOf` branch for fill). Non-trait entries keep the object identity their projection tests pin.
- **CLI output formatters**: `withSettleCapableNotes` wraps family formatter maps by trait; `back`/scroll no longer hand-pick the settle-aware formatter, and `tapCliOutput` no longer appends notes itself.
- **Session-event safe flags**: the settle/settleQuietMs projection derives from the trait instead of being re-listed in four per-command specs (`type`, which shares fill's text-entry spec but has no trait, correctly stops disclosing settle).
- **Contracts option types**: new `post-action-observation-client-options.ts` makes a dropped `& SettleCommandOptions` intersection (or a missing/extra cell) a **compile error**, following the `interaction-guarantees.ts` strategy.
- **find** (the issue's open call on intent): dropped the `settle` property from find's MCP output schema. Find carries no trait, no CLI flag, and no MCP input field for settle — advertising a payload no public surface can request was the drift. Internal flag-forwarding to delegated click/fill keeps working unadvertised; the contracts result type is unchanged.
- **Drive-by**: the dogfood help topic claimed `scroll` does not support `--settle` (stale since #1638); corrected to match the overview help and trait.

`scroll` is now typed end to end (review follow-up): `ScrollCommandResult` joins the `CommandResultMap` spine, grounded in `buildDispatchedScrollResult` and the platform leaf returns (direction, edge/passes, honored distance/timing, message, dispatcher-folded settle; platform gesture-plan coordinates ride the non-strict schema). The compiler-enforced map↔schema one-for-one invariant pulled in its output schema, and the MCP gate now asserts the trait denominator is covered by the schema keys — the motivating drift row from the issue can no longer recur silently. Still out of scope (per the issue): unifying the two daemon settle orchestrations.

## Validation

All evidence at 954c062c4 (branch rebased onto 93f8ae009):

- `pnpm typecheck` clean; `pnpm check:affected --run` fully green (413 files / 3517 tests, incl. layering, fallow dead-code, MCP parity, coverage gates).
- New gates in `post-action-observation.test.ts` observed red by planting violations, each naming the invariant: unwired schema graft ("press: settle advertisement must match descriptor trait"), unwired formatter wrap ("click: settle rendering must match descriptor trait"), unwired session spec ("click: session event must disclose settle"), seam merge disabled ("click: --settle must reach daemon input" + "settle option must survive projection"). The back-reader seam red was observed naturally: the pre-refactor `backCliReader` test failed once the spread moved to the seam, and was rewritten through `readInputFromCli`. Compile-time gate observed red by dropping `& SettleCommandOptions` from `ScrollOptions` (TS2559).
- One flake, not a regression: `provider-scenarios/ios-lifecycle.test.ts` timed out identically on a stashed clean tree in this worktree; passed in the full affected run. Provider/device lanes remain CI's authority.

Docs/skills: no user docs changed — no doc mentions `find` + `--settle`, and the corrected help text lives in versioned CLI help (source of truth).
