### PR TITLE
fix(macos): sign nested runner code so the host runner app can launch

### DIFF
--- a/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, test } from 'vitest';
+
+import { MACOS_DEVICE } from '../../../../__tests__/test-utils/device-fixtures.ts';
+import { AppError } from '@agent-device/kernel/errors';
+import {
+  isExpectedRunnerRepairFailure,
+  repairMacOsRunnerProductsIfNeeded,
+} from '../runner/runner-macos-products.ts';
+import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
+
+const XCTESTRUN_PATH = '/tmp/agent-device-runner.xctestrun';
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    fs.rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+test('repair re-signs nested code so the product passes deep verification', async () => {
+  const productPath = createProductPath();
+  const calls: string[][] = [];
+  // Nested Apple test frameworks lose their sealed Modules/ entries during the unsigned embed,
+  // so only a signature that reaches nested code clears deep verification.
+  const provider = createCodesignProvider(
+    calls,
+    (args) => args.includes('--deep') && args.includes('--sign'),
+  );
+
+  await withAppleToolProvider(provider, async () => {
+    await repairMacOsRunnerProductsIfNeeded(MACOS_DEVICE, [productPath], XCTESTRUN_PATH);
+  });
+
+  assert.deepEqual(calls.at(-2), ['--force', '--deep', '--sign', '-', productPath]);
+  assert.deepEqual(calls.at(-1), ['--verify', '--deep', '--strict', productPath]);
+});
+
+test('repair fails when re-signing leaves the product unverifiable', async () => {
+  const productPath = createProductPath();
+  const provider = createCodesignProvider([], () => false);
+
+  const error = await withAppleToolProvider(
+    provider,
+    async () =>
+      await repairMacOsRunnerProductsIfNeeded(MACOS_DEVICE, [productPath], XCTESTRUN_PATH).then(
+        () => null,
+        (thrown: unknown) => thrown,
+      ),
+  );
+
+  assert.ok(error instanceof AppError);
+  assert.equal(isExpectedRunnerRepairFailure(error), true);
+});
+
+function createProductPath(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-products-'));
+  tempRoots.push(root);
+  const productPath = path.join(root, 'AgentDeviceRunnerUITests-Runner.app');
+  fs.mkdirSync(productPath);
+  return productPath;
+}
+
+function createCodesignProvider(
+  calls: string[][],
+  isRepairingSignature: (args: readonly string[]) => boolean,
+) {
+  let repaired = false;
+  return createLocalAppleToolProvider({
+    runCommand: async (command, args = []) => {
+      assert.equal(command, 'codesign');
+      calls.push([...args]);
+      if (isRepairingSignature(args)) {
+        repaired = true;
+      }
+      const verifying = args[0] === '--verify';
+      return {
+        exitCode: verifying && !repaired ? 1 : 0,
+        stdout: '',
+        stderr: '',
+      };
+    },
+  });
+}

--- a/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, test } from 'vitest';
+import { test } from 'vitest';
 
 import { MACOS_DEVICE } from '../../../../__tests__/test-utils/device-fixtures.ts';
