### PR TITLE
fix(web): scope disabled detection to the ref-bearing annotation group

### DIFF
--- a/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
+++ b/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
@@ -31,6 +31,28 @@ describe('normalizeAgentBrowserSnapshot', () => {
     expect(result.nodes[0]?.label).toBe('Shows [disabled] in its label');
   });
 
+  test('does not read disabled from a trailing value outside the annotation group', async () => {
+    const result = await normalizeAgentBrowserSnapshot({
+      snapshot: '  - textbox "Status" [ref=e1]: [disabled]',
+      refs: { e1: { name: 'Status', role: 'textbox' } },
+    });
+
+    expect(result.nodes[0]?.enabled).toBeUndefined();
+    expect(result.nodes[0]?.value).toBe('[disabled]');
+  });
+
+  test('does not read disabled from a label that embeds a ref-shaped annotation', async () => {
+    // Live-derived from the pinned agent-browser: an enabled button whose
+    // aria-label is "Shows [disabled, ref=e1]" emits exactly this line.
+    const result = await normalizeAgentBrowserSnapshot({
+      snapshot: '  - button "Shows [disabled, ref=e1]" [ref=e1]',
+      refs: { e1: { name: 'Shows [disabled, ref=e1]', role: 'button' } },
+    });
+
+    expect(result.nodes[0]?.enabled).toBeUndefined();
+    expect(result.nodes[0]?.label).toBe('Shows [disabled, ref=e1]');
+  });
+
   test('metadata enabled still wins over the text annotation', async () => {
     const result = await normalizeAgentBrowserSnapshot({
       snapshot: '  - button "Odd" [disabled, ref=e1]',

--- a/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
+++ b/src/platforms/web/__tests__/agent-browser-snapshot.test.ts
@@ -33,17 +33,15 @@ describe('normalizeAgentBrowserSnapshot', () => {
 
   test('does not read disabled from a trailing value outside the annotation group', async () => {
     const result = await normalizeAgentBrowserSnapshot({
-      snapshot: '  - textbox "Status" [ref=e1]: [disabled]',
+      snapshot: '  - textbox "Status" [ref=e1]: [disabled, ref=e9]',
       refs: { e1: { name: 'Status', role: 'textbox' } },
     });
 
     expect(result.nodes[0]?.enabled).toBeUndefined();
-    expect(result.nodes[0]?.value).toBe('[disabled]');
+    expect(result.nodes[0]?.value).toBe('[disabled, ref=e9]');
   });
 
   test('does not read disabled from a label that embeds a ref-shaped annotation', async () => {
-    // Live-derived from the pinned agent-browser: an enabled button whose
-    // aria-label is "Shows [disabled, ref=e1]" emits exactly this line.
     const result = await normalizeAgentBrowserSnapshot({
       snapshot: '  - button "Shows [disabled, ref=e1]" [ref=e1]',
       refs: { e1: { name: 'Shows [disabled, ref=e1]', role: 'button' } },

--- a/src/platforms/web/agent-browser-snapshot.ts
+++ b/src/platforms/web/agent-browser-snapshot.ts
@@ -169,8 +169,18 @@ function extractQuotedText(line: string): string | undefined {
 }
 
 function isLineMarkedDisabled(line: string): boolean {
-  const withoutQuotedText = line.replace(/"[^"]*"/g, '').replace(/'[^']*'/g, '');
-  return /\[[^\]]*\bdisabled\b[^\]]*\]/i.test(withoutQuotedText);
+  // The structural annotation sits outside quoted label text, so strip
+  // strings first (escape-aware) — a label may itself embed ref-shaped
+  // bracket groups. The node's own annotation is the last remaining
+  // ref-bearing group; anything after it is the optional value.
+  const outsideQuotedText = line
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''");
+  const refGroups = (outsideQuotedText.match(/\[[^\]]*\]/g) ?? []).filter((group) =>
+    /\bref\s*=\s*['"]?@?e\d+/i.test(group),
+  );
+  const structuralAnnotation = refGroups.at(-1);
+  return structuralAnnotation !== undefined && /\bdisabled\b/i.test(structuralAnnotation);
 }
 
 function extractValue(line: string): string | undefined {

--- a/src/platforms/web/agent-browser-snapshot.ts
+++ b/src/platforms/web/agent-browser-snapshot.ts
@@ -145,9 +145,15 @@ function findParentIndex(lastIndexByDepth: Map<number, number>, depth: number): 
 }
 
 function extractBrowserRef(line: string): string | null {
+  const annotation = extractNodeAnnotation(line);
   return normalizeBrowserRef(
-    line.match(/\bref=['"]?(@?e\d+)['"]?/i)?.[1] ?? line.match(/@?(e\d+)\b/i)?.[1],
+    annotation?.match(/\bref\s*=\s*['"]?(@?e\d+)['"]?/i)?.[1] ?? line.match(/@?(e\d+)\b/i)?.[1],
   );
+}
+
+function extractNodeAnnotation(line: string): string | undefined {
+  const structure = line.replace(/"(?:[^"\\]|\\.)*"/g, '""').replace(/'(?:[^'\\]|\\.)*'/g, "''");
+  return structure.match(/\[([^\]]*\bref\s*=\s*['"]?@?e\d+[^\]]*)\]\s*(?=:|$)/i)?.[1];
 }
 
 function normalizeBrowserRef(value: string | undefined): string | null {
@@ -169,18 +175,7 @@ function extractQuotedText(line: string): string | undefined {
 }
 
 function isLineMarkedDisabled(line: string): boolean {
-  // The structural annotation sits outside quoted label text, so strip
-  // strings first (escape-aware) — a label may itself embed ref-shaped
-  // bracket groups. The node's own annotation is the last remaining
-  // ref-bearing group; anything after it is the optional value.
-  const outsideQuotedText = line
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-    .replace(/'(?:[^'\\]|\\.)*'/g, "''");
-  const refGroups = (outsideQuotedText.match(/\[[^\]]*\]/g) ?? []).filter((group) =>
-    /\bref\s*=\s*['"]?@?e\d+/i.test(group),
-  );
-  const structuralAnnotation = refGroups.at(-1);
-  return structuralAnnotation !== undefined && /\bdisabled\b/i.test(structuralAnnotation);
+  return /\bdisabled\b/i.test(extractNodeAnnotation(line) ?? '');
 }
 
 function extractValue(line: string): string | undefined {


### PR DESCRIPTION
## Summary

Keep `[disabled]` detection scoped to the node annotation that owns its browser ref. Literal bracket text in labels or trailing values remains user data and no longer changes `enabled`.

Ref extraction and disabled-state detection now share one annotation parser instead of independently reconstructing the snapshot grammar.

## Validation

- Observed the trailing-value regression fail against the pre-fix implementation (`enabled: false` instead of `undefined`).
- Focused web snapshot suite: 5/5 passed, including quoted labels and a ref-shaped trailing value.
- `pnpm check:affected --run`: all runnable checks passed; 259 related files and 1,672 tests passed.
- GitHub-authoritative coverage and web smoke are running on the updated head.
