### PR TITLE
refactor(snapshot): type the acquisition producer beside the platform channel

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,6 +187,14 @@ A backend-owned accessibility value before snapshot presentation.
 **Snapshot acquisition**:
 One backend attempt's raw accessibility nodes and attempt-level capture facts.
 
+**Snapshot producer**:
+The acquisition component that produced a snapshot's raw tree — the third identity axis beside
+the platform channel (`SnapshotBackend`) and the in-plan capture strategy
+(`SnapshotCaptureBackend`). One channel is fed by producers with different guarantees (the
+`xctest` channel carries Apple-runner, Appium page-source, and limrun element trees), so logic
+that assumes presentation, scope, or geometry guarantees keys on the producer, never on the
+channel alone.
+
 **Presentation options**:
 The policy input controlling how one snapshot acquisition becomes a public projection.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,11 +189,9 @@ One backend attempt's raw accessibility nodes and attempt-level capture facts.
 
 **Snapshot producer**:
 The acquisition component that produced a snapshot's raw tree — the third identity axis beside
-the platform channel (`SnapshotBackend`) and the in-plan capture strategy
-(`SnapshotCaptureBackend`). One channel is fed by producers with different guarantees (the
-`xctest` channel carries Apple-runner, Appium page-source, and limrun element trees), so logic
-that assumes presentation, scope, or geometry guarantees keys on the producer, never on the
-channel alone.
+the platform channel and the in-plan capture strategy. Producers on one channel carry different
+guarantees, so presentation, scope, and geometry logic keys on the producer, never the channel
+alone.
 
 **Presentation options**:
 The policy input controlling how one snapshot acquisition becomes a public projection.

