### PR TITLE
feat(maestro): support assertTrue phase 1 - literal/${VAR} truthiness (#1295)

### DIFF
--- a/docs/adr/0015-direct-maestro-engine.md
+++ b/docs/adr/0015-direct-maestro-engine.md
@@ -190,6 +190,11 @@ two-pointer plans, executor selection, and app-observable effects must remain un
 
 - agent-device supports selected Maestro Flow syntax and behavior. Unsupported features return
   explicit errors, and intentional differences are declared in the conformance fixtures.
+- `${...}` interpolation stays variable-lookup-only, by decision (#1292): upstream's GraalJS
+  expression evaluation is not reimplemented, so unresolved or expression-shaped payloads fail
+  loud with source context; the escape hatch is `runScript` (compute) → `${output.x}` (consume).
+  `assertTrue` (#1295) is scoped to that same lookup-only subset — literal values and bare
+  `${VAR}` lookups evaluated with a pinned string-truthiness table — for the same reason.
 - Shipping two production engines or a runtime fallback between them is rejected because it doubles
   semantic and performance ownership.
 - Source provenance and runtime values stay typed through execution.

--- a/packages/maestro/src/internal/__tests__/engine-truthiness.test.ts
+++ b/packages/maestro/src/internal/__tests__/engine-truthiness.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { isMaestroConditionTruthy } from '../engine-truthiness.ts';
+
+// assertTrue phase 1 (#1295): pin the string-value truthiness table explicitly
+// rather than relying on native JS coercion (which would treat every non-empty
+// string, including "false", as truthy). See engine-truthiness.ts for the
+// rationale — values arriving through a ${VAR} lookup are always strings.
+describe('isMaestroConditionTruthy', () => {
+  test.each([
+    ['', false],
+    ['false', false],
+    ['0', false],
+    ['null', false],
+    ['undefined', false],
+  ])('string %j is falsy', (value, expected) => {
+    expect(isMaestroConditionTruthy(value)).toBe(expected);
+  });
+
+  test.each([
+    ['False', true], // case-sensitive: only the exact lowercase sentinels are falsy
+    ['FALSE', true],
+    [' ', true],
+    ['0.0', true],
+    ['-0', true],
+    ['42', true],
+    ['-1', true],
+    ['{}', true],
+    ['[]', true],
+    ['{"flag":false}', true],
+    ['[1,2,3]', true],
+    ['hello', true],
+    ['nonEmptyString', true],
+  ])('string %j is truthy', (value, expected) => {
+    expect(isMaestroConditionTruthy(value)).toBe(expected);
+  });
+
+  test('booleans use native JS truthiness', () => {
+    expect(isMaestroConditionTruthy(true)).toBe(true);
+    expect(isMaestroConditionTruthy(false)).toBe(false);
+  });
+
+  test('numbers use native JS truthiness', () => {
+    expect(isMaestroConditionTruthy(0)).toBe(false);
+    expect(isMaestroConditionTruthy(Number.NaN)).toBe(false);
+    expect(isMaestroConditionTruthy(1)).toBe(true);
+    expect(isMaestroConditionTruthy(-1)).toBe(true);
+    expect(isMaestroConditionTruthy(123)).toBe(true);
+  });
+});

--- a/packages/maestro/src/internal/__tests__/engine.test.ts
+++ b/packages/maestro/src/internal/__tests__/engine.test.ts
@@ -173,6 +173,72 @@ describe('executeMaestroProgram', () => {
     );
   });
 
+  test('passes assertTrue for a truthy literal and a truthy ${VAR} lookup', async () => {
+    const port = makePort();
+    const program = parseMaestroProgram(
+      [
+        '---',
+        '- assertTrue: true',
+        '- assertTrue: 42',
+        '- assertTrue: nonEmptyString',
+        '- assertTrue: ${FLAG}',
+      ].join('\n'),
+    );
+
+    const result = await executeMaestroProgram(program, port, { env: { FLAG: 'yes' } });
+
+    expect(result).toMatchObject({ executed: 4, skipped: 0 });
+    expect(port.execute).not.toHaveBeenCalled();
+    expect(port.observe).not.toHaveBeenCalled();
+  });
+
+  test('fails assertTrue for a falsy literal and a falsy ${VAR} lookup', async () => {
+    const port = makePort();
+    const program = parseMaestroProgram(
+      ['---', '- assertTrue: false', '- inputText: unreachable'].join('\n'),
+    );
+
+    await expect(executeMaestroProgram(program, port)).rejects.toMatchObject({
+      code: 'COMMAND_FAILED',
+    });
+    expect(port.execute).not.toHaveBeenCalled();
+  });
+
+  test('treats stringified "false" from a ${VAR} lookup as falsy, not a non-empty string', async () => {
+    const port = makePort();
+    const program = parseMaestroProgram(['---', '- assertTrue: ${OUTPUT_FLAG}'].join('\n'));
+
+    await expect(
+      executeMaestroProgram(program, port, { env: { OUTPUT_FLAG: 'false' } }),
+    ).rejects.toMatchObject({ code: 'COMMAND_FAILED' });
+  });
+
+  test('continues after an optional assertTrue with a falsy condition', async () => {
+    const port = makePort();
+    const program = parseMaestroProgram(
+      [
+        '---',
+        '- assertTrue:',
+        '    condition: "false"',
+        '    optional: true',
+        '- inputText: continued',
+      ].join('\n'),
+    );
+
+    const result = await executeMaestroProgram(program, port);
+
+    expect(result).toMatchObject({ executed: 1, skipped: 1 });
+    expect(result.warnings).toEqual([
+      expect.stringMatching(/Optional Maestro assertTrue skipped at line 2/),
+    ]);
+  });
+
+  test('rejects a JS-expression assertTrue condition at parse time', () => {
+    expect(() => parseMaestroProgram(['---', '- assertTrue: ${1+1}'].join('\n'))).toThrow(
+      /assertTrue.*bare.*lookup.*runScript/is,
+    );
+  });
+
   test('propagates AMBIGUOUS_MATCH from an optional target command', async () => {
     const ambiguous = new AppError('AMBIGUOUS_MATCH', 'multiple target matches');
     const execute = vi.fn(async () => {

--- a/packages/maestro/src/internal/__tests__/program-ir-parser.test.ts
+++ b/packages/maestro/src/internal/__tests__/program-ir-parser.test.ts
@@ -229,6 +229,69 @@ describe('parseMaestroProgram', () => {
     });
   });
 
+  test('parses assertTrue literal, ${VAR} lookup, and map form with optional/label', () => {
+    const program = parseMaestroProgram(
+      [
+        '---',
+        '- assertTrue: true',
+        '- assertTrue: "false"',
+        '- assertTrue: ${FLAG}',
+        '- assertTrue:',
+        '    condition: "false"',
+        '    optional: true',
+        '    label: Flag check',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(program.commands[0], {
+      kind: 'assertTrue',
+      source: { line: 2 },
+      condition: true,
+    });
+    assert.deepEqual(program.commands[1], {
+      kind: 'assertTrue',
+      source: { line: 3 },
+      condition: 'false',
+    });
+    assert.deepEqual(program.commands[2], {
+      kind: 'assertTrue',
+      source: { line: 4 },
+      condition: '${FLAG}',
+    });
+    assert.deepEqual(program.commands[3], {
+      kind: 'assertTrue',
+      source: { line: 5 },
+      condition: 'false',
+      optional: true,
+      label: 'Flag check',
+    });
+  });
+
+  test('rejects a JS-expression assertTrue condition (only literals and bare ${VAR} lookups are supported)', () => {
+    assert.throws(
+      () => parseMaestroProgram(['---', '- assertTrue: ${1+1}'].join('\n')),
+      /assertTrue.*bare.*lookup.*runScript/is,
+    );
+    assert.throws(
+      () =>
+        parseMaestroProgram(
+          ['---', '- assertTrue:', '    condition: "prefix ${FLAG} suffix"'].join('\n'),
+        ),
+      /assertTrue\.condition.*bare.*lookup.*runScript/is,
+    );
+  });
+
+  test('rejects assertTrue with no condition', () => {
+    assert.throws(
+      () => parseMaestroProgram(['---', '- assertTrue:', '    optional: true'].join('\n')),
+      /assertTrue requires condition/i,
+    );
+    assert.throws(
+      () => parseMaestroProgram(['---', '- assertTrue'].join('\n')),
+      /assertTrue requires condition/i,
+    );
+  });
+
   test('rejects selectors that contain only optional and no matching criteria', () => {
     assert.throws(
       () =>

--- a/packages/maestro/src/internal/conformance-normalize.ts
+++ b/packages/maestro/src/internal/conformance-normalize.ts
@@ -52,11 +52,12 @@ export type CanonicalCommand =
     }
   | {
       kind: 'assert';
-      mode: 'visible' | 'notVisible';
+      mode: 'visible' | 'notVisible' | 'true';
       timed: boolean;
       timeout?: number | string;
       label?: string;
       selector?: CanonicalSelector;
+      expression?: string;
     }
   | { kind: 'swipe'; label?: string; gesture: CanonicalGesture }
   | { kind: 'inputText'; label?: string; text?: string }
@@ -147,6 +148,16 @@ function canonicalizeUpstreamCommand(command: UpstreamCommand): CanonicalCommand
           timeout,
           label: str(f.label),
           selector: canonicalizeUpstreamSelector(condition.notVisible),
+        });
+      }
+      if (condition.scriptCondition != null) {
+        return dropUndefined({
+          kind: 'assert',
+          mode: 'true',
+          timed: f.timeout != null,
+          timeout,
+          label: str(f.label),
+          expression: str(condition.scriptCondition),
         });
       }
       return { kind: 'unsupported', command: 'assertTrue' };
@@ -348,6 +359,14 @@ function canonicalizeAgentCommand(
         label: command.label,
         selector: canonicalizeAgentSelector(command.target),
       });
+    case 'assertTrue':
+      return dropUndefined({
+        kind: 'assert',
+        mode: 'true',
+        timed: false,
+        label: command.label,
+        expression: String(command.condition),
+      });
     case 'extendedWaitUntil':
       return dropUndefined({
         kind: 'assert',
@@ -368,9 +387,13 @@ function canonicalizeAgentCommand(
     case 'scroll':
       return { kind: 'scroll' };
     case 'scrollUntilVisible':
+      // Upstream materializes the DOWN default onto the command at parse time;
+      // our engine defers it to execution (runtime-port-commands.ts). Materialize
+      // it here too so the comparison is on effective values, matching the same
+      // pattern used for swipe duration and repeat delay above.
       return dropUndefined({
         kind: 'scrollUntilVisible',
-        direction: command.direction,
+        direction: command.direction ?? 'down',
         label: command.label,
         selector: canonicalizeAgentSelector(command.element),
         timeout: numLike(command.timeout),

--- a/packages/maestro/src/internal/engine-truthiness.ts
+++ b/packages/maestro/src/internal/engine-truthiness.ts
@@ -1,0 +1,24 @@
+// assertTrue phase 1 (#1295) truthiness for literal/`${VAR}`-lookup conditions.
+//
+// Flow config, runFlow env, and runScript `output.*` values are all stored as
+// strings in `MaestroExecutionContext` (see engine-context.ts), so a `${VAR}`
+// lookup always resolves to a string even when the script produced a boolean,
+// number, or object. Native JS truthiness would then treat every non-empty
+// string — including the string "false" a stringified `output.flag = false`
+// turns into — as truthy, which defeats the common
+// `runScript` (compute) -> `assertTrue: ${output.x}` (consume) idiom the #1292
+// decision relies on. Pin an explicit falsy-string table instead of inferring
+// one from native coercion: "", "false", "0", "null", and "undefined" (exact,
+// case-sensitive match) are falsy; every other string — including numeric
+// strings like "42" and JSON-shaped strings like "{}"/"[]" — is truthy,
+// matching upstream's own `${0}`/`${null}`/`${undefined}` falsy and
+// `${123}`/objects/arrays truthy reference table. Literal booleans and numbers
+// authored directly in YAML (not routed through a lookup) use native JS
+// truthiness since their type survives parsing intact.
+const FALSY_CONDITION_STRINGS = new Set(['', 'false', '0', 'null', 'undefined']);
+
+export function isMaestroConditionTruthy(condition: string | number | boolean): boolean {
+  if (typeof condition === 'boolean') return condition;
+  if (typeof condition === 'number') return condition !== 0 && !Number.isNaN(condition);
+  return !FALSY_CONDITION_STRINGS.has(condition);
+}

--- a/packages/maestro/src/internal/program-ir-command-parser.ts
+++ b/packages/maestro/src/internal/program-ir-command-parser.ts
@@ -1,6 +1,7 @@
 import { isMap, isScalar, isSeq, type Node } from 'yaml';
 import { stripUndefined } from './shared.ts';
 import type {
+  MaestroAssertTrueCommand,
   MaestroBackCommand,
   MaestroCommand,
   MaestroEraseTextCommand,
@@ -43,6 +44,7 @@ import {
   hasEntry,
   invalidAt,
   isNullNode,
+  readAssertTrueCondition,
   readMapEntries,
   readOptionalBoolean,
   readOptionalCommandOption,
@@ -109,6 +111,7 @@ const COMMAND_VALUE_PARSERS: Readonly<Record<string, CommandValueParser>> = {
     parseMaestroAssertion('assertVisible', value, node, context),
   assertNotVisible: (value, node, context) =>
     parseMaestroAssertion('assertNotVisible', value, node, context),
+  assertTrue: parseAssertTrue,
   extendedWaitUntil: parseExtendedWaitUntil,
   takeScreenshot: parseTakeScreenshot,
   scroll: parseScroll,
@@ -252,6 +255,34 @@ function parseOpenLink(
     source,
     link: readRequiredString(entryValue(entries, 'link'), 'openLink.link', context),
   };
+}
+
+function parseAssertTrue(
+  value: Node | null,
+  commandNode: Node,
+  context: MaestroProgramParseContext,
+): MaestroAssertTrueCommand {
+  const source = sourceAt(commandNode, context);
+  if (isNullNode(value)) invalidAt('Maestro assertTrue requires condition.', commandNode, context);
+  if (isScalar(value)) {
+    return {
+      kind: 'assertTrue',
+      source,
+      condition: readAssertTrueCondition(value, 'assertTrue', context),
+    };
+  }
+  const entries = readMapEntries(value, 'assertTrue', context);
+  assertOnlyKeys(entries, 'assertTrue', ['condition', 'optional', 'label'], context);
+  if (!hasEntry(entries, 'condition'))
+    invalidAt('Maestro assertTrue requires condition.', commandNode, context);
+  const condition = readAssertTrueCondition(
+    entryValue(entries, 'condition'),
+    'assertTrue.condition',
+    context,
+  );
+  const options = readOptionalCommandOption(entries, 'assertTrue', context);
+  const label = readMaestroCommandLabel(entries, 'assertTrue', context);
+  return stripUndefined({ kind: 'assertTrue' as const, source, condition, ...options, label });
 }
 
 function parseExtendedWaitUntil(

--- a/packages/maestro/src/internal/program-ir-values.ts
+++ b/packages/maestro/src/internal/program-ir-values.ts
@@ -314,6 +314,30 @@ export function readRequiredNumeric(
   return readNumericScalar(value, name, node, context, constraints);
 }
 
+/**
+ * assertTrue phase 1 (#1295): a literal value or a bare `${VAR}` lookup only.
+ * JS expressions stay unsupported per the #1292 decision — reject anything
+ * `${`-shaped that isn't an exact bare-name match, loud and at parse time (so
+ * the conformance oracle's parse-only layer still classifies expression flows
+ * as rejected) rather than deferring to runtime interpolation.
+ */
+export function readAssertTrueCondition(
+  node: Node | null | undefined,
+  name: string,
+  context: MaestroProgramParseContext,
+): string | number | boolean {
+  const value = readScalarValue(node, name, context);
+  if (value === null) invalidAt(`Maestro ${name} requires a condition.`, node, context);
+  if (typeof value === 'string' && value.includes('${') && !VARIABLE_PATTERN.test(value)) {
+    invalidAt(
+      `Maestro ${name} only supports a literal value or a bare \${VAR} lookup; JavaScript expressions are not supported — compute it in a runScript and reference \${output.x}.`,
+      node,
+      context,
+    );
+  }
+  return value;
+}
+
 export function readScalarMap(
   node: Node | null | undefined,
   name: string,

--- a/packages/maestro/src/internal/program-ir.ts
+++ b/packages/maestro/src/internal/program-ir.ts
@@ -143,6 +143,13 @@ export type MaestroAssertNotVisibleCommand = MaestroOptionalCommand & {
   label?: string;
 };
 
+export type MaestroAssertTrueCommand = MaestroOptionalCommand & {
+  kind: 'assertTrue';
+  source: MaestroSourceLocation;
+  condition: string | number | boolean;
+  label?: string;
+};
+
 export type MaestroExtendedWaitUntilCommand = MaestroOptionalCommand & {
   kind: 'extendedWaitUntil';
   source: MaestroSourceLocation;
@@ -248,6 +255,7 @@ export type MaestroCommand =
   | MaestroOpenLinkCommand
   | MaestroAssertVisibleCommand
   | MaestroAssertNotVisibleCommand
+  | MaestroAssertTrueCommand
   | MaestroExtendedWaitUntilCommand
   | MaestroTakeScreenshotCommand
   | MaestroScrollCommand

--- a/packages/maestro/src/internal/progress.ts
+++ b/packages/maestro/src/internal/progress.ts
@@ -76,6 +76,7 @@ function commandDetailProgressValue(
   if (command.kind === 'runFlow') {
     return valueOf(command.label ?? (command.include.kind === 'file' ? command.include.path : ''));
   }
+  if (command.kind === 'assertTrue') return valueOf(String(command.condition));
   return {};
 }
 

--- a/packages/maestro/src/internal/replay-plan-step-execution.ts
+++ b/packages/maestro/src/internal/replay-plan-step-execution.ts
@@ -1,6 +1,7 @@
 import { AppError } from '@agent-device/kernel/errors';
 import { stripUndefined } from './shared.ts';
 import { isMaestroTestFailure, maestroTestFailure } from './compatibility-errors.ts';
+import { isMaestroConditionTruthy } from './engine-truthiness.ts';
 import {
   MAESTRO_COMPATIBILITY_PRESETS,
   type MaestroCompatibilityTimingPolicy,
@@ -123,6 +124,14 @@ async function executeResolvedCommand(
         state.timing.assertNotVisibleTimeoutMs,
         state,
       );
+      state.executed += 1;
+      return undefined;
+    case 'assertTrue':
+      if (!isMaestroConditionTruthy(command.condition)) {
+        throw maestroTestFailure(
+          `Maestro assertTrue condition was falsy: ${JSON.stringify(command.condition)}`,
+        );
+      }
       state.executed += 1;
       return undefined;
     case 'extendedWaitUntil':

--- a/packages/maestro/src/internal/runtime-port-commands.ts
+++ b/packages/maestro/src/internal/runtime-port-commands.ts
@@ -37,7 +37,7 @@ type MaestroNavigationCommand = MaestroCommandOf<
 >;
 type MaestroSupportCommand = MaestroCommandOf<'takeScreenshot' | 'runScript'>;
 type MaestroObservationCommand = MaestroCommandOf<
-  'assertVisible' | 'assertNotVisible' | 'extendedWaitUntil'
+  'assertVisible' | 'assertNotVisible' | 'assertTrue' | 'extendedWaitUntil'
 >;
 type MaestroCommandKind = MaestroRuntimeCommand['kind'];
 type MaestroRuntimeCommandHandler<K extends MaestroCommandKind> = (
@@ -70,6 +70,7 @@ const MAESTRO_RUNTIME_COMMAND_HANDLERS = {
   runScript: executeSupportCommand,
   assertVisible: executeObservationCommand,
   assertNotVisible: executeObservationCommand,
+  assertTrue: executeObservationCommand,
   extendedWaitUntil: executeObservationCommand,
 } satisfies MaestroRuntimeCommandHandlers;
 
@@ -93,6 +94,7 @@ const MAESTRO_COMMAND_REQUIRES_SETTLED_PREDECESSOR = {
   runScript: false,
   assertVisible: false,
   assertNotVisible: false,
+  assertTrue: false,
   extendedWaitUntil: false,
 } satisfies Record<MaestroCommandKind, boolean>;
 

--- a/packages/maestro/src/internal/support-matrix.ts
+++ b/packages/maestro/src/internal/support-matrix.ts
@@ -1,13 +1,13 @@
 export const MAESTRO_COMPAT_SUPPORTED_CAPABILITIES = [
   'Flows: launchApp; runFlow file/inline with platform, visibility, and limited boolean conditions; onFlowStart/onFlowComplete; repeat.times and retry.',
   'Interactions: tapOn, doubleTapOn, longPressOn, inputText on the focused element, eraseText, openLink, hideKeyboard, basic pressKey, and back; selector targets poll until available and support recursive index, childOf, above, below, leftOf, rightOf, containsChild, containsDescendants, points, and optional; outer command labels are metadata, not target selectors.',
-  'Assertions and navigation: assertVisible, assertNotVisible, extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
+  'Assertions and navigation: assertVisible, assertNotVisible, assertTrue (literal values and ${VAR} lookups, evaluated with JS truthiness), extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
   'Scripts: ordered runScript file/env scripts with http.post, json, and output variables.',
 ] as const;
 
 export const MAESTRO_COMPAT_LIMITATIONS = [
   'Runtime: iOS and Android only; launchApp.clearState supports Android and iOS simulators, launch arguments are Apple-only, and standalone device utility/state commands are unsupported.',
-  'Expressions: when.true supports boolean literals and maestro.platform comparisons; repeat.while, evalScript, and broader JavaScript expressions are unsupported.',
+  'Expressions: when.true supports boolean literals and maestro.platform comparisons; assertTrue supports literal values and ${VAR} lookups only; repeat.while, evalScript, and broader JavaScript expressions are unsupported.',
   'Environment: flow env is the default, AD_VAR_* overrides it, and CLI -e KEY=VALUE wins over both.',
   'Failure diagnostics: resolved targets and runFlow paths are rendered, while inputText payloads remain hidden; do not place secrets in diagnostic identifiers.',
   'Trust: runScript executes trusted scripts, may make http.post network requests, and is not a security sandbox; output keys cannot contain a dot.',

--- a/packages/maestro/src/internal/support-matrix.ts
+++ b/packages/maestro/src/internal/support-matrix.ts
@@ -1,7 +1,7 @@
 export const MAESTRO_COMPAT_SUPPORTED_CAPABILITIES = [
   'Flows: launchApp; runFlow file/inline with platform, visibility, and limited boolean conditions; onFlowStart/onFlowComplete; repeat.times and retry.',
   'Interactions: tapOn, doubleTapOn, longPressOn, inputText on the focused element, eraseText, openLink, hideKeyboard, basic pressKey, and back; selector targets poll until available and support recursive index, childOf, above, below, leftOf, rightOf, containsChild, containsDescendants, points, and optional; outer command labels are metadata, not target selectors.',
-  'Assertions and navigation: assertVisible, assertNotVisible, assertTrue (literal values and ${VAR} lookups, evaluated with JS truthiness), extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
+  'Assertions and navigation: assertVisible, assertNotVisible, assertTrue (literal values and ${VAR} lookups only; "", "false", "0", "null", and "undefined" are falsy, everything else is truthy), extendedWaitUntil, scroll, scrollUntilVisible, absolute/percentage/target swipe, takeScreenshot, waitForAnimationToEnd, and stopApp.',
   'Scripts: ordered runScript file/env scripts with http.post, json, and output variables.',
 ] as const;
 

--- a/packages/maestro/test/conformance/expected-divergence.ts
+++ b/packages/maestro/test/conformance/expected-divergence.ts
@@ -38,8 +38,9 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
   },
   'upstream/067_assertTrue_pass': {
     classification: 'we-reject',
-    reason: 'assertTrue is outside the current subset; this flow requires a JavaScript expression.',
-    unsupported: ['assertTrue'],
+    reason:
+      'assertTrue supports literal values and bare ${VAR} lookups (#1295); this flow\'s condition is a JS expression (${1+1}), which stays unsupported by the #1292 lookup-only decision.',
+    unsupported: ['assertTrue (JS expression payload)'],
     tracking: 'https://github.com/callstack/agent-device/issues/1292',
   },
   'upstream/090_travel': {
@@ -82,13 +83,6 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
     classification: 'we-reject',
     reason: 'pressKey supports back/enter/home/return; the flow exercises ~30 Android/TV keycodes.',
     unsupported: ['pressKey (extended keycodes)'],
-  },
-  'upstream/076_optional_assertion': {
-    classification: 'we-reject',
-    reason:
-      'assertTrue is outside the supported subset; optional is now supported on scrollUntilVisible and extendedWaitUntil.',
-    unsupported: ['assertTrue'],
-    tracking: 'https://github.com/callstack/agent-device/issues/1295',
   },
   'upstream/079_scroll_until_visible': {
     classification: 'we-reject',
@@ -184,5 +178,11 @@ export const DOCUMENTED_DEVIATIONS: DocumentedDeviation[] = [
     area: 'tap',
     description:
       'agent-device omits the upstream iOS 3s pre-tap static-screen gate (IOSDriver.SCREEN_SETTLE_TIMEOUT_MS); see LAYER2_REFERENCE_ONLY.',
+  },
+  {
+    id: 'assert-true-string-truthiness',
+    area: 'assertTrue',
+    description:
+      'assertTrue (#1295) supports literal values and bare ${VAR} lookups only; JS expressions stay unsupported per #1292. Flow config/env/runScript-output values are stored as strings, so a looked-up condition is evaluated against a pinned falsy-string table ("", "false", "0", "null", "undefined", case-sensitive) rather than native JS truthiness (which would make the non-empty string "false" truthy) — every other string, including numeric and JSON-shaped strings, is truthy. Literal booleans/numbers use native JS truthiness.',
   },
 ];

--- a/packages/maestro/test/conformance/expected-divergence.ts
+++ b/packages/maestro/test/conformance/expected-divergence.ts
@@ -39,7 +39,7 @@ export const FLOW_DIVERGENCES: Record<string, FlowDivergence> = {
   'upstream/067_assertTrue_pass': {
     classification: 'we-reject',
     reason:
-      'assertTrue supports literal values and bare ${VAR} lookups (#1295); this flow\'s condition is a JS expression (${1+1}), which stays unsupported by the #1292 lookup-only decision.',
+      "assertTrue supports literal values and bare ${VAR} lookups (#1295); this flow's condition is a JS expression (${1+1}), which stays unsupported by the #1292 lookup-only decision.",
     unsupported: ['assertTrue (JS expression payload)'],
     tracking: 'https://github.com/callstack/agent-device/issues/1292',
   },

--- a/scripts/fuzz/validation-arbitraries-maestro.ts
+++ b/scripts/fuzz/validation-arbitraries-maestro.ts
@@ -37,6 +37,7 @@ function validMaestroCommand(pick: number, salt: number): string[] {
     () => ['- openLink: "https://example.com/page"'],
     () => [`- assertVisible: ${text}`],
     () => [`- assertNotVisible: ${text}`],
+    () => ['- assertTrue: true'],
     () => [`- takeScreenshot: ${text}`],
     () => ['- swipe:', `    direction: ${['UP', 'DOWN', 'LEFT', 'RIGHT'][salt % 4]}`],
     () => [`- pressKey: ${['back', 'enter', 'return', 'home'][salt % 4]}`],
@@ -51,7 +52,6 @@ function validMaestroCommand(pick: number, salt: number): string[] {
 const FAKE_MAESTRO_COMMANDS = [
   'clickOn',
   'tapOnPoint',
-  'assertTrue',
   'evalScript',
   'launchActivity',
   'inputTextt',

--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -199,7 +199,7 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   'packages/kernel/src/snapshot.ts': 1,
 
   // --- @agent-device/maestro ---
-  'packages/maestro/src/index.ts': 104,
+  'packages/maestro/src/index.ts': 105,
 
   // --- @agent-device/platform-*: ADR-0019's metadata-eager/implementation-lazy façades. Each
   // evaluates only itself; every implementation sits behind a function-scoped `await import`.

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -72,13 +72,13 @@ Supported subset:
 
 - Flows: `launchApp`; `runFlow` file/inline with platform, visibility, and limited boolean conditions; `onFlowStart`/`onFlowComplete`; `repeat.times` and retry.
 - Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText` on the focused element, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; selector targets poll until available and support recursive `index`, `childOf`, `above`, `below`, `leftOf`, `rightOf`, `containsChild`, `containsDescendants`, points, and `optional`; outer command labels are metadata, not target selectors.
-- Assertions and navigation: `assertVisible`, `assertNotVisible`, `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
+- Assertions and navigation: `assertVisible`, `assertNotVisible`, `assertTrue` (literal values and `${VAR}` lookups, evaluated with JS truthiness), `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
 - Scripts: ordered `runScript` file/env scripts with `http.post`, `json`, and `output` variables.
 
 Boundaries:
 
 - Runtime: iOS and Android only; `launchApp.clearState` supports Android and iOS simulators, launch arguments are Apple-only, and standalone device utility/state commands are unsupported.
-- Expressions: `when.true` supports boolean literals and `maestro.platform` comparisons; `repeat.while`, `evalScript`, and broader JavaScript expressions are unsupported.
+- Expressions: `when.true` supports boolean literals and `maestro.platform` comparisons; `assertTrue` supports literal values and `${VAR}` lookups only; `repeat.while`, `evalScript`, and broader JavaScript expressions are unsupported.
 - Environment: flow `env` is the default, `AD_VAR_*` overrides it, and CLI `-e KEY=VALUE` wins over both.
 - Failure diagnostics: resolved targets and `runFlow` paths are rendered, while `inputText` payloads remain hidden; do not place secrets in diagnostic identifiers.
 - Trust: `runScript` executes trusted scripts, may make `http.post` network requests, and is not a security sandbox; output keys cannot contain a dot.

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -72,7 +72,7 @@ Supported subset:
 
 - Flows: `launchApp`; `runFlow` file/inline with platform, visibility, and limited boolean conditions; `onFlowStart`/`onFlowComplete`; `repeat.times` and retry.
 - Interactions: `tapOn`, `doubleTapOn`, `longPressOn`, `inputText` on the focused element, `eraseText`, `openLink`, `hideKeyboard`, basic `pressKey`, and `back`; selector targets poll until available and support recursive `index`, `childOf`, `above`, `below`, `leftOf`, `rightOf`, `containsChild`, `containsDescendants`, points, and `optional`; outer command labels are metadata, not target selectors.
-- Assertions and navigation: `assertVisible`, `assertNotVisible`, `assertTrue` (literal values and `${VAR}` lookups, evaluated with JS truthiness), `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
+- Assertions and navigation: `assertVisible`, `assertNotVisible`, `assertTrue` (literal values and `${VAR}` lookups only; `""`, `"false"`, `"0"`, `"null"`, and `"undefined"` are falsy, everything else is truthy), `extendedWaitUntil`, `scroll`, `scrollUntilVisible`, absolute/percentage/target `swipe`, `takeScreenshot`, `waitForAnimationToEnd`, and `stopApp`.
 - Scripts: ordered `runScript` file/env scripts with `http.post`, `json`, and `output` variables.
 
 Boundaries:


### PR DESCRIPTION
## Summary

- Adds the `assertTrue` Maestro command, scoped to literal values and bare `${VAR}` lookups only (JS expressions stay unsupported per the closed #1292 decision — the parser rejects any `${...}` payload that isn't an exact bare-name match, at parse time, with a `runScript` → `${output.x}` hint).
- Truthiness on a resolved value is evaluated against a pinned falsy-string table (`""`, `"false"`, `"0"`, `"null"`, `"undefined"`, case-sensitive) rather than native JS truthiness, since flow config/env/`runScript` output values are always stored as strings in `MaestroExecutionContext` — native truthiness would make the string `"false"` truthy, which is almost certainly not what a flow author means.
- Wires `assertTrue` through the parser, interpreter, the existing generic `optional: true` → warning composition (no new machinery needed), the runtime-port command-dispatch tables, and the layer-1 conformance oracle's canonical projection.
- Narrows the `067_assertTrue_pass` conformance divergence to the JS-expression case (still correctly rejected) and removes the now-satisfied `076_optional_assertion` divergence entry entirely, since every command in that flow is now supported.
- Along the way, fixes a latent conformance gap: `scrollUntilVisible`'s canonical projection wasn't materializing upstream's default `direction: down`, which only became visible once `assertTrue` support let flow `076` reach full comparison.

## Testing

- `pnpm exec tsc -b packages/kernel packages/contracts packages/selectors packages/maestro` — clean.
- `pnpm exec vitest run packages/maestro` — 211 tests pass (new: parser tests for scalar/lookup/map-form/optional/label, expression rejection, missing-condition rejection; interpreter tests for pass/fail/falsy-string-lookup/optional composition; a dedicated truthiness-table test file).
- `pnpm maestro:conformance` — 47/47 pass, no new undeclared divergences.
- `pnpm exec vitest run src/cli/parser/__tests__/maestro-support-matrix.test.ts scripts/fuzz/validation-arbitraries-maestro.test.ts` — pass (fuzz corpus updated: `assertTrue` moved from the fake/unsupported command list to a valid-command case).
- Ran an independent adversarial review pass, which caught one real issue (fixed in a follow-up commit): the CLI help/docs claimed assertTrue is "evaluated with JS truthiness," which is the opposite of the actual pinned-string-table behavior — corrected to spell out the real falsy/truthy rule.

## Test plan

- [x] Typecheck
- [x] Maestro unit tests
- [x] Maestro conformance suite
- [x] CLI help / docs sync test
- [x] Fuzz corpus coverage test
- [x] Adversarial review pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01MsAta9qHbsC2uqiK1sy6To)_