### PR TITLE
fix(ios): isolate snapshot acquisition timing from presentation

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -842,7 +842,8 @@ extension RunnerTests {
         nodes: [planTestNode(index: 0, type: "Application", label: "App")],
         truncated: false
       ),
-      effectiveDepth: nil
+      effectiveDepth: nil,
+      timing: timing
     )
 
     let payload = stampedSnapshotPayload(
@@ -854,6 +855,34 @@ extension RunnerTests {
 
     XCTAssertEqual(payload.snapshotQuality?.timing, timing)
     XCTAssertEqual(payload.nodes?.count, 1)
+  }
+
+  func testDirectPresentationDoesNotClaimPlanTiming() {
+    let options = PresentationOptions(
+      interactiveOnly: false,
+      depth: nil,
+      scope: nil,
+      raw: true
+    )
+    let capture = SnapshotPresentation.presentRaw(
+      SnapshotAcquisition(
+        hint: SnapshotPresentation.captureHint(for: options),
+        nodes: [],
+        truncated: false,
+        effectiveDepth: nil,
+        viewport: .infinite
+      ),
+      options: options
+    )
+
+    let payload = stampedSnapshotPayload(
+      capture,
+      backend: .recursiveTree,
+      state: "healthy",
+      reason: nil
+    )
+
+    XCTAssertNil(payload.snapshotQuality?.timing)
   }
 
   /// The raw plan is derived from what each backend can actually serve, not from a second

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -25,6 +25,8 @@ struct SnapshotQuality: Codable {
   let collapsedLeafIndexes: [Int]?
   /// Coverage of the bounded custom-action pass, when the capture asked for one.
   let customActions: SnapshotCustomActionCoverage?
+  /// Response-level timing for the accepted backend attempt, never repeated per node.
+  var timing: SnapshotCaptureTiming? = nil
 }
 
 /// How much of the merged-element set the custom-action pass actually read. An
@@ -76,6 +78,9 @@ struct SnapshotBackendCapture {
   /// Broad presentation used only by the quality classifier when a scope narrows publication.
   /// A legitimate missing scope is an empty healthy projection, not backend failure evidence.
   var qualityPayload: DataPayload? = nil
+  /// Set by the capture plan after measuring acquisition and presentation separately. Direct
+  /// presentation fixtures do not claim a plan timing.
+  var timing: SnapshotCaptureTiming? = nil
 }
 
 extension RunnerTests {
@@ -327,42 +332,19 @@ extension RunnerTests {
         }
         continue
       }
-      let capture: SnapshotBackendCapture
-      let backendStartedAt = Date()
-      do {
-        guard
-          let result = try captureWithBackend(
-            kind,
-            app: app,
-            options: options,
-            deadline: deadline,
-            treeCaptureSliceBudgetOverride: effective.treeCaptureSliceBudgetOverride
-          )
-        else {
-          recordSlowXCTestSnapshotBackendIfNeeded(
-            kind,
-            startedAt: backendStartedAt,
-            penaltySuppressed: suppressXCTestPenalty
-          )
-          continue
-        }
-        capture = result
-        recordSlowXCTestSnapshotBackendIfNeeded(
-          kind,
-          startedAt: backendStartedAt,
-          penaltySuppressed: suppressXCTestPenalty
-        )
-      } catch let failure as SnapshotCaptureFailure {
-        recordXCTestSnapshotBackendFailureIfNeeded(
-          kind,
-          failure: failure,
-          penaltySuppressed: suppressXCTestPenalty
-        )
-        recordSlowXCTestSnapshotBackendIfNeeded(
-          kind,
-          startedAt: backendStartedAt,
-          penaltySuppressed: suppressXCTestPenalty
-        )
+      let attempt = try captureWithBackend(
+        kind,
+        app: app,
+        options: options,
+        deadline: deadline,
+        treeCaptureSliceBudgetOverride: effective.treeCaptureSliceBudgetOverride
+      )
+      recordXCTestSnapshotBackendAttemptIfNeeded(
+        kind,
+        attempt: attempt,
+        penaltySuppressed: suppressXCTestPenalty
+      )
+      if case let .failed(failure, phase: _) = attempt.outcome {
         if Self.isAxSnapshotFailure(failure) { axFailure = failure }
         if firstFailure == nil {
           firstFailure = (failure.message, Self.isAxSnapshotFailure(failure) ? "ax-rejected" : "capture-failed")
@@ -374,6 +356,7 @@ extension RunnerTests {
         )
         continue
       }
+      guard case let .captured(capture) = attempt.outcome else { continue }
 
       if let sparseReason = Self.sparsePayloadReason(capture.qualityPayload ?? capture.payload) {
         if firstFailure == nil { firstFailure = sparseReason }
@@ -429,92 +412,96 @@ extension RunnerTests {
     return fallbackPayload
   }
 
-  /// Marks XCTest-backed snapshot tiers as penalized when one attempt ground past the slow-capture
-  /// threshold — even a successful one: the next capture of this screen must not re-grind.
-  private func recordSlowXCTestSnapshotBackendIfNeeded(
-    _ kind: SnapshotBackendKind,
-    startedAt: Date,
-    penaltySuppressed: Bool
-  ) {
-    guard !penaltySuppressed else { return }
-    guard kind.usesXCTestAccessibilityChannel else { return }
-    let elapsed = Date().timeIntervalSince(startedAt)
-    guard elapsed > snapshotXCTestSlowCaptureThreshold else { return }
-    penalizeSnapshotXCTestChannel(
-      bundleId: currentBundleId,
-      reason: "slow_\(kind.rawValue)_capture_\(Int(elapsed * 1000))ms"
-    )
-  }
-
-  private func recordXCTestSnapshotBackendFailureIfNeeded(
-    _ kind: SnapshotBackendKind,
-    failure: SnapshotCaptureFailure,
-    penaltySuppressed: Bool
-  ) {
-    guard !penaltySuppressed else { return }
-    guard kind.usesXCTestAccessibilityChannel, failure.code == Self.xCTestSnapshotTimeoutCode else { return }
-    penalizeSnapshotXCTestChannel(
-      bundleId: currentBundleId,
-      reason: "\(kind.rawValue)_backend_timeout"
-    )
-  }
-
   private func captureWithBackend(
     _ kind: SnapshotBackendKind,
     app: XCUIApplication,
     options: PresentationOptions,
     deadline: Date,
     treeCaptureSliceBudgetOverride: TimeInterval?
-  ) throws -> SnapshotBackendCapture? {
+  ) throws -> SnapshotBackendAttempt {
     let hint = SnapshotPresentation.captureHint(for: options)
+    var timer = SnapshotPhaseTimer()
     let acquisition: SnapshotAcquisition?
-    switch kind {
-    case .recursiveTree:
-      guard
-        let context = try makeSnapshotTraversalContext(
-          app: app,
-          hint: hint,
-          captureDeadline: deadline,
-          treeCaptureSliceBudgetOverride: treeCaptureSliceBudgetOverride
-        )
-      else {
-        return nil
+    do {
+      acquisition = try timer.measure(.acquisition) {
+        switch kind {
+        case .recursiveTree:
+          guard
+            let context = try self.makeSnapshotTraversalContext(
+              app: app,
+              hint: hint,
+              captureDeadline: deadline,
+              treeCaptureSliceBudgetOverride: treeCaptureSliceBudgetOverride
+            )
+          else {
+            return nil
+          }
+          return try self.runMainThreadWork(
+            timeout: min(self.treeCaptureSliceBudget, max(0.5, deadline.timeIntervalSinceNow)),
+            timeoutError: self.snapshotMainThreadTimeoutError("processing tree snapshot")
+          ) {
+            hint.isRaw
+              ? try self.rawTreeSnapshotAcquisition(context: context, hint: hint)
+              : self.recursiveTreeSnapshotAcquisition(context: context, hint: hint)
+          }
+        case .querySweep:
+          return try self.runMainThreadWork(
+            timeout: min(Self.flatInteractiveFallbackBudget, max(0.1, deadline.timeIntervalSinceNow)),
+            timeoutError: self.snapshotMainThreadTimeoutError("running query-sweep snapshot")
+          ) {
+            self.querySweepSnapshotAcquisition(
+              app: app,
+              hint: hint,
+              planDeadline: deadline
+            )
+          }
+        case .privateAX:
+          return self.privateAXSnapshotAcquisition(
+            app: app,
+            hint: hint,
+            deadline: deadline
+          )
+        }
       }
-      acquisition = try runMainThreadWork(
-        timeout: min(treeCaptureSliceBudget, max(0.5, deadline.timeIntervalSinceNow)),
-        timeoutError: snapshotMainThreadTimeoutError("processing tree snapshot")
-      ) {
-        hint.isRaw
-          ? try self.rawTreeSnapshotAcquisition(context: context, hint: hint)
-          : self.recursiveTreeSnapshotAcquisition(context: context, hint: hint)
-      }
-    case .querySweep:
-      acquisition = try runMainThreadWork(
-        timeout: min(Self.flatInteractiveFallbackBudget, max(0.1, deadline.timeIntervalSinceNow)),
-        timeoutError: snapshotMainThreadTimeoutError("running query-sweep snapshot")
-      ) {
-        self.querySweepSnapshotAcquisition(
-          app: app,
-          hint: hint,
-          planDeadline: deadline
-        )
-      }
-    case .privateAX:
-      acquisition = privateAXSnapshotAcquisition(
-        app: app,
-        hint: hint,
-        deadline: deadline
+    } catch let failure as SnapshotCaptureFailure {
+      return SnapshotBackendAttempt(
+        outcome: .failed(failure, phase: .acquisition),
+        timing: timer.timing
       )
     }
-    guard let acquisition else { return nil }
-    guard let capture = SnapshotPresentation.present(acquisition, options: options) else {
-      throw Self.snapshotProjectionMismatchFailure(
-        kind,
-        requested: hint.projection,
-        acquired: acquisition.hint.projection
+
+    guard let acquisition else {
+      return SnapshotBackendAttempt(
+        outcome: .noCapture,
+        timing: timer.timing
       )
     }
-    return capture
+
+    let presented: SnapshotBackendCapture
+    do {
+      presented = try timer.measure(.presentation) {
+        guard let capture = SnapshotPresentation.present(acquisition, options: options) else {
+          throw Self.snapshotProjectionMismatchFailure(
+            kind,
+            requested: hint.projection,
+            acquired: acquisition.hint.projection
+          )
+        }
+        return capture
+      }
+    } catch let failure as SnapshotCaptureFailure {
+      return SnapshotBackendAttempt(
+        outcome: .failed(failure, phase: .presentation),
+        timing: timer.timing
+      )
+    }
+
+    var capture = presented
+    capture.timing = timer.timing
+    return SnapshotBackendAttempt(
+      outcome: .captured(capture),
+      timing: timer.timing
+    )
   }
 
   /// A backend that answers a request with the other projection loses its tier and says why, so
@@ -632,7 +619,8 @@ extension RunnerTests {
       reasonCode: reason?.code,
       effectiveDepth: capture.effectiveDepth,
       collapsedLeafIndexes: Self.collapsedLeafIndexes(payload.nodes ?? []),
-      customActions: capture.customActions
+      customActions: capture.customActions,
+      timing: capture.timing
     )
     return DataPayload(
       // Legacy human text for older daemons that read message instead of snapshotQuality.
@@ -845,6 +833,27 @@ extension RunnerTests {
     XCTAssertNil(Self.xcTestChannelStateFirstFailure(.normal))
     XCTAssertEqual(Self.xcTestChannelStateFirstFailure(.deferredToIndependentBackend)?.code, "deferred")
     XCTAssertEqual(Self.xcTestChannelStateFirstFailure(.boundedXCTestProbe)?.code, "budget")
+  }
+
+  func testSnapshotQualityCarriesPhaseTimingAtResponseLevel() {
+    let timing = SnapshotCaptureTiming(acquisitionMs: 12, presentationMs: 34)
+    let capture = SnapshotBackendCapture(
+      payload: DataPayload(
+        nodes: [planTestNode(index: 0, type: "Application", label: "App")],
+        truncated: false
+      ),
+      effectiveDepth: nil
+    )
+
+    let payload = stampedSnapshotPayload(
+      capture,
+      backend: .recursiveTree,
+      state: "healthy",
+      reason: nil
+    )
+
+    XCTAssertEqual(payload.snapshotQuality?.timing, timing)
+    XCTAssertEqual(payload.nodes?.count, 1)
   }
 
   /// The raw plan is derived from what each backend can actually serve, not from a second

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotTiming.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotTiming.swift
@@ -1,0 +1,185 @@
+import Foundation
+import XCTest
+
+struct SnapshotCaptureTiming: Codable, Equatable {
+  let acquisitionMs: Double
+  let presentationMs: Double
+
+  init(acquisitionMs: Double, presentationMs: Double) {
+    self.acquisitionMs = max(0, acquisitionMs)
+    self.presentationMs = max(0, presentationMs)
+  }
+
+  init(acquisition: TimeInterval, presentation: TimeInterval) {
+    self.init(
+      acquisitionMs: max(0, acquisition) * 1_000,
+      presentationMs: max(0, presentation) * 1_000
+    )
+  }
+}
+
+enum SnapshotCapturePhase: Equatable {
+  case acquisition
+  case presentation
+}
+
+struct SnapshotPhaseTimer {
+  private let now: () -> Date
+  private var acquisitionSeconds: TimeInterval = 0
+  private var presentationSeconds: TimeInterval = 0
+
+  init(now: @escaping () -> Date = { Date() }) {
+    self.now = now
+  }
+
+  mutating func measure<T>(
+    _ phase: SnapshotCapturePhase,
+    _ operation: () throws -> T
+  ) rethrows -> T {
+    let startedAt = now()
+    defer {
+      let elapsed = max(0, now().timeIntervalSince(startedAt))
+      switch phase {
+      case .acquisition:
+        acquisitionSeconds += elapsed
+      case .presentation:
+        presentationSeconds += elapsed
+      }
+    }
+    return try operation()
+  }
+
+  var timing: SnapshotCaptureTiming {
+    SnapshotCaptureTiming(
+      acquisition: acquisitionSeconds,
+      presentation: presentationSeconds
+    )
+  }
+}
+
+extension RunnerTests {
+  struct SnapshotBackendAttempt {
+    enum Outcome {
+      case noCapture
+      case captured(SnapshotBackendCapture)
+      case failed(SnapshotCaptureFailure, phase: SnapshotCapturePhase)
+    }
+
+    /// The failure phase is part of the result, so penalty policy cannot infer it from duration
+    /// or error text.
+    let outcome: Outcome
+    let timing: SnapshotCaptureTiming
+  }
+
+  /// The penalty breaker observes only acquisition facts. Presentation is a separate phase and
+  /// cannot arm the breaker, even when it is slower than the acquisition that produced the tree.
+  private static func snapshotXCTestPenaltyReason(
+    kind: SnapshotBackendKind,
+    attempt: SnapshotBackendAttempt,
+    slowThresholdMs: Double
+  ) -> String? {
+    guard kind.usesXCTestAccessibilityChannel else { return nil }
+    if case let .failed(failure, phase: .acquisition) = attempt.outcome,
+      failure.code == Self.xCTestSnapshotTimeoutCode
+    {
+      return "\(kind.rawValue)_backend_timeout"
+    }
+    guard attempt.timing.acquisitionMs > slowThresholdMs else { return nil }
+    return "slow_\(kind.rawValue)_capture_\(Int(attempt.timing.acquisitionMs))ms"
+  }
+
+  func recordXCTestSnapshotBackendAttemptIfNeeded(
+    _ kind: SnapshotBackendKind,
+    attempt: SnapshotBackendAttempt,
+    penaltySuppressed: Bool
+  ) {
+    guard !penaltySuppressed else { return }
+    guard
+      let reason = Self.snapshotXCTestPenaltyReason(
+        kind: kind,
+        attempt: attempt,
+        slowThresholdMs: snapshotXCTestSlowCaptureThreshold * 1_000
+      )
+    else { return }
+    penalizeSnapshotXCTestChannel(
+      bundleId: currentBundleId,
+      reason: reason
+    )
+  }
+}
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+extension RunnerTests {
+  func testXCTestPenaltyDecisionSeparatesAcquisitionAndPresentation() {
+    let slowPresentation = SnapshotBackendAttempt(
+      outcome: .noCapture,
+      timing: SnapshotCaptureTiming(acquisitionMs: 100, presentationMs: 4_000)
+    )
+    XCTAssertNil(
+      Self.snapshotXCTestPenaltyReason(
+        kind: .recursiveTree,
+        attempt: slowPresentation,
+        slowThresholdMs: 3_000
+      )
+    )
+
+    let slowAcquisition = SnapshotBackendAttempt(
+      outcome: .noCapture,
+      timing: SnapshotCaptureTiming(acquisitionMs: 3_001, presentationMs: 100)
+    )
+    XCTAssertEqual(
+      Self.snapshotXCTestPenaltyReason(
+        kind: .recursiveTree,
+        attempt: slowAcquisition,
+        slowThresholdMs: 3_000
+      ),
+      "slow_tree_capture_3001ms"
+    )
+
+    let timeout = SnapshotCaptureFailure(
+      code: Self.xCTestSnapshotTimeoutCode,
+      message: "test timeout",
+      hint: "test"
+    )
+    let acquisitionFailure = SnapshotBackendAttempt(
+      outcome: .failed(timeout, phase: .acquisition),
+      timing: SnapshotCaptureTiming(acquisitionMs: 100, presentationMs: 100)
+    )
+    XCTAssertEqual(
+      Self.snapshotXCTestPenaltyReason(
+        kind: .recursiveTree,
+        attempt: acquisitionFailure,
+        slowThresholdMs: 3_000
+      ),
+      "tree_backend_timeout"
+    )
+
+    let presentationFailure = SnapshotBackendAttempt(
+      outcome: .failed(timeout, phase: .presentation),
+      timing: SnapshotCaptureTiming(acquisitionMs: 100, presentationMs: 100)
+    )
+    XCTAssertNil(
+      Self.snapshotXCTestPenaltyReason(
+        kind: .recursiveTree,
+        attempt: presentationFailure,
+        slowThresholdMs: 3_000
+      )
+    )
+  }
+
+  func testSnapshotPhaseTimerReportsAcquisitionAndPresentationSeparately() {
+    var now = Date(timeIntervalSinceReferenceDate: 100)
+    var timer = SnapshotPhaseTimer(now: { now })
+
+    _ = timer.measure(.acquisition) {
+      now = now.addingTimeInterval(2)
+    }
+    _ = timer.measure(.presentation) {
+      now = now.addingTimeInterval(5)
+    }
+
+    XCTAssertEqual(timer.timing.acquisitionMs, 2_000, accuracy: 0.001)
+    XCTAssertEqual(timer.timing.presentationMs, 5_000, accuracy: 0.001)
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -275,7 +275,9 @@ extension RunnerTests {
           treatingPlaceholderAsEmpty: true
         )
       },
-      waitForNextObservation: { sleepFor(TextEntryTiming.pollInterval) }
+      // XCUI resolution shares the automation channel with the in-flight synthesized event.
+      // Sparse reads let the target consume that event instead of continuously interrupting it.
+      waitForNextObservation: { sleepFor(TextEntryTiming.synthesizedCommitPollInterval) }
     )
   }
 

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextEntry.swift
@@ -46,6 +46,7 @@ extension RunnerTests {
     static let warmupValueTimeout: TimeInterval = 0.4
     static let verificationStabilityWindow: TimeInterval = 0.2
     static let synthesizedCommitTimeout: TimeInterval = 3.0
+    static let synthesizedCommitPollInterval: TimeInterval = 0.2
   }
 
   struct TextEntryResult {

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -18,6 +18,11 @@ export type SnapshotCaptureBackend = 'tree' | 'queries' | 'private-ax';
 /** Internal backends that evidence probes may select explicitly. */
 export type SnapshotPreferredBackend = 'tree' | 'private-ax';
 
+export type SnapshotQualityTiming = {
+  acquisitionMs: number;
+  presentationMs: number;
+};
+
 export type SnapshotQualityVerdict = {
   state: 'healthy' | 'recovered' | 'sparse';
   backend: SnapshotCaptureBackend;
@@ -45,6 +50,8 @@ export type SnapshotQualityVerdict = {
    * pass has to be disclosed rather than left to look complete.
    */
   customActions?: { read: number; candidates: number; truncated: number; blocked: boolean };
+  /** Response-level phase timing for the backend named by `backend`. */
+  timing?: SnapshotQualityTiming;
 };
 
 export type Rect = {

--- a/src/snapshot-quality/__tests__/verdict.test.ts
+++ b/src/snapshot-quality/__tests__/verdict.test.ts
@@ -16,6 +16,7 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
     customActions: { read: 12, candidates: 19, truncated: 1, blocked: false },
+    timing: { acquisitionMs: 12.5, presentationMs: 34.75 },
   });
   assert.deepEqual(verdict, {
     state: 'recovered',
@@ -25,7 +26,18 @@ test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
     effectiveDepth: 56,
     collapsedLeafIndexes: [3],
     customActions: { read: 12, candidates: 19, truncated: 1, blocked: false },
+    timing: { acquisitionMs: 12.5, presentationMs: 34.75 },
   });
+});
+
+test('readSnapshotQualityVerdict drops incomplete phase timing without dropping the verdict', () => {
+  const verdict = readSnapshotQualityVerdict({
+    state: 'healthy',
+    backend: 'tree',
+    timing: { acquisitionMs: 12.5 },
+  });
+  assert.equal(verdict?.state, 'healthy');
+  assert.equal(verdict?.timing, undefined);
 });
 
 test('readSnapshotQualityVerdict rejects unknown state or backend as verdict-absent', () => {

--- a/src/snapshot-quality/verdict.ts
+++ b/src/snapshot-quality/verdict.ts
@@ -37,6 +37,7 @@ export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdi
   ) {
     return undefined;
   }
+  const timing = readSnapshotQualityTiming(raw.timing);
   return {
     state: raw.state as SnapshotQualityVerdict['state'],
     backend: raw.backend as SnapshotQualityVerdict['backend'],
@@ -55,6 +56,19 @@ export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdi
     collapsedLeafIndexes: Array.isArray(raw.collapsedLeafIndexes)
       ? raw.collapsedLeafIndexes.filter((entry): entry is number => typeof entry === 'number')
       : undefined,
+    ...(timing ? { timing } : {}),
+  };
+}
+
+function readSnapshotQualityTiming(value: unknown): SnapshotQualityVerdict['timing'] | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.acquisitionMs !== 'number' || typeof raw.presentationMs !== 'number') {
+    return undefined;
+  }
+  return {
+    acquisitionMs: raw.acquisitionMs,
+    presentationMs: raw.presentationMs,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements the acquisition/presentation timing-isolation slice of #1797.

- Measures backend acquisition and runner-side presentation separately within each capture-plan attempt.
- Restricts XCTest slow/timeout penalty decisions to qualifying acquisition time and failures, so slow presentation cannot arm the breaker.
- Reports acquisition and presentation timing once at response level through the existing snapshot-quality diagnostics contract.
- Preserves total command deadlines, fallback ordering, clip and quality-reason semantics, visible-depth behavior, backend differential lanes, and the file-private presentation construction boundary from PR #1937.
- The response-level timing fixture assigns its `SnapshotCaptureTiming` to `SnapshotBackendCapture`; a direct-presentation default test confirms timing remains omitted when no capture plan stamps it.
- The final iOS reruns exposed an existing automation-channel race in the hidden-keyboard text canary: commit verification resolved XCUI state every 20 ms while the synthesized text event was still in flight. The owning wait now observes at a dedicated 200 ms cadence, preserving the 3 s deadline while allowing the target to consume the event.
- Scope expanded from five to seven files for that CI-owned text-entry fix; there is no snapshot/text fallback or duplicated execution path.
- Exact local size comparison is +3.4 kB npm unpacked: +3.0 kB Apple runner source/project and +426 B JS/dist. The focused `RunnerTests+SnapshotTiming.swift` module adds +3.1 kB, `RunnerTests+SnapshotCapturePlan.swift` removes 382 B, and the text-entry cadence fix adds 272 B across its two owning files.
- The timing module is intentional: the capture-plan file is already over 1,000 lines, so keeping the typed phase carrier, injectable clock seam, penalty policy, and deterministic timing tests in a focused module avoids further coupling to plan orchestration. A smaller parameter-only seam would duplicate date arithmetic or lose the typed failure phase needed by the breaker.

This PR addresses only the timing-isolation slice and does not close all of #1797.

## Validation

- Exact base head: `d2f2dae798153a489623ac0e65d50f6c83f2dec3` (`origin/main`).
- Exact PR head: `b0122094552a9661af97b56a58dc9df37e9f57ad`.
- `pnpm check:affected --run` passed: 5,304 related tests plus format, lint, typecheck, layering, Fallow, build, and XCTest selection.
- iPhone 17 Pro simulator, iOS 26.2: the unchanged hidden-keyboard canary failed in the pre-fix five-iteration stress run; it passed 5/5 after the cadence fix, with every 17-character commit completing in 0.56–0.57 s.
- The complete 67-test iOS PR XCTest selection passed on the rebased head, including snapshot timing/presentation and the hidden-keyboard canary.
- Local package comparison: +234 B JS raw, +54 B JS gzip, +996 B npm tarball, +3.4 kB npm unpacked.
