### PR TITLE
fix(test): drain session-event-log writes before rmSync cleanup in save-script transport tests

### DIFF
--- a/src/daemon/__tests__/request-save-script-transports.test.ts
+++ b/src/daemon/__tests__/request-save-script-transports.test.ts
@@ -31,6 +31,7 @@ import {
   skipWhenLoopbackUnavailable,
 } from '../../__tests__/test-utils/loopback.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { flushSessionEventLogWrites } from '../session-event-log.ts';
 
 const TOKEN = 'save-script-transport-token';
 const SESSION = 'save-script-transport';
@@ -53,7 +54,10 @@ type Harness = {
 
 const roots: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
+  // #1998: request handling queues fire-and-forget session-event-log appends;
+  // drain them before rmSync or a late append re-creates the dir → ENOTEMPTY.
+  await flushSessionEventLogWrites();
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing flake documented in #1996 ("Known pre-existing flake") and analyzed in #1998: `request-save-script-transports.test.ts` hit `ENOTEMPTY` in its own `afterEach` under coverage-shard load.

Every request the tests send queues a fire-and-forget session-event-log append (`queueEventLogWrite`: unawaited `mkdir -p` → rotate → `appendFile` into `sessions/<session>/events.ndjson`). The daemon response resolves before the write lands, so under load a pending append could re-create the session dir between `rmSync`'s unlink sweep and its rmdir — cleanup then fails with `ENOTEMPTY`.

The fix awaits the existing quiesce hook, `flushSessionEventLogWrites()`, at the top of the `afterEach` before removing the temp roots. One line plus the import.

Closes #1998

## Validation

- `pnpm vitest run src/daemon/__tests__/request-save-script-transports.test.ts` — 8/8 green, six consecutive runs.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` clean.

The race itself is timing-dependent (one occurrence on a loaded shard), so the runs above show no regression rather than proving the flake gone; the flush removes the ordering hazard by construction. #1998 notes the wider sweep (other daemon tests that drive `createRequestHandler` then `rmSync` a temp root) as follow-up.