### PR TITLE
fix(android): update snapshot quality lifecycle import

### DIFF
--- a/src/platforms/android/__tests__/snapshot-quality.test.ts
+++ b/src/platforms/android/__tests__/snapshot-quality.test.ts
@@ -8,7 +8,7 @@ import {
   androidSnapshotQualityHelperArtifact,
 } from './snapshot-quality-fixtures.ts';
 import { resetAndroidSnapshotHelperInstallCache } from '../snapshot-helper-install.ts';
-import { resetAndroidSnapshotHelperSessions } from '../snapshot-helper-session.ts';
+import { resetAndroidSnapshotHelperSessions } from '../snapshot-helper-session-lifecycle.ts';
 
 beforeEach(async () => {
   await resetAndroidSnapshotHelperSessions();


### PR DESCRIPTION
## Summary

Update the snapshot quality test to import session reset from its lifecycle owner after #1974 extracted that API. This repairs the deterministic Typecheck and FreeRange failures currently affecting `main` and unrelated PR merge queues.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/platforms/android/__tests__/snapshot-quality.test.ts`
- `pnpm check:affected --run`