### PR TITLE
fix(daemon): close web sessions on daemon shutdown instead of leaking the browser fleet

### DIFF
--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -270,7 +270,7 @@ export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   'src/core/command-descriptor/registry.ts': 66,
   'src/core/command-descriptor/platform-execution-entry.ts': 3,
   'src/core/interactors/register-builtins.ts': 73,
-  'src/daemon/session-teardown.ts': 89,
+  'src/daemon/session-teardown.ts': 90,
 });
 
 function toRows(

--- a/src/daemon/__tests__/session-teardown-import-closure.test.ts
+++ b/src/daemon/__tests__/session-teardown-import-closure.test.ts
@@ -6,11 +6,13 @@ import { eagerClosureOf } from '../../__tests__/eager-import-closure.fixtures.ts
  * Session teardown runs for every closed session on every platform, so its eager
  * import closure is paid by all of them. The android cleanup helpers
  * (`perf.ts`, `snapshot-helper.ts`) only matter when the corresponding capture
- * actually ran on the session; they load through function-scoped `await import`
- * behind their existing guards (the register-builtins interactor lazy pattern).
+ * actually ran on the session, and the web managed-browser provider
+ * (`agent-browser-provider.ts`) only matters for a web session; they load through
+ * function-scoped `await import` behind their existing guards (the register-builtins
+ * interactor lazy pattern).
  *
- * This pins that seam: restoring either helper to a static import puts it back
- * in the eager closure and fails here.
+ * This pins that seam: restoring any of them to a static import puts it back in the
+ * eager closure and fails here.
  */
 
 const srcRoot = path.resolve(import.meta.dirname, '../..');
@@ -19,6 +21,7 @@ const LAZY_ANDROID_HELPERS = [
   /platforms[/\\]android[/\\]perf\.ts$/,
   /platforms[/\\]android[/\\]snapshot-helper\.ts$/,
 ];
+const LAZY_WEB_HELPERS = [/platforms[/\\]web[/\\]agent-browser-provider\.ts$/];
 
 test('the session teardown eager import closure never evaluates the android cleanup helpers', () => {
   const offenders = eagerClosureOf(teardownFile).filter((file) =>
@@ -30,6 +33,20 @@ test('the session teardown eager import closure never evaluates the android clea
     'Load the android perf/snapshot-helper cleanup helpers on demand instead: teardown is shared ' +
       'by every platform, and eagerly evaluating these drags their whole subtree into sessions ' +
       'that never ran an android capture.',
+  ).toEqual([]);
+});
+
+test('the session teardown eager import closure never evaluates the web managed-browser provider', () => {
+  const offenders = eagerClosureOf(teardownFile).filter((file) =>
+    LAZY_WEB_HELPERS.some((pattern) => pattern.test(file)),
+  );
+
+  expect(
+    offenders.map((file) => path.relative(srcRoot, file)),
+    'Load the agent-browser web provider on demand instead: teardown is shared by every ' +
+      'platform, and eagerly evaluating it drags its whole subtree (agent-browser tool ' +
+      'resolution, selectors, snapshot/network normalization) into sessions that never opened a ' +
+      'web session.',
   ).toEqual([]);
 });
 

--- a/src/daemon/handlers/__tests__/session-teardown-resources.test.ts
+++ b/src/daemon/handlers/__tests__/session-teardown-resources.test.ts
@@ -3,6 +3,7 @@ import {
   sessionCloseShutdownFixture,
   type SessionState,
 } from './session-close-shutdown.fixtures.ts';
+import { installFakeManagedAgentBrowser } from '../../../platforms/web/__tests__/test-utils.ts';
 
 const {
   AppError,
@@ -12,6 +13,7 @@ const {
   makeSessionStore,
   mockCleanupAndroidNativePerfSession,
   mockCleanupAppleXctracePerfCapture,
+  mockRunCmd,
   mockStopAndroidSnapshotHelperSessionForDevice,
   mockStopIosRunnerSession,
   mockStopIosRunnerSession: stopIosRunnerSession,
@@ -23,9 +25,14 @@ const {
   resetSessionCloseShutdownMocks,
   screenRecordingResourceStore,
   teardownSessionResources,
+  WEB_DESKTOP_DEVICE,
 } = sessionCloseShutdownFixture;
 
 beforeEach(resetSessionCloseShutdownMocks);
+
+function agentBrowserJsonResult(value: unknown, exitCode = 0) {
+  return { stdout: JSON.stringify(value), stderr: '', exitCode };
+}
 
 test('daemon session teardown stops active Apple xctrace perf capture', async () => {
   const sessionName = 'ios-active-xctrace-teardown-session';
@@ -325,4 +332,66 @@ test('daemon session teardown attempts every resource after an earlier cleanup r
 
   // The later resource still runs despite the earlier rejection.
   expect(mockStopAndroidSnapshotHelperSessionForDevice).toHaveBeenCalledWith(session.device);
+});
+
+test('daemon session teardown closes an open web session immediately, not on agent-browser idle timeout', async () => {
+  const sessionName = 'web-active-session-teardown-session';
+  const sessionStore = makeSessionStore();
+  installFakeManagedAgentBrowser(sessionStore.resolveDaemonStateDir());
+  const session = makeSession(sessionName, WEB_DESKTOP_DEVICE);
+  // Teardown always runs while the session it is tearing down is still in the store (session
+  // deletion happens after), which is what keeps the provider-startup orphan sweep from treating
+  // this session's own browser as an orphan and scanning real host processes for it.
+  sessionStore.set(sessionName, session);
+  mockRunCmd.mockResolvedValue(agentBrowserJsonResult({ success: true, data: {} }));
+
+  await teardownSessionResources({ appLog: 'already-settled', session, sessionName, sessionStore });
+
+  // A SIGTERM daemon shutdown (or an expired-session reap) tells agent-browser to close its
+  // fleet right away, the same way an explicit `session close` does, instead of leaving the
+  // Chrome processes to agent-browser's own multi-minute idle timer.
+  expect(mockRunCmd).toHaveBeenCalledTimes(1);
+  const [, args] = mockRunCmd.mock.calls[0] as [string, string[]];
+  expect(args).toEqual(['close', '--json', '--session', sessionName]);
+});
+
+test('daemon session teardown surfaces a web close failure through the cleanup-failure channel', async () => {
+  const sessionName = 'web-close-failure-teardown-session';
+  const sessionStore = makeSessionStore();
+  installFakeManagedAgentBrowser(sessionStore.resolveDaemonStateDir());
+  const session = makeSession(sessionName, WEB_DESKTOP_DEVICE);
+  sessionStore.set(sessionName, session);
+  mockRunCmd.mockResolvedValue(
+    agentBrowserJsonResult({ success: false, error: 'no active browser session' }),
+  );
+
+  await expect(
+    teardownSessionResources({ appLog: 'already-settled', session, sessionName, sessionStore }),
+  ).rejects.toMatchObject({
+    code: 'COMMAND_FAILED',
+    details: expect.objectContaining({
+      reason: 'session_cleanup_incomplete',
+      failedSteps: ['web_browser'],
+    }),
+  });
+});
+
+test('daemon session teardown never dispatches a web close for a non-web session', async () => {
+  const sessionName = 'android-non-web-teardown-session';
+  const session = makeSession(sessionName, {
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel',
+    kind: 'emulator',
+    booted: true,
+  });
+
+  await teardownSessionResources({
+    appLog: 'already-settled',
+    session,
+    sessionName,
+    sessionStore: makeSessionStore(),
+  });
+
+  expect(mockRunCmd).not.toHaveBeenCalled();
 });

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -15,7 +15,7 @@ import {
   recordRepairPlatformClose,
 } from '../session-replay-transaction.ts';
 import { isAuthoringArmedSession } from '../session-script-publication-capability.ts';
-import { type SessionCleanupFailure } from '../session-teardown.ts';
+import { isWebSession, type SessionCleanupFailure } from '../session-teardown.ts';
 import { clearDeviceClaim } from '../device-claims.ts';
 import { applicationLifecycleExecutionFromRequest } from '../application-lifecycle-execution.ts';
 import { hasRuntimeTransportHints } from './session-runtime.ts';
@@ -392,7 +392,7 @@ async function closeAppWithoutEndingSession(params: {
 }
 
 function shouldDispatchPlatformClose(req: DaemonRequest, session: SessionState): boolean {
-  return hasCloseTarget(req) || session.device.platform === 'web';
+  return hasCloseTarget(req) || isWebSession(session);
 }
 
 function hasCloseTarget(req: DaemonRequest): boolean {

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -55,6 +55,7 @@ import {
 import { unsupportedSaveScriptFlagResponse } from './request-save-script-policy.ts';
 import { canRunReplayScopedAction } from './daemon-command-registry.ts';
 import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-provider.ts';
+import { isWebSession } from './session-teardown.ts';
 import { openWebSessionNames } from './web-session-names.ts';
 import { inferFillText } from './action-utils.ts';
 import { createPlatformRequestScope } from './platform-request-scope.ts';
@@ -351,7 +352,10 @@ const createDefaultWebProvider =
     });
 
 function shouldUseDefaultWebProvider(scope: LockedRequestScope): boolean {
-  return scope.existingSession?.device.platform === 'web' || scope.req.flags?.platform === 'web';
+  return (
+    (scope.existingSession !== undefined && isWebSession(scope.existingSession)) ||
+    scope.req.flags?.platform === 'web'
+  );
 }
 
 function unauthorizedResponse(): DaemonResponse {

--- a/src/daemon/server/daemon-runtime-web-close-teardown.test.ts
+++ b/src/daemon/server/daemon-runtime-web-close-teardown.test.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('../../utils/exec.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/exec.ts')>();
+  return { ...actual, runCmd: vi.fn() };
+});
+
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { WEB_DESKTOP_DEVICE } from '../../__tests__/test-utils/device-fixtures.ts';
+import { AGENT_BROWSER_TIMEOUT_MS } from '../../platforms/web/agent-browser-provider.ts';
+import { installFakeManagedAgentBrowser } from '../../platforms/web/__tests__/test-utils.ts';
+import { runCmd } from '../../utils/exec.ts';
+import { SessionStore } from '../session-store.ts';
+import type { SessionState } from '../types.ts';
+import {
+  resolveDaemonSessionTeardownTimeoutMs,
+  teardownDaemonSessionForShutdown,
+  WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS,
+} from './daemon-runtime.ts';
+
+const mockRunCmd = vi.mocked(runCmd);
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function makeWebSession(name: string): SessionState {
+  return { name, device: WEB_DESKTOP_DEVICE, createdAt: Date.now(), actions: [] };
+}
+
+test('daemon session teardown budget extends for an open web session', () => {
+  const webSession = makeWebSession('budget-web-session');
+  const androidSession: SessionState = {
+    name: 'budget-android-session',
+    device: {
+      platform: 'android',
+      id: 'emulator-5554',
+      name: 'Pixel',
+      kind: 'emulator',
+      booted: true,
+    },
+    createdAt: Date.now(),
+    actions: [],
+  };
+
+  expect(
+    resolveDaemonSessionTeardownTimeoutMs(webSession) -
+      resolveDaemonSessionTeardownTimeoutMs(androidSession),
+  ).toBe(WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS);
+});
+
+// Pins the "mirrors AGENT_BROWSER_TIMEOUT_MS" comment on WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS
+// as a checked invariant rather than a claim nothing enforces: if agent-browser-provider.ts's own
+// per-call timeout changes, this budget must move with it in the same PR.
+test('the web-close teardown budget stays pinned to one agent-browser CLI call timeout', () => {
+  expect(WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS).toBe(AGENT_BROWSER_TIMEOUT_MS);
+});
+
+// The agent-browser CLI call this step makes has its own 30s internal timeout
+// (AGENT_BROWSER_TIMEOUT_MS in agent-browser-provider.ts), well past the 5s base teardown
+// budget every other resource shares; without the extended budget above, a close that takes
+// longer than 5s (closing ~15 Chrome processes under load is plausible) would be abandoned by
+// the daemon's own race before agent-browser ever got to finish it.
+test('daemon shutdown awaits a slow web close inside its extended budget', async () => {
+  vi.useFakeTimers();
+  const root = mkdtempForTestSync('agent-device-shutdown-web-close-slow-');
+  installFakeManagedAgentBrowser(root);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const session = makeWebSession('shutdown-slow-web-session');
+  sessionStore.set(session.name, session);
+  mockRunCmd.mockImplementation(
+    async () =>
+      await new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              stdout: JSON.stringify({ success: true, data: {} }),
+              stderr: '',
+              exitCode: 0,
+            }),
+          20_000,
+        );
+      }),
+  );
+  const stderrChunks: string[] = [];
+
+  const teardown = teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir: root,
+    stderr: { write: (chunk) => stderrChunks.push(chunk) },
+  });
+  await vi.advanceTimersByTimeAsync(20_000);
+  await teardown;
+
+  expect(stderrChunks.join('')).not.toMatch(/timed out/);
+  expect(sessionStore.get(session.name)).toBeUndefined();
+});
+
+// #1868: SIGTERM (or any other daemon-shutdown teardown) must tell agent-browser to close its
+// fleet right away instead of leaving the ~15 Chrome processes for agent-browser's own multi-
+// minute idle timer. This is the daemon-shutdown-entry-point counterpart to
+// daemon-runtime-recording-teardown.test.ts's coverage of the #1325 recording step.
+test('daemon shutdown closes an open web session immediately, without waiting for close', async () => {
+  const root = mkdtempForTestSync('agent-device-shutdown-web-close-');
+  installFakeManagedAgentBrowser(root);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const session = makeWebSession('shutdown-web-session');
+  // Teardown runs while the session it is tearing down is still in the store (session deletion
+  // happens after), which is also what keeps agent-browser's provider-startup orphan sweep from
+  // treating this session's own browser as an orphan and scanning real host processes for it.
+  sessionStore.set(session.name, session);
+  mockRunCmd.mockResolvedValue({
+    stdout: JSON.stringify({ success: true, data: {} }),
+    stderr: '',
+    exitCode: 0,
+  });
+  const stderrChunks: string[] = [];
+
+  await teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir: root,
+    stderr: { write: (chunk) => stderrChunks.push(chunk) },
+  });
+
+  expect(stderrChunks.join('')).toBe('');
+  expect(sessionStore.get(session.name)).toBeUndefined();
+  const closeCall = mockRunCmd.mock.calls.find(([, args]) => (args as string[]).includes('close'));
+  expect(closeCall?.[1]).toEqual(['close', '--json', '--session', session.name]);
+});
+
+test('daemon shutdown reports a web close failure on stderr instead of losing it silently', async () => {
+  const root = mkdtempForTestSync('agent-device-shutdown-web-close-failure-');
+  installFakeManagedAgentBrowser(root);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const session = makeWebSession('shutdown-web-close-failure-session');
+  sessionStore.set(session.name, session);
+  mockRunCmd.mockResolvedValue({
+    stdout: JSON.stringify({ success: false, error: 'no active browser session' }),
+    stderr: '',
+    exitCode: 1,
+  });
+  const stderrChunks: string[] = [];
+
+  await teardownDaemonSessionForShutdown({
+    session,
+    sessionStore,
+    stateDir: root,
+    stderr: { write: (chunk) => stderrChunks.push(chunk) },
+  });
+
+  // Best-effort: the failure is surfaced, but it never blocks the session from being torn down.
+  expect(stderrChunks.join('')).toMatch(/web_browser/);
+  expect(sessionStore.get(session.name)).toBeUndefined();
+});

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -17,7 +17,7 @@ import { LeaseRegistry } from '../lease-registry.ts';
 import { createExpiredProviderLeaseReleaser } from '../provider-lease-expiry.ts';
 import { clearDaemonShutdownReport, writeDaemonShutdownReport } from '../daemon-shutdown-report.ts';
 import { createRequestHandler } from '../request-router.ts';
