### PR TITLE
perf(typecheck): make the root tsc project incremental

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tmp/tsconfig.tsbuildinfo",
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "rewriteRelativeImportExtensions": true,


### PR DESCRIPTION
## Summary

The `tsc -b packages/*` half of `pnpm typecheck` already caches through composite builds, but the root `tsc -p tsconfig.json` re-checked from scratch every run. This adds `incremental` with a build-info file at `.tmp/tsconfig.tsbuildinfo` — repo-local, per-worktree, already covered by both the `.tmp/` and `*.tsbuildinfo` gitignore entries, and safe to delete at any time (performance state only, never correctness).

Measured on a warm machine: repeat `tsc -p tsconfig.json` drops **2.0s → 0.4s** wall. Cold runs unchanged. CI is unaffected (no cache persisted; cold behavior identical).

Scoped deliberately small: a second candidate from the same investigation — `NODE_COMPILE_CACHE` on the plain-node check lanes — was dropped because a controlled measurement showed no wall-time change on `check:layering` (12.5s with and without; the lane's cost is graph work, not module compilation).

## Validation

- `pnpm check:affected --run`: all runnable checks passed.
- `.tmp/tsconfig.tsbuildinfo` confirmed written and ignored by git.