### PR TITLE
refactor(test): fold the last two coverage-summary copies into the shared builder

### DIFF
--- a/test/integration/macos-e2e/coverage-manifest.ts
+++ b/test/integration/macos-e2e/coverage-manifest.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import { buildCoverageClassificationSummary } from '../support/coverage-classification.ts';
 import {
   MACOS_LIVE_SCENARIOS,
   type MacOsLiveScenario,
@@ -31,14 +32,6 @@ export type MacOsPlatformCoverageEntry =
       level: 'known-gap';
       trackingIssue: number;
     };
-
-export type MacOsPlatformCoverageClassificationSummary = {
-  capabilityDenial: number;
-  contract: number;
-  gap: number;
-  live: number;
-  total: number;
-};
 
 export const MACOS_COVERAGE_GAP_ISSUE = 1916;
 
@@ -266,33 +259,4 @@ function liveScenario(scenarioId: MacOsLiveScenarioId): MacOsLiveScenario {
   const scenario = MACOS_LIVE_SCENARIOS.find((candidate) => candidate.id === scenarioId);
   if (!scenario) throw new Error(`Unknown macOS coverage scenario: ${scenarioId}`);
   return scenario;
-}
-
-function buildCoverageClassificationSummary(
-  entries: readonly MacOsPlatformCoverageEntry[],
-): MacOsPlatformCoverageClassificationSummary {
-  const summary: MacOsPlatformCoverageClassificationSummary = {
-    capabilityDenial: 0,
-    contract: 0,
-    gap: 0,
-    live: 0,
-    total: entries.length,
-  };
-  for (const entry of entries) {
-    switch (entry.level) {
-      case 'live':
-        summary.live += 1;
-        break;
-      case 'command-contract':
-        summary.contract += 1;
-        break;
-      case 'capability-denial':
-        summary.capabilityDenial += 1;
-        break;
-      case 'known-gap':
-        summary.gap += 1;
-        break;
-    }
-  }
-  return summary;
 }

--- a/test/integration/tvos-e2e/coverage-manifest.ts
+++ b/test/integration/tvos-e2e/coverage-manifest.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import { buildCoverageClassificationSummary } from '../support/coverage-classification.ts';
 
 type PublicCommand = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
 
@@ -36,14 +37,6 @@ export type TvOsPlatformCoverageEntry =
       level: 'known-gap';
       trackingIssue: number;
     };
-
-export type TvOsPlatformCoverageClassificationSummary = {
-  capabilityDenial: number;
-  contract: number;
-  gap: number;
-  live: number;
-  total: number;
-};
 
 export const TVOS_COVERAGE_GAP_ISSUE = 1914;
 export const TVOS_REMOTE_TEST_NAME =
@@ -219,32 +212,3 @@ export const TVOS_PLATFORM_COVERAGE = {
 export const TVOS_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClassificationSummary(
   Object.values(TVOS_PLATFORM_COVERAGE),
 );
-
-function buildCoverageClassificationSummary(
-  entries: readonly TvOsPlatformCoverageEntry[],
-): TvOsPlatformCoverageClassificationSummary {
-  const summary: TvOsPlatformCoverageClassificationSummary = {
-    capabilityDenial: 0,
-    contract: 0,
-    gap: 0,
-    live: 0,
-    total: entries.length,
-  };
-  for (const entry of entries) {
-    switch (entry.level) {
-      case 'live':
-        summary.live += 1;
-        break;
-      case 'command-contract':
-        summary.contract += 1;
-        break;
-      case 'capability-denial':
-        summary.capabilityDenial += 1;
-        break;
-      case 'known-gap':
-        summary.gap += 1;
-        break;
-    }
-  }
-  return summary;
-}


### PR DESCRIPTION
## Summary

Completes the factoring the #1426 ground rule triggered at the fourth copy: `buildCoverageClassificationSummary` existed in five places; #1921's merge folded Android/web/Linux onto `test/integration/support/coverage-classification.ts`, but tvOS (#1919) kept its private copy and macOS (#1922, merged after the shared module existed) added a fresh one. This folds the remaining two and drops their structurally identical local summary types (no external users — Linux set the pattern).

Net −60 lines, no behavior change: the shared builder is byte-identical logic, and both gates pin their exact counts.

## Validation

- `pnpm typecheck` green
- tvOS gate: 7/7 pass (`smoke-tvos-platform-coverage.test.ts`)
- `pnpm gate macos-coverage`: 0 fail
- `pnpm format` applied

Refs #1426