-import { stopSessionAppLog, teardownSessionResources } from '../session-teardown.ts';
+import { isWebSession, stopSessionAppLog, teardownSessionResources } from '../session-teardown.ts';
 import { finalizeDaemonSessionApplicationLifecycle } from '../application-lifecycle-recovery.ts';
 import { runtimeHintValues } from '../handlers/session-runtime.ts';
 import { closeDaemonServers } from './server-shutdown.ts';
@@ -66,6 +66,10 @@ import { createScreenRecordingAdmissionLedger } from '../screen-recording-admiss
 
 const DAEMON_SESSION_TEARDOWN_TIMEOUT_MS = 5_000;
 export const SCREEN_RECORDING_SESSION_TEARDOWN_BUDGET_MS = 11_000;
+// Mirrors AGENT_BROWSER_TIMEOUT_MS in platforms/web/agent-browser-provider.ts: the ceiling that
+// module already places on one `agent-browser` CLI call, so the race below never gives up on the
+// web-close step while the close it started is still running within its own enforced limit.
+export const WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS = 30_000;
 const DAEMON_SESSION_LEASE_RELEASE_TIMEOUT_MS = 1_000;
 const DAEMON_PNG_WORKER_TERMINATE_TIMEOUT_MS = 1_000;
 const DAEMON_PROVIDER_RELEASE_DRAIN_TIMEOUT_MS = 2_000;
