### PR TITLE
refactor(daemon): lazy-load platform cleanup helpers in session teardown

### DIFF
--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -1,10 +1,7 @@
 import { expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  eagerClosureOf,
-  eagerlyEvaluatedModules,
-} from './eager-import-closure.fixtures';
+import { eagerClosureOf, eagerlyEvaluatedModules } from './eager-import-closure.fixtures.ts';
 
 /**
  * Every CLI invocation eagerly evaluates the static import closure of

--- a/src/__tests__/cli-startup-import-closure.test.ts
+++ b/src/__tests__/cli-startup-import-closure.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { parseSync } from 'oxc-parser';
+import {
+  eagerClosureOf,
+  eagerlyEvaluatedModules,
+} from './eager-import-closure.fixtures';
 
 /**
  * Every CLI invocation eagerly evaluates the static import closure of
@@ -17,179 +20,12 @@ import { parseSync } from 'oxc-parser';
  * static import of the Maestro engine (and the YAML parser behind it) put a 131 kB chunk and
  * ~28ms on every warm command, for a format most invocations never touch (#1802). The replay
  * script-source builder loads it on demand, only once an entry actually resolves to a flow.
- *
- * "On demand" is a claim about SCOPE, not about syntax, which is why this reads
- * the AST rather than matching import forms. Two shapes evaluate the module
- * during module evaluation while looking lazy or looking like nothing at all:
- * a bare side-effect `import 'node:http'` (binds no names, still evaluates),
- * and a dynamic `import('node:http')` sitting at module top level rather than
- * inside a function -- including `.then(...)` and an immediately-invoked
- * top-level function. A dynamic import is lazy only when its nearest enclosing
- * function scope is not the module itself. Type-only imports and re-exports are
- * erased at build and stay allowed.
- *
- * Known limitation: a top-level function that is invoked indirectly at load
- * time (stored, then called by another top-level statement) reads as lazy here.
- * Direct top-level invocation -- `(() => { ... })()` -- is detected.
  */
 
 const srcRoot = path.resolve(import.meta.dirname, '..');
 const LAZY_HTTP_MODULES = new Set(['node:http', 'node:https']);
 /** Engines heavy enough that evaluating them on startup is a measurable regression. */
 const LAZY_ENGINE_MODULES = new Set(['@agent-device/maestro']);
