### PR TITLE
feat(android): bound snapshot presentation quality

### DIFF
--- a/packages/contracts/src/snapshot-types.ts
+++ b/packages/contracts/src/snapshot-types.ts
@@ -59,6 +59,11 @@ export type AndroidSnapshotBackendMetadata = {
   nodeCount?: number;
   helperTruncated?: boolean;
   elapsedMs?: number;
+  presentationFailure?: {
+    phase: 'deadline' | 'complexity' | 'regular-invariant';
+    workUnits: number;
+    maxWorkUnits?: number;
+  };
   /** API 23 helper output carries no `drawing-order`; covered same-window surfaces are not pruned. */
   occlusionScanUnavailable?: boolean;
 };

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -1,5 +1,5 @@
 /**
- * Structured quality verdict computed once by the iOS runner's snapshot capture plan.
+ * Structured quality verdict computed once by a platform snapshot capture/presentation plan.
  * The daemon renders it; it never re-derives degradation from node shapes.
  *
  * Defined here (the foundational snapshot type module) rather than in
@@ -9,11 +9,11 @@
 /**
  * Which capture STRATEGY produced a snapshot, within one platform's plan —
  * distinct from `SnapshotBackend`, which names the platform channel
- * (`xctest`/`android`/…). The iOS plan walks these in order, so one session can
- * change strategy mid-sequence, and two strategies do not return comparable
- * views of one screen (#1569).
+ * (`xctest`/`android`/…). A platform plan may change strategy mid-sequence, and two strategies do
+ * not return comparable views of one screen (#1569). Android's helper presentation is included
+ * here so its quality verdict uses the same typed contract as the iOS strategy chain.
  */
-export type SnapshotCaptureBackend = 'tree' | 'queries' | 'private-ax';
+export type SnapshotCaptureBackend = 'tree' | 'queries' | 'private-ax' | 'android-helper';
 
 /** Internal backends that evidence probes may select explicitly. */
 export type SnapshotPreferredBackend = 'tree' | 'private-ax';

--- a/src/core/interactors/android.test.ts
+++ b/src/core/interactors/android.test.ts
@@ -29,6 +29,7 @@ test('preserves Android clickability evidence through the interactor snapshot ad
     nodes: [{ index: 0, identifier: 'target', rect: { x: 0, y: 0, width: 20, height: 20 } }],
     analysis: { rawNodeCount: 1, maxDepth: 0 },
     androidSnapshot: { backend: 'android-helper' as const },
+    quality: { state: 'healthy' as const, backend: 'android-helper' as const },
   };
   const evidence = {
     kind: 'exact' as const,
@@ -41,5 +42,6 @@ test('preserves Android clickability evidence through the interactor snapshot ad
   const result = await createAndroidInteractor(device).snapshot({});
 
   expect(readSnapshotClickabilityEvidence(result)).toEqual(evidence);
+  expect(result.quality).toEqual({ state: 'healthy', backend: 'android-helper' });
   expect(JSON.stringify(result)).not.toContain('clickable');
 });

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -123,6 +123,23 @@ test('resolveRecoveredWarningLatch transitions', () => {
   expect(switched.latch).toEqual({ appBundleId: 'com.example.other' });
 });
 
+test('Android helper quality never mutates the iOS penalty latch', () => {
+  const latch = { appBundleId: 'com.example.app' };
+  for (const state of ['healthy', 'recovered', 'sparse'] as const) {
+    const decision = resolveRecoveredWarningLatch({
+      verdict: {
+        state,
+        backend: 'android-helper',
+        reasonCode: state === 'recovered' ? 'presentation-failed' : undefined,
+      },
+      appBundleId: 'com.example.app',
+      latch,
+    });
+    expect(decision.warning).toBeUndefined();
+    expect(decision.latch).toBe(latch);
+  }
+});
+
 test('internal observation responses neither consume nor clear the latch', () => {
   const session = makeIosSession('default', { appBundleId: 'com.example.app' });
 

--- a/src/daemon/snapshot-quality-latch.ts
+++ b/src/daemon/snapshot-quality-latch.ts
@@ -43,6 +43,9 @@ export function resolveRecoveredWarningLatch(params: {
 }): LatchDecision {
   const { verdict, appBundleId, latch } = params;
   if (!verdict) return { latch };
+  // Android helper quality is a platform-local verdict. It must not arm, clear, or otherwise
+  // mutate the iOS XCTest penalty latch, which is session state for a different capture channel.
+  if (verdict.backend === 'android-helper') return { latch };
   if (verdict.state === 'healthy') return { latch: undefined };
   if (verdict.state !== 'recovered') return { latch };
   // A request-pinned backend never degraded anything, so it neither warns nor

--- a/src/platforms/android/__tests__/snapshot-presentation.test.ts
+++ b/src/platforms/android/__tests__/snapshot-presentation.test.ts
@@ -183,3 +183,36 @@ test('hostile nested Android presentation stays under a deterministic linear wor
     true,
   );
 });
+
+test('broad Android presentation rejects an oversized descendant footprint budget', () => {
+  const siblingCount = 24;
+  const buttons = (offset: number) =>
+    Array.from({ length: siblingCount }, (_, index) => {
+      const x = offset + index * 16;
+      const y = 16 + index * 16;
+      return `<node class="android.widget.Button" text="${offset}-${index}" bounds="[${x},${y}][${x + 8},${y + 8}]" clickable="true" visible-to-user="true" />`;
+    }).join('');
+  const tree = parseUiHierarchyTree(
+    `<hierarchy><node class="android.widget.FrameLayout" bounds="[0,0][512,512]" visible-to-user="true">
+      <node class="android.view.ViewGroup" drawing-order="1" bounds="[0,0][512,512]" visible-to-user="true">${buttons(0)}</node>
+      <node class="android.view.ViewGroup" drawing-order="2" bounds="[0,0][512,512]" visible-to-user="true">${buttons(0)}</node>
+    </node></hierarchy>`,
+  );
+
+  assert.throws(
+    () =>
+      buildUiHierarchySnapshot(tree, undefined, {
+        androidPresentation: {
+          deadlineAtMs: Number.POSITIVE_INFINITY,
+          maxWorkUnits: 1024,
+        },
+      }),
+    (error: unknown) => {
+      assert.equal(isAndroidSnapshotPresentationFailure(error), true);
+      assert(error instanceof AndroidSnapshotPresentationFailure);
+      assert.equal(error.details.phase, 'complexity');
+      assert(error.details.workUnits > 1024);
+      return true;
+    },
+  );
+});

--- a/src/platforms/android/__tests__/snapshot-presentation.test.ts
+++ b/src/platforms/android/__tests__/snapshot-presentation.test.ts
@@ -1,12 +1,18 @@
-import type { Rect } from '@agent-device/kernel/snapshot';
+import assert from 'node:assert/strict';
+import type { RawSnapshotNode, Rect } from '@agent-device/kernel/snapshot';
 import fc from 'fast-check';
 import { expect, test } from 'vitest';
 import { PROPERTY_RUNS } from '../../../__tests__/test-utils/property-arbitraries.ts';
 import {
+  AndroidSnapshotPresentationFailure,
   createAndroidSnapshotPresentationNode,
+  createAndroidSnapshotPresentationBudget,
   effectiveAndroidRect,
+  isAndroidSnapshotPresentationFailure,
   serializeAndroidRegularPresentationNode,
+  validateAndroidRegularPresentation,
 } from '../snapshot-presentation.ts';
+import { buildUiHierarchySnapshot, parseUiHierarchyTree } from '../ui-hierarchy.ts';
 import { parseUiHierarchy } from './ui-hierarchy-fixtures.ts';
 
 const rectArb = fc.record({
@@ -105,3 +111,75 @@ function rectContains(outer: Rect, inner: Rect): boolean {
     inner.y + inner.height <= outer.y + Math.max(0, outer.height)
   );
 }
+
+test('regular Android invariant rejects a framed node outside its cumulative clip', () => {
+  const budget = createAndroidSnapshotPresentationBudget(
+    { deadlineAtMs: Number.POSITIVE_INFINITY },
+    100,
+  );
+  const parent: RawSnapshotNode = {
+    index: 0,
+    rect: { x: 0, y: 0, width: 100, height: 100 },
+  };
+  const escaped: RawSnapshotNode = {
+    index: 1,
+    parentIndex: 0,
+    hittable: true,
+  };
+
+  assert.throws(
+    () =>
+      validateAndroidRegularPresentation(
+        [
+          createAndroidSnapshotPresentationNode(
+            parent,
+            { x: 0, y: 0, width: 100, height: 100 },
+            true,
+          ),
+          createAndroidSnapshotPresentationNode(escaped, {
+            x: 90,
+            y: 90,
+            width: 20,
+            height: 20,
+          }),
+        ],
+        { x: 0, y: 0, width: 100, height: 100 },
+        budget,
+      ),
+    (error: unknown) => {
+      assert.equal(isAndroidSnapshotPresentationFailure(error), true);
+      assert(error instanceof AndroidSnapshotPresentationFailure);
+      assert.equal(error.details.phase, 'regular-invariant');
+      assert.equal(error.details.nodeIndex, 1);
+      return true;
+    },
+  );
+});
+
+test('hostile nested Android presentation stays under a deterministic linear work cap', () => {
+  const depth = 240;
+  const opening = Array.from(
+    { length: depth },
+    (_, index) =>
+      `<node class="android.widget.FrameLayout" bounds="[0,0][320,640]"${
+        index === depth - 1
+          ? '><node class="android.widget.Button" text="Target" bounds="[0,0][80,40]" clickable="true" /></node>'
+          : '>'
+      }`,
+  ).join('');
+  const closing = '</node>'.repeat(depth - 1);
+  const tree = parseUiHierarchyTree(`<hierarchy>${opening}${closing}</hierarchy>`);
+
+  const built = buildUiHierarchySnapshot(tree, undefined, {
+    androidPresentation: {
+      deadlineAtMs: Number.POSITIVE_INFINITY,
+      maxWorkUnits: depth * 32,
+    },
+  });
+
+  assert.equal(built.truncated, undefined);
+  assert.equal(
+    built.nodes.some((node) => node.label === 'Target'),
+    true,
+  );
+});

--- a/src/platforms/android/__tests__/snapshot-presentation.test.ts
+++ b/src/platforms/android/__tests__/snapshot-presentation.test.ts
@@ -156,6 +156,31 @@ test('regular Android invariant rejects a framed node outside its cumulative cli
   );
 });
 
