### PR TITLE
perf(selectors): collapse the double tree scan for disambiguate/fail-closed rows

### DIFF
--- a/packages/contracts/src/facades/snapshot.ts
+++ b/packages/contracts/src/facades/snapshot.ts
@@ -12,6 +12,7 @@ export {
   findSnapshotAncestor,
 } from '../snapshot-tree.ts';
 export {
+  collectViewportRects,
   findNearestScrollableAncestor,
   isNodeVisibleInEffectiveViewport,
   isNodeVisibleOnScreen,

--- a/packages/contracts/src/snapshot-visibility.ts
+++ b/packages/contracts/src/snapshot-visibility.ts
@@ -42,6 +42,20 @@ export function isViewportRootNode(node: Pick<SnapshotNode, 'type' | 'role' | 's
 }
 
 /**
+ * The Application/Window rects a target's viewport resolves against — the
+ * whole-tree scan `resolveViewportRect` does per call when no
+ * `precomputedViewportRects` is given. A caller resolving visibility for
+ * several nodes against the SAME tree (e.g. ranking ambiguous selector
+ * candidates) should build this once and thread it through, so N candidates
+ * share one pass instead of each paying its own (#1970).
+ */
+export function collectViewportRects(nodes: RawSnapshotNode[]): Rect[] {
+  return nodes.flatMap((node) =>
+    isViewportRootNode(node) && hasValidRect(node.rect) ? [node.rect] : [],
+  );
+}
+
+/**
  * The root viewport a target rect is measured against: the largest
  * Application/Window rect containing the target's center, falling back to the
  * largest such rect, then to the largest containing rect of any node.
@@ -52,11 +66,7 @@ export function resolveViewportRect(
   precomputedViewportRects?: readonly Rect[],
 ): Rect | null {
   const targetCenter = centerOfRect(targetRect);
-  const viewportRects =
-    precomputedViewportRects ??
-    nodes.flatMap((node) =>
-      isViewportRootNode(node) && hasValidRect(node.rect) ? [node.rect] : [],
-    );
+  const viewportRects = precomputedViewportRects ?? collectViewportRects(nodes);
   const contains = (rect: Rect) => containsPoint(rect, targetCenter.x, targetCenter.y);
   const viewport =
     pickLargestRect(viewportRects.filter(contains)) ?? pickLargestRect(viewportRects);

--- a/packages/contracts/src/snapshot.test.ts
+++ b/packages/contracts/src/snapshot.test.ts
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import type { RawSnapshotNode, Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
 import {
   buildSnapshotNodeMap,
+  collectViewportRects,
   extractNodeText,
   findNearestAncestor,
   findNearestScrollableAncestor,
@@ -101,6 +102,33 @@ test('resolveViewportRect selects the containing application viewport', () => {
 
   assert.deepEqual(resolveViewportRect(nodes, target), viewport);
   assert.deepEqual(resolveViewportRect(nodes, target, [viewport]), viewport);
+});
+
+test('collectViewportRects reports exactly what resolveViewportRect gathers when uncached (#1970)', () => {
+  const viewport: Rect = { x: 0, y: 0, width: 300, height: 500 };
+  const nodes = [
+    node({ index: 0, type: 'Application', rect: viewport }),
+    node({
+      index: 1,
+      type: 'Button',
+      parentIndex: 0,
+      rect: { x: 10, y: 10, width: 20, height: 20 },
+    }),
+    // Invalid rects (non-finite) are excluded, same as resolveViewportRect's own inline gather.
+    node({ index: 2, type: 'Window', rect: { x: Number.NaN, y: 0, width: 10, height: 10 } }),
+  ];
+
+  assert.deepEqual(collectViewportRects(nodes), [viewport]);
+
+  // A caller sharing this precomputed set across several `resolveViewportRect`
+  // calls (as `analyzeSelectorMatches` now does for its lazily-built
+  // visibility index) must get the identical answer a fresh, uncached call
+  // would — precomputing must not change which viewport wins.
+  const target: Rect = { x: 20, y: 20, width: 40, height: 40 };
+  assert.deepEqual(
+    resolveViewportRect(nodes, target, collectViewportRects(nodes)),
+    resolveViewportRect(nodes, target),
+  );
 });
 
 test('snapshot visibility uses the nearest scrollable viewport before applying the tap-point rule', () => {

--- a/packages/selectors/src/index.test.ts
+++ b/packages/selectors/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   resolveReplaySuggestionCandidate,
   SELECTOR_RESOLUTION_POLICIES,
 } from './index.ts';
+import { loginFormNodes } from './internal/__tests__/login-form-nodes.ts';
 
 const saveNode: SnapshotNode = {
   ref: 'e1',
@@ -208,15 +209,25 @@ test('recorded-target resolution adds no second matching pass per selector alter
   // The ambiguous leg reports that same domain instead of re-listing the chain's
   // matches: one matching pass, no second one. The `map` is the deciding pass's
   // own lazily-built visibility index. The `flatMap`s are NOT that pass — they
-  // are four whole-tree viewport-rect scans per ambiguous candidate, charged by
-  // `isNodeVisibleOnScreen` because the caller passes no precomputed viewport
-  // rects. They scale with the candidate count and predate this change; they are
-  // pinned here so the number cannot grow unnoticed, and are tracked separately.
+  // are whole-tree viewport-rect scans inside `isNodeVisibleOnScreen`, charged
+  // once per candidate it is asked about.
+  //
+  // #1970 collapsed the Application/Window-rect gather (`collectViewportRects`)
+  // to one shared scan per alternative instead of one per candidate, which is
+  // why this dropped from 8 to 5: this fixture has no Application/Window root,
+  // so every `resolveViewportRect` call still falls through to its OTHER
+  // flatMap — the "largest rect of any node containing this target's center"
+  // fallback — which cannot be precomputed the same way because it depends on
+  // each node's own rect, not the shared viewport-root set. That fallback fires
+  // twice per candidate (`isNodeVisibleOnScreen` calls `resolveViewportRect`
+  // once via the effective-viewport check, once directly for the root
+  // viewport) plus the one shared gather: 2*2 + 1 = 5. It predates #1970 and is
+  // out of scope here; pinned so the number cannot grow unnoticed.
   assert.deepEqual(unresolved.passes, {
     iterated: 1,
     filter: 0,
     map: 1,
-    flatMap: 8,
+    flatMap: 5,
     forEach: 0,
     reduce: 0,
     reduceRight: 0,
@@ -229,6 +240,41 @@ test('recorded-target resolution adds no second matching pass per selector alter
     includes: 0,
     indexOf: 0,
   });
+});
+
+test('policy resolution for disambiguate/fail-closed rows adds no second matching pass per selector alternative (#1970)', () => {
+  for (const row of [
+    SELECTOR_RESOLUTION_POLICIES.readText,
+    SELECTOR_RESOLUTION_POLICIES.readUnique,
+  ]) {
+    const traced = observeTreeTraversals(loginFormNodes);
+    const outcome = resolveSelectorChainWithPolicy(
+      traced.observed,
+      'label="Continue" || id=auth_continue',
+      row,
+      { platform: 'ios' },
+    );
+    // The winner comes from the SECOND alternative — uniqueness skips the
+    // tied first one — but `matchedNodes` still reports the FIRST alternative
+    // that matched anything, the contract `wait`'s landmark check and the
+    // ambiguous outcome both rely on (resolve-with-policy.ts). Previously this
+    // ran `listSelectorChainMatches` once for that set and then
+    // `resolveSelectorChainDomain` (nee `resolveSelectorChain`) again for the
+    // winner: two full passes, one per alternative visited. `iterated: 2`
+    // below (one pass for each of the two alternatives) with `filter: 0`
+    // proves the redundant `listSelectorChainMatches` pass — which would show
+    // up as a `filter` — is gone.
+    assert.equal(outcome.kind, 'resolved');
+    if (outcome.kind !== 'resolved') throw new Error('unreachable');
+    assert.equal(outcome.resolution.selectorIndex, 1);
+    assert.equal(outcome.resolution.node.ref, 'e2');
+    assert.deepEqual(
+      outcome.matchedNodes.map((node) => node.ref),
+      ['e2', 'e3'],
+    );
+    assert.equal(traced.passes.filter, 0, 'no separate listSelectorChainMatches pass');
+    assert.equal(traced.passes.iterated, 2, 'one pass per alternative visited, not two');
+  }
 });
 
 test('recorded-target resolution applies requireRect to both winner and domain', () => {

--- a/packages/selectors/src/internal/resolve-with-policy.ts
+++ b/packages/selectors/src/internal/resolve-with-policy.ts
@@ -3,7 +3,8 @@ import type { SelectorChain } from './parse.ts';
 import type { SelectorMatchOptions } from './public-resolution-types.ts';
 import {
   listSelectorChainMatches,
-  resolveSelectorChain,
+  resolveSelectorChainDomain,
+  type AstSelectorChainMatchList,
   type AstSelectorResolution,
 } from './resolve.ts';
 import { selectorResolutionKnobs, type SelectorResolutionPolicy } from './resolution-policy.ts';
@@ -60,38 +61,46 @@ export function resolveSelectorChainWithPolicy(
   options: SelectorMatchOptions,
 ): AstPolicyResolutionOutcome {
   const ambiguity = policy.ambiguity;
-  // One matching pass serves every row. It also settles "nothing matched"
-  // once, up front: no alternative matching under this row's rect requirement
-  // is the only way any row reaches `none`, uniqueness included — a
-  // fail-closed row that finds candidates it will not choose between reports
-  // ambiguity, never absence.
-  const list = listSelectorChainMatches(nodes, chain, {
-    ...options,
-    requireRect: policy.requireRect,
-  });
-  if (!list || list.matchedNodes.length === 0) return { kind: 'none' };
-
-  if (ambiguity === 'first-match') return resolvedFromList(list);
-  if (ambiguity === 'reject-candidates') {
+  if (ambiguity === 'first-match' || ambiguity === 'reject-candidates') {
+    // Neither row disambiguates, so the plain existence-only scan
+    // `listSelectorChainMatches` does is the whole contract: one pass, no
+    // per-candidate visibility/tiebreak bookkeeping to pay for.
+    const list = listSelectorChainMatches(nodes, chain, {
+      ...options,
+      requireRect: policy.requireRect,
+    });
+    if (!list || list.matchedNodes.length === 0) return { kind: 'none' };
+    if (ambiguity === 'first-match') return resolvedFromList(list);
     return list.matchedNodes.length > 1 ? ambiguousFromList(list) : resolvedFromList(list);
   }
 
-  // The uniqueness knobs are named in exactly one place (#1630); the rows
-  // handled above leave only the two that map onto them. A resolution here may
-  // come from a LATER alternative than `list`, since uniqueness skips an
-  // ambiguous alternative to try the next one.
-  const resolution = resolveSelectorChain(nodes, chain, {
+  // `disambiguate` / `fail-closed`: the uniqueness knobs are named in exactly
+  // one place (#1630). `resolveSelectorChainDomain` visits each alternative
+  // once and reports both the winning resolution AND the first alternative
+  // that matched anything (`firstMatch`) from that SAME pass — previously this
+  // ran `listSelectorChainMatches` for `firstMatch` and then
+  // `resolveSelectorChainDomain` again for `resolution`, scanning the tree
+  // twice (#1970). A resolution can come from a LATER alternative than
+  // `firstMatch`, since uniqueness skips an ambiguous alternative to try the
+  // next one — `matchedNodes` below stays paired with `firstMatch`, not the
+  // winner, so a caller must pair it with `resolution.selector` before
+  // reading them as one set (see `AstPolicyResolutionOutcome`'s `resolved`
+  // case).
+  const domain = resolveSelectorChainDomain(nodes, chain, {
     ...options,
     ...selectorResolutionKnobs({ ambiguity, requireRect: policy.requireRect }),
   });
-  return resolution
-    ? { kind: 'resolved', resolution, matchedNodes: list.matchedNodes }
-    : ambiguousFromList(list);
+  if (!domain.firstMatch) return { kind: 'none' };
+  return domain.resolution
+    ? {
+        kind: 'resolved',
+        resolution: domain.resolution,
+        matchedNodes: domain.firstMatch.matchedNodes,
+      }
+    : ambiguousFromList(domain.firstMatch);
 }
 
-function ambiguousFromList(
-  list: NonNullable<ReturnType<typeof listSelectorChainMatches>>,
-): AstPolicyResolutionOutcome {
+function ambiguousFromList(list: AstSelectorChainMatchList): AstPolicyResolutionOutcome {
   return {
     kind: 'ambiguous',
     selector: list.selector.raw,
@@ -100,9 +109,7 @@ function ambiguousFromList(
   };
 }
 
-function resolvedFromList(
-  list: NonNullable<ReturnType<typeof listSelectorChainMatches>>,
-): AstPolicyResolutionOutcome {
+function resolvedFromList(list: AstSelectorChainMatchList): AstPolicyResolutionOutcome {
   const node = list.matchedNodes[0];
   if (!node) return { kind: 'none' };
   return {

--- a/packages/selectors/src/internal/resolve.test.ts
+++ b/packages/selectors/src/internal/resolve.test.ts
@@ -57,6 +57,27 @@ test("resolveSelectorChainDomain reports the winning alternative's matched nodes
   );
 });
 
+test('resolveSelectorChainDomain also reports the first alternative that matched anything, from the SAME pass (#1970)', () => {
+  const chain = parseSelectorChain('label="Continue" || id=auth_continue');
+  const domain = resolveSelectorChainDomain(loginFormNodes, chain, {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+  // `firstMatch` names the FIRST alternative that matched anything (index 0,
+  // both "Continue"s) even though `resolution`/`matchedNodes` name the winning
+  // SECOND alternative — a caller whose contract is "the first thing that
+  // matched" (resolveSelectorChainWithPolicy's disambiguate/fail-closed rows,
+  // #1970) reads this instead of re-scanning the tree with
+  // listSelectorChainMatches to get the same set.
+  assert.equal(domain.resolution?.selectorIndex, 1);
+  assert.equal(domain.firstMatch?.selectorIndex, 0);
+  assert.deepEqual(
+    domain.firstMatch?.matchedNodes.map((node) => node.ref),
+    ['e2', 'e3'],
+  );
+});
+
 test('resolveSelectorChainDomain reports the first matching alternative when nothing resolves', () => {
   const domain = resolveSelectorChainDomain(
     loginFormNodes,
@@ -78,7 +99,7 @@ test('resolveSelectorChainDomain reports the first matching alternative when not
     requireRect: true,
     requireUnique: true,
   });
-  assert.deepEqual(missing, { resolution: null, matchedNodes: [] });
+  assert.deepEqual(missing, { resolution: null, matchedNodes: [], firstMatch: null });
 });
 
 test('findSelectorChainMatch returns first matching selector for existence checks', () => {

--- a/packages/selectors/src/internal/resolve.ts
+++ b/packages/selectors/src/internal/resolve.ts
@@ -1,7 +1,11 @@
 import type { Platform, PublicPlatform } from '@agent-device/kernel/device';
 import type { DisambiguationTiebreak } from '@agent-device/contracts/interaction';
-import type { SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
-import { buildSnapshotNodeMap, isNodeVisibleOnScreen } from '@agent-device/contracts/snapshot';
+import type { Rect, SnapshotNode, SnapshotState } from '@agent-device/kernel/snapshot';
+import {
+  buildSnapshotNodeMap,
+  collectViewportRects,
+  isNodeVisibleOnScreen,
+} from '@agent-device/contracts/snapshot';
 import { matchesSelector } from './match.ts';
 import type { Selector, SelectorChain } from './parse.ts';
 import type {
@@ -35,10 +39,20 @@ export type AstSelectorResolution = {
  * non-null. When no alternative resolved, it describes the first alternative
  * that matched anything — the set `listSelectorChainMatches` reports, computed
  * here by the pass that already visited those nodes.
+ *
+ * `firstMatch` is the SAME "first alternative that matched anything" domain
+ * `listSelectorChainMatches` reports, but populated unconditionally — a
+ * uniqueness row can resolve from a LATER alternative than the one it first
+ * matched (uniqueness skips an ambiguous alternative to try the next one), so
+ * `firstMatch` and `matchedNodes`/`resolution` can name different
+ * alternatives. A caller whose contract is "the first thing that matched",
+ * not "what resolution bound to" (#1970), reads this instead of paying a
+ * second whole-tree scan for `listSelectorChainMatches`.
  */
 export type AstSelectorChainResolutionDomain = {
   resolution: AstSelectorResolution | null;
   matchedNodes: SnapshotNode[];
+  firstMatch: AstSelectorChainMatchList | null;
 };
 
 export function resolveSelectorChainDomain(
@@ -49,16 +63,17 @@ export function resolveSelectorChainDomain(
   const requireRect = options.requireRect ?? false;
   const requireUnique = options.requireUnique ?? true;
   const diagnostics: SelectorDiagnostics[] = [];
-  let firstMatchedNodes: SnapshotNode[] | null = null;
+  let firstMatch: AstSelectorChainMatchList | null = null;
   for (const [i, selector] of chain.selectors.entries()) {
     const summary = analyzeSelectorMatches(nodes, selector, options.platform, requireRect);
     diagnostics.push({ selector: selector.raw, matches: summary.count });
     if (summary.count === 0 || !summary.firstNode) continue;
-    firstMatchedNodes ??= summary.candidates;
+    firstMatch ??= { selector, selectorIndex: i, matchedNodes: summary.candidates };
     if (requireUnique && summary.count !== 1) {
       if (!options.disambiguateAmbiguous || !summary.disambiguated || !summary.tiebreak) continue;
       return {
         matchedNodes: summary.candidates,
+        firstMatch,
         resolution: {
           node: summary.disambiguated,
           selector,
@@ -77,6 +92,7 @@ export function resolveSelectorChainDomain(
     }
     return {
       matchedNodes: summary.candidates,
+      firstMatch,
       resolution: {
         node: summary.firstNode,
         selector,
@@ -86,7 +102,7 @@ export function resolveSelectorChainDomain(
       },
     };
   }
-  return { resolution: null, matchedNodes: firstMatchedNodes ?? [] };
+  return { resolution: null, matchedNodes: firstMatch?.matchedNodes ?? [], firstMatch };
 }
 
 export function resolveSelectorChain(
@@ -210,11 +226,16 @@ function analyzeSelectorMatches(
   let firstNode: SnapshotNode | null = null;
   const candidates: SnapshotNode[] = [];
   const state: DisambiguationState = { best: null, bestVisible: false, tie: false };
-  // Lazily built: only ambiguous matches pay for viewport inference.
+  // Lazily built: only ambiguous matches pay for viewport inference, and both
+  // maps are built once per alternative so N ambiguous candidates share one
+  // whole-tree pass instead of `isNodeVisibleOnScreen` re-deriving the
+  // viewport rects for each candidate it is asked about (#1970).
   let byIndex: Map<number, SnapshotNode> | undefined;
+  let viewportRects: Rect[] | undefined;
   const isVisible = (node: SnapshotNode): boolean => {
     byIndex ??= buildSnapshotNodeMap(nodes);
-    return isNodeVisibleOnScreen(node, nodes, byIndex);
+    viewportRects ??= collectViewportRects(nodes);
+    return isNodeVisibleOnScreen(node, nodes, byIndex, viewportRects);
   };
   for (const node of nodes) {
     if (requireRect && !node.rect) continue;


### PR DESCRIPTION
## Summary

`resolveSelectorChainWithPolicy` ran two full scans of the snapshot tree for the `disambiguate`/`fail-closed` policy rows (`readText`/`readUnique`, used by `get text`, `get attrs`, and `is` non-`exists` predicates): `listSelectorChainMatches` to compute the "first alternative that matched anything" (`matchedNodes`), then `resolveSelectorChain` again to compute the winning resolution — the same defect class #1690 already removed from replay's `resolveRecordedTarget`. `first-match`/`reject-candidates` rows were already single-pass and are untouched.

- `resolveSelectorChainDomain` (`packages/selectors/src/internal/resolve.ts`) now tracks `firstMatch` — the first alternative that matched anything, with its selector/index/matched-node set — unconditionally, in the same per-alternative loop that already decides the winning resolution. `resolveSelectorChainWithPolicy` now makes one call to it instead of two.
- The pre-existing semantic where `matchedNodes` names the *first* matching alternative rather than the *winning* one (when uniqueness skips a tied/ambiguous alternative to resolve from a later one — the exact case the issue flagged as "not mechanically foldable" with `resolveSelectorChainDomain`'s own `matchedNodes`, since that field reports the *winner's* domain) is preserved byte-for-byte: `wait`'s #1349 landmark check and the ambiguous outcome both depend on it.
- Also fixes the related `analyzeSelectorMatches` inefficiency: its lazily-built `isVisible` closure now builds the viewport-root rect list once per alternative (via a newly extracted `collectViewportRects` in `packages/contracts/src/snapshot-visibility.ts`) alongside the already-lazy `byIndex` map, instead of `isNodeVisibleOnScreen` re-deriving it via two whole-tree `flatMap` passes on every ambiguous candidate it's asked about.

No output shape or behavior changes for any caller — this is a pure perf/scan-count fix.

Closes #1970

## Validation

- `pnpm build`, `tsc --noEmit`, `pnpm lint`, `pnpm check:layering`, `pnpm check:production-exports`, `pnpm check:fallow --base origin/main` all clean.
- `pnpm check:affected --run`'s `vitest-related` lane surfaced only 2 pre-existing failures (`app-log-session-resource.test.ts`, `durable-capture-resource-adoption.test.ts`) — confirmed present and unrelated on a clean checkout before this change.
- Regression evidence per repo convention: extended the existing scan-count gate (`packages/selectors/src/index.test.ts`, the same `observeTreeTraversals` proxy #1988 introduced) with a new test asserting one matching pass per alternative for `readText`/`readUnique`. Reverting the `resolve-with-policy.ts` change reproduces the double-scan (`filter: 1`, the redundant pass) — observed red, restored green.
- The viewport-rect fix reduces the pre-existing pinned `flatMap` count on that same gate's ambiguous leg from 8 to 5 (the residual 5 is a separate, out-of-scope fallback scan in `resolveViewportRect` that fires only when the tree has no Application/Window root at all, documented inline).
- New unit coverage: `resolveSelectorChainDomain`'s `firstMatch` field (`packages/selectors/src/internal/resolve.test.ts`), `collectViewportRects`' equivalence with the previous inline scan (`packages/contracts/src/snapshot.test.ts`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJoiggu7utUNDBmdzSBK2h)_