### PR TITLE
perf(selectors): resolve a recorded replay target in one matching pass

### DIFF
--- a/packages/selectors/src/index.test.ts
+++ b/packages/selectors/src/index.test.ts
@@ -136,22 +136,33 @@ test('recorded-target resolution keeps the matched domain from the alternative t
  * Functions are bound to the target so a counted traversal cannot re-enter the
  * proxy.
  */
-const SCAN_METHODS = ['filter', 'map', 'flatMap', 'forEach', 'reduce', 'some'] as const;
-type ScanPasses = { iterated: number } & Record<(typeof SCAN_METHODS)[number], number>;
+const SCAN_METHODS = [
+  'filter',
+  'map',
+  'flatMap',
+  'forEach',
+  'reduce',
+  'reduceRight',
+  'some',
+  'every',
+  'find',
+  'findIndex',
+  'findLast',
+  'findLastIndex',
+  'includes',
+  'indexOf',
+] as const;
+type ScanMethod = (typeof SCAN_METHODS)[number];
+type ScanPasses = { iterated: number } & Record<ScanMethod, number>;
 
 function observeTreeTraversals(nodes: SnapshotNode[]): {
   observed: SnapshotNode[];
   passes: ScanPasses;
 } {
-  const passes: ScanPasses = {
-    iterated: 0,
-    filter: 0,
-    map: 0,
-    flatMap: 0,
-    forEach: 0,
-    reduce: 0,
-    some: 0,
-  };
+  const passes = Object.fromEntries([
+    ['iterated', 0],
+    ...SCAN_METHODS.map((method) => [method, 0]),
+  ]) as ScanPasses;
   const observed = new Proxy(nodes, {
     get(target, property) {
       if (property === Symbol.iterator) passes.iterated += 1;
@@ -181,7 +192,15 @@ test('recorded-target resolution adds no second matching pass per selector alter
     flatMap: 0,
     forEach: 0,
     reduce: 0,
+    reduceRight: 0,
     some: 0,
+    every: 0,
+    find: 0,
+    findIndex: 0,
+    findLast: 0,
+    findLastIndex: 0,
+    includes: 0,
+    indexOf: 0,
   });
 
   const unresolved = observeTreeTraversals(nodes);
@@ -200,7 +219,15 @@ test('recorded-target resolution adds no second matching pass per selector alter
     flatMap: 8,
     forEach: 0,
     reduce: 0,
+    reduceRight: 0,
     some: 0,
+    every: 0,
+    find: 0,
+    findIndex: 0,
+    findLast: 0,
+    findLastIndex: 0,
+    includes: 0,
+    indexOf: 0,
   });
 });
 

--- a/packages/selectors/src/index.test.ts
+++ b/packages/selectors/src/index.test.ts
@@ -129,18 +129,33 @@ test('recorded-target resolution keeps the matched domain from the alternative t
 
 /**
  * Counts whole-array traversals of the snapshot tree: `for...of` passes through
- * the iterator, plus any `filter`/`map` scan layered on top of them. Functions
- * are bound to the target so a counted traversal cannot re-enter the proxy.
+ * the iterator, plus every array scan layered on top of them. The scan list is
+ * the whole surface, not just the methods the resolver happens to use today, so
+ * a regression that reintroduces a full pass through `flatMap`/`forEach`/
+ * `reduce`/`some` cannot slip past a counter that only watches `filter`/`map`.
+ * Functions are bound to the target so a counted traversal cannot re-enter the
+ * proxy.
  */
+const SCAN_METHODS = ['filter', 'map', 'flatMap', 'forEach', 'reduce', 'some'] as const;
+type ScanPasses = { iterated: number } & Record<(typeof SCAN_METHODS)[number], number>;
+
 function observeTreeTraversals(nodes: SnapshotNode[]): {
   observed: SnapshotNode[];
-  passes: { iterated: number; filter: number; map: number };
+  passes: ScanPasses;
 } {
-  const passes = { iterated: 0, filter: 0, map: 0 };
+  const passes: ScanPasses = {
+    iterated: 0,
+    filter: 0,
+    map: 0,
+    flatMap: 0,
+    forEach: 0,
+    reduce: 0,
+    some: 0,
+  };
   const observed = new Proxy(nodes, {
     get(target, property) {
       if (property === Symbol.iterator) passes.iterated += 1;
-      if (property === 'filter' || property === 'map') passes[property] += 1;
+      for (const method of SCAN_METHODS) if (property === method) passes[method] += 1;
       const value = Reflect.get(target, property) as unknown;
       return typeof value === 'function' ? value.bind(target) : value;
     },
@@ -148,7 +163,7 @@ function observeTreeTraversals(nodes: SnapshotNode[]): {
   return { observed, passes };
 }
 
-test('recorded-target resolution reads the tree once per selector alternative', () => {
+test('recorded-target resolution adds no second matching pass per selector alternative', () => {
   const nodes: SnapshotNode[] = [
     { ...saveNode, ref: 'e1', label: 'Decoy', identifier: undefined, depth: 1 },
     { ...saveNode, ref: 'e2', label: 'Decoy', identifier: undefined, depth: 1 },
@@ -157,16 +172,36 @@ test('recorded-target resolution reads the tree once per selector alternative', 
 
   const resolved = observeTreeTraversals(nodes);
   resolveRecordedTarget('id="missing" || id="save"', resolved.observed, policy());
-  // One pass per alternative tried, and no further pass rebuilding the winner's
-  // matched-node domain that the deciding pass already collected.
-  assert.deepEqual(resolved.passes, { iterated: 2, filter: 0, map: 0 });
+  // One matching pass per alternative tried, and no further pass rebuilding the
+  // winner's matched-node domain that the deciding pass already collected.
+  assert.deepEqual(resolved.passes, {
+    iterated: 2,
+    filter: 0,
+    map: 0,
+    flatMap: 0,
+    forEach: 0,
+    reduce: 0,
+    some: 0,
+  });
 
   const unresolved = observeTreeTraversals(nodes);
   resolveRecordedTarget('label="Decoy"', unresolved.observed, policy());
-  // The ambiguous leg reports that same domain instead of re-listing the
-  // chain's matches. The one `map` is the deciding pass's own lazily-built
-  // visibility index, which only ambiguous candidates pay for.
-  assert.deepEqual(unresolved.passes, { iterated: 1, filter: 0, map: 1 });
+  // The ambiguous leg reports that same domain instead of re-listing the chain's
+  // matches: one matching pass, no second one. The `map` is the deciding pass's
+  // own lazily-built visibility index. The `flatMap`s are NOT that pass — they
+  // are four whole-tree viewport-rect scans per ambiguous candidate, charged by
+  // `isNodeVisibleOnScreen` because the caller passes no precomputed viewport
+  // rects. They scale with the candidate count and predate this change; they are
+  // pinned here so the number cannot grow unnoticed, and are tracked separately.
+  assert.deepEqual(unresolved.passes, {
+    iterated: 1,
+    filter: 0,
+    map: 1,
+    flatMap: 8,
+    forEach: 0,
+    reduce: 0,
+    some: 0,
+  });
 });
 
 test('recorded-target resolution applies requireRect to both winner and domain', () => {

--- a/packages/selectors/src/index.test.ts
+++ b/packages/selectors/src/index.test.ts
@@ -127,6 +127,48 @@ test('recorded-target resolution keeps the matched domain from the alternative t
   assert.equal(permissive.matchCount, 3);
 });
 
+/**
+ * Counts whole-array traversals of the snapshot tree: `for...of` passes through
+ * the iterator, plus any `filter`/`map` scan layered on top of them. Functions
+ * are bound to the target so a counted traversal cannot re-enter the proxy.
+ */
+function observeTreeTraversals(nodes: SnapshotNode[]): {
+  observed: SnapshotNode[];
+  passes: { iterated: number; filter: number; map: number };
+} {
+  const passes = { iterated: 0, filter: 0, map: 0 };
+  const observed = new Proxy(nodes, {
+    get(target, property) {
+      if (property === Symbol.iterator) passes.iterated += 1;
+      if (property === 'filter' || property === 'map') passes[property] += 1;
+      const value = Reflect.get(target, property) as unknown;
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return { observed, passes };
+}
+
+test('recorded-target resolution reads the tree once per selector alternative', () => {
+  const nodes: SnapshotNode[] = [
+    { ...saveNode, ref: 'e1', label: 'Decoy', identifier: undefined, depth: 1 },
+    { ...saveNode, ref: 'e2', label: 'Decoy', identifier: undefined, depth: 1 },
+    { ...saveNode, ref: 'e4', label: 'Save', identifier: 'save', depth: 1 },
+  ];
+
+  const resolved = observeTreeTraversals(nodes);
+  resolveRecordedTarget('id="missing" || id="save"', resolved.observed, policy());
+  // One pass per alternative tried, and no further pass rebuilding the winner's
+  // matched-node domain that the deciding pass already collected.
+  assert.deepEqual(resolved.passes, { iterated: 2, filter: 0, map: 0 });
+
+  const unresolved = observeTreeTraversals(nodes);
+  resolveRecordedTarget('label="Decoy"', unresolved.observed, policy());
+  // The ambiguous leg reports that same domain instead of re-listing the
+  // chain's matches. The one `map` is the deciding pass's own lazily-built
+  // visibility index, which only ambiguous candidates pay for.
+  assert.deepEqual(unresolved.passes, { iterated: 1, filter: 0, map: 1 });
+});
+
 test('recorded-target resolution applies requireRect to both winner and domain', () => {
   const rectless: SnapshotNode = { ...saveNode, label: 'Ghost row', rect: undefined };
   const required = resolveRecordedTarget('label="Ghost row"', [rectless], policy());

--- a/packages/selectors/src/internal/replay.ts
+++ b/packages/selectors/src/internal/replay.ts
@@ -4,10 +4,9 @@ import type { DisambiguationTiebreak } from '@agent-device/contracts/interaction
 import type { ReplayDivergenceSuggestionBasis } from '@agent-device/contracts/divergence';
 import { splitIsSelectorArgs, splitSelectorFromArgs } from './arguments.ts';
 import { buildSelectorChainForNode } from './build.ts';
-import { matchesSelector } from './match.ts';
 import { tryParseSelectorChain } from './parse.ts';
 import { selectorResolutionKnobs } from './resolution-policy.ts';
-import { listSelectorChainMatches, resolveSelectorChain } from './resolve.ts';
+import { resolveSelectorChain, resolveSelectorChainDomain } from './resolve.ts';
 
 /**
  * Which selector-bearing positional grammar a replay action uses. `is` puts a
@@ -104,33 +103,32 @@ export function resolveRecordedTarget(
 ): ReplayRecordedTargetResolution {
   const chain = tryParseSelectorChain(expression);
   if (!chain) return { kind: 'unresolved', reason: 'parse-invalid', matchedNodes: [] };
-  const resolved = resolveSelectorChain(nodes, chain, recordedTargetResolutionOptions(policy));
-  if (resolved) {
-    const matchedNodes = nodes.filter((node) => {
-      if (policy.requireRect && !node.rect) return false;
-      return matchesSelector(node, resolved.selector, policy.platform);
-    });
+  // One matching pass answers both legs. The winner's alternative and the
+  // recorded-identity set it must be checked against are the same question
+  // asked of the same tree, so resolution reports the domain it decided over
+  // instead of the caller re-deriving it node by node.
+  const { resolution, matchedNodes } = resolveSelectorChainDomain(
+    nodes,
+    chain,
+    recordedTargetResolutionOptions(policy),
+  );
+  if (resolution) {
     return {
       kind: 'resolved',
-      winner: resolved.node,
+      winner: resolution.node,
       matchedNodes,
       matchCount: matchedNodes.length,
-      ...(resolved.disambiguation
+      ...(resolution.disambiguation
         ? {
             disambiguation: {
-              tiebreak: resolved.disambiguation.tiebreak,
-              matchCount: resolved.disambiguation.matchCount,
-              alternatives: resolved.disambiguation.alternatives,
+              tiebreak: resolution.disambiguation.tiebreak,
+              matchCount: resolution.disambiguation.matchCount,
+              alternatives: resolution.disambiguation.alternatives,
             },
           }
         : {}),
     };
   }
-  const matchList = listSelectorChainMatches(nodes, chain, {
-    platform: policy.platform,
-    requireRect: policy.requireRect,
-  });
-  const matchedNodes = matchList?.matchedNodes ?? [];
   return {
     kind: 'unresolved',
     reason: matchedNodes.length > 0 ? 'ambiguous' : 'no-match',

--- a/packages/selectors/src/internal/resolve.test.ts
+++ b/packages/selectors/src/internal/resolve.test.ts
@@ -1,7 +1,11 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { parseSelectorChain } from './parse.ts';
-import { findSelectorChainMatch, resolveSelectorChain } from './resolve.ts';
+import {
+  findSelectorChainMatch,
+  resolveSelectorChain,
+  resolveSelectorChainDomain,
+} from './resolve.ts';
 import { loginFormNodes } from './__tests__/login-form-nodes.ts';
 
 test('resolveSelectorChain resolves unique match', () => {
@@ -35,6 +39,46 @@ test('resolveSelectorChain keeps strict ambiguity behavior by default', () => {
     requireUnique: true,
   });
   assert.equal(resolved, null);
+});
+
+test("resolveSelectorChainDomain reports the winning alternative's matched nodes", () => {
+  const chain = parseSelectorChain('label="Continue" || id=auth_continue');
+  const domain = resolveSelectorChainDomain(loginFormNodes, chain, {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+  // The winner comes from the SECOND alternative, so its domain must be that
+  // alternative's single match — not the first alternative's two "Continue"s.
+  assert.equal(domain.resolution?.selectorIndex, 1);
+  assert.deepEqual(
+    domain.matchedNodes.map((node) => node.ref),
+    ['e2'],
+  );
+});
+
+test('resolveSelectorChainDomain reports the first matching alternative when nothing resolves', () => {
+  const domain = resolveSelectorChainDomain(
+    loginFormNodes,
+    parseSelectorChain('label="Continue"'),
+    {
+      platform: 'ios',
+      requireRect: true,
+      requireUnique: true,
+    },
+  );
+  assert.equal(domain.resolution, null);
+  assert.deepEqual(
+    domain.matchedNodes.map((node) => node.ref),
+    ['e2', 'e3'],
+  );
+
+  const missing = resolveSelectorChainDomain(loginFormNodes, parseSelectorChain('id=absent'), {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+  assert.deepEqual(missing, { resolution: null, matchedNodes: [] });
 });
 
 test('findSelectorChainMatch returns first matching selector for existence checks', () => {

--- a/packages/selectors/src/internal/resolve.ts
+++ b/packages/selectors/src/internal/resolve.ts
@@ -27,44 +27,74 @@ export type AstSelectorResolution = {
   disambiguation?: SelectorDisambiguationDisclosure;
 };
 
+/**
+ * A resolution together with the matched-node domain the SAME pass decided it
+ * over, so a caller that needs both stops re-deriving the second one.
+ *
+ * `matchedNodes` describes the winning alternative when `resolution` is
+ * non-null. When no alternative resolved, it describes the first alternative
+ * that matched anything — the set `listSelectorChainMatches` reports, computed
+ * here by the pass that already visited those nodes.
+ */
+export type AstSelectorChainResolutionDomain = {
+  resolution: AstSelectorResolution | null;
+  matchedNodes: SnapshotNode[];
+};
+
+export function resolveSelectorChainDomain(
+  nodes: SnapshotState['nodes'],
+  chain: SelectorChain,
+  options: SelectorResolutionOptions,
+): AstSelectorChainResolutionDomain {
+  const requireRect = options.requireRect ?? false;
+  const requireUnique = options.requireUnique ?? true;
+  const diagnostics: SelectorDiagnostics[] = [];
+  let firstMatchedNodes: SnapshotNode[] | null = null;
+  for (const [i, selector] of chain.selectors.entries()) {
+    const summary = analyzeSelectorMatches(nodes, selector, options.platform, requireRect);
+    diagnostics.push({ selector: selector.raw, matches: summary.count });
+    if (summary.count === 0 || !summary.firstNode) continue;
+    firstMatchedNodes ??= summary.candidates;
+    if (requireUnique && summary.count !== 1) {
+      if (!options.disambiguateAmbiguous || !summary.disambiguated || !summary.tiebreak) continue;
+      return {
+        matchedNodes: summary.candidates,
+        resolution: {
+          node: summary.disambiguated,
+          selector,
+          selectorIndex: i,
+          matches: summary.count,
+          diagnostics,
+          disambiguation: {
+            matchCount: summary.count,
+            tiebreak: summary.tiebreak,
+            alternatives: summary.candidates.filter(
+              (candidate) => candidate !== summary.disambiguated,
+            ),
+          },
+        },
+      };
+    }
+    return {
+      matchedNodes: summary.candidates,
+      resolution: {
+        node: summary.firstNode,
+        selector,
+        selectorIndex: i,
+        matches: summary.count,
+        diagnostics,
+      },
+    };
+  }
+  return { resolution: null, matchedNodes: firstMatchedNodes ?? [] };
+}
+
 export function resolveSelectorChain(
   nodes: SnapshotState['nodes'],
   chain: SelectorChain,
   options: SelectorResolutionOptions,
 ): AstSelectorResolution | null {
-  const requireRect = options.requireRect ?? false;
-  const requireUnique = options.requireUnique ?? true;
-  const diagnostics: SelectorDiagnostics[] = [];
-  for (const [i, selector] of chain.selectors.entries()) {
-    const summary = analyzeSelectorMatches(nodes, selector, options.platform, requireRect);
-    diagnostics.push({ selector: selector.raw, matches: summary.count });
-    if (summary.count === 0 || !summary.firstNode) continue;
-    if (requireUnique && summary.count !== 1) {
-      if (!options.disambiguateAmbiguous || !summary.disambiguated || !summary.tiebreak) continue;
-      return {
-        node: summary.disambiguated,
-        selector,
-        selectorIndex: i,
-        matches: summary.count,
-        diagnostics,
-        disambiguation: {
-          matchCount: summary.count,
-          tiebreak: summary.tiebreak,
-          alternatives: summary.candidates.filter(
-            (candidate) => candidate !== summary.disambiguated,
-          ),
-        },
-      };
-    }
-    return {
-      node: summary.firstNode,
-      selector,
-      selectorIndex: i,
-      matches: summary.count,
-      diagnostics,
-    };
-  }
-  return null;
+  return resolveSelectorChainDomain(nodes, chain, options).resolution;
 }
 
 /** The parser-side twin of the façade's `SelectorChainMatchList`. */


### PR DESCRIPTION
Closes #1978. Split from #1971 (find index-once) per review — #1690's scope excludes selector/replay, so this lands separately on top of the now-merged find topology work.

## Summary

- New `resolveSelectorChainDomain` (`packages/selectors/src/internal/resolve.ts`): returns the matched-node set the deciding pass already collected — the winning alternative's when one resolves, else the first alternative with any match (exactly `listSelectorChainMatches`' selection rule).
- `resolveRecordedTarget` drops its redundant second full-tree scan on both legs: resolved leg {iterated: 2, filter: 1→0}; unresolved leg {filter: 1→0}.
- `observeTreeTraversals` widened to count the full array surface (flatMap/forEach/reduce/some) — the previous counter was blind to flatMap, which hid 4n uncounted scans per ambiguous candidate.
- Published ./ast surface unchanged; `listSelectorChainMatches` keeps its three other callers.

## Validation

- Red-first scan-count tables in-thread; semantic parity vs merge-base verified over a 112-combination fuzz (winner-in-later-alternative, empty trees, rectless nodes, requireRect/allowDisambiguation toggles) during the #1971 adversarial review — PASS.
- 8 selectors tests green at pushed head; rebased onto current main.