### PR TITLE
fix(ci): skip release instead of erroring when both fixtures are cached

### DIFF
--- a/.github/workflows/test-app-build-cache.yml
+++ b/.github/workflows/test-app-build-cache.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.fingerprint.outputs.matrix }}
+      has-work: ${{ steps.fingerprint.outputs.has-work }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,10 +95,12 @@ jobs:
               }
             ] | { include: map(select(.build)) }')"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "has-work=$(jq -r '.include | length > 0' <<<"$MATRIX")" >> "$GITHUB_OUTPUT"
 
   release:
     name: ${{ matrix.name }}
     needs: fingerprint
+    if: needs.fingerprint.outputs.has-work == 'true'
     runs-on: ${{ matrix.runsOn }}
     timeout-minutes: 60
     concurrency:

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -334,17 +334,22 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
       '',
     ].join('\n'),
   );
-  const writeNodeStub = (cached) =>
+  // cachedPlatforms: which platform artifact-name suffixes (".ios", ".android")
+  // the lookup should report as already cached.
+  const writeNodeStub = (cachedPlatforms) =>
     fs.writeFileSync(
       path.join(binDir, 'node'),
       [
         '#!/bin/sh',
         'printf "%s\\n" "$*" >> "$TEST_NODE_LOG"',
-        cached ? 'printf "111"' : 'true',
+        'case "$4" in',
+        ...cachedPlatforms.map((platform) => `  *.${platform}) printf "111" ;;`),
+        '  *) true ;;',
+        'esac',
         '',
       ].join('\n'),
     );
-  writeNodeStub(false);
+  writeNodeStub([]);
   fs.chmodSync(path.join(binDir, 'node'), 0o755);
 
   const run = fingerprintStep.run
@@ -388,7 +393,17 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
     '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.android-hash.android current-head',
   ]);
 
-  writeNodeStub(true);
+  // A mistaken `length > 1` in the has-work check would pass here while
+  // wrongly suppressing this valid single-platform build.
+  writeNodeStub(['ios']);
+  const iosCached = runFingerprint('output-ios-cached');
+  assert.deepEqual(
+    iosCached.matrix.include.map(({ platform }) => platform),
+    ['android'],
+  );
+  assert.equal(iosCached.hasWork, 'has-work=true');
+
+  writeNodeStub(['ios', 'android']);
   const bothCached = runFingerprint('output-both-cached');
   assert.deepEqual(bothCached.matrix, { include: [] });
   assert.equal(bothCached.hasWork, 'has-work=false');

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -305,14 +305,22 @@ test('Android APK repack signs the output and preserves its package id', (t) => 
   assert.match(mismatch.stderr, /did not preserve the source signing certificate/);
 });
 