+test('regular Android invariant validates disjoint roots against their owning windows', () => {
+  const statusBar = { x: 0, y: 0, width: 1080, height: 136 };
+  const dialog = { x: 28, y: 980, width: 1024, height: 513 };
+  const budget = createAndroidSnapshotPresentationBudget(
+    { deadlineAtMs: Number.POSITIVE_INFINITY },
+    100,
+  );
+
+  assert.doesNotThrow(() =>
+    validateAndroidRegularPresentation(
+      [
+        createAndroidSnapshotPresentationNode(
+          { index: 0, rect: statusBar },
+          statusBar,
+          false,
+          statusBar,
+        ),
+        createAndroidSnapshotPresentationNode({ index: 1, rect: dialog }, dialog, false, dialog),
+      ],
+      dialog,
+      budget,
+    ),
+  );
+});
+
 test('hostile nested Android presentation stays under a deterministic linear work cap', () => {
   const depth = 240;
   const opening = Array.from(

--- a/src/platforms/android/__tests__/snapshot-presentation.test.ts
+++ b/src/platforms/android/__tests__/snapshot-presentation.test.ts
@@ -245,6 +245,23 @@ test('hostile equal-order same-rect siblings charge the broad candidate scan', (
   );
 });
 
+test('default budget admits a bounded flat hierarchy', () => {
+  const siblings = Array.from(
+    { length: 100 },
+    (_, index) =>
+      `<node class="android.widget.Button" text="Sibling ${index}" bounds="[0,0][100,100]" clickable="true" drawing-order="1" visible-to-user="true" />`,
+  ).join('');
+  const tree = parseUiHierarchyTree(
+    `<hierarchy><node class="android.widget.FrameLayout" bounds="[0,0][100,100]" visible-to-user="true">${siblings}</node></hierarchy>`,
+  );
+
+  const built = buildUiHierarchySnapshot(tree, undefined, {
+    androidPresentation: { deadlineAtMs: Number.POSITIVE_INFINITY },
+  });
+
+  assert.equal(built.nodes.length, 101);
+});
+
 test('one-axis footprint indexing remains inside the deterministic work budget', () => {
   const childCount = 80;
   const labels = Array.from(

--- a/src/platforms/android/__tests__/snapshot-presentation.test.ts
+++ b/src/platforms/android/__tests__/snapshot-presentation.test.ts
@@ -216,3 +216,62 @@ test('broad Android presentation rejects an oversized descendant footprint budge
     },
   );
 });
+
+test('hostile equal-order same-rect siblings charge the broad candidate scan', () => {
+  const siblingCount = 72;
+  const siblings = Array.from(
+    { length: siblingCount },
+    (_, index) =>
+      `<node class="android.widget.Button" text="Sibling ${index}" bounds="[0,0][100,100]" clickable="true" drawing-order="1" visible-to-user="true" />`,
+  ).join('');
+  const tree = parseUiHierarchyTree(
+    `<hierarchy><node class="android.widget.FrameLayout" bounds="[0,0][100,100]" visible-to-user="true">${siblings}</node></hierarchy>`,
+  );
+
+  assert.throws(
+    () =>
+      buildUiHierarchySnapshot(tree, undefined, {
+        androidPresentation: {
+          deadlineAtMs: Number.POSITIVE_INFINITY,
+          maxWorkUnits: 2000,
+        },
+      }),
+    (error: unknown) => {
+      assert.equal(isAndroidSnapshotPresentationFailure(error), true);
+      assert(error instanceof AndroidSnapshotPresentationFailure);
+      assert.equal(error.details.phase, 'complexity');
+      return true;
+    },
+  );
+});
+
+test('one-axis footprint indexing remains inside the deterministic work budget', () => {
+  const childCount = 80;
+  const labels = Array.from(
+    { length: childCount },
+    (_, index) =>
+      `<node class="android.widget.TextView" text="Label ${index}" bounds="[${index * 3},0][${index * 3 + 2},10]" visible-to-user="true" />`,
+  ).join('');
+  const tree = parseUiHierarchyTree(
+    `<hierarchy><node class="android.widget.FrameLayout" bounds="[0,0][240,20]" visible-to-user="true">
+      <node class="android.widget.Button" text="Cover" bounds="[0,0][240,10]" clickable="true" drawing-order="2" visible-to-user="true" />
+      <node class="android.view.ViewGroup" bounds="[0,0][240,10]" drawing-order="1" visible-to-user="true">${labels}</node>
+    </node></hierarchy>`,
+  );
+
+  assert.throws(
+    () =>
+      buildUiHierarchySnapshot(tree, undefined, {
+        androidPresentation: {
+          deadlineAtMs: Number.POSITIVE_INFINITY,
+          maxWorkUnits: 1650,
+        },
+      }),
+    (error: unknown) => {
+      assert.equal(isAndroidSnapshotPresentationFailure(error), true);
+      assert(error instanceof AndroidSnapshotPresentationFailure);
+      assert.equal(error.details.phase, 'complexity');
+      return true;
+    },
+  );
+});

--- a/src/platforms/android/__tests__/snapshot-quality-fixtures.ts
+++ b/src/platforms/android/__tests__/snapshot-quality-fixtures.ts
@@ -1,0 +1,59 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT } from '../../../__tests__/test-utils/android-snapshot-helper.ts';
+import type { AndroidAdbExecutor } from '../snapshot-helper.ts';
+
+export const androidSnapshotQualityDevice: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+export const androidSnapshotQualityHelperArtifact = ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT;
+
+const installedHelperProbe = {
+  exitCode: 0,
+  stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode:13004',
+  stderr: '',
+};
+
+export function androidSnapshotQualityHelperAdb(xml: string): AndroidAdbExecutor {
+  return async (args) => {
+    if (args.includes('--show-versioncode')) return installedHelperProbe;
+    if (args[0] === 'shell' && args[1] === 'am' && args[2] === 'force-stop') {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (args.includes('instrument')) {
+      return { exitCode: 0, stdout: helperOutput(xml), stderr: '' };
+    }
+    throw new Error(`unexpected helper adb args: ${args.join(' ')}`);
+  };
+}
+
+function helperOutput(xml: string): string {
+  return [
+    'INSTRUMENTATION_STATUS: agentDeviceProtocol=android-snapshot-helper-v1',
+    'INSTRUMENTATION_STATUS: helperApiVersion=1',
+    'INSTRUMENTATION_STATUS: outputFormat=uiautomator-xml',
+    'INSTRUMENTATION_STATUS: chunkIndex=0',
+    'INSTRUMENTATION_STATUS: chunkCount=1',
+    `INSTRUMENTATION_STATUS: payloadBase64=${Buffer.from(xml, 'utf8').toString('base64')}`,
+    'INSTRUMENTATION_STATUS_CODE: 1',
+    'INSTRUMENTATION_RESULT: agentDeviceProtocol=android-snapshot-helper-v1',
+    'INSTRUMENTATION_RESULT: helperApiVersion=1',
+    'INSTRUMENTATION_RESULT: ok=true',
+    'INSTRUMENTATION_RESULT: outputFormat=uiautomator-xml',
+    'INSTRUMENTATION_RESULT: waitForIdleTimeoutMs=0',
+    'INSTRUMENTATION_RESULT: timeoutMs=8000',
+    'INSTRUMENTATION_RESULT: maxDepth=128',
+    'INSTRUMENTATION_RESULT: maxNodes=5000',
+    'INSTRUMENTATION_RESULT: rootPresent=true',
+    'INSTRUMENTATION_RESULT: captureMode=interactive-windows',
+    'INSTRUMENTATION_RESULT: windowCount=1',
+    'INSTRUMENTATION_RESULT: nodeCount=1',
+    'INSTRUMENTATION_RESULT: truncated=false',
+    'INSTRUMENTATION_RESULT: elapsedMs=12',
+    'INSTRUMENTATION_CODE: 0',
+  ].join('\n');
+}

--- a/src/platforms/android/__tests__/snapshot-quality.test.ts
+++ b/src/platforms/android/__tests__/snapshot-quality.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'vitest';
+import { snapshotAndroid } from '../snapshot.ts';
+import {
+  androidSnapshotQualityDevice,
+  androidSnapshotQualityHelperAdb,
+  androidSnapshotQualityHelperArtifact,
+} from './snapshot-quality-fixtures.ts';
+import { resetAndroidSnapshotHelperInstallCache } from '../snapshot-helper-install.ts';
+import { resetAndroidSnapshotHelperSessions } from '../snapshot-helper-session.ts';
+
+beforeEach(async () => {
+  await resetAndroidSnapshotHelperSessions();
+  resetAndroidSnapshotHelperInstallCache();
+});
+
+afterEach(async () => {
+  await resetAndroidSnapshotHelperSessions();
+});
+
+test('snapshotAndroid publishes an Android helper quality verdict', async () => {
+  const result = await snapshotAndroid(androidSnapshotQualityDevice, {
+    helperAdb: androidSnapshotQualityHelperAdb(
+      '<hierarchy><node text="quality" bounds="[0,0][10,10]" /></hierarchy>',
+    ),
+    helperArtifact: androidSnapshotQualityHelperArtifact,
+  });
+
+  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
+    state: 'healthy',
+    backend: 'android-helper',
+  });
+});
+
+test('snapshotAndroid discards the whole projection after a presentation deadline failure', async () => {
+  const result = await snapshotAndroid(androidSnapshotQualityDevice, {
+    helperAdb: androidSnapshotQualityHelperAdb(
+      '<hierarchy><node text="deadline" bounds="[0,0][10,10]" /></hierarchy>',
+    ),
+    helperArtifact: androidSnapshotQualityHelperArtifact,
+    androidPresentation: {
+      deadlineAtMs: 100,
+      now: () => 100,
+    },
+  });
+
+  assert.deepEqual(result.nodes, []);
+  assert.equal(result.truncated, true);
+  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
+    state: 'sparse',
+    backend: 'android-helper',
+    reason: 'Android snapshot presentation exceeded its cooperative deadline',
+    reasonCode: 'presentation-failed',
+  });
+});

--- a/src/platforms/android/__tests__/snapshot-quality.test.ts
+++ b/src/platforms/android/__tests__/snapshot-quality.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, test } from 'vitest';
 import { snapshotAndroid } from '../snapshot.ts';
+import { findAndroidAlertCandidate } from '../alert-detection.ts';
 import {
   androidSnapshotQualityDevice,
   androidSnapshotQualityHelperAdb,
@@ -52,4 +53,28 @@ test('snapshotAndroid discards the whole projection after a presentation deadlin
     reason: 'Android snapshot presentation exceeded its cooperative deadline',
     reasonCode: 'presentation-failed',
   });
