### PR TITLE
feat: add Linux command evidence lane

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -136,6 +136,14 @@ jobs:
             --report-junit
             test/artifacts/replays-linux.junit.xml
 
+      - name: Reset daemon before Linux command evidence
+        run: pnpm clean:daemon
+
+      - name: Execute Linux command evidence
+        uses: ./.github/actions/run-gate
+        with:
+          gate: linux-command-evidence
+
       - name: Upload Linux artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/package.json
+++ b/package.json
@@ -192,7 +192,8 @@
     "test:replay:ios-device": "node --experimental-strip-types src/bin.ts test test/integration/replays/ios/device",
     "test:replay:android": "node --experimental-strip-types src/bin.ts test test/integration/replays/android/emulator",
     "test:replay:macos": "node --experimental-strip-types src/bin.ts test test/integration/replays/macos",
-    "test:replay:linux": "node --experimental-strip-types src/bin.ts test test/integration/replays/linux"
+    "test:replay:linux": "node --experimental-strip-types src/bin.ts test test/integration/replays/linux",
+    "test:linux:command-evidence": "node --experimental-strip-types test/integration/linux-e2e/live-runner.ts"
   },
   "files": [
     "bin",

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -145,6 +145,12 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
   gate('replay-ios-device', 'iOS physical device replay suite', 'test:replay:ios-device', false),
   gate('replay-macos', 'macOS replay suite', 'test:replay:macos', false),
   gate('replay-linux', 'Linux replay suite', 'test:replay:linux', false),
+  gate(
+    'linux-command-evidence',
+    'Linux command evidence suite',
+    'test:linux:command-evidence',
+    false,
+  ),
   gate('replay-android', 'Android replay suite', 'test:replay:android', false),
 ];
 