-test('producer maps each platform to its resolved lookup and matrix artifact name', (t) => {
+test('producer maps each platform to its resolved lookup and matrix artifact name, and gates has-work when both are cached', (t) => {
   const workflow = parse(fs.readFileSync('.github/workflows/test-app-build-cache.yml', 'utf8'));
   const fingerprintStep = workflow.jobs.fingerprint.steps.find((step) => step.id === 'fingerprint');
+  // #2034: an empty `include` matrix is legal JSON but GitHub Actions rejects it as
+  // `strategy.matrix`, so `release` must be skipped -- not handed a zero-length
+  // matrix -- whenever both fixtures are already cached.
+  assert.equal(
+    workflow.jobs.fingerprint.outputs['has-work'],
+    '${{ steps.fingerprint.outputs.has-work }}',
+  );
+  assert.equal(workflow.jobs.release.if, "needs.fingerprint.outputs.has-work == 'true'");
+
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-producer-name-'));
   t.after(() => fs.rmSync(tempRoot, { force: true, recursive: true }));
   const actionDir = path.join(tempRoot, '.github/actions/setup-fixture-app');
   const binDir = path.join(tempRoot, 'bin');
-  const outputPath = path.join(tempRoot, 'output');
   const resolverLog = path.join(tempRoot, 'resolver-calls');
   const nodeLog = path.join(tempRoot, 'node-calls');
   fs.mkdirSync(actionDir, { recursive: true });
@@ -326,95 +334,26 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
       '',
     ].join('\n'),
   );
-  fs.writeFileSync(
-    path.join(binDir, 'node'),
-    ['#!/bin/sh', 'printf "%s\\n" "$*" >> "$TEST_NODE_LOG"', ''].join('\n'),
-  );
+  const writeNodeStub = (cached) =>
+    fs.writeFileSync(
+      path.join(binDir, 'node'),
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$*" >> "$TEST_NODE_LOG"',
+        cached ? 'printf "111"' : 'true',
+        '',
+      ].join('\n'),
+    );
+  writeNodeStub(false);
   fs.chmodSync(path.join(binDir, 'node'), 0o755);
+
   const run = fingerprintStep.run
     .replaceAll('${{ github.event.pull_request.head.sha || github.sha }}', 'current-head')
     .replaceAll('${{ github.repository }}', 'octo/repo')
     .replaceAll('${{ github.event_name }}', 'pull_request')
     .replaceAll('${{ github.event.pull_request.head.repo.full_name }}', 'octo/repo');
-  const result = spawnSync('bash', ['-c', run], {
-    cwd: tempRoot,
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      GITHUB_OUTPUT: outputPath,
-      PATH: `${binDir}:${process.env.PATH}`,
-      TEST_NODE_LOG: nodeLog,
-      TEST_RESOLVER_LOG: resolverLog,
-    },
-  });
-  assert.equal(result.status, 0, result.stderr);
-  const outputLines = fs.readFileSync(outputPath, 'utf8').trim().split('\n');
-  const matrixLine = outputLines.find((line) => line.startsWith('matrix='));
-  const matrix = JSON.parse(matrixLine.slice('matrix='.length));
-  assert.deepEqual(
-    matrix.include.map(({ platform, artifactName }) => ({ platform, artifactName })),
-    [
-      { platform: 'ios', artifactName: 'fingerprint.ios-hash.ios' },
-      { platform: 'android', artifactName: 'fingerprint.android-hash.android' },
-    ],
-  );
-  assert.deepEqual(
-    outputLines.find((line) => line.startsWith('has-work=')),
-    'has-work=true',
-  );
-  assert.deepEqual(fs.readFileSync(resolverLog, 'utf8').trim().split('\n'), ['ios', 'android']);
-  assert.deepEqual(fs.readFileSync(nodeLog, 'utf8').trim().split('\n'), [
-    '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.ios-hash.ios current-head',
-    '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.android-hash.android current-head',
-  ]);
-});
-
-test('fingerprint matrix covers all four cache combinations and gates has-work on both-cached', (t) => {
-  const workflow = parse(fs.readFileSync('.github/workflows/test-app-build-cache.yml', 'utf8'));
-  const fingerprintStep = workflow.jobs.fingerprint.steps.find((step) => step.id === 'fingerprint');
-  // #2034: an empty `include` matrix is legal JSON but GitHub Actions rejects
-  // it as `strategy.matrix`, so the `release` job must be skipped -- not
-  // handed a zero-length matrix -- whenever both fixtures are cached.
-  assert.equal(
-    workflow.jobs.fingerprint.outputs['has-work'],
-    '${{ steps.fingerprint.outputs.has-work }}',
-  );
-  assert.equal(workflow.jobs.release.if, "needs.fingerprint.outputs.has-work == 'true'");
-
-  const run = fingerprintStep.run
-    .replaceAll('${{ github.event.pull_request.head.sha || github.sha }}', 'current-head')
-    .replaceAll('${{ github.repository }}', 'octo/repo')
-    .replaceAll('${{ github.event_name }}', 'push')
-    .replaceAll('${{ github.event.pull_request.head.repo.full_name }}', '');
-
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-matrix-combinations-'));
-  t.after(() => fs.rmSync(tempRoot, { force: true, recursive: true }));
-  const actionDir = path.join(tempRoot, '.github/actions/setup-fixture-app');
-  const binDir = path.join(tempRoot, 'bin');
-  fs.mkdirSync(actionDir, { recursive: true });
-  fs.mkdirSync(binDir);
-  fs.writeFileSync(
-    path.join(actionDir, 'resolve-artifact-name.sh'),
-    ['#!/bin/sh', 'printf "fingerprint.%s-hash.%s\\n" "$1" "$1"', ''].join('\n'),
-  );
-  fs.chmodSync(path.join(actionDir, 'resolve-artifact-name.sh'), 0o755);
-  fs.writeFileSync(
-    path.join(binDir, 'node'),
-    [
-      '#!/bin/sh',
-      // Invoked as: node trusted-artifact.mjs find <repo> <name> <sha>
-      'name="$4"',
-      'case "$name" in',
-      '  *.ios) [ "$TEST_IOS_CACHED" = 1 ] && printf "111"; true ;;',
-      '  *.android) [ "$TEST_ANDROID_CACHED" = 1 ] && printf "222"; true ;;',
-      'esac',
-      '',
-    ].join('\n'),
-  );
-  fs.chmodSync(path.join(binDir, 'node'), 0o755);
-
-  const runFingerprint = (iosCached, androidCached) => {
-    const outputPath = path.join(tempRoot, `output-${iosCached}-${androidCached}`);
+  const runFingerprint = (outputName) => {
+    const outputPath = path.join(tempRoot, outputName);
     const result = spawnSync('bash', ['-c', run], {
       cwd: tempRoot,
       encoding: 'utf8',
@@ -422,44 +361,37 @@ test('fingerprint matrix covers all four cache combinations and gates has-work o
         ...process.env,
         GITHUB_OUTPUT: outputPath,
         PATH: `${binDir}:${process.env.PATH}`,
-        TEST_ANDROID_CACHED: androidCached ? '1' : '0',
-        TEST_IOS_CACHED: iosCached ? '1' : '0',
+        TEST_NODE_LOG: nodeLog,
+        TEST_RESOLVER_LOG: resolverLog,
       },
     });
     assert.equal(result.status, 0, result.stderr);
     const lines = fs.readFileSync(outputPath, 'utf8').trim().split('\n');
-    const matrixLine = lines.find((line) => line.startsWith('matrix='));
-    const hasWorkLine = lines.find((line) => line.startsWith('has-work='));
     return {
-      hasWork: hasWorkLine.slice('has-work='.length),
-      matrix: JSON.parse(matrixLine.slice('matrix='.length)),
+      hasWork: lines.find((line) => line.startsWith('has-work=')),
+      matrix: JSON.parse(lines.find((line) => line.startsWith('matrix=')).slice('matrix='.length)),
     };
   };
 
-  const bothCached = runFingerprint(true, true);
+  const neitherCached = runFingerprint('output-neither-cached');
+  assert.deepEqual(
+    neitherCached.matrix.include.map(({ platform, artifactName }) => ({ platform, artifactName })),
+    [
+      { platform: 'ios', artifactName: 'fingerprint.ios-hash.ios' },
+      { platform: 'android', artifactName: 'fingerprint.android-hash.android' },
+    ],
+  );
+  assert.equal(neitherCached.hasWork, 'has-work=true');
+  assert.deepEqual(fs.readFileSync(resolverLog, 'utf8').trim().split('\n'), ['ios', 'android']);
+  assert.deepEqual(fs.readFileSync(nodeLog, 'utf8').trim().split('\n'), [
+    '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.ios-hash.ios current-head',
+    '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.android-hash.android current-head',
+  ]);
+
+  writeNodeStub(true);
+  const bothCached = runFingerprint('output-both-cached');
   assert.deepEqual(bothCached.matrix, { include: [] });
-  assert.equal(bothCached.hasWork, 'false');
-
-  const iosOnlyCached = runFingerprint(true, false);
-  assert.deepEqual(
-    iosOnlyCached.matrix.include.map((entry) => entry.platform),
-    ['android'],
-  );
-  assert.equal(iosOnlyCached.hasWork, 'true');
-
-  const androidOnlyCached = runFingerprint(false, true);
-  assert.deepEqual(
-    androidOnlyCached.matrix.include.map((entry) => entry.platform),
-    ['ios'],
-  );
-  assert.equal(androidOnlyCached.hasWork, 'true');
-
-  const neitherCached = runFingerprint(false, false);
-  assert.deepEqual(
-    neitherCached.matrix.include.map((entry) => entry.platform),
-    ['ios', 'android'],
-  );
-  assert.equal(neitherCached.hasWork, 'true');
+  assert.equal(bothCached.hasWork, 'has-work=false');
 });
 
 test('artifact name resolver scopes both platforms and rejects invalid output', (t) => {

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -348,8 +348,8 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
     },
   });
   assert.equal(result.status, 0, result.stderr);