@@ -75,14 +79,17 @@ type WritableOutput = {
 };
 
 /**
- * Per-session teardown budget for daemon shutdown. The base budget covers ordinary resources;
- * an active durable recording gets an additional owner-finalization budget so the daemon cannot
- * exit while its runtime handle is still producing the terminal media artifact. The base portion
- * remains available to cleanup steps that follow recording finalization.
+ * Per-session teardown budget for daemon shutdown. The base budget covers ordinary resources; an
+ * active durable recording or an open web session gets an additional owner-finalization budget so
+ * the daemon cannot exit while its runtime handle is still producing the terminal media artifact,
+ * or while agent-browser is still closing its Chrome fleet. The base portion remains available to
+ * cleanup steps that follow recording finalization or the web close.
  */
 export function resolveDaemonSessionTeardownTimeoutMs(session: SessionState): number {
-  if (!session.screenRecording) return DAEMON_SESSION_TEARDOWN_TIMEOUT_MS;
-  return DAEMON_SESSION_TEARDOWN_TIMEOUT_MS + SCREEN_RECORDING_SESSION_TEARDOWN_BUDGET_MS;
+  let timeoutMs = DAEMON_SESSION_TEARDOWN_TIMEOUT_MS;
+  if (session.screenRecording) timeoutMs += SCREEN_RECORDING_SESSION_TEARDOWN_BUDGET_MS;
+  if (isWebSession(session)) timeoutMs += WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS;
+  return timeoutMs;
 }
 
 async function settleDaemonTeardownStep(params: {

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -8,12 +8,13 @@ import type { SessionStore } from './session-store.ts';
 import { forceCleanupSessionAppLog } from './app-log-session-resource.ts';
 import { appLogResourceStore } from './app-log-resource-store.ts';
 import { finishLiveScreenRecording } from './screen-recording-session-resource.ts';
+import { openWebSessionNames } from './web-session-names.ts';
 
-// Android cleanup helpers stay behind dynamic imports: every teardown caller pays this module's
-// graph, while the helpers only matter when the corresponding capture actually ran on the session.
-// Each import sits inside its sole caller, next to the existing guard, matching register-builtins'
-// interactor lazy pattern; the seam is pinned by
-// src/daemon/__tests__/session-teardown-import-closure.test.ts.
+// Android cleanup helpers and the web managed-browser provider stay behind dynamic imports: every
+// teardown caller pays this module's graph, while the helpers only matter when the corresponding
+// capture (or platform) actually applies to the session. Each import sits inside its sole caller,
+// next to the existing guard, matching register-builtins' interactor lazy pattern; the seam is
+// pinned by src/daemon/__tests__/session-teardown-import-closure.test.ts.
 
 export { stopSessionAudioProbe } from './audio-probe.ts';
 
@@ -51,6 +52,33 @@ export async function stopSessionAndroidSnapshotHelper(session: SessionState): P
   const { stopAndroidSnapshotHelperSessionForDevice } =
     await import('../platforms/android/snapshot-helper.ts');
   await stopAndroidSnapshotHelperSessionForDevice(session.device);
+}
+
+// Single source of truth for "is this a web session", shared with `shouldDispatchPlatformClose`
+// in daemon/handlers/session-close.ts so the ordinary-close and teardown platform-close gates
+// cannot silently drift apart.
+export function isWebSession(session: SessionState): boolean {
+  return session.device.platform === 'web';
+}
+
+// Best-effort mirror of the platform close `session close` dispatches for a web session
+// (`shouldDispatchPlatformClose` in daemon/handlers/session-close.ts) so a daemon shutdown or
+// expired-session reap tells agent-browser to close its fleet immediately instead of leaving it
+// for agent-browser's own idle timer (`DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS`).
+export async function stopSessionWebBrowser(params: {
+  session: SessionState;
+  sessionName: string;
+  sessionStore: SessionStore;
+}): Promise<void> {
+  const { session, sessionName, sessionStore } = params;
+  if (!isWebSession(session)) return;
+  const { createAgentBrowserWebProvider } =
+    await import('../platforms/web/agent-browser-provider.ts');
+  await createAgentBrowserWebProvider({
+    session: sessionName,
+    stateDir: sessionStore.resolveDaemonStateDir(),
+    openWebSessionNames: () => openWebSessionNames(sessionStore),
+  }).close();
 }
 
 type SessionCleanupStep = { step: string; run: () => Promise<void> };
@@ -153,6 +181,13 @@ export async function teardownSessionResources(
     { step: 'apple_perf', run: () => stopSessionApplePerfCapture(session) },
     { step: 'android_native_perf', run: () => stopSessionAndroidNativePerfCapture(session) },
     { step: 'android_snapshot_helper', run: () => stopSessionAndroidSnapshotHelper(session) },
+    // Runs after the resource steps above (recording, app-log, audio, perf) so nothing is still
+    // reading through the browser when it closes, mirroring the ordering `runSessionCloseTeardown`
+    // uses for an ordinary `session close`: best-effort resources first, platform close after.
+    {
+      step: 'web_browser',
+      run: () => stopSessionWebBrowser({ session, sessionName, sessionStore }),
+    },
   ];
   steps.push({
     step: 'materialized_paths',

--- a/src/daemon/session-teardown.ts
+++ b/src/daemon/session-teardown.ts
@@ -64,8 +64,10 @@ export function isWebSession(session: SessionState): boolean {
 // Best-effort mirror of the platform close `session close` dispatches for a web session
 // (`shouldDispatchPlatformClose` in daemon/handlers/session-close.ts) so a daemon shutdown or
 // expired-session reap tells agent-browser to close its fleet immediately instead of leaving it
-// for agent-browser's own idle timer (`DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS`).
-export async function stopSessionWebBrowser(params: {
+// for agent-browser's own idle timer (`DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS`). Unlike its
+// siblings above, this has no second caller in the ordinary-close path (that path already
+// reaches the browser through `dispatchTargetedPlatformClose`), so it stays module-private.
+async function stopSessionWebBrowser(params: {
   session: SessionState;
   sessionName: string;
   sessionStore: SessionStore;

--- a/src/platforms/web/agent-browser-provider.ts
+++ b/src/platforms/web/agent-browser-provider.ts
@@ -24,7 +24,9 @@ import {
 import { cleanupManagedAgentBrowserOrphansForProviderStartup } from './agent-browser-lifecycle.ts';
 
 const AGENT_BROWSER = 'agent-browser';
-const AGENT_BROWSER_TIMEOUT_MS = 30_000;
+// Exported so WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS (daemon/server/daemon-runtime.ts) can be
+// pinned to it instead of drifting out of sync with a copied number.
+export const AGENT_BROWSER_TIMEOUT_MS = 30_000;
 const AGENT_BROWSER_DOCTOR_HINT =
   'Run `agent-device web setup` to install the managed web backend.';
 

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -1,14 +1,29 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import path from 'node:path';
 import test from 'node:test';
 import { type CliJsonResult, formatResultDebug, runBuiltCliJson } from './cli-json.ts';
 import { assertPngDimensions, assertPngFile } from './provider-scenarios/assertions.ts';
 import { runCleanupWithCoverageReport } from './web-e2e/coverage-report.ts';
+import { assertNoDaemonLeaks } from './support/daemon-leak-oracle.ts';
+import {
+  inspectManagedAgentBrowserProcesses,
+  type AgentBrowserProcessSummary,
+} from '../../src/platforms/web/agent-browser-lifecycle.ts';
+import { getManagedAgentBrowserStatus } from '../../src/platforms/web/agent-browser-tool.ts';
+import { isProcessAlive } from '../../src/utils/host-process.ts';
 
 const TEST_NAME = 'live web platform e2e smoke';
+const SHUTDOWN_TEST_NAME = 'live web platform e2e daemon-shutdown browser cleanup';
 const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
+// #1868: SIGTERM must close the managed Chrome fleet well before agent-browser's own idle timer
+// (DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS, 5 minutes) would have. Left at its production default
+// here (unlike the functional smoke test's shortened override below) so a pass can only mean the
+// daemon's shutdown teardown actively closed the browser, not that the idle timer coincidentally
+// beat this test's own poll deadline.
+const WEB_SHUTDOWN_SETTLE_TIMEOUT_MS = 45_000;
+const WEB_SHUTDOWN_SETTLE_POLL_MS = 500;
 
 type StepRecord = {
   step: string;
@@ -41,6 +56,95 @@ test(
     await runWebSmoke(await createWebSmokeContext());
   },
 );
+
+// #1868: teardownSessionResources gained a best-effort web-close step so a daemon shutdown (or
+// an expired-session reap) tells agent-browser to close its Chrome fleet immediately instead of
+// leaving it for agent-browser's own multi-minute idle timer. The unit tests around
+// teardownSessionResources and teardownDaemonSessionForShutdown mock the agent-browser CLI call
+// and prove only that it gets dispatched with the right arguments; this live lane is the one
+// place that proves the whole chain — a real managed browser, a real daemon process, a real
+// SIGTERM — actually ends with zero owned Chrome processes, not just an issued close command.
+test(
+  SHUTDOWN_TEST_NAME,
+  {
+    skip: WEB_E2E_ENABLED
+      ? false
+      : 'Set AGENT_DEVICE_WEB_E2E=1 to run the managed web backend smoke.',
+  },
+  async () => {
+    await runWebShutdownSmoke(await createWebSmokeContext());
+  },
+);
+
+async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
+  try {
+    await runStep(context, 'set up managed web backend', ['web', 'setup', '--json']);
+    await runStep(context, 'open local fixture', ['open', context.url, ...context.common]);
+
+    const stateDir = context.env.AGENT_DEVICE_STATE_DIR;
+    assert.ok(stateDir, 'expected the smoke context to configure a state dir');
+    const status = getManagedAgentBrowserStatus({ stateDir });
+
+    const before = await inspectManagedAgentBrowserProcesses(status);
+    assert.ok(
+      before.count > 0,
+      `expected the managed browser fleet to be running after open, found none: ${formatProcessSummary(before)}`,
+    );
+
+    const daemonPid = readDaemonPid(stateDir);
+    assert.equal(isProcessAlive(daemonPid), true, 'expected a live daemon before SIGTERM');
+
+    // The scenario #1868 is about: SIGTERM the daemon directly, the way an operator or an
+    // orchestrator shutting the container down would, rather than going through `close`.
+    process.kill(daemonPid, 'SIGTERM');
+
+    const after = await settleManagedBrowserProcesses(status);
+    assert.equal(
+      after.count,
+      0,
+      `expected zero owned Chrome processes after daemon shutdown, found: ${formatProcessSummary(after)}`,
+    );
+    assert.equal(
+      isProcessAlive(daemonPid),
+      false,
+      'expected the daemon process itself to have exited after SIGTERM',
+    );
+
+    // #1781 B1: the daemon leak oracle this fix unblocks wiring to a web lane — no stray
+    // state-dir residue either, on top of the process-level proof above.
+    await assertNoDaemonLeaks({ stateDir, daemonPids: [daemonPid], phase: 'after-shutdown' });
+  } finally {
+    await closeServer(context.server);
+  }
+}
+
+function readDaemonPid(stateDir: string): number {
+  const info = JSON.parse(readFileSync(path.join(stateDir, 'daemon.json'), 'utf8')) as {
+    pid?: number;
+  };
+  assert.equal(typeof info.pid, 'number', `daemon.json has no pid: ${JSON.stringify(info)}`);
+  return info.pid as number;
+}
+
+async function settleManagedBrowserProcesses(
+  status: Parameters<typeof inspectManagedAgentBrowserProcesses>[0],
+): Promise<AgentBrowserProcessSummary> {
+  const deadline = Date.now() + WEB_SHUTDOWN_SETTLE_TIMEOUT_MS;
+  let summary = await inspectManagedAgentBrowserProcesses(status);
+  while (summary.count > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, WEB_SHUTDOWN_SETTLE_POLL_MS));
+    summary = await inspectManagedAgentBrowserProcesses(status);
+  }
+  return summary;
+}
+
+function formatProcessSummary(summary: AgentBrowserProcessSummary): string {
+  return JSON.stringify({
+    count: summary.count,
+    pids: summary.pids,
+    reasons: summary.processes.map((match) => match.reason),
+  });
+}
 
 async function runWebSmoke(context: WebSmokeContext): Promise<void> {
   let opened = false;

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -8,22 +8,30 @@ import { assertPngDimensions, assertPngFile } from './provider-scenarios/asserti
 import { runCleanupWithCoverageReport } from './web-e2e/coverage-report.ts';
 import { assertNoDaemonLeaks } from './support/daemon-leak-oracle.ts';
 import {
+  cleanupManagedAgentBrowserOrphans,
   inspectManagedAgentBrowserProcesses,
   type AgentBrowserProcessSummary,
 } from '../../src/platforms/web/agent-browser-lifecycle.ts';
-import { getManagedAgentBrowserStatus } from '../../src/platforms/web/agent-browser-tool.ts';
+import {
+  getManagedAgentBrowserStatus,
+  type AgentBrowserToolStatus,
+} from '../../src/platforms/web/agent-browser-tool.ts';
+import { stopProcessForTakeover } from '../../src/daemon/daemon-process.ts';
 import { isProcessAlive } from '../../src/utils/host-process.ts';
 
 const TEST_NAME = 'live web platform e2e smoke';
 const SHUTDOWN_TEST_NAME = 'live web platform e2e daemon-shutdown browser cleanup';
 const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
 // #1868: SIGTERM must close the managed Chrome fleet well before agent-browser's own idle timer
-// (DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS, 5 minutes) would have. Left at its production default
-// here (unlike the functional smoke test's shortened override below) so a pass can only mean the
-// daemon's shutdown teardown actively closed the browser, not that the idle timer coincidentally
-// beat this test's own poll deadline.
+// would have. This lane's context omits the AGENT_BROWSER_IDLE_TIMEOUT_MS override the functional
+// smoke test above uses, so the idle timer that could otherwise reap the fleet on its own stays at
+// its production default — DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS, 5 minutes, pinned by
+// `resolveAgentBrowserIdleTimeoutMs({})` in agent-browser-lifecycle.test.ts — comfortably past this
+// poll deadline. A pass can then only mean the daemon's shutdown teardown actively closed the
+// browser, not that the idle timer coincidentally beat this test's own wait.
 const WEB_SHUTDOWN_SETTLE_TIMEOUT_MS = 45_000;
 const WEB_SHUTDOWN_SETTLE_POLL_MS = 500;
+const WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS = 5_000;
 
 type StepRecord = {
   step: string;
@@ -53,7 +61,9 @@ test(
       : 'Set AGENT_DEVICE_WEB_E2E=1 to run the managed web backend smoke.',
   },
   async () => {
-    await runWebSmoke(await createWebSmokeContext());
+    // Shortens agent-browser's own idle-reap window so a leaked fleet from this test doesn't
+    // linger on the runner; the shutdown lane below deliberately omits this override instead.
+    await runWebSmoke(await createWebSmokeContext({ agentBrowserIdleTimeoutMs: '30000' }));
   },
 );
 
@@ -77,13 +87,18 @@ test(
 );
 
 async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
+  // Cleanup authority lives entirely in `finally`, driven by these two, so a failed assertion
+  // above (including the very failure this test exists to catch: processes still alive when the
+  // fix regresses) can never leave a daemon or a Chrome fleet running on the host afterward.
+  let daemonPid: number | undefined;
+  let status: AgentBrowserToolStatus | undefined;
   try {
     await runStep(context, 'set up managed web backend', ['web', 'setup', '--json']);
     await runStep(context, 'open local fixture', ['open', context.url, ...context.common]);
 
     const stateDir = context.env.AGENT_DEVICE_STATE_DIR;
     assert.ok(stateDir, 'expected the smoke context to configure a state dir');
-    const status = getManagedAgentBrowserStatus({ stateDir });
+    status = getManagedAgentBrowserStatus({ stateDir });
 
     const before = await inspectManagedAgentBrowserProcesses(status);
     assert.ok(
@@ -91,7 +106,7 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
       `expected the managed browser fleet to be running after open, found none: ${formatProcessSummary(before)}`,
     );
 
-    const daemonPid = readDaemonPid(stateDir);
+    daemonPid = readDaemonPid(stateDir);
     assert.equal(isProcessAlive(daemonPid), true, 'expected a live daemon before SIGTERM');
 
     // The scenario #1868 is about: SIGTERM the daemon directly, the way an operator or an
@@ -114,8 +129,45 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
     // state-dir residue either, on top of the process-level proof above.
     await assertNoDaemonLeaks({ stateDir, daemonPids: [daemonPid], phase: 'after-shutdown' });
   } finally {
-    await closeServer(context.server);
+    await cleanupWebShutdownSmoke(context, daemonPid, status);
   }
+}
+
+// Best-effort and independent of how far the `try` block got: a daemon that survived SIGTERM
+// (stopProcessForTakeover escalates to SIGKILL) and a Chrome fleet that outlived it (the same
+// orphan sweep daemon startup runs) are reaped here regardless of which assertion above failed,
+// or whether none did. Mirrors cleanupWebSmoke's AggregateError shape so a cleanup failure never
+// silently swallows the original assertion failure it ran alongside.
+async function cleanupWebShutdownSmoke(
+  context: WebSmokeContext,
+  daemonPid: number | undefined,
+  status: AgentBrowserToolStatus | undefined,
+): Promise<void> {
+  const errors: unknown[] = [];
+  if (daemonPid !== undefined) {
+    try {
+      await stopProcessForTakeover(daemonPid, {
+        termTimeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS,
+        killTimeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS,
+      });
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (status) {
+    try {
+      await cleanupManagedAgentBrowserOrphans(status, 'daemon-startup', {});
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  try {
+    await closeServer(context.server);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, 'web shutdown smoke cleanup failed');
 }
 
 function readDaemonPid(stateDir: string): number {
@@ -127,7 +179,7 @@ function readDaemonPid(stateDir: string): number {
 }
 
 async function settleManagedBrowserProcesses(
-  status: Parameters<typeof inspectManagedAgentBrowserProcesses>[0],
+  status: AgentBrowserToolStatus,
 ): Promise<AgentBrowserProcessSummary> {
   const deadline = Date.now() + WEB_SHUTDOWN_SETTLE_TIMEOUT_MS;
   let summary = await inspectManagedAgentBrowserProcesses(status);
@@ -174,7 +226,9 @@ async function assertWebViewport(context: WebSmokeContext): Promise<void> {
   });
 }
 
-async function createWebSmokeContext(): Promise<WebSmokeContext> {
+async function createWebSmokeContext(
+  options: { agentBrowserIdleTimeoutMs?: string } = {},
+): Promise<WebSmokeContext> {
   const artifactDir = createArtifactDir();
   const stateDir = path.join(artifactDir, 'agent-device-state');
   const agentBrowserConfigPath = path.join(artifactDir, 'agent-browser.json');
@@ -185,7 +239,9 @@ async function createWebSmokeContext(): Promise<WebSmokeContext> {
     AGENT_DEVICE_STATE_DIR: stateDir,
     AGENT_BROWSER_CONFIG: agentBrowserConfigPath,
     AGENT_BROWSER_HEADED: 'false',
-    AGENT_BROWSER_IDLE_TIMEOUT_MS: '30000',
+    ...(options.agentBrowserIdleTimeoutMs === undefined
+      ? {}
+      : { AGENT_BROWSER_IDLE_TIMEOUT_MS: options.agentBrowserIdleTimeoutMs }),
   };
 
   mkdirSync(stateDir, { recursive: true });

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -8,8 +8,8 @@ import { assertPngDimensions, assertPngFile } from './provider-scenarios/asserti
 import { runCleanupWithCoverageReport } from './web-e2e/coverage-report.ts';
 import { assertNoDaemonLeaks } from './support/daemon-leak-oracle.ts';
 import {
-  cleanupManagedAgentBrowserOrphans,
   inspectManagedAgentBrowserProcesses,
+  summarizeAgentBrowserProcesses,
   type AgentBrowserProcessSummary,
 } from '../../src/platforms/web/agent-browser-lifecycle.ts';
 import {
@@ -17,21 +17,26 @@ import {
   type AgentBrowserToolStatus,
 } from '../../src/platforms/web/agent-browser-tool.ts';
 import { stopProcessForTakeover } from '../../src/daemon/daemon-process.ts';
-import { isProcessAlive } from '../../src/utils/host-process.ts';
+import {
+  expandProcessTree,
+  isProcessAlive,
+  listHostProcesses,
+  stopPidsWithEscalation,
+} from '../../src/utils/host-process.ts';
 
 const TEST_NAME = 'live web platform e2e smoke';
 const SHUTDOWN_TEST_NAME = 'live web platform e2e daemon-shutdown browser cleanup';
 const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
-// #1868: SIGTERM must close the managed Chrome fleet well before agent-browser's own idle timer
-// would have. This lane's context omits the AGENT_BROWSER_IDLE_TIMEOUT_MS override the functional
-// smoke test above uses, so the idle timer that could otherwise reap the fleet on its own stays at
-// its production default — DEFAULT_AGENT_BROWSER_IDLE_TIMEOUT_MS, 5 minutes, pinned by
-// `resolveAgentBrowserIdleTimeoutMs({})` in agent-browser-lifecycle.test.ts — comfortably past this
-// poll deadline. A pass can then only mean the daemon's shutdown teardown actively closed the
-// browser, not that the idle timer coincidentally beat this test's own wait.
 const WEB_SHUTDOWN_SETTLE_TIMEOUT_MS = 45_000;
 const WEB_SHUTDOWN_SETTLE_POLL_MS = 500;
 const WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS = 5_000;
+// #1868: SIGTERM must close the managed Chrome fleet well before agent-browser's own idle timer
+// would have. The shutdown lane owns this value directly, at a fixed offset above its own poll
+// deadline, rather than the functional smoke test's shortened override or an omitted-env-var
+// assumption about agent-browser's default — so a future change to either stays unable to make
+// this pass for the wrong reason. A pass can then only mean the daemon's shutdown teardown
+// actively closed the browser, not that agent-browser's own idle timer beat this test's own wait.
+const WEB_SHUTDOWN_IDLE_TIMEOUT_MS = WEB_SHUTDOWN_SETTLE_TIMEOUT_MS + 60_000;
 
 type StepRecord = {
   step: string;
@@ -82,7 +87,11 @@ test(
       : 'Set AGENT_DEVICE_WEB_E2E=1 to run the managed web backend smoke.',
   },
   async () => {
-    await runWebShutdownSmoke(await createWebSmokeContext());
+    await runWebShutdownSmoke(
+      await createWebSmokeContext({
+        agentBrowserIdleTimeoutMs: String(WEB_SHUTDOWN_IDLE_TIMEOUT_MS),
+      }),
+    );
   },
 );
 
@@ -134,10 +143,11 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
 }
 
 // Best-effort and independent of how far the `try` block got: a daemon that survived SIGTERM
-// (stopProcessForTakeover escalates to SIGKILL) and a Chrome fleet that outlived it (the same
-// orphan sweep daemon startup runs) are reaped here regardless of which assertion above failed,
-// or whether none did. Mirrors cleanupWebSmoke's AggregateError shape so a cleanup failure never
-// silently swallows the original assertion failure it ran alongside.
+// (stopProcessForTakeover escalates to SIGKILL) and a Chrome fleet that outlived it (a forceful
+// reap, not cleanupManagedAgentBrowserOrphans — see forceKillManagedBrowserProcesses) are reaped
+// here regardless of which assertion above failed, or whether none did. Mirrors cleanupWebSmoke's
+// AggregateError shape so a cleanup failure never silently swallows the assertion failure it ran
+// alongside.
 async function cleanupWebShutdownSmoke(
   context: WebSmokeContext,
   daemonPid: number | undefined,
@@ -156,7 +166,7 @@ async function cleanupWebShutdownSmoke(
   }
   if (status) {
     try {
-      await cleanupManagedAgentBrowserOrphans(status, 'daemon-startup', {});
+      await forceKillManagedBrowserProcesses(status);
     } catch (error) {
       errors.push(error);
     }
@@ -168,6 +178,27 @@ async function cleanupWebShutdownSmoke(
   }
   if (errors.length === 1) throw errors[0];
   if (errors.length > 1) throw new AggregateError(errors, 'web shutdown smoke cleanup failed');
+}
+
+// Deliberately NOT cleanupManagedAgentBrowserOrphans: that function exists to leave an actively
+// used fleet alone, and skips killing anything once it sees activity inside the (here, minutes-
+// long) idle window — precisely the state this test's own fleet is always in. A forced safety-net
+// cleanup needs the opposite property: reap whatever this test's own fleet still owns, regardless
+// of how recently it was used, so a planted regression (no active close on shutdown) cannot leave
+// Chrome processes running on the host just because cleanup honored the same idle guard the
+// regression exploits.
+async function forceKillManagedBrowserProcesses(status: AgentBrowserToolStatus): Promise<void> {
+  const processes = await listHostProcesses({ timeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS });
+  const summary = summarizeAgentBrowserProcesses(processes, status);
+  if (summary.count === 0) return;
+  const signalPids = expandProcessTree(summary.pids, processes).map(
+    (processInfo) => processInfo.pid,
+  );
+  await stopPidsWithEscalation({
+    pids: signalPids,
+    termTimeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS,
+    killTimeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS,
+  });
 }
 
 function readDaemonPid(stateDir: string): number {


### PR DESCRIPTION
## Summary

- `teardownSessionResources` finalized recording, app-log, audio, and perf captures on daemon shutdown, but had no step for an open web session — unlike an ordinary `session close`, which dispatches a platform close for web. A SIGTERM on a daemon holding an open web session left the full agent-browser Chrome fleet (~15 processes) alive until agent-browser's own 5-minute idle timer fired, and a fresh daemon on the same state dir wouldn't reap it either (startup orphan cleanup skips fleets with recent activity).
- Add a best-effort `web_browser` step to `teardownSessionResources` that tells agent-browser to close its session-scoped fleet, mirroring the recording step added in #1325. It runs after the other best-effort resource steps (recording, app-log, audio, perf), matching the ordering an ordinary `session close` already uses between resource cleanup and platform close. Since `teardownSessionResources` is shared by both the daemon-shutdown path and the expired-session reap path, both now close the browser immediately instead of leaving it to agent-browser's own idle timer.
- Extend the per-session daemon-shutdown teardown budget for a web session the same way it already is for an active recording, sized to (and tested against) agent-browser's own per-call CLI timeout, so the shutdown race doesn't give up on a slow close before agent-browser could have finished it.
- Extract `isWebSession()` as the single source of truth for "is this a web session", now shared by the new teardown step, the existing ordinary-close gate (`session-close.ts`), and the web-provider request-routing gate (`request-router.ts`), so the three can't silently drift apart.

Fixes #1868.

## Review

Ran two rounds of adversarial code review against the diff:
- Round 1 found the new step had no extended shutdown budget (a slow close could be abandoned by the daemon's 5s race before agent-browser finished) and that the "is this web" check was about to be duplicated a third time. Both fixed.
- Round 2 found a third pre-existing `platform === 'web'` check in `request-router.ts` that the new shared helper had missed. Fixed.
- Round 3 raised no further actionable findings.

## Test plan

- [x] `pnpm lint` (oxlint, repo-wide)
- [x] `pnpm format:check` (oxfmt, repo-wide)
- [x] `pnpm typecheck` (full monorepo)
- [x] `pnpm check:layering`
- [x] `pnpm check:production-exports` (unchanged pre-existing 29 issues, none from this diff)
- [x] New/updated unit tests: `session-teardown.ts`'s web-close step (happy path, failure isolation, non-web gating), the shutdown-budget extension and its pinned relationship to `AGENT_BROWSER_TIMEOUT_MS`, and a slow-close-inside-budget regression, all exercised through the real `teardownDaemonSessionForShutdown` entry point (mirroring `daemon-runtime-recording-teardown.test.ts`'s coverage of the #1325 recording step)
- [x] Full `src/daemon` unit suite and the web `provider-scenarios` integration tests (326/328 files, 2308/2310 tests pass — the 2 failures are pre-existing/unrelated flakes, confirmed identical on a clean `main` checkout)


---
_Generated by [Claude Code](https://claude.ai/code/session_011ot5wg8YUEyWRrphs8bMSJ)_