-const FUNCTION_NODES = new Set([
-  'FunctionDeclaration',
-  'FunctionExpression',
-  'ArrowFunctionExpression',
-]);
-const WORKSPACE_SPECIFIER = /^(@agent-device\/[^/]+)(\/.*)?$/;
-
-type AstNode = { type?: string; [key: string]: unknown };
-
-type ParsedModuleRecord = ReturnType<typeof parseSync>['module'];
-
-/** Static specifiers this file causes to be EVALUATED (not type-only). */
-function staticEvaluatedRefs(module: ParsedModuleRecord): string[] {
-  const refs: string[] = [];
-  for (const staticImport of module.staticImports) {
-    // No entries at all is a side-effect import (`import 'x'`), which always
-    // evaluates. Otherwise it evaluates unless every binding is type-only.
-    const evaluates =
-      staticImport.entries.length === 0 || staticImport.entries.some((entry) => !entry.isType);
-    if (evaluates) refs.push(staticImport.moduleRequest.value);
-  }
-  for (const staticExport of module.staticExports) {
-    for (const entry of staticExport.entries) {
-      if (entry.moduleRequest && !entry.isType) refs.push(entry.moduleRequest.value);
-    }
-  }
-  return refs;
-}
-
-function unwrapParentheses(node: unknown): AstNode | null {
-  let current = node as AstNode | null;
-  while (current?.type === 'ParenthesizedExpression')
-    current = current.expression as AstNode | null;
-  return current;
-}
-
-/** The body of a function invoked right where it is defined, if this is that call. */
-function immediatelyInvokedBody(node: AstNode): unknown {
-  if (node.type !== 'CallExpression') return null;
-  const callee = unwrapParentheses(node.callee);
-  return callee && FUNCTION_NODES.has(String(callee.type)) ? callee.body : null;
-}
-
-function dynamicImportSpecifier(node: AstNode): string | null {
-  if (node.type !== 'ImportExpression') return null;
-  const source = node.source as { type?: string; value?: unknown } | undefined;
-  return source?.type === 'Literal' && typeof source.value === 'string' ? source.value : null;
-}
-
-function recordDynamicImport(record: AstNode, eager: boolean, found: string[]): void {
-  if (!eager) return;
-  const specifier = dynamicImportSpecifier(record);
-  if (specifier !== null) found.push(specifier);
-}
-
-/** Descends into a node's children, dropping `eager` on the way into a function body. */
-function visitChildren(record: AstNode, eager: boolean, found: string[]): void {
-  const childEager = eager && !FUNCTION_NODES.has(String(record.type));
-  for (const [key, value] of Object.entries(record)) {
-    if (key !== 'type') collectEagerDynamicImports(value, childEager, found);
-  }
-}
-
-/** Walks the AST, collecting only `import()` calls reached without entering a function. */
-function collectEagerDynamicImports(node: unknown, eager: boolean, found: string[]): void {
-  if (Array.isArray(node)) {
-    for (const child of node) collectEagerDynamicImports(child, eager, found);
-    return;
-  }
-  if (!node || typeof node !== 'object') return;
-  const record = node as AstNode;
-  recordDynamicImport(record, eager, found);
-  // An immediately-invoked function runs now, so its body inherits `eager`.
-  const invokedBody = immediatelyInvokedBody(record);
-  if (invokedBody) collectEagerDynamicImports(invokedBody, eager, found);
-  visitChildren(record, eager, found);
-}
-
-/** Every specifier this file evaluates at load time, static or dynamic. */
-function eagerlyEvaluatedModules(fileName: string, source: string): string[] {
-  const parsed = parseSync(fileName, source);
-  const dynamic: string[] = [];
-  collectEagerDynamicImports(parsed.program, true, dynamic);
-  return [...new Set([...staticEvaluatedRefs(parsed.module), ...dynamic])];
-}
-
-function resolveRelative(fromFile: string, specifier: string): string | null {
-  const candidate = path.resolve(path.dirname(fromFile), specifier);
-  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
-  for (const suffix of ['.ts', '.tsx', '/index.ts']) {
-    if (fs.existsSync(`${candidate}${suffix}`)) return `${candidate}${suffix}`;
-  }
-  return null;
-}
-
-/** `@agent-device/<pkg>` -> that package's directory, keyed by its declared name. */
-function readWorkspacePackageDirs(): Map<string, string> {
-  const packagesRoot = path.resolve(srcRoot, '..', 'packages');
-  const dirs = new Map<string, string>();
-  for (const entry of fs.readdirSync(packagesRoot)) {
-    const manifestPath = path.join(packagesRoot, entry, 'package.json');
-    if (!fs.existsSync(manifestPath)) continue;
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { name?: string };
-    if (manifest.name) dirs.set(manifest.name, path.join(packagesRoot, entry));
-  }
-  return dirs;
-}
-
-type ExportTarget = { default?: string; types?: string } | string;
-
-function readExportTarget(packageDir: string, subpath: string): string | undefined {
-  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
-    exports?: Record<string, ExportTarget>;
-  };
-  const target = manifest.exports?.[subpath];
-  if (typeof target === 'string') return target;
-  return target?.default ?? target?.types;
-}
-
-/**
- * Workspace subpath imports are followed too: a package the CLI evaluates can
- * pull `node:http` in just as effectively as a file under src/, and stopping the
- * walk at the package boundary would be the same blind spot in a new place.
- */
-function resolveWorkspace(specifier: string, packageDirs: Map<string, string>): string | null {
-  const match = WORKSPACE_SPECIFIER.exec(specifier);
-  const packageName = match?.[1];
-  const packageDir = packageName ? packageDirs.get(packageName) : undefined;
-  if (!packageDir) return null;
-  const target = readExportTarget(packageDir, `.${match?.[2] ?? ''}`);
-  if (!target) return null;
-  const resolved = path.resolve(packageDir, target);
-  return fs.existsSync(resolved) ? resolved : null;
-}
-
-/** Every repo file evaluated as a consequence of importing `src/cli.ts`. */
-function eagerClosureOfCli(): string[] {
-  const packageDirs = readWorkspacePackageDirs();
-  const queue = [path.join(srcRoot, 'cli.ts')];
-  const visited = new Set<string>();
-  while (queue.length > 0) {
-    const current = queue.pop();
-    if (!current || visited.has(current)) continue;
-    visited.add(current);
-    for (const specifier of eagerlyEvaluatedModules(current, fs.readFileSync(current, 'utf8'))) {
-      const resolved = specifier.startsWith('.')
-        ? resolveRelative(current, specifier)
-        : resolveWorkspace(specifier, packageDirs);
-      if (resolved) queue.push(resolved);
-    }
-  }
-  return [...visited];
-}
 
 test.for([
   // --- static forms ---
@@ -252,7 +88,7 @@ test.for([
 
 test('the CLI startup import closure never evaluates node:http or node:https', () => {
   const offenders: string[] = [];
-  for (const file of eagerClosureOfCli()) {
+  for (const file of eagerClosureOf(path.join(srcRoot, 'cli.ts'))) {
     for (const specifier of eagerlyEvaluatedModules(file, fs.readFileSync(file, 'utf8'))) {
       if (LAZY_HTTP_MODULES.has(specifier)) {
         offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
@@ -269,7 +105,7 @@ test('the CLI startup import closure never evaluates node:http or node:https', (
 
 test('the CLI startup import closure never evaluates the Maestro engine', () => {
   const offenders: string[] = [];
-  for (const file of eagerClosureOfCli()) {
+  for (const file of eagerClosureOf(path.join(srcRoot, 'cli.ts'))) {
     for (const specifier of eagerlyEvaluatedModules(file, fs.readFileSync(file, 'utf8'))) {
       if (LAZY_ENGINE_MODULES.has(specifier)) {
         offenders.push(`${path.relative(srcRoot, file)} -> ${specifier}`);
@@ -289,7 +125,7 @@ test('the CLI startup import closure is reachable and crosses the package bounda
   // Guards the test above from silently passing because the walk found nothing:
   // a resolver that returned null for everything would leave both the src side
   // and the workspace side of the closure empty while the guard stayed green.
-  const closure = eagerClosureOfCli();
+  const closure = eagerClosureOf(path.join(srcRoot, 'cli.ts'));
   expect(closure.length).toBeGreaterThan(50);
   expect(
     closure.filter((file) => file.includes(`${path.sep}packages${path.sep}`)).length,

--- a/src/__tests__/eager-import-closure.fixtures.ts
+++ b/src/__tests__/eager-import-closure.fixtures.ts
@@ -1,0 +1,181 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseSync } from 'oxc-parser';
+
+/**
+ * Eager-import-closure machinery shared by the startup/teardown lazy-seam pins.
+ *
+ * "On demand" is a claim about SCOPE, not about syntax, which is why this reads
+ * the AST rather than matching import forms. Two shapes evaluate the module
+ * during module evaluation while looking lazy or looking like nothing at all:
+ * a bare side-effect `import 'x'` (binds no names, still evaluates),
+ * and a dynamic `import('x')` sitting at module top level rather than
+ * inside a function -- including `.then(...)` and an immediately-invoked
+ * top-level function. A dynamic import is lazy only when its nearest enclosing
+ * function scope is not the module itself. Type-only imports and re-exports are
+ * erased at build and stay allowed.
+ *
+ * Known limitation: a top-level function that is invoked indirectly at load
+ * time (stored, then called by another top-level statement) reads as lazy here.
+ * Direct top-level invocation -- `(() => { ... })()` -- is detected.
+ */
+
+const FUNCTION_NODES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+]);
+const WORKSPACE_SPECIFIER = /^(@agent-device\/[^/]+)(\/.*)?$/;
+
+type AstNode = { type?: string; [key: string]: unknown };
+
+type ParsedModuleRecord = ReturnType<typeof parseSync>['module'];
+
+/** Static specifiers this file causes to be EVALUATED (not type-only). */
+function staticEvaluatedRefs(module: ParsedModuleRecord): string[] {
+  const refs: string[] = [];
+  for (const staticImport of module.staticImports) {
+    // No entries at all is a side-effect import (`import 'x'`), which always
+    // evaluates. Otherwise it evaluates unless every binding is type-only.
+    const evaluates =
+      staticImport.entries.length === 0 || staticImport.entries.some((entry) => !entry.isType);
+    if (evaluates) refs.push(staticImport.moduleRequest.value);
+  }
+  for (const staticExport of module.staticExports) {
+    for (const entry of staticExport.entries) {
+      if (entry.moduleRequest && !entry.isType) refs.push(entry.moduleRequest.value);
+    }
+  }
+  return refs;
+}
+
+function unwrapParentheses(node: unknown): AstNode | null {
+  let current = node as AstNode | null;
+  while (current?.type === 'ParenthesizedExpression')
+    current = current.expression as AstNode | null;
+  return current;
+}
+
+/** The body of a function invoked right where it is defined, if this is that call. */
+function immediatelyInvokedBody(node: AstNode): unknown {
+  if (node.type !== 'CallExpression') return null;
+  const callee = unwrapParentheses(node.callee);
+  return callee && FUNCTION_NODES.has(String(callee.type)) ? callee.body : null;
+}
+
+function dynamicImportSpecifier(node: AstNode): string | null {
+  if (node.type !== 'ImportExpression') return null;
+  const source = node.source as { type?: string; value?: unknown } | undefined;
+  return source?.type === 'Literal' && typeof source.value === 'string' ? source.value : null;
+}
+
+function recordDynamicImport(record: AstNode, eager: boolean, found: string[]): void {
+  if (!eager) return;
+  const specifier = dynamicImportSpecifier(record);
+  if (specifier !== null) found.push(specifier);
+}
+
+/** Descends into a node's children, dropping `eager` on the way into a function body. */
+function visitChildren(record: AstNode, eager: boolean, found: string[]): void {
+  const childEager = eager && !FUNCTION_NODES.has(String(record.type));
+  for (const [key, value] of Object.entries(record)) {
+    if (key !== 'type') collectEagerDynamicImports(value, childEager, found);
+  }
+}
+
+/** Walks the AST, collecting only `import()` calls reached without entering a function. */
+function collectEagerDynamicImports(node: unknown, eager: boolean, found: string[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectEagerDynamicImports(child, eager, found);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const record = node as AstNode;
+  recordDynamicImport(record, eager, found);
+  // An immediately-invoked function runs now, so its body inherits `eager`.
+  const invokedBody = immediatelyInvokedBody(record);
+  if (invokedBody) collectEagerDynamicImports(invokedBody, eager, found);
+  visitChildren(record, eager, found);
+}
+
+export { FUNCTION_NODES };
+
+export function parseEagerModule(fileName: string, source: string): ParsedModuleRecord {
+  return parseSync(fileName, source).module;
+}
+
+/** Every specifier this file evaluates at load time, static or dynamic. */
+export function eagerlyEvaluatedModules(fileName: string, source: string): string[] {
+  const parsed = parseSync(fileName, source);
+  const dynamic: string[] = [];
+  collectEagerDynamicImports(parsed.program, true, dynamic);
+  return [...new Set([...staticEvaluatedRefs(parsed.module), ...dynamic])];
+}
+
+export function resolveRelative(fromFile: string, specifier: string): string | null {
+  const candidate = path.resolve(path.dirname(fromFile), specifier);
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  for (const suffix of ['.ts', '.tsx', '/index.ts']) {
+    if (fs.existsSync(`${candidate}${suffix}`)) return `${candidate}${suffix}`;
+  }
+  return null;
+}
+
+/** `@agent-device/<pkg>` -> that package's directory, keyed by its declared name. */
+function readWorkspacePackageDirs(): Map<string, string> {
+  const packagesRoot = path.resolve(import.meta.dirname, '../../packages');
+  const dirs = new Map<string, string>();
+  for (const entry of fs.readdirSync(packagesRoot)) {
+    const manifestPath = path.join(packagesRoot, entry, 'package.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { name?: string };
+    if (manifest.name) dirs.set(manifest.name, path.join(packagesRoot, entry));
+  }
+  return dirs;
+}
+
+type ExportTarget = { default?: string; types?: string } | string;
+
+function readExportTarget(packageDir: string, subpath: string): string | undefined {
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')) as {
+    exports?: Record<string, ExportTarget>;
+  };
+  const target = manifest.exports?.[subpath];
+  if (typeof target === 'string') return target;
+  return target?.default ?? target?.types;
+}
+
+/**
+ * Workspace subpath imports are followed too: a package the entry evaluates can
+ * pull a heavy module in just as effectively as a file under src/, and stopping the
+ * walk at the package boundary would be the same blind spot in a new place.
+ */
+function resolveWorkspace(specifier: string, packageDirs: Map<string, string>): string | null {
+  const match = WORKSPACE_SPECIFIER.exec(specifier);
+  const packageName = match?.[1];
+  const packageDir = packageName ? packageDirs.get(packageName) : undefined;
+  if (!packageDir) return null;
+  const target = readExportTarget(packageDir, `.${match?.[2] ?? ''}`);
+  if (!target) return null;
+  const resolved = path.resolve(packageDir, target);
+  return fs.existsSync(resolved) ? resolved : null;
+}
+
+/** Every repo file evaluated as a consequence of importing `entryFile`. */
+export function eagerClosureOf(entryFile: string): string[] {
+  const packageDirs = readWorkspacePackageDirs();
+  const queue = [entryFile];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current || visited.has(current)) continue;
+    visited.add(current);
+    for (const specifier of eagerlyEvaluatedModules(current, fs.readFileSync(current, 'utf8'))) {
+      const resolved = specifier.startsWith('.')
+        ? resolveRelative(current, specifier)
+        : resolveWorkspace(specifier, packageDirs);
+      if (resolved) queue.push(resolved);
+    }
+  }
+  return [...visited];
+}

--- a/src/__tests__/eager-import-closure.fixtures.ts
+++ b/src/__tests__/eager-import-closure.fixtures.ts
@@ -98,12 +98,6 @@ function collectEagerDynamicImports(node: unknown, eager: boolean, found: string
   visitChildren(record, eager, found);
 }
 
-export { FUNCTION_NODES };
-
-export function parseEagerModule(fileName: string, source: string): ParsedModuleRecord {
-  return parseSync(fileName, source).module;
-}
-
 /** Every specifier this file evaluates at load time, static or dynamic. */
 export function eagerlyEvaluatedModules(fileName: string, source: string): string[] {
   const parsed = parseSync(fileName, source);
@@ -112,7 +106,7 @@ export function eagerlyEvaluatedModules(fileName: string, source: string): strin
   return [...new Set([...staticEvaluatedRefs(parsed.module), ...dynamic])];
 }
 
-export function resolveRelative(fromFile: string, specifier: string): string | null {
+function resolveRelative(fromFile: string, specifier: string): string | null {
   const candidate = path.resolve(path.dirname(fromFile), specifier);
   if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   for (const suffix of ['.ts', '.tsx', '/index.ts']) {

--- a/src/daemon/__tests__/session-teardown-import-closure.test.ts
+++ b/src/daemon/__tests__/session-teardown-import-closure.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import path from 'node:path';
+import { eagerClosureOf } from '../../__tests__/eager-import-closure.fixtures';
+
+/**
+ * Session teardown runs for every closed session on every platform, so its eager
+ * import closure is paid by all of them. The android cleanup helpers
+ * (`perf.ts`, `snapshot-helper.ts`) only matter when the corresponding capture
+ * actually ran on the session; they load through function-scoped `await import`
+ * behind their existing guards (the register-builtins interactor lazy pattern).
+ *
+ * This pins that seam: restoring either helper to a static import puts it back
+ * in the eager closure and fails here.
+ */
+
+const srcRoot = path.resolve(import.meta.dirname, '../..');
+const teardownFile = path.resolve(srcRoot, 'daemon/session-teardown.ts');
+const LAZY_ANDROID_HELPERS = [
+  /platforms[/\\]android[/\\]perf\.ts$/,
+  /platforms[/\\]android[/\\]snapshot-helper\.ts$/,
+];
+
+test('the session teardown eager import closure never evaluates the android cleanup helpers', () => {
+  const offenders = eagerClosureOf(teardownFile).filter((file) =>
+    LAZY_ANDROID_HELPERS.some((pattern) => pattern.test(file)),
+  );
+
+  expect(
+    offenders.map((file) => path.relative(srcRoot, file)),
+    'Load the android perf/snapshot-helper cleanup helpers on demand instead: teardown is shared ' +
+      'by every platform, and eagerly evaluating these drags their whole subtree into sessions ' +
+      'that never ran an android capture.',
+  ).toEqual([]);
+});
+
+test('the teardown closure walk is reachable and the dynamic seam exists', () => {
+  // Non-vacuity: a resolver bug that returned an empty closure would make the
+  // guard above pass while proving nothing, so pin a real lower bound…
+  const closure = eagerClosureOf(teardownFile);
+  expect(closure.length).toBeGreaterThan(20);
+  expect(closure).toContain(path.resolve(srcRoot, 'daemon/materialized-path-registry.ts'));
+});

--- a/src/daemon/__tests__/session-teardown-import-closure.test.ts
+++ b/src/daemon/__tests__/session-teardown-import-closure.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import path from 'node:path';
-import { eagerClosureOf } from '../../__tests__/eager-import-closure.fixtures';
+import { eagerClosureOf } from '../../__tests__/eager-import-closure.fixtures.ts';
 
 /**
  * Session teardown runs for every closed session on every platform, so its eager

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -1,5 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { cleanupAppleXctracePerfCapture } from '../platforms/apple/core/perf-xctrace.ts';
 import { cleanupRetainedMaterializedPathsForSession } from './materialized-path-registry.ts';
 import { stopSessionAudioProbe } from './audio-probe.ts';
 import type { SessionState } from './types.ts';
@@ -8,9 +9,10 @@ import { forceCleanupSessionAppLog } from './app-log-session-resource.ts';
 import { appLogResourceStore } from './app-log-resource-store.ts';
 import { finishLiveScreenRecording } from './screen-recording-session-resource.ts';
 
-// Platform cleanup helpers stay behind dynamic imports: every teardown caller pays this module's
+// Android cleanup helpers stay behind dynamic imports: every teardown caller pays this module's
 // graph, while the helpers only matter when the corresponding capture actually ran on the session.
-// The guards below match register-builtins' interactor lazy pattern.
+// The guards below match register-builtins' interactor lazy pattern; the seam is pinned by
+// src/daemon/__tests__/session-teardown-import-closure.test.ts.
 async function cleanupAndroidNativePerfSessionLazy(
   device: SessionState['device'],
   active: NonNullable<NonNullable<SessionState['nativePerf']>['android']>,
@@ -22,8 +24,9 @@ async function cleanupAndroidNativePerfSessionLazy(
 async function stopAndroidSnapshotHelperSessionForDeviceLazy(
   device: SessionState['device'],
 ): Promise<void> {
-  const { stopAndroidSnapshotHelperSessionForDevice } =
-    await import('../platforms/android/snapshot-helper.ts');
+  const { stopAndroidSnapshotHelperSessionForDevice } = await import(
+    '../platforms/android/snapshot-helper.ts'
+  );
   await stopAndroidSnapshotHelperSessionForDevice(device);
 }
 
@@ -46,8 +49,6 @@ export async function stopSessionAppLog(params: {
 
 export async function stopSessionApplePerfCapture(session: SessionState): Promise<void> {
   if (!session.applePerf?.active) return;
-  const { cleanupAppleXctracePerfCapture } =
-    await import('../platforms/apple/core/perf-xctrace.ts');
   await cleanupAppleXctracePerfCapture(session.applePerf.active);
   session.applePerf = { ...(session.applePerf ?? {}), active: undefined };
 }

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -1,8 +1,5 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import { cleanupAppleXctracePerfCapture } from '../platforms/apple/core/perf-xctrace.ts';
-import { cleanupAndroidNativePerfSession } from '../platforms/android/perf.ts';
-import { stopAndroidSnapshotHelperSessionForDevice } from '../platforms/android/snapshot-helper.ts';
 import { cleanupRetainedMaterializedPathsForSession } from './materialized-path-registry.ts';
 import { stopSessionAudioProbe } from './audio-probe.ts';
 import type { SessionState } from './types.ts';
@@ -10,6 +7,25 @@ import type { SessionStore } from './session-store.ts';
 import { forceCleanupSessionAppLog } from './app-log-session-resource.ts';
 import { appLogResourceStore } from './app-log-resource-store.ts';
 import { finishLiveScreenRecording } from './screen-recording-session-resource.ts';
+
+// Platform cleanup helpers stay behind dynamic imports: every teardown caller pays this module's
+// graph, while the helpers only matter when the corresponding capture actually ran on the session.
+// The guards below match register-builtins' interactor lazy pattern.
+async function cleanupAndroidNativePerfSessionLazy(
+  device: SessionState['device'],
+  active: NonNullable<NonNullable<SessionState['nativePerf']>['android']>,
+): Promise<void> {
+  const { cleanupAndroidNativePerfSession } = await import('../platforms/android/perf.ts');
+  await cleanupAndroidNativePerfSession(device, active);
+}
+
+async function stopAndroidSnapshotHelperSessionForDeviceLazy(
+  device: SessionState['device'],
+): Promise<void> {
+  const { stopAndroidSnapshotHelperSessionForDevice } =
+    await import('../platforms/android/snapshot-helper.ts');
+  await stopAndroidSnapshotHelperSessionForDevice(device);
+}
 
 export { stopSessionAudioProbe } from './audio-probe.ts';
 
@@ -30,6 +46,8 @@ export async function stopSessionAppLog(params: {
 
 export async function stopSessionApplePerfCapture(session: SessionState): Promise<void> {
   if (!session.applePerf?.active) return;
+  const { cleanupAppleXctracePerfCapture } =
+    await import('../platforms/apple/core/perf-xctrace.ts');
   await cleanupAppleXctracePerfCapture(session.applePerf.active);
   session.applePerf = { ...(session.applePerf ?? {}), active: undefined };
 }
@@ -37,13 +55,13 @@ export async function stopSessionApplePerfCapture(session: SessionState): Promis
 export async function stopSessionAndroidNativePerfCapture(session: SessionState): Promise<void> {
   const active = session.nativePerf?.android;
   if (!active) return;
-  await cleanupAndroidNativePerfSession(session.device, active);
+  await cleanupAndroidNativePerfSessionLazy(session.device, active);
   session.nativePerf = { ...(session.nativePerf ?? {}), android: undefined };
 }
 
 export async function stopSessionAndroidSnapshotHelper(session: SessionState): Promise<void> {
   if (session.device.platform !== 'android') return;
-  await stopAndroidSnapshotHelperSessionForDevice(session.device);
+  await stopAndroidSnapshotHelperSessionForDeviceLazy(session.device);
 }
 
 type SessionCleanupStep = { step: string; run: () => Promise<void> };

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -24,9 +24,8 @@ async function cleanupAndroidNativePerfSessionLazy(
 async function stopAndroidSnapshotHelperSessionForDeviceLazy(
   device: SessionState['device'],
 ): Promise<void> {
-  const { stopAndroidSnapshotHelperSessionForDevice } = await import(
-    '../platforms/android/snapshot-helper.ts'
-  );
+  const { stopAndroidSnapshotHelperSessionForDevice } =
+    await import('../platforms/android/snapshot-helper.ts');
   await stopAndroidSnapshotHelperSessionForDevice(device);
 }
 

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -11,23 +11,9 @@ import { finishLiveScreenRecording } from './screen-recording-session-resource.t
 
 // Android cleanup helpers stay behind dynamic imports: every teardown caller pays this module's
 // graph, while the helpers only matter when the corresponding capture actually ran on the session.
-// The guards below match register-builtins' interactor lazy pattern; the seam is pinned by
+// Each import sits inside its sole caller, next to the existing guard, matching register-builtins'
+// interactor lazy pattern; the seam is pinned by
 // src/daemon/__tests__/session-teardown-import-closure.test.ts.
-async function cleanupAndroidNativePerfSessionLazy(
-  device: SessionState['device'],
-  active: NonNullable<NonNullable<SessionState['nativePerf']>['android']>,
-): Promise<void> {
-  const { cleanupAndroidNativePerfSession } = await import('../platforms/android/perf.ts');
-  await cleanupAndroidNativePerfSession(device, active);
-}
-
-async function stopAndroidSnapshotHelperSessionForDeviceLazy(
-  device: SessionState['device'],
-): Promise<void> {
-  const { stopAndroidSnapshotHelperSessionForDevice } =
-    await import('../platforms/android/snapshot-helper.ts');
-  await stopAndroidSnapshotHelperSessionForDevice(device);
-}
 
 export { stopSessionAudioProbe } from './audio-probe.ts';
 
@@ -55,13 +41,16 @@ export async function stopSessionApplePerfCapture(session: SessionState): Promis
 export async function stopSessionAndroidNativePerfCapture(session: SessionState): Promise<void> {
   const active = session.nativePerf?.android;
   if (!active) return;
-  await cleanupAndroidNativePerfSessionLazy(session.device, active);
+  const { cleanupAndroidNativePerfSession } = await import('../platforms/android/perf.ts');
+  await cleanupAndroidNativePerfSession(session.device, active);
   session.nativePerf = { ...(session.nativePerf ?? {}), android: undefined };
 }
 
 export async function stopSessionAndroidSnapshotHelper(session: SessionState): Promise<void> {
   if (session.device.platform !== 'android') return;
-  await stopAndroidSnapshotHelperSessionForDeviceLazy(session.device);
+  const { stopAndroidSnapshotHelperSessionForDevice } =
+    await import('../platforms/android/snapshot-helper.ts');
+  await stopAndroidSnapshotHelperSessionForDevice(session.device);
 }
 
 type SessionCleanupStep = { step: string; run: () => Promise<void> };


### PR DESCRIPTION
## Summary

Session teardown is shared by every platform, but it statically imported the android perf cleanup, the android snapshot helper, and the apple xctrace cleanup — so all of them sat in teardown's eager import closure whether or not any capture ran. The android helpers now load via `await import` behind their existing guards, matching the established `register-builtins` interactor lazy pattern. The apple helper stays static.

**This is a seam-hygiene and regression-pin change, not a measurable speedup.** Measured honestly: teardown's module import takes ~0.10s on main vs ~0.11s here — the lazied modules are individually cheap, and no suite-level wall-clock gain is claimed. The value is:

1. **The pin**: `session-teardown-import-closure.test.ts` fails with an explanatory message if either android helper is restored to a static import (observed red against main's static imports before green here).
2. **Shared machinery**: the eager-closure walker from `cli-startup-import-closure.test.ts` is extracted to `eager-import-closure.fixtures.ts` so future lazy-seam claims can pin themselves the same way; the CLI test now consumes the fixture.
3. **Hygiene**: teardown's eager closure (146 → 121 repo modules, `module.registerHooks` counter) stays platform-neutral as the capture subtrees grow.

The apple `perf-xctrace` hunk was dropped per review: the existing Apple unit test mocks the cleanup module, so it could not prove the dynamic chunk loads on the shipped path.

## Validation

- Planted-red check on the final implementation: restoring only the two production static imports made the eager-closure guard fail while the non-vacuity test remained green; restoring the dynamic imports returned both tests to green.
- Teardown graph measured 146 (main) → 121 (branch) with a `module.registerHooks` load counter.
- `session-teardown-resources`, `lease-lifecycle`, `daemon-client-lifecycle`, `daemon-runtime-device-claims`: 39 tests green; CLI startup closure tests green against the extracted fixture (22/22).
- `pnpm check:affected --run`: all runnable checks passed (143 files, 837 tests in the related-test lane).

Scope: 4 files (1 source, 1 new fixture, 1 rewritten test, 1 new test).
