### PR TITLE
fix(ios): enforce regular snapshot clip invariant

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -153,6 +153,11 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBoundedSystemModalProbeTimeoutRecoversThenReleasesOnDrainForSnapshotRaw \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotTraversalIdentityPreservesSameOriginNodesWithDifferentBounds \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotPresentationPreservesCurrentWireShape \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRegularPresentationKeepsNestedClipGeometryCumulative \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRegularPresentationKeepsFramelessSemanticCarriersNonActionableAndNonClipping \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRawPresentationKeepsReportedOffscreenAndFramelessFacts \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testFixedSeedRegularPresentationMaintainsCumulativeClipInvariant \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPresentationFailureKeepsItsNamedSnapshotQualityReason \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testRegularPresentationPublishesEffectiveRectWhileRawKeepsReportedFrame \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotPresentationOwnsBackendNeutralEligibility \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSnapshotPresentationOwnsScopeAndRelativeDepth \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -690,7 +690,7 @@ extension RunnerTests {
     XCTAssertTrue(labels.contains("unrelated sibling"))
   }
 
-  func testPrivateAXInteractiveFiltersLoginLikeHiddenDrawer() {
+  func testPrivateAXInteractiveFiltersLoginLikeHiddenDrawer() throws {
     let tree: [String: Any] = [
       "type": Int(XCUIElement.ElementType.application.rawValue),
       "label": "Blue Sky",
@@ -761,7 +761,7 @@ extension RunnerTests {
     // Acquisition serializes the drawer too; the shared fold is what hides it (#1797).
     XCTAssertTrue(acquired.compactMap(\.label).contains("Admin settings"))
 
-    let capture = SnapshotPresentation.presentRegular(
+    let capture = try SnapshotPresentation.presentRegular(
       SnapshotAcquisition(
         hint: hint, nodes: acquired, truncated: false, effectiveDepth: nil, viewport: viewport),
       options: PresentationOptions(interactiveOnly: true, depth: nil, scope: nil, raw: false),

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+PrivateAXPresentation.swift
@@ -132,11 +132,11 @@ extension RunnerTests {
     rawRoot: [String: Any],
     viewport: CGRect,
     interactiveOnly: Bool = false
-  ) -> [PresentedNode] {
+  ) throws -> [PresentedNode] {
     let hint = CaptureHint(
       projection: .regular, depth: nil, interactiveOnly: interactiveOnly, customActions: false)
     let acquired = privateAXAcquisition(rawRoot: rawRoot, hint: hint, viewport: viewport)
-    return SnapshotPresentation.presentRegular(
+    return try SnapshotPresentation.presentRegular(
       SnapshotAcquisition(
         hint: hint, nodes: acquired, truncated: false, effectiveDepth: nil, viewport: viewport),
       options: PresentationOptions(
@@ -145,8 +145,8 @@ extension RunnerTests {
     ).payload.nodes ?? []
   }
 
-  func testPrivateAXRegularPresentationProjectsToViewportAndKeepsScrollHint() {
-    let nodes = privateAXRegularPresentation(
+  func testPrivateAXRegularPresentationProjectsToViewportAndKeepsScrollHint() throws {
+    let nodes = try privateAXRegularPresentation(
       rawRoot: Self.privateAXScrolledFixture,
       viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Profile picture"])
@@ -158,10 +158,10 @@ extension RunnerTests {
   /// #1797 D4: the raw projection is the acquired tree. The offscreen row and the sub-pixel
   /// decoration the regular projection folds away are both present, at traversal depth, and every
   /// regular node still appears -- `regular ⊆ raw` on the same capture.
-  func testPrivateAXRawProjectionKeepsEveryAcquiredNode() {
+  func testPrivateAXRawProjectionKeepsEveryAcquiredNode() throws {
     let viewport = CGRect(x: 0, y: 0, width: 402, height: 874)
     let root = Self.privateAXScrolledFixture
-    let regular = privateAXRegularPresentation(rawRoot: root, viewport: viewport,
+    let regular = try privateAXRegularPresentation(rawRoot: root, viewport: viewport,
       interactiveOnly: true)
     let raw = privateAXAcquisition(rawRoot: root,
       hint: CaptureHint(projection: .raw, depth: nil, interactiveOnly: false, customActions: false),
@@ -196,7 +196,7 @@ extension RunnerTests {
     XCTAssertEqual(raw.map(\.depth), [0, 1, 2, 2])
   }
 
-  func testPrivateAXPresentationKeepsOffscreenSubtreeExcludedWhenChildFramesAreClamped() {
+  func testPrivateAXPresentationKeepsOffscreenSubtreeExcludedWhenChildFramesAreClamped() throws {
     let frame = Self.privateAXFrame
     let root: [String: Any] = ["type": Int(XCUIElement.ElementType.application.rawValue),
       "label": "Element", "frame": frame(0, 0, 402, 874), "children": [[
@@ -208,14 +208,14 @@ extension RunnerTests {
           ["type": Int(XCUIElement.ElementType.switch.rawValue),
             "label": "Theme", "frame": frame(340, 96, 46, 44)]]]]]]]
 
-    let nodes = privateAXRegularPresentation(
+    let nodes = try privateAXRegularPresentation(
       rawRoot: root, viewport: CGRect(x: 0, y: 0, width: 402, height: 874))
 
     XCTAssertEqual(nodes.compactMap(\.label), ["Element"])
     XCTAssertEqual(nodes.first { $0.type == "Table" }?.hiddenContentBelow, true)
   }
 
-  func testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts() {
+  func testPrivateAXGeometrylessSemanticsAreNeverActionableOrScrollContexts() throws {
     let zero = ["x": 0, "y": 0, "width": 0, "height": 0]
     let root: [String: Any] = ["type": Int(XCUIElement.ElementType.application.rawValue),
       "label": "Element", "frame": ["x": 0, "y": 0, "width": 402, "height": 874],
@@ -223,7 +223,7 @@ extension RunnerTests {
         "label": "Settings semantics", "frame": zero, "children": [[
           "type": Int(XCUIElement.ElementType.button.rawValue), "label": "Theme", "frame": zero],
         ["type": Int(XCUIElement.ElementType.other.rawValue), "frame": zero]]]]]
-    let nodes = privateAXRegularPresentation(
+    let nodes = try privateAXRegularPresentation(
       rawRoot: root, viewport: CGRect(x: 0, y: 0, width: 402, height: 874),
       interactiveOnly: true)
     XCTAssertEqual(nodes.compactMap(\.label), ["Element", "Settings semantics", "Theme"])

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -36,6 +36,7 @@ extension RunnerTests {
     let code: String
     let message: String
     let hint: String
+    let qualityReasonCode: String? = nil
   }
 
   // MARK: - Snapshot Entry

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -36,7 +36,14 @@ extension RunnerTests {
     let code: String
     let message: String
     let hint: String
-    let qualityReasonCode: String? = nil
+    let qualityReasonCode: String?
+
+    init(code: String, message: String, hint: String, qualityReasonCode: String? = nil) {
+      self.code = code
+      self.message = message
+      self.hint = hint
+      self.qualityReasonCode = qualityReasonCode
+    }
   }
 
   // MARK: - Snapshot Entry

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -480,7 +480,7 @@ extension RunnerTests {
     let presented: SnapshotBackendCapture
     do {
       presented = try timer.measure(.presentation) {
-        guard let capture = SnapshotPresentation.present(acquisition, options: options) else {
+        guard let capture = try SnapshotPresentation.present(acquisition, options: options) else {
           throw Self.snapshotProjectionMismatchFailure(
             kind,
             requested: hint.projection,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -17,7 +17,8 @@ struct SnapshotQuality: Codable {
   /// Why recovery ran (first failure), why the payload is degraded, or why an internal backend
   /// selection was honored.
   let reason: String?
-  /// Machine-readable reason: ax-rejected | sparse-tree | budget | no-nodes | requested-backend.
+  /// Machine-readable reason: ax-rejected | sparse-tree | budget | no-nodes | capture-failed |
+  /// presentation-failed | deferred | requested-backend.
   let reasonCode: String?
   /// Private AX ladder cap when the accepted tree is shallower than requested.
   let effectiveDepth: Int?
@@ -347,7 +348,7 @@ extension RunnerTests {
       if case let .failed(failure, phase: _) = attempt.outcome {
         if Self.isAxSnapshotFailure(failure) { axFailure = failure }
         if firstFailure == nil {
-          firstFailure = (failure.message, Self.isAxSnapshotFailure(failure) ? "ax-rejected" : "capture-failed")
+          firstFailure = (failure.message, Self.snapshotQualityReasonCode(for: failure))
         }
         NSLog(
           "AGENT_DEVICE_RUNNER_SNAPSHOT_BACKEND_FAILED backend=%@ error=%@",
@@ -469,7 +470,6 @@ extension RunnerTests {
         timing: timer.timing
       )
     }
-
     guard let acquisition else {
       return SnapshotBackendAttempt(
         outcome: .noCapture,
@@ -489,6 +489,11 @@ extension RunnerTests {
         }
         return capture
       }
+    } catch let failure as SnapshotPresentationFailure {
+      return SnapshotBackendAttempt(
+        outcome: .failed(Self.snapshotCaptureFailure(for: failure), phase: .presentation),
+        timing: timer.timing
+      )
     } catch let failure as SnapshotCaptureFailure {
       return SnapshotBackendAttempt(
         outcome: .failed(failure, phase: .presentation),
@@ -668,9 +673,15 @@ extension RunnerTests {
     else { return nil }
     var parts: [String] = []
     if quality.state == "recovered" {
-      let meaning = quality.reasonCode == "budget" || quality.reasonCode == "deferred"
-        ? " The primary capture ran out of its time budget (busy app or simulator); the recovered tree is authoritative for this screen."
-        : " This usually means the app publishes an unhealthy accessibility tree — fixing the app's accessibility is the real cure. Treat screenshot as visual truth when this warning appears."
+      let meaning: String
+      switch quality.reasonCode {
+      case "budget", "deferred":
+        meaning = " The primary capture ran out of its time budget (busy app or simulator); the recovered tree is authoritative for this screen."
+      case "presentation-failed":
+        meaning = " The runner rejected a regular presentation because its cumulative clip invariant failed; report this as a runner bug and treat screenshot as visual truth."
+      default:
+        meaning = " This usually means the app publishes an unhealthy accessibility tree — fixing the app's accessibility is the real cure. Treat screenshot as visual truth when this warning appears."
+      }
       parts.append(
         "Detected an overly complex or slow accessibility tree. Fell back to the \(quality.backend) snapshot backend"
           + (quality.reason.map { " after: \($0)." } ?? ".")

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentation.swift
@@ -98,7 +98,7 @@ enum SnapshotPresentation {
   static func present(
     _ acquisition: SnapshotAcquisition,
     options: PresentationOptions
-  ) -> SnapshotBackendCapture? {
+  ) throws -> SnapshotBackendCapture? {
     let requested = captureHint(for: options)
     guard acquisition.hint.projection == requested.projection else {
       NSLog(
@@ -110,7 +110,7 @@ enum SnapshotPresentation {
     }
     switch requested.projection {
     case .regular:
-      return presentRegular(acquisition, options: options)
+      return try presentRegular(acquisition, options: options)
     case .raw:
       return presentRaw(acquisition, options: options)
     }
@@ -119,19 +119,26 @@ enum SnapshotPresentation {
   /// Visible projection: the clip fold (viewport ∩ scroll clip, ancestor cursor, scroll hints),
   /// eligibility (an interactive type or non-empty semantic content, below the root carrier), and
   /// scope. The only interpreter of what a screen currently shows -- no backend folds its own
-  /// visibility (#1797).
+  /// visibility (#1797). Throws a typed `SnapshotPresentationFailure` if the folded result would
+  /// violate the regular projection's geometry or actionability contract.
   static func presentRegular(
     _ acquisition: SnapshotAcquisition,
     options: PresentationOptions,
     policy: SnapshotVisibilityFold.Policy = .platformDefault
-  ) -> SnapshotBackendCapture {
-    project(
-      SnapshotVisibilityFold.fold(
-        acquisition.nodes,
-        viewport: acquisition.viewport,
-        interactiveOnly: options.interactiveOnly,
-        policy: policy
-      ),
+  ) throws -> SnapshotBackendCapture {
+    let folded = SnapshotVisibilityFold.fold(
+      acquisition.nodes,
+      viewport: acquisition.viewport,
+      interactiveOnly: options.interactiveOnly,
+      policy: policy
+    )
+    try SnapshotPresentation.validateRegularInvariant(
+      folded,
+      viewport: acquisition.viewport,
+      policy: policy
+    )
+    return project(
+      folded,
       acquisition: acquisition,
       options: options,
       projection: .regular

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationInvariant.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationInvariant.swift
@@ -29,18 +29,59 @@ enum SnapshotPresentationFailure: Error {
 /// nodes, not raw acquisition facts, so replacing the fold with reported geometry cannot silently
 /// reach `PresentedNode` construction.
 extension SnapshotPresentation {
+  private struct InvariantValidationMetrics {
+    var parentClipLookups = 0
+  }
+
   static func validateRegularInvariant(
     _ nodes: [SnapshotPresentationNode],
     viewport: CGRect,
     policy: SnapshotVisibilityFold.Policy
   ) throws {
-    var nodesByIndex: [Int: SnapshotPresentationNode] = [:]
-    for node in nodes {
-      nodesByIndex[node.raw.index] = node
-    }
+    var metrics = InvariantValidationMetrics()
+    try validateRegularInvariant(
+      nodes,
+      viewport: viewport,
+      policy: policy,
+      metrics: &metrics
+    )
+  }
+
+  private static func validateRegularInvariant(
+    _ nodes: [SnapshotPresentationNode],
+    viewport: CGRect,
+    policy: SnapshotVisibilityFold.Policy,
+    metrics: inout InvariantValidationMetrics
+  ) throws {
+    // SnapshotVisibilityFold emits preorder, so every parent clip is available when its child is
+    // visited. The effective frame already contains the fold's viewport/ancestor clipping. Cache
+    // a scroll node's effective frame for descendants; the node itself is checked against its
+    // parent's context.
+    var clipIncludingNodeByIndex: [Int: CGRect] = [:]
+    clipIncludingNodeByIndex.reserveCapacity(nodes.count)
 
     for node in nodes {
+      let ancestorClip: CGRect
+      if let parentIndex = node.raw.parentIndex {
+        metrics.parentClipLookups += 1
+        ancestorClip = clipIncludingNodeByIndex[parentIndex] ?? viewport
+      } else {
+        ancestorClip = viewport
+      }
+
       let frame = cgRect(from: node.effectiveRect)
+      let clipIncludingNode: CGRect
+      if policy == .cursorProjected,
+        SnapshotVisibilityFold.scrollContainerTypeNames.contains(node.raw.type),
+        !frame.isNull,
+        !frame.isEmpty
+      {
+        clipIncludingNode = frame
+      } else {
+        clipIncludingNode = ancestorClip
+      }
+      clipIncludingNodeByIndex[node.raw.index] = clipIncludingNode
+
       guard !frame.isNull, !frame.isEmpty else {
         if node.raw.hittable {
           throw SnapshotPresentationFailure.regularDegenerateNodeIsActionable(
@@ -51,45 +92,14 @@ extension SnapshotPresentation {
         continue
       }
 
-      let clip = cumulativeClip(
-        for: node,
-        nodesByIndex: nodesByIndex,
-        viewport: viewport,
-        policy: policy
-      )
-      guard contains(frame, in: clip) else {
+      guard contains(frame, in: ancestorClip) else {
         throw SnapshotPresentationFailure.regularNodeOutsideCumulativeClip(
           index: node.raw.index,
           frame: node.effectiveRect,
-          clip: snapshotRect(from: clip)
+          clip: snapshotRect(from: ancestorClip)
         )
       }
     }
-  }
-
-  private static func cumulativeClip(
-    for node: SnapshotPresentationNode,
-    nodesByIndex: [Int: SnapshotPresentationNode],
-    viewport: CGRect,
-    policy: SnapshotVisibilityFold.Policy
-  ) -> CGRect {
-    guard policy == .cursorProjected else { return viewport }
-
-    var clip = viewport
-    var parentIndex = node.raw.parentIndex
-    var visited = Set<Int>()
-    while let currentIndex = parentIndex, visited.insert(currentIndex).inserted,
-      let parent = nodesByIndex[currentIndex]
-    {
-      if SnapshotVisibilityFold.scrollContainerTypeNames.contains(parent.raw.type) {
-        let parentFrame = cgRect(from: parent.effectiveRect)
-        if !parentFrame.isNull, !parentFrame.isEmpty {
-          clip = clip.intersection(parentFrame)
-        }
-      }
-      parentIndex = parent.raw.parentIndex
-    }
-    return clip
   }
 
   private static func contains(_ frame: CGRect, in clip: CGRect) -> Bool {
@@ -113,6 +123,27 @@ extension SnapshotPresentation {
       height: Double(rect.height)
     )
   }
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+  struct InvariantValidationStats {
+    let parentClipLookups: Int
+  }
+
+  static func validateRegularInvariantForTesting(
+    _ nodes: [SnapshotPresentationNode],
+    viewport: CGRect,
+    policy: SnapshotVisibilityFold.Policy
+  ) throws -> InvariantValidationStats {
+    var metrics = InvariantValidationMetrics()
+    try validateRegularInvariant(
+      nodes,
+      viewport: viewport,
+      policy: policy,
+      metrics: &metrics
+    )
+    return InvariantValidationStats(parentClipLookups: metrics.parentClipLookups)
+  }
+#endif
 }
 
 extension RunnerTests {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationInvariant.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotPresentationInvariant.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// A presentation failure is a runner-owned degradation, not evidence that the app published a
+/// sparse accessibility tree. The capture plan maps this typed failure onto its existing quality
+/// payload at the acquisition/presentation boundary.
+enum SnapshotPresentationFailure: Error {
+  case regularNodeOutsideCumulativeClip(index: Int, frame: SnapshotRect, clip: SnapshotRect)
+  case regularDegenerateNodeIsActionable(index: Int, frame: SnapshotRect)
+
+  var code: String { "IOS_SNAPSHOT_PRESENTATION_FAILED" }
+
+  var qualityReasonCode: String { "presentation-failed" }
+
+  var message: String {
+    switch self {
+    case .regularNodeOutsideCumulativeClip(let index, _, _):
+      return "regular snapshot node \(index) escaped its cumulative clip"
+    case .regularDegenerateNodeIsActionable(let index, _):
+      return "regular snapshot node \(index) with a frameless or degenerate frame was marked hittable"
+    }
+  }
+
+  var hint: String {
+    "This is a runner presentation bug: report it with the failing command and the app under test."
+  }
+}
+
+/// The choke-point check for the regular presentation. It consumes the folded presentation
+/// nodes, not raw acquisition facts, so replacing the fold with reported geometry cannot silently
+/// reach `PresentedNode` construction.
+extension SnapshotPresentation {
+  static func validateRegularInvariant(
+    _ nodes: [SnapshotPresentationNode],
+    viewport: CGRect,
+    policy: SnapshotVisibilityFold.Policy
+  ) throws {
+    var nodesByIndex: [Int: SnapshotPresentationNode] = [:]
+    for node in nodes {
+      nodesByIndex[node.raw.index] = node
+    }
+
+    for node in nodes {
+      let frame = cgRect(from: node.effectiveRect)
+      guard !frame.isNull, !frame.isEmpty else {
+        if node.raw.hittable {
+          throw SnapshotPresentationFailure.regularDegenerateNodeIsActionable(
+            index: node.raw.index,
+            frame: node.effectiveRect
+          )
+        }
+        continue
+      }
+
+      let clip = cumulativeClip(
+        for: node,
+        nodesByIndex: nodesByIndex,
+        viewport: viewport,
+        policy: policy
+      )
+      guard contains(frame, in: clip) else {
+        throw SnapshotPresentationFailure.regularNodeOutsideCumulativeClip(
+          index: node.raw.index,
+          frame: node.effectiveRect,
+          clip: snapshotRect(from: clip)
+        )
+      }
+    }
+  }
+
+  private static func cumulativeClip(
+    for node: SnapshotPresentationNode,
+    nodesByIndex: [Int: SnapshotPresentationNode],
+    viewport: CGRect,
+    policy: SnapshotVisibilityFold.Policy
+  ) -> CGRect {
+    guard policy == .cursorProjected else { return viewport }
+
+    var clip = viewport
+    var parentIndex = node.raw.parentIndex
+    var visited = Set<Int>()
+    while let currentIndex = parentIndex, visited.insert(currentIndex).inserted,
+      let parent = nodesByIndex[currentIndex]
+    {
+      if SnapshotVisibilityFold.scrollContainerTypeNames.contains(parent.raw.type) {
+        let parentFrame = cgRect(from: parent.effectiveRect)
+        if !parentFrame.isNull, !parentFrame.isEmpty {
+          clip = clip.intersection(parentFrame)
+        }
+      }
+      parentIndex = parent.raw.parentIndex
+    }
+    return clip
+  }
+
+  private static func contains(_ frame: CGRect, in clip: CGRect) -> Bool {
+    guard !clip.isNull, !clip.isEmpty else { return false }
+    let tolerance = 0.0001
+    return frame.minX >= clip.minX - tolerance
+      && frame.minY >= clip.minY - tolerance
+      && frame.maxX <= clip.maxX + tolerance
+      && frame.maxY <= clip.maxY + tolerance
+  }
+
+  private static func cgRect(from rect: SnapshotRect) -> CGRect {
+    CGRect(x: rect.x, y: rect.y, width: rect.width, height: rect.height)
+  }
+
+  private static func snapshotRect(from rect: CGRect) -> SnapshotRect {
+    SnapshotRect(
+      x: Double(rect.minX),
+      y: Double(rect.minY),
+      width: Double(rect.width),
+      height: Double(rect.height)
+    )
+  }
+}
+
+extension RunnerTests {
+  static func snapshotCaptureFailure(
+    for failure: SnapshotPresentationFailure
+  ) -> SnapshotCaptureFailure {
+    SnapshotCaptureFailure(
+      code: failure.code,
+      message: failure.message,
+      hint: failure.hint,
+      qualityReasonCode: failure.qualityReasonCode
+    )
+  }
+
+  static func snapshotQualityReasonCode(for failure: SnapshotCaptureFailure) -> String {
+    failure.qualityReasonCode
+      ?? (Self.isAxSnapshotFailure(failure) ? "ax-rejected" : "capture-failed")
+  }
+}

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotHittabilityTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotHittabilityTests.swift
@@ -90,7 +90,7 @@ extension RunnerTests {
     ]
     let options = PresentationOptions(
       interactiveOnly: false, depth: nil, scope: nil, raw: false)
-    let capture = SnapshotPresentation.presentRegular(
+    let capture = try SnapshotPresentation.presentRegular(
       SnapshotAcquisition(
         hint: SnapshotPresentation.captureHint(for: options),
         nodes: nodes,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationInvariantTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationInvariantTests.swift
@@ -99,48 +99,6 @@ extension RunnerTests {
     )
   }
 
-  private static func assertFramedNodesStayInsideTheirCumulativeClip(
-    _ nodes: [SnapshotPresentation.PresentedNode],
-    viewport: CGRect,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    let nodesByIndex = Dictionary(uniqueKeysWithValues: nodes.map { ($0.index, $0) })
-    for node in nodes {
-      let frame = CGRect(
-        x: node.rect.x, y: node.rect.y, width: node.rect.width, height: node.rect.height)
-      guard !frame.isNull, !frame.isEmpty else {
-        XCTAssertFalse(node.hittable, "degenerate regular node is actionable", file: file, line: line)
-        continue
-      }
-
-      var cumulativeClip = viewport
-      var parentIndex = node.parentIndex
-      var visited = Set<Int>()
-      while let currentIndex = parentIndex, visited.insert(currentIndex).inserted,
-        let parent = nodesByIndex[currentIndex]
-      {
-        if SnapshotVisibilityFold.scrollContainerTypeNames.contains(parent.type) {
-          let parentFrame = CGRect(
-            x: parent.rect.x,
-            y: parent.rect.y,
-            width: parent.rect.width,
-            height: parent.rect.height
-          )
-          if !parentFrame.isNull, !parentFrame.isEmpty {
-            cumulativeClip = cumulativeClip.intersection(parentFrame)
-          }
-        }
-        parentIndex = parent.parentIndex
-      }
-
-      XCTAssertGreaterThanOrEqual(frame.minX, cumulativeClip.minX, file: file, line: line)
-      XCTAssertGreaterThanOrEqual(frame.minY, cumulativeClip.minY, file: file, line: line)
-      XCTAssertLessThanOrEqual(frame.maxX, cumulativeClip.maxX, file: file, line: line)
-      XCTAssertLessThanOrEqual(frame.maxY, cumulativeClip.maxY, file: file, line: line)
-    }
-  }
-
   func testRegularPresentationKeepsNestedClipGeometryCumulative() throws {
     let acquisition = SnapshotAcquisition(
       hint: CaptureHint(
@@ -191,7 +149,8 @@ extension RunnerTests {
 
     let options = PresentationOptions(
       interactiveOnly: false, depth: nil, scope: nil, raw: false)
-    let capture = try SnapshotPresentation.presentRegular(acquisition, options: options)
+    let capture = try SnapshotPresentation.presentRegular(
+      acquisition, options: options, policy: .cursorProjected)
     let nodes = try XCTUnwrap(capture.payload.nodes)
 
     XCTAssertEqual(nodes.compactMap(\.label), ["App", "Outer", "Inner", "Partially visible"])
@@ -199,8 +158,6 @@ extension RunnerTests {
     XCTAssertEqual(clipped.rect.x, 150)
     XCTAssertEqual(clipped.rect.width, 46)
     XCTAssertFalse(nodes.contains { $0.label == "Escaped child" })
-    Self.assertFramedNodesStayInsideTheirCumulativeClip(
-      nodes, viewport: acquisition.viewport)
   }
 
   func testRegularPresentationKeepsFramelessSemanticCarriersNonActionableAndNonClipping() throws {
@@ -248,14 +205,14 @@ extension RunnerTests {
     let options = PresentationOptions(
       interactiveOnly: true, depth: nil, scope: nil, raw: false)
     let nodes = try XCTUnwrap(
-      try SnapshotPresentation.presentRegular(acquisition, options: options).payload.nodes)
+      try SnapshotPresentation.presentRegular(
+        acquisition, options: options, policy: .cursorProjected
+      ).payload.nodes)
 
     XCTAssertEqual(nodes.compactMap(\.label), [
       "App", "Geometryless semantics", "Child is not clipped", "Zero-area semantics",
     ])
     XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, true, false])
-    Self.assertFramedNodesStayInsideTheirCumulativeClip(
-      nodes, viewport: acquisition.viewport)
   }
 
   func testRawPresentationKeepsReportedOffscreenAndFramelessFacts() throws {
@@ -308,18 +265,82 @@ extension RunnerTests {
   }
 
   func testFixedSeedRegularPresentationMaintainsCumulativeClipInvariant() throws {
-    // Non-vacuity: replacing the regular fold with reported geometry makes the presentation
-    // choke point throw `presentation-failed`; removing that check makes this fixed-seed property
-    // fail on the first nested-clip case that emits an out-of-clip node.
+    // Fixed-seed coverage keeps the one-pass validator exercised across nested and degenerate
+    // ancestry without relying on a wall-clock performance threshold.
     for seed in 1...64 {
       let acquisition = Self.fixedSeedAcquisition(seed: UInt64(seed))
       let options = PresentationOptions(
         interactiveOnly: false, depth: nil, scope: nil, raw: false)
-      let capture = try SnapshotPresentation.presentRegular(acquisition, options: options)
-      let nodes = try XCTUnwrap(capture.payload.nodes)
-      Self.assertFramedNodesStayInsideTheirCumulativeClip(
-        nodes, viewport: acquisition.viewport)
+      _ = try SnapshotPresentation.presentRegular(
+        acquisition, options: options, policy: .cursorProjected)
     }
+  }
+
+  func testRegularInvariantRejectsEscapedEffectiveGeometry() throws {
+    let viewport = CGRect(x: 0, y: 0, width: 200, height: 200)
+    let rawNodes = [
+      Self.invariantNode(
+        0,
+        type: "Application",
+        rect: SnapshotRect(x: 0, y: 0, width: 200, height: 200),
+        parentIndex: nil
+      ),
+      Self.invariantNode(
+        1,
+        type: "ScrollView",
+        rect: SnapshotRect(x: 20, y: 20, width: 100, height: 100),
+        parentIndex: 0
+      ),
+      Self.invariantNode(
+        2,
+        type: "Button",
+        rect: SnapshotRect(x: 110, y: 40, width: 20, height: 20),
+        parentIndex: 1
+      ),
+    ]
+    let folded = rawNodes.map {
+      SnapshotPresentationNode(raw: $0, effectiveRect: $0.rect)
+    }
+
+    XCTAssertThrowsError(
+      try SnapshotPresentation.validateRegularInvariantForTesting(
+        folded,
+        viewport: viewport,
+        policy: .cursorProjected
+      )
+    ) { error in
+      guard case let SnapshotPresentationFailure.regularNodeOutsideCumulativeClip(index, _, clip) = error
+      else {
+        return XCTFail("expected cumulative clip failure, got \(error)")
+      }
+      XCTAssertEqual(index, 2)
+      XCTAssertEqual(clip.x, 20)
+      XCTAssertEqual(clip.width, 100)
+    }
+  }
+
+  func testRegularInvariantUsesOneParentClipLookupPerNode() throws {
+    let nodeCount = 5_000
+    let viewport = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let nodes = (0..<nodeCount).map { index in
+      let raw = Self.invariantNode(
+        index,
+        type: index == 0 ? "Application" : "ScrollView",
+        rect: SnapshotRect(x: 0, y: 0, width: 100, height: 100),
+        parentIndex: index == 0 ? nil : index - 1
+      )
+      return SnapshotPresentationNode(raw: raw, effectiveRect: raw.rect)
+    }
+
+    let stats = try SnapshotPresentation.validateRegularInvariantForTesting(
+      nodes,
+      viewport: viewport,
+      policy: .cursorProjected
+    )
+
+    // The former per-node ancestor walk performs 12,497,500 lookups for this chain. Counting the
+    // cached parent resolutions makes the linear guarantee deterministic without timing the test.
+    XCTAssertEqual(stats.parentClipLookups, nodeCount - 1)
   }
 
   func testPresentationFailureKeepsItsNamedSnapshotQualityReason() {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationInvariantTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationInvariantTests.swift
@@ -1,0 +1,356 @@
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+import XCTest
+
+extension RunnerTests {
+  private struct FixedSeedGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+      state = seed
+    }
+
+    mutating func nextInt(_ upperBound: Int) -> Int {
+      precondition(upperBound > 0)
+      state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+      return Int(state % UInt64(upperBound))
+    }
+  }
+
+  private static func invariantNode(
+    _ index: Int,
+    type: String,
+    label: String? = nil,
+    rect: SnapshotRect,
+    parentIndex: Int?,
+    hittable: Bool = false
+  ) -> RawAXNode {
+    RawAXNode(
+      index: index,
+      type: type,
+      label: label,
+      identifier: nil,
+      value: nil,
+      rect: rect,
+      enabled: true,
+      focused: nil,
+      selected: nil,
+      hittable: hittable,
+      depth: parentIndex == nil ? 0 : 1,
+      parentIndex: parentIndex,
+      hiddenContentAbove: nil,
+      hiddenContentBelow: nil
+    )
+  }
+
+  private static func fixedSeedAcquisition(seed: UInt64) -> SnapshotAcquisition {
+    var generator = FixedSeedGenerator(seed: seed)
+    let viewport = CGRect(x: 0, y: 0, width: 320, height: 240)
+    var nodes = [
+      invariantNode(
+        0,
+        type: "Application",
+        label: "App",
+        rect: SnapshotRect(x: 0, y: 0, width: 320, height: 240),
+        parentIndex: nil
+      ),
+      invariantNode(
+        1,
+        type: "ScrollView",
+        label: "Outer scroll",
+        rect: SnapshotRect(x: 16, y: 20, width: 220, height: 180),
+        parentIndex: 0
+      ),
+      invariantNode(
+        2,
+        type: "ScrollView",
+        label: "Inner scroll",
+        rect: SnapshotRect(x: 120, y: 40, width: 180, height: 160),
+        parentIndex: 1
+      ),
+    ]
+
+    for index in 3...18 {
+      let parentIndex = generator.nextInt(index)
+      let type = generator.nextInt(4) == 0 ? "StaticText" : "Button"
+      let width = generator.nextInt(120) + 1
+      let height = generator.nextInt(48) + 1
+      let x = generator.nextInt(360) - 20
+      let y = generator.nextInt(280) - 20
+      nodes.append(
+        invariantNode(
+          index,
+          type: type,
+          label: "seed-\(seed)-\(index)",
+          rect: SnapshotRect(
+            x: Double(x), y: Double(y), width: Double(width), height: Double(height)),
+          parentIndex: parentIndex,
+          hittable: true
+        )
+      )
+    }
+
+    return SnapshotAcquisition(
+      hint: CaptureHint(
+        projection: .regular, depth: nil, interactiveOnly: false, customActions: false),
+      nodes: nodes,
+      truncated: false,
+      effectiveDepth: nil,
+      viewport: viewport
+    )
+  }
+
+  private static func assertFramedNodesStayInsideTheirCumulativeClip(
+    _ nodes: [SnapshotPresentation.PresentedNode],
+    viewport: CGRect,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let nodesByIndex = Dictionary(uniqueKeysWithValues: nodes.map { ($0.index, $0) })
+    for node in nodes {
+      let frame = CGRect(
+        x: node.rect.x, y: node.rect.y, width: node.rect.width, height: node.rect.height)
+      guard !frame.isNull, !frame.isEmpty else {
+        XCTAssertFalse(node.hittable, "degenerate regular node is actionable", file: file, line: line)
+        continue
+      }
+
+      var cumulativeClip = viewport
+      var parentIndex = node.parentIndex
+      var visited = Set<Int>()
+      while let currentIndex = parentIndex, visited.insert(currentIndex).inserted,
+        let parent = nodesByIndex[currentIndex]
+      {
+        if SnapshotVisibilityFold.scrollContainerTypeNames.contains(parent.type) {
+          let parentFrame = CGRect(
+            x: parent.rect.x,
+            y: parent.rect.y,
+            width: parent.rect.width,
+            height: parent.rect.height
+          )
+          if !parentFrame.isNull, !parentFrame.isEmpty {
+            cumulativeClip = cumulativeClip.intersection(parentFrame)
+          }
+        }
+        parentIndex = parent.parentIndex
+      }
+
+      XCTAssertGreaterThanOrEqual(frame.minX, cumulativeClip.minX, file: file, line: line)
+      XCTAssertGreaterThanOrEqual(frame.minY, cumulativeClip.minY, file: file, line: line)
+      XCTAssertLessThanOrEqual(frame.maxX, cumulativeClip.maxX, file: file, line: line)
+      XCTAssertLessThanOrEqual(frame.maxY, cumulativeClip.maxY, file: file, line: line)
+    }
+  }
+
+  func testRegularPresentationKeepsNestedClipGeometryCumulative() throws {
+    let acquisition = SnapshotAcquisition(
+      hint: CaptureHint(
+        projection: .regular, depth: nil, interactiveOnly: false, customActions: false),
+      nodes: [
+        Self.invariantNode(
+          0,
+          type: "Application",
+          label: "App",
+          rect: SnapshotRect(x: 0, y: 0, width: 320, height: 240),
+          parentIndex: nil
+        ),
+        Self.invariantNode(
+          1,
+          type: "ScrollView",
+          label: "Outer",
+          rect: SnapshotRect(x: 16, y: 20, width: 180, height: 180),
+          parentIndex: 0
+        ),
+        Self.invariantNode(
+          2,
+          type: "ScrollView",
+          label: "Inner",
+          rect: SnapshotRect(x: 120, y: 40, width: 180, height: 160),
+          parentIndex: 1
+        ),
+        Self.invariantNode(
+          3,
+          type: "Button",
+          label: "Partially visible",
+          rect: SnapshotRect(x: 150, y: 80, width: 100, height: 40),
+          parentIndex: 2,
+          hittable: true
+        ),
+        Self.invariantNode(
+          4,
+          type: "Button",
+          label: "Escaped child",
+          rect: SnapshotRect(x: 210, y: 80, width: 100, height: 40),
+          parentIndex: 2,
+          hittable: true
+        ),
+      ],
+      truncated: false,
+      effectiveDepth: nil,
+      viewport: CGRect(x: 0, y: 0, width: 320, height: 240)
+    )
+
+    let options = PresentationOptions(
+      interactiveOnly: false, depth: nil, scope: nil, raw: false)
+    let capture = try SnapshotPresentation.presentRegular(acquisition, options: options)
+    let nodes = try XCTUnwrap(capture.payload.nodes)
+
+    XCTAssertEqual(nodes.compactMap(\.label), ["App", "Outer", "Inner", "Partially visible"])
+    let clipped = try XCTUnwrap(nodes.first { $0.label == "Partially visible" })
+    XCTAssertEqual(clipped.rect.x, 150)
+    XCTAssertEqual(clipped.rect.width, 46)
+    XCTAssertFalse(nodes.contains { $0.label == "Escaped child" })
+    Self.assertFramedNodesStayInsideTheirCumulativeClip(
+      nodes, viewport: acquisition.viewport)
+  }
+
+  func testRegularPresentationKeepsFramelessSemanticCarriersNonActionableAndNonClipping() throws {
+    let acquisition = SnapshotAcquisition(
+      hint: CaptureHint(
+        projection: .regular, depth: nil, interactiveOnly: true, customActions: false),
+      nodes: [
+        Self.invariantNode(
+          0,
+          type: "Application",
+          label: "App",
+          rect: SnapshotRect(x: 0, y: 0, width: 320, height: 240),
+          parentIndex: nil
+        ),
+        Self.invariantNode(
+          1,
+          type: "ScrollView",
+          label: "Geometryless semantics",
+          rect: SnapshotRect(x: 20, y: 20, width: 0, height: 0),
+          parentIndex: 0,
+          hittable: true
+        ),
+        Self.invariantNode(
+          2,
+          type: "Button",
+          label: "Child is not clipped",
+          rect: SnapshotRect(x: 40, y: 40, width: 80, height: 32),
+          parentIndex: 1,
+          hittable: true
+        ),
+        Self.invariantNode(
+          3,
+          type: "StaticText",
+          label: "Zero-area semantics",
+          rect: SnapshotRect(x: 40, y: 100, width: 0, height: 20),
+          parentIndex: 0,
+          hittable: true
+        ),
+      ],
+      truncated: false,
+      effectiveDepth: nil,
+      viewport: CGRect(x: 0, y: 0, width: 320, height: 240)
+    )
+
+    let options = PresentationOptions(
+      interactiveOnly: true, depth: nil, scope: nil, raw: false)
+    let nodes = try XCTUnwrap(
+      try SnapshotPresentation.presentRegular(acquisition, options: options).payload.nodes)
+
+    XCTAssertEqual(nodes.compactMap(\.label), [
+      "App", "Geometryless semantics", "Child is not clipped", "Zero-area semantics",
+    ])
+    XCTAssertEqual(nodes.filter { $0.index != 0 }.map(\.hittable), [false, true, false])
+    Self.assertFramedNodesStayInsideTheirCumulativeClip(
+      nodes, viewport: acquisition.viewport)
+  }
+
+  func testRawPresentationKeepsReportedOffscreenAndFramelessFacts() throws {
+    let nodes = [
+      Self.invariantNode(
+        0,
+        type: "Application",
+        label: "App",
+        rect: SnapshotRect(x: 0, y: 0, width: 100, height: 100),
+        parentIndex: nil
+      ),
+      Self.invariantNode(
+        1,
+        type: "Button",
+        label: "Offscreen",
+        rect: SnapshotRect(x: 200, y: 200, width: 40, height: 40),
+        parentIndex: 0,
+        hittable: true
+      ),
+      Self.invariantNode(
+        2,
+        type: "StaticText",
+        label: "Frameless",
+        rect: SnapshotRect(x: 12, y: 20, width: 0, height: 20),
+        parentIndex: 0,
+        hittable: true
+      ),
+    ]
+    let options = PresentationOptions(
+      interactiveOnly: true, depth: nil, scope: nil, raw: true)
+    let raw = try XCTUnwrap(
+      SnapshotPresentation.presentRaw(
+        SnapshotAcquisition(
+          hint: SnapshotPresentation.captureHint(for: options),
+          nodes: nodes,
+          truncated: false,
+          effectiveDepth: nil,
+          viewport: .infinite
+        ),
+        options: options
+      ).payload.nodes)
+
+    XCTAssertEqual(raw.map(\.label), ["App", "Offscreen", "Frameless"])
+    XCTAssertEqual(raw[1].rect.x, 200)
+    XCTAssertEqual(raw[1].rect.width, 40)
+    XCTAssertEqual(raw[2].rect.width, 0)
+    XCTAssertEqual(raw[2].rect.height, 20)
+    XCTAssertEqual(raw[1].hittable, true)
+    XCTAssertEqual(raw[2].hittable, true)
+  }
+
+  func testFixedSeedRegularPresentationMaintainsCumulativeClipInvariant() throws {
+    // Non-vacuity: replacing the regular fold with reported geometry makes the presentation
+    // choke point throw `presentation-failed`; removing that check makes this fixed-seed property
+    // fail on the first nested-clip case that emits an out-of-clip node.
+    for seed in 1...64 {
+      let acquisition = Self.fixedSeedAcquisition(seed: UInt64(seed))
+      let options = PresentationOptions(
+        interactiveOnly: false, depth: nil, scope: nil, raw: false)
+      let capture = try SnapshotPresentation.presentRegular(acquisition, options: options)
+      let nodes = try XCTUnwrap(capture.payload.nodes)
+      Self.assertFramedNodesStayInsideTheirCumulativeClip(
+        nodes, viewport: acquisition.viewport)
+    }
+  }
+
+  func testPresentationFailureKeepsItsNamedSnapshotQualityReason() {
+    // Non-vacuity: dropping the typed reason preference in the plan mapper changes the assertion
+    // below to `capture-failed`, losing the distinction this contract is meant to preserve.
+    let presentationFailure = SnapshotPresentationFailure.regularNodeOutsideCumulativeClip(
+      index: 7,
+      frame: SnapshotRect(x: 150, y: 40, width: 80, height: 20),
+      clip: SnapshotRect(x: 0, y: 0, width: 100, height: 100)
+    )
+    let captureFailure = Self.snapshotCaptureFailure(for: presentationFailure)
+
+    XCTAssertEqual(captureFailure.code, "IOS_SNAPSHOT_PRESENTATION_FAILED")
+    XCTAssertEqual(captureFailure.qualityReasonCode, "presentation-failed")
+    XCTAssertEqual(Self.snapshotQualityReasonCode(for: captureFailure), "presentation-failed")
+    XCTAssertNotEqual(Self.snapshotQualityReasonCode(for: captureFailure), "capture-failed")
+    XCTAssertTrue(captureFailure.message.contains("cumulative clip"))
+
+    let warning = Self.legacyQualityMessage(
+      SnapshotQuality(
+        state: "recovered",
+        backend: "queries",
+        reason: captureFailure.message,
+        reasonCode: captureFailure.qualityReasonCode,
+        effectiveDepth: nil,
+        collapsedLeafIndexes: nil,
+        customActions: nil
+      )
+    )
+    XCTAssertTrue(warning?.contains("runner bug") == true)
+    XCTAssertFalse(warning?.contains("fixing the app's accessibility") == true)
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+SnapshotPresentationTests.swift
@@ -25,7 +25,7 @@ extension RunnerTests {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
 
-    let capture = try XCTUnwrap(SnapshotPresentation.present(
+    let capture = try XCTUnwrap(try SnapshotPresentation.present(
       SnapshotAcquisition(
         hint: CaptureHint(
           projection: .raw, depth: nil, interactiveOnly: false, customActions: false),
@@ -105,7 +105,7 @@ extension RunnerTests {
       node(10, type: "StaticText", label: "Reparented content", depth: 2, parentIndex: 9),
     ]
     let regular = try XCTUnwrap(
-      SnapshotPresentation.presentRegular(
+      try SnapshotPresentation.presentRegular(
         SnapshotAcquisition(
           hint: CaptureHint(
             projection: .regular, depth: nil, interactiveOnly: false, customActions: false),
@@ -115,7 +115,7 @@ extension RunnerTests {
       ).payload.nodes
     )
     let interactive = try XCTUnwrap(
-      SnapshotPresentation.presentRegular(
+      try SnapshotPresentation.presentRegular(
         SnapshotAcquisition(
           hint: CaptureHint(
             projection: .regular, depth: nil, interactiveOnly: true, customActions: false),
@@ -151,7 +151,7 @@ extension RunnerTests {
     XCTAssertEqual(raw.last?.parentIndex, 9)
   }
 
-  func testRegularPresentationRoutesThroughVisibilityFold() {
+  func testRegularPresentationRoutesThroughVisibilityFold() throws {
     let nodes = [
       RawAXNode(
         index: 0, type: "Application", label: "App", identifier: nil, value: nil,
@@ -173,7 +173,7 @@ extension RunnerTests {
       viewport: CGRect(x: 0, y: 0, width: 100, height: 100)
     )
 
-    let presented = SnapshotPresentation.presentRegular(
+    let presented = try SnapshotPresentation.presentRegular(
       acquisition,
       options: PresentationOptions(
         interactiveOnly: false, depth: nil, scope: nil, raw: false)
@@ -199,7 +199,7 @@ extension RunnerTests {
     let regularOptions = PresentationOptions(
       interactiveOnly: false, depth: nil, scope: nil, raw: false)
     let regular = try XCTUnwrap(
-      SnapshotPresentation.presentRegular(
+      try SnapshotPresentation.presentRegular(
         SnapshotAcquisition(
           hint: SnapshotPresentation.captureHint(for: regularOptions),
           nodes: acquired,
@@ -287,7 +287,7 @@ extension RunnerTests {
       scope: " SCOPE-ROOT ",
       raw: false
     )
-    let capture = try XCTUnwrap(SnapshotPresentation.present(acquisition, options: options))
+    let capture = try XCTUnwrap(try SnapshotPresentation.present(acquisition, options: options))
     let nodes = try XCTUnwrap(capture.payload.nodes)
 
     XCTAssertEqual(nodes.map(\.label), [nil, "Child"])
@@ -323,7 +323,7 @@ extension RunnerTests {
     XCTAssertTrue(hint.interactiveOnly)
     XCTAssertEqual(hint.projection, .regular)
 
-    let missing = try XCTUnwrap(SnapshotPresentation.present(
+    let missing = try XCTUnwrap(try SnapshotPresentation.present(
       acquisition,
       options: PresentationOptions(
         interactiveOnly: true,
@@ -367,13 +367,17 @@ extension RunnerTests {
       hint: SnapshotPresentation.captureHint(for: rawRequest),
       nodes: nodes, truncated: false, effectiveDepth: nil, viewport: .infinite)
 
-    XCTAssertNil(SnapshotPresentation.present(regularAcquisition, options: rawRequest))
-    XCTAssertNil(SnapshotPresentation.present(rawAcquisition, options: regularRequest))
-    XCTAssertEqual(
-      SnapshotPresentation.present(rawAcquisition, options: rawRequest)?.payload.nodes?.count, 2)
-    XCTAssertEqual(
-      SnapshotPresentation.present(regularAcquisition, options: regularRequest)?
-        .payload.nodes?.count, 2)
+    let regularCaptureForRawRequest = try SnapshotPresentation.present(
+      regularAcquisition, options: rawRequest)
+    let rawCaptureForRegularRequest = try SnapshotPresentation.present(
+      rawAcquisition, options: regularRequest)
+    let rawCapture = try SnapshotPresentation.present(rawAcquisition, options: rawRequest)
+    let regularCapture = try SnapshotPresentation.present(
+      regularAcquisition, options: regularRequest)
+    XCTAssertNil(regularCaptureForRawRequest)
+    XCTAssertNil(rawCaptureForRegularRequest)
+    XCTAssertEqual(rawCapture?.payload.nodes?.count, 2)
+    XCTAssertEqual(regularCapture?.payload.nodes?.count, 2)
   }
 
   /// The one derivation every backend reads. Non-vacuity: returning the request's own depth for a

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -156,7 +156,13 @@ scroll anchors, and reparenting of survivors with collapsed depth. The fold also
 emitted `hittable` to the clip: nothing outside its clip, and nothing without geometry, is ever
 hittable regardless of what a backend reported. Platform differences are a `SnapshotFoldPolicy`
 input to the shared algorithm (iOS cursor-projected; macOS/tvOS plain viewport intersection),
-never a backend exception. The remaining acquisition-side narrowings are declared: the
+never a backend exception. The presentation owner validates every framed regular node against its
+cumulative effective clip before constructing `SnapshotPresentation.PresentedNode`; frameless and
+degenerate semantic carriers stay
+eligible but are never actionable, while raw projection remains exempt by contract. A violation is
+a typed `IOS_SNAPSHOT_PRESENTATION_FAILED` capture failure with the named `presentation-failed`
+snapshot-quality reason, preserved through recovery and the existing TypeScript verdict/warning
+contract. The remaining acquisition-side narrowings are declared:
 traversal-depth budget cut, the flat query sweep's frameless-element drop (a flat query has no
 hierarchy for geometryless semantics to attach to), and the private-AX bridge's device-side node
 cap.

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -39,6 +39,7 @@ export type SnapshotQualityVerdict = {
     | 'budget'
     | 'no-nodes'
     | 'capture-failed'
+    | 'presentation-failed'
     | 'deferred'
     | 'requested-backend';
   effectiveDepth?: number;

--- a/src/snapshot-quality/__tests__/verdict.test.ts
+++ b/src/snapshot-quality/__tests__/verdict.test.ts
@@ -60,6 +60,17 @@ test('readSnapshotQualityVerdict keeps the verdict but drops an unknown reasonCo
   assert.equal(verdict?.reasonCode, undefined);
 });
 
+test('readSnapshotQualityVerdict preserves a presentation failure reason', () => {
+  const verdict = readSnapshotQualityVerdict({
+    state: 'sparse',
+    backend: 'tree',
+    reason: 'regular snapshot node 7 escaped its cumulative clip',
+    reasonCode: 'presentation-failed',
+  });
+
+  assert.equal(verdict?.reasonCode, 'presentation-failed');
+});
+
 test('isSparseSnapshotQualityVerdict identifies sparse captures', () => {
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'sparse', backend: 'private-ax' }), true);
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'healthy', backend: 'tree' }), false);

--- a/src/snapshot-quality/__tests__/warnings.test.ts
+++ b/src/snapshot-quality/__tests__/warnings.test.ts
@@ -3,6 +3,9 @@ import { test } from 'vitest';
 import { readSnapshotQualityVerdict } from '../verdict.ts';
 import { renderSnapshotQualityWarnings } from '../warnings.ts';
 
+const sharedRecoveryReason =
+  'iOS XCTest snapshot failed while serializing the accessibility tree. Error kAXErrorIllegalArgument getting snapshot for element <AXUIElementRef 0x1>';
+
 test("the runner-wire 'deferred' reasonCode survives parsing into warning suppression", () => {
   // End-to-end through the raw wire parser: 'deferred' must be a member of the accepted
   // reason-code set, or it is silently stripped and every downstream deferred behavior
@@ -36,13 +39,12 @@ test('penalty-deferred recovered captures suppress the fallback warning but keep
   ]);
 });
 
-test('renderSnapshotQualityWarnings keeps recovered snapshot copy concise', () => {
+test('non-presentation recovery keeps the generic warning for the same reason text', () => {
   const warnings = renderSnapshotQualityWarnings(
     {
       state: 'recovered',
       backend: 'private-ax',
-      reason:
-        'iOS XCTest snapshot failed while serializing the accessibility tree. Error kAXErrorIllegalArgument getting snapshot for element <AXUIElementRef 0x1>',
+      reason: sharedRecoveryReason,
       reasonCode: 'ax-rejected',
       effectiveDepth: 56,
     },
@@ -51,6 +53,24 @@ test('renderSnapshotQualityWarnings keeps recovered snapshot copy concise', () =
 
   assert.deepEqual(warnings, [
     'Detected an overly complex or slow accessibility tree. Fell back to the private-ax snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.',
+    'Some deeper accessibility nodes were omitted; this tree is capped at depth 56. Re-run with --depth 56 --scope <container> only if you need deeper content.',
+  ]);
+});
+
+test('presentation failures identify a runner bug and preserve composed warnings', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    {
+      state: 'recovered',
+      backend: 'private-ax',
+      reason: sharedRecoveryReason,
+      reasonCode: 'presentation-failed',
+      effectiveDepth: 56,
+    },
+    [],
+  );
+
+  assert.deepEqual(warnings, [
+    'Agent Device could not safely present the captured accessibility tree and fell back to the private-ax snapshot backend. This is an Agent Device runner bug, not an app accessibility-tree issue. Use screenshot as visual truth and report snapshotQuality.reason with the screenshot.',
     'Some deeper accessibility nodes were omitted; this tree is capped at depth 56. Re-run with --depth 56 --scope <container> only if you need deeper content.',
   ]);
 });

--- a/src/snapshot-quality/__tests__/warnings.test.ts
+++ b/src/snapshot-quality/__tests__/warnings.test.ts
@@ -73,7 +73,13 @@ test('renderSnapshotQualityWarnings rejects semantic targets from a sparse tree'
 });
 
 test('sparse warnings blame the app only when the backends reached the screen', () => {
-  for (const reasonCode of ['ax-rejected', 'budget', 'no-nodes', 'capture-failed'] as const) {
+  for (const reasonCode of [
+    'ax-rejected',
+    'budget',
+    'no-nodes',
+    'capture-failed',
+    'presentation-failed',
+  ] as const) {
     const warnings = renderSnapshotQualityWarnings(
       { state: 'sparse', backend: 'tree', reason: 'capture gave up', reasonCode },
       [],

--- a/src/snapshot-quality/verdict.ts
+++ b/src/snapshot-quality/verdict.ts
@@ -15,6 +15,7 @@ const SNAPSHOT_QUALITY_REASON_CODES = new Set<NonNullable<SnapshotQualityVerdict
   'budget',
   'no-nodes',
   'capture-failed',
+  'presentation-failed',
   'deferred',
   'requested-backend',
 ]);

--- a/src/snapshot-quality/warnings.ts
+++ b/src/snapshot-quality/warnings.ts
@@ -67,6 +67,11 @@ function stateWarning(verdict: SnapshotQualityVerdict): string[] {
     // (selector resolution, settle observation loops, system-modal probes) and never rendered it,
     // the daemon's session latch re-renders the warning once at the response seam.
     if (verdict.reasonCode === 'deferred' || verdict.reasonCode === 'requested-backend') return [];
+    if (verdict.reasonCode === 'presentation-failed') {
+      return [
+        `Agent Device could not safely present the captured accessibility tree and fell back to the ${verdict.backend} snapshot backend. This is an Agent Device runner bug, not an app accessibility-tree issue. Use screenshot as visual truth and report snapshotQuality.reason with the screenshot.`,
+      ];
+    }
     return [recoveredSnapshotQualityWarning(verdict.backend)];
   }
   if (verdict.state === 'sparse') {


### PR DESCRIPTION
## Summary

Regular iOS snapshot presentation now enforces the cumulative effective clip at the presentation choke point before constructing nested `SnapshotPresentation.PresentedNode` values. Framed regular nodes cannot escape their cumulative effective clip; frameless and degenerate semantic carriers remain preserved but non-actionable. Raw projection remains its declared acquired-tree contract.

Presentation invariant failures also remain typed end to end as `IOS_SNAPSHOT_PRESENTATION_FAILED` / `presentation-failed`. Their public warning now identifies an Agent Device runner bug and recommends screenshot-based verification instead of blaming a complex app accessibility tree or saying it is safe to continue. This is keyed on the typed reason code, not message text, and still composes with depth and other quality warnings.

The validator consumes the visibility fold's effective geometry in one preorder pass, caching each parent's cumulative clip. A deterministic 5,000-node regression observes 4,999 parent-clip lookups; the previous ancestor walk would perform 12,497,500. The three host failures were test-policy mismatches, so the iOS-semantics tests explicitly request `.cursorProjected`; production `.platformDefault` is unchanged.

This covers the cumulative-clip and named-quality slice of #1797; it does not close the whole issue. The separate invariant owner reuses the existing visibility fold, effective geometry, nested `PresentedNode` construction boundary, and quality payload, without a parallel quality system or generic message sniffing.

Scope: 16 files.

## Validation

- Exact final head: `96861b5d7731ebff1c7394d0efccf7b0a42f2a16`; exact base: `919c478013b7a3d7d0ffe81e12dd2dc1bbf55940`; 16 files touched.
- Red evidence: the focused warning test reproduced the review bug exactly: a recovered `presentation-failed` verdict emitted the generic “complex or slow accessibility tree” / “OK to continue” warning. The positive and negative fixtures deliberately share identical reason text, proving the behavior is selected by `reasonCode`. Earlier planted reds also caught escaped cumulative clips, the missing typed Swift construction boundary, host-policy mismatches, and the nonlinear ancestor walk.
- Focused green evidence: the rebased TypeScript verdict/warning suite passes 23/23 and preserves warning composition. Exact-content native validation passed macOS and iOS XCTest build-for-testing plus focused iOS XCTest 7/7, covering nested clips, frameless carriers, raw projection, escaped geometry, typed quality, and the 5,000-node linearity regression.
- Local final-head gate: `pnpm check:affected --run` passed all runnable checks, including 662 related files / 5,309 tests.
- Exact-head GitHub validation is fully green: Swift Runner Host XCTests, changed-line Coverage, affected/static/layering/typecheck/lint/package/integration checks, Web Smoke, macOS/Linux/Android/iOS Smoke, CodeQL, and Bundle Size all pass.
- Live iOS evidence for the unchanged native diff was recorded at parent head `d015d39dedc6f89d06fb44046b0a1172e8558c50` on the iPhone 17 simulator (`1604B975-D6CD-41D7-ABBD-BE95F0796F90`) through the public CLI. After opening Catalog and scrolling, the healthy/tree regular snapshot had 33 nodes, `partial: true`, and both `scroll-hidden-above` and `scroll-hidden-below`; `product-card-citrus-kit` was clipped to `y=62`, `height=300`. The same state through `--raw` was healthy/tree with 279 nodes, `partial: false`, retained the offscreen `Bakery` node at `y=-8.33`, and retained the unclipped Citrus card at `y=57.67`, `height=304.33`. The final commit changes only TypeScript warning selection and its focused test; the session was closed and the simulator returned to shutdown.
- Size: final Bundle Size workflow `32564743344` reports npm-unpacked `+6.3 kB`: Apple runner source/project `+6.0 kB`, JS/dist `+368 B`, and no macOS helper, Android, or other-package growth. The largest addition is `RunnerTests+SnapshotPresentationInvariant.swift` at `+4.9 kB`; the warning follow-up adds `+322 B` to `dist/src/runtime.js`. Startup medians did not regress (`--version -0.8 ms`, `--help -4.3 ms`).
- Native, simulator, and live sessions are closed. No merge performed.

Ready for review. Refs #1797.
