### PR TITLE
feat: session-scoped echo protection for parameterized recorded inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Parameterized `fill --record-as` protection is now recording-session-scoped instead of
+  fill-step-scoped (ADR 0017 amendment): a later, unrelated recorded action (`wait`, `is`, `get`) can no
+  longer re-serialize an app-rendered echo of an already-parameterized value into its own result or
+  `target-v1` identity evidence. An echoing `wait` landmark no longer qualifies as an ADR 0016
+  destination guard, so `session save-script` refuses it and directs the author to a stable landmark
+  instead of silently publishing the secret. The protection uses one small, explicit, ephemeral,
+  never-serialized per-session map populated only from values the author already opted to parameterize;
+  ordinary non-parameterized recordings are unaffected (#1398).
 - Android covered-state publication now has one owner: same-window surfaces remain visible for
   diagnosis, while the daemon marks exactly ordered covered controls non-actionable with
   `interactionBlocked: "covered"`. Helper-only `drawing-order` stays private rather than entering

--- a/docs/adr/0012-interactive-replay.md
+++ b/docs/adr/0012-interactive-replay.md
@@ -188,6 +188,13 @@ in force, a parent-only payload fits arithmetically, so the downgrade branch is 
 not an expected path. The record-time self-check (step 5 below) runs against the reduced tuple, so a
 `verified` claim is always honest for exactly what was written.
 
+> **Amendment (#1398, ADR 0017):** action-mode evidence gains a second, independent cause for this same
+> `"unverifiable"` downgrade — a matched node whose label carries an app-rendered echo of a literal the
+> recording session already parameterized. Unlike the size-overflow case, the label is also redacted to
+> its placeholder before the downgrade, so the literal itself never reaches the payload either. Landmark
+> mode (`wait`) does not use this downgrade; it drops the annotation entirely (see the #1349 amendment
+> above). See ADR 0017's session-scoped echo protection amendment for the full mechanism.
+
 **Local identity.** Two nodes share local identity when both carry `id` and the normalized ids are equal;
 or, when the recording carries no `id`, when their normalized roles are equal and their normalized labels
 are equal (label absent on both sides counts as equal; label present on exactly one side is a mismatch).
@@ -266,6 +273,11 @@ A recorded `id` never matches a node without that id.
 >   identity is near-vacuous, and an unannotated wait keeps its existing selector-existence semantics
 >   instead of failing closed on evidence that never discriminated anything. ADR 0016's destination
 >   guard consumes exactly this: a qualifying guard is a selector wait with a `verified` annotation.
+>   **Amendment (#1398, ADR 0017):** the same no-annotation outcome now also fires when the matched
+>   node's identity carries an app-rendered echo of a literal the recording session already
+>   parameterized via `fill --record-as` — a placeholder written into a recorded label could never
+>   verify against the live tree's real value at replay time, so the evidence is dropped rather than
+>   published unverified. See ADR 0017's session-scoped echo protection amendment for the mechanism.
 > - **`get` — unchanged**; already covered by the pre-dispatch path and the post-resolution guard.
 > - **`is` (all predicates except `exists`) — covered, `pre-dispatch`, the `get` pattern end-to-end.**
 >   `is` resolves a unique node immediately, so pre-action verification is semantically valid; the

--- a/docs/adr/0016-active-session-script-publication.md
+++ b/docs/adr/0016-active-session-script-publication.md
@@ -26,7 +26,9 @@ Normative summary; the binding contracts and refusal cases are in [Decision](#de
   what lets a one-shot client keep the daemon alive on a close-less handoff.
 - Sensitive `fill` inputs must be recorded as placeholders via `fill --record-as <VAR>`
   (ADR 0017, shipped for #1348); unparameterized `fill`/`type` values persist literally into the
-  artifact, so a secret entered without `--record-as` is published.
+  artifact, so a secret entered without `--record-as` is published. The protection is
+  recording-session-scoped (ADR 0017's #1398 amendment): a later action's own recorded evidence can
+  never re-serialize an app-rendered echo of an already-parameterized value either.
 
 ## Context
 
@@ -186,6 +188,13 @@ record one. V1 does not infer a screen identity from a snapshot or synthesize an
 > `identity-mismatch` `REPLAY_DIVERGENCE` before the wait reports success. The reshuffled-screen
 > false-pass below is covered by a provider-scenario regression (record → publish → replay against a
 > reshuffled tree whose same-label node sits under a different id/ancestry).
+>
+> **Amendment (#1398, ADR 0017).** An identity-empty landmark is not the only case that fails to
+> qualify: a selector wait whose only identity is an app-rendered echo of a literal the recording
+> session already parameterized via `fill --record-as` also records no annotation (ADR 0017's
+> session-scoped echo protection), so it does not qualify as a destination guard either. Publication
+> refuses it with the same recovery hint, directing the author to a stable, non-value-bearing landmark
+> — an enforced version of exactly the fix issue #1398's motivating scenario applied by hand.
 
 The original selector-level caveat, retained as context: the guard proved that an element matching its
 selector exists, not that it is the same landmark element observed while authoring, so a reshuffled
@@ -228,6 +237,11 @@ sensitive fills: `fill ... --record-as PASSWORD` sends the live text to the app 
 This is opt-in and fill-only. Unparameterized fill/type inputs remain literal artifact content, so
 authors must use ADR 0017 for each sensitive fill and avoid secret-bearing `type` steps. CLI help states
 both the safe workflow and the remaining literal-input warning next to publication guidance.
+
+ADR 0017's #1398 amendment extends this protection to the whole recording session: a later, unrelated
+recorded action can no longer re-serialize an app-rendered echo of an already-parameterized literal into
+its own result or `target-v1` evidence, so a value protected once by `--record-as` stays protected for
+every action recorded after it in the same session, not only its own originating fill.
 
 ### Artifact contract
 

--- a/docs/adr/0017-parameterized-recorded-inputs.md
+++ b/docs/adr/0017-parameterized-recorded-inputs.md
@@ -86,6 +86,86 @@ or whitespace. If the replay is itself being recorded or repaired, the recorder 
 original placeholder rather than serializing the expanded value. Embedded interpolation remains
 ordinary script input; safe authoring emits one complete placeholder token.
 
+### Session-scoped echo protection (amendment, #1398)
+
+> **Status: accepted.** Amends the data-flow boundary above from fill-step-scoped to
+> recording-session-scoped, per issue [#1398](https://github.com/callstack/agent-device/issues/1398).
+
+The boundary above protects only the originating fill's own request/recording path. After
+[#1349](https://github.com/callstack/agent-device/issues/1349), a later read-only action —
+`wait`'s landmark-mode evidence, `is`, `get` — records `target-v1` identity evidence and a result
+payload independently, computed from whatever the app renders at that later step. That capture has no
+memory of an earlier fill's literal, so an app-rendered echo of it (the filled field's own displayed
+value; a search result, validation message, or confirmation label containing it; a destination landmark
+whose accessible label includes it) can re-enter session state and publication through a completely
+different, unparameterized action — even though the originating fill was parameterized.
+
+**The guarantee is now recording-session-scoped, not fill-step-scoped.** For the lifetime of one
+recording session, no later recorded action's own result payload or `target-v1`/`targets-v1` identity
+evidence may re-serialize an app-rendered echo of a literal the session already parameterized.
+
+The mechanism is the smallest explicit, ephemeral state that can recognize a later echo:
+`SessionState.recordedFillLiterals`, an in-memory `Map<literal, placeholder>` populated only by the SAME
+(literal, placeholder) pair a `fill --record-as` entry already computes for its own boundary above — one
+entry per parameterized fill, added only after that fill's own entry has been recorded. It is never
+serialized (not to the script, the session event log, or diagnostics), has no read API beyond the
+recorder that owns it, and disappears with the session.
+
+This is not a reversal of the "no secret-to-name table" rule in the Mapping contract above. That rule
+rejects retaining state to influence a *naming* decision — comparing a new `--record-as` value against
+prior ones to infer or deduplicate a variable name. `recordedFillLiterals` never informs a naming
+decision: every entry's placeholder is exactly the name the author already chose, and the map is
+consulted only to recognize that same, already-named value reappearing in unrelated later evidence — a
+redaction lookup, not a secret registry with a naming or comparison API.
+
+**Two treatments, by data class:**
+
+- **Result/event/backend-output fields** (display data, never compared at replay): content-aware
+  substring redaction, reusing the same recursive backend-output scrub the fill boundary already applies
+  to its own entry, generalized over every literal registered so far in the session. Pairs are applied
+  longest-literal-first so one registered value that is a substring of another (e.g. a username that is a
+  prefix of a password) is never partially consumed by the shorter pair first.
+- **`target-v1`/`targets-v1` identity evidence** (`label`, `ancestry[].label`, `scrollRegion.label` — the
+  fields replay's own classification compares): never silently text-substituted while still claiming a
+  trustworthy identity. Replay compares recorded identity against the *live* tree, which legitimately
+  re-renders the real value again at replay time; a placeholder written into a recorded identity field
+  could therefore never verify correctly. Instead:
+  - **Landmark mode (`wait`).** An echo is treated exactly like #1349's existing identity-empty case: no
+    annotation is recorded, and the wait keeps its selector-existence semantics. Because ADR 0016's
+    destination guard requires `verification: "verified"`, a landmark whose only identity is a
+    parameterized-value echo simply stops qualifying as a guard — `session save-script` refuses it with
+    the existing "record a selector-targeted wait on a labeled or id-bearing landmark" recovery,
+    reproducing the motivating scenario's real resolution (switching the guard to the stable `Apps`
+    landmark) as an enforced outcome rather than an authoring convention.
+  - **Action mode (`get`, `is`, mutating element-targeting actions).** ADR 0012/0016 require identity
+    evidence for every element-targeting recorded action and forbid silently dropping it, so an echo here
+    is never dropped. The literal-bearing label(s) are redacted to the placeholder (content-aware,
+    substring-based — unlike the exact-match fill-boundary redaction, because a cross-step echo is
+    typically surrounded by app-authored text such as "Welcome, `<value>`") and `verification` is
+    downgraded to `"unverifiable"` — the same fail-closed downgrade decision 3's writer-parser invariant
+    already uses for an oversized payload. That fails the action's replay loudly
+    (`identity-unverifiable`) rather than silently weakening it to selector-only matching or publishing a
+    label that could never match again.
+
+**Explicit scope limits:**
+
+- A whitespace-only or empty resolved fill value is excluded from the session-wide registry; it keeps
+  only the existing fill-step-scoped protection above. Collapsing arbitrary later strings on a value with
+  no discriminating content is a disproportionate readability cost for a value that reveals nothing
+  distinctive if echoed, and would corrupt unrelated short incidental substrings throughout the rest of
+  the recording.
+- The originating fill's own recorded entry is protected only by the existing exact-match fill-boundary
+  pass; it is never passed through the coarser, substring-based session-wide pass using the pair it just
+  contributed. The session-wide guarantee is for later, distinct actions, exactly as #1398 frames it.
+- An author's own explicitly typed selector or positional text is not scanned — only derived, resolved
+  evidence and result payloads are. An author who types the secret directly into a new selector is making
+  the same choice as an unparameterized fill/type value; that remains literal script content.
+- The registry is keyed by literal, so two distinct `--record-as` names that happen to share the same
+  typed value (a password/confirm-password pair, say) are genuinely indistinguishable from a later
+  echo's perspective — the literal alone cannot say which fill produced it. The first-registered name
+  wins deterministically; the literal is redacted either way, so this only affects which placeholder
+  name a later echo is attributed to, never whether the value is protected.
+
 ## Consequences
 
 - Secret-bearing login/bootstrap scripts can use ADR 0016 active publication safely.
@@ -93,4 +173,6 @@ ordinary script input; safe authoring emits one complete placeholder token.
   script content and help warns accordingly.
 - `type` and mutating `find ... fill|type` parameterization are not added by this decision. They require
   their own surface and provenance design if needed.
-- No new publication format, variable store, secret registry, or sensitivity heuristic is introduced.
+- No new publication format, variable store, or sensitivity heuristic is introduced. The #1398 amendment
+  adds one ephemeral, non-serialized, per-session redaction map with no naming or lookup-by-name API —
+  never a persistent secret registry.

--- a/docs/adr/0017-parameterized-recorded-inputs.md
+++ b/docs/adr/0017-parameterized-recorded-inputs.md
@@ -122,9 +122,15 @@ redaction lookup, not a secret registry with a naming or comparison API.
 
 - **Result/event/backend-output fields** (display data, never compared at replay): content-aware
   substring redaction, reusing the same recursive backend-output scrub the fill boundary already applies
-  to its own entry, generalized over every literal registered so far in the session. Pairs are applied
-  longest-literal-first so one registered value that is a substring of another (e.g. a username that is a
-  prefix of a password) is never partially consumed by the shorter pair first.
+  to its own entry, generalized over every literal registered so far in the session. The substitution
+  itself is one placeholder-safe left-to-right pass over each string, not N sequential full-string passes
+  — a naive sequential pass over the same value can corrupt an EARLIER pair's just-inserted placeholder
+  when a LATER pair's literal happens to be a substring of it (register `somethinglong -> ${ABC}`, then
+  `ABC -> ${OTHER}`, and a second pass over a value already rewritten to `${ABC}` matches "ABC" *inside*
+  that token, producing `${${OTHER}}`). The single pass tries every registered literal longest-first at
+  each position — so one registered value that is a substring of another (a username that is a prefix of
+  a password) is never partially consumed by the shorter pair — and never re-scans text it has already
+  emitted, so no literal can ever be matched inside another pair's placeholder token in either direction.
 - **`target-v1`/`targets-v1` identity evidence** (`label`, `ancestry[].label`, `scrollRegion.label` — the
   fields replay's own classification compares): never silently text-substituted while still claiming a
   trustworthy identity. Replay compares recorded identity against the *live* tree, which legitimately

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -14,8 +14,10 @@ const LARGEST_TYPE_CYCLE_ZONE_CEILINGS: Readonly<Record<string, number>> = {
 
 export const DAEMON_MODULARITY_BASELINE = {
   sessionState: {
-    writerOwnedFields: 21,
-    ownerFileClaims: 25,
+    // #1398: +1 field (`recordedFillLiterals`), +1 owner claim (its single owner,
+    // src/daemon/session-action-recorder.ts).
+    writerOwnedFields: 22,
+    ownerFileClaims: 26,
   },
   largestTypeCycle: {
     zoneMembers: LARGEST_TYPE_CYCLE_ZONE_CEILINGS,

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -85,6 +85,11 @@ export const SESSION_STATE_FIELD_OWNERS: Readonly<Record<string, readonly string
   // a second durable owner as the execution seam stays package-bound.
   lease: ['src/daemon/handlers/session-open-execution.ts'],
   deviceClaim: ['src/daemon/handlers/session-open-execution.ts'],
+
+  // #1398 (ADR 0017 session-scoped echo protection amendment): the ephemeral
+  // literal->placeholder registry is populated and consulted only at the
+  // recorder's single choke point.
+  recordedFillLiterals: ['src/daemon/session-action-recorder.ts'],
 };
 
 /**

--- a/src/daemon/__tests__/session-action-recorder.test.ts
+++ b/src/daemon/__tests__/session-action-recorder.test.ts
@@ -500,6 +500,109 @@ test('#1398: two distinct --record-as names sharing the same literal value deter
   expect(JSON.stringify(session.actions)).not.toContain('hunter2');
 });
 
+// #1398 review fix: a naive sequential per-pair pass can corrupt an EARLIER
+// pair's just-inserted placeholder when a LATER pair's literal happens to be
+// a substring of it. Register `somethinglong -> ${ABC}` then `ABC ->
+// ${OTHER}` (a --record-as name that collides with an unrelated variable's
+// own literal value): a later echo of "somethinglong" must become exactly
+// `${ABC}`, never the corrupted `${${OTHER}}` a naive second full-string pass
+// over the already-rewritten text would produce.
+test('#1398: redacting one literal never corrupts a placeholder another literal already produced (result payload)', () => {
+  const session = makeIosSession('default');
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="field-one"', 'somethinglong'],
+    flags: { recordAs: 'ABC' },
+    result: { text: 'somethinglong' },
+  });
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="field-two"', 'ABC'],
+    flags: { recordAs: 'OTHER' },
+    result: { text: 'ABC' },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['id="confirmation-banner"'],
+    flags: {},
+    result: { waitedMs: 1, text: 'Echo: somethinglong' },
+  });
+
+  expect(session.actions[2]?.result).toEqual({ waitedMs: 1, text: 'Echo: ${ABC}' });
+  const serialized = JSON.stringify(session.actions);
+  expect(serialized).not.toContain('somethinglong');
+  expect(serialized).not.toContain('${${OTHER}}');
+});
+
+test('#1398: redacting one literal never corrupts a placeholder another literal already produced (action-mode target evidence)', () => {
+  const session = makeIosSession('default');
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="field-one"', 'somethinglong'],
+    flags: { recordAs: 'ABC' },
+    result: { text: 'somethinglong' },
+  });
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="field-two"', 'ABC'],
+    flags: { recordAs: 'OTHER' },
+    result: { text: 'ABC' },
+  });
+  recordActionEntry(session, {
+    command: 'is',
+    positionals: ['visible', 'id="confirmation-banner"'],
+    flags: {},
+    result: {},
+    targetEvidence: {
+      role: 'text',
+      label: 'Echo: somethinglong',
+      ancestry: [],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+  });
+
+  expect(session.actions[2]?.targetEvidence).toEqual({
+    role: 'text',
+    label: 'Echo: ${ABC}',
+    ancestry: [],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'unverifiable',
+  });
+  const serialized = JSON.stringify(session.actions);
+  expect(serialized).not.toContain('somethinglong');
+  expect(serialized).not.toContain('${${OTHER}}');
+});
+
+// #1398 review fix: a registered literal is matched BEFORE checking whether
+// an existing placeholder token starts at the current position, so a typed
+// value that itself happens to look like `${SOMETHING}` is still redacted
+// rather than being skipped as if it were already-parameterized text.
+test('#1398: a literal whose own text is shaped like an existing placeholder is still redacted', () => {
+  const session = makeIosSession('default');
+  const literal = '${OTHERVAR}';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="field"', literal],
+    flags: { recordAs: 'TOKEN' },
+    result: { text: literal },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['id="confirmation-banner"'],
+    flags: {},
+    result: { waitedMs: 1, text: `Echo: ${literal}` },
+  });
+
+  expect(session.actions[1]?.result).toEqual({ waitedMs: 1, text: 'Echo: ${TOKEN}' });
+  expect(JSON.stringify(session.actions)).not.toContain('OTHERVAR');
+});
+
 test('#1398: dual-endpoint (targetEvidences) evidence is protected independently per endpoint', () => {
   const session = makeIosSession('default');
   const literal = 'hunter2-secret';

--- a/src/daemon/__tests__/session-action-recorder.test.ts
+++ b/src/daemon/__tests__/session-action-recorder.test.ts
@@ -318,3 +318,314 @@ test('#1533: an ARMED authoring lifecycle still takes the ingress (retarget + fo
     authoringPublication('armed', { path: '/tmp/out.ad', force: true }),
   );
 });
+
+// #1398: session-scoped echo protection. A LATER, unrelated action can
+// independently observe an app-rendered echo of an earlier parameterized
+// fill's literal (its own displayed value, a search result, a confirmation
+// label, a caller-authored destination landmark). These tests prove the
+// echo never reaches `session.actions` regardless of which later command
+// records it, while never falsely claiming replay-verified identity.
+
+test('#1398: a landmark-mode wait recorded after a parameterized fill drops identity evidence that echoes the literal', () => {
+  const session = makeIosSession('default');
+  const literal = 'hunter2-secret';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', literal],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: literal },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['role="heading"'],
+    flags: {},
+    result: { waitedMs: 12, text: `Welcome, ${literal}`, hint: `matched Welcome, ${literal}` },
+    targetEvidence: {
+      role: 'heading',
+      label: `Welcome, ${literal}`,
+      ancestry: [{ role: 'window' }],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+    targetEvidenceMode: 'landmark',
+  });
+
+  const wait = session.actions[1];
+  expect(wait?.command).toBe('wait');
+  expect(wait?.targetEvidence).toBeUndefined();
+  expect(wait?.result).toEqual({
+    waitedMs: 12,
+    text: 'Welcome, ${PASSWORD}',
+    hint: 'matched Welcome, ${PASSWORD}',
+  });
+  expect(JSON.stringify(session.actions)).not.toContain(literal);
+});
+
+test('#1398: a landmark-mode wait drops identity evidence when the echo is only in the ancestry chain', () => {
+  const session = makeIosSession('default');
+  const literal = 'hunter2-secret';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', literal],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: literal },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['role="button" label="Continue"'],
+    flags: {},
+    result: { waitedMs: 5 },
+    targetEvidence: {
+      role: 'button',
+      label: 'Continue',
+      ancestry: [{ role: 'group', label: `Signed in as ${literal}` }],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+    targetEvidenceMode: 'landmark',
+  });
+
+  expect(session.actions[1]?.targetEvidence).toBeUndefined();
+});
+
+test('#1398: action-mode evidence (get/is) redacts an echoed label and downgrades to unverifiable instead of dropping required identity evidence', () => {
+  const session = makeIosSession('default');
+  const literal = 'hunter2-secret';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', literal],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: literal },
+  });
+  recordActionEntry(session, {
+    command: 'is',
+    positionals: ['visible', 'id="password"'],
+    flags: {},
+    result: {},
+    targetEvidence: {
+      role: 'textinput',
+      label: `Password: ${literal}`,
+      ancestry: [{ role: 'form', label: 'Credentials' }],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+  });
+
+  expect(session.actions[1]?.targetEvidence).toEqual({
+    role: 'textinput',
+    label: 'Password: ${PASSWORD}',
+    ancestry: [{ role: 'form', label: 'Credentials' }],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'unverifiable',
+  });
+  expect(JSON.stringify(session.actions)).not.toContain(literal);
+});
+
+test('#1398: action-mode evidence redacts EVERY registered literal echoed in the same label, not just the first match', () => {
+  const session = makeIosSession('default');
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="username"', 'bob'],
+    flags: { recordAs: 'USERNAME' },
+    result: { text: 'bob' },
+  });
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', 'hunter2-secret'],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: 'hunter2-secret' },
+  });
+  recordActionEntry(session, {
+    command: 'is',
+    positionals: ['visible', 'id="session-banner"'],
+    flags: {},
+    result: {},
+    targetEvidence: {
+      role: 'text',
+      label: 'Signed in as bob, session hunter2-secret',
+      ancestry: [],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+  });
+
+  expect(session.actions[2]?.targetEvidence).toEqual({
+    role: 'text',
+    label: 'Signed in as ${USERNAME}, session ${PASSWORD}',
+    ancestry: [],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'unverifiable',
+  });
+  const serialized = JSON.stringify(session.actions);
+  expect(serialized).not.toContain('bob');
+  expect(serialized).not.toContain('hunter2-secret');
+});
+
+test('#1398: two distinct --record-as names sharing the same literal value deterministically keep the first-registered name', () => {
+  const session = makeIosSession('default');
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', 'hunter2'],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: 'hunter2' },
+  });
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="confirm"', 'hunter2'],
+    flags: { recordAs: 'CONFIRM_PASSWORD' },
+    result: { text: 'hunter2' },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['id="confirmation-banner"'],
+    flags: {},
+    result: { waitedMs: 1, text: 'Passwords match: hunter2' },
+  });
+
+  expect(session.actions[2]?.result).toEqual({
+    waitedMs: 1,
+    text: 'Passwords match: ${PASSWORD}',
+  });
+  expect(JSON.stringify(session.actions)).not.toContain('hunter2');
+});
+
+test('#1398: dual-endpoint (targetEvidences) evidence is protected independently per endpoint', () => {
+  const session = makeIosSession('default');
+  const literal = 'hunter2-secret';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', literal],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: literal },
+  });
+  recordActionEntry(session, {
+    command: 'drag',
+    positionals: ['id="source"', 'id="dest"'],
+    flags: {},
+    result: {},
+    targetEvidences: {
+      source: {
+        role: 'button',
+        label: 'Drag me',
+        ancestry: [],
+        sibling: 0,
+        viewportOrder: 0,
+        verification: 'verified',
+      },
+      destination: {
+        role: 'dropzone',
+        label: literal,
+        ancestry: [],
+        sibling: 0,
+        viewportOrder: 0,
+        verification: 'verified',
+      },
+    },
+  });
+
+  const drag = session.actions[1];
+  expect(drag?.targetEvidences?.source).toEqual({
+    role: 'button',
+    label: 'Drag me',
+    ancestry: [],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'verified',
+  });
+  expect(drag?.targetEvidences?.destination).toEqual({
+    role: 'dropzone',
+    label: '${PASSWORD}',
+    ancestry: [],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'unverifiable',
+  });
+});
+
+test('#1398: multiple registered literals apply longest-first so a shorter value never partially consumes a longer one', () => {
+  const session = makeIosSession('default');
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', 'bob123'],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: 'bob123' },
+  });
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="username"', 'bob'],
+    flags: { recordAs: 'USERNAME' },
+    result: { text: 'bob' },
+  });
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['text="Welcome bob123!"'],
+    flags: {},
+    result: { waitedMs: 1, text: 'Welcome bob123!' },
+  });
+
+  expect(session.actions[2]?.result).toEqual({ waitedMs: 1, text: 'Welcome ${PASSWORD}!' });
+});
+
+test('#1398: a whitespace-only --record-as value keeps only fill-step-scoped protection (not registered session-wide)', () => {
+  const session = makeIosSession('default');
+  const whitespace = '   ';
+
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="password"', whitespace],
+    flags: { recordAs: 'PASSWORD' },
+    result: { text: whitespace },
+  });
+  expect(session.recordedFillLiterals).toBeUndefined();
+
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['text="a b c"'],
+    flags: {},
+    result: { waitedMs: 1, text: 'a b c' },
+  });
+
+  expect(session.actions[1]?.result).toEqual({ waitedMs: 1, text: 'a b c' });
+});
+
+test('#1398: ordinary recordings with no --record-as fill are completely unaffected', () => {
+  const session = makeIosSession('default');
+  recordActionEntry(session, {
+    command: 'wait',
+    positionals: ['role="heading" label="Home"'],
+    flags: {},
+    result: { waitedMs: 2, text: 'Home' },
+    targetEvidence: {
+      role: 'heading',
+      label: 'Home',
+      ancestry: [],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+    targetEvidenceMode: 'landmark',
+  });
+
+  expect(session.recordedFillLiterals).toBeUndefined();
+  expect(session.actions[0]?.targetEvidence).toEqual({
+    role: 'heading',
+    label: 'Home',
+    ancestry: [],
+    sibling: 0,
+    viewportOrder: 0,
+    verification: 'verified',
+  });
+});

--- a/src/daemon/parameterized-recorded-fill.ts
+++ b/src/daemon/parameterized-recorded-fill.ts
@@ -128,7 +128,100 @@ export function parameterizeRecordedFillPayload<
   } as TPayload;
 }
 
+/**
+ * #1398: content-aware echo redaction for a LATER, unrelated action's own
+ * recorded result payload. Unlike `parameterizeRecordedFillPayload`, this
+ * never force-replaces a field just because it holds a string — that
+ * shortcut is only valid for a fill's OWN semantic `text` field, which by
+ * construction equals the literal. Here `literal` is a DIFFERENT, earlier
+ * action's already-parameterized value, so every string field must be
+ * checked for actually containing it before anything is rewritten.
+ */
+export function parameterizeRecordedResultEcho<
+  TPayload extends Record<string, unknown> | undefined,
+>(payload: TPayload, literal: string, placeholder: string): TPayload {
+  if (!payload) return payload;
+  return parameterizeBackendOutput(payload, literal, placeholder) as TPayload;
+}
+
+/**
+ * #1398: content-aware label redaction for a LATER, unrelated action's own
+ * identity evidence. Unlike `parameterizeRecordedFillTargetEvidence` (which
+ * matches only an EXACT value-bearing label, correct for the originating
+ * fill's own field), a cross-step echo is typically a label that CONTAINS
+ * the literal inside app-authored surrounding text — a search result, a
+ * confirmation banner, a destination landmark ("Welcome, <value>") — so this
+ * does a substring-aware replacement, exactly like the result-payload echo
+ * scrub above, over `label`/`ancestry[].label`/`scrollRegion.label` only.
+ */
+export function parameterizeTargetEvidenceEcho(
+  evidence: TargetAnnotationV1,
+  literal: string,
+  placeholder: string,
+): TargetAnnotationV1;
+export function parameterizeTargetEvidenceEcho(
+  evidence: TargetAnnotationV1 | undefined,
+  literal: string,
+  placeholder: string,
+): TargetAnnotationV1 | undefined;
+export function parameterizeTargetEvidenceEcho(
+  evidence: TargetAnnotationV1 | undefined,
+  literal: string,
+  placeholder: string,
+): TargetAnnotationV1 | undefined {
+  if (!evidence) return evidence;
+  return {
+    ...evidence,
+    ...(evidence.label !== undefined
+      ? { label: parameterizeSensitiveString(evidence.label, literal, placeholder) }
+      : {}),
+    ancestry: evidence.ancestry.map((entry) => ({
+      ...entry,
+      ...(entry.label !== undefined
+        ? { label: parameterizeSensitiveString(entry.label, literal, placeholder) }
+        : {}),
+    })),
+    ...(evidence.scrollRegion
+      ? {
+          scrollRegion: {
+            ...evidence.scrollRegion,
+            ...(evidence.scrollRegion.label !== undefined
+              ? {
+                  label: parameterizeSensitiveString(
+                    evidence.scrollRegion.label,
+                    literal,
+                    placeholder,
+                  ),
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+/** Whether any label tier of the evidence carries the literal as a substring. */
+export function targetEvidenceCarriesLiteral(
+  evidence: TargetAnnotationV1,
+  literal: string,
+): boolean {
+  if (evidence.label !== undefined && evidence.label.includes(literal)) return true;
+  if (evidence.ancestry.some((entry) => entry.label?.includes(literal) === true)) return true;
+  if (evidence.scrollRegion?.label?.includes(literal) === true) return true;
+  return false;
+}
+
 /** Parameterize exact accessibility labels without rewriting identity fragments. */
+export function parameterizeRecordedFillTargetEvidence(
+  evidence: TargetAnnotationV1,
+  literal: string,
+  placeholder: string,
+): TargetAnnotationV1;
+export function parameterizeRecordedFillTargetEvidence(
+  evidence: TargetAnnotationV1 | undefined,
+  literal: string,
+  placeholder: string,
+): TargetAnnotationV1 | undefined;
 export function parameterizeRecordedFillTargetEvidence(
   evidence: TargetAnnotationV1 | undefined,
   literal: string,

--- a/src/daemon/parameterized-recorded-fill.ts
+++ b/src/daemon/parameterized-recorded-fill.ts
@@ -426,7 +426,7 @@ function sortedLiteralPairs(
  * during a payload/evidence walk, so the sort happens once at the caller
  * rather than being repeated on every leaf.
  */
-export function parameterizeAgainstLiteralMap(
+function parameterizeAgainstLiteralMap(
   value: string,
   pairs: readonly (readonly [string, string])[],
 ): string {

--- a/src/daemon/parameterized-recorded-fill.ts
+++ b/src/daemon/parameterized-recorded-fill.ts
@@ -115,70 +115,78 @@ export function parameterizeRecordedFillPayload<
 >(payload: TPayload, literal: string, placeholder: string): TPayload {
   if (!payload) return payload;
   const selectorChain = readStringArray(payload.selectorChain);
+  const carries = (candidate: string) => selectorCandidateCarriesFillValue(candidate, literal);
   return {
-    ...parameterizeBackendOutput(payload, literal, placeholder),
+    ...parameterizeBackendOutput(
+      payload,
+      (value) => parameterizeSensitiveString(value, literal, placeholder),
+      carries,
+    ),
     ...(typeof payload.text === 'string' ? { text: placeholder } : {}),
     ...(selectorChain
-      ? {
-          selectorChain: selectorChain.filter(
-            (candidate) => !selectorCandidateCarriesFillValue(candidate, literal),
-          ),
-        }
+      ? { selectorChain: selectorChain.filter((candidate) => !carries(candidate)) }
       : {}),
   } as TPayload;
 }
 
 /**
  * #1398: content-aware echo redaction for a LATER, unrelated action's own
- * recorded result payload. Unlike `parameterizeRecordedFillPayload`, this
- * never force-replaces a field just because it holds a string — that
- * shortcut is only valid for a fill's OWN semantic `text` field, which by
- * construction equals the literal. Here `literal` is a DIFFERENT, earlier
- * action's already-parameterized value, so every string field must be
- * checked for actually containing it before anything is rewritten.
+ * recorded result payload, against every literal registered so far in the
+ * recording session. Unlike `parameterizeRecordedFillPayload`, this never
+ * force-replaces a field just because it holds a string — that shortcut is
+ * only valid for a fill's OWN semantic `text` field, which by construction
+ * equals the literal. Here every literal belongs to a DIFFERENT, earlier
+ * action, so every string field must be checked for actually containing one
+ * before anything is rewritten. Delegates to `parameterizeAgainstLiteralMap`
+ * for the actual substitution, so redacting one literal can never corrupt a
+ * placeholder another literal (or an earlier stage) already inserted.
  */
 export function parameterizeRecordedResultEcho<
   TPayload extends Record<string, unknown> | undefined,
->(payload: TPayload, literal: string, placeholder: string): TPayload {
+>(payload: TPayload, literals: ReadonlyMap<string, string>): TPayload {
   if (!payload) return payload;
-  return parameterizeBackendOutput(payload, literal, placeholder) as TPayload;
+  const pairs = sortedLiteralPairs(literals);
+  return parameterizeBackendOutput(
+    payload,
+    (value) => parameterizeAgainstLiteralMap(value, pairs),
+    (candidate) => selectorCandidateCarriesAnyLiteral(candidate, literals),
+  ) as TPayload;
 }
 
 /**
  * #1398: content-aware label redaction for a LATER, unrelated action's own
- * identity evidence. Unlike `parameterizeRecordedFillTargetEvidence` (which
+ * identity evidence, against every literal registered so far in the
+ * recording session. Unlike `parameterizeRecordedFillTargetEvidence` (which
  * matches only an EXACT value-bearing label, correct for the originating
- * fill's own field), a cross-step echo is typically a label that CONTAINS
- * the literal inside app-authored surrounding text — a search result, a
+ * fill's own field), a cross-step echo is typically a label that CONTAINS a
+ * literal inside app-authored surrounding text — a search result, a
  * confirmation banner, a destination landmark ("Welcome, <value>") — so this
  * does a substring-aware replacement, exactly like the result-payload echo
  * scrub above, over `label`/`ancestry[].label`/`scrollRegion.label` only.
  */
 export function parameterizeTargetEvidenceEcho(
   evidence: TargetAnnotationV1,
-  literal: string,
-  placeholder: string,
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1;
 export function parameterizeTargetEvidenceEcho(
   evidence: TargetAnnotationV1 | undefined,
-  literal: string,
-  placeholder: string,
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1 | undefined;
 export function parameterizeTargetEvidenceEcho(
   evidence: TargetAnnotationV1 | undefined,
-  literal: string,
-  placeholder: string,
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1 | undefined {
   if (!evidence) return evidence;
+  const pairs = sortedLiteralPairs(literals);
   return {
     ...evidence,
     ...(evidence.label !== undefined
-      ? { label: parameterizeSensitiveString(evidence.label, literal, placeholder) }
+      ? { label: parameterizeAgainstLiteralMap(evidence.label, pairs) }
       : {}),
     ancestry: evidence.ancestry.map((entry) => ({
       ...entry,
       ...(entry.label !== undefined
-        ? { label: parameterizeSensitiveString(entry.label, literal, placeholder) }
+        ? { label: parameterizeAgainstLiteralMap(entry.label, pairs) }
         : {}),
     })),
     ...(evidence.scrollRegion
@@ -186,13 +194,7 @@ export function parameterizeTargetEvidenceEcho(
           scrollRegion: {
             ...evidence.scrollRegion,
             ...(evidence.scrollRegion.label !== undefined
-              ? {
-                  label: parameterizeSensitiveString(
-                    evidence.scrollRegion.label,
-                    literal,
-                    placeholder,
-                  ),
-                }
+              ? { label: parameterizeAgainstLiteralMap(evidence.scrollRegion.label, pairs) }
               : {}),
           },
         }
@@ -200,14 +202,42 @@ export function parameterizeTargetEvidenceEcho(
   };
 }
 
-/** Whether any label tier of the evidence carries the literal as a substring. */
-export function targetEvidenceCarriesLiteral(
+/** Whether any label tier of the evidence carries any registered literal as a substring. */
+export function targetEvidenceCarriesAnyLiteral(
   evidence: TargetAnnotationV1,
-  literal: string,
+  literals: ReadonlyMap<string, string>,
 ): boolean {
-  if (evidence.label !== undefined && evidence.label.includes(literal)) return true;
-  if (evidence.ancestry.some((entry) => entry.label?.includes(literal) === true)) return true;
-  if (evidence.scrollRegion?.label?.includes(literal) === true) return true;
+  if (evidence.label !== undefined && labelCarriesAnyLiteral(evidence.label, literals)) {
+    return true;
+  }
+  if (
+    evidence.ancestry.some((entry) => entry.label && labelCarriesAnyLiteral(entry.label, literals))
+  ) {
+    return true;
+  }
+  if (
+    evidence.scrollRegion?.label &&
+    labelCarriesAnyLiteral(evidence.scrollRegion.label, literals)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function labelCarriesAnyLiteral(value: string, literals: ReadonlyMap<string, string>): boolean {
+  for (const literal of literals.keys()) {
+    if (value.includes(literal)) return true;
+  }
+  return false;
+}
+
+function selectorCandidateCarriesAnyLiteral(
+  candidate: string,
+  literals: ReadonlyMap<string, string>,
+): boolean {
+  for (const literal of literals.keys()) {
+    if (selectorCandidateCarriesFillValue(candidate, literal)) return true;
+  }
   return false;
 }
 
@@ -250,17 +280,20 @@ function selectorCandidateCarriesFillValue(candidate: string, literal: string): 
   return selectorContainsValue(candidate, literal);
 }
 
+/** A leaf string rewrite rule injected into the shared structural walk below. */
+type LeafTransform = (value: string) => string;
+/** Whether a selector-chain candidate carries whatever this call's leaf transform redacts. */
+type CarriesSensitiveValue = (candidate: string) => boolean;
+
 function parameterizeBackendOutput(
   value: Record<string, unknown>,
-  literal: string,
-  placeholder: string,
+  transform: LeafTransform,
+  carries: CarriesSensitiveValue,
 ): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(value).map(([key, entry]) => {
-      const outputKey = STRUCTURAL_ROOT_OUTPUT_KEYS.has(key)
-        ? key
-        : parameterizeSensitiveString(key, literal, placeholder);
-      return [outputKey, parameterizeRootOutputValue(entry, key, literal, placeholder)];
+      const outputKey = STRUCTURAL_ROOT_OUTPUT_KEYS.has(key) ? key : transform(key);
+      return [outputKey, parameterizeRootOutputValue(entry, key, transform, carries)];
     }),
   );
 }
@@ -268,36 +301,36 @@ function parameterizeBackendOutput(
 function parameterizeRootOutputValue(
   value: unknown,
   key: string,
-  literal: string,
-  placeholder: string,
+  transform: LeafTransform,
+  carries: CarriesSensitiveValue,
 ): unknown {
   if (typeof value === 'string') {
     if (STABLE_ROOT_OUTPUT_STRING_KEYS.has(key)) return value;
   }
   if (key === 'selectorChain' && isStringArray(value)) {
-    return filterSensitiveSelectorCandidates(value, literal);
+    return filterSensitiveSelectorCandidates(value, carries);
   }
   return parameterizeBackendOutputValue(
     value,
-    literal,
-    placeholder,
+    transform,
+    carries,
     STRUCTURED_OUTPUT_KEYS.has(key) ? key : undefined,
   );
 }
 
 function parameterizeBackendOutputValue(
   value: unknown,
-  literal: string,
-  placeholder: string,
+  transform: LeafTransform,
+  carries: CarriesSensitiveValue,
   structuralPath: string | undefined,
 ): unknown {
   if (typeof value === 'string') {
     if (structuralPath && STABLE_STRUCTURAL_STRING_PATHS.has(structuralPath)) return value;
-    return parameterizeSensitiveString(value, literal, placeholder);
+    return transform(value);
   }
   if (Array.isArray(value)) {
     return value.map((entry) =>
-      parameterizeBackendOutputValue(entry, literal, placeholder, structuralPath),
+      parameterizeBackendOutputValue(entry, transform, carries, structuralPath),
     );
   }
   if (!value || typeof value !== 'object') return value;
@@ -305,15 +338,13 @@ function parameterizeBackendOutputValue(
   return Object.fromEntries(
     Object.entries(value).map(([nestedKey, entry]) => {
       const isStructural = structuralKeys?.has(nestedKey) === true;
-      const outputKey = isStructural
-        ? nestedKey
-        : parameterizeSensitiveString(nestedKey, literal, placeholder);
+      const outputKey = isStructural ? nestedKey : transform(nestedKey);
       return [
         outputKey,
         parameterizeBackendOutputValue(
           entry,
-          literal,
-          placeholder,
+          transform,
+          carries,
           isStructural ? `${structuralPath}.${nestedKey}` : undefined,
         ),
       ];
@@ -321,8 +352,11 @@ function parameterizeBackendOutputValue(
   );
 }
 
-function filterSensitiveSelectorCandidates(value: string[], literal: string): string[] {
-  return value.filter((candidate) => !selectorCandidateCarriesFillValue(candidate, literal));
+function filterSensitiveSelectorCandidates(
+  value: string[],
+  carries: CarriesSensitiveValue,
+): string[] {
+  return value.filter((candidate) => !carries(candidate));
 }
 
 function parameterizeSensitiveString(value: string, literal: string, placeholder: string): string {
@@ -338,6 +372,89 @@ function parameterizeSensitiveString(value: string, literal: string, placeholder
   return unparameterizedSegments
     .map((segment) => segment.replaceAll(literal, placeholder))
     .join(placeholder);
+}
+
+/**
+ * Mirrors the `${VAR}` grammar `@agent-device/ad-script`'s `REPLAY_VAR_KEY_RE`
+ * and `src/replay/recorded-input.ts`'s `RECORDED_INPUT_PLACEHOLDER_RE` define.
+ * The sticky (`y`) flag makes `exec` match only starting exactly at
+ * `lastIndex` (never scanning ahead to find a later match), so the scan below
+ * can test one position at a time without slicing a fresh substring per
+ * character — an O(n) scan stays O(n), not O(n^2).
+ */
+const PLACEHOLDER_TOKEN_START_RE = /\$\{[A-Z_][A-Z0-9_]*\}/y;
+
+/**
+ * Sorts the session's literal registry longest-literal-first exactly once,
+ * so a registered value that is a substring of another registered value (a
+ * username that is a prefix of a password, say) is never partially consumed
+ * by the shorter pair. Callers that walk many string leaves (the payload and
+ * target-evidence echo scrubs below) sort once and thread the result down,
+ * rather than re-sorting the same small map on every leaf.
+ */
+function sortedLiteralPairs(
+  literals: ReadonlyMap<string, string>,
+): readonly (readonly [string, string])[] {
+  return [...literals].sort(([a], [b]) => b.length - a.length);
+}
+
+/**
+ * #1398: the placeholder-safe multi-literal redaction primitive. A single
+ * left-to-right pass — not N sequential full-string passes over the same
+ * value. Sequential per-pair passes can corrupt an EARLIER pair's
+ * just-inserted placeholder when a LATER pair's literal happens to be a
+ * substring of it: register `somethinglong -> ${ABC}`, then `ABC -> ${OTHER}`,
+ * and a naive second pass over a value already rewritten to `${ABC}` matches
+ * "ABC" *inside* that placeholder token, producing the corrupted
+ * `${${OTHER}}`. This never re-scans text it has already emitted in THIS
+ * call — `index` only ever advances forward through the source `value`, so a
+ * placeholder just appended to `result` is never fed back through the match
+ * loop.
+ *
+ * A registered literal is matched BEFORE checking whether an existing
+ * placeholder token starts here, so a literal whose own text happens to look
+ * like `${SOMETHING}` (an edge case, but a real typed value can be shaped
+ * like that) is still redacted correctly. The placeholder-token check exists
+ * for the OTHER direction: text already rewritten to `${VAR}` by an earlier
+ * stage (the fill's own single-pair boundary, or the parser's own replay
+ * source) before this pass ever ran, where no current literal matches at
+ * that position — that existing token is left untouched rather than
+ * partially matched.
+ *
+ * `pairs` must already be sorted longest-literal-first (`sortedLiteralPairs`)
+ * — this is the hot leaf-level primitive, invoked once per string field
+ * during a payload/evidence walk, so the sort happens once at the caller
+ * rather than being repeated on every leaf.
+ */
+export function parameterizeAgainstLiteralMap(
+  value: string,
+  pairs: readonly (readonly [string, string])[],
+): string {
+  if (!value || pairs.length === 0) return value;
+
+  let result = '';
+  let index = 0;
+  scan: while (index < value.length) {
+    for (const [literal, placeholder] of pairs) {
+      if (value.startsWith(literal, index)) {
+        result += placeholder;
+        index += literal.length;
+        continue scan;
+      }
+    }
+    if (value[index] === '$') {
+      PLACEHOLDER_TOKEN_START_RE.lastIndex = index;
+      const existingPlaceholder = PLACEHOLDER_TOKEN_START_RE.exec(value);
+      if (existingPlaceholder) {
+        result += existingPlaceholder[0];
+        index += existingPlaceholder[0].length;
+        continue;
+      }
+    }
+    result += value[index];
+    index += 1;
+  }
+  return result;
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/src/daemon/selector-recording.ts
+++ b/src/daemon/selector-recording.ts
@@ -151,7 +151,10 @@ export function recordIfSession(
     // class AND the provenance — so an authored plan step recorded through
     // this same path keeps its place in the healed script.
     interactiveObservation: isInteractiveObservation(req),
-    ...(targetEvidence ? { targetEvidence } : {}),
+    // #1398: lets session-scoped echo protection apply the SAME
+    // landmark-vs-action treatment #1349 already established for
+    // identity-empty evidence.
+    ...(targetEvidence ? { targetEvidence, targetEvidenceMode: evidenceMode ?? 'action' } : {}),
   });
 }
 

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -16,7 +16,7 @@ import {
   parameterizeRecordedFillTargetEvidence,
   parameterizeRecordedResultEcho,
   parameterizeTargetEvidenceEcho,
-  targetEvidenceCarriesLiteral,
+  targetEvidenceCarriesAnyLiteral,
 } from './parameterized-recorded-fill.ts';
 import type { TargetEvidenceMode } from './session-target-evidence.ts';
 
@@ -170,10 +170,11 @@ function registerRecordedFillLiteral(session: SessionState, fillLiteral: FillLit
 /**
  * #1398: apply every literal registered so far in THIS session to the
  * CURRENT entry, whatever command produced it. A no-op fast path keeps
- * ordinary, non-parameterized recordings byte-for-byte unchanged. Pairs are
- * applied longest-literal-first so one registered value that happens to be a
- * substring of another (e.g. a username that is a prefix of a password) is
- * never partially consumed by the shorter pair first.
+ * ordinary, non-parameterized recordings byte-for-byte unchanged.
+ * `parameterizeRecordedResultEcho`/`parameterizeTargetEvidenceEcho` redact
+ * every registered literal in one placeholder-safe pass each (see
+ * `parameterizeAgainstLiteralMap`), so no per-literal sequencing is needed
+ * here.
  */
 function applySessionEchoProtection(
   session: SessionState,
@@ -181,22 +182,17 @@ function applySessionEchoProtection(
 ): RecordActionEntry {
   const literals = session.recordedFillLiterals;
   if (!literals || literals.size === 0) return entry;
-  const pairs = [...literals].sort(([a], [b]) => b.length - a.length);
 
-  let result = entry.result;
-  for (const [literal, placeholder] of pairs) {
-    result = parameterizeRecordedResultEcho(result, literal, placeholder);
-  }
-
+  const result = parameterizeRecordedResultEcho(entry.result, literals);
   const evidenceMode = entry.targetEvidenceMode ?? 'action';
   const targetEvidence =
     evidenceMode === 'landmark'
-      ? redactLandmarkEvidenceEcho(entry.targetEvidence, pairs)
-      : redactActionModeEvidenceEcho(entry.targetEvidence, pairs);
+      ? redactLandmarkEvidenceEcho(entry.targetEvidence, literals)
+      : redactActionModeEvidenceEcho(entry.targetEvidence, literals);
   const targetEvidences = entry.targetEvidences
     ? {
-        source: redactActionModeEvidenceEcho(entry.targetEvidences.source, pairs),
-        destination: redactActionModeEvidenceEcho(entry.targetEvidences.destination, pairs),
+        source: redactActionModeEvidenceEcho(entry.targetEvidences.source, literals),
+        destination: redactActionModeEvidenceEcho(entry.targetEvidences.destination, literals),
       }
     : entry.targetEvidences;
 
@@ -215,17 +211,19 @@ function applySessionEchoProtection(
  */
 function redactLandmarkEvidenceEcho(
   evidence: TargetAnnotationV1 | undefined,
-  pairs: readonly (readonly [string, string])[],
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1 | undefined {
   if (!evidence) return evidence;
-  const echoed = pairs.some(([literal]) => targetEvidenceCarriesLiteral(evidence, literal));
-  return echoed ? undefined : evidence;
+  return targetEvidenceCarriesAnyLiteral(evidence, literals) ? undefined : evidence;
 }
 
 /**
  * #1398: action-mode evidence (`get`, `is`, and mutating element-targeting
  * actions) is required by ADR 0012/0016 and must never be silently dropped.
- * An echoed literal-bearing label is redacted to its placeholder AND
+ * Every echoed literal-bearing label is redacted to its placeholder in one
+ * placeholder-safe pass (a label can legitimately echo more than one
+ * already-parameterized value, e.g. "Signed in as bob, session
+ * hunter2-secret" after separate USERNAME and PASSWORD fills) AND
  * `verification` is downgraded to `"unverifiable"` — the SAME fail-closed
  * downgrade decision 3's writer-parser invariant already uses for an
  * oversized payload. That fails the action's replay loudly
@@ -235,30 +233,19 @@ function redactLandmarkEvidenceEcho(
  */
 function redactActionModeEvidenceEcho(
   evidence: TargetAnnotationV1,
-  pairs: readonly (readonly [string, string])[],
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1;
 function redactActionModeEvidenceEcho(
   evidence: TargetAnnotationV1 | undefined,
-  pairs: readonly (readonly [string, string])[],
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1 | undefined;
 function redactActionModeEvidenceEcho(
   evidence: TargetAnnotationV1 | undefined,
-  pairs: readonly (readonly [string, string])[],
+  literals: ReadonlyMap<string, string>,
 ): TargetAnnotationV1 | undefined {
   if (!evidence) return evidence;
-  // Every registered pair is checked, not just the first match — a label can
-  // legitimately echo more than one already-parameterized value (e.g. "Signed
-  // in as bob, session hunter2-secret" after separate USERNAME and PASSWORD
-  // fills), and leaving a later literal untouched would defeat the guarantee
-  // for that value alone.
-  let redacted = evidence;
-  let echoed = false;
-  for (const [literal, placeholder] of pairs) {
-    if (!targetEvidenceCarriesLiteral(redacted, literal)) continue;
-    redacted = parameterizeTargetEvidenceEcho(redacted, literal, placeholder);
-    echoed = true;
-  }
-  return echoed ? { ...redacted, verification: 'unverifiable' } : evidence;
+  if (!targetEvidenceCarriesAnyLiteral(evidence, literals)) return evidence;
+  return { ...parameterizeTargetEvidenceEcho(evidence, literals), verification: 'unverifiable' };
 }
 
 function replaceFillText(positionals: string[], placeholder: string): string[] {

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -14,7 +14,11 @@ import {
 import {
   parameterizeRecordedFillPayload,
   parameterizeRecordedFillTargetEvidence,
+  parameterizeRecordedResultEcho,
+  parameterizeTargetEvidenceEcho,
+  targetEvidenceCarriesLiteral,
 } from './parameterized-recorded-fill.ts';
+import type { TargetEvidenceMode } from './session-target-evidence.ts';
 
 export type RecordActionEntry = {
   command: string;
@@ -24,6 +28,15 @@ export type RecordActionEntry = {
   result?: Record<string, unknown>;
   targetEvidence?: TargetAnnotationV1;
   targetEvidences?: MultiTargetAnnotationV1;
+  /**
+   * #1398: which `computeTargetEvidence` mode produced `targetEvidence`, so
+   * session-scoped echo protection (below) can apply the SAME
+   * landmark-vs-action treatment #1349 already established for identity-empty
+   * evidence. Defaults to `action` when absent — every call site other than
+   * `wait`'s landmark recording computes action-mode evidence and never needs
+   * to set this explicitly.
+   */
+  targetEvidenceMode?: TargetEvidenceMode;
   /**
    * #1271 stage 2 (ADR 0012 amendment): an observation-only command
    * (`snapshot`/`get`/`is`/read-only `find`) dispatched OUT OF BAND — typed by
@@ -47,7 +60,21 @@ export function recordActionEntry(
   if (entry.flags?.noRecord) return undefined;
   if (isExcludedRepairSegmentObservation(session, entry)) return undefined;
   if (entry.flags) applyRecordedSaveScriptFlags(session, entry.flags);
-  const recordedEntry = parameterizeRecordedFill(entry);
+  const fillLiteral = readRecordedFillLiteral(entry);
+  // #1398: register the literal only AFTER protecting this SAME entry, so a
+  // fill's own recording is never passed through the session-wide substring
+  // scan against the value it JUST introduced — that pass is coarser
+  // (content-aware substring, not the fill boundary's exact-field match) and
+  // would otherwise mangle unrelated short incidental substrings (e.g. a
+  // one-character `--record-as` value colliding with ordinary words) in the
+  // very entry that introduced it. The session-wide guarantee is for LATER,
+  // distinct actions, exactly as #1398 frames it; this entry keeps only the
+  // existing fill-step-scoped exact-match protection below.
+  const recordedEntry = applySessionEchoProtection(
+    session,
+    parameterizeRecordedFill(entry, fillLiteral),
+  );
+  if (fillLiteral) registerRecordedFillLiteral(session, fillLiteral);
   const action: SessionAction = {
     ts: Date.now(),
     command: recordedEntry.command,
@@ -70,6 +97,22 @@ export function recordActionEntry(
   return action;
 }
 
+type FillLiteral = { literal: string; placeholder: string };
+
+/** The (literal, placeholder) pair a `fill --record-as` entry carries, or `undefined` for an ordinary fill/other command. */
+function readRecordedFillLiteral(entry: RecordActionEntry): FillLiteral | undefined {
+  if (entry.command !== 'fill' || typeof entry.flags.recordAs !== 'string') return undefined;
+  const variableName = validateRecordedInputVariableName(entry.flags.recordAs);
+  const placeholder = recordedInputPlaceholder(variableName);
+  const literal = inferFillText({
+    ts: 0,
+    command: entry.command,
+    positionals: entry.positionals,
+    flags: entry.flags,
+  });
+  return { literal, placeholder };
+}
+
 /**
  * #1348: the recorder is the first durable boundary. The live request keeps
  * the literal fill value through device execution, but the SessionAction gets
@@ -79,16 +122,12 @@ export function recordActionEntry(
  * value labels in ADR 0012 evidence are parameterized without rewriting
  * unrelated identity fragments.
  */
-function parameterizeRecordedFill(entry: RecordActionEntry): RecordActionEntry {
-  if (entry.command !== 'fill' || typeof entry.flags.recordAs !== 'string') return entry;
-  const variableName = validateRecordedInputVariableName(entry.flags.recordAs);
-  const placeholder = recordedInputPlaceholder(variableName);
-  const literal = inferFillText({
-    ts: 0,
-    command: entry.command,
-    positionals: entry.positionals,
-    flags: entry.flags,
-  });
+function parameterizeRecordedFill(
+  entry: RecordActionEntry,
+  fillLiteral: FillLiteral | undefined,
+): RecordActionEntry {
+  if (!fillLiteral) return entry;
+  const { literal, placeholder } = fillLiteral;
   return {
     ...entry,
     positionals: replaceFillText(entry.positionals, placeholder),
@@ -99,6 +138,127 @@ function parameterizeRecordedFill(entry: RecordActionEntry): RecordActionEntry {
       placeholder,
     ),
   };
+}
+
+/**
+ * #1398 (ADR 0017 session-scoped echo protection amendment): remember an
+ * explicitly parameterized literal for the REST of this recording session, so
+ * a later, unrelated action's own recorded evidence can be checked against
+ * it. A whitespace-only or empty resolved value is deliberately excluded —
+ * it keeps only the fill-step-scoped protection `parameterizeRecordedFill`
+ * already gives it above. Collapsing arbitrary later strings on a value with
+ * no discriminating content would be a disproportionate readability cost for
+ * a value that reveals nothing distinctive if echoed, and an empty literal
+ * would match every string.
+ *
+ * The map is keyed by literal, so two DIFFERENT `--record-as` names that
+ * happen to share the same typed value (a password/confirm-password pair,
+ * say) are genuinely indistinguishable from a later echo's perspective — the
+ * literal alone cannot say which fill produced it. The first-registered name
+ * wins deterministically rather than a later, unrelated fill silently
+ * re-attributing an earlier echo to its own name; the literal itself is
+ * redacted either way, so this only affects WHICH placeholder name is used,
+ * never whether the value is protected.
+ */
+function registerRecordedFillLiteral(session: SessionState, fillLiteral: FillLiteral): void {
+  if (!fillLiteral.literal.trim()) return;
+  session.recordedFillLiterals ??= new Map();
+  if (session.recordedFillLiterals.has(fillLiteral.literal)) return;
+  session.recordedFillLiterals.set(fillLiteral.literal, fillLiteral.placeholder);
+}
+
+/**
+ * #1398: apply every literal registered so far in THIS session to the
+ * CURRENT entry, whatever command produced it. A no-op fast path keeps
+ * ordinary, non-parameterized recordings byte-for-byte unchanged. Pairs are
+ * applied longest-literal-first so one registered value that happens to be a
+ * substring of another (e.g. a username that is a prefix of a password) is
+ * never partially consumed by the shorter pair first.
+ */
+function applySessionEchoProtection(
+  session: SessionState,
+  entry: RecordActionEntry,
+): RecordActionEntry {
+  const literals = session.recordedFillLiterals;
+  if (!literals || literals.size === 0) return entry;
+  const pairs = [...literals].sort(([a], [b]) => b.length - a.length);
+
+  let result = entry.result;
+  for (const [literal, placeholder] of pairs) {
+    result = parameterizeRecordedResultEcho(result, literal, placeholder);
+  }
+
+  const evidenceMode = entry.targetEvidenceMode ?? 'action';
+  const targetEvidence =
+    evidenceMode === 'landmark'
+      ? redactLandmarkEvidenceEcho(entry.targetEvidence, pairs)
+      : redactActionModeEvidenceEcho(entry.targetEvidence, pairs);
+  const targetEvidences = entry.targetEvidences
+    ? {
+        source: redactActionModeEvidenceEcho(entry.targetEvidences.source, pairs),
+        destination: redactActionModeEvidenceEcho(entry.targetEvidences.destination, pairs),
+      }
+    : entry.targetEvidences;
+
+  return { ...entry, result, targetEvidence, targetEvidences };
+}
+
+/**
+ * #1398: a landmark-mode echo is treated exactly like #1349's existing
+ * identity-empty case — record NO annotation rather than a placeholder that
+ * could never replay-match (the app re-echoes the REAL value at replay time,
+ * so a recorded `${VAR}` label can only ever mismatch it). A `wait` used as
+ * an ADR 0016 destination guard requires `verification: "verified"`, so a
+ * landmark whose only identity is a parameterized-value echo simply stops
+ * qualifying as a guard — publication refuses it and directs the author to a
+ * different, non-value-bearing landmark, same as the motivating scenario.
+ */
+function redactLandmarkEvidenceEcho(
+  evidence: TargetAnnotationV1 | undefined,
+  pairs: readonly (readonly [string, string])[],
+): TargetAnnotationV1 | undefined {
+  if (!evidence) return evidence;
+  const echoed = pairs.some(([literal]) => targetEvidenceCarriesLiteral(evidence, literal));
+  return echoed ? undefined : evidence;
+}
+
+/**
+ * #1398: action-mode evidence (`get`, `is`, and mutating element-targeting
+ * actions) is required by ADR 0012/0016 and must never be silently dropped.
+ * An echoed literal-bearing label is redacted to its placeholder AND
+ * `verification` is downgraded to `"unverifiable"` — the SAME fail-closed
+ * downgrade decision 3's writer-parser invariant already uses for an
+ * oversized payload. That fails the action's replay loudly
+ * (`identity-unverifiable`) instead of silently weakening it to
+ * selector-only matching or falsely claiming `verified` against a label that
+ * can never match again.
+ */
+function redactActionModeEvidenceEcho(
+  evidence: TargetAnnotationV1,
+  pairs: readonly (readonly [string, string])[],
+): TargetAnnotationV1;
+function redactActionModeEvidenceEcho(
+  evidence: TargetAnnotationV1 | undefined,
+  pairs: readonly (readonly [string, string])[],
+): TargetAnnotationV1 | undefined;
+function redactActionModeEvidenceEcho(
+  evidence: TargetAnnotationV1 | undefined,
+  pairs: readonly (readonly [string, string])[],
+): TargetAnnotationV1 | undefined {
+  if (!evidence) return evidence;
+  // Every registered pair is checked, not just the first match — a label can
+  // legitimately echo more than one already-parameterized value (e.g. "Signed
+  // in as bob, session hunter2-secret" after separate USERNAME and PASSWORD
+  // fills), and leaving a later literal untouched would defeat the guarantee
+  // for that value alone.
+  let redacted = evidence;
+  let echoed = false;
+  for (const [literal, placeholder] of pairs) {
+    if (!targetEvidenceCarriesLiteral(redacted, literal)) continue;
+    redacted = parameterizeTargetEvidenceEcho(redacted, literal, placeholder);
+    echoed = true;
+  }
+  return echoed ? { ...redacted, verification: 'unverifiable' } : evidence;
 }
 
 function replaceFillText(positionals: string[], placeholder: string): string[] {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -415,6 +415,18 @@ export type SessionState = {
   pendingRecordAndHeal?: { expectedFrom: number; actionsCountAtDivergence: number };
   actions: SessionAction[];
   /**
+   * #1398 (ADR 0017 session-scoped echo protection amendment): explicit,
+   * ephemeral `literal -> ${VAR}` placeholder map, populated only from the
+   * SAME pair `fill --record-as` (ADR 0017) already computes as each
+   * parameterized fill records. Consulted by `recordActionEntry` so a LATER
+   * recorded action's own result/target evidence never re-serializes an
+   * app-rendered echo of an already-authored literal. In-memory only for
+   * this session's lifetime: never read by the script writer, the event
+   * log, or diagnostics, and dropped with the session. Owned by
+   * `src/daemon/session-action-recorder.ts`.
+   */
+  recordedFillLiterals?: Map<string, string>;
+  /**
    * Neutral session-owned app-log resource. Durable coordinates are persisted
    * independently; the in-memory handle is never serialized or reconstructed
    * by SessionStore.

--- a/test/integration/provider-scenarios/active-session-script-publication.test.ts
+++ b/test/integration/provider-scenarios/active-session-script-publication.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { emitDiagnostic } from '../../../src/utils/diagnostics.ts';
+import { INTERNAL_COMMANDS } from '../../../src/command-catalog.ts';
 import { test } from 'vitest';
 import { assertRpcError, assertRpcOk } from './assertions.ts';
 import { androidSettingsXml, createAndroidSettingsWorld } from './android-world.ts';
@@ -387,6 +388,123 @@ test('parameterized fill publishes only ${VAR} and replay resolves it immediatel
         );
         assertRpcError(unarmed, 'INVALID_ARGS', /requires an armed script recording/);
         assert.equal(world.textInjectionCalls.length, callsBeforeUnarmed);
+        await client.sessions.close();
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+}, 20_000);
+
+// #1398: a LATER, distinct read-only action can independently observe an
+// app-rendered echo of an already-parameterized fill's literal — here, a
+// confirmation label containing the typed search term, the exact scenario
+// that motivated the issue (a provider scenario whose destination guard
+// waited on a populated field carrying the opaque input value). The fix must
+// keep the literal out of session state/publication AND refuse to let an
+// echoing landmark serve as the ADR 0016 destination guard, through the real
+// provider/publication path rather than a serializer helper.
+function settingsXmlWithSearchResult(searchText: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<hierarchy rotation="0">',
+    '  <node index="0" text="" resource-id="com.android.settings:id/main_content_scrollable_container" class="android.widget.ScrollView" package="com.android.settings" content-desc="" bounds="[0,0][390,600]" clickable="false" enabled="true">',
+    '    <node index="0" text="Apps" resource-id="android:id/title" class="android.widget.TextView" package="com.android.settings" content-desc="" bounds="[24,124][152,178]" clickable="true" enabled="true" focusable="true" focused="false" />',
+    `    <node index="1" text="${searchText}" resource-id="com.android.settings:id/search" class="android.widget.EditText" package="com.android.settings" content-desc="Search" bounds="[16,24][374,80]" clickable="true" enabled="true" focusable="true" focused="true" password="false" />`,
+    ...(searchText
+      ? [
+          `    <node index="2" text="Results for ${searchText}" resource-id="com.android.settings:id/results_summary" class="android.widget.TextView" package="com.android.settings" content-desc="" bounds="[24,190][350,244]" clickable="false" enabled="true" />`,
+        ]
+      : []),
+    '  </node>',
+    '</hierarchy>',
+  ].join('\n');
+}
+
+test('#1398: a read-only wait recorded after a parameterized fill never re-serializes an app-rendered echo, and cannot serve as the destination guard', async () => {
+  const secret = 'OpaqueEchoValue1398';
+  let injectedText: string | undefined;
+  await withProviderScenarioResource(
+    async () =>
+      await createAndroidSettingsWorld({
+        nativeTextInjection: true,
+        onTextInjection: (request) => {
+          injectedText = request.text;
+        },
+        snapshotXml: () => settingsXmlWithSearchResult(injectedText ?? ''),
+      }),
+    async (world) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-echo-protection-'));
+      const scriptPath = path.join(root, 'echo-protection.ad');
+      const client = world.daemon.client();
+      try {
+        await client.apps.open({ app: 'settings', saveScript: scriptPath, ...world.selection });
+        const snapshot = await client.capture.snapshot({
+          interactiveOnly: true,
+          ...world.selection,
+        });
+        const search = snapshot.nodes.find((node) => node.label === 'Search');
+        assert.ok(search?.ref);
+
+        await client.interactions.fill({
+          ref: `@${search.ref}`,
+          text: secret,
+          recordAs: 'SEARCH_TERM',
+          settle: true,
+          settleQuietMs: 1,
+          timeoutMs: 1_000,
+          ...world.selection,
+        });
+
+        // The app echoes the typed value back in an unrelated confirmation
+        // label. A wait on it records, but must never carry the literal.
+        await client.command.wait({
+          selector: 'id="com.android.settings:id/results_summary"',
+          ...world.selection,
+        });
+
+        const stateBeforeGuard = JSON.stringify(world.daemon.session()?.actions);
+        assert.equal(stateBeforeGuard.includes(secret), false, stateBeforeGuard);
+        assert.match(stateBeforeGuard, /\$\{SEARCH_TERM\}/);
+
+        // Being the only wait so far, it cannot serve as the destination
+        // guard: its ONLY identity was the parameterized-value echo, so
+        // landmark evidence was dropped rather than published unverifiable.
+        const refusedPublish = await world.daemon.callCommand(
+          INTERNAL_COMMANDS.sessionSaveScript,
+          [scriptPath],
+          world.selection,
+        );
+        assertRpcError(refusedPublish, 'COMMAND_FAILED', /destination guard/);
+
+        // Recording a stable, non-value-bearing landmark — mirroring the
+        // real-world fix of switching to the "Apps" landmark — recovers a
+        // valid guard.
+        await client.command.wait({ selector: 'label="Apps"', ...world.selection });
+        const published = await client.sessions.saveScript({ path: scriptPath });
+        assert.equal(published.savedScript, scriptPath);
+
+        const script = fs.readFileSync(scriptPath, 'utf8');
+        assert.equal(script.includes(secret), false, script);
+        assert.match(script, /\$\{SEARCH_TERM\}/);
+
+        const lines = script.split('\n');
+        const resultsLineIndex = lines.findIndex((line) => line.includes('results_summary'));
+        assert.ok(resultsLineIndex > 0, script);
+        assert.equal(
+          lines[resultsLineIndex - 1]?.includes('agent-device:target-v1'),
+          false,
+          script,
+        );
+        const guardLineIndex = lines.findIndex(
+          (line) => line.startsWith('wait ') && line.includes('Apps'),
+        );
+        assert.ok(guardLineIndex > 0, script);
+        assert.match(
+          lines[guardLineIndex - 1] ?? '',
+          /agent-device:target-v1.*"verification":"verified"/,
+        );
+
         await client.sessions.close();
       } finally {
         fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #1398, a follow-up to #1348/#1369 (ADR 0017: Parameterized Recorded Inputs).

`fill --record-as VAR` already protects the *originating* fill: the live request uses the real value, but the recorded/published representation uses `${VAR}`. After #1349, a later read-only action (`wait`, `is`, `get`) records `target-v1` identity evidence from the *resolved* accessibility tree — and that evidence can independently contain an app-rendered echo of the earlier parameterized value (the filled field's own displayed value, a search result, a confirmation label, or a caller-authored destination landmark). Because that later action has no memory of the earlier fill's literal, the secret could re-enter session state and the published `.ad` script through a completely different, unparameterized action.

This PR resolves the boundary the issue's triage comment flagged as needing an explicit maintainer decision: the guarantee is now **recording-session-scoped**, not fill-step-scoped (option 2 from the issue's "Desired outcome"), using the smallest explicit, ephemeral mechanism that can recognize a later echo.

## Design

- `SessionState` gains `recordedFillLiterals?: Map<string, string>` — an in-memory `literal -> placeholder` registry populated **only** from the same `(literal, placeholder)` pair `fill --record-as` already computes for its own boundary. Never serialized (not to the script, event log, or diagnostics), no lookup-by-name API, dropped with the session. This is *not* a reintroduction of ADR 0017's rejected "secret-to-name table" — that rule rejected retaining state to influence a *naming* decision for new `--record-as` calls; this map only redacts an already-author-named value out of unrelated later evidence.
- **Result/event/backend-output fields** (display data, never compared at replay): content-aware substring redaction, reusing the fill boundary's existing recursive scrub, applied for every literal registered so far in the session (longest-literal-first, so one registered value that's a substring of another is never partially consumed).
- **`target-v1`/`targets-v1` identity evidence** (the fields replay's own classification actually compares) is *never* silently text-substituted while still claiming a trustworthy identity — replay compares against the live tree, which legitimately re-renders the real value again, so a placeholder written into a recorded identity field could never verify correctly. Instead:
  - **Landmark mode (`wait`)**: an echo is treated exactly like #1349's existing identity-empty case — no annotation is recorded, and the wait keeps its selector-existence semantics. Since ADR 0016's destination guard requires `verification: "verified"`, an echoing landmark simply stops qualifying as a guard; publication refuses it and directs the author to a stable landmark — reproducing the issue's own motivating scenario (switching the guard to the stable `Apps` landmark) as an *enforced* outcome.
  - **Action mode (`get`, `is`, mutating element-targeting actions)**: evidence is required by ADR 0012/0016 and is never dropped. The literal-bearing label is redacted (content-aware, substring-based) and `verification` is downgraded to `"unverifiable"` — the same fail-closed downgrade decision 3's writer-parser invariant already uses for an oversized payload — failing the action's replay loudly instead of silently weakening it or publishing a label that could never match again.
- A whitespace-only or empty fill value is excluded from the session-wide registry (kept only fill-step-scoped protection), and the originating fill's own entry is never passed through the session-wide pass using the pair it just contributed — both to avoid collateral damage on short/incidental substrings.
- Two distinct `--record-as` names that happen to share the same literal value are genuinely indistinguishable from a later echo's perspective; the first-registered name wins deterministically (the literal is redacted either way).

## ADR changes

- **ADR 0017**: new "Session-scoped echo protection (amendment, #1398)" section documenting the mechanism, the reconciliation with "no secret-to-name table", and explicit scope limits.
- **ADR 0012**: cross-references in the #1349 wait-landmark amendment and the writer-parser invariant's `unverifiable` downgrade.
- **ADR 0016**: cross-references in the destination-guard identity amendment and the sensitive-inputs section.

## Validation

- `pnpm check:quick` (lint + typecheck)
- `pnpm check:layering` (182/182 — bumped the R7 daemon-modularity ratchet for the new `SessionState` field/owner claim)
- `pnpm exec vitest run --project unit-core` — full suite green (2 pre-existing failures on `main`, unrelated to this change, confirmed via `git stash`)
- `pnpm exec vitest run --project provider-integration` — full suite green (54/54 files, 161/161 tests)
- New unit tests in `session-action-recorder.test.ts` covering: landmark-mode drop (own label and ancestry-only echo), action-mode redact+unverifiable, multiple literals in one label, dual-endpoint (`targetEvidences`) evidence, longest-literal-first ordering, whitespace-literal exclusion, first-registered-name-wins for a shared literal, and ordinary (non-parameterized) recordings left unchanged.
- New provider-integration regression test exercising the **real** provider/publication path end-to-end: a parameterized fill followed by a read-only `wait` whose resolved identity echoes the literal — proves the published `.ad` never contains the secret, the echoing wait can't serve as the destination guard (refused with the existing recovery hint), and a stable landmark recovers a valid, verified guard.
- Two rounds of adversarial code review; both real findings (a `.find()` that only redacted the first of several literals echoed in one label, and a silent last-write-wins collision when two distinct variable names share the same value) were fixed and each has its own regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RarRVX34ZW25TJejBZJ2Ui


---
_Generated by [Claude Code](https://claude.ai/code/session_01RarRVX34ZW25TJejBZJ2Ui)_