### PR TITLE
refactor: dedupe containsPoint and rectArea into @agent-device/kernel

### DIFF
--- a/src/core/interaction-touch-point.ts
+++ b/src/core/interaction-touch-point.ts
@@ -1,4 +1,5 @@
 import type { Point, Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
+import { containsPoint } from '@agent-device/kernel/rect';
 import {
   areRectsApproximatelyEqual,
   normalizeRect,
@@ -132,7 +133,7 @@ function findNearestParentOwnedPoint(
   const rankedPoints = xCandidates.flatMap((x) =>
     yCandidates.flatMap((y) => {
       const point = { x: Math.round(x), y: Math.round(y) };
-      if (!containsPoint(searchRect, point)) return [];
+      if (!containsPoint(searchRect, point.x, point.y)) return [];
       const ranked = rankParentOwnedPoint(
         point,
         targetRect,
@@ -144,15 +145,6 @@ function findNearestParentOwnedPoint(
     }),
   );
   return rankedPoints.sort(compareRankedPoints)[0]?.point ?? null;
-}
-
-function containsPoint(rect: Rect, point: Point): boolean {
-  return (
-    point.x >= rect.x &&
-    point.x <= rect.x + rect.width &&
-    point.y >= rect.y &&
-    point.y <= rect.y + rect.height
-  );
 }
 
 function rankParentOwnedPoint(

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -1,7 +1,7 @@
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import type { Rect } from '@agent-device/kernel/snapshot';
+import { containsPoint } from '@agent-device/kernel/rect';
 import {
   buildFillFailureDetails,
   isSensitiveFillDiagnosticNode,
@@ -387,21 +387,17 @@ function updateAndroidTextAtPointScan(
   x: number,
   y: number,
 ): void {
-  const containsPoint = containsAndroidPoint(candidate.rect, x, y);
-  if (containsPoint && candidate.editText) {
+  const atPoint = containsPoint(candidate.rect, x, y);
+  if (atPoint && candidate.editText) {
     scan.editAtPoint = smallerAndroidFillCandidate(scan.editAtPoint, candidate);
   }
   if (candidate.focused && candidate.editText) {
     scan.focusedEdit = smallerAndroidFillCandidate(scan.focusedEdit, candidate);
     return;
   }
-  if (containsPoint && candidate.text) {
+  if (atPoint && candidate.text) {
     scan.anyAtPoint = smallerAndroidFillCandidate(scan.anyAtPoint, candidate);
   }
-}
-
-function containsAndroidPoint(rect: Rect, x: number, y: number): boolean {
-  return x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
 }
 
 function smallerAndroidFillCandidate<T extends AndroidFillVerificationCandidate>(

--- a/src/screenshot-diff/screenshot-diff-overlay-matches.ts
+++ b/src/screenshot-diff/screenshot-diff-overlay-matches.ts
@@ -2,7 +2,8 @@ import type {
   ScreenshotDiffRegion,
   ScreenshotDiffRegionOverlayMatch,
 } from './screenshot-diff-regions.ts';
-import type { Rect, ScreenshotOverlayRef } from '@agent-device/kernel/snapshot';
+import type { ScreenshotOverlayRef } from '@agent-device/kernel/snapshot';
+import { rectArea } from '@agent-device/kernel/rect';
 import { intersectArea } from '../utils/screenshot-geometry.ts';
 
 const MAX_MATCHES_PER_REGION = 3;
@@ -51,10 +52,6 @@ function findRegionOverlayMatches(
       rect: match.rect,
       regionCoveragePercentage: match.regionCoveragePercentage,
     }));
-}
-
-function rectArea(rect: Rect): number {
-  return rect.width * rect.height;
 }
 
 function roundPercentage(ratio: number): number {


### PR DESCRIPTION
## Summary

Three byte-identical geometry helpers collapse into the existing `@agent-device/kernel/rect` exports:

- `containsAndroidPoint` (android fill verification) and a local `containsPoint` (interaction touch-point) → kernel `containsPoint`
- local `rectArea` in screenshot-diff overlay matching → kernel `rectArea`

The linux snapshot `rectArea` variant is intentionally **not** touched: its undefined-tolerant `?? 0` semantics differ from the kernel's non-null contract.

Net −15 lines; no behavior change.

## Validation

- Android snapshot suite + screenshot-diff suite green (62 tests); full `check:affected` green; `tsc --noEmit` clean.
- Pure refactor of identical implementations — no runtime validation beyond unit suites applies.