+});
+
+test('snapshotAndroid preserves a focused native dialog for alert detection', async () => {
+  const result = await snapshotAndroid(androidSnapshotQualityDevice, {
+    helperAdb: androidSnapshotQualityHelperAdb(`
+      <hierarchy>
+        <node package="com.example.app" class="android.widget.FrameLayout" bounds="[0,0][390,844]" visible-to-user="true" window-index="0" window-type="1" window-layer="0" window-active="false" window-focused="false">
+          <node class="android.widget.Button" text="Underlying" bounds="[20,100][200,160]" clickable="true" visible-to-user="true" />
+        </node>
+        <node package="com.example.app" class="android.app.AlertDialog" bounds="[40,240][350,600]" visible-to-user="true" window-index="1" window-type="1" window-layer="1" window-active="true" window-focused="true">
+          <node class="android.widget.FrameLayout" resource-id="android:id/parentPanel" bounds="[40,240][350,600]" visible-to-user="true">
+            <node class="android.widget.TextView" resource-id="android:id/alertTitle" text="Automation confirmation" bounds="[60,280][330,330]" visible-to-user="true" />
+            <node class="android.widget.Button" resource-id="android:id/button1" text="OK" bounds="[220,520][320,570]" clickable="true" visible-to-user="true" />
+          </node>
+        </node>
+      </hierarchy>
+    `),
+    helperArtifact: androidSnapshotQualityHelperArtifact,
+  });
+
+  assert.deepEqual(result.quality, { state: 'healthy', backend: 'android-helper' });
+  const candidate = findAndroidAlertCandidate(result.nodes);
+  assert.equal(candidate?.alert.title, 'Automation confirmation');
+  assert.deepEqual(candidate?.alert.buttons, ['OK']);
 });

