### PR TITLE
perf(daemon): revalidate the source code-signature cache by stat instead of rereading the graph

### DIFF
--- a/packages/contracts/src/facades/divergence.ts
+++ b/packages/contracts/src/facades/divergence.ts
@@ -8,6 +8,7 @@ export {
   createReplayDivergenceSanitizer,
   formatReplayDivergenceReport,
   measureReplayDivergenceBytes,
+  readReplayDivergenceResume,
   sanitizeReplayDivergenceField,
   scrubReplayVarValues,
   truncateUtf8Field,

--- a/packages/contracts/src/replay-divergence.test.ts
+++ b/packages/contracts/src/replay-divergence.test.ts
@@ -4,6 +4,7 @@ import {
   applyReplayDivergenceLevelCaps,
   boundReplayDivergence,
   measureReplayDivergenceBytes,
+  readReplayDivergenceResume,
   sanitizeReplayDivergenceField,
   REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT,
   REPLAY_DIVERGENCE_DIGEST_REF_LIMIT,
@@ -886,3 +887,44 @@ test('formatReplayDivergenceReport OMITS the diagnostics clause for manual when 
   assert.ok(report);
   assert.doesNotMatch(report!, /Read-only inspection/);
 });
+
+// --- readReplayDivergenceResume: the one narrowing of `details.divergence.resume`
+// (ADR 0012 decision 6). The daemon stamps `resume.repairSessionHeld` through
+// this reader and the client keys its keep-alive on the record it returns, so
+// both ends admit exactly the same payloads. ---
+
+test('readReplayDivergenceResume returns the live record so an in-place stamp is observable', () => {
+  const divergence = { resume: { allowed: true, from: 3, planDigest: 'digest-abc' } };
+
+  const resume = readReplayDivergenceResume(divergence);
+  assert.ok(resume);
+  assert.equal(resume, divergence.resume);
+
+  resume.repairSessionHeld = true;
+  assert.equal(readReplayDivergenceResume(divergence)?.repairSessionHeld, true);
+});
+
+test('readReplayDivergenceResume accepts a non-resumable divergence carrying its reason', () => {
+  const resume = readReplayDivergenceResume({
+    resume: { allowed: false, from: 2, planDigest: 'digest-x', reason: 'output-env-skip' },
+  });
+
+  assert.equal(resume?.allowed, false);
+});
+
+const UNREADABLE_DIVERGENCE_PAYLOADS: [label: string, payload: unknown][] = [
+  ['undefined', undefined],
+  ['a non-record', 'REPLAY_DIVERGENCE'],
+  ['a divergence without resume', { kind: 'selector-miss' }],
+  ['a non-record resume', { resume: 'held' }],
+  ['a resume without allowed', { resume: { from: 1, planDigest: 'd' } }],
+  ['a fractional from', { resume: { allowed: true, from: 1.5, planDigest: 'd' } }],
+  ['a missing planDigest', { resume: { allowed: true, from: 1 } }],
+  ['a blocked resume without reason', { resume: { allowed: false, from: 1, planDigest: 'd' } }],
+];
+
+for (const [label, payload] of UNREADABLE_DIVERGENCE_PAYLOADS) {
+  test(`readReplayDivergenceResume rejects ${label}`, () => {
+    assert.equal(readReplayDivergenceResume(payload), undefined);
+  });
+}

--- a/packages/contracts/src/replay-divergence.test.ts
+++ b/packages/contracts/src/replay-divergence.test.ts
@@ -921,6 +921,14 @@ const UNREADABLE_DIVERGENCE_PAYLOADS: [label: string, payload: unknown][] = [
   ['a fractional from', { resume: { allowed: true, from: 1.5, planDigest: 'd' } }],
   ['a missing planDigest', { resume: { allowed: true, from: 1 } }],
   ['a blocked resume without reason', { resume: { allowed: false, from: 1, planDigest: 'd' } }],
+  [
+    'a non-true repairSessionHeld',
+    { resume: { allowed: true, from: 1, planDigest: 'd', repairSessionHeld: 'yes' } },
+  ],
+  [
+    'a fractional alternateFrom',
+    { resume: { allowed: true, from: 1, planDigest: 'd', alternateFrom: 2.5 } },
+  ],
 ];
 
 for (const [label, payload] of UNREADABLE_DIVERGENCE_PAYLOADS) {

--- a/packages/contracts/src/replay-divergence.ts
+++ b/packages/contracts/src/replay-divergence.ts
@@ -187,6 +187,11 @@ export type ReplayDivergenceResume =
  * on the narrowed record too — a payload this reader rejects cannot be
  * carrying the R7 liveness signal, because the stamp is only ever written to
  * a record it accepted.
+ *
+ * Every field the returned type declares is checked, the two optional ones
+ * included: this is the owning interface for the shape, so a payload it
+ * accepts cannot type as `repairSessionHeld: true` while carrying something
+ * else.
  */
 export function readReplayDivergenceResume(
   divergence: unknown,
@@ -196,6 +201,10 @@ export function readReplayDivergenceResume(
   if (typeof resume.allowed !== 'boolean') return undefined;
   if (!Number.isInteger(resume.from) || typeof resume.planDigest !== 'string') return undefined;
   if (!resume.allowed && typeof resume.reason !== 'string') return undefined;
+  if (resume.repairSessionHeld !== undefined && resume.repairSessionHeld !== true) return undefined;
+  if (resume.alternateFrom !== undefined && !Number.isInteger(resume.alternateFrom)) {
+    return undefined;
+  }
   return resume as ReplayDivergenceResume;
 }
 

--- a/packages/contracts/src/replay-divergence.ts
+++ b/packages/contracts/src/replay-divergence.ts
@@ -1,6 +1,5 @@
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import { redactDiagnosticData } from '@agent-device/kernel/redaction';
-import { isRecord } from './json.ts';
 
 /**
  * ADR 0012 migration steps 2 + 4: structured replay divergence report.
@@ -191,14 +190,17 @@ export type ReplayDivergenceResume =
  * Every field the returned type declares is checked, the two optional ones
  * included: this is the owning interface for the shape, so a payload it
  * accepts cannot type as `repairSessionHeld: true` while carrying something
- * else.
+ * else. The narrowing is structural and local, like this module's other
+ * wire readers: the divergence façade is pinned at the modules it evaluates,
+ * and `json.ts` is not otherwise one of them.
  */
 export function readReplayDivergenceResume(
   divergence: unknown,
 ): ReplayDivergenceResume | undefined {
-  if (!isRecord(divergence) || !isRecord(divergence.resume)) return undefined;
-  const resume = divergence.resume;
-  if (typeof resume.allowed !== 'boolean') return undefined;
+  const resume = (divergence as Record<string, unknown> | null | undefined)?.resume as
+    | Record<string, unknown>
+    | undefined;
+  if (typeof resume?.allowed !== 'boolean') return undefined;
   if (!Number.isInteger(resume.from) || typeof resume.planDigest !== 'string') return undefined;
   if (!resume.allowed && typeof resume.reason !== 'string') return undefined;
   if (resume.repairSessionHeld !== undefined && resume.repairSessionHeld !== true) return undefined;

--- a/packages/contracts/src/replay-divergence.ts
+++ b/packages/contracts/src/replay-divergence.ts
@@ -1,5 +1,6 @@
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import { redactDiagnosticData } from '@agent-device/kernel/redaction';
+import { isRecord } from './json.ts';
 
 /**
  * ADR 0012 migration steps 2 + 4: structured replay divergence report.
@@ -175,6 +176,28 @@ export type ReplayDivergenceResume =
       repairSessionHeld?: true;
     }
   | { allowed: false; from: number; planDigest: string; reason: string; repairSessionHeld?: true };
+
+/**
+ * The `resume` record carried by a divergence-shaped payload, or `undefined`
+ * when the payload does not carry a contract-shaped one.
+ *
+ * Returns the LIVE record rather than a copy: the daemon stamps
+ * `repairSessionHeld` onto it in place (`session-replay-coordinator.ts`)
+ * through this same reader. That is what lets the client key its keep-alive
+ * on the narrowed record too — a payload this reader rejects cannot be
+ * carrying the R7 liveness signal, because the stamp is only ever written to
+ * a record it accepted.
+ */
+export function readReplayDivergenceResume(
+  divergence: unknown,
+): ReplayDivergenceResume | undefined {
+  if (!isRecord(divergence) || !isRecord(divergence.resume)) return undefined;
+  const resume = divergence.resume;
+  if (typeof resume.allowed !== 'boolean') return undefined;
+  if (!Number.isInteger(resume.from) || typeof resume.planDigest !== 'string') return undefined;
+  if (!resume.allowed && typeof resume.reason !== 'string') return undefined;
+  return resume as ReplayDivergenceResume;
+}
 
 export type ReplayDivergenceOverflow = {
   omittedBytes: number;

--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -266,7 +266,16 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
  * only), so its pin is also the assertion that composing the registry stays metadata-eager.
  */
 export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
-  'src/cli.ts': 363,
+  // 362 -> 364 in #2004, which cuts per-invocation work and pays two modules for it:
+  // `src/utils/ttl-memo.ts` (version.ts now resolves the package version and the project root
+  // once per process instead of re-reading package.json several times an invocation) and
+  // `src/daemon/client/daemon-launch-spec.ts` (the launch-entry probe, split out of the 726-line
+  // daemon-client-lifecycle.ts). Both run on the path every local command already takes, so
+  // neither has a lazy seam to hide behind -- unlike `src/daemon/code-signature-cache.ts`, which
+  // the same PR added and only a source checkout reaches, and which therefore loads on demand
+  // (`resolveLocalDaemonCodeSignature`) rather than appearing here.
+  'src/cli.ts': 364,
+c9b32809 (fix(daemon): keep the code-signature cache out of the startup closure)
   'src/platform-runtime.ts': 39,
   'src/core/dispatch.ts': 83,
   'src/core/capabilities.ts': 75,

--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -266,7 +266,7 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
  * only), so its pin is also the assertion that composing the registry stays metadata-eager.
  */
 export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
-  // 362 -> 364 in #2004, which cuts per-invocation work and pays two modules for it:
+  // 363 -> 365 in #2004, which cuts per-invocation work and pays two modules for it:
   // `src/utils/ttl-memo.ts` (version.ts now resolves the package version and the project root
   // once per process instead of re-reading package.json several times an invocation) and
   // `src/daemon/client/daemon-launch-spec.ts` (the launch-entry probe, split out of the 726-line
@@ -274,8 +274,7 @@ export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   // neither has a lazy seam to hide behind -- unlike `src/daemon/code-signature-cache.ts`, which
   // the same PR added and only a source checkout reaches, and which therefore loads on demand
   // (`resolveLocalDaemonCodeSignature`) rather than appearing here.
-  'src/cli.ts': 364,
-c9b32809 (fix(daemon): keep the code-signature cache out of the startup closure)
+  'src/cli.ts': 365,
   'src/platform-runtime.ts': 39,
   'src/core/dispatch.ts': 83,
   'src/core/capabilities.ts': 75,

--- a/src/daemon/__tests__/code-signature-cache.test.ts
+++ b/src/daemon/__tests__/code-signature-cache.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import { computeDaemonCodeSignature } from '../code-signature.ts';
+import { resolveCachedDaemonCodeSignature } from '../code-signature-cache.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * A source-checkout graph: an entry, a dependency it imports, and a file
+ * outside the graph. Sizes differ per revision on purpose — the fingerprint
+ * buckets on `size:mtime`, not content (see the sibling walk tests), so a
+ * same-length rewrite can land in the same bucket on a fast filesystem.
+ */
+function writeGraphFixture(prefix: string): { root: string; entryPath: string; depPath: string } {
+  const root = mkdtempForTestSync(prefix);
+  const entryPath = path.join(root, 'src', 'daemon.ts');
+  const depPath = path.join(root, 'src', 'dep.ts');
+  fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+  fs.writeFileSync(entryPath, "import './dep.ts';\n", 'utf8');
+  fs.writeFileSync(depPath, 'export const dep = 1;\n', 'utf8');
+  return { root, entryPath, depPath };
+}
+
+/** Replaces every published cache document, whichever key this fixture landed on. */
+function overwriteCacheDocuments(contents: string): void {
+  const cacheDir = path.join(os.tmpdir(), 'agent-device-code-signature');
+  for (const name of fs.readdirSync(cacheDir)) {
+    fs.writeFileSync(path.join(cacheDir, name), contents, 'utf8');
+  }
+}
+
+/** Spies on reads while calling through, so the walk still works if it happens. */
+function spyOnReads(): () => string[] {
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  return () =>
+    readSpy.mock.calls
+      .map(([target]) => target)
+      .filter((target): target is string => typeof target === 'string');
+}
+
+test('resolveCachedDaemonCodeSignature returns the uncached signature and stops reading sources once warm', () => {
+  const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-warm-');
+  try {
+    const expected = computeDaemonCodeSignature(entryPath, root);
+
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+
+    const readPaths = spyOnReads();
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    assert.deepEqual(
+      readPaths().filter((target) => target.startsWith(root)),
+      [],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature re-walks when a graph file changes', () => {
+  const { root, entryPath, depPath } = writeGraphFixture('agent-device-signature-cache-change-');
+  try {
+    const initial = resolveCachedDaemonCodeSignature(entryPath, root);
+
+    fs.writeFileSync(depPath, 'export const dep = 20000;\n', 'utf8');
+    const changed = resolveCachedDaemonCodeSignature(entryPath, root);
+
+    assert.notEqual(changed, initial);
+    assert.equal(changed, computeDaemonCodeSignature(entryPath, root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature discovers an import edge added after the cache was written', () => {
+  const { root, entryPath, depPath } = writeGraphFixture('agent-device-signature-cache-edge-');
+  try {
+    const initial = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(initial, /^graph:2:/);
+
+    fs.writeFileSync(path.join(root, 'src', 'added.ts'), 'export const added = 1;\n', 'utf8');
+    fs.writeFileSync(depPath, "import './added.ts';\nexport const dep = 1;\n", 'utf8');
+
+    const grown = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(grown, /^graph:3:/);
+    assert.equal(grown, computeDaemonCodeSignature(entryPath, root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature re-walks when a cached graph file is deleted', () => {
+  const { root, entryPath, depPath } = writeGraphFixture('agent-device-signature-cache-delete-');
+  try {
+    const initial = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(initial, /^graph:2:/);
+
+    // Only the dependency goes: the unchanged entry still stamps identically,
+    // so the vanished file is the sole invalidation signal.
+    fs.rmSync(depPath);
+
+    const shrunk = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(shrunk, /^graph:1:/);
+    assert.equal(shrunk, computeDaemonCodeSignature(entryPath, root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The cache is a best-effort artifact in a shared temporary directory:
+// truncated, half-written, or foreign content must never surface as a
+// signature, because a wrong signature restarts a healthy daemon on every
+// invocation.
+const UNUSABLE_CACHE_DOCUMENTS = [
+  '{"version":1,"files":[["src/dep.ts",12,34]]',
+  '{"version":1,"files":[["src/dep.ts"]]}',
+  '{"version":99,"files":[]}',
+  'null',
+];
+
+for (const document of UNUSABLE_CACHE_DOCUMENTS) {
+  test(`resolveCachedDaemonCodeSignature falls back to the walk for cache document ${document}`, () => {
+    const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-corrupt-');
+    try {
+      const expected = resolveCachedDaemonCodeSignature(entryPath, root);
+      overwriteCacheDocuments(document);
+
+      assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test('resolveCachedDaemonCodeSignature reports an unreadable entry as unknown', () => {
+  const root = mkdtempForTestSync('agent-device-signature-cache-missing-');
+  try {
+    assert.equal(
+      resolveCachedDaemonCodeSignature(path.join(root, 'src', 'daemon.ts'), root),
+      'unknown',
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/daemon/__tests__/code-signature-cache.test.ts
+++ b/src/daemon/__tests__/code-signature-cache.test.ts
@@ -17,11 +17,21 @@ afterEach(() => {
  * buckets on `size:mtime`, not content (see the sibling walk tests), so a
  * same-length rewrite can land in the same bucket on a fast filesystem.
  *
+ * `dependency` names how the entry imports that file: extension-full by
+ * default, so that resolution has exactly one candidate, and extensionless for
+ * the tests about which candidate wins.
+ *
  * The cache's temporary directory is redirected inside the fixture, so the
  * documents a test sees are exactly the ones its own fixture published — never
  * a document a parallel worker owns in the run's shared `TMPDIR`.
  */
-function writeGraphFixture(prefix: string): {
+function writeGraphFixture(
+  prefix: string,
+  dependency: { specifier: string; fileName: string } = {
+    specifier: './dep.ts',
+    fileName: 'dep.ts',
+  },
+): {
   root: string;
   entryPath: string;
   depPath: string;
@@ -29,9 +39,9 @@ function writeGraphFixture(prefix: string): {
 } {
   const root = mkdtempForTestSync(prefix);
   const entryPath = path.join(root, 'src', 'daemon.ts');
-  const depPath = path.join(root, 'src', 'dep.ts');
+  const depPath = path.join(root, 'src', dependency.fileName);
   fs.mkdirSync(path.dirname(entryPath), { recursive: true });
-  fs.writeFileSync(entryPath, "import './dep.ts';\n", 'utf8');
+  fs.writeFileSync(entryPath, `import '${dependency.specifier}';\n`, 'utf8');
   fs.writeFileSync(depPath, 'export const dep = 1;\n', 'utf8');
   const cacheHome = path.join(root, 'cache-home');
   fs.mkdirSync(cacheHome, { recursive: true });
@@ -114,6 +124,76 @@ test('resolveCachedDaemonCodeSignature discovers an import edge added after the 
   }
 });
 
+test('resolveCachedDaemonCodeSignature re-walks when a higher-precedence extension appears', () => {
+  const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-precedence-', {
+    specifier: './dep',
+    fileName: 'dep.js',
+  });
+  try {
+    const initial = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.equal(initial, computeDaemonCodeSignature(entryPath, root));
+
+    // Resolution probes `.ts` before `.js`, so `./dep` now means this file and
+    // `dep.js` has left the graph — while every file the cache recorded still
+    // stamps identically. A cache that only revalidates recorded stamps hands
+    // back a signature the daemon this client would reuse never reports.
+    fs.writeFileSync(path.join(root, 'src', 'dep.ts'), 'export const dep = 20000;\n', 'utf8');
+
+    const fresh = computeDaemonCodeSignature(entryPath, root);
+    assert.notEqual(fresh, initial);
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), fresh);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature stays warm when a lower-precedence extension appears', () => {
+  const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-behind-', {
+    specifier: './dep',
+    fileName: 'dep.ts',
+  });
+  try {
+    const expected = resolveCachedDaemonCodeSignature(entryPath, root);
+
+    // `.ts` already won, so resolution never probes this far and the graph is
+    // unchanged. Recording candidates BEHIND the winner would spend the whole
+    // point of the cache re-walking edits that cannot move an edge.
+    fs.writeFileSync(path.join(root, 'src', 'dep.js'), 'export const dep = 20000;\n', 'utf8');
+
+    // Uncached first, so the walk this comparison needs is not itself counted
+    // as a read the cached call made.
+    assert.equal(computeDaemonCodeSignature(entryPath, root), expected);
+
+    const readPaths = spyOnReads();
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    assert.deepEqual(
+      readPaths().filter((target) => target.startsWith(root)),
+      [],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature re-walks when a specifier that resolved to nothing gains a target', () => {
+  const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-appears-');
+  try {
+    fs.appendFileSync(entryPath, "import './later';\n", 'utf8');
+    const initial = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(initial, /^graph:2:/);
+
+    // The entry is not rewritten to add this edge: the edge was always there,
+    // and only its target was missing when the document was published.
+    fs.writeFileSync(path.join(root, 'src', 'later.ts'), 'export const later = 1;\n', 'utf8');
+
+    const grown = resolveCachedDaemonCodeSignature(entryPath, root);
+    assert.match(grown, /^graph:3:/);
+    assert.equal(grown, computeDaemonCodeSignature(entryPath, root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('resolveCachedDaemonCodeSignature re-walks when a cached graph file is deleted', () => {
   const { root, entryPath, depPath } = writeGraphFixture('agent-device-signature-cache-delete-');
   try {
@@ -137,10 +217,12 @@ test('resolveCachedDaemonCodeSignature re-walks when a cached graph file is dele
 // signature, because a wrong signature restarts a healthy daemon on every
 // invocation.
 const UNUSABLE_CACHE_DOCUMENTS = [
-  '{"version":1,"files":[["src/dep.ts",12,34]]',
-  '{"version":1,"files":[["src/dep.ts"]]}',
-  '{"version":99,"files":[]}',
-  '{"version":1,"files":[]}',
+  '{"version":2,"files":[["src/dep.ts",12,34]],"absent":[]',
+  '{"version":2,"files":[["src/dep.ts"]],"absent":[]}',
+  '{"version":2,"files":[["src/daemon.ts",1,2]]}',
+  '{"version":2,"files":[["src/daemon.ts",1,2]],"absent":[7]}',
+  '{"version":99,"files":[],"absent":[]}',
+  '{"version":2,"files":[],"absent":[]}',
   'null',
 ];
 
@@ -162,7 +244,7 @@ for (const document of UNUSABLE_CACHE_DOCUMENTS) {
 
 test('resolveCachedDaemonCodeSignature republishes over a zero-entry document instead of restarting the daemon forever', () => {
   const { root, entryPath, cacheHome } = writeGraphFixture('agent-device-signature-cache-empty-');
-  const emptyDocument = '{"version":1,"files":[]}';
+  const emptyDocument = '{"version":2,"files":[],"absent":[]}';
   try {
     const expected = resolveCachedDaemonCodeSignature(entryPath, root);
     const documents = listCacheDocuments(cacheHome);
@@ -197,10 +279,11 @@ test('resolveCachedDaemonCodeSignature refuses a document that omits the entry i
     for (const document of documents) {
       const parsed = JSON.parse(fs.readFileSync(document, 'utf8')) as {
         files: [string, number, number][];
+        absent: string[];
       };
       const files = parsed.files.filter(([label]) => label !== path.join('src', 'daemon.ts'));
       assert.equal(files.length, parsed.files.length - 1);
-      fs.writeFileSync(document, JSON.stringify({ version: 1, files }), 'utf8');
+      fs.writeFileSync(document, JSON.stringify({ ...parsed, files }), 'utf8');
     }
 
     assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);

--- a/src/daemon/__tests__/code-signature-cache.test.ts
+++ b/src/daemon/__tests__/code-signature-cache.test.ts
@@ -16,22 +16,42 @@ afterEach(() => {
  * outside the graph. Sizes differ per revision on purpose — the fingerprint
  * buckets on `size:mtime`, not content (see the sibling walk tests), so a
  * same-length rewrite can land in the same bucket on a fast filesystem.
+ *
+ * The cache's temporary directory is redirected inside the fixture, so the
+ * documents a test sees are exactly the ones its own fixture published — never
+ * a document a parallel worker owns in the run's shared `TMPDIR`.
  */
-function writeGraphFixture(prefix: string): { root: string; entryPath: string; depPath: string } {
+function writeGraphFixture(prefix: string): {
+  root: string;
+  entryPath: string;
+  depPath: string;
+  cacheHome: string;
+} {
   const root = mkdtempForTestSync(prefix);
   const entryPath = path.join(root, 'src', 'daemon.ts');
   const depPath = path.join(root, 'src', 'dep.ts');
   fs.mkdirSync(path.dirname(entryPath), { recursive: true });
   fs.writeFileSync(entryPath, "import './dep.ts';\n", 'utf8');
   fs.writeFileSync(depPath, 'export const dep = 1;\n', 'utf8');
-  return { root, entryPath, depPath };
+  const cacheHome = path.join(root, 'cache-home');
+  fs.mkdirSync(cacheHome, { recursive: true });
+  vi.spyOn(os, 'tmpdir').mockReturnValue(cacheHome);
+  return { root, entryPath, depPath, cacheHome };
 }
 
-/** Replaces every published cache document, whichever key this fixture landed on. */
-function overwriteCacheDocuments(contents: string): void {
-  const cacheDir = path.join(os.tmpdir(), 'agent-device-code-signature');
-  for (const name of fs.readdirSync(cacheDir)) {
-    fs.writeFileSync(path.join(cacheDir, name), contents, 'utf8');
+/** Every document this fixture published, whatever key each landed on. */
+function listCacheDocuments(cacheHome: string): string[] {
+  return fs
+    .readdirSync(cacheHome)
+    .flatMap((name) =>
+      fs.readdirSync(path.join(cacheHome, name)).map((doc) => path.join(cacheHome, name, doc)),
+    );
+}
+
+function writeDocuments(documents: readonly string[], contents: string): void {
+  assert.ok(documents.length > 0);
+  for (const document of documents) {
+    fs.writeFileSync(document, contents, 'utf8');
   }
 }
 
@@ -120,15 +140,18 @@ const UNUSABLE_CACHE_DOCUMENTS = [
   '{"version":1,"files":[["src/dep.ts",12,34]]',
   '{"version":1,"files":[["src/dep.ts"]]}',
   '{"version":99,"files":[]}',
+  '{"version":1,"files":[]}',
   'null',
 ];
 
 for (const document of UNUSABLE_CACHE_DOCUMENTS) {
   test(`resolveCachedDaemonCodeSignature falls back to the walk for cache document ${document}`, () => {
-    const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-corrupt-');
+    const { root, entryPath, cacheHome } = writeGraphFixture(
+      'agent-device-signature-cache-corrupt-',
+    );
     try {
       const expected = resolveCachedDaemonCodeSignature(entryPath, root);
-      overwriteCacheDocuments(document);
+      writeDocuments(listCacheDocuments(cacheHome), document);
 
       assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
     } finally {
@@ -136,6 +159,75 @@ for (const document of UNUSABLE_CACHE_DOCUMENTS) {
     }
   });
 }
+
+test('resolveCachedDaemonCodeSignature republishes over a zero-entry document instead of restarting the daemon forever', () => {
+  const { root, entryPath, cacheHome } = writeGraphFixture('agent-device-signature-cache-empty-');
+  const emptyDocument = '{"version":1,"files":[]}';
+  try {
+    const expected = resolveCachedDaemonCodeSignature(entryPath, root);
+    const documents = listCacheDocuments(cacheHome);
+    // Every stamp in an empty list matches vacuously, so a document that
+    // merely fell back to the walk without republishing would be re-read and
+    // re-refused on every invocation: a permanent daemon-restart loop.
+    writeDocuments(documents, emptyDocument);
+
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    for (const document of documents) {
+      assert.notEqual(fs.readFileSync(document, 'utf8'), emptyDocument);
+    }
+
+    const readPaths = spyOnReads();
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    assert.deepEqual(
+      readPaths().filter((target) => target.startsWith(root)),
+      [],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature refuses a document that omits the entry itself', () => {
+  const { root, entryPath, cacheHome } = writeGraphFixture('agent-device-signature-cache-subset-');
+  try {
+    const expected = resolveCachedDaemonCodeSignature(entryPath, root);
+    const documents = listCacheDocuments(cacheHome);
+    // Every surviving stamp still matches disk, so a subset of the real graph
+    // would validate — and answer with a signature no daemon ever reports.
+    for (const document of documents) {
+      const parsed = JSON.parse(fs.readFileSync(document, 'utf8')) as {
+        files: [string, number, number][];
+      };
+      const files = parsed.files.filter(([label]) => label !== path.join('src', 'daemon.ts'));
+      assert.equal(files.length, parsed.files.length - 1);
+      fs.writeFileSync(document, JSON.stringify({ version: 1, files }), 'utf8');
+    }
+
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveCachedDaemonCodeSignature ignores a cache document another user wrote', () => {
+  const { root, entryPath } = writeGraphFixture('agent-device-signature-cache-foreign-');
+  try {
+    const expected = resolveCachedDaemonCodeSignature(entryPath, root);
+
+    // On Linux the cache directory lives in the shared `/tmp`: a document this
+    // user did not write must not choose the signature the client compares a
+    // running daemon against.
+    const foreignStats = fs.statSync(entryPath);
+    foreignStats.uid += 1;
+    vi.spyOn(fs, 'fstatSync').mockReturnValue(foreignStats);
+
+    const readPaths = spyOnReads();
+    assert.equal(resolveCachedDaemonCodeSignature(entryPath, root), expected);
+    assert.ok(readPaths().includes(entryPath));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test('resolveCachedDaemonCodeSignature reports an unreadable entry as unknown', () => {
   const root = mkdtempForTestSync('agent-device-signature-cache-missing-');

--- a/src/daemon/client/__tests__/daemon-launch-spec.test.ts
+++ b/src/daemon/client/__tests__/daemon-launch-spec.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { afterEach, test, vi } from 'vitest';
+import { computeDaemonCodeSignature } from '../../code-signature.ts';
+import { resolveDaemonLaunchSpec, resolveLocalDaemonCodeSignature } from '../daemon-launch-spec.ts';
+import { resetAllProcessMemosForTests } from '../../../utils/ttl-memo.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// The daemon-reuse check reads the launch entry and its code signature on
+// every command. The entry is fixed for the process; the signature is not, so
+// it stays live and leans on the stat-validated cache instead.
+
+test('resolveDaemonLaunchSpec probes the entry candidates once per process', () => {
+  resetAllProcessMemosForTests();
+  const existsSpy = vi.spyOn(fs, 'existsSync');
+
+  const first = resolveDaemonLaunchSpec();
+  const probeCalls = existsSpy.mock.calls.length;
+  assert.ok(probeCalls > 0);
+
+  const second = resolveDaemonLaunchSpec();
+  assert.equal(second, first);
+  assert.equal(existsSpy.mock.calls.length, probeCalls);
+});
+
+test('resolveLocalDaemonCodeSignature re-reads the filesystem on every call', () => {
+  resetAllProcessMemosForTests();
+
+  const first = resolveLocalDaemonCodeSignature();
+  const statSpy = vi.spyOn(fs, 'statSync');
+  const second = resolveLocalDaemonCodeSignature();
+
+  assert.equal(second, first);
+  // Not memoized in either mode: a long-lived client (the MCP server) has to
+  // notice a daemon rebuilt underneath it. What the source mode avoids is the
+  // content reads, not the question (`code-signature-cache.ts`).
+  assert.ok(statSpy.mock.calls.length > 0);
+});
+
+test('resolveLocalDaemonCodeSignature agrees with the uncached walk over the launch entry', () => {
+  resetAllProcessMemosForTests();
+  const spec = resolveDaemonLaunchSpec();
+  const entryPath = spec.useSrc ? spec.srcPath : spec.distPath;
+
+  assert.equal(resolveLocalDaemonCodeSignature(), computeDaemonCodeSignature(entryPath, spec.root));
+});

--- a/src/daemon/client/__tests__/daemon-launch-spec.test.ts
+++ b/src/daemon/client/__tests__/daemon-launch-spec.test.ts
@@ -27,12 +27,12 @@ test('resolveDaemonLaunchSpec probes the entry candidates once per process', () 
   assert.equal(existsSpy.mock.calls.length, probeCalls);
 });
 
-test('resolveLocalDaemonCodeSignature re-reads the filesystem on every call', () => {
+test('resolveLocalDaemonCodeSignature re-reads the filesystem on every call', async () => {
   resetAllProcessMemosForTests();
 
-  const first = resolveLocalDaemonCodeSignature();
+  const first = await resolveLocalDaemonCodeSignature();
   const statSpy = vi.spyOn(fs, 'statSync');
-  const second = resolveLocalDaemonCodeSignature();
+  const second = await resolveLocalDaemonCodeSignature();
 
   assert.equal(second, first);
   // Not memoized in either mode: a long-lived client (the MCP server) has to
@@ -41,18 +41,21 @@ test('resolveLocalDaemonCodeSignature re-reads the filesystem on every call', ()
   assert.ok(statSpy.mock.calls.length > 0);
 });
 
-test('resolveLocalDaemonCodeSignature agrees with the uncached walk over the launch entry', () => {
+test('resolveLocalDaemonCodeSignature agrees with the uncached walk over the launch entry', async () => {
   resetAllProcessMemosForTests();
   const spec = resolveDaemonLaunchSpec();
   const entryPath = spec.useSrc ? spec.srcPath : spec.distPath;
 
-  assert.equal(resolveLocalDaemonCodeSignature(), computeDaemonCodeSignature(entryPath, spec.root));
+  assert.equal(
+    await resolveLocalDaemonCodeSignature(),
+    computeDaemonCodeSignature(entryPath, spec.root),
+  );
 });
 
-test('a source client fingerprints the source entry through the stat-validated cache', () => {
+test('a source client fingerprints the source entry through the stat-validated cache', async () => {
   // A built checkout runs Vitest without `--experimental-strip-types`, so
-  // every other test in this file routes the DIST branch of the ternary. This
-  // is the branch the cache exists for; stub the mode marker to reach it.
+  // every other test in this file routes the DIST branch. This is the branch
+  // the cache exists for; stub the mode marker to reach it.
   const execArgv = process.execArgv;
   process.execArgv = [...execArgv, '--experimental-strip-types'];
   resetAllProcessMemosForTests();
@@ -60,10 +63,10 @@ test('a source client fingerprints the source entry through the stat-validated c
     const spec = resolveDaemonLaunchSpec();
     assert.equal(spec.useSrc, true);
     const expected = computeDaemonCodeSignature(spec.srcPath, spec.root);
-    assert.equal(resolveLocalDaemonCodeSignature(), expected);
+    assert.equal(await resolveLocalDaemonCodeSignature(), expected);
 
     const readSpy = vi.spyOn(fs, 'readFileSync');
-    assert.equal(resolveLocalDaemonCodeSignature(), expected);
+    assert.equal(await resolveLocalDaemonCodeSignature(), expected);
     const sourceReads = readSpy.mock.calls
       .map(([target]) => target)
       .filter((target): target is string => typeof target === 'string')

--- a/src/daemon/client/__tests__/daemon-launch-spec.test.ts
+++ b/src/daemon/client/__tests__/daemon-launch-spec.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import { computeDaemonCodeSignature } from '../../code-signature.ts';
 import { resolveDaemonLaunchSpec, resolveLocalDaemonCodeSignature } from '../daemon-launch-spec.ts';
@@ -46,4 +47,30 @@ test('resolveLocalDaemonCodeSignature agrees with the uncached walk over the lau
   const entryPath = spec.useSrc ? spec.srcPath : spec.distPath;
 
   assert.equal(resolveLocalDaemonCodeSignature(), computeDaemonCodeSignature(entryPath, spec.root));
+});
+
+test('a source client fingerprints the source entry through the stat-validated cache', () => {
+  // A built checkout runs Vitest without `--experimental-strip-types`, so
+  // every other test in this file routes the DIST branch of the ternary. This
+  // is the branch the cache exists for; stub the mode marker to reach it.
+  const execArgv = process.execArgv;
+  process.execArgv = [...execArgv, '--experimental-strip-types'];
+  resetAllProcessMemosForTests();
+  try {
+    const spec = resolveDaemonLaunchSpec();
+    assert.equal(spec.useSrc, true);
+    const expected = computeDaemonCodeSignature(spec.srcPath, spec.root);
+    assert.equal(resolveLocalDaemonCodeSignature(), expected);
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    assert.equal(resolveLocalDaemonCodeSignature(), expected);
+    const sourceReads = readSpy.mock.calls
+      .map(([target]) => target)
+      .filter((target): target is string => typeof target === 'string')
+      .filter((target) => target.startsWith(path.join(spec.root, 'src')));
+    assert.deepEqual(sourceReads, []);
+  } finally {
+    process.execArgv = execArgv;
+    resetAllProcessMemosForTests();
+  }
 });

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { runCmdDetachedMonitored, type ExecDetachedExit } from '../../utils/exec.ts';
-import { findProjectRoot, readVersion } from '../../utils/version.ts';
+import { readVersion } from '../../utils/version.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { findUnrecoveredRepairCommitFailure } from '../session-store.ts';
 import {
@@ -16,7 +16,7 @@ import {
   type DaemonServerMode,
   type DaemonTransportPreference,
 } from '../config.ts';
-import { computeDaemonCodeSignature } from '../code-signature.ts';
+import { resolveDaemonLaunchSpec, resolveLocalDaemonCodeSignature } from './daemon-launch-spec.ts';
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { shellQuoteIfNeeded } from '../../utils/shell-quote.ts';
 import { sleep } from '../../utils/timeouts.ts';
@@ -607,43 +607,6 @@ function startDaemon(settings: DaemonClientSettings): DaemonStartupLaunch {
     fs.closeSync(stdoutFd);
     fs.closeSync(stderrFd);
   }
-}
-
-type DaemonLaunchSpec = {
-  root: string;
-  distPath: string;
-  distPaths: string[];
-  srcPath: string;
-  useSrc: boolean;
-};
-
-function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
-  const root = findProjectRoot();
-  const distPaths = [
-    path.join(root, 'dist', 'src', 'internal', 'daemon.js'),
-    path.join(root, 'dist', 'src', 'daemon.js'),
-  ];
-  const defaultDistPath = distPaths[0];
-  if (defaultDistPath === undefined) {
-    throw new AppError('COMMAND_FAILED', 'Daemon dist path list is empty');
-  }
-  const distPath = distPaths.find((candidate) => fs.existsSync(candidate)) ?? defaultDistPath;
-  const srcPath = path.join(root, 'src', 'daemon.ts');
-
-  const hasDist = distPaths.some((candidate) => fs.existsSync(candidate));
-  const hasSrc = fs.existsSync(srcPath);
-  if (!hasDist && !hasSrc) {
-    throw new AppError('COMMAND_FAILED', 'Daemon entry not found', { distPaths, srcPath });
-  }
-  const runningFromSource = process.execArgv.includes('--experimental-strip-types');
-  const useSrc = runningFromSource ? hasSrc : !hasDist && hasSrc;
-  return { root, distPath, distPaths, srcPath, useSrc };
-}
-
-function resolveLocalDaemonCodeSignature(): string {
-  const launchSpec = resolveDaemonLaunchSpec();
-  const entryPath = launchSpec.useSrc ? launchSpec.srcPath : launchSpec.distPath;
-  return computeDaemonCodeSignature(entryPath, launchSpec.root);
 }
 
 function describeDaemonEarlyExit(exit: ExecDetachedExit): string {

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -3,6 +3,7 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
+import { readReplayDivergenceResume } from '@agent-device/contracts/divergence';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { runCmdDetachedMonitored, type ExecDetachedExit } from '../../utils/exec.ts';
 import { readVersion } from '../../utils/version.ts';
@@ -458,11 +459,8 @@ function surfaceUnrecoveredRepairCommitFailure(
 export function isHeldRepairDivergence(response: DaemonResponse | undefined): boolean {
   if (!response || response.ok) return false;
   if (response.error.code !== 'REPLAY_DIVERGENCE') return false;
-  const divergence = response.error.details?.divergence;
-  if (!divergence || typeof divergence !== 'object') return false;
-  const resume = (divergence as Record<string, unknown>).resume;
-  if (!resume || typeof resume !== 'object') return false;
-  return (resume as Record<string, unknown>).repairSessionHeld === true;
+  const resume = readReplayDivergenceResume(response.error.details?.divergence);
+  return resume?.repairSessionHeld === true;
 }
 
 /**

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -181,9 +181,10 @@ async function readReusableLocalDaemon(settings: DaemonClientSettings): Promise<
   if (!existing) return null;
 
   const existingReachable = await canConnectReusableDaemon(existing, settings.transportPreference);
-  if (isReusableDaemonInfo(existing, existingReachable)) return existing;
+  const takeoverReason = await resolveDaemonTakeoverReason(existing, existingReachable);
+  if (!takeoverReason) return existing;
 
-  emitDaemonTakeoverNotice(existing, existingReachable, settings.paths.baseDir);
+  emitDaemonTakeoverNotice(existing, takeoverReason, settings.paths.baseDir);
   await stopDaemonProcessForTakeover(existing);
   removeDaemonInfo(settings.paths.infoPath);
   return null;
@@ -210,29 +211,33 @@ function isDaemonTransportUnavailableError(error: unknown): boolean {
   );
 }
 
-function isReusableDaemonInfo(info: DaemonInfo, reachable: boolean): boolean {
-  return (
-    info.version === readVersion() &&
-    info.codeSignature === resolveLocalDaemonCodeSignature() &&
-    reachable
-  );
+/**
+ * Why this daemon cannot be reused, or `undefined` when it can be.
+ *
+ * One ladder answers both questions, so a daemon can never be reused and
+ * announced as replaced, or replaced without a reason to print. The code
+ * signature is asked for after the version because it is the expensive check
+ * (`resolveLocalDaemonCodeSignature`), and a version mismatch already decides.
+ */
+async function resolveDaemonTakeoverReason(
+  info: DaemonInfo,
+  reachable: boolean,
+): Promise<string | undefined> {
+  if (info.version !== readVersion()) return `version mismatch (client v${readVersion()})`;
+  if (info.codeSignature !== (await resolveLocalDaemonCodeSignature())) {
+    return 'code-signature mismatch';
+  }
+  if (!reachable) return 'unreachable';
+  return undefined;
 }
 
-function emitDaemonTakeoverNotice(info: DaemonInfo, reachable: boolean, stateDir: string): void {
+function emitDaemonTakeoverNotice(info: DaemonInfo, reason: string, stateDir: string): void {
   try {
     const identity = info.version ? `pid ${info.pid}, v${info.version}` : `pid ${info.pid}`;
-    const reason = resolveDaemonTakeoverReason(info, reachable);
     process.stderr.write(`Replacing daemon (${identity}) in ${stateDir}: ${reason}\n`);
   } catch {
     // The takeover notice is best effort; never fail the command on stderr issues.
   }
-}
-
-function resolveDaemonTakeoverReason(info: DaemonInfo, reachable: boolean): string {
-  if (info.version !== readVersion()) return `version mismatch (client v${readVersion()})`;
-  if (info.codeSignature !== resolveLocalDaemonCodeSignature()) return 'code-signature mismatch';
-  if (!reachable) return 'unreachable';
-  return 'not reusable';
 }
 
 async function startLocalDaemon(settings: DaemonClientSettings): Promise<EnsuredDaemon> {

--- a/src/daemon/client/daemon-launch-spec.ts
+++ b/src/daemon/client/daemon-launch-spec.ts
@@ -4,7 +4,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import { createTtlMemo } from '../../utils/ttl-memo.ts';
 import { findProjectRoot } from '../../utils/version.ts';
 import { computeDaemonCodeSignature } from '../code-signature.ts';
-import { resolveCachedDaemonCodeSignature } from '../code-signature-cache.ts';
 
 export type DaemonLaunchSpec = {
   root: string;
@@ -57,13 +56,20 @@ export function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
  * stat-validated cache (`code-signature-cache.ts`), which returns the
  * identical signature in ~1.5ms.
  *
+ * The cache loads on demand, which is why this is async: an installed client
+ * runs the dist arm on every invocation and never reaches it, so a static
+ * import would put the cache and its atomic-publish dependency in the startup
+ * closure of a CLI that cannot use them (`eager-closure-budgets.ts`).
+ *
  * Deliberately NOT memoized, unlike the launch spec above: a long-lived
  * client (the MCP server) must still notice a daemon rebuilt underneath it,
  * and the cache is what makes re-answering that question per request cheap.
  */
-export function resolveLocalDaemonCodeSignature(): string {
+export async function resolveLocalDaemonCodeSignature(): Promise<string> {
   const launchSpec = resolveDaemonLaunchSpec();
-  return launchSpec.useSrc
-    ? resolveCachedDaemonCodeSignature(launchSpec.srcPath, launchSpec.root)
-    : computeDaemonCodeSignature(launchSpec.distPath, launchSpec.root);
+  if (!launchSpec.useSrc) {
+    return computeDaemonCodeSignature(launchSpec.distPath, launchSpec.root);
+  }
+  const { resolveCachedDaemonCodeSignature } = await import('../code-signature-cache.ts');
+  return resolveCachedDaemonCodeSignature(launchSpec.srcPath, launchSpec.root);
 }

--- a/src/daemon/client/daemon-launch-spec.ts
+++ b/src/daemon/client/daemon-launch-spec.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppError } from '@agent-device/kernel/errors';
+import { createTtlMemo } from '../../utils/ttl-memo.ts';
+import { findProjectRoot } from '../../utils/version.ts';
+import { computeDaemonCodeSignature } from '../code-signature.ts';
+import { resolveCachedDaemonCodeSignature } from '../code-signature-cache.ts';
+
+export type DaemonLaunchSpec = {
+  root: string;
+  distPath: string;
+  distPaths: string[];
+  srcPath: string;
+  useSrc: boolean;
+};
+
+// Which entry this client launches cannot change under it: a source client
+// stays a source client whatever a concurrent build produces, and the paths
+// themselves are derived from the project root. So the ~8 existence probes run
+// once per process, cleared between tests by the shared process-memo reset.
+const launchSpecMemo = createTtlMemo<'local', DaemonLaunchSpec>();
+
+/** Which daemon entry this client would launch, and the root it belongs to. */
+export function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
+  const memoized = launchSpecMemo.get('local');
+  if (memoized) return memoized;
+
+  const root = findProjectRoot();
+  const distPaths = [
+    path.join(root, 'dist', 'src', 'internal', 'daemon.js'),
+    path.join(root, 'dist', 'src', 'daemon.js'),
+  ];
+  const defaultDistPath = distPaths[0];
+  if (defaultDistPath === undefined) {
+    throw new AppError('COMMAND_FAILED', 'Daemon dist path list is empty');
+  }
+  const distPath = distPaths.find((candidate) => fs.existsSync(candidate)) ?? defaultDistPath;
+  const srcPath = path.join(root, 'src', 'daemon.ts');
+
+  const hasDist = distPaths.some((candidate) => fs.existsSync(candidate));
+  const hasSrc = fs.existsSync(srcPath);
+  if (!hasDist && !hasSrc) {
+    throw new AppError('COMMAND_FAILED', 'Daemon entry not found', { distPaths, srcPath });
+  }
+  const runningFromSource = process.execArgv.includes('--experimental-strip-types');
+  const useSrc = runningFromSource ? hasSrc : !hasDist && hasSrc;
+
+  const spec: DaemonLaunchSpec = { root, distPath, distPaths, srcPath, useSrc };
+  launchSpecMemo.set('local', spec);
+  return spec;
+}
+
+/**
+ * The signature a running daemon must report to be reusable. A dist entry is
+ * a bundle of ~120 chunks and walks in ~5ms, so it keeps the direct walk; a
+ * source checkout's ~800-module graph costs ~30ms and goes through the
+ * stat-validated cache (`code-signature-cache.ts`), which returns the
+ * identical signature in ~1.5ms.
+ *
+ * Deliberately NOT memoized, unlike the launch spec above: a long-lived
+ * client (the MCP server) must still notice a daemon rebuilt underneath it,
+ * and the cache is what makes re-answering that question per request cheap.
+ */
+export function resolveLocalDaemonCodeSignature(): string {
+  const launchSpec = resolveDaemonLaunchSpec();
+  return launchSpec.useSrc
+    ? resolveCachedDaemonCodeSignature(launchSpec.srcPath, launchSpec.root)
+    : computeDaemonCodeSignature(launchSpec.distPath, launchSpec.root);
+}

--- a/src/daemon/code-signature-cache.ts
+++ b/src/daemon/code-signature-cache.ts
@@ -8,13 +8,14 @@ import {
   formatDaemonCodeSignature,
   walkDaemonCodeGraph,
   type DaemonCodeFileStamp,
+  type DaemonCodeGraphWalk,
 } from './code-signature.ts';
 
 // Bump when the stored shape changes; old documents then miss instead of
 // parsing wrong. Only this module needs the guard: `code-signature.ts` is
 // itself inside the graph it walks, so changing the WALK invalidates every
 // document through the ordinary stamp comparison.
-const CACHE_FORMAT_VERSION = 1;
+const CACHE_FORMAT_VERSION = 2;
 // Per-user, and readable only by that user: `os.tmpdir()` is per-user on
 // macOS but the shared `/tmp` on Linux, where a single directory would mean
 // whichever uid ran first owns it and every other uid's publish fails EACCES
@@ -27,6 +28,7 @@ const CACHE_DOCUMENT_MODE = 0o600;
 type CacheDocument = {
   version: typeof CACHE_FORMAT_VERSION;
   files: DaemonCodeFileStamp[];
+  absent: string[];
 };
 
 /**
@@ -36,61 +38,66 @@ type CacheDocument = {
  * its edges means reading all ~800 files: ~30ms of a ~245ms invocation, for a
  * graph that is identical on every invocation but the first one after an edit.
  *
- * So the walk is cached and revalidated by `statSync` alone. For an edit to a
- * file ALREADY in the graph that is exactly as strong as the walk it
- * replaces: the signature itself treats a file's `size:mtime` as the stand-in
- * for its contents (`DaemonCodeFileStamp`), so a still-matching pair means an
- * unchanged file, therefore an unchanged specifier list, therefore an
- * unchanged graph. It is deliberately weaker in one direction, because the
- * set of files to revalidate is read out of the document: a module that JOINS
- * the graph without touching any recorded file — an import whose target did
- * not exist when the document was published and is created afterwards — stays
- * invisible until some recorded file changes. The cost is a source-checkout
- * dev loop reusing a daemon one edit stale; the next edit to any graph file
- * republishes.
+ * So the walk is cached and revalidated by `statSync` alone, which is exactly
+ * as strong as the walk it replaces because a document records the walk's
+ * whole input, not just its output. Every recorded file still matching its
+ * `size:mtime` means an unchanged file — that pair is what the signature
+ * already treats as the stand-in for contents (`DaemonCodeFileStamp`) —
+ * therefore an unchanged specifier list; and every path in `absent` still
+ * being absent means each of those specifiers still resolves where it did
+ * (`DaemonCodeGraphWalk`). Unchanged specifiers resolving unchanged is an
+ * unchanged graph, so re-walking could only rediscover the recorded stamps.
  *
- * Any mismatched, vanished, or newly non-file entry, and any unreadable,
- * malformed, foreign, or entry-less cache document, falls back to the full
- * walk, which republishes. The cache is a best-effort artifact under
- * `os.tmpdir()`, like the Swift toolchain cache: failing to read or write one
- * only costs the walk.
+ * Any mismatched, vanished, or newly non-file entry, any path recorded as
+ * absent that now exists, and any unreadable, malformed, foreign, or
+ * entry-less cache document, falls back to the full walk, which republishes.
+ * The cache is a best-effort artifact under `os.tmpdir()`, like the Swift
+ * toolchain cache: failing to read or write one only costs the walk.
  */
 export function resolveCachedDaemonCodeSignature(entryPath: string, root: string): string {
   const cachePath = resolveCachePath(entryPath, root);
   const entryLabel = buildDaemonCodeFileLabel(root, entryPath);
-  const validated = readValidatedStamps(cachePath, root, entryLabel);
-  if (validated) return formatDaemonCodeSignature(validated);
+  const validated = readValidatedWalk(cachePath, root, entryLabel);
+  if (validated) return formatDaemonCodeSignature(validated.files);
 
-  let stamps: DaemonCodeFileStamp[];
+  let walk: DaemonCodeGraphWalk;
   try {
-    stamps = walkDaemonCodeGraph(entryPath, root);
+    walk = walkDaemonCodeGraph(entryPath, root);
   } catch {
     return 'unknown';
   }
-  if (describesEntry(stamps, entryLabel)) publishStamps(cachePath, stamps);
-  return formatDaemonCodeSignature(stamps);
+  if (describesEntry(walk.files, entryLabel)) publishWalk(cachePath, walk);
+  return formatDaemonCodeSignature(walk.files);
 }
 
-/** The recorded stamps when every one of them still describes the file on disk. */
-function readValidatedStamps(
+/** The recorded walk when the filesystem still answers every probe the way it did. */
+function readValidatedWalk(
   cachePath: string,
   root: string,
   entryLabel: string,
-): DaemonCodeFileStamp[] | undefined {
-  const stamps = readCachedStamps(cachePath);
-  if (!stamps || !describesEntry(stamps, entryLabel)) return undefined;
-  for (const [label, size, mtimeMs] of stamps) {
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(path.resolve(root, label));
-    } catch {
-      return undefined;
-    }
-    if (!stat.isFile() || stat.size !== size || Math.trunc(stat.mtimeMs) !== mtimeMs) {
+): DaemonCodeGraphWalk | undefined {
+  const walk = readCachedWalk(cachePath);
+  if (!walk || !describesEntry(walk.files, entryLabel)) return undefined;
+  for (const [label, size, mtimeMs] of walk.files) {
+    const stat = statCandidate(path.resolve(root, label));
+    if (!stat?.isFile() || stat.size !== size || Math.trunc(stat.mtimeMs) !== mtimeMs) {
       return undefined;
     }
   }
-  return stamps;
+  for (const label of walk.absentPaths) {
+    // A directory is still a resolution miss, so only a FILE appearing here
+    // moves an edge; that is the same question `walkDaemonCodeGraph` asked.
+    if (statCandidate(path.resolve(root, label))?.isFile()) return undefined;
+  }
+  return walk;
+}
+
+function statCandidate(candidatePath: string): fs.Stats | undefined {
+  try {
+    return fs.statSync(candidatePath);
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -105,20 +112,23 @@ function describesEntry(stamps: readonly DaemonCodeFileStamp[], entryLabel: stri
   return stamps.some(([label]) => label === entryLabel);
 }
 
-function readCachedStamps(cachePath: string): DaemonCodeFileStamp[] | undefined {
-  const entries = readCachedEntries(cachePath);
-  if (!entries) return undefined;
-  const stamps: DaemonCodeFileStamp[] = [];
-  for (const entry of entries) {
+function readCachedWalk(cachePath: string): DaemonCodeGraphWalk | undefined {
+  const document = readCachedDocument(cachePath);
+  if (!document) return undefined;
+  const files: DaemonCodeFileStamp[] = [];
+  for (const entry of document.files) {
     const stamp = readStamp(entry);
     if (!stamp) return undefined;
-    stamps.push(stamp);
+    files.push(stamp);
   }
-  return stamps;
+  if (!document.absent.every((label) => typeof label === 'string')) return undefined;
+  return { files, absentPaths: document.absent as string[] };
 }
 
-/** The document's raw entries, or `undefined` for anything this format cannot own. */
-function readCachedEntries(cachePath: string): unknown[] | undefined {
+/** The document's raw arrays, or `undefined` for anything this format cannot own. */
+function readCachedDocument(
+  cachePath: string,
+): { files: unknown[]; absent: unknown[] } | undefined {
   const contents = readOwnedDocument(cachePath);
   if (contents === undefined) return undefined;
   let parsed: unknown;
@@ -130,7 +140,8 @@ function readCachedEntries(cachePath: string): unknown[] | undefined {
   if (!parsed || typeof parsed !== 'object') return undefined;
   const document = parsed as Partial<CacheDocument>;
   if (document.version !== CACHE_FORMAT_VERSION) return undefined;
-  return Array.isArray(document.files) ? document.files : undefined;
+  if (!Array.isArray(document.files) || !Array.isArray(document.absent)) return undefined;
+  return { files: document.files, absent: document.absent };
 }
 
 /** The document's text, but only when this user is the one who wrote it. */
@@ -164,8 +175,12 @@ function readStamp(entry: unknown): DaemonCodeFileStamp | undefined {
   return [label, size, mtimeMs];
 }
 
-function publishStamps(cachePath: string, files: DaemonCodeFileStamp[]): void {
-  const document: CacheDocument = { version: CACHE_FORMAT_VERSION, files };
+function publishWalk(cachePath: string, walk: DaemonCodeGraphWalk): void {
+  const document: CacheDocument = {
+    version: CACHE_FORMAT_VERSION,
+    files: [...walk.files],
+    absent: [...walk.absentPaths],
+  };
   try {
     fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: CACHE_DIRECTORY_MODE });
     publishFileSync({

--- a/src/daemon/code-signature-cache.ts
+++ b/src/daemon/code-signature-cache.ts
@@ -1,0 +1,128 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { publishFileSync } from '../utils/atomic-file.ts';
+import {
+  formatDaemonCodeSignature,
+  walkDaemonCodeGraph,
+  type DaemonCodeFileStamp,
+} from './code-signature.ts';
+
+// Bump when the stored shape changes; old documents then miss instead of
+// parsing wrong. Only this module needs the guard: `code-signature.ts` is
+// itself inside the graph it walks, so changing the WALK invalidates every
+// document through the ordinary stamp comparison.
+const CACHE_FORMAT_VERSION = 1;
+const CACHE_DIRECTORY_NAME = 'agent-device-code-signature';
+
+type CacheDocument = {
+  version: typeof CACHE_FORMAT_VERSION;
+  files: DaemonCodeFileStamp[];
+};
+
+/**
+ * The daemon code signature for a SOURCE checkout, where the import graph is
+ * ~800 separate modules rather than a bundle. The client fingerprints that
+ * graph on every CLI invocation (`isReusableDaemonInfo`), and rediscovering
+ * its edges means reading all ~800 files: ~30ms of a ~245ms invocation, for a
+ * graph that is identical on every invocation but the first one after an edit.
+ *
+ * So the walk is cached and revalidated by `statSync` alone. That is sound
+ * against the walk it replaces, not merely close to it: the signature already
+ * treats a file's `size:mtime` as the stand-in for its contents
+ * (`DaemonCodeFileStamp`), so if every previously visited file still carries
+ * its recorded pair, no file's contents changed, therefore no import
+ * specifier changed, therefore the graph and its signature are unchanged. Any
+ * mismatched, vanished, or newly non-file entry, and any unreadable or
+ * malformed cache document, falls back to the full walk, which republishes.
+ *
+ * The cache is a best-effort artifact under `os.tmpdir()`, like the Swift
+ * toolchain cache: failing to read or write one only costs the walk.
+ */
+export function resolveCachedDaemonCodeSignature(entryPath: string, root: string): string {
+  const cachePath = resolveCachePath(entryPath, root);
+  const validated = readValidatedStamps(cachePath, root);
+  if (validated) return formatDaemonCodeSignature(validated);
+
+  let stamps: DaemonCodeFileStamp[];
+  try {
+    stamps = walkDaemonCodeGraph(entryPath, root);
+  } catch {
+    return 'unknown';
+  }
+  publishStamps(cachePath, stamps);
+  return formatDaemonCodeSignature(stamps);
+}
+
+/** The recorded stamps when every one of them still describes the file on disk. */
+function readValidatedStamps(cachePath: string, root: string): DaemonCodeFileStamp[] | undefined {
+  const stamps = readCachedStamps(cachePath);
+  if (!stamps) return undefined;
+  for (const [label, size, mtimeMs] of stamps) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(path.resolve(root, label));
+    } catch {
+      return undefined;
+    }
+    if (!stat.isFile() || stat.size !== size || Math.trunc(stat.mtimeMs) !== mtimeMs) {
+      return undefined;
+    }
+  }
+  return stamps;
+}
+
+function readCachedStamps(cachePath: string): DaemonCodeFileStamp[] | undefined {
+  const entries = readCachedEntries(cachePath);
+  if (!entries) return undefined;
+  const stamps: DaemonCodeFileStamp[] = [];
+  for (const entry of entries) {
+    const stamp = readStamp(entry);
+    if (!stamp) return undefined;
+    stamps.push(stamp);
+  }
+  return stamps;
+}
+
+/** The document's raw entries, or `undefined` for anything this format cannot own. */
+function readCachedEntries(cachePath: string): unknown[] | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const document = parsed as Partial<CacheDocument>;
+  if (document.version !== CACHE_FORMAT_VERSION) return undefined;
+  return Array.isArray(document.files) ? document.files : undefined;
+}
+
+function readStamp(entry: unknown): DaemonCodeFileStamp | undefined {
+  if (!Array.isArray(entry) || entry.length !== 3) return undefined;
+  const [label, size, mtimeMs] = entry as unknown[];
+  if (typeof label !== 'string' || typeof size !== 'number' || typeof mtimeMs !== 'number') {
+    return undefined;
+  }
+  return [label, size, mtimeMs];
+}
+
+function publishStamps(cachePath: string, files: DaemonCodeFileStamp[]): void {
+  const document: CacheDocument = { version: CACHE_FORMAT_VERSION, files };
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    publishFileSync({ destination: cachePath, contents: JSON.stringify(document) });
+  } catch {
+    // Best effort: an uncached signature is still a correct signature.
+  }
+}
+
+/** One document per (entry, root) pair, so sibling checkouts never share one. */
+function resolveCachePath(entryPath: string, root: string): string {
+  const key = crypto
+    .createHash('sha1')
+    .update(`${path.resolve(root)} ${path.resolve(entryPath)}`)
+    .digest('hex');
+  return path.join(os.tmpdir(), CACHE_DIRECTORY_NAME, `${key}.json`);
+}

--- a/src/daemon/code-signature-cache.ts
+++ b/src/daemon/code-signature-cache.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { publishFileSync } from '../utils/atomic-file.ts';
 import {
+  buildDaemonCodeFileLabel,
   formatDaemonCodeSignature,
   walkDaemonCodeGraph,
   type DaemonCodeFileStamp,
@@ -14,7 +15,14 @@ import {
 // itself inside the graph it walks, so changing the WALK invalidates every
 // document through the ordinary stamp comparison.
 const CACHE_FORMAT_VERSION = 1;
-const CACHE_DIRECTORY_NAME = 'agent-device-code-signature';
+// Per-user, and readable only by that user: `os.tmpdir()` is per-user on
+// macOS but the shared `/tmp` on Linux, where a single directory would mean
+// whichever uid ran first owns it and every other uid's publish fails EACCES
+// forever, silently — and where a document any local process could write
+// would choose the signature this client compares a running daemon against.
+const CACHE_DIRECTORY_PREFIX = 'agent-device-code-signature';
+const CACHE_DIRECTORY_MODE = 0o700;
+const CACHE_DOCUMENT_MODE = 0o600;
 
 type CacheDocument = {
   version: typeof CACHE_FORMAT_VERSION;
@@ -28,21 +36,29 @@ type CacheDocument = {
  * its edges means reading all ~800 files: ~30ms of a ~245ms invocation, for a
  * graph that is identical on every invocation but the first one after an edit.
  *
- * So the walk is cached and revalidated by `statSync` alone. That is sound
- * against the walk it replaces, not merely close to it: the signature already
- * treats a file's `size:mtime` as the stand-in for its contents
- * (`DaemonCodeFileStamp`), so if every previously visited file still carries
- * its recorded pair, no file's contents changed, therefore no import
- * specifier changed, therefore the graph and its signature are unchanged. Any
- * mismatched, vanished, or newly non-file entry, and any unreadable or
- * malformed cache document, falls back to the full walk, which republishes.
+ * So the walk is cached and revalidated by `statSync` alone. For an edit to a
+ * file ALREADY in the graph that is exactly as strong as the walk it
+ * replaces: the signature itself treats a file's `size:mtime` as the stand-in
+ * for its contents (`DaemonCodeFileStamp`), so a still-matching pair means an
+ * unchanged file, therefore an unchanged specifier list, therefore an
+ * unchanged graph. It is deliberately weaker in one direction, because the
+ * set of files to revalidate is read out of the document: a module that JOINS
+ * the graph without touching any recorded file — an import whose target did
+ * not exist when the document was published and is created afterwards — stays
+ * invisible until some recorded file changes. The cost is a source-checkout
+ * dev loop reusing a daemon one edit stale; the next edit to any graph file
+ * republishes.
  *
- * The cache is a best-effort artifact under `os.tmpdir()`, like the Swift
- * toolchain cache: failing to read or write one only costs the walk.
+ * Any mismatched, vanished, or newly non-file entry, and any unreadable,
+ * malformed, foreign, or entry-less cache document, falls back to the full
+ * walk, which republishes. The cache is a best-effort artifact under
+ * `os.tmpdir()`, like the Swift toolchain cache: failing to read or write one
+ * only costs the walk.
  */
 export function resolveCachedDaemonCodeSignature(entryPath: string, root: string): string {
   const cachePath = resolveCachePath(entryPath, root);
-  const validated = readValidatedStamps(cachePath, root);
+  const entryLabel = buildDaemonCodeFileLabel(root, entryPath);
+  const validated = readValidatedStamps(cachePath, root, entryLabel);
   if (validated) return formatDaemonCodeSignature(validated);
 
   let stamps: DaemonCodeFileStamp[];
@@ -51,14 +67,18 @@ export function resolveCachedDaemonCodeSignature(entryPath: string, root: string
   } catch {
     return 'unknown';
   }
-  publishStamps(cachePath, stamps);
+  if (describesEntry(stamps, entryLabel)) publishStamps(cachePath, stamps);
   return formatDaemonCodeSignature(stamps);
 }
 
 /** The recorded stamps when every one of them still describes the file on disk. */
-function readValidatedStamps(cachePath: string, root: string): DaemonCodeFileStamp[] | undefined {
+function readValidatedStamps(
+  cachePath: string,
+  root: string,
+  entryLabel: string,
+): DaemonCodeFileStamp[] | undefined {
   const stamps = readCachedStamps(cachePath);
-  if (!stamps) return undefined;
+  if (!stamps || !describesEntry(stamps, entryLabel)) return undefined;
   for (const [label, size, mtimeMs] of stamps) {
     let stat: fs.Stats;
     try {
@@ -71,6 +91,18 @@ function readValidatedStamps(cachePath: string, root: string): DaemonCodeFileSta
     }
   }
   return stamps;
+}
+
+/**
+ * Whether a stamp list can be this entry's graph at all. The walk always
+ * stamps the entry itself, so a list without it is foreign or truncated — and
+ * the empty list is the dangerous shape: every stamp in it matches vacuously,
+ * so it would validate forever, and a signature no daemon reports restarts a
+ * healthy daemon on every invocation. Publishing is gated on the same
+ * question, so a document this reader would refuse is never written.
+ */
+function describesEntry(stamps: readonly DaemonCodeFileStamp[], entryLabel: string): boolean {
+  return stamps.some(([label]) => label === entryLabel);
 }
 
 function readCachedStamps(cachePath: string): DaemonCodeFileStamp[] | undefined {
@@ -87,9 +119,11 @@ function readCachedStamps(cachePath: string): DaemonCodeFileStamp[] | undefined 
 
 /** The document's raw entries, or `undefined` for anything this format cannot own. */
 function readCachedEntries(cachePath: string): unknown[] | undefined {
+  const contents = readOwnedDocument(cachePath);
+  if (contents === undefined) return undefined;
   let parsed: unknown;
   try {
-    parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    parsed = JSON.parse(contents);
   } catch {
     return undefined;
   }
@@ -97,6 +131,28 @@ function readCachedEntries(cachePath: string): unknown[] | undefined {
   const document = parsed as Partial<CacheDocument>;
   if (document.version !== CACHE_FORMAT_VERSION) return undefined;
   return Array.isArray(document.files) ? document.files : undefined;
+}
+
+/** The document's text, but only when this user is the one who wrote it. */
+function readOwnedDocument(cachePath: string): string | undefined {
+  let handle: number;
+  try {
+    handle = fs.openSync(cachePath, 'r');
+  } catch {
+    return undefined;
+  }
+  try {
+    // The ownership check and the read share one descriptor, so what is
+    // trusted is what is read. Where uids do not exist the temporary
+    // directory is per-user by construction and there is nothing to check.
+    const userId = process.getuid?.();
+    if (userId !== undefined && fs.fstatSync(handle).uid !== userId) return undefined;
+    return fs.readFileSync(handle, 'utf8');
+  } catch {
+    return undefined;
+  } finally {
+    fs.closeSync(handle);
+  }
 }
 
 function readStamp(entry: unknown): DaemonCodeFileStamp | undefined {
@@ -111,8 +167,12 @@ function readStamp(entry: unknown): DaemonCodeFileStamp | undefined {
 function publishStamps(cachePath: string, files: DaemonCodeFileStamp[]): void {
   const document: CacheDocument = { version: CACHE_FORMAT_VERSION, files };
   try {
-    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    publishFileSync({ destination: cachePath, contents: JSON.stringify(document) });
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: CACHE_DIRECTORY_MODE });
+    publishFileSync({
+      destination: cachePath,
+      contents: JSON.stringify(document),
+      mode: CACHE_DOCUMENT_MODE,
+    });
   } catch {
     // Best effort: an uncached signature is still a correct signature.
   }
@@ -122,7 +182,17 @@ function publishStamps(cachePath: string, files: DaemonCodeFileStamp[]): void {
 function resolveCachePath(entryPath: string, root: string): string {
   const key = crypto
     .createHash('sha1')
-    .update(`${path.resolve(root)} ${path.resolve(entryPath)}`)
+    .update(`${resolveRealPath(root)} ${resolveRealPath(entryPath)}`)
     .digest('hex');
-  return path.join(os.tmpdir(), CACHE_DIRECTORY_NAME, `${key}.json`);
+  const directory = `${CACHE_DIRECTORY_PREFIX}-${process.getuid?.() ?? 'user'}`;
+  return path.join(os.tmpdir(), directory, `${key}.json`);
+}
+
+/** Symlinked paths to one checkout are one checkout, as in `buildSourceCheckoutStateDirName`. */
+function resolveRealPath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
 }

--- a/src/daemon/code-signature.ts
+++ b/src/daemon/code-signature.ts
@@ -26,6 +26,25 @@ const RESOLVABLE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'] as 
  */
 export type DaemonCodeFileStamp = readonly [label: string, size: number, mtimeMs: number];
 
+/**
+ * One walk of the graph: the stamps that make up its signature, plus the paths
+ * whose ABSENCE that shape depended on.
+ *
+ * A file OUTSIDE the graph can still decide the graph. `./dep` means `dep.js`
+ * only for as long as `dep.ts` does not exist, because resolution probes the
+ * extensions in `RESOLVABLE_EXTENSIONS` order — and a specifier that resolves
+ * to nothing today is an edge whose target merely has not been written yet.
+ * `absentPaths` therefore carries every candidate probed and missed ahead of a
+ * specifier's winner, and every candidate of a specifier with no winner at
+ * all: creating any one of them redirects or adds an edge. Together with the
+ * stamps it is the complete input to this walk, which is what lets
+ * `code-signature-cache.ts` replay the result from `statSync` alone.
+ */
+export type DaemonCodeGraphWalk = {
+  readonly files: readonly DaemonCodeFileStamp[];
+  readonly absentPaths: readonly string[];
+};
+
 export function resolveDaemonCodeSignature(): string {
   const entryPath = process.argv[1];
   if (!entryPath) return 'unknown';
@@ -37,7 +56,7 @@ export function computeDaemonCodeSignature(
   root: string = findProjectRoot(),
 ): string {
   try {
-    return formatDaemonCodeSignature(walkDaemonCodeGraph(entryPath, root));
+    return formatDaemonCodeSignature(walkDaemonCodeGraph(entryPath, root).files);
   } catch {
     return 'unknown';
   }
@@ -45,14 +64,16 @@ export function computeDaemonCodeSignature(
 
 /**
  * Stamps every module reachable from `entryPath` through relative import
- * specifiers. Throws when the entry itself cannot be read; callers decide
- * whether that is an `'unknown'` signature or a cache miss.
+ * specifiers, and records what every resolution along the way needed to be
+ * missing. Throws when the entry itself cannot be read; callers decide whether
+ * that is an `'unknown'` signature or a cache miss.
  */
-export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCodeFileStamp[] {
+export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCodeGraphWalk {
   const normalizedRoot = path.resolve(root);
   const queue = [path.resolve(entryPath)];
   const visited = new Set<string>();
-  const stamps: DaemonCodeFileStamp[] = [];
+  const files: DaemonCodeFileStamp[] = [];
+  const absentPaths = new Set<string>();
 
   while (queue.length > 0) {
     const currentPath = queue.pop();
@@ -62,7 +83,7 @@ export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCode
     const stat = fs.statSync(currentPath);
     if (!stat.isFile()) continue;
 
-    stamps.push([
+    files.push([
       buildDaemonCodeFileLabel(normalizedRoot, currentPath),
       stat.size,
       Math.trunc(stat.mtimeMs),
@@ -70,14 +91,17 @@ export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCode
 
     const content = fs.readFileSync(currentPath, 'utf8');
     for (const specifier of collectRelativeImportSpecifiers(content)) {
-      const dependencyPath = resolveRelativeImportPath(currentPath, specifier);
-      if (dependencyPath) {
-        queue.push(dependencyPath);
+      const resolution = resolveRelativeImportPath(currentPath, specifier);
+      for (const missed of resolution.missedCandidates) {
+        absentPaths.add(buildDaemonCodeFileLabel(normalizedRoot, missed));
+      }
+      if (resolution.filePath) {
+        queue.push(resolution.filePath);
       }
     }
   }
 
-  return stamps;
+  return { files, absentPaths: [...absentPaths] };
 }
 
 /**
@@ -111,28 +135,38 @@ function collectRelativeImportSpecifiers(content: string): string[] {
   return [...specifiers];
 }
 
-function resolveRelativeImportPath(fromPath: string, specifier: string): string | null {
+/**
+ * What one specifier resolves to, and what that answer rests on: the
+ * candidates probed and missed AHEAD of the winner. Candidates behind it are
+ * never reached, so creating one of those cannot move the resolution and none
+ * is reported.
+ */
+type ImportResolution = {
+  readonly filePath: string | null;
+  readonly missedCandidates: readonly string[];
+};
+
+function resolveRelativeImportPath(fromPath: string, specifier: string): ImportResolution {
   const basePath = path.resolve(path.dirname(fromPath), specifier);
-  const direct = resolveExistingFile(basePath);
-  if (direct) return direct;
-
-  for (const extension of RESOLVABLE_EXTENSIONS) {
-    const withExtension = resolveExistingFile(`${basePath}${extension}`);
-    if (withExtension) return withExtension;
+  const missedCandidates: string[] = [];
+  for (const candidatePath of resolutionCandidates(basePath)) {
+    if (isExistingFile(candidatePath)) return { filePath: candidatePath, missedCandidates };
+    missedCandidates.push(candidatePath);
   }
-
-  for (const extension of RESOLVABLE_EXTENSIONS) {
-    const indexPath = resolveExistingFile(path.join(basePath, `index${extension}`));
-    if (indexPath) return indexPath;
-  }
-
-  return null;
+  return { filePath: null, missedCandidates };
 }
 
-function resolveExistingFile(candidatePath: string): string | null {
+/** Every path the specifier could name, in the order resolution prefers them. */
+function* resolutionCandidates(basePath: string): Generator<string> {
+  yield basePath;
+  for (const extension of RESOLVABLE_EXTENSIONS) yield `${basePath}${extension}`;
+  for (const extension of RESOLVABLE_EXTENSIONS) yield path.join(basePath, `index${extension}`);
+}
+
+function isExistingFile(candidatePath: string): boolean {
   try {
-    return fs.statSync(candidatePath).isFile() ? candidatePath : null;
+    return fs.statSync(candidatePath).isFile();
   } catch {
-    return null;
+    return false;
   }
 }

--- a/src/daemon/code-signature.ts
+++ b/src/daemon/code-signature.ts
@@ -17,6 +17,15 @@ import { findProjectRoot } from '../utils/version.ts';
 const RELATIVE_SPECIFIER_RE = /(['"])(\.\.?\/[^'"]*)\1/g;
 const RESOLVABLE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'] as const;
 
+/**
+ * One visited module's contribution to the fingerprint: the label it is
+ * recorded under (repository-relative where possible) and the `size:mtime`
+ * pair that stands in for its contents. Contents are never hashed — a
+ * same-length rewrite inside one filesystem timestamp tick is deliberately
+ * out of scope, and `code-signature-cache.ts` reuses exactly this bound.
+ */
+export type DaemonCodeFileStamp = readonly [label: string, size: number, mtimeMs: number];
+
 export function resolveDaemonCodeSignature(): string {
   const entryPath = process.argv[1];
   if (!entryPath) return 'unknown';
@@ -28,38 +37,57 @@ export function computeDaemonCodeSignature(
   root: string = findProjectRoot(),
 ): string {
   try {
-    const normalizedRoot = path.resolve(root);
-    const normalizedEntryPath = path.resolve(entryPath);
-    const queue = [normalizedEntryPath];
-    const visited = new Set<string>();
-    const fingerprintParts: string[] = [];
-
-    while (queue.length > 0) {
-      const currentPath = queue.pop();
-      if (!currentPath || visited.has(currentPath)) continue;
-      visited.add(currentPath);
-
-      const stat = fs.statSync(currentPath);
-      if (!stat.isFile()) continue;
-
-      const relativePath = path.relative(normalizedRoot, currentPath) || currentPath;
-      fingerprintParts.push(`${relativePath}:${stat.size}:${Math.trunc(stat.mtimeMs)}`);
-
-      const content = fs.readFileSync(currentPath, 'utf8');
-      for (const specifier of collectRelativeImportSpecifiers(content)) {
-        const dependencyPath = resolveRelativeImportPath(currentPath, specifier);
-        if (dependencyPath) {
-          queue.push(dependencyPath);
-        }
-      }
-    }
-
-    const fingerprint = fingerprintParts.sort().join('|');
-    const hash = crypto.createHash('sha1').update(fingerprint).digest('hex');
-    return `graph:${fingerprintParts.length}:${hash}`;
+    return formatDaemonCodeSignature(walkDaemonCodeGraph(entryPath, root));
   } catch {
     return 'unknown';
   }
+}
+
+/**
+ * Stamps every module reachable from `entryPath` through relative import
+ * specifiers. Throws when the entry itself cannot be read; callers decide
+ * whether that is an `'unknown'` signature or a cache miss.
+ */
+export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCodeFileStamp[] {
+  const normalizedRoot = path.resolve(root);
+  const queue = [path.resolve(entryPath)];
+  const visited = new Set<string>();
+  const stamps: DaemonCodeFileStamp[] = [];
+
+  while (queue.length > 0) {
+    const currentPath = queue.pop();
+    if (!currentPath || visited.has(currentPath)) continue;
+    visited.add(currentPath);
+
+    const stat = fs.statSync(currentPath);
+    if (!stat.isFile()) continue;
+
+    stamps.push([
+      path.relative(normalizedRoot, currentPath) || currentPath,
+      stat.size,
+      Math.trunc(stat.mtimeMs),
+    ]);
+
+    const content = fs.readFileSync(currentPath, 'utf8');
+    for (const specifier of collectRelativeImportSpecifiers(content)) {
+      const dependencyPath = resolveRelativeImportPath(currentPath, specifier);
+      if (dependencyPath) {
+        queue.push(dependencyPath);
+      }
+    }
+  }
+
+  return stamps;
+}
+
+/** The wire form of a signature; identical for a walked and a cache-validated stamp list. */
+export function formatDaemonCodeSignature(stamps: readonly DaemonCodeFileStamp[]): string {
+  const fingerprint = stamps
+    .map(([label, size, mtimeMs]) => `${label}:${size}:${mtimeMs}`)
+    .sort()
+    .join('|');
+  const hash = crypto.createHash('sha1').update(fingerprint).digest('hex');
+  return `graph:${stamps.length}:${hash}`;
 }
 
 function collectRelativeImportSpecifiers(content: string): string[] {

--- a/src/daemon/code-signature.ts
+++ b/src/daemon/code-signature.ts
@@ -63,7 +63,7 @@ export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCode
     if (!stat.isFile()) continue;
 
     stamps.push([
-      path.relative(normalizedRoot, currentPath) || currentPath,
+      buildDaemonCodeFileLabel(normalizedRoot, currentPath),
       stat.size,
       Math.trunc(stat.mtimeMs),
     ]);
@@ -78,6 +78,17 @@ export function walkDaemonCodeGraph(entryPath: string, root: string): DaemonCode
   }
 
   return stamps;
+}
+
+/**
+ * The label a visited module is stamped under: repository-relative where
+ * possible, absolute when it lies outside the root. `code-signature-cache.ts`
+ * derives the ENTRY's label through this same function, so a stored document
+ * that does not list it cannot be a document for this graph.
+ */
+export function buildDaemonCodeFileLabel(root: string, filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+  return path.relative(path.resolve(root), resolvedPath) || resolvedPath;
 }
 
 /** The wire form of a signature; identical for a walked and a cache-validated stamp list. */

--- a/src/daemon/session-replay-coordinator.ts
+++ b/src/daemon/session-replay-coordinator.ts
@@ -1,9 +1,12 @@
 import type { SessionAction } from '@agent-device/contracts/session';
 import path from 'node:path';
-import type { ReplayDivergenceResume, ReplayRepairHint } from '@agent-device/contracts/divergence';
+import {
+  readReplayDivergenceResume,
+  type ReplayDivergenceResume,
+  type ReplayRepairHint,
+} from '@agent-device/contracts/divergence';
 import type { DaemonResponse, SessionState } from './types.ts';
 import type { SessionStore } from './session-store.ts';
-import { isRecord } from '../utils/parsing.ts';
 import {
   armRepairStep,
   isUncommittedRepairSession,
@@ -151,7 +154,7 @@ export function createReplayCoordinator(params: {
       // per R2) is therefore still held on divergence and stays in the
       // transaction.
       if (!isUncommittedRepairSession(current())) return response;
-      const resume = readDivergenceResumeRecord(response);
+      const resume = readReplayDivergenceResume(response.error.details?.divergence);
       if (resume) resume.repairSessionHeld = true;
       return response;
     },
@@ -176,21 +179,6 @@ export function healedScriptSiblingPath(sourcePath: string): string {
   const dir = path.dirname(sourcePath);
   const base = path.basename(sourcePath, path.extname(sourcePath));
   return path.join(dir, `${base}.healed.ad`);
-}
-
-/** The mutable `details.divergence.resume` record on a failed response, or `undefined`. */
-function readDivergenceResumeRecord(
-  response: Extract<DaemonResponse, { ok: false }>,
-): ReplayDivergenceResume | undefined {
-  const divergence = response.error.details?.divergence;
-  if (!isRecord(divergence) || !isReplayDivergenceResume(divergence.resume)) return undefined;
-  return divergence.resume;
-}
-
-function isReplayDivergenceResume(value: unknown): value is ReplayDivergenceResume {
-  if (!isRecord(value) || typeof value.allowed !== 'boolean') return false;
-  if (!Number.isInteger(value.from) || typeof value.planDigest !== 'string') return false;
-  return value.allowed || typeof value.reason === 'string';
 }
 
 /**

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { resetAllProcessMemosForTests } from '../ttl-memo.ts';
+import { findProjectRoot, readVersion } from '../version.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Counts package.json reads while calling through to the real read. */
+function countPackageJsonReads(): () => number {
+  const readSpy = vi.spyOn(fs, 'readFileSync');
+  return () =>
+    readSpy.mock.calls.filter(
+      ([target]) => typeof target === 'string' && target.endsWith('package.json'),
+    ).length;
+}
+
+// The package version and the project root are immutable for the life of a
+// process: nothing can rewrite the running code's own package.json in a way
+// the process is allowed to observe. Every CLI invocation reads both several
+// times (daemon reuse check, transport client version, help header), so they
+// are computed once per process and reset between tests.
+
+test('readVersion parses each root package.json once per process', () => {
+  const root = mkdtempForTestSync('agent-device-version-memo-');
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), '{"version":"1.2.3"}\n', 'utf8');
+    const packageJsonReads = countPackageJsonReads();
+
+    assert.equal(readVersion(root), '1.2.3');
+    assert.equal(readVersion(root), '1.2.3');
+
+    assert.equal(packageJsonReads(), 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readVersion keys the memo per root and re-reads after a process memo reset', () => {
+  const first = mkdtempForTestSync('agent-device-version-memo-first-');
+  const second = mkdtempForTestSync('agent-device-version-memo-second-');
+  try {
+    fs.writeFileSync(path.join(first, 'package.json'), '{"version":"1.0.0"}\n', 'utf8');
+    fs.writeFileSync(path.join(second, 'package.json'), '{"version":"2.0.0"}\n', 'utf8');
+
+    assert.equal(readVersion(first), '1.0.0');
+    assert.equal(readVersion(second), '2.0.0');
+
+    fs.writeFileSync(path.join(first, 'package.json'), '{"version":"1.0.1"}\n', 'utf8');
+    assert.equal(readVersion(first), '1.0.0');
+
+    resetAllProcessMemosForTests();
+    assert.equal(readVersion(first), '1.0.1');
+  } finally {
+    fs.rmSync(first, { recursive: true, force: true });
+    fs.rmSync(second, { recursive: true, force: true });
+  }
+});
+
+test('readVersion does not memoize a package.json it could not read', () => {
+  const root = mkdtempForTestSync('agent-device-version-memo-absent-');
+  try {
+    assert.equal(readVersion(root), '0.0.0');
+
+    fs.writeFileSync(path.join(root, 'package.json'), '{"version":"3.0.0"}\n', 'utf8');
+    assert.equal(readVersion(root), '3.0.0');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findProjectRoot walks the ancestor chain once per process', () => {
+  resetAllProcessMemosForTests();
+  const existsSpy = vi.spyOn(fs, 'existsSync');
+
+  const root = findProjectRoot();
+  const walkCalls = existsSpy.mock.calls.length;
+  assert.ok(walkCalls > 0);
+
+  assert.equal(findProjectRoot(), root);
+  assert.equal(existsSpy.mock.calls.length, walkCalls);
+});

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,24 +1,47 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createTtlMemo } from './ttl-memo.ts';
+
+// A running process cannot observe its own package version or its own project
+// root changing, and both are read several times per CLI invocation (daemon
+// reuse check, transport client version, help header, runner cache key), so
+// each is resolved once and cleared between tests by the process-memo reset.
+const versionMemo = createTtlMemo<string, string>();
+const projectRootMemo = createTtlMemo<'self', string>();
 
 export function readVersion(root: string = findProjectRoot()): string {
+  const memoized = versionMemo.get(root);
+  if (memoized !== undefined) return memoized;
+
+  let pkg: { version?: unknown };
   try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
+    pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
       version?: unknown;
     };
-    return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
   } catch {
+    // An absent or unreadable package.json is not memoized: the caller may be
+    // asking about a root that is still being materialized (a runner or helper
+    // package), and '0.0.0' must not stick to it for the rest of the process.
     return '0.0.0';
   }
+  const version = typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+  versionMemo.set(root, version);
+  return version;
 }
 
 export function findProjectRoot(): string {
+  const memoized = projectRootMemo.get('self');
+  if (memoized !== undefined) return memoized;
+
   const start = path.dirname(fileURLToPath(import.meta.url));
   let current = start;
   for (let i = 0; i < 6; i += 1) {
     const pkgPath = path.join(current, 'package.json');
-    if (fs.existsSync(pkgPath)) return current;
+    if (fs.existsSync(pkgPath)) {
+      projectRootMemo.set('self', current);
+      return current;
+    }
     current = path.dirname(current);
   }
   return start;


### PR DESCRIPTION
Verified audit item V5 (dev-from-source path only; dist behavior byte-identical).

## Summary

Every CLI invocation from source paid 803 `readFileSync` (4.6 MB) + 3,915 `statSync` to recompute the daemon code signature before any device work (~26–30 ms warm, on top of ~10 stat/probe redundancies).

- The graph walk is split into `walkDaemonCodeGraph` (stamps: label+size+mtime) and `formatDaemonCodeSignature`; `computeDaemonCodeSignature` is externally unchanged.
- New `code-signature-cache.ts` persists the stamp list under `os.tmpdir()/agent-device-code-signature/<sha1(root+entry)>.json`; revalidation is stat-only. A changed walk invalidates through ordinary stamp comparison because the walker is inside its own graph.
- Adversarial-review F1 fixed red-first: zero-entry or foreign-graph documents are refused (previously permanently valid — could restart-loop the daemon); F2 addressed; symlink-key parity with `buildSourceCheckpointStateDirName`'s realpath noted and handled.
- `resolveDaemonLaunchSpec`/`readVersion` memoized per process; repair-divergence sniffing now reads the typed `ReplayDivergenceResume` contract instead of ad-hoc casts.

## Validation

- Adversarial review of the first implementation: 8/10 claims PASS; F1 (high, zero-entry restart-loop) and F2 fixed with planted-document tests; numbers re-measured independently.
- Owning suites green (66 tests across daemon-client), fallow/format clean at pushed head.