### PR TITLE
test: close web platform command-coverage gaps from #1426

### DIFF
--- a/packages/platform-web/src/runtime.test.ts
+++ b/packages/platform-web/src/runtime.test.ts
@@ -531,8 +531,9 @@ test('push reports the runtime-owned unavailable readiness and push facts', asyn
   }
 });
 
-// #1900: `logs` resolves to `appLogRuntimePlanUses`, which spans all five app-log facts; web has
-// no native app-log channel to inspect, start, or reattach to.
+// #1900: `logs` resolves to `appLogRuntimePlanUses` (three of these five facts: appLogInspect,
+// appLogDoctor, appLogStart); the other two, appLogReattach/appLogCleanup, are asserted here too
+// since they answer the same "no native app-log channel" question a web target has no route for.
 test('logs reports the runtime-owned unavailable app-log facts', async () => {
   const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
     device,

--- a/packages/platform-web/src/runtime.test.ts
+++ b/packages/platform-web/src/runtime.test.ts
@@ -460,3 +460,120 @@ test('refuses web scrolling on a non-browser web cell', async () => {
   expect(binding.facts.operations.scrollDirection.available).toBe(false);
   expect(binding.operations.scrollDirection).toBeUndefined();
 });
+
+// #1900: `boot`/`bootTargetHeadless` and `shutdown` have no web-specific evidence beyond this
+// runtime-owned fact — a managed browser session has no OS-level boot or shutdown to drive.
+test('boot and shutdown report the runtime-owned unavailable readiness fact', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  for (const operation of ['bootTarget', 'bootTargetHeadless', 'shutdownTarget'] as const) {
+    expect(binding.facts.operations[operation]).toEqual({
+      available: false,
+      reason: 'unsupported-platform-leaf',
+    });
+    expect(binding.operations[operation]).toBeUndefined();
+  }
+});
+
+// #1900: `install` and `reinstall` both resolve to `deployAppUse`, so one shared fact covers
+// both — a managed browser session has no installable native app package.
+test('install and reinstall share the runtime-owned unavailable deploy fact', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  expect(binding.facts.operations.deployApp).toEqual({
+    available: false,
+    reason: 'unsupported-platform-leaf',
+  });
+  expect(binding.operations.deployApp).toBeUndefined();
+});
+
+// #1900: `install-from-source` resolves to `readyMaterializeAndDeployAppUse`, requiring all three
+// of these facts; none of them exist for a browser target.
+test('install-from-source reports the runtime-owned unavailable materialize and deploy facts', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  for (const operation of [
+    'ensureReady',
+    'materializeAppSource',
+    'deployMaterializedApp',
+  ] as const) {
+    expect(binding.facts.operations[operation]).toEqual({
+      available: false,
+      reason: 'unsupported-platform-leaf',
+    });
+    expect(binding.operations[operation]).toBeUndefined();
+  }
+});
+
+// #1900: `push` resolves to `readySendPushNotificationUse`, requiring both facts below; a browser
+// session has no native push channel to deliver through.
+test('push reports the runtime-owned unavailable readiness and push facts', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  for (const operation of ['ensureReady', 'sendPushNotification'] as const) {
+    expect(binding.facts.operations[operation]).toEqual({
+      available: false,
+      reason: 'unsupported-platform-leaf',
+    });
+    expect(binding.operations[operation]).toBeUndefined();
+  }
+});
+
+// #1900: `logs` resolves to `appLogRuntimePlanUses`, which spans all five app-log facts; web has
+// no native app-log channel to inspect, start, or reattach to.
+test('logs reports the runtime-owned unavailable app-log facts', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  for (const operation of [
+    'appLogInspect',
+    'appLogDoctor',
+    'appLogStart',
+    'appLogReattach',
+    'appLogCleanup',
+  ] as const) {
+    expect(binding.facts.operations[operation]).toEqual({
+      available: false,
+      reason: 'unsupported-platform-leaf',
+    });
+    expect(binding.operations[operation]).toBeUndefined();
+  }
+});
+
+// #1900: `diff` resolves to the exact same `snapshotRuntimePlanUses` as the live `snapshot`
+// command, so the admitted fact backing `snapshot` also backs `diff`.
+test('diff shares the admitted captureSnapshot fact that live snapshot and diff both require', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  expect(binding.facts.operations.captureSnapshot).toEqual({ available: true });
+  expect(binding.operations.captureSnapshot).toBeTypeOf('function');
+});
+
+// #1900: `pressRuntimeUses` is literally `clickRuntimeUses` (`platform-runtime-operations.ts`),
+// so the admitted fact backing the live `click` command also backs `press`.
+test('press shares the admitted tapPoint fact that live click and press both require', async () => {
+  const binding = await createWebPlatformRuntime(host({ mode: 'transport-composed' })).bind({
+    device,
+    intent: { kind: 'ordinary' },
+    scope: scope(),
+  });
+  expect(binding.facts.operations.tapPoint).toEqual({ available: true });
+  expect(binding.operations.tapPoint).toBeTypeOf('function');
+});

--- a/src/core/command-descriptor/__tests__/click-runtime-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/click-runtime-execution.test.ts
@@ -1,0 +1,23 @@
+import {
+  clickRuntimeUses,
+  pressRuntimeUses,
+} from '@agent-device/contracts/platform-runtime-operations';
+import { expect, test } from 'vitest';
+import { commandDescriptors } from '../registry.ts';
+
+// #1900: the web coverage manifest's `press` row claims press shares click's admitted web
+// operation ("press shares the admitted tapPoint fact that live click and press both require").
+// That claim rests on `pressRuntimeUses` and the `press` descriptor literally being click's, not
+// merely looking similar — pin both here so a future divergence fails this test, not silently.
+test('press descriptor reuses the complete click plan uses with no legacy projection', () => {
+  const click = commandDescriptors.find(({ name }) => name === 'click');
+  const press = commandDescriptors.find(({ name }) => name === 'press');
+
+  expect(click).not.toHaveProperty('capability');
+  expect(click).not.toHaveProperty('dispatch');
+  expect(press).not.toHaveProperty('capability');
+  expect(press).not.toHaveProperty('dispatch');
+  expect(click?.platformExecution).toEqual({ kind: 'device-runtime', uses: clickRuntimeUses });
+  expect(press?.platformExecution).toEqual({ kind: 'device-runtime', uses: clickRuntimeUses });
+  expect(pressRuntimeUses).toBe(clickRuntimeUses);
+});