--- a/src/platforms/android/__tests__/snapshot-quality.test.ts
+++ b/src/platforms/android/__tests__/snapshot-quality.test.ts
@@ -47,6 +47,11 @@ test('snapshotAndroid discards the whole projection after a presentation deadlin
 
   assert.deepEqual(result.nodes, []);
   assert.equal(result.truncated, true);
+  assert.deepEqual(result.androidSnapshot.presentationFailure, {
+    phase: 'deadline',
+    workUnits: 1,
+    maxWorkUnits: 1024,
+  });
   assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
     state: 'sparse',
     backend: 'android-helper',

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -692,6 +692,43 @@ test('snapshotAndroid resolves helper adb through scoped provider', async () => 
   assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
+test('snapshotAndroid publishes an Android helper quality verdict', async () => {
+  const result = await snapshotAndroidWithHelper(
+    androidSnapshotHelperAdb(
+      '<hierarchy><node text="quality" bounds="[0,0][10,10]" /></hierarchy>',
+    ),
+  );
+
+  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
+    state: 'healthy',
+    backend: 'android-helper',
+  });
+});
+
+test('snapshotAndroid discards the whole projection after a presentation deadline failure', async () => {
+  const options = {
+    helperAdb: androidSnapshotHelperAdb(
+      '<hierarchy><node text="deadline" bounds="[0,0][10,10]" /></hierarchy>',
+    ),
+    helperArtifact,
+    androidPresentation: {
+      deadlineAtMs: 100,
+      now: () => 100,
+    },
+  } as Parameters<typeof snapshotAndroid>[1];
+
+  const result = await snapshotAndroid(device, options);
+
+  assert.deepEqual(result.nodes, []);
+  assert.equal(result.truncated, true);
+  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
+    state: 'sparse',
+    backend: 'android-helper',
+    reason: 'Android snapshot presentation exceeded its cooperative deadline',
+    reasonCode: 'presentation-failed',
+  });
+});
+
 test('snapshotAndroid stops command-scoped persistent helper session after capture', async () => {
   const adbCalls: string[][] = [];
   const spawnArgs: string[][] = [];

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -692,43 +692,6 @@ test('snapshotAndroid resolves helper adb through scoped provider', async () => 
   assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
-test('snapshotAndroid publishes an Android helper quality verdict', async () => {
-  const result = await snapshotAndroidWithHelper(
-    androidSnapshotHelperAdb(
-      '<hierarchy><node text="quality" bounds="[0,0][10,10]" /></hierarchy>',
-    ),
-  );
-
-  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
-    state: 'healthy',
-    backend: 'android-helper',
-  });
-});
-
-test('snapshotAndroid discards the whole projection after a presentation deadline failure', async () => {
-  const options = {
-    helperAdb: androidSnapshotHelperAdb(
-      '<hierarchy><node text="deadline" bounds="[0,0][10,10]" /></hierarchy>',
-    ),
-    helperArtifact,
-    androidPresentation: {
-      deadlineAtMs: 100,
-      now: () => 100,
-    },
-  } as Parameters<typeof snapshotAndroid>[1];
-
-  const result = await snapshotAndroid(device, options);
-
-  assert.deepEqual(result.nodes, []);
-  assert.equal(result.truncated, true);
-  assert.deepEqual((result as typeof result & { quality?: unknown }).quality, {
-    state: 'sparse',
-    backend: 'android-helper',
-    reason: 'Android snapshot presentation exceeded its cooperative deadline',
-    reasonCode: 'presentation-failed',
-  });
-});
-
 test('snapshotAndroid stops command-scoped persistent helper session after capture', async () => {
   const adbCalls: string[][] = [];
   const spawnArgs: string[][] = [];

--- a/src/platforms/android/__tests__/ui-hierarchy-fixtures.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy-fixtures.ts
@@ -1,15 +1,16 @@
-import type { RawSnapshotNode, SnapshotOptions } from '@agent-device/kernel/snapshot';
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
 import {
   buildUiHierarchySnapshot,
   parseUiHierarchyTree,
   type AndroidSnapshotAnalysis,
+  type AndroidUiHierarchySnapshotOptions,
 } from '../ui-hierarchy.ts';
 
 /** XML in, presented nodes out — the production pair (`snapshotAndroid`) minus the helper capture. */
 export function parseUiHierarchy(
   xml: string,
   maxNodes: number | undefined,
-  options: SnapshotOptions,
+  options: AndroidUiHierarchySnapshotOptions,
 ): { nodes: RawSnapshotNode[]; truncated?: boolean; analysis: AndroidSnapshotAnalysis } {
   const { sourceNodes: _sourceNodes, ...snapshot } = buildUiHierarchySnapshot(
     parseUiHierarchyTree(xml),

--- a/src/platforms/android/__tests__/ui-hierarchy-scope.test.ts
+++ b/src/platforms/android/__tests__/ui-hierarchy-scope.test.ts
@@ -4,6 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { buildSnapshotState } from '../../../daemon/snapshot-state.ts';
 import { parseUiHierarchy } from './ui-hierarchy-fixtures.ts';
+import {
+  AndroidSnapshotPresentationFailure,
+  isAndroidSnapshotPresentationFailure,
+} from '../snapshot-presentation.ts';
 
 // Android's scope leg of the golden table (#1832 C2). Android resolves `--scope` exactly once,
 // over the PRESENTED nodes of the requested projection, inside its projection; the daemon never
@@ -233,5 +237,38 @@ test('a match whose subtree presents nothing is skipped for the next candidate',
   assert.deepEqual(
     parseUiHierarchy(xml, undefined, { scope: 'settings' }).nodes.map((node) => node.label),
     ['Settings'],
+  );
+});
+
+test('hostile nested scope search is charged to the presentation budget', () => {
+  const depth = 180;
+  const opening = Array.from(
+    { length: depth },
+    () =>
+      '<node class="android.view.View" content-desc="target" bounds="[0,0][320,640]" visible-to-user="true">',
+  ).join('');
+  const xml = `<hierarchy>${opening}${'</node>'.repeat(depth)}</hierarchy>`;
+  const androidPresentation = {
+    deadlineAtMs: Number.POSITIVE_INFINITY,
+    maxWorkUnits: depth * 10,
+  };
+
+  assert.doesNotThrow(() =>
+    parseUiHierarchy(xml, undefined, { interactiveOnly: true, androidPresentation }),
+  );
+
+  assert.throws(
+    () =>
+      parseUiHierarchy(xml, undefined, {
+        interactiveOnly: true,
+        scope: 'target',
+        androidPresentation,
+      }),
+    (error: unknown) => {
+      assert.equal(isAndroidSnapshotPresentationFailure(error), true);
+      assert(error instanceof AndroidSnapshotPresentationFailure);
+      assert.equal(error.details.phase, 'complexity');
+      return true;
+    },
   );
 });

--- a/src/platforms/android/snapshot-presentation.ts
+++ b/src/platforms/android/snapshot-presentation.ts
@@ -132,17 +132,20 @@ export type AndroidSnapshotPresentationNode = {
   raw: RawSnapshotNode;
   effectiveRect?: Rect;
   clipsDescendants?: boolean;
+  windowRect?: Rect;
 };
 
 export function createAndroidSnapshotPresentationNode(
   raw: RawSnapshotNode,
   effectiveRect?: Rect,
   clipsDescendants?: boolean,
+  windowRect?: Rect,
 ): AndroidSnapshotPresentationNode {
   return {
     raw,
     ...(effectiveRect ? { effectiveRect } : {}),
     ...(clipsDescendants ? { clipsDescendants: true } : {}),
+    ...(windowRect ? { windowRect } : {}),
   };
 }
 
@@ -210,10 +213,7 @@ export function validateAndroidRegularPresentation(
 
   for (const node of nodes) {
     budget.check('regular-invariant');
-    const ancestorClip =
-      node.raw.parentIndex === undefined
-        ? viewport
-        : (clipIncludingNodeByIndex.get(node.raw.parentIndex) ?? viewport);
+    const ancestorClip = resolvePresentationAncestorClip(node, clipIncludingNodeByIndex, viewport);
     const frame = node.effectiveRect;
 
     if (!frame || !isPositiveFiniteRect(frame)) {
@@ -250,6 +250,16 @@ export function validateAndroidRegularPresentation(
 
     clipIncludingNodeByIndex.set(node.raw.index, node.clipsDescendants ? frame : ancestorClip);
   }
+}
+
+function resolvePresentationAncestorClip(
+  node: AndroidSnapshotPresentationNode,
+  clipIncludingNodeByIndex: ReadonlyMap<number, Rect | undefined>,
+  viewport: Rect | undefined,
+): Rect | undefined {
+  const parentIndex = node.raw.parentIndex;
+  if (parentIndex === undefined) return node.windowRect ?? viewport;
+  return clipIncludingNodeByIndex.get(parentIndex) ?? node.windowRect ?? viewport;
 }
 
 function containsRect(frame: Rect, clip: Rect): boolean {

--- a/src/platforms/android/snapshot-presentation.ts
+++ b/src/platforms/android/snapshot-presentation.ts
@@ -83,7 +83,11 @@ export class AndroidSnapshotPresentationBudget {
 
   check(phase: 'deadline' | 'complexity' | 'regular-invariant' | 'work'): void {
     void phase;
-    this.workUnits += 1;
+    this.consume(1);
+  }
+
+  consume(units: number): void {
+    this.workUnits += units;
     const maxWorkUnits = this.options.maxWorkUnits ?? this.defaultMaxWorkUnits;
     if (this.workUnits > maxWorkUnits) {
       throw new AndroidSnapshotPresentationFailure(

--- a/src/platforms/android/snapshot-presentation.ts
+++ b/src/platforms/android/snapshot-presentation.ts
@@ -1,6 +1,122 @@
 import type { RawSnapshotNode, Rect } from '@agent-device/kernel/snapshot';
 import { isPositiveFiniteRect } from '@agent-device/kernel/rect';
 
+const ANDROID_SNAPSHOT_PRESENTATION_FAILED = 'ANDROID_SNAPSHOT_PRESENTATION_FAILED';
+export const ANDROID_SNAPSHOT_PRESENTATION_DEFAULT_DEADLINE_MS = 250;
+
+export type AndroidSnapshotPresentationOptions = {
+  /** Absolute wall-clock deadline. This is internal and never CLI-exposed. */
+  deadlineAtMs?: number;
+  /** Injectable clock for deterministic deadline tests. */
+  now?: () => number;
+  /** Optional linear work cap; production builds derive one from the raw node count. */
+  maxWorkUnits?: number;
+};
+
+export type AndroidSnapshotPresentationFailurePhase =
+  | 'deadline'
+  | 'complexity'
+  | 'regular-invariant';
+
+export type AndroidSnapshotPresentationFailureDetails = {
+  phase: AndroidSnapshotPresentationFailurePhase;
+  workUnits: number;
+  deadlineAtMs?: number;
+  maxWorkUnits?: number;
+  nodeIndex?: number;
+  frame?: Rect;
+  clip?: Rect;
+};
+
+export type AndroidSnapshotPresentationAnalysis = {
+  rawNodeCount: number;
+  maxDepth: number;
+};
+
+export class AndroidSnapshotPresentationFailure extends Error {
+  readonly code = ANDROID_SNAPSHOT_PRESENTATION_FAILED;
+  readonly qualityReasonCode = 'presentation-failed' as const;
+  readonly details: AndroidSnapshotPresentationFailureDetails;
+  analysis?: AndroidSnapshotPresentationAnalysis;
+
+  constructor(
+    message: string,
+    details: AndroidSnapshotPresentationFailureDetails,
+    analysis?: AndroidSnapshotPresentationAnalysis,
+  ) {
+    super(message);
+    this.name = 'AndroidSnapshotPresentationFailure';
+    this.details = details;
+    this.analysis = analysis;
+  }
+}
+
+export function isAndroidSnapshotPresentationFailure(
+  error: unknown,
+): error is AndroidSnapshotPresentationFailure {
+  if (error instanceof AndroidSnapshotPresentationFailure) {
+    return error.code === ANDROID_SNAPSHOT_PRESENTATION_FAILED;
+  }
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    (error as { code?: unknown }).code === ANDROID_SNAPSHOT_PRESENTATION_FAILED,
+  );
+}
+
+export class AndroidSnapshotPresentationBudget {
+  private workUnits = 0;
+  private readonly options: AndroidSnapshotPresentationOptions;
+  private readonly defaultMaxWorkUnits: number;
+  private readonly deadlineAtMs: number;
+
+  constructor(options: AndroidSnapshotPresentationOptions, defaultMaxWorkUnits: number) {
+    this.options = options;
+    this.defaultMaxWorkUnits = defaultMaxWorkUnits;
+    const now = options.now ?? Date.now;
+    this.deadlineAtMs = options.deadlineAtMs ?? now() + defaultDeadlineMs();
+  }
+
+  get workUnitCount(): number {
+    return this.workUnits;
+  }
+
+  check(phase: 'deadline' | 'complexity' | 'regular-invariant' | 'work'): void {
+    void phase;
+    this.workUnits += 1;
+    const maxWorkUnits = this.options.maxWorkUnits ?? this.defaultMaxWorkUnits;
+    if (this.workUnits > maxWorkUnits) {
+      throw new AndroidSnapshotPresentationFailure(
+        'Android snapshot presentation exceeded its linear work budget',
+        {
+          phase: 'complexity',
+          workUnits: this.workUnits,
+          maxWorkUnits,
+        },
+      );
+    }
+    const now = this.options.now ?? Date.now;
+    if (now() >= this.deadlineAtMs) {
+      throw new AndroidSnapshotPresentationFailure(
+        'Android snapshot presentation exceeded its cooperative deadline',
+        {
+          phase: 'deadline',
+          workUnits: this.workUnits,
+          deadlineAtMs: this.deadlineAtMs,
+          maxWorkUnits,
+        },
+      );
+    }
+  }
+}
+
+export function createAndroidSnapshotPresentationBudget(
+  options: AndroidSnapshotPresentationOptions | undefined,
+  defaultMaxWorkUnits: number,
+): AndroidSnapshotPresentationBudget {
+  return new AndroidSnapshotPresentationBudget(options ?? {}, defaultMaxWorkUnits);
+}
+
 /**
  * The typed carrier between Android acquisition facts and regular snapshot wire projection.
  *
@@ -11,13 +127,19 @@ import { isPositiveFiniteRect } from '@agent-device/kernel/rect';
 export type AndroidSnapshotPresentationNode = {
   raw: RawSnapshotNode;
   effectiveRect?: Rect;
+  clipsDescendants?: boolean;
 };
 
 export function createAndroidSnapshotPresentationNode(
   raw: RawSnapshotNode,
   effectiveRect?: Rect,
+  clipsDescendants?: boolean,
 ): AndroidSnapshotPresentationNode {
-  return { raw, ...(effectiveRect ? { effectiveRect } : {}) };
+  return {
+    raw,
+    ...(effectiveRect ? { effectiveRect } : {}),
+    ...(clipsDescendants ? { clipsDescendants: true } : {}),
+  };
 }
 
 /**
@@ -73,4 +195,69 @@ function normalizeRect(rect: Rect): Rect {
     width: Math.max(0, rect.width),
     height: Math.max(0, rect.height),
   };
+}
+
+export function validateAndroidRegularPresentation(
+  nodes: AndroidSnapshotPresentationNode[],
+  viewport: Rect | undefined,
+  budget: AndroidSnapshotPresentationBudget,
+): void {
+  const clipIncludingNodeByIndex = new Map<number, Rect | undefined>();
+
+  for (const node of nodes) {
+    budget.check('regular-invariant');
+    const ancestorClip =
+      node.raw.parentIndex === undefined
+        ? viewport
+        : (clipIncludingNodeByIndex.get(node.raw.parentIndex) ?? viewport);
+    const frame = node.effectiveRect;
+
+    if (!frame || !isPositiveFiniteRect(frame)) {
+      // A helper may report a clickable node outside a scroll clip. The regular serializer clears
+      // that actionability claim when its effective geometry is empty, so validate the wire-facing
+      // projection rather than treating the raw acquisition fact as a presentation violation.
+      if (serializeAndroidRegularPresentationNode(node).hittable === true) {
+        throw new AndroidSnapshotPresentationFailure(
+          `Android regular snapshot node ${node.raw.index} with degenerate effective geometry was marked hittable`,
+          {
+            phase: 'regular-invariant',
+            workUnits: budget.workUnitCount,
+            nodeIndex: node.raw.index,
+            frame,
+          },
+        );
+      }
+      clipIncludingNodeByIndex.set(node.raw.index, ancestorClip);
+      continue;
+    }
+
+    if (ancestorClip && !containsRect(frame, ancestorClip)) {
+      throw new AndroidSnapshotPresentationFailure(
+        `Android regular snapshot node ${node.raw.index} escaped its cumulative clip`,
+        {
+          phase: 'regular-invariant',
+          workUnits: budget.workUnitCount,
+          nodeIndex: node.raw.index,
+          frame,
+          clip: ancestorClip,
+        },
+      );
+    }
+
+    clipIncludingNodeByIndex.set(node.raw.index, node.clipsDescendants ? frame : ancestorClip);
+  }
+}
+
+function containsRect(frame: Rect, clip: Rect): boolean {
+  const tolerance = 0.0001;
+  return (
+    frame.x >= clip.x - tolerance &&
+    frame.y >= clip.y - tolerance &&
+    frame.x + frame.width <= clip.x + clip.width + tolerance &&
+    frame.y + frame.height <= clip.y + clip.height + tolerance
+  );
+}
+
+function defaultDeadlineMs(): number {
+  return ANDROID_SNAPSHOT_PRESENTATION_DEFAULT_DEADLINE_MS;
 }

--- a/src/platforms/android/snapshot-types.ts
+++ b/src/platforms/android/snapshot-types.ts
@@ -23,6 +23,11 @@ export type AndroidSnapshotBackendMetadata = {
   nodeCount?: number;
   helperTruncated?: boolean;
   elapsedMs?: number;
+  presentationFailure?: {
+    phase: 'deadline' | 'complexity' | 'regular-invariant';
+    workUnits: number;
+    maxWorkUnits?: number;
+  };
   /** API 23 helper output carries no `drawing-order`; covered same-window surfaces are not pruned. */
   occlusionScanUnavailable?: boolean;
 };

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -163,7 +163,16 @@ function attachAndroidPresentationFailureEvidence(params: {
       nodes: [],
       truncated: true,
       analysis: params.failure.analysis ?? { rawNodeCount: 0, maxDepth: 0 },
-      androidSnapshot: params.androidSnapshot,
+      androidSnapshot: {
+        ...params.androidSnapshot,
+        presentationFailure: {
+          phase: params.failure.details.phase,
+          workUnits: params.failure.details.workUnits,
+          ...(params.failure.details.maxWorkUnits !== undefined
+            ? { maxWorkUnits: params.failure.details.maxWorkUnits }
+            : {}),
+        },
+      },
       quality: {
         state: 'sparse',
         backend: 'android-helper',

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -13,6 +13,7 @@ import {
   attachRefs,
   type HiddenContentHint,
   type RawSnapshotNode,
+  type SnapshotQualityVerdict,
   type SnapshotOptions,
 } from '@agent-device/kernel/snapshot';
 import { attachSnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
@@ -22,6 +23,7 @@ import {
   parseUiHierarchyTree,
   type AndroidBuiltSnapshot,
   type AndroidSnapshotAnalysis,
+  type AndroidUiHierarchySnapshotOptions,
   type AndroidUiHierarchy,
 } from './ui-hierarchy.ts';
 import { buildAndroidSnapshotClickabilityEvidence } from './snapshot-clickability.ts';
@@ -53,6 +55,12 @@ import {
   resetAndroidSnapshotHelperRuntime,
   retireAndroidSnapshotHelperAfterContentFailure,
 } from './snapshot-helper-runtime.ts';
+import {
+  ANDROID_SNAPSHOT_PRESENTATION_DEFAULT_DEADLINE_MS,
+  isAndroidSnapshotPresentationFailure,
+  type AndroidSnapshotPresentationFailure,
+  type AndroidSnapshotPresentationOptions,
+} from './snapshot-presentation.ts';
 
 const HELPER_INSTALL_TIMEOUT_MS = 30_000;
 const HELPER_CAPTURE_TIMEOUT_MS = 5_000;
@@ -73,6 +81,7 @@ export type AndroidSnapshotOptions = SnapshotOptions & {
   helperSessionScope?: 'command' | 'daemon-session';
   helperAdb?: AndroidAdbExecutor | AndroidAdbProvider;
   includeHiddenContentHints?: boolean;
+  androidPresentation?: AndroidSnapshotPresentationOptions;
 };
 
 export async function captureAndroidUiHierarchyXml(
@@ -91,30 +100,78 @@ export async function snapshotAndroid(
   truncated?: boolean;
   analysis: AndroidSnapshotAnalysis;
   androidSnapshot: AndroidSnapshotBackendMetadata;
+  quality?: SnapshotQualityVerdict;
 }> {
   const adb = resolveAndroidAdbProvider(device, options.helperAdb).exec;
   const capture = await captureAndroidUiHierarchy(device, options, adb);
   const xml = capture.xml;
   const tree = parseUiHierarchyTree(xml);
-  const built = buildUiHierarchySnapshot(tree, undefined, options);
-  const truncated = mergeAndroidSnapshotTruncation(built.truncated, capture.metadata);
-  if (options.interactiveOnly && options.includeHiddenContentHints !== false) {
-    applyHiddenContentHintsToInteractiveSnapshot({
-      options,
-      tree,
-      xml,
-      interactiveSnapshot: built,
+  const androidSnapshot = withOcclusionScanDisclosure(capture.metadata, tree);
+  const presentationOptions: AndroidUiHierarchySnapshotOptions = {
+    ...options,
+    androidPresentation: {
+      ...options.androidPresentation,
+      deadlineAtMs:
+        options.androidPresentation?.deadlineAtMs ??
+        Date.now() + ANDROID_SNAPSHOT_PRESENTATION_DEFAULT_DEADLINE_MS,
+    },
+  };
+
+  try {
+    const built = buildUiHierarchySnapshot(tree, undefined, presentationOptions);
+    const truncated = mergeAndroidSnapshotTruncation(built.truncated, capture.metadata);
+    if (options.interactiveOnly && options.includeHiddenContentHints !== false) {
+      applyHiddenContentHintsToInteractiveSnapshot({
+        options: presentationOptions,
+        tree,
+        xml,
+        interactiveSnapshot: built,
+      });
+    }
+    const { sourceNodes: _sourceNodes, ...snapshot } = built;
+    const result = {
+      ...snapshot,
+      ...androidSnapshotTruncationFields(truncated),
+      androidSnapshot,
+      quality: { state: 'healthy', backend: 'android-helper' } as const,
+    };
+    return attachSnapshotClickabilityEvidence(
+      result,
+      buildAndroidSnapshotClickabilityEvidence(built),
+    );
+  } catch (error) {
+    if (!isAndroidSnapshotPresentationFailure(error)) throw error;
+    return attachAndroidPresentationFailureEvidence({
+      failure: error,
+      androidSnapshot,
     });
   }
-  const { sourceNodes: _sourceNodes, ...snapshot } = built;
-  const result = {
-    ...snapshot,
-    ...androidSnapshotTruncationFields(truncated),
-    androidSnapshot: withOcclusionScanDisclosure(capture.metadata, tree),
-  };
+}
+
+function attachAndroidPresentationFailureEvidence(params: {
+  failure: AndroidSnapshotPresentationFailure;
+  androidSnapshot: AndroidSnapshotBackendMetadata;
+}): {
+  nodes: RawSnapshotNode[];
+  truncated: true;
+  analysis: AndroidSnapshotAnalysis;
+  androidSnapshot: AndroidSnapshotBackendMetadata;
+  quality: SnapshotQualityVerdict;
+} {
   return attachSnapshotClickabilityEvidence(
-    result,
-    buildAndroidSnapshotClickabilityEvidence(built),
+    {
+      nodes: [],
+      truncated: true,
+      analysis: params.failure.analysis ?? { rawNodeCount: 0, maxDepth: 0 },
+      androidSnapshot: params.androidSnapshot,
+      quality: {
+        state: 'sparse',
+        backend: 'android-helper',
+        reason: params.failure.message,
+        reasonCode: params.failure.qualityReasonCode,
+      },
+    },
+    { kind: 'exact', provider: 'android-helper', clickableByNodeIndex: new Map() },
   );
 }
 

--- a/src/platforms/android/ui-hierarchy-builder.ts
+++ b/src/platforms/android/ui-hierarchy-builder.ts
@@ -12,7 +12,12 @@ import { isCollectionContainerType, shouldIncludeAndroidNode } from './ui-hierar
 import {
   createAndroidSnapshotPresentationNode,
   effectiveAndroidRect,
+  isAndroidSnapshotPresentationFailure,
   serializeAndroidRegularPresentationNode,
+  validateAndroidRegularPresentation,
+  createAndroidSnapshotPresentationBudget,
+  type AndroidSnapshotPresentationBudget,
+  type AndroidSnapshotPresentationOptions,
 } from './snapshot-presentation.ts';
 
 type AndroidRawSnapshotNode = RawSnapshotNode & AndroidSystemChromeProvenance;
@@ -20,6 +25,10 @@ type AndroidRawSnapshotNode = RawSnapshotNode & AndroidSystemChromeProvenance;
 export type AndroidSnapshotAnalysis = {
   rawNodeCount: number;
   maxDepth: number;
+};
+
+export type AndroidUiHierarchySnapshotOptions = SnapshotOptions & {
+  androidPresentation?: AndroidSnapshotPresentationOptions;
 };
 
 export type AndroidBuiltSnapshot = {
@@ -34,24 +43,30 @@ type AndroidSnapshotBuildState = {
   sourceNodes: AndroidUiHierarchy[];
   maxNodes?: number;
   maxDepth: number;
-  options: SnapshotOptions;
+  options: AndroidUiHierarchySnapshotOptions;
   analysis: AndroidSnapshotAnalysis;
   interactiveDescendantMemo: Map<AndroidNode, boolean>;
   /** Subtrees the regular projection hides (invisible / stale window / covered). Empty for raw. */
   hidden: ReadonlySet<AndroidNode>;
   /** Largest helper-reported application/window frame, used as the regular viewport fallback. */
   viewport?: Rect;
+  presentationBudget: AndroidSnapshotPresentationBudget;
+  presentationNodes: ReturnType<typeof createAndroidSnapshotPresentationNode>[];
   truncated: boolean;
 };
 
 export function buildUiHierarchySnapshot(
   tree: AndroidUiHierarchy,
   maxNodes: number | undefined,
-  options: SnapshotOptions,
+  options: AndroidUiHierarchySnapshotOptions,
 ): AndroidBuiltSnapshot {
   const requestedDepth = options.depth ?? Number.POSITIVE_INFINITY;
   const scope = normalizeSnapshotScope(options.scope);
-  const viewport = resolveAndroidSnapshotViewport(tree);
+  const analysis = analyzeAndroidTree(tree);
+  const presentationBudget = createAndroidSnapshotPresentationBudget(
+    options.androidPresentation,
+    Math.max(1024, analysis.rawNodeCount * 64),
+  );
   const state: AndroidSnapshotBuildState = {
     nodes: [],
     sourceNodes: [],
@@ -60,18 +75,37 @@ export function buildUiHierarchySnapshot(
     // presented: walk unbounded and cut after scoping.
     maxDepth: scope ? Number.POSITIVE_INFINITY : requestedDepth,
     options,
-    analysis: analyzeAndroidTree(tree),
+    analysis,
     interactiveDescendantMemo: new Map(),
     // C3: raw is the acquired tree (normalization only); regular additionally hides what Android
     // marks invisible, stale application windows, and covered same-window surfaces.
-    hidden: options.raw ? new Set() : collectAndroidHiddenNodes(tree),
-    ...(viewport ? { viewport } : {}),
+    hidden: new Set(),
+    presentationBudget,
+    presentationNodes: [],
     truncated: false,
   };
 
-  for (const root of tree.children) {
-    walkUiHierarchyNode(state, root, 0);
-    if (state.truncated) break;
+  try {
+    presentationBudget.check('work');
+    state.viewport = resolveAndroidSnapshotViewport(tree, presentationBudget);
+    state.hidden = options.raw ? new Set() : collectAndroidHiddenNodes(tree, presentationBudget);
+    for (const root of tree.children) {
+      walkUiHierarchyNode(state, root, 0);
+      if (state.truncated) break;
+    }
+    if (!options.raw) {
+      validateAndroidRegularPresentation(
+        state.presentationNodes,
+        state.viewport,
+        presentationBudget,
+      );
+    }
+  } catch (error) {
+    if (isAndroidSnapshotPresentationFailure(error)) {
+      error.analysis ??= state.analysis;
+      throw error;
+    }
+    throw error;
   }
 
   const { nodes, sourceNodes } = scope
@@ -102,6 +136,7 @@ function walkUiHierarchyNode(
   ancestorWindowRect?: Rect,
   ancestorClip?: Rect,
 ): void {
+  state.presentationBudget.check('work');
   if (shouldStopAndroidWalk(state, node, depth)) return;
   const currentWindowRect = node.windowRect ?? ancestorWindowRect ?? state.viewport;
   const effectiveRect = resolveAndroidEffectiveRect(state, node, ancestorClip, currentWindowRect);
@@ -227,8 +262,19 @@ function appendAndroidSnapshotNode(
   // fixed sibling that follows scroll content can be re-parented under the last
   // retained row by normalizeSnapshotTree's depth fallback (#1377).
   state.sourceNodes.push(node);
-  const rawNode: AndroidRawSnapshotNode = {
-    index: currentIndex,
+  const rawNode = createAndroidRawSnapshotNode(state, node, parentIndex, systemChrome);
+  publishAndroidPresentationNode(state, node, rawNode, effectiveRect);
+  return currentIndex;
+}
+
+function createAndroidRawSnapshotNode(
+  state: AndroidSnapshotBuildState,
+  node: AndroidNode,
+  parentIndex: number | undefined,
+  systemChrome: boolean,
+): AndroidRawSnapshotNode {
+  return {
+    index: state.nodes.length,
     type: node.type ?? undefined,
     label: node.label ?? undefined,
     value: node.value ?? undefined,
@@ -244,19 +290,35 @@ function appendAndroidSnapshotNode(
     ...androidScrollActionHints(node, state.hidden),
     ...(systemChrome ? { systemChrome: true } : {}),
   };
-  const presentationNode = createAndroidSnapshotPresentationNode(rawNode, effectiveRect);
+}
+
+function publishAndroidPresentationNode(
+  state: AndroidSnapshotBuildState,
+  node: AndroidNode,
+  rawNode: AndroidRawSnapshotNode,
+  effectiveRect: Rect | undefined,
+): void {
+  const presentationNode = createAndroidSnapshotPresentationNode(
+    rawNode,
+    effectiveRect,
+    !state.options.raw && isAndroidScrollClipNode(node),
+  );
+  state.presentationNodes.push(presentationNode);
   state.nodes.push(
     state.options.raw
       ? presentationNode.raw
       : serializeAndroidRegularPresentationNode(presentationNode),
   );
-  return currentIndex;
 }
 
-function resolveAndroidSnapshotViewport(root: AndroidUiHierarchy): Rect | undefined {
+function resolveAndroidSnapshotViewport(
+  root: AndroidUiHierarchy,
+  budget: AndroidSnapshotPresentationBudget,
+): Rect | undefined {
   const windowRects: Rect[] = [];
   const stack = [...root.children];
   while (stack.length > 0) {
+    budget.check('work');
     const node = stack.pop()!;
     if (isPositiveFiniteRect(node.windowRect)) windowRects.push(node.windowRect);
     stack.push(...node.children);

--- a/src/platforms/android/ui-hierarchy-builder.ts
+++ b/src/platforms/android/ui-hierarchy-builder.ts
@@ -22,6 +22,8 @@ import {
 
 type AndroidRawSnapshotNode = RawSnapshotNode & AndroidSystemChromeProvenance;
 
+const ANDROID_PRESENTATION_WORK_UNITS_PER_NODE = 128;
+
 export type AndroidSnapshotAnalysis = {
   rawNodeCount: number;
   maxDepth: number;
@@ -65,7 +67,7 @@ export function buildUiHierarchySnapshot(
   const analysis = analyzeAndroidTree(tree);
   const presentationBudget = createAndroidSnapshotPresentationBudget(
     options.androidPresentation,
-    Math.max(1024, analysis.rawNodeCount * 64),
+    Math.max(1024, analysis.rawNodeCount * ANDROID_PRESENTATION_WORK_UNITS_PER_NODE),
   );
   const state: AndroidSnapshotBuildState = {
     nodes: [],

--- a/src/platforms/android/ui-hierarchy-builder.ts
+++ b/src/platforms/android/ui-hierarchy-builder.ts
@@ -100,6 +100,17 @@ export function buildUiHierarchySnapshot(
         presentationBudget,
       );
     }
+    const { nodes, sourceNodes } = scope
+      ? scopePresentedAndroidSnapshot(
+          state,
+          tree.children,
+          scope,
+          requestedDepth,
+          presentationBudget,
+        )
+      : state;
+    const snapshot = { nodes, sourceNodes, analysis: state.analysis };
+    return state.truncated ? { ...snapshot, truncated: true } : snapshot;
   } catch (error) {
     if (isAndroidSnapshotPresentationFailure(error)) {
       error.analysis ??= state.analysis;
@@ -107,12 +118,6 @@ export function buildUiHierarchySnapshot(
     }
     throw error;
   }
-
-  const { nodes, sourceNodes } = scope
-    ? scopePresentedAndroidSnapshot(state, tree.children, scope, requestedDepth)
-    : state;
-  const snapshot = { nodes, sourceNodes, analysis: state.analysis };
-  return state.truncated ? { ...snapshot, truncated: true } : snapshot;
 }
 
 /**

--- a/src/platforms/android/ui-hierarchy-builder.ts
+++ b/src/platforms/android/ui-hierarchy-builder.ts
@@ -155,6 +155,7 @@ function walkUiHierarchyNode(
     ancestorCollection,
     ancestorSystemChrome,
     effectiveRect,
+    currentWindowRect,
   );
   const nextAncestorHittable = ancestorHittable || isAgentTarget(node);
   const nextAncestorCollection = ancestorCollection || isCollectionContainerType(node.type);
@@ -201,6 +202,7 @@ function appendAndroidNodeIfPresented(
   ancestorCollection: boolean,
   ancestorSystemChrome: boolean,
   effectiveRect: Rect | undefined,
+  windowRect: Rect | undefined,
 ): number | undefined {
   if (
     !state.options.raw &&
@@ -216,7 +218,14 @@ function appendAndroidNodeIfPresented(
   }
   const systemChrome =
     ancestorSystemChrome || isAndroidSystemChromeWindowResourceId(node.identifier);
-  return appendAndroidSnapshotNode(state, node, parentIndex, systemChrome, effectiveRect);
+  return appendAndroidSnapshotNode(
+    state,
+    node,
+    parentIndex,
+    systemChrome,
+    effectiveRect,
+    windowRect,
+  );
 }
 
 function resolveAndroidDescendantClip(
@@ -262,6 +271,7 @@ function appendAndroidSnapshotNode(
   parentIndex: number | undefined,
   systemChrome: boolean,
   effectiveRect: Rect | undefined,
+  windowRect: Rect | undefined,
 ): number {
   const currentIndex = state.nodes.length;
   // Snapshot filtering removes Compose layout wrappers. Keep depth aligned with
@@ -270,7 +280,7 @@ function appendAndroidSnapshotNode(
   // retained row by normalizeSnapshotTree's depth fallback (#1377).
   state.sourceNodes.push(node);
   const rawNode = createAndroidRawSnapshotNode(state, node, parentIndex, systemChrome);
-  publishAndroidPresentationNode(state, node, rawNode, effectiveRect);
+  publishAndroidPresentationNode(state, node, rawNode, effectiveRect, windowRect);
   return currentIndex;
 }
 
@@ -304,11 +314,13 @@ function publishAndroidPresentationNode(
   node: AndroidNode,
   rawNode: AndroidRawSnapshotNode,
   effectiveRect: Rect | undefined,
+  windowRect: Rect | undefined,
 ): void {
   const presentationNode = createAndroidSnapshotPresentationNode(
     rawNode,
     effectiveRect,
     !state.options.raw && isAndroidScrollClipNode(node),
+    windowRect,
   );
   state.presentationNodes.push(presentationNode);
   state.nodes.push(

--- a/src/platforms/android/ui-hierarchy-scope.ts
+++ b/src/platforms/android/ui-hierarchy-scope.ts
@@ -3,6 +3,7 @@ import {
   reindexSnapshotNodes,
   type SnapshotScopeCandidate,
 } from '@agent-device/contracts/snapshot';
+import type { AndroidSnapshotPresentationBudget } from './snapshot-presentation.ts';
 
 type PresentedNode = { index: number; depth?: number; parentIndex?: number };
 type SourceNode = SnapshotScopeCandidate & { depth: number; children: SourceNode[] };
@@ -46,21 +47,33 @@ export function scopePresentedAndroidSnapshot<
   roots: readonly Source[],
   scope: string,
   maxDepth: number,
+  budget: AndroidSnapshotPresentationBudget,
 ): AndroidPresentedNodes<Node, Source> {
   const presented = new Set<Source>(state.sourceNodes);
-  const scopeRoot = findAndroidScopeRoot(roots, scope, presented);
+  const order = collectDocumentOrder(roots, budget);
+  const contributing = collectPresentedSubtrees(order, presented, budget);
+  const scopeRoot = findAndroidScopeRoot(order, scope, contributing, budget);
   if (!scopeRoot) return { nodes: [], sourceNodes: [] };
 
-  const inScope = collectSubtree(scopeRoot);
-  const subtree = [...state.sourceNodes.entries()]
-    .filter(([, source]) => inScope.has(source))
-    .map(([position]) => position);
+  const inScope = new Set(collectDocumentOrder([scopeRoot], budget));
+  const subtree: number[] = [];
+  for (const [position, source] of state.sourceNodes.entries()) {
+    budget.check('work');
+    if (inScope.has(source)) subtree.push(position);
+  }
   if (subtree.length === 0) return { nodes: [], sourceNodes: [] };
 
-  const depthOffset = Math.min(...subtree.map((position) => state.nodes[position]?.depth ?? 0));
-  const positions = subtree.filter(
-    (position) => (state.nodes[position]?.depth ?? 0) - depthOffset <= maxDepth,
-  );
+  let depthOffset = Number.POSITIVE_INFINITY;
+  for (const position of subtree) {
+    budget.check('work');
+    depthOffset = Math.min(depthOffset, state.nodes[position]?.depth ?? 0);
+  }
+  const positions: number[] = [];
+  for (const position of subtree) {
+    budget.check('work');
+    if ((state.nodes[position]?.depth ?? 0) - depthOffset <= maxDepth) positions.push(position);
+  }
+  budget.consume(positions.length);
   return {
     nodes: reindexSnapshotNodes(
       positions.map((position) => state.nodes[position] as Node),
@@ -72,37 +85,56 @@ export function scopePresentedAndroidSnapshot<
 
 /** First document-order match whose subtree contributes presented content. */
 function findAndroidScopeRoot<Source extends SourceNode>(
-  roots: readonly Source[],
+  order: readonly Source[],
   scope: string,
-  presented: ReadonlySet<Source>,
+  contributing: ReadonlySet<Source>,
+  budget: AndroidSnapshotPresentationBudget,
 ): Source | null {
-  for (const node of documentOrder(roots)) {
-    if (matchesSnapshotScope(node, scope) && subtreeHasPresentedNode(node, presented)) return node;
+  for (const node of order) {
+    budget.check('work');
+    if (matchesSnapshotScope(node, scope) && contributing.has(node)) return node;
   }
   return null;
 }
 
-function* documentOrder<Source extends SourceNode>(roots: readonly Source[]): Generator<Source> {
+function collectDocumentOrder<Source extends SourceNode>(
+  roots: readonly Source[],
+  budget: AndroidSnapshotPresentationBudget,
+): Source[] {
+  const order: Source[] = [];
   const stack = [...roots].reverse();
   while (stack.length > 0) {
+    budget.check('work');
     const node = stack.pop() as Source;
-    yield node;
+    order.push(node);
     for (let index = node.children.length - 1; index >= 0; index -= 1) {
+      budget.check('work');
       stack.push(node.children[index] as Source);
     }
   }
+  return order;
 }
 
-function subtreeHasPresentedNode<Source extends SourceNode>(
-  root: Source,
+function collectPresentedSubtrees<Source extends SourceNode>(
+  order: readonly Source[],
   presented: ReadonlySet<Source>,
-): boolean {
-  for (const node of documentOrder([root])) {
-    if (presented.has(node)) return true;
+  budget: AndroidSnapshotPresentationBudget,
+): ReadonlySet<Source> {
+  const contributing = new Set<Source>();
+  for (let index = order.length - 1; index >= 0; index -= 1) {
+    budget.check('work');
+    const node = order[index] as Source;
+    if (presented.has(node)) {
+      contributing.add(node);
+      continue;
+    }
+    for (const child of node.children) {
+      budget.check('work');
+      if (contributing.has(child as Source)) {
+        contributing.add(node);
+        break;
+      }
+    }
   }
-  return false;
-}
-
-function collectSubtree<Source extends SourceNode>(root: Source): ReadonlySet<Source> {
-  return new Set(documentOrder([root]));
+  return contributing;
 }

--- a/src/platforms/android/ui-hierarchy-visibility.ts
+++ b/src/platforms/android/ui-hierarchy-visibility.ts
@@ -173,13 +173,16 @@ function unionCoverage(
   ]);
   const covering = markCells(coveringRects, xs, ys, presentationBudget);
   const covered = markCells(coveredRects, xs, ys, presentationBudget);
+  const rows = ys.length - 1;
+  const columns = xs.length - 1;
+  presentationBudget?.consume(columns * rows);
   let coveredArea = 0;
   let overlapArea = 0;
-  for (let column = 0; column < xs.length - 1; column += 1) {
+  for (let column = 0; column < columns; column += 1) {
     presentationBudget?.check('work');
     const width = xs[column + 1]! - xs[column]!;
-    for (let row = 0; row < ys.length - 1; row += 1) {
-      const cell = column * (ys.length - 1) + row;
+    for (let row = 0; row < rows; row += 1) {
+      const cell = column * rows + row;
       if (!covered[cell]) continue;
       const area = width * (ys[row + 1]! - ys[row]!);
       coveredArea += area;
@@ -200,7 +203,10 @@ function markCells(
   presentationBudget?: AndroidSnapshotPresentationBudget,
 ): Uint8Array {
   const rows = ys.length - 1;
-  const cells = new Uint8Array((xs.length - 1) * rows);
+  const columns = xs.length - 1;
+  const cellCount = columns * rows;
+  presentationBudget?.consume(cellCount);
+  const cells = new Uint8Array(cellCount);
   for (const rect of rects) {
     presentationBudget?.check('work');
     const firstColumn = xs.indexOf(rect.x);
@@ -209,6 +215,7 @@ function markCells(
     const lastRow = ys.indexOf(rect.y + rect.height);
     for (let column = firstColumn; column < lastColumn; column += 1) {
       presentationBudget?.check('work');
+      presentationBudget?.consume(lastRow - firstRow);
       cells.fill(1, column * rows + firstRow, column * rows + lastRow);
     }
   }

--- a/src/platforms/android/ui-hierarchy-visibility.ts
+++ b/src/platforms/android/ui-hierarchy-visibility.ts
@@ -1,4 +1,5 @@
 import type { Rect } from '@agent-device/kernel/snapshot';
+import type { AndroidSnapshotPresentationBudget } from './snapshot-presentation.ts';
 import {
   hasMeaningfulLabel,
   hasPositiveRect,
@@ -18,26 +19,43 @@ import {
  * derivation, which builds a second projection from the same tree; a pruner that edited
  * `node.children` in place made the tree depend on which projection ran first.
  */
-export function collectAndroidHiddenNodes(root: AndroidUiHierarchy): ReadonlySet<AndroidNode> {
+export function collectAndroidHiddenNodes(
+  root: AndroidUiHierarchy,
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): ReadonlySet<AndroidNode> {
   const hidden = new Set<AndroidNode>();
-  collectInvisibleSubtrees(root, hidden);
-  collectInactiveApplicationWindows(root, hidden);
-  collectCoveredSubtrees(root, { footprintMemo: new WeakMap(), hidden });
+  collectInvisibleSubtrees(root, hidden, presentationBudget);
+  collectInactiveApplicationWindows(root, hidden, presentationBudget);
+  collectCoveredSubtrees(root, {
+    footprintMemo: new WeakMap(),
+    hidden,
+    presentationBudget,
+  });
   return hidden;
 }
 
-function collectInvisibleSubtrees(node: AndroidNode, hidden: Set<AndroidNode>): void {
+function collectInvisibleSubtrees(
+  node: AndroidNode,
+  hidden: Set<AndroidNode>,
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): void {
   for (const child of node.children) {
+    presentationBudget?.check('work');
     if (child.visibleToUser === false) {
       hidden.add(child);
       continue;
     }
-    collectInvisibleSubtrees(child, hidden);
+    collectInvisibleSubtrees(child, hidden, presentationBudget);
   }
 }
 
 /** The children of `node` this projection still shows, in document order. */
-function retainedChildren(node: AndroidNode, hidden: ReadonlySet<AndroidNode>): AndroidNode[] {
+function retainedChildren(
+  node: AndroidNode,
+  hidden: ReadonlySet<AndroidNode>,
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): AndroidNode[] {
+  presentationBudget?.check('work');
   return node.children.filter((child) => !hidden.has(child) && child.visibleToUser !== false);
 }
 
@@ -52,6 +70,7 @@ type AndroidFootprint = {
 type AndroidTreePruneState = {
   footprintMemo: WeakMap<AndroidNode, AndroidFootprint>;
   hidden: Set<AndroidNode>;
+  presentationBudget?: AndroidSnapshotPresentationBudget;
 };
 
 type AndroidCoveringCandidate = {
@@ -73,7 +92,7 @@ function hasDirectOcclusionEvidence(node: AndroidNode): boolean {
 
 /** Evidence the node is a real surface because it contains something an agent could drive. */
 function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePruneState): boolean {
-  return retainedChildren(node, state.hidden).some(
+  return retainedChildren(node, state.hidden, state.presentationBudget).some(
     (child) => subtreeFootprint(child, state).hasAgentTarget,
   );
 }
@@ -90,6 +109,7 @@ function hasDescendantOcclusionEvidence(node: AndroidNode, state: AndroidTreePru
  * counts toward what a covered sibling has.
  */
 function subtreeFootprint(node: AndroidNode, state: AndroidTreePruneState): AndroidFootprint {
+  state.presentationBudget?.check('work');
   const cached = state.footprintMemo.get(node);
   if (cached !== undefined) return cached;
   const footprint = hasPositiveRect(node)
@@ -119,7 +139,7 @@ function childrenFootprint(node: AndroidNode, state: AndroidTreePruneState): And
     shows: [],
     hasAgentTarget: isAgentTarget(node),
   };
-  for (const child of retainedChildren(node, state.hidden)) {
+  for (const child of retainedChildren(node, state.hidden, state.presentationBudget)) {
     const childFootprint = subtreeFootprint(child, state);
     footprint.hasAgentTarget ||= childFootprint.hasAgentTarget;
     footprint.paints.push(...childFootprint.paints);
@@ -138,7 +158,11 @@ function paintsOwnBox(node: AndroidNode, hidden: ReadonlySet<AndroidNode>): bool
 }
 
 /** Fraction of the covered rects' union that lies under the covering rects' union. */
-function unionCoverage(coveringRects: Rect[], coveredRects: Rect[]): number {
+function unionCoverage(
+  coveringRects: Rect[],
+  coveredRects: Rect[],
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): number {
   const xs = compressedEdges([...coveringRects, ...coveredRects], (rect) => [
     rect.x,
     rect.x + rect.width,
@@ -147,11 +171,12 @@ function unionCoverage(coveringRects: Rect[], coveredRects: Rect[]): number {
     rect.y,
     rect.y + rect.height,
   ]);
-  const covering = markCells(coveringRects, xs, ys);
-  const covered = markCells(coveredRects, xs, ys);
+  const covering = markCells(coveringRects, xs, ys, presentationBudget);
+  const covered = markCells(coveredRects, xs, ys, presentationBudget);
   let coveredArea = 0;
   let overlapArea = 0;
   for (let column = 0; column < xs.length - 1; column += 1) {
+    presentationBudget?.check('work');
     const width = xs[column + 1]! - xs[column]!;
     for (let row = 0; row < ys.length - 1; row += 1) {
       const cell = column * (ys.length - 1) + row;
@@ -168,15 +193,22 @@ function compressedEdges(rects: Rect[], edgesOf: (rect: Rect) => [number, number
   return [...new Set(rects.flatMap(edgesOf))].sort((left, right) => left - right);
 }
 
-function markCells(rects: Rect[], xs: number[], ys: number[]): Uint8Array {
+function markCells(
+  rects: Rect[],
+  xs: number[],
+  ys: number[],
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): Uint8Array {
   const rows = ys.length - 1;
   const cells = new Uint8Array((xs.length - 1) * rows);
   for (const rect of rects) {
+    presentationBudget?.check('work');
     const firstColumn = xs.indexOf(rect.x);
     const lastColumn = xs.indexOf(rect.x + rect.width);
     const firstRow = ys.indexOf(rect.y);
     const lastRow = ys.indexOf(rect.y + rect.height);
     for (let column = firstColumn; column < lastColumn; column += 1) {
+      presentationBudget?.check('work');
       cells.fill(1, column * rows + firstRow, column * rows + lastRow);
     }
   }
@@ -195,10 +227,11 @@ function isPresentationLeaf(node: AndroidNode, hidden: ReadonlySet<AndroidNode>)
 }
 
 function collectCoveredSubtrees(node: AndroidNode, state: AndroidTreePruneState): void {
-  for (const child of retainedChildren(node, state.hidden)) {
+  state.presentationBudget?.check('work');
+  for (const child of retainedChildren(node, state.hidden, state.presentationBudget)) {
     collectCoveredSubtrees(child, state);
   }
-  const siblings = retainedChildren(node, state.hidden);
+  const siblings = retainedChildren(node, state.hidden, state.presentationBudget);
   if (siblings.length < 2) return;
   const coveringCandidates = siblings
     .map((sibling) => coveringCandidateOf(sibling, state))
@@ -240,7 +273,7 @@ function isCoveredByHigherDrawingOrderSibling(
     if (candidate.node === node || candidate.drawingOrder <= node.drawingOrder) {
       continue;
     }
-    if (unionCoverage(candidate.footprint, coveredRects) >= 0.9) {
+    if (unionCoverage(candidate.footprint, coveredRects, state.presentationBudget) >= 0.9) {
       return true;
     }
   }
@@ -266,8 +299,9 @@ function coveringCandidateOf(
 function collectInactiveApplicationWindows(
   root: AndroidUiHierarchy,
   hidden: Set<AndroidNode>,
+  presentationBudget?: AndroidSnapshotPresentationBudget,
 ): void {
-  const windows = retainedChildren(root, hidden).filter(isAndroidWindowRoot);
+  const windows = retainedChildren(root, hidden, presentationBudget).filter(isAndroidWindowRoot);
   if (windows.length < 2) return;
 
   // Android can keep stale application windows in the accessibility tree after drawer and
@@ -279,7 +313,8 @@ function collectInactiveApplicationWindows(
   if (foregroundApplicationWindows.length === 0) return;
   const foregroundLayer = highestAndroidWindowLayer(foregroundApplicationWindows);
 
-  for (const window of retainedChildren(root, hidden)) {
+  for (const window of retainedChildren(root, hidden, presentationBudget)) {
+    presentationBudget?.check('work');
     if (!isAndroidApplicationWindow(window)) continue;
     const keep =
       isAndroidForegroundWindow(window) &&

--- a/src/platforms/android/ui-hierarchy-visibility.ts
+++ b/src/platforms/android/ui-hierarchy-visibility.ts
@@ -171,8 +171,10 @@ function unionCoverage(
     rect.y,
     rect.y + rect.height,
   ]);
-  const covering = markCells(coveringRects, xs, ys, presentationBudget);
-  const covered = markCells(coveredRects, xs, ys, presentationBudget);
+  const xIndex = createEdgeIndex(xs, presentationBudget);
+  const yIndex = createEdgeIndex(ys, presentationBudget);
+  const covering = markCells(coveringRects, xIndex, yIndex, presentationBudget);
+  const covered = markCells(coveredRects, xIndex, yIndex, presentationBudget);
   const rows = ys.length - 1;
   const columns = xs.length - 1;
   presentationBudget?.consume(columns * rows);
@@ -196,23 +198,31 @@ function compressedEdges(rects: Rect[], edgesOf: (rect: Rect) => [number, number
   return [...new Set(rects.flatMap(edgesOf))].sort((left, right) => left - right);
 }
 
+function createEdgeIndex(
+  edges: number[],
+  presentationBudget?: AndroidSnapshotPresentationBudget,
+): ReadonlyMap<number, number> {
+  presentationBudget?.consume(edges.length);
+  return new Map(edges.map((edge, index) => [edge, index]));
+}
+
 function markCells(
   rects: Rect[],
-  xs: number[],
-  ys: number[],
+  xIndex: ReadonlyMap<number, number>,
+  yIndex: ReadonlyMap<number, number>,
   presentationBudget?: AndroidSnapshotPresentationBudget,
 ): Uint8Array {
-  const rows = ys.length - 1;
-  const columns = xs.length - 1;
+  const rows = yIndex.size - 1;
+  const columns = xIndex.size - 1;
   const cellCount = columns * rows;
   presentationBudget?.consume(cellCount);
   const cells = new Uint8Array(cellCount);
   for (const rect of rects) {
     presentationBudget?.check('work');
-    const firstColumn = xs.indexOf(rect.x);
-    const lastColumn = xs.indexOf(rect.x + rect.width);
-    const firstRow = ys.indexOf(rect.y);
-    const lastRow = ys.indexOf(rect.y + rect.height);
+    const firstColumn = xIndex.get(rect.x)!;
+    const lastColumn = xIndex.get(rect.x + rect.width)!;
+    const firstRow = yIndex.get(rect.y)!;
+    const lastRow = yIndex.get(rect.y + rect.height)!;
     for (let column = firstColumn; column < lastColumn; column += 1) {
       presentationBudget?.check('work');
       presentationBudget?.consume(lastRow - firstRow);
@@ -277,6 +287,7 @@ function isCoveredByHigherDrawingOrderSibling(
   const shows = subtreeFootprint(node, state).shows;
   const coveredRects = shows.length > 0 ? shows : [node.rect];
   for (const candidate of coveringCandidates) {
+    state.presentationBudget?.check('work');
     if (candidate.node === node || candidate.drawingOrder <= node.drawingOrder) {
       continue;
     }

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -9,7 +9,11 @@ import type { AndroidNode, AndroidUiHierarchy } from './ui-hierarchy-node.ts';
 
 export type { AndroidUiHierarchy } from './ui-hierarchy-node.ts';
 export { buildUiHierarchySnapshot } from './ui-hierarchy-builder.ts';
-export type { AndroidBuiltSnapshot, AndroidSnapshotAnalysis } from './ui-hierarchy-builder.ts';
+export type {
+  AndroidBuiltSnapshot,
+  AndroidSnapshotAnalysis,
+  AndroidUiHierarchySnapshotOptions,
+} from './ui-hierarchy-builder.ts';
 
 /** Parsed node metadata plus status/navigation subtree provenance when present. */
 export type AndroidUiNodeMetadata = {

--- a/src/snapshot-quality/__tests__/verdict.test.ts
+++ b/src/snapshot-quality/__tests__/verdict.test.ts
@@ -71,6 +71,16 @@ test('readSnapshotQualityVerdict preserves a presentation failure reason', () =>
   assert.equal(verdict?.reasonCode, 'presentation-failed');
 });
 
+test('readSnapshotQualityVerdict accepts the Android helper backend', () => {
+  const verdict = readSnapshotQualityVerdict({
+    state: 'healthy',
+    backend: 'android-helper',
+  });
+
+  assert.equal(verdict?.state, 'healthy');
+  assert.equal(verdict?.backend, 'android-helper');
+});
+
 test('isSparseSnapshotQualityVerdict identifies sparse captures', () => {
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'sparse', backend: 'private-ax' }), true);
   assert.equal(isSparseSnapshotQualityVerdict({ state: 'healthy', backend: 'tree' }), false);

--- a/src/snapshot-quality/backend-capabilities.test.ts
+++ b/src/snapshot-quality/backend-capabilities.test.ts
@@ -3,7 +3,10 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import { SNAPSHOT_BACKEND_CAPABILITIES } from './backend-capabilities.ts';
+import {
+  ANDROID_SNAPSHOT_BACKEND_CAPABILITIES,
+  SNAPSHOT_BACKEND_CAPABILITIES,
+} from './backend-capabilities.ts';
 
 type SnapshotBackendParityFixture = {
   backends: Array<{
@@ -105,6 +108,15 @@ test('iOS snapshot registry classifies every backend and conformance target', ()
     forceable: false,
     supportsRawProjection: false,
     regularDepth: 'flat',
+    hittable: 'geometric-actionability',
+  });
+});
+
+test('Android helper quality is classified outside the iOS CLI registry', () => {
+  expect(ANDROID_SNAPSHOT_BACKEND_CAPABILITIES['android-helper']).toMatchObject({
+    forceable: false,
+    supportsRawProjection: true,
+    regularDepth: 'presented-frontier',
     hittable: 'geometric-actionability',
   });
 });

--- a/src/snapshot-quality/backend-capabilities.ts
+++ b/src/snapshot-quality/backend-capabilities.ts
@@ -3,7 +3,7 @@ import type {
   SnapshotPreferredBackend,
 } from '@agent-device/kernel/snapshot';
 
-/** #1933: every iOS backend publishes this shared predicate in the wire `hittable` field. */
+/** #1933: every classified backend publishes this shared predicate in the wire `hittable` field. */
 type SnapshotBackendHittable = 'geometric-actionability';
 type SnapshotBackendSupport = 'yes' | 'no' | 'n/a';
 type SnapshotRegularDepthCapability = 'presented-frontier' | 'flat' | 'raw-only';
@@ -17,15 +17,23 @@ type SnapshotBackendCapability = {
   knownGaps: readonly string[];
 };
 
+type IosSnapshotCaptureBackend = Exclude<SnapshotCaptureBackend, 'android-helper'>;
+
 type SnapshotBackendCapabilityRegistry = {
+  [Backend in IosSnapshotCaptureBackend]: SnapshotBackendCapability & {
+    forceable: Backend extends SnapshotPreferredBackend ? true : false;
+  };
+};
+
+type SnapshotQualityBackendCapabilityRegistry = {
   [Backend in SnapshotCaptureBackend]: SnapshotBackendCapability & {
     forceable: Backend extends SnapshotPreferredBackend ? true : false;
   };
 };
 
 /**
- * Internal contract for the iOS snapshot strategies. The mapped registry keeps every backend
- * classified and makes forceability agree with the request wire type at compile time.
+ * Internal contract for snapshot strategies. The mapped registry keeps every backend classified
+ * and makes forceability agree with the request wire type at compile time.
  */
 export const SNAPSHOT_BACKEND_CAPABILITIES = {
   tree: {
@@ -56,3 +64,22 @@ export const SNAPSHOT_BACKEND_CAPABILITIES = {
     knownGaps: [],
   },
 } as const satisfies SnapshotBackendCapabilityRegistry;
+
+/** Android's helper is a quality backend, not an iOS CLI-selectable backend. */
+export const ANDROID_SNAPSHOT_BACKEND_CAPABILITIES = {
+  'android-helper': {
+    forceable: false,
+    supportsRawProjection: true,
+    regularDepth: 'presented-frontier',
+    hittable: 'geometric-actionability',
+    deepExtension: 'n/a',
+    depthLadder: 'n/a',
+    knownGaps: [],
+  },
+} as const satisfies Pick<SnapshotQualityBackendCapabilityRegistry, 'android-helper'>;
+
+/** The validator registry combines platform-owned declarations without widening iOS CLI help. */
+export const SNAPSHOT_QUALITY_BACKEND_CAPABILITIES = {
+  ...SNAPSHOT_BACKEND_CAPABILITIES,
+  ...ANDROID_SNAPSHOT_BACKEND_CAPABILITIES,
+} as const satisfies SnapshotQualityBackendCapabilityRegistry;

--- a/src/snapshot-quality/verdict.ts
+++ b/src/snapshot-quality/verdict.ts
@@ -1,5 +1,5 @@
 import type { SnapshotQualityVerdict } from '@agent-device/kernel/snapshot';
-import { SNAPSHOT_BACKEND_CAPABILITIES } from './backend-capabilities.ts';
+import { SNAPSHOT_QUALITY_BACKEND_CAPABILITIES } from './backend-capabilities.ts';
 
 const SNAPSHOT_QUALITY_STATES = new Set<SnapshotQualityVerdict['state']>([
   'healthy',
@@ -7,7 +7,7 @@ const SNAPSHOT_QUALITY_STATES = new Set<SnapshotQualityVerdict['state']>([
   'sparse',
 ]);
 const SNAPSHOT_QUALITY_BACKENDS = new Set<SnapshotQualityVerdict['backend']>(
-  Object.keys(SNAPSHOT_BACKEND_CAPABILITIES) as SnapshotQualityVerdict['backend'][],
+  Object.keys(SNAPSHOT_QUALITY_BACKEND_CAPABILITIES) as SnapshotQualityVerdict['backend'][],
 );
 const SNAPSHOT_QUALITY_REASON_CODES = new Set<NonNullable<SnapshotQualityVerdict['reasonCode']>>([
   'ax-rejected',


### PR DESCRIPTION
## Summary

Bound Android snapshot presentation with one typed work/time budget, including scope selection and reindexing, and return a typed `presentation-failed` sparse result when the budget is exhausted.

Scope discovery uses one document-order pass plus bottom-up subtree collection. Coverage allocation, candidate scans, edge indexing, scope traversal, and reindexing all charge the same owner budget. Each node also retains its owning window rectangle so disjoint system and application windows are validated independently.

This completes #1832 C5 and C6. C4/C1 ownership remains in #1968; drawing-order pruning is unchanged.

The PR is 21 files, +1,022/-110 against #1968. The npm growth is the typed presentation/quality safety contract and regression coverage. Smaller message-sniffing, backend branching, unmetered coverage, per-candidate subtree rescans, or a single global window clip were rejected because they weaken the contract or reject valid multi-window captures.

## Validation

At `28f7d724f`:

- planted-red multi-window regression reproduced `Android regular snapshot node 0 escaped its cumulative clip`, then passed with the owning-window carrier
- focused Android presentation and quality tests: 13/13 passed
- `pnpm check:affected --run`: 632 files / 5,029 tests; all runnable checks passed
- live Pixel 7 / API 36: the exact CI fixture reproduced the alert failure; the raw hierarchy contained the alert while regular presentation returned zero nodes
- after the fix, the same live alert produced a healthy four-node interactive snapshot and the complete Android smoke scenario passed in 83 seconds

Fresh GitHub Android Smoke remains authoritative for the exact pushed head.
