### PR TITLE
test(daemon): harden the timed-out wait decoration test against CI load

### DIFF
--- a/src/daemon/__tests__/wait-runtime.test.ts
+++ b/src/daemon/__tests__/wait-runtime.test.ts
@@ -308,19 +308,44 @@ test('a provider owner that cannot capture fails closed instead of borrowing the
 // the SAME binding rather than reaching a second capture owner.
 // ---------------------------------------------------------------------------
 
+/**
+ * The 1ms timeout races the real clock: on a loaded CI host the first capture can take longer
+ * than 1ms to resolve, so `runWithinWaitDeadline` classifies it `capture-stalled` (or, once a
+ * later poll is readable, `capture-truncated`) instead of a completed target-absent poll, and
+ * `maybeWaitTimeoutSurfaceResponse` skips the decoration outright (see wait-current-surface.ts).
+ * A fake clock removes the race the same way `runFill` does in
+ * packages/provider-webdriver/src/webdriver-interactor.test.ts: virtual time only advances when
+ * `advanceTimersByTimeAsync` says so, so the mocked (instant, non-timer) capture always resolves
+ * before the deadline timer is due, on any host (docs/agents/testing.md: production time must
+ * never be real time in tests).
+ */
 test('a timed-out wait decorates its failure through the same single binding', async () => {
-  const harness = waitRuntimeHarness({
-    nodesPerPoll: [[{ index: 0, depth: 0, type: 'Button', label: 'Checkout', hittable: true }]],
-  });
+  vi.useFakeTimers();
+  try {
+    const harness = waitRuntimeHarness({
+      nodesPerPoll: [[{ index: 0, depth: 0, type: 'Button', label: 'Checkout', hittable: true }]],
+    });
 
-  const { response } = await runWait(['text', 'Ready', '1'], harness);
+    // Settled-shaped from the start: a rejection that lands while the clock is being advanced
+    // would otherwise be unhandled until the await below.
+    const pending = runWait(['text', 'Ready', '1'], harness).then(
+      (value) => ({ rejected: false, value }) as const,
+      (error: unknown) => ({ rejected: true, error }) as const,
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    const settled = await pending;
+    if (settled.rejected) throw settled.error;
+    const { response } = settled.value;
 
-  expect(response.ok).toBe(false);
-  if (response.ok) return;
-  expect(response.error.message).toContain('wait timed out for text: Ready');
-  expect(response.error.message).toContain('Current surface: Checkout');
-  expect(harness.inspectFacts).toHaveBeenCalledTimes(1);
-  expect(harness.bindDevice).toHaveBeenCalledTimes(1);
+    expect(response.ok).toBe(false);
+    if (response.ok) return;
+    expect(response.error.message).toContain('wait timed out for text: Ready');
+    expect(response.error.message).toContain('Current surface: Checkout');
+    expect(harness.inspectFacts).toHaveBeenCalledTimes(1);
+    expect(harness.bindDevice).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/__tests__/wait-runtime.test.ts
+++ b/src/daemon/__tests__/wait-runtime.test.ts
@@ -308,17 +308,6 @@ test('a provider owner that cannot capture fails closed instead of borrowing the
 // the SAME binding rather than reaching a second capture owner.
 // ---------------------------------------------------------------------------
 
-/**
- * The 1ms timeout races the real clock: on a loaded CI host the first capture can take longer
- * than 1ms to resolve, so `runWithinWaitDeadline` classifies it `capture-stalled` (or, once a
- * later poll is readable, `capture-truncated`) instead of a completed target-absent poll, and
- * `maybeWaitTimeoutSurfaceResponse` skips the decoration outright (see wait-current-surface.ts).
- * A fake clock removes the race the same way `runFill` does in
- * packages/provider-webdriver/src/webdriver-interactor.test.ts: virtual time only advances when
- * `advanceTimersByTimeAsync` says so, so the mocked (instant, non-timer) capture always resolves
- * before the deadline timer is due, on any host (docs/agents/testing.md: production time must
- * never be real time in tests).
- */
 test('a timed-out wait decorates its failure through the same single binding', async () => {
   vi.useFakeTimers();
   try {
@@ -326,16 +315,9 @@ test('a timed-out wait decorates its failure through the same single binding', a
       nodesPerPoll: [[{ index: 0, depth: 0, type: 'Button', label: 'Checkout', hittable: true }]],
     });
 
-    // Settled-shaped from the start: a rejection that lands while the clock is being advanced
-    // would otherwise be unhandled until the await below.
-    const pending = runWait(['text', 'Ready', '1'], harness).then(
-      (value) => ({ rejected: false, value }) as const,
-      (error: unknown) => ({ rejected: true, error }) as const,
-    );
+    const pending = runWait(['text', 'Ready', '1'], harness);
     await vi.advanceTimersByTimeAsync(5_000);
-    const settled = await pending;
-    if (settled.rejected) throw settled.error;
-    const { response } = settled.value;
+    const { response } = await pending;
 
     expect(response.ok).toBe(false);
     if (response.ok) return;


### PR DESCRIPTION
## Summary

- `src/daemon/__tests__/wait-runtime.test.ts`'s `'a timed-out wait decorates its failure through the same single binding'` used a 1ms real-clock `wait` timeout, which races the first capture's resolution: on a loaded CI host (e.g. CI Coverage shard 2, run 32752619090 on PR #2000, head `30bd80967`) the capture can take longer than 1ms wall-clock to resolve, so `runWithinWaitDeadline` classifies the poll `capture-stalled`/`capture-truncated` instead of a completed target-absent poll, and `maybeWaitTimeoutSurfaceResponse` (`src/daemon/wait-current-surface.ts`) skips the "Current surface" decoration outright — failing the `toContain('Current surface: Checkout')` assertion.
- Fixed by driving the test on a fake clock (`vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync`), the same pattern `runFill` uses in `packages/provider-webdriver/src/webdriver-interactor.test.ts`, per `docs/agents/testing.md`'s rule that production time must never be real time in tests. Virtual time now only advances when the test says so, so the mocked (instant, non-timer) capture always resolves before the deadline timer is due — removing the race entirely, regardless of host load.
- The assertion itself is unchanged.

## Regression evidence

- Reproduced the exact CI failure locally by pegging all CPU cores (`yes > /dev/null` × nproc) during repeated runs of the *unfixed* test — it failed with the identical assertion error (`expected 'wait timed out for text: Ready' to contain 'Current surface: Checkout'`) multiple times out of 8 runs.
- Applied the fix and re-ran under the same simulated load: 10/10 passes.
- Full file (`wait-runtime.test.ts`, 19 tests) and the sibling `wait-current-surface.test.ts` pass without load.

## Test plan

- [x] `pnpm exec vitest run --project unit-core src/daemon/__tests__/wait-runtime.test.ts src/daemon/wait-current-surface.test.ts` — all pass
- [x] Reproduced the flake on the pre-fix test under simulated CPU load, then confirmed the fix eliminates it (10/10 passes under the same load)
- [x] `pnpm check:affected --run`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1Ps2n6f5yA9hzEo3AgDFQ)_