### PR TITLE
refactor(android): admit text onto one resolved channel

### DIFF
--- a/src/platforms/android/__tests__/text-input-test-ime.test.ts
+++ b/src/platforms/android/__tests__/text-input-test-ime.test.ts
@@ -124,6 +124,11 @@ test('fillAndroid clears then commits non-ASCII text through the test IME and ve
     false,
     'the ASCII shell input path must not run while the test IME is active',
   );
+  assert.equal(
+    calls.filter((args) => args[1] === 'input' && args[2] === 'tap').length,
+    1,
+    'one focus tap serves both channel resolution and the first helper attempt',
+  );
 });
 
 // The device, not this daemon process, decides which IME is active. A previous run (or another
@@ -205,6 +210,59 @@ test('fillAndroid batches ASCII text when the device is already on the helper IM
     calls.some((args) => args.includes('KEYCODE_DEL')),
     false,
     'the helper clears the field over the broadcast channel, not with delete keyevents',
+  );
+  assert.equal(
+    calls.filter((args) => args[1] === 'input' && args[2] === 'tap').length,
+    1,
+    'the focus tap that resolved the channel is the first helper attempt’s focus — no second tap',
+  );
+});
+
+test('fillAndroid re-focuses the target when the first helper attempt fails verification', async () => {
+  setAndroidTestImeActiveForTests(ANDROID_EMULATOR, true);
+  let currentText = 'stale value';
+  let commits = 0;
+  const calls: string[][] = [];
+  const adb: AndroidAdbExecutor = createAndroidSnapshotHelperExecutor({
+    exec: async (args) => {
+      calls.push(args);
+      if (args[1] === 'am' && args[2] === 'broadcast') {
+        const action = args[args.indexOf('-a') + 1];
+        if (action === 'com.callstack.agentdevice.imehelper.ACTION_CLEAR_TEXT') {
+          currentText = '';
+        } else if (action === 'com.callstack.agentdevice.imehelper.ACTION_INPUT_TEXT_B64') {
+          commits += 1;
+          currentText += decodeBroadcastText(args);
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    // The first commit never lands in the tree — the not-yet-bound InputConnection case the helper
+    // retry exists for — so every verification sample keeps showing the stale value until the
+    // second attempt's commit.
+    captureXml: () => androidInputXml({ text: commits >= 2 ? currentText : 'stale value' }),
+  });
+
+  await withAndroidAdbProvider(
+    { exec: adb, snapshotHelperArtifact: ANDROID_SNAPSHOT_HELPER_FIXTURE_ARTIFACT },
+    { serial: ANDROID_EMULATOR.id },
+    async () => {
+      await fillAndroid(ANDROID_EMULATOR, 10, 10, 'filed the expense');
+    },
+  );
+
+  assert.equal(currentText, 'filed the expense');
+  assert.equal(
+    calls.filter((args) => args[1] === 'input' && args[2] === 'tap').length,
+    2,
+    'the retry attempt must re-focus the target before its clear-and-commit round',
+  );
+  assert.equal(
+    calls.filter((args) => args.includes('com.callstack.agentdevice.imehelper.ACTION_CLEAR_TEXT'))
+      .length,
+    2,
+    'each helper attempt clears before it commits',
   );
 });
 

--- a/src/platforms/android/ime-helper.ts
+++ b/src/platforms/android/ime-helper.ts
@@ -127,7 +127,7 @@ export function getAndroidImeHelperDeviceKey(device: DeviceInfo): string {
  * run, a second daemon on the same emulator, or an `open --no-test-ime` onto a device that already
  * carries the helper all leave the channel available with an empty activation cache.
  */
-export function isAndroidImeHelperPackage(packageName: string | undefined): boolean {
+export function isAndroidImeHelperPackage(packageName: string | undefined): packageName is string {
   return packageName === ANDROID_IME_HELPER_PACKAGE;
 }
 

--- a/src/platforms/android/text-input.ts
+++ b/src/platforms/android/text-input.ts
@@ -48,28 +48,11 @@ export async function typeAndroid(device: DeviceInfo, text: string, delayMs = 0)
     emitAndroidTextDiagnostic('type', 'provider-native', text);
     return;
   }
-  if (isAndroidTestImeActive(device)) {
-    await typeAndroidImeHelper(
-      device,
-      await activatedAndroidImeHelperPackage(device),
-      text,
-      delayMs,
-    );
+  const channel = await admitAndroidTextChannel(device, 'type', text);
+  if (channel.backend === 'test-ime') {
+    await typeAndroidImeHelper(device, channel.packageName, text, delayMs);
     return;
   }
-  // The shell path needs the input-method read anyway, and it also names the device's active IME.
-  // If that is the helper, its batch channel writes the whole string in one broadcast instead of
-  // ceil(n/8) `input text` spawns — no flag, no IME switch, nothing this process had to arrange.
-  // Read it before refusing anything: what the text has to be encodable for is not known until the
-  // channel is, and the broadcast channel carries any Unicode.
-  const inputState = await readAndroidShellTextInputState(device, 'type');
-  const helperPackage = androidImeHelperInputMethod(inputState);
-  if (helperPackage) {
-    await typeAndroidImeHelper(device, helperPackage, text, delayMs);
-    return;
-  }
-  assertAndroidShellTextSupported(text);
-  assertAndroidShellInputIsAppOwned(inputState, 'type');
   if (delayMs > 0 && Array.from(text).length > 1) {
     await typeAndroidShell(device, { action: 'type', text, chunkSize: 1, delayMs });
     return;
@@ -98,19 +81,6 @@ export async function fillAndroid(
     const verification = await verifyAndroidFilledText(device, x, y, text, helper);
     return completeAndroidFillVerification(text, beforeTarget, verification);
   }
-  if (isAndroidTestImeActive(device)) {
-    const verification = await fillAndroidImeHelper(
-      device,
-      await activatedAndroidImeHelperPackage(device),
-      x,
-      y,
-      text,
-      beforeTarget,
-      helper,
-    );
-    return completeAndroidFillVerification(text, beforeTarget, verification);
-  }
-
   const textCodePointLength = Array.from(text).length;
   const attempts: Array<{
     clearPadding: number;
@@ -139,15 +109,11 @@ export async function fillAndroid(
 
   for (const attempt of attempts) {
     await focusAndroid(device, x, y);
-    // Same read, same reason, same ordering as `typeAndroid`: when the helper is the active IME its
-    // channel replaces both the delete-key clear and the chunked write for the rest of this fill,
-    // and the ASCII limit that would refuse this text applies only once the shell path is chosen.
-    const inputState = await readAndroidShellTextInputState(device, 'fill');
-    const helperPackage = androidImeHelperInputMethod(inputState);
-    if (helperPackage) {
+    const channel = await admitAndroidTextChannel(device, 'fill', text);
+    if (channel.backend === 'test-ime') {
       const verification = await fillAndroidImeHelper(
         device,
-        helperPackage,
+        channel.packageName,
         x,
         y,
         text,
@@ -156,8 +122,6 @@ export async function fillAndroid(
       );
       return completeAndroidFillVerification(text, beforeTarget, verification);
     }
-    assertAndroidShellTextSupported(text);
-    assertAndroidShellInputIsAppOwned(inputState, 'fill');
     const clearCount = clampCount(
       textCodePointLength + attempt.clearPadding,
       attempt.minClear,
@@ -184,17 +148,32 @@ export async function fillAndroid(
 }
 
 /**
- * The helper package this process switched the device to. The observed-IME route reads the package
- * off the device instead, so it never depends on a packaged artifact being present.
+ * Which channel writes this text on this device, already admitted: the helper's package for the
+ * broadcast, or the adb-shell channel once this text and the focused input pass its asserts. The
+ * helper IME serves whenever it is the device's active input method — because this process
+ * switched to it (the activation cache answers without a device read, off the packaged artifact's
+ * manifest), or because a previous run left it active and the input-method read observes it. That
+ * read precedes the shell asserts by construction: the ASCII limit belongs to the shell channel
+ * alone, and the helper's batch broadcast carries any Unicode in one spawn instead of ceil(n/8)
+ * `input text` chunks.
  */
-async function activatedAndroidImeHelperPackage(device: DeviceInfo): Promise<string> {
-  const artifact = await selectAndroidImeHelperArtifact(resolveAndroidAdbProvider(device));
-  return artifact.manifest.packageName;
-}
-
-function androidImeHelperInputMethod(state: AndroidKeyboardState | null): string | undefined {
-  const packageName = state?.inputMethodPackage;
-  return isAndroidImeHelperPackage(packageName) ? packageName : undefined;
+async function admitAndroidTextChannel(
+  device: DeviceInfo,
+  action: AndroidTextInputAction,
+  text: string,
+): Promise<{ backend: 'test-ime'; packageName: string } | { backend: 'adb-shell' }> {
+  if (isAndroidTestImeActive(device)) {
+    const artifact = await selectAndroidImeHelperArtifact(resolveAndroidAdbProvider(device));
+    return { backend: 'test-ime', packageName: artifact.manifest.packageName };
+  }
+  const inputState = await readAndroidShellTextInputState(device, action);
+  const packageName = inputState?.inputMethodPackage;
+  if (isAndroidImeHelperPackage(packageName)) {
+    return { backend: 'test-ime', packageName };
+  }
+  assertAndroidShellTextSupported(text);
+  assertAndroidShellInputIsAppOwned(inputState, action);
+  return { backend: 'adb-shell' };
 }
 
 async function typeAndroidImeHelper(
@@ -231,9 +210,10 @@ async function fillAndroidImeHelper(
 ): Promise<AndroidFillVerification> {
   const adb = resolveAndroidAdbExecutor(device);
   let lastVerification: AndroidFillVerification | null = null;
-  // One retry covers the rare not-yet-bound InputConnection right after focus.
+  // The caller focused the target while resolving the channel; the retry re-focuses because it
+  // covers the rare not-yet-bound InputConnection right after focus.
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    await focusAndroid(device, x, y);
+    if (attempt > 0) await focusAndroid(device, x, y);
     await clearAndroidImeHelperText(adb, packageName);
     if (text) await sendAndroidImeHelperText(adb, packageName, text);
     const verification = await verifyAndroidFilledText(device, x, y, text, helper);


### PR DESCRIPTION
Follow-up to #2003. Collapses the text-entry routing that #2003 spread across `typeAndroid`/`fillAndroid` — three predicates × two entry points, with the helper package plumbed differently per source — into one module-private seam.

## Summary

- **One resolver owns the whole decision.** `admitAndroidTextChannel(device, action, text)` returns a discriminated union: `{backend: 'test-ime', packageName}` (package already resolved from either provenance — the activation cache answers spawn-free off the artifact manifest; the observed route reads it off the device) or `{backend: 'adb-shell'}` — returned only after the ASCII and input-ownership asserts pass. Callers make one call and one dispatch; the read-before-refuse ordering (#2003's F-fix) and both shell asserts are unreachable from outside the resolver, so a caller cannot reintroduce the refuse-before-read defect or run the asserts against a stale read.
- **One focus tap per helper fill.** `fillAndroid` resolves the channel inside its attempts loop after `focusAndroid`, so the helper fill's first attempt reuses that focus; only the retry re-focuses. This deletes the pre-loop activation-cache special case *and* removes a real double-tap: on main, the observed-IME fill route (helper active, cache empty — a crashed run or a second daemon) taps the target twice. Activated and shell routes are spawn-identical to main, including the per-attempt admission re-read and mid-fill promotion to the helper.
- Tests pin both halves of the focus contract: one tap on first-attempt helper fills, and exactly two taps when the first attempt fails verification (the not-yet-bound-InputConnection retry).

## Live evidence (exact head `fbb146241`, Pixel_9_Pro_XL emulator, Android 16 / API 36)

Spawn counts from `--debug` request ndjson (`exec_command` events), same staging on a main-built (`b5adf966b`) daemon as A/B where the sequence changed:

| Route | main | this head |
|---|---|---|
| Activated fill, Unicode (`open` auto test-IME) | — | 1 `input tap`, 2 `am broadcast` (clear+commit), 0 `input text`, 0 routing reads; verified |
| Activated type | — | 1 broadcast, 0 reads |
| **Observed fill**, Unicode (helper set via `ime set`, fresh daemon, `open --no-test-ime`) | **2 taps**, 2 broadcasts, 1 routing + 2 verification `dumpsys input_method` | **1 tap**, otherwise identical; verified |
| Observed type | — | 1 routing read, 1 broadcast (Unicode accepted with empty cache) |
| Shell fill, ASCII (stock LatinIME) | — | 1 tap, 2 DEL batches, 3× chunked `input text` (23 chars), backend `adb-shell`; verified — unchanged shape |
| Close restore | — | helper → previous IME restored; device left on stock with no stray records |

## Validation

- android + daemon suites green at this head (2,771 tests), `tsc` clean, oxlint clean, `fallow audit` clean on changed files.
- `check:affected` maps the change to the android device lanes; the live table above covers the device-facing sequences at exact head.