+import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   isExpectedRunnerRepairFailure,
@@ -14,13 +14,6 @@ import {
 import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
 
 const XCTESTRUN_PATH = '/tmp/agent-device-runner.xctestrun';
-const tempRoots: string[] = [];
-
-afterEach(() => {
-  while (tempRoots.length > 0) {
-    fs.rmSync(tempRoots.pop() as string, { recursive: true, force: true });
-  }
-});
 
 test('repair re-signs nested code so the product passes deep verification', async () => {
   const productPath = createProductPath();
@@ -58,8 +51,7 @@ test('repair fails when re-signing leaves the product unverifiable', async () =>
 });
 
 function createProductPath(): string {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-products-'));
-  tempRoots.push(root);
+  const root = mkdtempForTestSync('agent-device-runner-products-');
   const productPath = path.join(root, 'AgentDeviceRunnerUITests-Runner.app');
   fs.mkdirSync(productPath);
   return productPath;

--- a/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
@@ -16,20 +16,27 @@ import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-pro
 const XCTESTRUN_PATH = '/tmp/agent-device-runner.xctestrun';
 
 test('repair re-signs nested code so the product passes deep verification', async () => {
-  const productPath = createProductPath();
+  const { productPath, embeddedItemPaths } = createProduct();
   const calls: string[][] = [];
-  // Nested Apple test frameworks lose their sealed Modules/ entries during the unsigned embed,
-  // so only a signature that reaches nested code clears deep verification.
   const provider = createCodesignProvider(
     calls,
-    (args) => args.includes('--deep') && args.includes('--sign'),
+    (args) => args.includes('--sign') && args.at(-1) === productPath,
   );
 
   await withAppleToolProvider(provider, async () => {
     await repairMacOsRunnerProductsIfNeeded(MACOS_DEVICE, [productPath], XCTESTRUN_PATH);
   });
 
-  assert.deepEqual(calls.at(-2), ['--force', '--deep', '--sign', '-', productPath]);
+  const signingArgs = [
+    '--force',
+    '--preserve-metadata=identifier,entitlements,flags,runtime',
+    '--sign',
+    '-',
+  ];
+  assert.deepEqual(calls.slice(1, -1), [
+    ...embeddedItemPaths.map((itemPath) => [...signingArgs, itemPath]),
+    [...signingArgs, productPath],
+  ]);
   assert.deepEqual(calls.at(-1), ['--verify', '--deep', '--strict', productPath]);
 });
 
@@ -51,10 +58,36 @@ test('repair fails when re-signing leaves the product unverifiable', async () =>
 });
 
 function createProductPath(): string {
+  return createProduct().productPath;
+}
+
+function createProduct(): {
+  productPath: string;
+  embeddedItemPaths: string[];
+} {
   const root = mkdtempForTestSync('agent-device-runner-products-');
   const productPath = path.join(root, 'AgentDeviceRunnerUITests-Runner.app');
   fs.mkdirSync(productPath);
-  return productPath;
+  const frameworksRoot = path.join(productPath, 'Contents', 'Frameworks');
+  const embeddedItemPaths = [
+    'Testing.framework',
+    'XCTAutomationSupport.framework',
+    'XCTest.framework',
+    'XCTestCore.framework',
+    'XCTestSupport.framework',
+    'XCUIAutomation.framework',
+    'XCUnit.framework',
+    'libXCTestSwiftSupport.dylib',
+  ].map((itemName) => path.join(frameworksRoot, itemName));
+  for (const itemPath of embeddedItemPaths) {
+    if (itemPath.endsWith('.framework')) {
+      fs.mkdirSync(itemPath, { recursive: true });
+    } else {
+      fs.mkdirSync(path.dirname(itemPath), { recursive: true });
+      fs.writeFileSync(itemPath, '');
+    }
+  }
+  return { productPath, embeddedItemPaths };
 }
 
 function createCodesignProvider(

--- a/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-macos-products.test.ts
@@ -15,7 +15,7 @@ import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-pro
 
 const XCTESTRUN_PATH = '/tmp/agent-device-runner.xctestrun';
 
-test('repair re-signs nested code so the product passes deep verification', async () => {
+test('repair discovers and re-signs nested code before the product', async () => {
   const { productPath, embeddedItemPaths } = createProduct();
   const calls: string[][] = [];
   const provider = createCodesignProvider(
@@ -70,14 +70,9 @@ function createProduct(): {
   fs.mkdirSync(productPath);
   const frameworksRoot = path.join(productPath, 'Contents', 'Frameworks');
   const embeddedItemPaths = [
-    'Testing.framework',
-    'XCTAutomationSupport.framework',
-    'XCTest.framework',
-    'XCTestCore.framework',
-    'XCTestSupport.framework',
-    'XCUIAutomation.framework',
-    'XCUnit.framework',
-    'libXCTestSwiftSupport.dylib',
+    'FutureTestSupport.framework',
+    'AnotherTestSupport.framework',
+    'libFutureTestSupport.dylib',
   ].map((itemName) => path.join(frameworksRoot, itemName));
   for (const itemPath of embeddedItemPaths) {
     if (itemPath.endsWith('.framework')) {
@@ -87,7 +82,7 @@ function createProduct(): {
       fs.writeFileSync(itemPath, '');
     }
   }
-  return { productPath, embeddedItemPaths };
+  return { productPath, embeddedItemPaths: embeddedItemPaths.sort() };
 }
 
 function createCodesignProvider(

--- a/src/platforms/apple/core/runner/runner-macos-products.ts
+++ b/src/platforms/apple/core/runner/runner-macos-products.ts
@@ -39,22 +39,46 @@ export async function repairMacOsRunnerProductsIfNeeded(
     if (await hasValidCodeSignature(productPath)) {
       continue;
     }
-    await runAppleToolCommand('codesign', ['--remove-signature', productPath], {
-      allowFailure: true,
-    });
-    try {
-      await runAppleToolCommand('codesign', ['--force', '--sign', '-', productPath]);
-    } catch (error) {
-      const appError = asAppError(error, 'COMMAND_FAILED');
-      throw new AppError('COMMAND_FAILED', 'Failed to repair macOS runner product signature', {
-        reason: 'RUNNER_PRODUCT_REPAIR_FAILED',
-        productPath,
-        xctestrunPath,
-        error: appError.message,
-        details: appError.details,
-      });
-    }
+    await resignRunnerProduct(productPath, xctestrunPath);
   }
+}
+
+async function resignRunnerProduct(productPath: string, xctestrunPath: string): Promise<void> {
+  await runAppleToolCommand('codesign', ['--remove-signature', productPath], {
+    allowFailure: true,
+  });
+  try {
+    // --deep is required: macOS runners build with CODE_SIGNING_ALLOWED=NO, so Xcode embeds the
+    // Apple test frameworks without re-signing them while dropping their sealed Modules/ entries.
+    // Signing only the outer bundle leaves those nested seals broken and the app unlaunchable.
+    await runAppleToolCommand('codesign', ['--force', '--deep', '--sign', '-', productPath]);
+  } catch (error) {
+    const appError = asAppError(error, 'COMMAND_FAILED');
+    throw repairFailure(productPath, xctestrunPath, appError.message, appError.details);
+  }
+
+  if (!(await hasValidCodeSignature(productPath))) {
+    throw repairFailure(
+      productPath,
+      xctestrunPath,
+      'Product still fails code signature verification after re-signing',
+    );
+  }
+}
+
+function repairFailure(
+  productPath: string,
+  xctestrunPath: string,
+  error: string,
+  details?: unknown,
+): AppError {
+  return new AppError('COMMAND_FAILED', 'Failed to repair macOS runner product signature', {
+    reason: 'RUNNER_PRODUCT_REPAIR_FAILED',
+    productPath,
+    xctestrunPath,
+    error,
+    details,
+  });
 }
 
 export function isExpectedRunnerRepairFailure(error: unknown): boolean {

--- a/src/platforms/apple/core/runner/runner-macos-products.ts
+++ b/src/platforms/apple/core/runner/runner-macos-products.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { isMacOs, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import { runAppleToolCommand } from '../tool-provider.ts';
@@ -7,6 +8,25 @@ const RUNNER_PRODUCT_REPAIR_FAILURE_REASONS = new Set([
   'RUNNER_PRODUCT_MISSING',
   'RUNNER_PRODUCT_REPAIR_FAILED',
 ]);
+
+const EMBEDDED_TEST_SUPPORT_ITEMS = [
+  'Testing.framework',
+  'XCTAutomationSupport.framework',
+  'XCTest.framework',
+  'XCTestCore.framework',
+  'XCTestSupport.framework',
+  'XCUIAutomation.framework',
+  'XCUnit.framework',
+  'libXCTestSwiftSupport.dylib',
+] as const;
+
+const AD_HOC_RESIGN_ARGS = [
+  '--force',
+  // Designated requirements must be regenerated for the ad-hoc identity.
+  '--preserve-metadata=identifier,entitlements,flags,runtime',
+  '--sign',
+  '-',
+] as const;
 
 export async function repairMacOsRunnerProductsIfNeeded(
   device: DeviceInfo,
@@ -44,14 +64,14 @@ export async function repairMacOsRunnerProductsIfNeeded(
 }
 
 async function resignRunnerProduct(productPath: string, xctestrunPath: string): Promise<void> {
-  await runAppleToolCommand('codesign', ['--remove-signature', productPath], {
-    allowFailure: true,
-  });
   try {
-    // --deep is required: macOS runners build with CODE_SIGNING_ALLOWED=NO, so Xcode embeds the
-    // Apple test frameworks without re-signing them while dropping their sealed Modules/ entries.
-    // Signing only the outer bundle leaves those nested seals broken and the app unlaunchable.
-    await runAppleToolCommand('codesign', ['--force', '--deep', '--sign', '-', productPath]);
+    for (const itemName of EMBEDDED_TEST_SUPPORT_ITEMS) {
+      const itemPath = path.join(productPath, 'Contents', 'Frameworks', itemName);
+      if (fs.existsSync(itemPath)) {
+        await runAppleToolCommand('codesign', [...AD_HOC_RESIGN_ARGS, itemPath]);
+      }
+    }
+    await runAppleToolCommand('codesign', [...AD_HOC_RESIGN_ARGS, productPath]);
   } catch (error) {
     const appError = asAppError(error, 'COMMAND_FAILED');
     throw repairFailure(productPath, xctestrunPath, appError.message, appError.details);

--- a/src/platforms/apple/core/runner/runner-macos-products.ts
+++ b/src/platforms/apple/core/runner/runner-macos-products.ts
@@ -9,17 +9,6 @@ const RUNNER_PRODUCT_REPAIR_FAILURE_REASONS = new Set([
   'RUNNER_PRODUCT_REPAIR_FAILED',
 ]);
 
-const EMBEDDED_TEST_SUPPORT_ITEMS = [
-  'Testing.framework',
-  'XCTAutomationSupport.framework',
-  'XCTest.framework',
-  'XCTestCore.framework',
-  'XCTestSupport.framework',
-  'XCUIAutomation.framework',
-  'XCUnit.framework',
-  'libXCTestSwiftSupport.dylib',
-] as const;
-
 const AD_HOC_RESIGN_ARGS = [
   '--force',
   // Designated requirements must be regenerated for the ad-hoc identity.
@@ -65,11 +54,15 @@ export async function repairMacOsRunnerProductsIfNeeded(
 
 async function resignRunnerProduct(productPath: string, xctestrunPath: string): Promise<void> {
   try {
-    for (const itemName of EMBEDDED_TEST_SUPPORT_ITEMS) {
-      const itemPath = path.join(productPath, 'Contents', 'Frameworks', itemName);
-      if (fs.existsSync(itemPath)) {
-        await runAppleToolCommand('codesign', [...AD_HOC_RESIGN_ARGS, itemPath]);
-      }
+    const frameworksPath = path.join(productPath, 'Contents', 'Frameworks');
+    const embeddedCodePaths = fs.existsSync(frameworksPath)
+      ? fs
+          .readdirSync(frameworksPath)
+          .sort()
+          .map((itemName) => path.join(frameworksPath, itemName))
+      : [];
+    for (const embeddedCodePath of embeddedCodePaths) {
+      await runAppleToolCommand('codesign', [...AD_HOC_RESIGN_ARGS, embeddedCodePath]);
     }
     await runAppleToolCommand('codesign', [...AD_HOC_RESIGN_ARGS, productPath]);
   } catch (error) {


### PR DESCRIPTION
## Summary

Repair unsigned macOS runner products by signing their embedded Apple test-support code explicitly, then signing the parent app.

The repair preserves identifiers, entitlements, flags, and hardened-runtime metadata while allowing codesign to regenerate designated requirements for the ad-hoc identity. It avoids deprecated signing-time `--deep`; deep traversal remains verification-only.

Post-repair strict verification is retained so an invalid cached or freshly built product cannot be reported as repaired.

## Validation

- Observed the new ordering/metadata regression test fail against the previous `--force --deep` implementation, then pass after the repair.
- `pnpm check:affected --run`: format, lint, typecheck, layering, fallow, build, and 2,317/2,318 related tests passed; the sole timeout passed in isolation in 126 ms and is unrelated to this two-file change.
- Fresh `pnpm build:xcuitest:macos` product passed `codesign --verify --deep --strict`, including its nested `.xctest` bundle and all embedded test-support items.
- Real CLI open launched TextEdit and reached the macOS XCTest runner. Interactive snapshot then hit the existing host Automation-permission timeout; the isolated session closed cleanly.