-  const matrixLine = fs.readFileSync(outputPath, 'utf8').trim();
-  assert.match(matrixLine, /^matrix=/);
+  const outputLines = fs.readFileSync(outputPath, 'utf8').trim().split('\n');
+  const matrixLine = outputLines.find((line) => line.startsWith('matrix='));
   const matrix = JSON.parse(matrixLine.slice('matrix='.length));
   assert.deepEqual(
     matrix.include.map(({ platform, artifactName }) => ({ platform, artifactName })),
@@ -358,11 +358,108 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
       { platform: 'android', artifactName: 'fingerprint.android-hash.android' },
     ],
   );
+  assert.deepEqual(
+    outputLines.find((line) => line.startsWith('has-work=')),
+    'has-work=true',
+  );
   assert.deepEqual(fs.readFileSync(resolverLog, 'utf8').trim().split('\n'), ['ios', 'android']);
   assert.deepEqual(fs.readFileSync(nodeLog, 'utf8').trim().split('\n'), [
     '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.ios-hash.ios current-head',
     '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.android-hash.android current-head',
   ]);
+});
+
+test('fingerprint matrix covers all four cache combinations and gates has-work on both-cached', (t) => {
+  const workflow = parse(fs.readFileSync('.github/workflows/test-app-build-cache.yml', 'utf8'));
+  const fingerprintStep = workflow.jobs.fingerprint.steps.find((step) => step.id === 'fingerprint');
+  // #2034: an empty `include` matrix is legal JSON but GitHub Actions rejects
+  // it as `strategy.matrix`, so the `release` job must be skipped -- not
+  // handed a zero-length matrix -- whenever both fixtures are cached.
+  assert.equal(
+    workflow.jobs.fingerprint.outputs['has-work'],
+    '${{ steps.fingerprint.outputs.has-work }}',
+  );
+  assert.equal(workflow.jobs.release.if, "needs.fingerprint.outputs.has-work == 'true'");
+
+  const run = fingerprintStep.run
+    .replaceAll('${{ github.event.pull_request.head.sha || github.sha }}', 'current-head')
+    .replaceAll('${{ github.repository }}', 'octo/repo')
+    .replaceAll('${{ github.event_name }}', 'push')
+    .replaceAll('${{ github.event.pull_request.head.repo.full_name }}', '');
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-matrix-combinations-'));
+  t.after(() => fs.rmSync(tempRoot, { force: true, recursive: true }));
+  const actionDir = path.join(tempRoot, '.github/actions/setup-fixture-app');
+  const binDir = path.join(tempRoot, 'bin');
+  fs.mkdirSync(actionDir, { recursive: true });
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(
+    path.join(actionDir, 'resolve-artifact-name.sh'),
+    ['#!/bin/sh', 'printf "fingerprint.%s-hash.%s\\n" "$1" "$1"', ''].join('\n'),
+  );
+  fs.chmodSync(path.join(actionDir, 'resolve-artifact-name.sh'), 0o755);
+  fs.writeFileSync(
+    path.join(binDir, 'node'),
+    [
+      '#!/bin/sh',
+      // Invoked as: node trusted-artifact.mjs find <repo> <name> <sha>
+      'name="$4"',
+      'case "$name" in',
+      '  *.ios) [ "$TEST_IOS_CACHED" = 1 ] && printf "111"; true ;;',
+      '  *.android) [ "$TEST_ANDROID_CACHED" = 1 ] && printf "222"; true ;;',
+      'esac',
+      '',
+    ].join('\n'),
+  );
+  fs.chmodSync(path.join(binDir, 'node'), 0o755);
+
+  const runFingerprint = (iosCached, androidCached) => {
+    const outputPath = path.join(tempRoot, `output-${iosCached}-${androidCached}`);
+    const result = spawnSync('bash', ['-c', run], {
+      cwd: tempRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        PATH: `${binDir}:${process.env.PATH}`,
+        TEST_ANDROID_CACHED: androidCached ? '1' : '0',
+        TEST_IOS_CACHED: iosCached ? '1' : '0',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const lines = fs.readFileSync(outputPath, 'utf8').trim().split('\n');
+    const matrixLine = lines.find((line) => line.startsWith('matrix='));
+    const hasWorkLine = lines.find((line) => line.startsWith('has-work='));
+    return {
+      hasWork: hasWorkLine.slice('has-work='.length),
+      matrix: JSON.parse(matrixLine.slice('matrix='.length)),
+    };
+  };
+
+  const bothCached = runFingerprint(true, true);
+  assert.deepEqual(bothCached.matrix, { include: [] });
+  assert.equal(bothCached.hasWork, 'false');
+
+  const iosOnlyCached = runFingerprint(true, false);
+  assert.deepEqual(
+    iosOnlyCached.matrix.include.map((entry) => entry.platform),
+    ['android'],
+  );
+  assert.equal(iosOnlyCached.hasWork, 'true');
+
+  const androidOnlyCached = runFingerprint(false, true);
+  assert.deepEqual(
+    androidOnlyCached.matrix.include.map((entry) => entry.platform),
+    ['ios'],
+  );
+  assert.equal(androidOnlyCached.hasWork, 'true');
+
+  const neitherCached = runFingerprint(false, false);
+  assert.deepEqual(
+    neitherCached.matrix.include.map((entry) => entry.platform),
+    ['ios', 'android'],
+  );
+  assert.equal(neitherCached.hasWork, 'true');
 });
 
 test('artifact name resolver scopes both platforms and rejects invalid output', (t) => {

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -373,7 +373,7 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
     assert.equal(result.status, 0, result.stderr);
     const lines = fs.readFileSync(outputPath, 'utf8').trim().split('\n');
     return {
-      hasWork: lines.find((line) => line.startsWith('has-work=')),
+      hasWork: lines.find((line) => line.startsWith('has-work=')).slice('has-work='.length),
       matrix: JSON.parse(lines.find((line) => line.startsWith('matrix=')).slice('matrix='.length)),
     };
   };
@@ -386,7 +386,7 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
       { platform: 'android', artifactName: 'fingerprint.android-hash.android' },
     ],
   );
-  assert.equal(neitherCached.hasWork, 'has-work=true');
+  assert.equal(neitherCached.hasWork, 'true');
   assert.deepEqual(fs.readFileSync(resolverLog, 'utf8').trim().split('\n'), ['ios', 'android']);
   assert.deepEqual(fs.readFileSync(nodeLog, 'utf8').trim().split('\n'), [
     '.github/actions/setup-fixture-app/trusted-artifact.mjs find octo/repo fingerprint.ios-hash.ios current-head',
@@ -401,12 +401,12 @@ test('producer maps each platform to its resolved lookup and matrix artifact nam
     iosCached.matrix.include.map(({ platform }) => platform),
     ['android'],
   );
-  assert.equal(iosCached.hasWork, 'has-work=true');
+  assert.equal(iosCached.hasWork, 'true');
 
   writeNodeStub(['ios', 'android']);
   const bothCached = runFingerprint('output-both-cached');
   assert.deepEqual(bothCached.matrix, { include: [] });
-  assert.equal(bothCached.hasWork, 'has-work=false');
+  assert.equal(bothCached.hasWork, 'false');
 });
 
 test('artifact name resolver scopes both platforms and rejects invalid output', (t) => {


### PR DESCRIPTION
## Summary

Fixes #2034. `Test App Build Cache` has failed on every run since 2026-08-24 14:42 UTC, including on `main`.

#1996 changed the release matrix builder to filter to only entries that will actually build:

```diff
-            '{ include: [ {...iOS...}, {...Android...} ] }')"
+            '[ {...iOS...}, {...Android...} ] | { include: map(select(.build)) }')"
```

That's correct when at least one fixture needs building, but when **both** are already cached, `map(select(.build))` yields `include: []`. GitHub Actions rejects an empty `strategy.matrix` at the workflow level, so the `release` job is never created and the whole run is marked `failure`. Both-cached is the steady state, which is why this fails on nearly every run rather than intermittently.

- `fingerprint` now also publishes a `has-work` output (`jq -r '.include | length > 0'` over the matrix).
- `release` gets `if: needs.fingerprint.outputs.has-work == 'true'`, so a both-cached run **skips** `release` instead of erroring.

I checked whether a skipped `release` breaks anything downstream that `needs:` it: nothing does — consumers (`setup-fixture-app` / `trusted-artifact.mjs`) poll `classifyProducerState`, which reads the *workflow run's* overall `status`/`conclusion`, not individual job state. A workflow with a skipped job (and no failed jobs) reports `success`, so consumers correctly see the producer as done rather than failed.

## Test plan

- Added a regression test (`test/ci/trusted-fixture-artifact.test.mjs`) that executes the real fingerprint jq/shell step across all four cache combinations (both-cached, iOS-only, Android-only, neither), pinning that both-cached produces `include: []` + `has-work=false`, and every other combination produces `has-work=true`. This is the combination that shipped broken and had no prior coverage.
- Updated the existing producer test to account for the new `has-work=` output line in `$GITHUB_OUTPUT`.
- `pnpm run test:fixture-cache` — all 12 tests pass.
- `actionlint .github/workflows/test-app-build-cache.yml` — clean.
- `oxlint` on the modified test file — clean.

After merge, a push to `main` with no native change should show `Test App Build Cache` green with `release` skipped rather than errored; a run where a fingerprint actually changed should still build and publish as before.