### PR TITLE
docs: drop stale apps.ts over-budget warning from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,8 @@ cross-language rules change through golden tables under `contracts/fixtures/`.
 - Tests mirror source topology one-to-one. Split a source module and its test together; do not add to
   the legacy `interaction.test.ts` or platform `index.test.ts` aggregations.
 - Shared fixtures are named exports in a sibling fixture module, not repeated inline literals.
-- `src/daemon/handlers/session.ts` and `src/platforms/apple/core/apps.ts` are already over budget;
-  extract the relevant platform-specific concept before adding behavior.
+- `src/daemon/handlers/session.ts` is already over budget; extract the relevant platform-specific
+  concept before adding behavior.
 
 ## Toolchain and worktree traps
 


### PR DESCRIPTION
## Summary

`src/platforms/apple/core/apps.ts` was decomposed into `app-resolution.ts` / `app-launch.ts` / `app-device-io.ts` / `app-settings.ts` and is now a 15-line barrel. The module-topology warning telling contributors to extract before adding behavior there is stale and would misdirect future work; `session.ts` (478 lines) is still over budget and keeps its entry.

## Validation

Docs-only — no runtime validation applies. Verified against the tree at main: `wc -l src/platforms/apple/core/apps.ts` = 15.