--- a/src/daemon/__tests__/request-router-artifacts-web.test.ts
+++ b/src/daemon/__tests__/request-router-artifacts-web.test.ts
@@ -1,0 +1,63 @@
+import { createTestDeviceInventoryGateways } from '../../__tests__/test-utils/device-inventory-gateways.ts';
+import { test, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequestHandler } from './test-device-runtime-gateway.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import type { DaemonArtifactInventoryEntry } from '@agent-device/contracts/observability';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { makeSession } from '../../__tests__/test-utils/session-factories.ts';
+import { WEB_DESKTOP_DEVICE } from '../../__tests__/test-utils/device-fixtures.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { cleanupDownloadableArtifact, trackDownloadableArtifact } from '../artifact-tracking.ts';
+
+// #1900: `artifacts` (`handlers/lease.ts`) lists daemon-tracked artifacts by tenant scope with no
+// device or platform involvement at all — `listArtifactsForRequest` never reads `device.platform`.
+// This proves the command actually resolves and lists an artifact end to end for a session whose
+// device is web, the same round trip `request-router-events.test.ts` already proves for `events`.
+test('artifacts lists a daemon-tracked artifact produced during a web session', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-artifacts-web-');
+  sessionStore.set('web-session', makeSession('web-session', { device: WEB_DESKTOP_DEVICE }));
+  const artifactDir = mkdtempForTestSync('agent-device-router-artifacts-web-file-');
+  const artifactPath = path.join(artifactDir, 'web-smoke.png');
+  fs.writeFileSync(artifactPath, 'fixture-bytes');
+  const artifactId = trackDownloadableArtifact({
+    artifactPath,
+    artifactType: 'screenshot',
+    fileName: 'web-smoke.png',
+  });
+
+  try {
+    const handler = createRequestHandler({
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      token: 'test-token',
+      sessionStore,
+      leaseRegistry: new LeaseRegistry(),
+      deviceInventoryGateways: createTestDeviceInventoryGateways(),
+      trackDownloadableArtifact: () => 'unused-artifact-id',
+    });
+
+    const response = await handler({
+      token: 'test-token',
+      session: 'web-session',
+      command: 'artifacts',
+      positionals: [],
+      flags: {},
+      meta: { requestId: 'req-artifacts-web' },
+    });
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    expect(response.data?.source).toBe('daemon');
+    expect(response.data?.status).toBe('ready');
+    const artifacts = response.data?.artifacts as unknown as DaemonArtifactInventoryEntry[];
+    expect(
+      artifacts.some(
+        (artifact) => artifact.id === artifactId && artifact.filename === 'web-smoke.png',
+      ),
+    ).toBe(true);
+  } finally {
+    cleanupDownloadableArtifact(artifactId);
+  }
+});

--- a/src/daemon/__tests__/request-router-events.test.ts
+++ b/src/daemon/__tests__/request-router-events.test.ts
@@ -6,7 +6,8 @@ import path from 'node:path';
 import { createRequestHandler } from './test-device-runtime-gateway.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
-import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import { makeIosSession, makeSession } from '../../__tests__/test-utils/session-factories.ts';
+import { WEB_DESKTOP_DEVICE } from '../../__tests__/test-utils/device-fixtures.ts';
 
 test('events reads the daemon-owned session timeline without appending poll noise', async () => {
   const sessionStore = makeSessionStore('agent-device-router-events-');
@@ -170,6 +171,47 @@ test('events flushes pending event writes before reading', async () => {
   if (!response.ok) return;
   expect(response.data?.events).toEqual([
     expect.objectContaining({ kind: 'action.recorded', summary: 'Opened session' }),
+  ]);
+});
+
+// #1900: `events` reads/flushes the session-owned timeline (`session-observability.ts`) with no
+// device-runtime binding at all, so a web-backed session exercises the exact same code path as
+// every other platform.
+test('events reads the daemon-owned session timeline for a web-backed session', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-web-');
+  sessionStore.set('web-session', makeSession('web-session', { device: WEB_DESKTOP_DEVICE }));
+  sessionStore.recordEvent('web-session', {
+    kind: 'action.recorded',
+    command: 'click',
+    summary: 'Tapped Submit order',
+  });
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    deviceInventoryGateways: createTestDeviceInventoryGateways(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'web-session',
+    command: 'events',
+    positionals: ['10'],
+    flags: {},
+    meta: { requestId: 'req-events-web' },
+  });
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  expect(response.data?.events).toEqual([
+    expect.objectContaining({
+      kind: 'action.recorded',
+      command: 'click',
+      summary: 'Tapped Submit order',
+    }),
   ]);
 });
 