--- a/scripts/check-affected/device-lanes.test.ts
+++ b/scripts/check-affected/device-lanes.test.ts
@@ -13,7 +13,7 @@ function lanes(file: string): CheckId[] {
   const plan = selectChecks({ changedFiles: [file] });
   assert.equal(plan.failOpen, false, `${file} must not fail open`);
   return plan.checks.filter((id) =>
-    /^macos-coverage$|^replay-|^web-smoke$|^swift-runner-|^macos-helper$|^android-helpers$/.test(
+    /^macos-coverage$|^replay-|^linux-command-evidence$|^web-smoke$|^swift-runner-|^macos-helper$|^android-helpers$/.test(
       id,
     ),
   );
@@ -84,6 +84,7 @@ test('shared runtime surface owns every device lane', () => {
       'replay-ios-device',
       'replay-macos',
       'replay-linux',
+      'linux-command-evidence',
       'replay-android',
     ]);
   }
@@ -103,8 +104,11 @@ test('another family owns only its own lanes, so an Android-only change carries 
   assert.deepEqual(lanes('test/integration/android-emulator-e2e/live-runner.ts'), [
     'replay-android',
   ]);
-  assert.deepEqual(lanes('src/platforms/linux/snapshot.ts'), ['replay-linux']);
-  assert.deepEqual(lanes('linux/atspi-dump.py'), ['replay-linux']);
+  assert.deepEqual(lanes('src/platforms/linux/snapshot.ts'), [
+    'replay-linux',
+    'linux-command-evidence',
+  ]);
+  assert.deepEqual(lanes('linux/atspi-dump.py'), ['replay-linux', 'linux-command-evidence']);
   assert.deepEqual(lanes('src/platforms/web/provider.ts'), ['web-smoke']);
   assert.deepEqual(lanes('test/integration/smoke-web-platform.test.ts'), ['web-smoke']);
   // Families with no CI lane fall through to the static gates only.

--- a/scripts/check-affected/device-lanes.ts
+++ b/scripts/check-affected/device-lanes.ts
@@ -1,8 +1,8 @@
 // Device-lane ownership: which live device lanes a changed path can break (#1781 A9-2).
 //
 // The live lanes (`replay-ios`, `replay-ios-device`, `replay-macos`, `replay-android`,
-// `replay-linux`, `web-smoke`) drive the CLI and daemon against a real simulator, emulator,
-// desktop, or browser. Before this rule the selector could reach them only through a full
+// `replay-linux`, `linux-command-evidence`, `web-smoke`) drive the CLI and daemon against a real
+// simulator, emulator, desktop, or browser. Before this rule the selector could reach them only through a full
 // fail-open, so a TypeScript-only Apple change (`src/platforms/apple/**`) produced a plan
 // with no iOS check in it at all, and nothing could route `ios.yml` on the plan.
 //
@@ -42,7 +42,7 @@ const LEAF_LANES: Readonly<Record<Leaf, readonly CheckId[]>> = {
   macos: ['replay-macos'],
   apple: ['replay-ios', 'replay-ios-device', 'replay-macos'],
   android: ['replay-android'],
-  linux: ['replay-linux'],
+  linux: ['replay-linux', 'linux-command-evidence'],
   web: ['web-smoke'],
   harmonyos: [],
   vega: [],

--- a/scripts/check-affected/model.ts
+++ b/scripts/check-affected/model.ts
@@ -84,6 +84,7 @@ export type CheckId =
   | 'replay-ios-device'
   | 'replay-macos'
   | 'replay-linux'
+  | 'linux-command-evidence'
   | 'replay-android';
 
 // The complete local check universe. A fail-open plan selects all of these;
@@ -144,6 +145,7 @@ export const ALL_CHECKS: readonly CheckId[] = [
   'replay-ios-device',
   'replay-macos',
   'replay-linux',
+  'linux-command-evidence',
   'replay-android',
 ];
 

--- a/test/integration/cli-json.ts
+++ b/test/integration/cli-json.ts
@@ -9,17 +9,19 @@ export type CliJsonResult = {
   stderr: string;
 };
 
-export function runSourceCliJsonSync(
-  args: string[],
-  options?: { env?: NodeJS.ProcessEnv },
-): CliJsonResult {
+export type CliJsonOptions = {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+};
+
+export function runSourceCliJsonSync(args: string[], options?: CliJsonOptions): CliJsonResult {
   const result = runCmdSync(
     process.execPath,
     ['--experimental-strip-types', 'src/bin.ts', ...args],
     {
       allowFailure: true,
       env: options?.env,
-      timeoutMs: CLI_TIMEOUT_MS,
+      timeoutMs: options?.timeoutMs ?? CLI_TIMEOUT_MS,
     },
   );
   return cliJsonResult(result);

--- a/test/integration/linux-e2e/command-evidence.ad
+++ b/test/integration/linux-e2e/command-evidence.ad
@@ -1,0 +1,8 @@
+# This script is intentionally outside replays/linux: the existing Linux replay smoke scope is
+# kept unchanged while this lane proves the public test and replay commands independently.
+context platform=linux target=desktop
+open gnome-calculator --relaunch
+wait "appname=gnome-calculator || windowtitle=Calculator || label=Calculator || label=0 || label=1 || label=5" 15000
+snapshot -i
+find role "button" exists
+close

--- a/test/integration/linux-e2e/command-evidence.ad
+++ b/test/integration/linux-e2e/command-evidence.ad
@@ -1,5 +1,6 @@
 # This script is intentionally outside replays/linux: the existing Linux replay smoke scope is
-# kept unchanged while this lane proves the public test and replay commands independently.
+# kept unchanged. It owns the lane's test and replay evidence; the runner owns the other direct
+# command-specific evidence.
 context platform=linux target=desktop
 open gnome-calculator --relaunch
 wait "appname=gnome-calculator || windowtitle=Calculator || label=Calculator || label=0 || label=1 || label=5" 15000

--- a/test/integration/linux-e2e/command-evidence.ts
+++ b/test/integration/linux-e2e/command-evidence.ts
@@ -2,7 +2,6 @@ import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 
 /** Commands exercised by the separate Linux/Xvfb command-evidence lane. */
 export const LINUX_COMMAND_EVIDENCE_COMMANDS = [
-  PUBLIC_COMMANDS.artifacts,
   PUBLIC_COMMANDS.capabilities,
   PUBLIC_COMMANDS.doctor,
   PUBLIC_COMMANDS.events,

--- a/test/integration/linux-e2e/command-evidence.ts
+++ b/test/integration/linux-e2e/command-evidence.ts
@@ -1,0 +1,18 @@
+import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+
+/** Commands exercised by the separate Linux/Xvfb command-evidence lane. */
+export const LINUX_COMMAND_EVIDENCE_COMMANDS = [
+  PUBLIC_COMMANDS.artifacts,
+  PUBLIC_COMMANDS.capabilities,
+  PUBLIC_COMMANDS.doctor,
+  PUBLIC_COMMANDS.events,
+  PUBLIC_COMMANDS.replay,
+  PUBLIC_COMMANDS.test,
+  PUBLIC_COMMANDS.batch,
+  PUBLIC_COMMANDS.diff,
+  PUBLIC_COMMANDS.find,
+  PUBLIC_COMMANDS.swipe,
+] as const;
+
+export const LINUX_COMMAND_EVIDENCE_SCRIPT =
+  'test/integration/linux-e2e/command-evidence.ad' as const;

--- a/test/integration/linux-e2e/coverage-manifest.ts
+++ b/test/integration/linux-e2e/coverage-manifest.ts
@@ -96,7 +96,9 @@ const gap = (assertion: string): LinuxPlatformCoverageEntry => ({
  * work, not an implicit claim that a generic command works.
  */
 export const LINUX_PLATFORM_COVERAGE = {
-  [C.artifacts]: commandEvidenceLive('the command-evidence lane lists a live screenshot artifact'),
+  [C.artifacts]: gap(
+    'No Linux live command creates a downloadable daemon artifact for inventory yet',
+  ),
   [C.devices]: contract(
     LINUX_PROVIDER_EVIDENCE.path,
     LINUX_PROVIDER_EVIDENCE.test,

--- a/test/integration/linux-e2e/coverage-manifest.ts
+++ b/test/integration/linux-e2e/coverage-manifest.ts
@@ -36,6 +36,11 @@ export const LINUX_REPLAY_EVIDENCE: RepositoryEvidence = {
   test: '# Smoke test for Linux desktop automation on CI.',
 };
 
+export const LINUX_COMMAND_EVIDENCE: RepositoryEvidence = {
+  path: 'test/integration/linux-e2e/live-runner.ts',
+  test: 'runLinuxCommandEvidence',
+};
+
 const LINUX_PROVIDER_EVIDENCE: RepositoryEvidence = {
   path: 'test/integration/provider-scenarios/linux-desktop.test.ts',
   test: 'Provider-backed integration Linux desktop flow uses semantic desktop and input providers',
@@ -50,11 +55,16 @@ const LINUX_CAPABILITY_DECLARATION_PATH = 'src/core/command-descriptor/registry.
 const LINUX_CAPABILITY_DECLARATION = 'linux: LINUX_NONE';
 
 const C = PUBLIC_COMMANDS;
-const live = (assertion: string): LinuxPlatformCoverageEntry => ({
+const live = (
+  assertion: string,
+  owner: RepositoryEvidence = LINUX_REPLAY_EVIDENCE,
+): LinuxPlatformCoverageEntry => ({
   assertion,
   level: 'live',
-  owner: LINUX_REPLAY_EVIDENCE,
+  owner,
 });
+const commandEvidenceLive = (assertion: string): LinuxPlatformCoverageEntry =>
+  live(assertion, LINUX_COMMAND_EVIDENCE);
 const contract = (path: string, test: string, assertion: string): LinuxPlatformCoverageEntry => ({
   assertion,
   level: 'command-contract',
@@ -78,21 +88,24 @@ const gap = (assertion: string): LinuxPlatformCoverageEntry => ({
 /**
  * One primary, observable owner for every public command on the Linux desktop.
  *
- * Live rows are limited to the existing Linux replay. Contract rows cite the
- * existing provider scenario or dedicated Linux unit/runtime evidence; they do
- * not turn mocked provider calls into live desktop claims. Capability denials
- * are derived from the owning command-descriptor matrix. Known gaps are
- * explicit follow-up work, not an implicit claim that a generic command works.
+ * Live rows cite either the existing Linux replay or the separate command-evidence
+ * lane. The existing replay scope stays unchanged. Contract rows cite the existing
+ * provider scenario or dedicated Linux unit/runtime evidence; they do not turn
+ * mocked provider calls into live desktop claims. Capability denials are derived
+ * from the owning command-descriptor matrix. Known gaps are explicit follow-up
+ * work, not an implicit claim that a generic command works.
  */
 export const LINUX_PLATFORM_COVERAGE = {
-  [C.artifacts]: gap('No Linux-specific artifact inventory command evidence exists yet'),
+  [C.artifacts]: commandEvidenceLive('the command-evidence lane lists a live screenshot artifact'),
   [C.devices]: contract(
     LINUX_PROVIDER_EVIDENCE.path,
     LINUX_PROVIDER_EVIDENCE.test,
     'Linux provider scenario inventories the selected desktop device through the daemon client',
   ),
-  [C.capabilities]: gap('No Linux-specific capabilities command evidence exists yet'),
-  [C.doctor]: gap('No Linux-specific doctor command evidence exists yet'),
+  [C.capabilities]: commandEvidenceLive(
+    'the command-evidence lane reads capabilities for the selected Linux desktop',
+  ),
+  [C.doctor]: commandEvidenceLive('the command-evidence lane reads Linux doctor diagnostics'),
   [C.apps]: contract(
     LINUX_RUNTIME_EVIDENCE.path,
     LINUX_RUNTIME_EVIDENCE.test,
@@ -111,15 +124,21 @@ export const LINUX_PLATFORM_COVERAGE = {
   ),
   [C.perf]: denial('perf', 'Linux capability declaration rejects native performance inspection'),
   [C.logs]: gap('No Linux-specific app-log command evidence exists yet'),
-  [C.events]: gap('No Linux-specific session event command evidence exists yet'),
+  [C.events]: commandEvidenceLive(
+    'the command-evidence lane reads the event timeline produced by its Linux session',
+  ),
   [C.network]: contract(
     LINUX_RUNTIME_EVIDENCE.path,
     LINUX_RUNTIME_EVIDENCE.test,
     'Linux runtime facts explicitly report network capture unavailable',
   ),
   [C.audio]: denial('audio', 'Linux capability declaration rejects native audio probing'),
-  [C.replay]: gap('No Linux-specific replay command evidence exists yet'),
-  [C.test]: gap('No Linux-specific test-suite command evidence exists yet'),
+  [C.replay]: commandEvidenceLive(
+    'the command-evidence lane replays a dedicated Linux script with a live session',
+  ),
+  [C.test]: commandEvidenceLive(
+    'the command-evidence lane runs a dedicated Linux script as a test suite',
+  ),
   [C.clipboard]: contract(
     'src/platforms/linux/__tests__/clipboard.test.ts',
     'writeLinuxClipboard uses xclip with stdin on X11',
@@ -143,14 +162,16 @@ export const LINUX_PLATFORM_COVERAGE = {
     LINUX_RUNTIME_EVIDENCE.test,
     'Linux runtime facts explicitly report Apple runner preparation unavailable',
   ),
-  [C.batch]: gap('No Linux-specific batch command evidence exists yet'),
+  [C.batch]: commandEvidenceLive('the command-evidence lane executes two live Linux read steps'),
   [C.close]: contract(
     LINUX_PROVIDER_EVIDENCE.path,
     LINUX_PROVIDER_EVIDENCE.test,
     'Linux provider scenario closes the calculator and observes the desktop close call',
   ),
   [C.snapshot]: live('the existing Linux replay captures the calculator accessibility tree'),
-  [C.diff]: gap('No Linux-specific snapshot diff command evidence exists yet'),
+  [C.diff]: commandEvidenceLive(
+    'the command-evidence lane observes a non-empty calculator snapshot mutation',
+  ),
   [C.wait]: live('the existing Linux replay waits for an observable calculator landmark'),
   [C.alert]: denial('alert', 'Linux capability declaration rejects native alert operations'),
   [C.settings]: denial(
@@ -163,7 +184,7 @@ export const LINUX_PLATFORM_COVERAGE = {
   ),
   [C.record]: gap('No Linux-specific recording command evidence exists yet'),
   [C.trace]: gap('No Linux-specific trace command evidence exists yet'),
-  [C.find]: gap('No Linux-specific find command evidence exists yet'),
+  [C.find]: commandEvidenceLive('the command-evidence lane resolves a live AT-SPI role match'),
   // Promoted from command-contract to live: the desktop replay now clicks a resolved digit
   // button on real Linux hardware and the downstream wait only passes if the click landed
   // (formerly missed — AT-SPI extents were computed screen-absolute-wrong under GTK4; see
@@ -230,7 +251,7 @@ export const LINUX_PLATFORM_COVERAGE = {
     'scrollLinux uses ydotool mousemove --wheel for vertical scroll',
     'Linux scroll dispatch uses the Wayland ydotool wheel primitive',
   ),
-  [C.swipe]: gap('No Linux-specific public swipe command evidence exists yet'),
+  [C.swipe]: commandEvidenceLive('the command-evidence lane dispatches a coordinate swipe'),
   // Promoted from command-contract to live by #1925: the desktop replay now runs a coordinate
   // focus on real Linux hardware, so the migrated `focusPoint` path has live changed-path
   // evidence rather than only the provider scenario at LINUX_PROVIDER_EVIDENCE.
@@ -254,6 +275,16 @@ export const LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY = buildCoverageClass
 
 export function liveCommandsForLinuxReplay(): PublicCommand[] {
   return Object.entries(LINUX_PLATFORM_COVERAGE)
-    .filter(([, entry]) => entry.level === 'live')
+    .filter(
+      ([, entry]) => entry.level === 'live' && entry.owner.path === LINUX_REPLAY_EVIDENCE.path,
+    )
+    .map(([command]) => command as PublicCommand);
+}
+
+export function liveCommandsForLinuxCommandEvidence(): PublicCommand[] {
+  return Object.entries(LINUX_PLATFORM_COVERAGE)
+    .filter(
+      ([, entry]) => entry.level === 'live' && entry.owner.path === LINUX_COMMAND_EVIDENCE.path,
+    )
     .map(([command]) => command as PublicCommand);
 }

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -154,7 +154,7 @@ async function runDiffEvidence(context: LinuxContext): Promise<void> {
 }
 
 async function runSwipeEvidence(context: LinuxContext): Promise<void> {
-  await runStep(context, 'swipe across the Linux desktop', ['swipe', '500', '700', '500', '500']);
+  await runStep(context, 'swipe across the Linux desktop', ['swipe', '100', '400', '100', '300']);
   verifyCommand(context, C.swipe, 'coordinate swipe reaches the Linux input runtime');
 }
 

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -121,7 +121,7 @@ async function runFindEvidence(context: LinuxContext): Promise<void> {
 }
 
 async function runDiffEvidence(context: LinuxContext): Promise<void> {
-  await runStep(context, 'close the replay session before diff reset', ['close']);
+  await closeIfOpen(context);
   await runStep(context, 'reset the calculator before diff', [
     'open',
     'gnome-calculator',

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -98,11 +98,14 @@ async function runCommandDiscoveryEvidence(context: LinuxContext): Promise<void>
   assert.equal(suite.commandsByScript.get(SCRIPT_PATH)?.includes('find'), true);
   verifyCommand(context, C.test, 'the Linux command-evidence script passes through test');
 
-  await runStep(context, 'replay the command-evidence script', [
+  const replay = await runStep(context, 'replay the command-evidence script', [
     'replay',
     SCRIPT_PATH,
     '--keep-session',
   ]);
+  assert.equal(replay.json?.data?.sessionActive, true, JSON.stringify(replay.json));
+  assert.equal(typeof replay.json?.data?.session, 'string', JSON.stringify(replay.json));
+  context.session = replay.json.data.session;
   verifyCommand(context, C.replay, 'the Linux command-evidence script passes through replay');
 }
 

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -58,6 +58,10 @@ async function runLinuxCommandEvidence(): Promise<void> {
     artifactRoot: 'test/artifacts/linux-command-evidence',
     session: `${SCENARIO_ID}-${process.pid}`,
   });
+  context.env = {
+    ...context.env,
+    AGENT_DEVICE_STATE_DIR: path.join(context.artifactDir, 'daemon-state'),
+  };
   const primaryError = await captureError(() =>
     runScenario(context, {
       id: SCENARIO_ID,

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -121,6 +121,7 @@ async function runFindEvidence(context: LinuxContext): Promise<void> {
 }
 
 async function runDiffEvidence(context: LinuxContext): Promise<void> {
+  await runStep(context, 'close the replay session before diff reset', ['close']);
   await runStep(context, 'reset the calculator before diff', [
     'open',
     'gnome-calculator',

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -116,7 +116,7 @@ async function runFindEvidence(context: LinuxContext): Promise<void> {
     'exists',
     '--first',
   ]);
-  assert.equal(find.json?.found, true, JSON.stringify(find.json));
+  assert.equal(find.json?.data?.found, true, JSON.stringify(find.json));
   verifyCommand(context, C.find, 'find resolves a live AT-SPI role match');
 }
 

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -14,7 +14,6 @@ import {
   createLiveDeviceHarness,
   type LiveDeviceContext,
 } from '../live-device-e2e/runtime.ts';
-import { assertPngFile } from '../provider-scenarios/assertions.ts';
 import { runLiveReplayTestSuite } from '../live-device-e2e/replay-suite.ts';
 import { writeCoverageReport } from '../live-device-e2e/coverage.ts';
 import {
@@ -75,7 +74,7 @@ async function runLinuxCommandEvidence(): Promise<void> {
 async function runCommandEvidence(context: LinuxContext): Promise<void> {
   await runCommandDiscoveryEvidence(context);
   await runSnapshotEvidence(context);
-  await runArtifactEvidence(context);
+  await runEventEvidence(context);
 }
 
 async function runCommandDiscoveryEvidence(context: LinuxContext): Promise<void> {
@@ -186,24 +185,7 @@ function assertLinuxBatchResults(json: any): void {
   assert.equal(second.command, 'snapshot', JSON.stringify(json));
 }
 
-async function runArtifactEvidence(context: LinuxContext): Promise<void> {
-  const screenshotPath = path.join(context.artifactDir, 'linux-command-evidence.png');
-  await runStep(context, 'capture a Linux artifact for inventory', ['screenshot', screenshotPath]);
-  assertPngFile(screenshotPath);
-
-  const artifacts = await runStep(context, 'list Linux session artifacts', ['artifacts']);
-  const artifactEntries = artifacts.json?.data?.artifacts;
-  assert.ok(Array.isArray(artifactEntries), JSON.stringify(artifacts.json));
-  assert.ok(
-    artifactEntries.some(
-      (entry: Record<string, unknown>) =>
-        entry.artifactType === 'screenshot' &&
-        String(entry.path ?? entry.filename ?? '').includes(path.basename(screenshotPath)),
-    ),
-    `Linux artifact inventory did not include the screenshot: ${JSON.stringify(artifacts.json)}`,
-  );
-  verifyCommand(context, C.artifacts, 'artifact inventory exposes the live screenshot');
-
+async function runEventEvidence(context: LinuxContext): Promise<void> {
   const timeline = await collectPagedEventTimeline((cursor) => readLinuxEventPage(context, cursor));
   for (const command of [C.open, C.snapshot]) {
     assert.ok(

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
+import { runSourceCliJsonSync } from '../cli-json.ts';
+import { assertJsonContains } from '../live-device-e2e/assertions.ts';
+import {
+  createLiveDeviceContext,
+  createLiveDeviceHarness,
+  type LiveDeviceContext,
+} from '../live-device-e2e/runtime.ts';
+import { assertPngFile } from '../provider-scenarios/assertions.ts';
+import { runLiveReplayTestSuite } from '../live-device-e2e/replay-suite.ts';
+import { writeCoverageReport } from '../live-device-e2e/coverage.ts';
+import {
+  LINUX_COMMAND_EVIDENCE_COMMANDS,
+  LINUX_COMMAND_EVIDENCE_SCRIPT,
+} from './command-evidence.ts';
+
+const C = PUBLIC_COMMANDS;
+const LINUX_CALCULATOR_LANDMARK =
+  'appname=gnome-calculator || windowtitle=Calculator || label=Calculator || label=0 || label=1 || label=5';
+const SCENARIO_ID = 'linux-command-evidence';
+const SCRIPT_PATH = path.resolve(LINUX_COMMAND_EVIDENCE_SCRIPT);
+
+type LinuxBehavior = 'command-evidence';
+type LinuxContext = LiveDeviceContext<LinuxBehavior>;
+
+const harness = createLiveDeviceHarness<LinuxContext, LinuxBehavior>({
+  behaviorsForScenario: () => [],
+  commandsForScenario: () => LINUX_COMMAND_EVIDENCE_COMMANDS,
+  commonFlags: (context, args) => [
+    ...args,
+    '--platform',
+    'linux',
+    '--session',
+    context.session,
+    '--json',
+  ],
+  runCli: async (args, env) => runSourceCliJsonSync(args, { env }),
+  writeCoverageReport: (context) =>
+    writeCoverageReport(context, {
+      platform: 'linux',
+      script: SCRIPT_PATH,
+    }),
+});
+
+const { runScenario, runStep, sessionExists, verifyCommand } = harness;
+
+async function runLinuxCommandEvidence(): Promise<void> {
+  const context = createLiveDeviceContext<LinuxBehavior>({
+    artifactRoot: 'test/artifacts/linux-command-evidence',
+    session: `${SCENARIO_ID}-${process.pid}`,
+  });
+  const primaryError = await captureError(() =>
+    runScenario(context, {
+      id: SCENARIO_ID,
+      run: runCommandEvidence,
+    }),
+  );
+  const cleanupError = await finalize(context);
+  throwErrors(primaryError, cleanupError);
+}
+
+async function runCommandEvidence(context: LinuxContext): Promise<void> {
+  await runCommandDiscoveryEvidence(context);
+  await runSnapshotEvidence(context);
+  await runArtifactEvidence(context);
+}
+
+async function runCommandDiscoveryEvidence(context: LinuxContext): Promise<void> {
+  const capabilities = await runStep(context, 'read Linux capabilities', ['capabilities']);
+  assertJsonContains(capabilities, 'find', 'Linux capabilities should expose find');
+  assertJsonContains(capabilities, 'swipe', 'Linux capabilities should expose swipe');
+  verifyCommand(
+    context,
+    C.capabilities,
+    'Linux capabilities reports command admission for the selected desktop',
+  );
+
+  const doctor = await runStep(context, 'run Linux doctor', ['doctor']);
+  assertJsonContains(doctor, 'linux', 'Linux doctor should report the selected platform');
+  verifyCommand(context, C.doctor, 'Linux doctor returns platform-specific diagnostics');
+
+  const suite = await runLiveReplayTestSuite({
+    context,
+    runStep,
+    step: 'run the command-evidence script as a test suite',
+    scripts: [SCRIPT_PATH],
+    artifactName: 'command-evidence-test',
+  });
+  assert.equal(suite.commandsByScript.get(SCRIPT_PATH)?.includes('find'), true);
+  verifyCommand(context, C.test, 'the Linux command-evidence script passes through test');
+
+  await runStep(context, 'replay the command-evidence script', [
+    'replay',
+    SCRIPT_PATH,
+    '--keep-session',
+  ]);
+  verifyCommand(context, C.replay, 'the Linux command-evidence script passes through replay');
+}
+
+async function runSnapshotEvidence(context: LinuxContext): Promise<void> {
+  await runFindEvidence(context);
+  await runDiffEvidence(context);
+  await runSwipeEvidence(context);
+  await runBatchEvidence(context);
+}
+
+async function runFindEvidence(context: LinuxContext): Promise<void> {
+  const find = await runStep(context, 'find a calculator button', [
+    'find',
+    'role',
+    'button',
+    'exists',
+    '--first',
+  ]);
+  assertJsonContains(find, 'button', 'find should return a calculator button match');
+  verifyCommand(context, C.find, 'find resolves a live AT-SPI role match');
+}
+
+async function runDiffEvidence(context: LinuxContext): Promise<void> {
+  await runStep(context, 'capture the diff baseline', ['snapshot', '-i']);
+  await runStep(context, 'mutate the calculator before diff', ['click', 'role=button label=1']);
+  const diff = await runStep(context, 'read the live snapshot diff', ['diff', 'snapshot', '-i']);
+  const summary = diff.json!.data!.summary!;
+  const additions = Number(summary.additions);
+  const removals = Number(summary.removals);
+  assert.ok(
+    additions + removals > 0,
+    `expected a non-empty Linux snapshot diff: ${JSON.stringify(diff.json)}`,
+  );
+  verifyCommand(context, C.diff, 'snapshot diff observes the calculator mutation');
+}
+
+async function runSwipeEvidence(context: LinuxContext): Promise<void> {
+  await runStep(context, 'swipe across the Linux desktop', ['swipe', '500', '700', '500', '500']);
+  verifyCommand(context, C.swipe, 'coordinate swipe reaches the Linux input runtime');
+}
+
+async function runBatchEvidence(context: LinuxContext): Promise<void> {
+  const batchSteps = JSON.stringify([
+    { command: 'is', input: { predicate: 'exists', selector: LINUX_CALCULATOR_LANDMARK } },
+    { command: 'snapshot', input: { interactiveOnly: true } },
+  ]);
+  const batch = await runStep(context, 'run a Linux batch of live reads', [
+    'batch',
+    '--steps',
+    batchSteps,
+  ]);
+  assert.equal(batch.json?.data?.executed, 2, JSON.stringify(batch.json));
+  assert.equal(batch.json?.data?.results?.length, 2, JSON.stringify(batch.json));
+  verifyCommand(context, C.batch, 'batch executes two successful Linux session reads');
+}
+
+async function runArtifactEvidence(context: LinuxContext): Promise<void> {
+  const screenshotPath = path.join(context.artifactDir, 'linux-command-evidence.png');
+  await runStep(context, 'capture a Linux artifact for inventory', ['screenshot', screenshotPath]);
+  assertPngFile(screenshotPath);
+
+  const artifacts = await runStep(context, 'list Linux session artifacts', ['artifacts']);
+  const artifactEntries = artifacts.json?.data?.artifacts;
+  assert.ok(Array.isArray(artifactEntries), JSON.stringify(artifacts.json));
+  assert.ok(
+    artifactEntries.some(
+      (entry: Record<string, unknown>) =>
+        entry.artifactType === 'screenshot' ||
+        String(entry.path ?? entry.filename ?? '').includes(path.basename(screenshotPath)),
+    ),
+    `Linux artifact inventory did not include the screenshot: ${JSON.stringify(artifacts.json)}`,
+  );
+  verifyCommand(context, C.artifacts, 'artifact inventory exposes the live screenshot');
+
+  const events = await runStep(context, 'read Linux session events', ['events']);
+  const eventEntries = events.json?.data?.events;
+  assert.ok(Array.isArray(eventEntries) && eventEntries.length > 0, JSON.stringify(events.json));
+  verifyCommand(context, C.events, 'event timeline contains requests from the Linux session');
+}
+
+async function finalize(context: LinuxContext): Promise<unknown> {
+  const closeError = await captureError(() => closeIfOpen(context));
+  const reportError = await captureError(() => {
+    writeCoverageReport(context, {
+      platform: 'linux',
+      script: SCRIPT_PATH,
+    });
+  });
+  return combineErrors([closeError, reportError]);
+}
+
+async function closeIfOpen(context: LinuxContext): Promise<void> {
+  if (!(await sessionExists(context))) return;
+  await runStep(context, 'close the Linux command-evidence session', ['close']);
+}
+
+async function captureError(action: () => Promise<void> | void): Promise<unknown | undefined> {
+  try {
+    await action();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
+
+function combineErrors(errors: readonly (unknown | undefined)[]): unknown {
+  const failures = errors.filter((error): error is unknown => error !== undefined);
+  if (failures.length === 0) return undefined;
+  if (failures.length === 1) return failures[0];
+  return new AggregateError(failures, 'Linux command evidence cleanup failed');
+}
+
+function throwErrors(primaryError: unknown | undefined, cleanupError: unknown): void {
+  if (primaryError === undefined) {
+    if (cleanupError !== undefined) throw cleanupError;
+    return;
+  }
+  if (cleanupError === undefined) throw primaryError;
+  throw new AggregateError(
+    [primaryError, cleanupError],
+    'Linux command evidence failed and cleanup also failed',
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await runLinuxCommandEvidence();
+}

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -121,6 +121,11 @@ async function runFindEvidence(context: LinuxContext): Promise<void> {
 }
 
 async function runDiffEvidence(context: LinuxContext): Promise<void> {
+  await runStep(context, 'reset the calculator before diff', [
+    'open',
+    'gnome-calculator',
+    '--relaunch',
+  ]);
   await runStep(context, 'capture the diff baseline', ['snapshot', '-i']);
   await runStep(context, 'mutate the calculator before diff', ['click', 'role=button label=1']);
   const diff = await runStep(context, 'read the live snapshot diff', ['diff', 'snapshot', '-i']);

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -6,6 +6,10 @@ import { PUBLIC_COMMANDS } from '../../../src/command-catalog.ts';
 import { runSourceCliJsonSync } from '../cli-json.ts';
 import { assertJsonContains } from '../live-device-e2e/assertions.ts';
 import {
+  collectPagedEventTimeline,
+  type EventTimelinePage,
+} from '../live-device-e2e/event-timeline.ts';
+import {
   createLiveDeviceContext,
   createLiveDeviceHarness,
   type LiveDeviceContext,
@@ -156,9 +160,22 @@ async function runBatchEvidence(context: LinuxContext): Promise<void> {
     '--steps',
     batchSteps,
   ]);
-  assert.equal(batch.json?.data?.executed, 2, JSON.stringify(batch.json));
-  assert.equal(batch.json?.data?.results?.length, 2, JSON.stringify(batch.json));
+  assertLinuxBatchResults(batch.json);
   verifyCommand(context, C.batch, 'batch executes two successful Linux session reads');
+}
+
+function assertLinuxBatchResults(json: any): void {
+  const data = json?.data;
+  assert.ok(data, JSON.stringify(json));
+  assert.equal(data.executed, 2, JSON.stringify(json));
+  const results = data.results;
+  assert.ok(Array.isArray(results), JSON.stringify(json));
+  assert.equal(results.length, 2, JSON.stringify(json));
+  const first = results[0] as { command?: string; data?: { pass?: boolean } };
+  const second = results[1] as { command?: string };
+  assert.equal(first.command, 'is', JSON.stringify(json));
+  assert.equal(first.data?.pass, true, JSON.stringify(json));
+  assert.equal(second.command, 'snapshot', JSON.stringify(json));
 }
 
 async function runArtifactEvidence(context: LinuxContext): Promise<void> {
@@ -172,17 +189,33 @@ async function runArtifactEvidence(context: LinuxContext): Promise<void> {
   assert.ok(
     artifactEntries.some(
       (entry: Record<string, unknown>) =>
-        entry.artifactType === 'screenshot' ||
+        entry.artifactType === 'screenshot' &&
         String(entry.path ?? entry.filename ?? '').includes(path.basename(screenshotPath)),
     ),
     `Linux artifact inventory did not include the screenshot: ${JSON.stringify(artifacts.json)}`,
   );
   verifyCommand(context, C.artifacts, 'artifact inventory exposes the live screenshot');
 
-  const events = await runStep(context, 'read Linux session events', ['events']);
-  const eventEntries = events.json?.data?.events;
-  assert.ok(Array.isArray(eventEntries) && eventEntries.length > 0, JSON.stringify(events.json));
-  verifyCommand(context, C.events, 'event timeline contains requests from the Linux session');
+  const timeline = await collectPagedEventTimeline((cursor) => readLinuxEventPage(context, cursor));
+  for (const command of [C.open, C.snapshot]) {
+    assert.ok(
+      timeline.commands.includes(command),
+      `Linux events missing ${command}: ${JSON.stringify(timeline)}`,
+    );
+  }
+  verifyCommand(context, C.events, 'event timeline names open and snapshot from the Linux session');
+}
+
+async function readLinuxEventPage(
+  context: LinuxContext,
+  cursor: string | undefined,
+): Promise<EventTimelinePage> {
+  const args = ['events', '100'];
+  if (cursor !== undefined) args.push(cursor);
+  const events = await runStep(context, 'read Linux session events', args);
+  const json = events.json as { data?: EventTimelinePage };
+  assert.ok(json.data, JSON.stringify(events.json));
+  return json.data;
 }
 
 async function finalize(context: LinuxContext): Promise<unknown> {

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -106,6 +106,7 @@ async function runCommandDiscoveryEvidence(context: LinuxContext): Promise<void>
   assert.equal(replay.json?.data?.sessionActive, true, JSON.stringify(replay.json));
   assert.equal(typeof replay.json?.data?.session, 'string', JSON.stringify(replay.json));
   context.session = replay.json.data.session;
+  context.sessionOpen = true;
   verifyCommand(context, C.replay, 'the Linux command-evidence script passes through replay');
 }
 
@@ -233,7 +234,7 @@ async function finalize(context: LinuxContext): Promise<unknown> {
 }
 
 async function closeIfOpen(context: LinuxContext): Promise<void> {
-  if (!(await sessionExists(context))) return;
+  if (!context.sessionOpen && !(await sessionExists(context))) return;
   await runStep(context, 'close the Linux command-evidence session', ['close']);
 }
 

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -116,7 +116,7 @@ async function runFindEvidence(context: LinuxContext): Promise<void> {
     'exists',
     '--first',
   ]);
-  assertJsonContains(find, 'button', 'find should return a calculator button match');
+  assert.equal(find.json?.found, true, JSON.stringify(find.json));
   verifyCommand(context, C.find, 'find resolves a live AT-SPI role match');
 }
 

--- a/test/integration/linux-e2e/live-runner.ts
+++ b/test/integration/linux-e2e/live-runner.ts
@@ -38,7 +38,8 @@ const harness = createLiveDeviceHarness<LinuxContext, LinuxBehavior>({
     context.session,
     '--json',
   ],
-  runCli: async (args, env) => runSourceCliJsonSync(args, { env }),
+  runCli: async (args, env, options) =>
+    runSourceCliJsonSync(args, { env, timeoutMs: options?.timeoutMs }),
   writeCoverageReport: (context) =>
     writeCoverageReport(context, {
       platform: 'linux',

--- a/test/integration/live-device-e2e/runtime.ts
+++ b/test/integration/live-device-e2e/runtime.ts
@@ -44,6 +44,11 @@ type HarnessOptions<Context, BehaviorId extends string> = {
   behaviorsForScenario: (scenarioId: string) => readonly BehaviorId[];
   commandsForScenario: (scenarioId: string) => readonly string[];
   commonFlags: (context: Context, args: readonly string[]) => string[];
+  runCli?: (
+    args: string[],
+    env: NodeJS.ProcessEnv,
+    options?: { timeoutMs?: number },
+  ) => Promise<CliJsonResult>;
   writeCoverageReport: (context: Context) => void;
 };
 
@@ -120,7 +125,7 @@ export function createLiveDeviceHarness<
   ): Promise<CliJsonResult> {
     const fullArgs = buildStepArgs(context, args, stepOptions);
     const startedAt = Date.now();
-    const result = await runBuiltCliJson(fullArgs, context.env, {
+    const result = await (options.runCli ?? runBuiltCliJson)(fullArgs, context.env, {
       timeoutMs: stepOptions.timeoutMs,
     });
     const failedAsExpected = stepOptions.expectFailure === true && result.status !== 0;

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -46,12 +46,14 @@ test('Linux coverage exhaustively classifies the public catalog', () => {
 test('Linux coverage report has the expected classification counts', () => {
   assert.deepEqual(LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
     // focus (#1925), click, and type remain live via the existing replay. The separate
-    // command-evidence lane adds ten generic-command rows without changing that replay. Keyboard,
-    // orientation, and tv-remote remain fact-owned command-contract rows, not catalog denials.
+    // command-evidence lane adds nine generic-command rows without changing that replay. Artifact
+    // inventory remains a gap because local Linux screenshot paths are not daemon-downloadable.
+    // Keyboard, orientation, and tv-remote remain fact-owned command-contract rows, not catalog
+    // denials.
     capabilityDenial: 7,
     contract: 21,
-    gap: 8,
-    live: 18,
+    gap: 9,
+    live: 17,
     total: 54,
   });
 

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -82,6 +82,11 @@ test('Linux command-evidence claims name every executable lane command', () => {
   const runnerPath = path.resolve(LINUX_COMMAND_EVIDENCE.path);
   const runnerSource = fs.readFileSync(runnerPath, 'utf8');
   assert.ok(runnerSource.includes(LINUX_COMMAND_EVIDENCE.test));
+  assert.match(
+    runnerSource,
+    /runSourceCliJsonSync\(args, \{ env, timeoutMs: options\?\.timeoutMs \}\)/,
+    'Linux source CLI adapter must forward the shared harness timeout bound',
+  );
 
   const scriptPath = path.resolve(LINUX_COMMAND_EVIDENCE_SCRIPT);
   const scriptSource = fs.readFileSync(scriptPath, 'utf8');

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -9,11 +9,17 @@ import { PUBLIC_COMMANDS } from '../../src/command-catalog.ts';
 import { isCommandSupportedOnDevice } from '../../src/core/capabilities.ts';
 import {
   LINUX_COVERAGE_GAP_ISSUE,
+  LINUX_COMMAND_EVIDENCE,
   LINUX_PLATFORM_COVERAGE,
   LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY,
   LINUX_REPLAY_EVIDENCE,
+  liveCommandsForLinuxCommandEvidence,
   liveCommandsForLinuxReplay,
 } from './linux-e2e/coverage-manifest.ts';
+import {
+  LINUX_COMMAND_EVIDENCE_COMMANDS,
+  LINUX_COMMAND_EVIDENCE_SCRIPT,
+} from './linux-e2e/command-evidence.ts';
 
 const publicCommands = Object.values(PUBLIC_COMMANDS).sort();
 
@@ -39,14 +45,13 @@ test('Linux coverage exhaustively classifies the public catalog', () => {
 
 test('Linux coverage report has the expected classification counts', () => {
   assert.deepEqual(LINUX_PLATFORM_COVERAGE_CLASSIFICATION_SUMMARY, {
-    // focus (#1925), click, and type are live via the replay: click resolves and lands on a
-    // digit button, and the typed calculation's result is now selectable (see the manifest
-    // entries for the platform defects this fixed). keyboard/orientation/tv-remote moved from
-    // capability-denial to command-contract: they're fact-owned now, not catalog-owned.
+    // focus (#1925), click, and type remain live via the existing replay. The separate
+    // command-evidence lane adds ten generic-command rows without changing that replay. Keyboard,
+    // orientation, and tv-remote remain fact-owned command-contract rows, not catalog denials.
     capabilityDenial: 7,
     contract: 21,
-    gap: 18,
-    live: 8,
+    gap: 8,
+    live: 18,
     total: 54,
   });
 
@@ -69,6 +74,28 @@ test('Linux live claims reference commands in the existing smoke replay', () => 
       replayCommands.has(command),
       true,
       `${command} is not invoked by ${LINUX_REPLAY_EVIDENCE.path}`,
+    );
+  }
+});
+
+test('Linux command-evidence claims name every executable lane command', () => {
+  const runnerPath = path.resolve(LINUX_COMMAND_EVIDENCE.path);
+  const runnerSource = fs.readFileSync(runnerPath, 'utf8');
+  assert.ok(runnerSource.includes(LINUX_COMMAND_EVIDENCE.test));
+
+  const scriptPath = path.resolve(LINUX_COMMAND_EVIDENCE_SCRIPT);
+  const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+  assert.ok(scriptSource.includes('find role "button" exists'));
+  assert.deepEqual(
+    new Set(liveCommandsForLinuxCommandEvidence()),
+    new Set(LINUX_COMMAND_EVIDENCE_COMMANDS),
+  );
+
+  for (const command of LINUX_COMMAND_EVIDENCE_COMMANDS) {
+    assert.match(
+      runnerSource,
+      new RegExp(`verifyCommand\\([\\s\\S]{0,220}C\\.${command}\\b`),
+      `${command} must have a named command-evidence assertion`,
     );
   }
 });

--- a/test/integration/smoke-linux-coverage.test.ts
+++ b/test/integration/smoke-linux-coverage.test.ts
@@ -69,6 +69,11 @@ test('Linux live claims reference commands in the existing smoke replay', () => 
   );
   const liveCommands = liveCommandsForLinuxReplay();
   assert.deepEqual(liveCommands.length, 8);
+  assert.deepEqual(
+    [...replayCommands].sort(),
+    [...liveCommands].sort(),
+    'the existing replay smoke command set must remain unchanged',
+  );
   for (const command of liveCommands) {
     assert.equal(
       replayCommands.has(command),


### PR DESCRIPTION
## Summary

Closes #1915.

Adds a narrow Linux/Xvfb command-evidence lane so the Linux manifest reports executable evidence instead of only capability or contract rows. The lane runs the source CLI against the existing Ubuntu/Xvfb/AT-SPI setup and asserts command-specific results for:

- `capabilities`, `doctor`, `events`, `replay`, `test`, `batch`, `diff`, `find`, and `swipe`.
- A unique per-run `AGENT_DEVICE_STATE_DIR` under the lane artifact directory keeps `test`, `replay --keep-session`, and the follow-up direct commands on one daemon across CLI processes.
- The swipe evidence uses an in-viewport trajectory for the CI desktop (`100,400` to `100,300`).

The existing Linux replay smoke scope and `test:replay:linux` step are unchanged. The new `.ad` script is separate from `test/integration/replays/linux/01-desktop-smoke.ad`; its commands are counted only where the new lane actually exercises them.

The manifest now reports 17 live commands (8 existing replay commands plus 9 command-evidence commands), 21 contract rows, 7 capability-denial rows, and 9 honest gaps. Remaining gaps are `artifacts`, `logs`, `shutdown`, `install`, `reinstall`, `push`, `record`, `trace`, and `install-from-source`. The `artifacts` row remains a gap because local Linux screenshot paths are caller-owned and do not create downloadable daemon inventory entries; this PR does not claim physical Linux desktop coverage, unsupported capability coverage, or the existing macOS `DEVICE_NOT_FOUND` live gap.

## Validation

- `pnpm check:affected --run` passed all runnable checks on `476fdfc8c`.
- Focused Linux manifest/coverage tests: 7/7 passed; `pnpm check:fallow --base origin/main`, `pnpm build`, formatting, typecheck, and lint passed.
- Planted-red proof: temporarily requiring one additional live command made the focused structural gate fail (6 passed, 1 failed); the violation was reverted.
- A read-only adversarial `claude -p` review challenged evidence depth, command ownership clarity, batch/artifact/event assertions, replay-scope proof, and possible scope expansion. The actionable evidence-quality findings were addressed; duplicate contract rows and extra isolation checks were not adopted because they would duplicate or broaden the owning lane. The later CI-driven artifact correction preserves that review disposition by removing a vacuous claim and keeping the row an explicit gap.
- Superseded exact-head runs passed Ubuntu setup and the unchanged replay smoke, then exposed deterministic lane issues in sequence: daemon-state sharing, out-of-bounds swipe coordinates for the reported `365x497` viewport, and the assumption that a local screenshot should appear in daemon artifact inventory. The first two are fixed in the lane; the final head keeps the third as an explicit gap rather than asserting non-existent evidence. These are lane-only changes; production runtime behavior is unchanged. Fresh CI for this exact head is the authority still to come.

Scope: 13 files touched (10 existing files and 3 new evidence files), all within Linux CI/test wiring and affected-check registration. No production runtime, docs, or skills changed.
