### PR TITLE
fix(mutation): move the repo size ratchet where the lane cannot reach it

### DIFF
--- a/scripts/__tests__/test-file-size-ratchet.test.ts
+++ b/scripts/__tests__/test-file-size-ratchet.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'vitest';
-import { walkFiles } from '../../scripts/lib/walk-files.ts';
-import { runCmdSync } from '../utils/exec.ts';
+import { walkFiles } from '../lib/walk-files.ts';
+import { runCmdSync } from '../../src/utils/exec.ts';
 
 /**
  * Test-file size ratchet (AGENTS.md "Scope & shape": past 1,000 lines is architecture debt,

--- a/scripts/mutation/modules.test.ts
+++ b/scripts/mutation/modules.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   affectedModules,
   ALL_MODULE_IDS,
+  isKernelTestFile,
   KERNEL_MODULES,
   moduleForFile,
   mutateGlobs,
@@ -74,4 +75,17 @@ test('the shard matrix slices only the modules that declare shards', () => {
       `${id} has no shard`,
     );
   }
+});
+
+test('a kernel test is reachable only under root or package src', () => {
+  // Load-bearing for where `test-file-size-ratchet.test.ts` lives. It measures the
+  // repository's own files and git history, neither of which Stryker's sandbox copy can
+  // answer, so it sits in `scripts/__tests__/` (explicitly included by `unit-core`) and
+  // this predicate is what keeps it out of every mutation lane. Widening the pattern to
+  // scripts/ would silently pull it back in and fail every dry run.
+  assert.ok(isKernelTestFile('src/daemon/__tests__/ref-frame.test.ts'));
+  assert.ok(isKernelTestFile('packages/selectors/src/parse.test.ts'));
+  assert.ok(!isKernelTestFile('scripts/__tests__/test-file-size-ratchet.test.ts'));
+  assert.ok(!isKernelTestFile('test/integration/daemon.test.ts'));
+  assert.ok(!isKernelTestFile('src/daemon/ref-frame.ts'));
 });

--- a/test/integration/provider-scenarios/android-settings-contract.ts
+++ b/test/integration/provider-scenarios/android-settings-contract.ts
@@ -7,7 +7,7 @@ type AndroidSettingsWorld = Awaited<ReturnType<typeof createAndroidSettingsWorld
  * The adb evidence the Android settings flow must leave behind: the appearance, location,
  * fingerprint, permission, animation-scale, and network mutations each named with the exact
  * argv the provider saw. Extracted from `android-lifecycle.test.ts`, which sits over the
- * test-file tripwire (`src/__tests__/test-file-size-ratchet.test.ts`).
+ * test-file tripwire (`scripts/__tests__/test-file-size-ratchet.test.ts`).
  */
 export function assertAndroidSettingsContract(world: AndroidSettingsWorld): void {
   const { adbCalls } = world;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,13 @@ export default defineConfig({
             'scripts/__tests__/help-conformance-expectation-falsification.test.ts',
             'scripts/__tests__/help-conformance-sample-outputs.test.ts',
             'scripts/__tests__/help-conformance-topic-coverage.test.ts',
+            // Lives here rather than under src/ on purpose: it measures the repository's own
+            // files and git history, which Stryker's sandbox copy cannot answer (the copies are
+            // rewritten, and there is no origin/main). The mutation lane admits only root/package
+            // `src` tests, so this address makes it unreachable there by construction instead of
+            // by a classifier that has to recognise it — see KERNEL_TEST_FILE_RE in
+            // scripts/mutation/modules.ts.
+            'scripts/__tests__/test-file-size-ratchet.test.ts',
             'scripts/__tests__/agent-setup-startup-contract.test.ts',
             'scripts/__tests__/npm-skills-exclusion.test.ts',
             'scripts/__tests__/simulator-skills-contract.test.ts',


### PR DESCRIPTION
Repairs the mutation baseline on `main`, as asked on #1964.

## The defect

Stryker runs the suite from a sandbox copy under `.tmp/stryker/`. A test that asserts about **the repository checkout itself** — its files on disk, or its git history — therefore reads a repository that does not exist.

`test-file-size-ratchet.test.ts` is such a gate, and it fails there for **two independent reasons**:

1. `disableTypeChecks` (Stryker's default) prepends `// @ts-nocheck` to every copied `{test,src,lib}/**/*.ts`, so all 26 pinned files read one line longer than they are.
2. The sandbox has no `origin/main`, so the gate's history-backed half cannot resolve its merge-base.

Fixing either leaves the other — I confirmed that the hard way, by fixing (1) first and watching CI fail on (2). Its own `.tmp` skip entry cannot help either: that is matched relative to `REPO_ROOT`, which inside the sandbox *is* the sandbox.

## The fix

Move the gate to `scripts/__tests__/` and include it explicitly in `unit-core` — the address this repo already uses for maintained gates that are not `src` tests (the help-conformance, xctest-selection and package-closure gates all live there).

`KERNEL_TEST_FILE_RE` admits only root/package `src` tests, and **its own comment already names `scripts/__tests__` as unreachable by construction**. So the gate leaves every mutation lane by virtue of where it lives: no classifier to recognise it, nothing to keep in sync, and no way for a future lane to pull it back in without deliberately widening that pattern.

Nothing about the gate's behavior changes. `REPO_ROOT` is `../..` from either address, and `TEST_ROOTS` already included `scripts`, so it measures exactly the same tree — 4/4 tests pass unmoved.

## What this replaces, and why

The previous revision added a `repoIntrospectionTestFiles` scanner that classified tests by source text — a single-quoted `walk-files` import, or the string `origin/main`. That was the wrong boundary, as reviewed: a behavioral test could match it and be silently excluded, while an equivalent repo gate written with double quotes, a different walker, or a different base ref would be missed. The scanner, its test, and its justifying comment are all deleted; `scripts/mutation/test-scope.ts` is now byte-identical to `main`.

The one assertion added instead pins the invariant this fix depends on: `isKernelTestFile` accepts root/package `src` tests and rejects `scripts/__tests__`. That is the whole invariant, not a sample of it — widening the pattern would silently pull the gate back into every lane, and now fails loudly at that edit instead of confusingly during a dry run.

## Verification

`pnpm mutation:run --modules kernel-errors` at this commit, `.tmp` cleared first:

- scope **804 → 803** test files — exactly this gate
- dry run clean; lane envelope `pass` at stage `complete`
- score **74.8%** (187 killed / 63 survived / 250, 0 timeouts) — unchanged from the pre-existing baseline, as expected: a file-length-and-history gate can never kill a kernel mutant
- `pnpm mutation:test` **39/39** · `pnpm check:layering` **181/181** · `typecheck`, `lint`, `format` clean

`stryker.config.json` is untouched, so the config content hash the report and lane envelope carry is unchanged and scores stay comparable across this commit.

## Whose fault this was

Nobody's, and in particular **not #1964's**. You and that PR's author independently measured **804** kernel-related test files on both the exact base and its head, with a zero-line diff between the lists. Before #1969 rewired the module graph, nothing pulled this gate into a lane's scope, so the trap stayed hidden.