--- a/src/daemon/handlers/__tests__/session-command-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-command-replay.test.ts
@@ -2,11 +2,12 @@ import { test, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { makeSessionStore } from './session-test-harness.ts';
+import { makeSession, makeSessionStore } from './session-test-harness.ts';
 import { handleSessionCommands } from './session-command-harness.ts';
 import type { DaemonRequest } from '../../types.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 import { replayScriptSourceBundleFor } from '../../../__tests__/test-utils/replay-script-source.ts';
+import { WEB_DESKTOP_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
 
 test('replay parses open --relaunch flag and replays open with relaunch semantics', async () => {
   const sessionStore = makeSessionStore();
@@ -157,4 +158,78 @@ test('replay inherits parent device selectors for each invoked step', async () =
   expect(invoked[0]?.flags?.platform).toBe('ios');
   expect(invoked[0]?.flags?.device).toBe('thymikee-iphone');
   expect(invoked[0]?.flags?.udid).toBe('00008150-001849640CF8401C');
+});
+
+// #1900: `replay` routes through `handleSessionReplayCommandGroup` -> `session-replay.ts`, which
+// re-invokes each recorded step with no `platform === 'web'` branch anywhere in that path.
+test('replay inherits the parent web platform selector for each invoked step', async () => {
+  const sessionStore = makeSessionStore();
+  const replayRoot = mkdtempForTestSync('agent-device-replay-web-selectors-');
+  const replayPath = path.join(replayRoot, 'web-selectors.ad');
+  fs.writeFileSync(replayPath, 'open "http://127.0.0.1/"\n');
+
+  const invoked: DaemonRequest[] = [];
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'replay',
+      positionals: [replayPath],
+      flags: {
+        platform: 'web',
+        replayScriptSource: replayScriptSourceBundleFor(replayPath),
+      },
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req);
+      return { ok: true, data: {} };
+    },
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(invoked.length).toBe(1);
+  expect(invoked[0]?.flags?.platform).toBe('web');
+});
+
+// #1900: with no `--platform` filter, `discoverReplayTestEntries` (`session-test-discovery.ts`)
+// runs every discovered script unconditionally (`if (!platformFilter) { entries.push(run); ... }`)
+// — the per-script `context platform=` declaration matters only for filtering, and
+// `readReplayScriptMetadata` deliberately drops `web` as a declarable value (`ad-script`'s
+// `readReplayScriptMetadata drops unsupported web platform` test), so an unfiltered `test` run
+// against a session already bound to a web device runs its script the same as any other platform.
+test('test runs an undeclared script against a session already bound to a web device', async () => {
+  const sessionStore = makeSessionStore();
+  sessionStore.set('default', makeSession('default', WEB_DESKTOP_DEVICE));
+  const root = mkdtempForTestSync('agent-device-test-suite-web-session-');
+  fs.writeFileSync(path.join(root, '01-web.ad'), 'open "http://127.0.0.1/"\n');
+
+  const invoked: DaemonRequest[] = [];
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'test',
+      positionals: [root],
+      flags: {},
+      meta: { cwd: root, requestId: 'suite-web-session' },
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req);
+      return { ok: true, data: {} };
+    },
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(invoked.length).toBe(1);
+  if (response?.ok) {
+    expect(response.data?.passed).toBe(1);
+    expect(response.data?.skipped).toBe(0);
+  }
 });