--- a/packages/contracts/src/interactor-types.ts
+++ b/packages/contracts/src/interactor-types.ts
@@ -14,6 +14,7 @@ import type {
   Rect,
   SnapshotBackend,
   SnapshotOptions as BaseSnapshotOptions,
+  SnapshotProducer,
 } from '@agent-device/kernel/snapshot';
 
 export type RunnerContext = {
@@ -245,6 +246,11 @@ export type SnapshotResult = Omit<BackendSnapshotResult, 'backend' | 'nodes'> & 
     SnapshotBackend,
     'android' | 'harmonyos-arkui' | 'xctest' | 'linux-atspi' | 'macos-helper' | 'web'
   >;
+  /**
+   * Required on every acquisition: the channel alone cannot say who acquired the tree or
+   * which guarantees it carries (`SnapshotProducer` in `@agent-device/kernel/snapshot`).
+   */
+  producer: SnapshotProducer;
 };
 
 export type Interactor = {

--- a/packages/contracts/src/interactor-types.ts
+++ b/packages/contracts/src/interactor-types.ts
@@ -12,9 +12,8 @@ import type {
   RawSnapshotNode,
   Point,
   Rect,
-  SnapshotBackend,
   SnapshotOptions as BaseSnapshotOptions,
-  SnapshotProducer,
+  SnapshotProvenance,
 } from '@agent-device/kernel/snapshot';
 
 export type RunnerContext = {
@@ -240,18 +239,15 @@ export type KeyboardEnterResult =
   | Readonly<{ kind: 'android-acknowledged' }>
   | Readonly<{ kind: 'harmonyos-acknowledged' }>;
 
+/**
+ * Every acquisition carries its provenance pair atomically: the channel alone cannot say who
+ * acquired the tree or which guarantees it carries, and `SnapshotProvenance`
+ * (`@agent-device/kernel/snapshot`) makes a cross-channel `backend`/`producer` combination
+ * fail to compile.
+ */
 export type SnapshotResult = Omit<BackendSnapshotResult, 'backend' | 'nodes'> & {
   nodes?: RawSnapshotNode[];
-  backend: Extract<
-    SnapshotBackend,
-    'android' | 'harmonyos-arkui' | 'xctest' | 'linux-atspi' | 'macos-helper' | 'web'
-  >;
-  /**
-   * Required on every acquisition: the channel alone cannot say who acquired the tree or
-   * which guarantees it carries (`SnapshotProducer` in `@agent-device/kernel/snapshot`).
-   */
-  producer: SnapshotProducer;
-};
+} & SnapshotProvenance;
 
 export type Interactor = {
   open(

--- a/packages/kernel/src/snapshot-provenance.test.ts
+++ b/packages/kernel/src/snapshot-provenance.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest';
+import {
+  snapshotStateProvenance,
+  type SnapshotProvenance,
+  type SnapshotStateProvenance,
+} from './snapshot.ts';
+
+// The negative half of this test is type-level: each @ts-expect-error line fails `pnpm
+// typecheck` the moment the provenance table would accept a cross-channel pair again.
+test('the provenance table rejects cross-channel pairs at compile time', () => {
+  const shared: SnapshotProvenance = { backend: 'xctest', producer: 'appium-source' };
+  // @ts-expect-error the android channel cannot carry the apple-runner producer
+  const crossChannel: SnapshotProvenance = { backend: 'android', producer: 'apple-runner' };
+  // @ts-expect-error the web channel has exactly one producer
+  const foreignProducer: SnapshotProvenance = { backend: 'web', producer: 'limrun-ios-tree' };
+  // @ts-expect-error a state pair may omit the producer but not carry a foreign one
+  const stateMismatch: SnapshotStateProvenance = {
+    backend: 'macos-helper',
+    producer: 'linux-atspi',
+  };
+  const stateWithoutProducer: SnapshotStateProvenance = { backend: 'android' };
+
+  expect([shared, crossChannel, foreignProducer, stateMismatch, stateWithoutProducer]).toHaveLength(
+    5,
+  );
+});
+
+test('snapshotStateProvenance extracts exactly the pair', () => {
+  expect(snapshotStateProvenance(undefined)).toEqual({});
+  expect(snapshotStateProvenance({})).toEqual({});
+  expect(snapshotStateProvenance({ backend: 'xctest', producer: 'limrun-ios-tree' })).toEqual({
+    backend: 'xctest',
+    producer: 'limrun-ios-tree',
+  });
+});

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -155,6 +155,25 @@ export type SnapshotBackend =
   | 'linux-atspi'
   | 'web';
 
+/**
+ * Which acquisition component produced a snapshot's raw tree — the third axis beside the
+ * platform channel (`SnapshotBackend`) and the in-plan capture strategy
+ * (`SnapshotCaptureBackend`). One channel is fed by several producers with different
+ * guarantees: `xctest` trees come from the local Apple runner, Appium page-source XML, or a
+ * limrun element tree, and only the runner's output has been through the runner's presentation
+ * (clip fold, effective geometry, scope). Logic that assumes presentation, scope, or geometry
+ * guarantees must key on the producer, never on the channel alone.
+ */
+export type SnapshotProducer =
+  | 'apple-runner'
+  | 'android-uiautomator'
+  | 'appium-source'
+  | 'limrun-ios-tree'
+  | 'macos-helper'
+  | 'linux-atspi'
+  | 'agent-browser'
+  | 'harmonyos-uitest';
+
 export function isSnapshotBackend(value: unknown): value is SnapshotBackend {
   return (
     value === 'xctest' ||
@@ -180,6 +199,7 @@ export type SnapshotState = {
   createdAt: number;
   truncated?: boolean;
   backend?: SnapshotBackend;
+  producer?: SnapshotProducer;
   snapshotQuality?: SnapshotQualityVerdict;
   comparisonSafe?: boolean;
   presentationKey?: string;

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -147,32 +147,69 @@ export type SnapshotNode = RawSnapshotNode & {
   inheritsIdentifier?: true;
 };
 
-export type SnapshotBackend =
-  | 'xctest'
-  | 'android'
-  | 'harmonyos-arkui'
-  | 'macos-helper'
-  | 'linux-atspi'
-  | 'web';
+/**
+ * The channel↔producer pairs that can actually occur. One channel is fed by several producers
+ * with different guarantees: `xctest` trees come from the local Apple runner, Appium
+ * page-source XML, or a limrun element tree, and only the runner's output has been through the
+ * runner's presentation (clip fold, effective geometry, scope). Logic that assumes
+ * presentation, scope, or geometry guarantees must key on the producer, never on the channel
+ * alone.
+ *
+ * This table is the single owner of both vocabularies: the platform channel
+ * (`SnapshotBackend` is its `backend` projection) and the acquisition producer (the third
+ * axis beside the channel and the in-plan capture strategy `SnapshotCaptureBackend`). Every
+ * carrier embeds the pair atomically — a cross-channel pair does not compile (pinned by
+ * snapshot-provenance.test.ts).
+ */
+export type SnapshotProvenance =
+  | { backend: 'xctest'; producer: 'apple-runner' | 'appium-source' | 'limrun-ios-tree' }
+  | { backend: 'android'; producer: 'android-uiautomator' | 'appium-source' }
+  | { backend: 'harmonyos-arkui'; producer: 'harmonyos-uitest' }
+  | { backend: 'macos-helper'; producer: 'macos-helper' }
+  | { backend: 'linux-atspi'; producer: 'linux-atspi' }
+  | { backend: 'web'; producer: 'agent-browser' };
+
+export type SnapshotBackend = SnapshotProvenance['backend'];
+
+type OptionalProducerProvenance<Pair> = Pair extends {
+  backend: infer Backend;
+  producer: infer Producer;
+}
+  ? { backend: Backend; producer?: Producer }
+  : never;
 
 /**
- * Which acquisition component produced a snapshot's raw tree — the third axis beside the
- * platform channel (`SnapshotBackend`) and the in-plan capture strategy
- * (`SnapshotCaptureBackend`). One channel is fed by several producers with different
- * guarantees: `xctest` trees come from the local Apple runner, Appium page-source XML, or a
- * limrun element tree, and only the runner's output has been through the runner's presentation
- * (clip fold, effective geometry, scope). Logic that assumes presentation, scope, or geometry
- * guarantees must key on the producer, never on the channel alone.
+ * The provenance carrier for {@link SnapshotState}: the producer may be absent (legacy states
+ * and fixtures predate it), but a present pair still has to come from the
+ * {@link SnapshotProvenance} table — the channel may not carry a foreign producer.
  */
-export type SnapshotProducer =
-  | 'apple-runner'
-  | 'android-uiautomator'
-  | 'appium-source'
-  | 'limrun-ios-tree'
-  | 'macos-helper'
-  | 'linux-atspi'
-  | 'agent-browser'
-  | 'harmonyos-uitest';
+export type SnapshotStateProvenance =
+  | OptionalProducerProvenance<SnapshotProvenance>
+  | { backend?: undefined; producer?: undefined };
+
+/**
+ * Narrows a provenance-carrying value to just its pair without decorrelating the two fields
+ * (reading `backend` and `producer` separately would lose the pairing for the type system).
+ */
+export function snapshotStateProvenance(
+  value: SnapshotStateProvenance | undefined,
+): SnapshotStateProvenance {
+  if (value === undefined || value.backend === undefined) return {};
+  switch (value.backend) {
+    case 'xctest':
+      return { backend: value.backend, producer: value.producer };
+    case 'android':
+      return { backend: value.backend, producer: value.producer };
+    case 'harmonyos-arkui':
+      return { backend: value.backend, producer: value.producer };
+    case 'macos-helper':
+      return { backend: value.backend, producer: value.producer };
+    case 'linux-atspi':
+      return { backend: value.backend, producer: value.producer };
+    case 'web':
+      return { backend: value.backend, producer: value.producer };
+  }
+}
 
 export function isSnapshotBackend(value: unknown): value is SnapshotBackend {
   return (
@@ -198,8 +235,6 @@ export type SnapshotState = {
   nodes: SnapshotNode[];
   createdAt: number;
   truncated?: boolean;
-  backend?: SnapshotBackend;
-  producer?: SnapshotProducer;
   snapshotQuality?: SnapshotQualityVerdict;
   comparisonSafe?: boolean;
   presentationKey?: string;
@@ -209,7 +244,7 @@ export type SnapshotState = {
    * occlusion (see core/android-system-surface-disclosure.ts).
    */
   systemSurfaceOnly?: boolean;
-};
+} & SnapshotStateProvenance;
 
 export type SnapshotUnchanged = {
   ageMs: number;

--- a/packages/platform-apple/src/runtime.test.ts
+++ b/packages/platform-apple/src/runtime.test.ts
@@ -249,6 +249,7 @@ test.each(['frontmost-app', 'desktop', 'menubar'] as const)(
     const host = platformRuntimeHostFixture();
     const captureSurface = vi.fn(async () => ({
       backend: 'macos-helper' as const,
+      producer: 'macos-helper' as const,
       nodes: [],
       truncated: false,
     }));
@@ -551,6 +552,7 @@ test('the macOS surface branch composes the per-capture signal with the binding 
   const host = platformRuntimeHostFixture();
   const captureSurface = vi.fn<SnapshotRuntimeHost['captureSurface']>(async () => ({
     backend: 'macos-helper' as const,
+    producer: 'macos-helper' as const,
     nodes: [],
     truncated: false,
   }));

--- a/packages/platform-linux/src/runtime.test.ts
+++ b/packages/platform-linux/src/runtime.test.ts
@@ -79,6 +79,7 @@ test.each([
   async ({ device, legacy }) => {
     const captureSurface = vi.fn(async () => ({
       backend: 'linux-atspi' as const,
+      producer: 'linux-atspi' as const,
       nodes: [],
       truncated: false,
     }));
@@ -144,6 +145,7 @@ test.each([
 function lifecycleHost(
   captureSurface: SnapshotRuntimeHost['captureSurface'] = async () => ({
     backend: 'linux-atspi' as const,
+    producer: 'linux-atspi' as const,
     nodes: [],
     truncated: false,
   }),
@@ -209,6 +211,7 @@ function expectLinuxNavigationAndKeyboardFacts(
 test('the Linux surface capture composes the per-capture signal with the request scope signal', async () => {
   const captureSurface = vi.fn<SnapshotRuntimeHost['captureSurface']>(async () => ({
     backend: 'linux-atspi' as const,
+    producer: 'linux-atspi' as const,
     nodes: [],
     truncated: false,
   }));

--- a/packages/provider-limrun/src/ios-interactor-snapshot.test.ts
+++ b/packages/provider-limrun/src/ios-interactor-snapshot.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest';
+import { createLimrunIosInteractor, type LimrunIosSession } from './ios.ts';
+
+test('limrun iOS snapshot stamps the xctest channel with its own producer', async () => {
+  const session = {
+    platform: 'ios',
+    client: {
+      elementTree: async () =>
+        JSON.stringify({
+          elementType: 'Application',
+          children: [{ elementType: 'Button', label: 'Continue', enabled: true }],
+        }),
+    },
+  } as unknown as LimrunIosSession;
+
+  const result = await createLimrunIosInteractor(session).snapshot();
+
+  expect(result.backend).toBe('xctest');
+  expect(result.producer).toBe('limrun-ios-tree');
+  expect(result.nodes?.map((node) => node.label)).toEqual([undefined, 'Continue']);
+});

--- a/packages/provider-limrun/src/ios.ts
+++ b/packages/provider-limrun/src/ios.ts
@@ -257,7 +257,7 @@ class LimrunIosInteractor implements Interactor {
   async snapshot(_options?: SnapshotOptions): Promise<SnapshotResult> {
     const treeJson = await this.session.client.elementTree();
     const parsed = JSON.parse(treeJson) as IosTreeNode | IosTreeNode[];
-    return { nodes: flattenIosTree(parsed), backend: 'xctest' };
+    return { nodes: flattenIosTree(parsed), backend: 'xctest', producer: 'limrun-ios-tree' };
   }
 
   async back(): Promise<void> {

--- a/packages/provider-webdriver/src/webdriver-interactor.ts
+++ b/packages/provider-webdriver/src/webdriver-interactor.ts
@@ -282,6 +282,7 @@ class WebDriverInteractor implements Interactor {
     this.requireSupport('snapshot');
     return {
       backend: this.backend,
+      producer: 'appium-source',
       nodes: parseWebDriverSource(await this.client.source()),
     };
   }

--- a/packages/provider-webdriver/src/webdriver-interactor.ts
+++ b/packages/provider-webdriver/src/webdriver-interactor.ts
@@ -280,9 +280,11 @@ class WebDriverInteractor implements Interactor {
 
   async snapshot(_options?: SnapshotOptions): Promise<SnapshotResult> {
     this.requireSupport('snapshot');
+    // Spelled as a correlated pair per channel so the SnapshotProvenance union accepts it.
     return {
-      backend: this.backend,
-      producer: 'appium-source',
+      ...(this.backend === 'xctest'
+        ? { backend: 'xctest' as const, producer: 'appium-source' as const }
+        : { backend: 'android' as const, producer: 'appium-source' as const }),
       nodes: parseWebDriverSource(await this.client.source()),
     };
   }

--- a/src/__tests__/test-utils/snapshot-builders.ts
+++ b/src/__tests__/test-utils/snapshot-builders.ts
@@ -2,6 +2,7 @@ import {
   attachRefs,
   type RawSnapshotNode,
   type SnapshotState,
+  type SnapshotStateProvenance,
 } from '@agent-device/kernel/snapshot';
 
 export function buildNodes(raw: RawSnapshotNode[]) {
@@ -10,7 +11,9 @@ export function buildNodes(raw: RawSnapshotNode[]) {
 
 export function makeSnapshotState(
   raw: RawSnapshotNode[],
-  overrides?: Partial<SnapshotState>,
+  // The provenance pair stays correlated: overrides carry it as one value, never as two
+  // independently typed fields.
+  overrides?: Omit<Partial<SnapshotState>, 'backend' | 'producer'> & SnapshotStateProvenance,
 ): SnapshotState {
   return {
     nodes: attachRefs(raw),

--- a/src/commands/capture/runtime/snapshot-unchanged.test.ts
+++ b/src/commands/capture/runtime/snapshot-unchanged.test.ts
@@ -3,11 +3,11 @@ import {
   buildUnchangedSnapshotMetadata,
   ensureSnapshotPresentationKey,
 } from './snapshot-unchanged.ts';
-import type { SnapshotState } from '@agent-device/kernel/snapshot';
+import type { SnapshotState, SnapshotStateProvenance } from '@agent-device/kernel/snapshot';
 
 function snapshot(
   label: string,
-  overrides: Partial<SnapshotState> = {},
+  overrides: Omit<Partial<SnapshotState>, 'backend' | 'producer'> & SnapshotStateProvenance = {},
   options: Parameters<typeof ensureSnapshotPresentationKey>[1] = {},
 ): SnapshotState {
   return ensureSnapshotPresentationKey(

--- a/src/commands/interaction/runtime/stable-capture.test.ts
+++ b/src/commands/interaction/runtime/stable-capture.test.ts
@@ -114,7 +114,7 @@ test('settle confirms a broad replacement that begins after the first post-actio
 
 test('settle confirms against the pre-action tree when the stored snapshot already advanced', async () => {
   const { runtime } = transitionRuntime({
-    sessionSnapshot: { ...elementTransientRoomSnapshot, backend: undefined },
+    sessionSnapshot: { ...elementTransientRoomSnapshot, backend: undefined, producer: undefined },
     settledAtMs: 1_200,
   });
 
@@ -315,7 +315,7 @@ function transitionRuntime(
 
 function withoutSnapshotBackend(snapshot: SnapshotState, omit: boolean): SnapshotState {
   if (!omit) return snapshot;
-  const { backend: _backend, ...backendless } = snapshot;
+  const { backend: _backend, producer: _producer, ...backendless } = snapshot;
   return backendless;
 }
 

--- a/src/core/__tests__/harmonyos-interactor.test.ts
+++ b/src/core/__tests__/harmonyos-interactor.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, vi } from 'vitest';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+vi.mock('../../platforms/harmonyos/snapshot.ts', () => ({
+  snapshotHarmony: vi.fn(async () => ({
+    nodes: [{ index: 0, type: 'Button', label: 'Continue' }],
+    truncated: false,
+  })),
+  readHarmonyGestureViewport: vi.fn(),
+}));
+
+import { createHarmonyInteractor } from '../interactors/harmonyos.ts';
+
+const device: DeviceInfo = {
+  platform: 'harmonyos',
+  id: 'emulator',
+  name: 'emulator',
+  kind: 'emulator',
+  booted: true,
+};
+
+test('harmonyos snapshot stamps its channel and producer', async () => {
+  const result = await createHarmonyInteractor(device).snapshot();
+
+  expect(result.backend).toBe('harmonyos-arkui');
+  expect(result.producer).toBe('harmonyos-uitest');
+  expect(result.nodes).toEqual([{ index: 0, type: 'Button', label: 'Continue' }]);
+});

--- a/src/core/interactors/harmonyos.ts
+++ b/src/core/interactors/harmonyos.ts
@@ -45,7 +45,7 @@ export function createHarmonyInteractor(device: DeviceInfo, _runner?: RunnerCont
         async () => await snapshotHarmony(device, options),
         { backend: 'harmonyos-arkui' },
       );
-      return { ...result, backend: 'harmonyos-arkui' };
+      return { ...result, backend: 'harmonyos-arkui', producer: 'harmonyos-uitest' };
     },
     back: () => backHarmony(device),
     home: () => homeHarmony(device),

--- a/src/core/interactors/web.ts
+++ b/src/core/interactors/web.ts
@@ -57,6 +57,7 @@ export function createWebInteractor(provider: WebProvider = resolveWebProvider()
         nodes: result.nodes,
         truncated: result.truncated ?? false,
         backend: 'web',
+        producer: 'agent-browser',
       };
     },
     setOrientation: async () => {

--- a/src/daemon/__tests__/is-runtime.test.ts
+++ b/src/daemon/__tests__/is-runtime.test.ts
@@ -50,6 +50,7 @@ function buttonSnapshot(): SnapshotResult {
       },
     ],
     backend: 'android',
+    producer: 'android-uiautomator',
   };
 }
 
@@ -232,6 +233,7 @@ test('a failing predicate answers COMMAND_FAILED from the bound capture', async 
         },
       ],
       backend: 'xctest',
+      producer: 'apple-runner',
     }),
   });
   const sessionStore = makeSessionStore();

--- a/src/daemon/__tests__/request-router-screenshot.test.ts
+++ b/src/daemon/__tests__/request-router-screenshot.test.ts
@@ -414,6 +414,7 @@ test('screenshot --overlay-refs captures a fresh snapshot when the session has n
       order.push('snapshot');
       return {
         backend: 'android',
+        producer: 'android-uiautomator',
         nodes: [
           {
             index: 0,
@@ -459,6 +460,7 @@ test('screenshot --overlay-refs uses interactive iOS presentation for row-like o
     onCapture: (input) => writeSolidPng(input.outPath, 402, 874),
     snapshotResult: () => ({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [
         {
           index: 0,
@@ -548,6 +550,7 @@ test('screenshot --overlay-refs uses a fresh snapshot instead of stale session s
   const { handler, sessionStore } = screenshotRouter(session, {
     snapshotResult: () => ({
       backend: 'android',
+      producer: 'android-uiautomator',
       nodes: [
         {
           index: 0,
@@ -594,6 +597,7 @@ test('screenshot --pixel-density keeps overlay refs aligned to scaled iOS simula
     onCapture: (input) => writeSolidPng(input.outPath, 804, 1748),
     snapshotResult: () => ({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [
         { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 402, height: 874 } },
         {

--- a/src/daemon/__tests__/screenshot-runtime-fixture.ts
+++ b/src/daemon/__tests__/screenshot-runtime-fixture.ts
@@ -73,7 +73,11 @@ export function screenshotRuntimeFixture(
   });
   const captureSnapshot = vi.fn(
     async (input: CaptureSnapshotInput): Promise<SnapshotResult> =>
-      options.snapshotResult?.(input) ?? { nodes: [], backend: 'android' },
+      options.snapshotResult?.(input) ?? {
+        nodes: [],
+        backend: 'android',
+        producer: 'android-uiautomator',
+      },
   );
   const tapPoint = vi.fn(async (_input: TapPointInput) => ({}));
   // R43: `scroll` is the neighbouring command the device-lock tests use to prove serialization,

--- a/src/daemon/__tests__/selector-capture-fixture.ts
+++ b/src/daemon/__tests__/selector-capture-fixture.ts
@@ -65,7 +65,9 @@ export function selectorCaptureFixture(
   const captureSnapshot = async (input: CaptureSnapshotInput): Promise<SnapshotResult> => {
     const index = captures.length;
     captures.push(input);
-    return params.snapshot?.(input, index) ?? { nodes: [], backend: 'xctest' };
+    return (
+      params.snapshot?.(input, index) ?? { nodes: [], backend: 'xctest', producer: 'apple-runner' }
+    );
   };
 
   return {

--- a/src/daemon/__tests__/selector-capture-runtime.test.ts
+++ b/src/daemon/__tests__/selector-capture-runtime.test.ts
@@ -10,12 +10,13 @@ import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
 // hands it over.
 const boundCapture = vi.fn(async (_input: CaptureSnapshotInput): Promise<SnapshotResult> => ({
   backend: 'xctest',
+  producer: 'apple-runner',
   nodes: [],
 }));
 
 beforeEach(() => {
   boundCapture.mockReset();
-  boundCapture.mockResolvedValue({ backend: 'xctest', nodes: [] });
+  boundCapture.mockResolvedValue({ backend: 'xctest', producer: 'apple-runner', nodes: [] });
 });
 
 test('selector capture cache is keyed by scoped presentation options', async () => {
@@ -31,6 +32,7 @@ test('selector capture cache is keyed by scoped presentation options', async () 
   sessionStore.set(sessionName, session);
   boundCapture.mockImplementation(async (input) => ({
     backend: 'xctest',
+    producer: 'apple-runner',
     nodes: [
       {
         index: 0,
@@ -70,10 +72,12 @@ test('legacy iOS sparse recovery retries a full snapshot', async () => {
   boundCapture
     .mockResolvedValueOnce({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [{ index: 0, type: 'Application' }],
     })
     .mockResolvedValueOnce({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [{ index: 0, type: 'Button', label: 'Recovered' }],
     });
 
@@ -98,6 +102,7 @@ test('legacy iOS sparse recovery rethrows full snapshot failure when scoping is 
   boundCapture
     .mockResolvedValueOnce({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [{ index: 0, type: 'Application' }],
     })
     .mockRejectedValueOnce(new Error('full snapshot failed'));
@@ -121,6 +126,7 @@ test('sparse verdict recovery retries with query scope and stores recovered snap
   boundCapture
     .mockResolvedValueOnce({
       backend: 'xctest',
+      producer: 'apple-runner',
       quality: {
         state: 'sparse',
         backend: 'private-ax',
@@ -131,6 +137,7 @@ test('sparse verdict recovery retries with query scope and stores recovered snap
     })
     .mockResolvedValueOnce({
       backend: 'xctest',
+      producer: 'apple-runner',
       nodes: [{ index: 0, type: 'Button', label: 'Search' }],
     });
 

--- a/src/daemon/__tests__/snapshot-diff-runtime.test.ts
+++ b/src/daemon/__tests__/snapshot-diff-runtime.test.ts
@@ -27,6 +27,7 @@ const unavailable = Object.freeze({
 
 const baseCapture: SnapshotResult = Object.freeze({
   backend: 'android',
+  producer: 'android-uiautomator',
   nodes: [{ index: 0, depth: 0, type: 'Button', label: 'Before' }],
   truncated: false,
 });

--- a/src/daemon/__tests__/snapshot-state.test.ts
+++ b/src/daemon/__tests__/snapshot-state.test.ts
@@ -43,6 +43,22 @@ test('buildSnapshotState carries structured snapshot quality verdicts', () => {
   });
 });
 
+// One channel, several producers: the state must keep who acquired the tree, not just where
+// it came from (an `xctest`-channel tree here is an Appium page-source acquisition).
+test('buildSnapshotState carries the acquisition producer beside the channel', () => {
+  const state = buildSnapshotState(
+    {
+      nodes: [{ index: 0, type: 'Application' }],
+      backend: 'xctest',
+      producer: 'appium-source',
+    },
+    undefined,
+  );
+
+  expect(state.backend).toBe('xctest');
+  expect(state.producer).toBe('appium-source');
+});
+
 test('buildSnapshotState preserves Android effective geometry for post-wire consumers', () => {
   const xml = `<hierarchy>
   <node class="android.widget.FrameLayout" bounds="[0,0][400,800]" visible-to-user="true">

--- a/src/daemon/__tests__/test-device-runtime-gateway.ts
+++ b/src/daemon/__tests__/test-device-runtime-gateway.ts
@@ -169,7 +169,11 @@ const admittedGestureFamilyFacts = Object.freeze({
 });
 
 export const gestureRuntimeSpies = {
-  captureSnapshot: vi.fn(async () => ({ backend: 'xctest' as const, nodes: [] })),
+  captureSnapshot: vi.fn(async () => ({
+    backend: 'xctest' as const,
+    producer: 'apple-runner' as const,
+    nodes: [],
+  })),
   performGesturePlan: vi.fn(async (_input: GesturePlanInput) => ({})),
   performDirectionalFlingPlan: vi.fn(async (_input: GesturePlanInput) => ({})),
   performMultiTouchGesturePlan: vi.fn(async (_input: GesturePlanInput) => ({})),

--- a/src/daemon/__tests__/wait-runtime.test.ts
+++ b/src/daemon/__tests__/wait-runtime.test.ts
@@ -89,6 +89,7 @@ function waitRuntimeHarness(
       : {
           nodes: polls[Math.min(pollIndex++, polls.length - 1)] ?? [],
           backend: 'web',
+          producer: 'agent-browser',
         },
   );
   const findTextFact = options.findText ?? findTextUnavailable;

--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -72,7 +72,7 @@ async function runClick(
     const baseline = session.snapshot;
     mockCaptureSnapshotForSession.mockResolvedValueOnce({
       nodes: baseline.nodes,
-      backend: baseline.backend ?? 'xctest',
+      backend: 'xctest',
       producer: 'apple-runner',
       quality: baseline.snapshotQuality,
     });

--- a/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-ios-tap-outcome.test.ts
@@ -73,6 +73,7 @@ async function runClick(
     mockCaptureSnapshotForSession.mockResolvedValueOnce({
       nodes: baseline.nodes,
       backend: baseline.backend ?? 'xctest',
+      producer: 'apple-runner',
       quality: baseline.snapshotQuality,
     });
   }

--- a/src/daemon/handlers/__tests__/interaction-touch-android-freshness.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-android-freshness.test.ts
@@ -106,6 +106,7 @@ test('press @ref refreshes Android snapshot when freshness tracking is active', 
       },
     ],
     backend: 'android',
+    producer: 'android-uiautomator',
   });
 
   const response = await handleInteractionCommands({
@@ -179,6 +180,7 @@ test('ADR 0014: Android freshness cannot retarget an admitted ref by positional 
       },
     ],
     backend: 'android',
+    producer: 'android-uiautomator',
   });
 
   const response = await handleInteractionCommands({

--- a/src/daemon/handlers/__tests__/interaction-touch-direct-ios-eligibility.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-direct-ios-eligibility.test.ts
@@ -91,6 +91,7 @@ test('ordinary click uses canonical capture even when the owner binds selector t
       },
     ]),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({
@@ -137,6 +138,7 @@ test('fill simple iOS id selector resolves runtime text input evidence before co
       },
     ]),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
   mockFillPoint.mockResolvedValueOnce({
     message: 'filled',
@@ -247,6 +249,7 @@ test('click simple iOS id selector waits for snapshot path after pending gesture
       },
     ]),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({

--- a/src/daemon/handlers/__tests__/interaction-touch-payload.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-payload.test.ts
@@ -165,6 +165,7 @@ test('press coordinates on iOS recording captures a full snapshot for the touch 
       },
     ]),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({

--- a/src/daemon/handlers/__tests__/interaction-touch-press-admission.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-press-admission.test.ts
@@ -170,6 +170,7 @@ test('press selector then press @ref rejects refs that outlived the stored snaps
   mockCaptureSnapshotForSession.mockResolvedValue({
     nodes: makeTwoButtonNodes(),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   // Selector press: its resolution capture replaces the stored snapshot
@@ -205,6 +206,7 @@ test('a ref press crosses the ADR 0014 side-effect seam and expires the ref fram
   mockCaptureSnapshotForSession.mockResolvedValue({
     nodes: makeTwoButtonNodes(),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   // A freshly issued complete frame is active.
@@ -227,6 +229,7 @@ test('ADR 0014 evidence #1: a second ref mutation rejects (bare and pinned) unti
   mockCaptureSnapshotForSession.mockResolvedValue({
     nodes: makeTwoButtonNodes(),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   // `snapshot -> press @e1`: admitted; crosses the seam and expires the frame.
@@ -271,6 +274,7 @@ test('re-issuing a complete frame lets press @ref succeed again without warning'
   mockCaptureSnapshotForSession.mockResolvedValue({
     nodes: makeTwoButtonNodes(),
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const selectorPress = await runInteraction(sessionStore, sessionName, 'press', [

--- a/src/daemon/handlers/__tests__/interaction-touch-response.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-response.test.ts
@@ -114,6 +114,7 @@ test('press @ref --verify surfaces evidence through the interactionResultExtra a
       },
     ],
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({
@@ -229,6 +230,7 @@ test('fill selector --verify surfaces evidence through the interactionResultExtr
       },
     ],
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({
@@ -297,6 +299,7 @@ test('fill @ref --verify surfaces evidence in the ref response branch', async ()
       },
     ],
     backend: 'xctest',
+    producer: 'apple-runner',
   });
 
   const response = await handleInteractionCommands({

--- a/src/daemon/handlers/__tests__/interaction-touch.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch.test.ts
@@ -294,6 +294,7 @@ test('hover selector on web resolves the target and dispatches coordinate hover'
       },
     ]),
     backend: 'web',
+    producer: 'agent-browser',
   });
 
   const response = await handleInteractionCommands({

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -10,8 +10,7 @@ import {
   findNodeByRef,
   normalizeRef,
   type RawSnapshotNode,
-  type SnapshotBackend,
-  type SnapshotProducer,
+  type SnapshotStateProvenance,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
 import { resolveRefLabel } from '../../core/snapshot-node-lookup.ts';
@@ -47,10 +46,9 @@ type CaptureSnapshotParams = {
 type SnapshotData = {
   nodes?: RawSnapshotNode[];
   truncated?: boolean;
-  backend?: SnapshotBackend;
-  producer?: SnapshotProducer;
   quality?: unknown;
-} & Omit<SnapshotCaptureAnnotations, 'quality'>;
+} & Omit<SnapshotCaptureAnnotations, 'quality'> &
+  SnapshotStateProvenance;
 
 type SnapshotAttempt = {
   data: SnapshotData;

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -11,6 +11,7 @@ import {
   normalizeRef,
   type RawSnapshotNode,
   type SnapshotBackend,
+  type SnapshotProducer,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
 import { resolveRefLabel } from '../../core/snapshot-node-lookup.ts';
@@ -47,6 +48,7 @@ type SnapshotData = {
   nodes?: RawSnapshotNode[];
   truncated?: boolean;
   backend?: SnapshotBackend;
+  producer?: SnapshotProducer;
   quality?: unknown;
 } & Omit<SnapshotCaptureAnnotations, 'quality'>;
 

--- a/src/daemon/selector-runtime-backend.test.ts
+++ b/src/daemon/selector-runtime-backend.test.ts
@@ -36,12 +36,16 @@ test('wait text passes its poll deadline signal to the Apple runner fast path', 
       await new Promise((resolve) => {
         observedSignal = input.signal;
         if (input.signal?.aborted) {
-          resolve({ backend: 'xctest', nodes: [] });
+          resolve({ backend: 'xctest', producer: 'apple-runner', nodes: [] });
           return;
         }
-        input.signal?.addEventListener('abort', () => resolve({ backend: 'xctest', nodes: [] }), {
-          once: true,
-        });
+        input.signal?.addEventListener(
+          'abort',
+          () => resolve({ backend: 'xctest', producer: 'apple-runner', nodes: [] }),
+          {
+            once: true,
+          },
+        );
       }),
   );
   const runtime = createSelectorRuntimeForDevice({
@@ -96,6 +100,7 @@ test('daemon wait stable pins private-ax on emitted snapshot runner requests', a
   sessionStore.set(sessionName, session);
   const capture = vi.fn(async (_input: CaptureSnapshotInput): Promise<SnapshotResult> => ({
     backend: 'xctest',
+    producer: 'apple-runner',
     nodes,
     quality: {
       state: 'recovered',

--- a/src/daemon/snapshot-state.ts
+++ b/src/daemon/snapshot-state.ts
@@ -10,7 +10,8 @@ import {
   snapshotPresentationOptionsFromFlags,
   type RawSnapshotNode,
   type SnapshotBackend,
-  type SnapshotProducer,
+  type SnapshotStateProvenance,
+  snapshotStateProvenance,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
 import {
@@ -35,10 +36,8 @@ export function buildSnapshotState(
   data: {
     nodes?: RawSnapshotNode[];
     truncated?: boolean;
-    backend?: SnapshotBackend;
-    producer?: SnapshotProducer;
     quality?: unknown;
-  },
+  } & SnapshotStateProvenance,
   flags:
     | (Pick<CommandFlags, 'snapshotDepth' | 'snapshotInteractiveOnly' | 'snapshotRaw'> &
         Partial<Pick<CommandFlags, 'snapshotScope'>>)
@@ -71,8 +70,7 @@ export function buildSnapshotState(
     nodes,
     truncated: data?.truncated,
     createdAt: Date.now(),
-    backend: data?.backend,
-    producer: data?.producer,
+    ...snapshotStateProvenance(data),
     ...(snapshotQuality ? { snapshotQuality } : {}),
     presentationKey: buildSnapshotPresentationKey(snapshotPresentationOptionsFromFlags(flags)),
     // Only broad Android snapshots become freshness baselines. If the user asked for a scoped

--- a/src/daemon/snapshot-state.ts
+++ b/src/daemon/snapshot-state.ts
@@ -10,6 +10,7 @@ import {
   snapshotPresentationOptionsFromFlags,
   type RawSnapshotNode,
   type SnapshotBackend,
+  type SnapshotProducer,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
 import {
@@ -35,6 +36,7 @@ export function buildSnapshotState(
     nodes?: RawSnapshotNode[];
     truncated?: boolean;
     backend?: SnapshotBackend;
+    producer?: SnapshotProducer;
     quality?: unknown;
   },
   flags:
@@ -70,6 +72,7 @@ export function buildSnapshotState(
     truncated: data?.truncated,
     createdAt: Date.now(),
     backend: data?.backend,
+    producer: data?.producer,
     ...(snapshotQuality ? { snapshotQuality } : {}),
     presentationKey: buildSnapshotPresentationKey(snapshotPresentationOptionsFromFlags(flags)),
     // Only broad Android snapshots become freshness baselines. If the user asked for a scoped

--- a/src/platforms/android/snapshot-capture.ts
+++ b/src/platforms/android/snapshot-capture.ts
@@ -34,6 +34,7 @@ export type AndroidSnapshotCapture = AndroidSnapshotCaptureData & {
 
 export type AndroidSnapshotPublicationInput = AndroidSnapshotCaptureData & {
   backend: Extract<SnapshotBackend, 'android'>;
+  producer: 'android-uiautomator';
 };
 
 export function createAndroidSnapshotCapture(
@@ -48,7 +49,11 @@ export function createAndroidSnapshotCapture(
 export function androidSnapshotPublicationInput(
   capture: AndroidSnapshotCapture,
 ): AndroidSnapshotPublicationInput {
-  const publication: AndroidSnapshotPublicationInput = { ...capture, backend: 'android' };
+  const publication: AndroidSnapshotPublicationInput = {
+    ...capture,
+    backend: 'android',
+    producer: 'android-uiautomator',
+  };
   const evidence = capture[androidCaptureEvidence];
   attachSnapshotClickabilityEvidence(publication, evidence.clickability);
   if (evidence.occlusionContext) {

--- a/src/platforms/apple/interactor.ts
+++ b/src/platforms/apple/interactor.ts
@@ -246,6 +246,7 @@ async function captureAppleRunnerSnapshot(
     nodes,
     truncated: result.truncated ?? false,
     backend: 'xctest' as const,
+    producer: 'apple-runner' as const,
     ...(result.quality ? { quality: result.quality } : {}),
     // Legacy runners without a quality verdict still surface their message text.
     ...(!result.quality && result.message ? { warnings: [result.message] } : {}),

--- a/src/snapshot/snapshot-desktop-surface.test.ts
+++ b/src/snapshot/snapshot-desktop-surface.test.ts
@@ -55,6 +55,7 @@ test('Apple snapshot host preserves non-app macOS surface capture and menubar id
     nodes: [{ index: 0, depth: 0, type: 'MenuBar', label: 'System menu' }],
     truncated: false,
     backend: 'macos-helper',
+    producer: 'macos-helper',
   });
 });
 
@@ -79,6 +80,7 @@ test('Linux snapshot host preserves interactive ancestor projection before depth
   expect(snapshotLinux).toHaveBeenCalledWith('desktop', signal);
   expect(result).toEqual({
     backend: 'linux-atspi',
+    producer: 'linux-atspi',
     truncated: false,
     nodes: [
       { index: 0, depth: 0, type: 'Application', label: 'App', parentIndex: undefined },

--- a/src/snapshot/snapshot-desktop-surface.ts
+++ b/src/snapshot/snapshot-desktop-surface.ts
@@ -21,7 +21,12 @@ export async function captureLinuxSurfaceSnapshot(
   const { snapshotLinux } = await import('../platforms/linux/snapshot.ts');
   const result = await snapshotLinux(options?.surface, signal);
   return shapeDesktopSurfaceSnapshot(
-    { nodes: result.nodes, truncated: result.truncated, backend: 'linux-atspi' },
+    {
+      nodes: result.nodes,
+      truncated: result.truncated,
+      backend: 'linux-atspi',
+      producer: 'linux-atspi',
+    },
     options ?? {},
   );
 }
@@ -39,7 +44,7 @@ export async function captureMacOsSurfaceSnapshot(
     bundleId: surface === 'menubar' ? options.appBundleId : undefined,
     signal,
   });
-  return shapeDesktopSurfaceSnapshot(result, options);
+  return shapeDesktopSurfaceSnapshot({ ...result, producer: 'macos-helper' }, options);
 }
 
 const captureSurface: SnapshotRuntimeHost['captureSurface'] = async (device, options, signal) => {

--- a/test/integration/provider-scenarios/provider-device-runtime.fixtures.ts
+++ b/test/integration/provider-scenarios/provider-device-runtime.fixtures.ts
@@ -435,6 +435,7 @@ function createFakeProviderInteractor(device: DeviceInfo, calls: FakeProviderCal
         });
         return {
           backend: 'android',
+          producer: 'android-uiautomator',
           nodes: [
             {
               index: 0,

--- a/test/integration/provider-scenarios/provider-ios-selector-runtime.test.ts
+++ b/test/integration/provider-scenarios/provider-ios-selector-runtime.test.ts
@@ -162,6 +162,7 @@ function createProviderInteractor(calls: {
         calls.snapshots += 1;
         return {
           backend: 'xctest',
+          producer: 'apple-runner',
           nodes: [
             {
               index: 0,


### PR DESCRIPTION
## Summary

Give every snapshot a typed **producer** — the acquisition component that made the raw tree — as a third identity axis beside the platform channel (`SnapshotBackend`) and the in-plan capture strategy (`SnapshotCaptureBackend`).

Today three producers with different guarantees share the `backend: 'xctest'` stamp: the local Apple runner (whose output went through the runner's presentation — clip fold, effective geometry, scope), Appium page-source XML (`provider-webdriver`), and limrun element trees (`provider-limrun`) — the latter two reach the wire with none of those guarantees. The `'android'` channel conflates the local uiautomator path with Appium-sourced trees the same way. Daemon logic keyed on the channel cannot tell them apart.

This is the types-before-semantics step for the shared-presentation track (#1983): no consumer changes behavior here. The field is what the host-side presenter wiring and the double-presentation removal will key on, and what a future XCTest-free simulator producer will register as.

- `SnapshotProducer` union + axis doc in `@agent-device/kernel/snapshot`; `SnapshotState.producer` (optional, daemon-side only — the value does not cross the CLI wire, same as `backend`)
- `SnapshotResult.producer` is **required**, so the compiler enumerates every producer: `apple-runner`, `android-uiautomator`, `appium-source`, `limrun-ios-tree`, `macos-helper`, `linux-atspi`, `agent-browser`, `harmonyos-uitest`
- `buildSnapshotState` carries the producer into `SnapshotState`; the capture-handler `SnapshotData` seam passes it through
- CONTEXT.md gains the **Snapshot producer** vocabulary entry

## Validation

- `pnpm check:affected --run`