--- a/src/daemon/handlers/__tests__/session-command-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-command-replay.test.ts
@@ -2,12 +2,11 @@ import { test, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { makeSession, makeSessionStore } from './session-test-harness.ts';
+import { makeSessionStore } from './session-test-harness.ts';
 import { handleSessionCommands } from './session-command-harness.ts';
 import type { DaemonRequest } from '../../types.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 import { replayScriptSourceBundleFor } from '../../../__tests__/test-utils/replay-script-source.ts';
-import { WEB_DESKTOP_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
 
 test('replay parses open --relaunch flag and replays open with relaunch semantics', async () => {
   const sessionStore = makeSessionStore();
@@ -195,41 +194,43 @@ test('replay inherits the parent web platform selector for each invoked step', a
   expect(invoked[0]?.flags?.platform).toBe('web');
 });
 
-// #1900: with no `--platform` filter, `discoverReplayTestEntries` (`session-test-discovery.ts`)
-// runs every discovered script unconditionally (`if (!platformFilter) { entries.push(run); ... }`)
-// — the per-script `context platform=` declaration matters only for filtering, and
-// `readReplayScriptMetadata` deliberately drops `web` as a declarable value (`ad-script`'s
-// `readReplayScriptMetadata drops unsupported web platform` test), so an unfiltered `test` run
-// against a session already bound to a web device runs its script the same as any other platform.
-test('test runs an undeclared script against a session already bound to a web device', async () => {
+// #1900: `test`'s script discovery filters by each script's own `context platform=` declaration
+// (`session-test-discovery.ts`'s `matchesPlatformFilter`), but `readReplayScriptMetadata`
+// deliberately drops `web` as a declarable value (`ad-script`'s own
+// `readReplayScriptMetadata drops unsupported web platform` test) and
+// `ReplayTestPlatform = Exclude<PlatformSelector, 'web'>` (`session-test-types.ts`) excludes it
+// structurally. So no `.ad` script -- typed or untyped -- can ever declare or match `web`, and
+// `discoverReplayTestEntries` throws "No replay tests matched" for every source once a
+// `--platform web` filter is active (an untyped source is skipped as unfiltered-out, and no typed
+// source can ever carry the value the filter is looking for). That is the real, deterministic,
+// command-specific web behavior of `test`: not "it runs on web" but "its declared-platform filter
+// can never select web", proven here rather than merely asserted.
+test('test --platform web reports no matching scripts, typed or untyped, because ReplayTestPlatform excludes web', async () => {
   const sessionStore = makeSessionStore();
-  sessionStore.set('default', makeSession('default', WEB_DESKTOP_DEVICE));
-  const root = mkdtempForTestSync('agent-device-test-suite-web-session-');
-  fs.writeFileSync(path.join(root, '01-web.ad'), 'open "http://127.0.0.1/"\n');
+  const root = mkdtempForTestSync('agent-device-test-suite-web-excluded-');
+  fs.writeFileSync(path.join(root, '01-untyped.ad'), 'open "http://127.0.0.1/"\n');
+  fs.writeFileSync(path.join(root, '02-android.ad'), 'context platform=android\nopen "Demo"\n');
 
-  const invoked: DaemonRequest[] = [];
   const response = await handleSessionCommands({
     req: {
       token: 't',
       session: 'default',
       command: 'test',
       positionals: [root],
-      flags: {},
-      meta: { cwd: root, requestId: 'suite-web-session' },
+      flags: { platform: 'web' },
+      meta: { cwd: root, requestId: 'suite-web-excluded' },
     },
     sessionName: 'default',
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     sessionStore,
-    invoke: async (req) => {
-      invoked.push(req);
-      return { ok: true, data: {} };
+    invoke: async () => {
+      throw new Error('test must not invoke any step when --platform web matches nothing');
     },
   });
 
-  expect(response?.ok).toBe(true);
-  expect(invoked.length).toBe(1);
-  if (response?.ok) {
-    expect(response.data?.passed).toBe(1);
-    expect(response.data?.skipped).toBe(0);
+  expect(response?.ok).toBe(false);
+  if (response && !response.ok) {
+    expect(response.error.code).toBe('INVALID_ARGS');
+    expect(response.error.message).toBe('No replay tests matched for --platform web.');
   }
 });

--- a/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
@@ -258,6 +258,37 @@ test('batch step flags override parent selector flags', async () => {
   expect(response?.ok).toBe(true);
 });
 
+// #1900: `batch` (`session-batch.ts` -> `runBatch`) just re-invokes each step through the normal
+// `DaemonInvokeFn` with no platform branching of its own, so a web platform selector threads
+// through the same way any other platform selector does.
+test('batch step forwards the parent web platform selector to each invoked step', async () => {
+  const sessionStore = makeSessionStore();
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'batch',
+      positionals: [],
+      flags: {
+        platform: 'web',
+        batchSteps: [
+          { command: 'open', positionals: ['http://127.0.0.1/'] },
+          { command: 'screenshot', positionals: ['/tmp/web-batch.png'] },
+        ],
+      },
+    },
+    sessionName: 'default',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (stepReq) => {
+      expect(stepReq.flags?.platform).toBe('web');
+      return { ok: true, data: {} };
+    },
+  });
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+});
+
 test('batch step forwards typed runtime payload', async () => {
   const sessionStore = makeSessionStore();
   const seenRuntimes: Array<DaemonRequest['runtime']> = [];

--- a/src/daemon/handlers/__tests__/trace-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/trace-runtime.test.ts
@@ -83,6 +83,35 @@ test('relocates trace output and projects the client artifact path', () => {
   });
 });
 
+// #1900: `trace` never binds a device runtime (no `bindDevice`/`inspectFacts` call anywhere in
+// `handleTraceCommand`), so its session-scoped start/stop bookkeeping works identically for a web
+// session as it does for the android fixture every other test in this file uses.
+test('starts and stops one trace through the session-owned trace slot on a web session', () => {
+  const { session, sessionStore } = fixture();
+  session.device = {
+    platform: 'web',
+    id: 'agent-browser-chrome',
+    name: 'Agent Browser Chrome',
+    kind: 'device',
+  };
+  const start = handleTraceCommand({
+    req: request(['start']),
+    sessionName: session.name,
+    sessionStore,
+  });
+  const startedPath = session.trace?.outPath;
+  expect(startedPath).toMatch(/trace-session-.*\.trace\.log$/);
+  expect(start).toMatchObject({ ok: true, data: { trace: 'started', outPath: startedPath } });
+
+  const stop = handleTraceCommand({
+    req: request(['stop']),
+    sessionName: session.name,
+    sessionStore,
+  });
+  expect(stop).toMatchObject({ ok: true, data: { trace: 'stopped' } });
+  expect(session.trace).toBeUndefined();
+});
+
 test('rejects invalid actions, missing sessions, and incoherent lifecycle transitions', () => {
   const { session, sessionStore } = fixture();
   expect(

--- a/test/integration/smoke-web-platform-coverage.test.ts
+++ b/test/integration/smoke-web-platform-coverage.test.ts
@@ -8,6 +8,7 @@ import { mkdtempForTest } from '../../src/__tests__/test-utils/tmp-dir.ts';
 import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
 import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
 import {
+  WEB_COVERAGE_GAP_ISSUE,
   WEB_PLATFORM_COVERAGE,
   WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
   WEB_SMOKE_EVIDENCE,
@@ -29,9 +30,10 @@ test('web coverage exhaustively classifies the public catalog', () => {
       assert.ok(entry.owner.test.trim().length > 0, `${command} needs named evidence`);
     }
     if (entry.level === 'known-gap') {
-      assert.ok(
-        Number.isInteger(entry.trackingIssue) && entry.trackingIssue > 0,
-        `${command} needs a valid gap tracking issue`,
+      assert.equal(
+        entry.trackingIssue,
+        WEB_COVERAGE_GAP_ISSUE,
+        `${command} has the wrong gap issue`,
       );
     }
   }
@@ -40,8 +42,8 @@ test('web coverage exhaustively classifies the public catalog', () => {
 test('web coverage report has the expected classification counts', () => {
   assert.deepEqual(WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
     capabilityDenial: 7,
-    contract: 35,
-    gap: 0,
+    contract: 34,
+    gap: 1,
     live: 12,
     total: 54,
   });
@@ -87,15 +89,22 @@ test('web capability denials match the mechanical capability matrix', () => {
   assert.deepEqual(deniedByManifest, deniedByCapabilities);
 });
 
-// #1900 closed every known-gap row this manifest carried (see the comment above
-// `WEB_PLATFORM_COVERAGE`): each now cites a runtime-owned denial fact or a new test proving the
-// command's existing code path already runs for a web-backed session. This is the planted-red
-// proof that a future row can't silently regress back to 'known-gap' without failing here.
-test('web has no known-gap rows left after #1900', () => {
-  const gaps = Object.entries(WEB_PLATFORM_COVERAGE).filter(
-    ([, entry]) => entry.level === 'known-gap',
+// #1900 closed 14 of the 15 known-gap rows this manifest originally carried (see the comment
+// above `WEB_PLATFORM_COVERAGE`); `test` stays a known gap because its only candidate evidence
+// proves the command CANNOT be targeted at web, not that it works. This is the planted-red proof
+// that no other row can silently regress back to 'known-gap', and that `test`'s stays pinned to
+// the one tracking issue.
+test('web known gaps use one grouped tracking issue', () => {
+  const gapIssues = new Set(
+    Object.values(WEB_PLATFORM_COVERAGE)
+      .filter((entry) => entry.level === 'known-gap')
+      .map((entry) => entry.trackingIssue),
   );
-  assert.deepEqual(gaps, []);
+  const gapCommands = Object.entries(WEB_PLATFORM_COVERAGE)
+    .filter(([, entry]) => entry.level === 'known-gap')
+    .map(([command]) => command);
+  assert.deepEqual(gapCommands, ['test']);
+  assert.deepEqual([...gapIssues], [WEB_COVERAGE_GAP_ISSUE]);
 });
 
 test('web coverage report persists the manifest rollup and live command list', async () => {

--- a/test/integration/smoke-web-platform-coverage.test.ts
+++ b/test/integration/smoke-web-platform-coverage.test.ts
@@ -8,7 +8,6 @@ import { mkdtempForTest } from '../../src/__tests__/test-utils/tmp-dir.ts';
 import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
 import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
 import {
-  WEB_COVERAGE_GAP_ISSUE,
   WEB_PLATFORM_COVERAGE,
   WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
   WEB_SMOKE_EVIDENCE,
@@ -30,10 +29,9 @@ test('web coverage exhaustively classifies the public catalog', () => {
       assert.ok(entry.owner.test.trim().length > 0, `${command} needs named evidence`);
     }
     if (entry.level === 'known-gap') {
-      assert.equal(
-        entry.trackingIssue,
-        WEB_COVERAGE_GAP_ISSUE,
-        `${command} has the wrong gap issue`,
+      assert.ok(
+        Number.isInteger(entry.trackingIssue) && entry.trackingIssue > 0,
+        `${command} needs a valid gap tracking issue`,
       );
     }
   }
@@ -42,8 +40,8 @@ test('web coverage exhaustively classifies the public catalog', () => {
 test('web coverage report has the expected classification counts', () => {
   assert.deepEqual(WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
     capabilityDenial: 7,
-    contract: 20,
-    gap: 15,
+    contract: 35,
+    gap: 0,
     live: 12,
     total: 54,
   });
@@ -89,13 +87,15 @@ test('web capability denials match the mechanical capability matrix', () => {
   assert.deepEqual(deniedByManifest, deniedByCapabilities);
 });
 
-test('web known gaps use one grouped tracking issue', () => {
-  const gapIssues = new Set(
-    Object.values(WEB_PLATFORM_COVERAGE)
-      .filter((entry) => entry.level === 'known-gap')
-      .map((entry) => entry.trackingIssue),
+// #1900 closed every known-gap row this manifest carried (see the comment above
+// `WEB_PLATFORM_COVERAGE`): each now cites a runtime-owned denial fact or a new test proving the
+// command's existing code path already runs for a web-backed session. This is the planted-red
+// proof that a future row can't silently regress back to 'known-gap' without failing here.
+test('web has no known-gap rows left after #1900', () => {
+  const gaps = Object.entries(WEB_PLATFORM_COVERAGE).filter(
+    ([, entry]) => entry.level === 'known-gap',
   );
-  assert.deepEqual([...gapIssues], [WEB_COVERAGE_GAP_ISSUE]);
+  assert.deepEqual(gaps, []);
 });
 
 test('web coverage report persists the manifest rollup and live command list', async () => {

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -49,17 +49,20 @@ const denial = (assertion: string): WebPlatformCoverageEntry => ({
 /**
  * One primary, observable owner for every public command on the managed web target.
  *
- * Live rows are limited to the existing web-smoke scenario. Contract rows cite
- * existing web-specific unit/provider evidence; they do not turn fixture-backed
- * tests into live E2E claims. Capability denials are derived from the web bucket
- * in the command capability matrix.
+ * Live rows are limited to the existing web-smoke scenario; they do not widen its scope. Capability
+ * denials are derived from the web bucket in the command capability matrix. Contract rows do not
+ * turn fixture-backed tests into live E2E claims, and cite one of three evidence shapes:
+ * a web-specific unit/provider test exercising the command's own operation (e.g. `click`, `hover`);
+ * the web runtime's own unavailable-operation fact, a real and permanent denial (e.g. `boot`,
+ * `push`); or, for a command whose handler has no platform branch at all, a test proving its
+ * existing generic/shared code path runs correctly for a web-backed session or device (e.g.
+ * `artifacts`, `batch`, `diff`, `press`) — including, for `test`, proving the one command-specific
+ * limitation that mechanism does have (its declared-platform filter cannot select web) rather than
+ * a "this works" claim it would not be honest to make.
  *
- * #1900 closed every known-gap row this manifest originally carried: each now cites either the
- * web runtime's own unavailable-operation fact (a real, permanent denial — e.g. `boot`, `push`),
- * or a new test proving the command's existing generic/shared-runtime-plan code path already
- * runs correctly for a web-backed session (e.g. `artifacts`, `diff`, `press`). None of this widens
- * the live web-smoke scope. `WebPlatformCoverageEntry` keeps the `known-gap` variant for any
- * future command whose web behavior genuinely isn't decided yet.
+ * #1900 closed every known-gap row this manifest originally carried using the shapes above.
+ * `WebPlatformCoverageEntry` keeps the `known-gap` variant for any future command whose web
+ * behavior genuinely isn't decided yet.
  */
 export const WEB_PLATFORM_COVERAGE = {
   [C.artifacts]: contract(
@@ -126,8 +129,8 @@ export const WEB_PLATFORM_COVERAGE = {
   ),
   [C.test]: contract(
     'src/daemon/handlers/__tests__/session-command-replay.test.ts',
-    'test runs an undeclared script against a session already bound to a web device',
-    'an unfiltered test run executes its script against a session already bound to a web device',
+    'test --platform web reports no matching scripts, typed or untyped, because ReplayTestPlatform excludes web',
+    "test's declared-platform filter structurally excludes web (ReplayTestPlatform = Exclude<PlatformSelector, 'web'>), so --platform web deterministically matches no script",
   ),
   [C.clipboard]: denial('Web capability model rejects native clipboard operations'),
   [C.keyboard]: contract(

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -24,6 +24,7 @@ export type WebPlatformCoverageEntry =
       trackingIssue: number;
     };
 
+export const WEB_COVERAGE_GAP_ISSUE = 1900;
 export const WEB_SMOKE_TEST_NAME = 'live web platform e2e smoke';
 export const WEB_SMOKE_EVIDENCE: RepositoryEvidence = {
   path: 'test/integration/smoke-web-platform.test.ts',
@@ -45,24 +46,31 @@ const denial = (assertion: string): WebPlatformCoverageEntry => ({
   assertion,
   level: 'capability-denial',
 });
+const gap = (assertion: string): WebPlatformCoverageEntry => ({
+  assertion,
+  level: 'known-gap',
+  trackingIssue: WEB_COVERAGE_GAP_ISSUE,
+});
 
 /**
  * One primary, observable owner for every public command on the managed web target.
  *
  * Live rows are limited to the existing web-smoke scenario; they do not widen its scope. Capability
  * denials are derived from the web bucket in the command capability matrix. Contract rows do not
- * turn fixture-backed tests into live E2E claims, and cite one of three evidence shapes:
- * a web-specific unit/provider test exercising the command's own operation (e.g. `click`, `hover`);
- * the web runtime's own unavailable-operation fact, a real and permanent denial (e.g. `boot`,
- * `push`); or, for a command whose handler has no platform branch at all, a test proving its
- * existing generic/shared code path runs correctly for a web-backed session or device (e.g.
- * `artifacts`, `batch`, `diff`, `press`) — including, for `test`, proving the one command-specific
- * limitation that mechanism does have (its declared-platform filter cannot select web) rather than
- * a "this works" claim it would not be honest to make.
+ * turn fixture-backed tests into live E2E claims, and cite one of two evidence shapes: a
+ * web-specific unit/provider test exercising the command's own operation (e.g. `click`, `hover`);
+ * or, for a command whose handler has no platform branch at all, a test proving its existing
+ * generic/shared code path runs correctly for a web-backed session or device (e.g. `artifacts`,
+ * `batch`, `diff`, `press`), OR the web runtime's own unavailable-operation fact, a real and
+ * permanent denial (e.g. `boot`, `push`).
  *
- * #1900 closed every known-gap row this manifest originally carried using the shapes above.
- * `WebPlatformCoverageEntry` keeps the `known-gap` variant for any future command whose web
- * behavior genuinely isn't decided yet.
+ * #1900 closed 14 of the 15 known-gap rows this manifest originally carried using the shapes
+ * above. `test` stays `known-gap`: its declared-platform filter structurally excludes web
+ * (`ReplayTestPlatform = Exclude<PlatformSelector, 'web'>`), so `test --platform web` can never
+ * select a script — real, tested, command-specific behavior (see
+ * `session-command-replay.test.ts`), but evidence of what the command cannot do, not executable
+ * evidence that it works on web. Closing this row needs a separate product decision: either web
+ * replay-test support, or an explicit denial.
  */
 export const WEB_PLATFORM_COVERAGE = {
   [C.artifacts]: contract(
@@ -127,10 +135,8 @@ export const WEB_PLATFORM_COVERAGE = {
     'replay inherits the parent web platform selector for each invoked step',
     'replay re-invokes each recorded step with no platform branch, so a web selector threads through unchanged',
   ),
-  [C.test]: contract(
-    'src/daemon/handlers/__tests__/session-command-replay.test.ts',
-    'test --platform web reports no matching scripts, typed or untyped, because ReplayTestPlatform excludes web',
-    "test's declared-platform filter structurally excludes web (ReplayTestPlatform = Exclude<PlatformSelector, 'web'>), so --platform web deterministically matches no script",
+  [C.test]: gap(
+    "Web test-suite execution has no executable web evidence: ReplayTestPlatform = Exclude<PlatformSelector, 'web'> structurally excludes web from the declared-platform filter, so `test --platform web` can never select a script (proven by a regression test in session-command-replay.test.ts) — that is evidence of what the command cannot do, not that it works on web",
   ),
   [C.clipboard]: denial('Web capability model rejects native clipboard operations'),
   [C.keyboard]: contract(

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -24,7 +24,6 @@ export type WebPlatformCoverageEntry =
       trackingIssue: number;
     };
 
-export const WEB_COVERAGE_GAP_ISSUE = 1900;
 export const WEB_SMOKE_TEST_NAME = 'live web platform e2e smoke';
 export const WEB_SMOKE_EVIDENCE: RepositoryEvidence = {
   path: 'test/integration/smoke-web-platform.test.ts',
@@ -46,11 +45,6 @@ const denial = (assertion: string): WebPlatformCoverageEntry => ({
   assertion,
   level: 'capability-denial',
 });
-const gap = (assertion: string): WebPlatformCoverageEntry => ({
-  assertion,
-  level: 'known-gap',
-  trackingIssue: WEB_COVERAGE_GAP_ISSUE,
-});
 
 /**
  * One primary, observable owner for every public command on the managed web target.
@@ -58,11 +52,21 @@ const gap = (assertion: string): WebPlatformCoverageEntry => ({
  * Live rows are limited to the existing web-smoke scenario. Contract rows cite
  * existing web-specific unit/provider evidence; they do not turn fixture-backed
  * tests into live E2E claims. Capability denials are derived from the web bucket
- * in the command capability matrix. Known gaps are explicit follow-up work, not
- * an implicit claim that a generic command works on web.
+ * in the command capability matrix.
+ *
+ * #1900 closed every known-gap row this manifest originally carried: each now cites either the
+ * web runtime's own unavailable-operation fact (a real, permanent denial — e.g. `boot`, `push`),
+ * or a new test proving the command's existing generic/shared-runtime-plan code path already
+ * runs correctly for a web-backed session (e.g. `artifacts`, `diff`, `press`). None of this widens
+ * the live web-smoke scope. `WebPlatformCoverageEntry` keeps the `known-gap` variant for any
+ * future command whose web behavior genuinely isn't decided yet.
  */
 export const WEB_PLATFORM_COVERAGE = {
-  [C.artifacts]: gap('No web-specific artifact inventory command evidence exists yet'),
+  [C.artifacts]: contract(
+    'src/daemon/__tests__/request-router-artifacts-web.test.ts',
+    'artifacts lists a daemon-tracked artifact produced during a web session',
+    'daemon artifact listing round-trips a tracked artifact for a web-backed session',
+  ),
   [C.devices]: contract(
     'test/integration/provider-scenarios/web-desktop.test.ts',
     'Provider-backed integration web desktop flow uses semantic web provider calls',
@@ -83,33 +87,69 @@ export const WEB_PLATFORM_COVERAGE = {
     'capabilities omits apps when $label runtime facts deny the operation',
     'web runtime facts keep native app inventory unavailable',
   ),
-  [C.boot]: gap('Web boot has no command-level executable evidence'),
-  [C.shutdown]: gap('Web shutdown has no command-level executable evidence'),
+  [C.boot]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'boot and shutdown report the runtime-owned unavailable readiness fact',
+    'the web runtime fact rejects device boot',
+  ),
+  [C.shutdown]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'boot and shutdown report the runtime-owned unavailable readiness fact',
+    'the web runtime fact rejects device shutdown',
+  ),
   [C.appState]: contract(
     'packages/platform-web/src/runtime.test.ts',
     'preserves a narrow web provider dump including empty successful entries',
     'web runtime facts keep app state unavailable',
   ),
   [C.perf]: denial('Web capability model rejects native performance inspection'),
-  [C.logs]: gap('Web app-log commands have no command-level executable evidence'),
-  [C.events]: gap('Web session event timeline has no command-level executable evidence'),
+  [C.logs]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'logs reports the runtime-owned unavailable app-log facts',
+    'the web runtime fact rejects native app-log commands',
+  ),
+  [C.events]: contract(
+    'src/daemon/__tests__/request-router-events.test.ts',
+    'events reads the daemon-owned session timeline for a web-backed session',
+    'the session-owned event timeline works the same for a web-backed session as any other platform',
+  ),
   [C.network]: live('network dump returns the fixture GET request and requested headers'),
   [C.audio]: contract(
     'src/daemon/handlers/__tests__/session-audio.test.ts',
     'audio probe forwards daemon millisecond timing to web provider',
     'web audio probe forwards typed duration and bucket values',
   ),
-  [C.replay]: gap('Web replay has no executable command evidence'),
-  [C.test]: gap('Web test-suite execution has no executable command evidence'),
+  [C.replay]: contract(
+    'src/daemon/handlers/__tests__/session-command-replay.test.ts',
+    'replay inherits the parent web platform selector for each invoked step',
+    'replay re-invokes each recorded step with no platform branch, so a web selector threads through unchanged',
+  ),
+  [C.test]: contract(
+    'src/daemon/handlers/__tests__/session-command-replay.test.ts',
+    'test runs an undeclared script against a session already bound to a web device',
+    'an unfiltered test run executes its script against a session already bound to a web device',
+  ),
   [C.clipboard]: denial('Web capability model rejects native clipboard operations'),
   [C.keyboard]: contract(
     'packages/platform-web/src/runtime.test.ts',
     'back/home/orientation/tv-remote/keyboard never carried a web capability bucket',
     'the exact-owner runtime fact rejects native keyboard operations on the web target',
   ),
-  [C.install]: gap('Web application installation has no command-level executable evidence'),
-  [C.reinstall]: gap('Web application reinstallation has no command-level executable evidence'),
-  [C.push]: gap('Web application push delivery has no command-level executable evidence'),
+  [C.install]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'install and reinstall share the runtime-owned unavailable deploy fact',
+    'the web runtime fact rejects native app installation',
+  ),
+  [C.reinstall]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'install and reinstall share the runtime-owned unavailable deploy fact',
+    'the web runtime fact rejects native app reinstallation',
+  ),
+  [C.push]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'push reports the runtime-owned unavailable readiness and push facts',
+    'the web runtime fact rejects native push notification delivery',
+  ),
   [C.triggerAppEvent]: denial('Web capability model rejects native app event delivery'),
   [C.open]: live('the managed browser opens the local fixture page'),
   [C.prepare]: contract(
@@ -117,10 +157,18 @@ export const WEB_PLATFORM_COVERAGE = {
     'preserves a narrow web provider dump including empty successful entries',
     'web runtime facts keep Apple runner preparation unavailable',
   ),
-  [C.batch]: gap('Web batch execution has no command-level executable evidence'),
+  [C.batch]: contract(
+    'src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts',
+    'batch step forwards the parent web platform selector to each invoked step',
+    'batch re-invokes each step through the normal dispatcher with no platform branch, so a web selector threads through unchanged',
+  ),
   [C.close]: live('close releases the managed browser session during smoke cleanup'),
   [C.snapshot]: live('interactive snapshot exposes the fixture ready marker and form controls'),
-  [C.diff]: gap('Web snapshot diff has no command-level executable evidence'),
+  [C.diff]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'diff shares the admitted captureSnapshot fact that live snapshot and diff both require',
+    'web diff shares the browser-admitted snapshot capture that backs the live snapshot command',
+  ),
   [C.wait]: live('wait observes ready text and post-interaction fixture state'),
   [C.alert]: denial('Web capability model rejects native alert operations'),
   [C.settings]: denial('Web capability model rejects native device settings operations'),
@@ -130,7 +178,11 @@ export const WEB_PLATFORM_COVERAGE = {
     'start web recording',
     'web recording starts and stops through the scoped provider',
   ),
-  [C.trace]: gap('Web trace capture has no command-level executable evidence'),
+  [C.trace]: contract(
+    'src/daemon/handlers/__tests__/trace-runtime.test.ts',
+    'starts and stops one trace through the session-owned trace slot on a web session',
+    'session-scoped trace start/stop bookkeeping works the same for a web session as any other platform',
+  ),
   [C.find]: live('find locates the ready marker through text and selector expressions'),
   [C.click]: live('click changes the fixture status to Submitted'),
   [C.fill]: live('fill updates the accessible email value and fixture status'),
@@ -144,7 +196,11 @@ export const WEB_PLATFORM_COVERAGE = {
     'hover submit ref',
     'web hover moves the pointer through the provider element handle',
   ),
-  [C.press]: gap('Web press has no direct command-level executable evidence'),
+  [C.press]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'press shares the admitted tapPoint fact that live click and press both require',
+    'web press shares the browser-admitted tap operation that backs the live click command',
+  ),
   [C.type]: contract(
     'test/integration/provider-scenarios/web-desktop.test.ts',
     'type suffix',
@@ -197,7 +253,11 @@ export const WEB_PLATFORM_COVERAGE = {
   [C.screenshot]: live('screenshot creates a valid 640x480 PNG artifact'),
   [C.viewport]: live('viewport resizes the browser and the PNG reports 640x480 dimensions'),
   [C.appSwitcher]: denial('Web capability model rejects native app switcher navigation'),
-  [C.installFromSource]: gap('Web source installation has no command-level executable evidence'),
+  [C.installFromSource]: contract(
+    'packages/platform-web/src/runtime.test.ts',
+    'install-from-source reports the runtime-owned unavailable materialize and deploy facts',
+    'the web runtime fact rejects source-based app installation',
+  ),
 } satisfies Record<PublicCommand, WebPlatformCoverageEntry>;
 
 export const WEB_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClassificationSummary(


### PR DESCRIPTION
## Summary

Part of #1900. The web coverage manifest (`test/integration/web-e2e/coverage-manifest.ts`) carried 15 `known-gap` rows recording that HEAD had no command-specific web evidence for: `artifacts`, `boot`, `shutdown`, `logs`, `events`, `replay`, `test`, `install`, `reinstall`, `push`, `batch`, `diff`, `trace`, `press`, `install-from-source`.

**14 of the 15 are now `command-contract` rows** backed by new or cited tests, added per the issue's ground rule ("add or identify executable web command evidence... keep the existing live web smoke scope unchanged"):

- **Deliberate, permanent runtime denials** (`boot`, `shutdown`, `install`, `reinstall`, `install-from-source`, `push`, `logs`) — new tests in `packages/platform-web/src/runtime.test.ts` prove the web runtime explicitly reports `unsupported-platform-leaf` for these operations (a managed browser session has no OS-level boot/shutdown, no installable native package, no native log/push channel). Same evidence pattern already used for `longPress`/`back`/`home`/`orientation`/`tvRemote`/`keyboard`.
- **Shares an already-live operation** (`diff`, `press`) — `diff` uses the exact same `snapshotRuntimePlanUses` as the live `snapshot` command, and `press`'s runtime-use plan is literally `clickRuntimeUses` (both pinned by `src/core/command-descriptor/__tests__/{snapshot,click}-runtime-execution.test.ts` in addition to the fact-availability tests). New tests prove the shared operation is admitted on web.
- **Zero platform branching, just untested for web** (`artifacts`, `events`, `batch`, `trace`, `replay`) — these handlers never call into platform-runtime binding at all. New tests dispatch each through its real production handler against a web-typed session/device to prove the existing generic code path runs correctly.

**`test` stays `known-gap`** (this PR does not close it): its declared-platform filter structurally excludes web (`ReplayTestPlatform = Exclude<PlatformSelector, 'web'>` in `packages/replay-test`), so `test --platform web` can never select a script. A regression test in `session-command-replay.test.ts` proves that exclusion is real and deterministic, but it's evidence of what the command *cannot* do, not that it works on web — so it isn't cited as manifest coverage evidence. Closing this row needs a separate product decision: either web replay-test support, or an explicit denial classification.

The manifest's classification-count gate is updated to `{capabilityDenial: 7, contract: 34, gap: 1, live: 12, total: 54}`, and the "known gaps share one tracking issue" gate now also pins the single remaining gap to `test`. **No new live E2E scenarios were added** — `test/integration/smoke-web-platform.test.ts`'s scope is unchanged.

## Validation

- `pnpm typecheck` — clean.
- `pnpm test:unit` (full `unit-core` + `subprocess-stub` + `fuzz-worker`) — 7876 passed, 3 skipped; the 2 failures that appear in that run (`app-log-session-resource.test.ts`, `durable-capture-resource-adoption.test.ts`) are pre-existing and reproduce identically on the base commit with this branch's changes stashed — unrelated to this PR.
- `node --experimental-strip-types scripts/node-test-tmpdir.ts --test test/integration/smoke-web-platform-coverage.test.ts` — all 9 manifest gate tests pass, including the one that verifies every cited `command-contract` file/test-name actually exists.
- `fallow audit` — no issues in changed files.
- `oxlint`/`oxfmt` — clean.

Reviewed against an independent adversarial pass plus @thymikee's review, both of which found the `test` row's original `command-contract` classification was an overclaim; it's been reverted to `known-gap` as described above.
