### PR TITLE
refactor: centralize common input field audience metadata

### DIFF
--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -4,6 +4,7 @@ import { AppError, type NormalizedError } from '@agent-device/kernel/errors';
 import { createAgentDeviceClient } from '../agent-device-client.ts';
 import type { AgentDeviceClient } from '../client/client-types.ts';
 import type { JsonSchema } from '../commands/command-contract.ts';
+import { commonInputKeysHiddenFromAiSdk } from '../commands/command-input.ts';
 import { resolveCommandFrameworkTier } from '../core/command-descriptor/registry.ts';
 import { createCommandToolExecutor, listCommandTools } from '../mcp/command-tools.ts';
 import { formatToolErrorText } from '../mcp/tool-error.ts';
@@ -49,21 +50,11 @@ export type AgentDeviceTools = {
   toolApproval?: Partial<Record<string, ToolApprovalStatus>>;
 };
 
-// Hidden unconditionally, from both the schema the model sees and the input
-// `execute` forwards to the shared executor:
-//  - `session` is always pinned by this factory — the whole point is that a
-//    tool call can never target a session other than the one passed in.
-//  - `stateDir` selects which daemon state directory (and therefore which
-//    daemon/session namespace) a call resolves against. Left model-visible,
-//    it would let a call escape the pinned session into another daemon's
-//    state entirely, defeating that guarantee.
-//  - `mcpOutputFormat`, `includeCost`, `responseLevel` are MCP tool-config
-//    knobs, not command arguments; irrelevant here since `execute` below
-//    returns structuredContent directly and never reads a tool's rendered
-//    text, and shaping the response is this factory's decision, not the
-//    model's.
-const ALWAYS_HIDDEN_FIELDS = [
-  'session',
+// MCP tool-config knobs, not command arguments; irrelevant here since
+// `execute` below returns structuredContent directly and never reads a tool's
+// rendered text. Common pinned fields such as `session`/`platform` come from
+// the common input-field table.
+const AI_SDK_HIDDEN_MCP_FIELDS = [
   'stateDir',
   'mcpOutputFormat',
   'includeCost',
@@ -104,8 +95,10 @@ export async function createAgentDeviceTools(
   });
   const executor = createCommandToolExecutor();
 
-  const hiddenFields = new Set<string>(ALWAYS_HIDDEN_FIELDS);
-  if (platform) hiddenFields.add('platform');
+  const hiddenFields = new Set<string>([
+    ...AI_SDK_HIDDEN_MCP_FIELDS,
+    ...commonInputKeysHiddenFromAiSdk({ platformPinned: Boolean(platform) }),
+  ]);
 
   const tools: ToolSet = {};
   for (const definition of listCommandTools()) {

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -11,7 +11,11 @@ import {
   SELECTOR_EXPRESSION_REQUIRED_MESSAGE,
   splitSelectorFromArgs,
 } from '@agent-device/selectors';
-import { compactRecord, type SelectorSnapshotInput } from '../command-input.ts';
+import {
+  commonCommandInputFromFlags,
+  compactRecord,
+  type SelectorSnapshotInput,
+} from '../command-input.ts';
 import type {
   CommandInput,
   DaemonCommandRequest,
@@ -56,33 +60,7 @@ function readDeviceTarget(value: unknown): InternalRequestOptions['target'] | un
 }
 
 export function commonInputFromFlags(flags: CliFlags): Record<string, unknown> {
-  return compactRecord({
-    // `--no-record` is a COMMON flag (`COMMON_COMMAND_SUPPORTED_FLAG_KEYS`): it
-    // is accepted on, and meaningful for, every recordable command. It rides
-    // the common seam every reader already spreads, so a reader cannot forget
-    // it and a new reader inherits it for free. The three seams it must survive
-    // are this one, `readCommonInput`, and `commonToClientOptions`
-    // (`commands/command-input.ts`) — a drop at any one of them silently
-    // disables the flag (#1304/#1305 fixed only the reader layer, so the flag
-    // still never reached the daemon).
-    //
-    // `--record` deliberately does NOT ride here: it is scoped to the
-    // observation-only commands the repair-segment exclusion can drop
-    // (ADR 0012 decision 6 amendment), so it stays on the narrow
-    // `observationRecordInputFromFlags` seam below.
-    noRecord: flags.noRecord,
-    session: flags.session,
-    platform: flags.platform,
-    deviceTarget: flags.target,
-    device: flags.device,
-    udid: flags.udid,
-    serial: flags.serial,
-    iosSimulatorDeviceSet: flags.iosSimulatorDeviceSet,
-    iosXctestrunFile: flags.iosXctestrunFile,
-    iosXctestDerivedDataPath: flags.iosXctestDerivedDataPath,
-    iosXctestEnvDir: flags.iosXctestEnvDir,
-    androidDeviceAllowlist: flags.androidDeviceAllowlist,
-  });
+  return commonCommandInputFromFlags(flags);
 }
 
 /**

--- a/src/commands/cli-grammar/flag-groups.ts
+++ b/src/commands/cli-grammar/flag-groups.ts
@@ -1,4 +1,5 @@
 import type { FlagKey } from './flag-types.ts';
+import { commonCommandSupportedFlagKeys } from '../command-input.ts';
 
 function flagKeys<const TKeys extends readonly FlagKey[]>(...keys: TKeys): TKeys {
   return keys;
@@ -45,22 +46,14 @@ export const REPEATED_TOUCH_FLAGS = flagKeys(
 export const SETTLE_FLAGS = flagKeys('settle', 'settleQuietMs', 'timeoutMs');
 export const REPLAY_FLAGS = flagKeys('replayUpdate', 'replayEnv');
 
-export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
+export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS: readonly FlagKey[] = flagKeys(
   'remoteConfig',
   'stateDir',
-  'daemonBaseUrl',
-  'daemonAuthToken',
   'daemonTransport',
   'daemonServerMode',
-  'tenant',
   'sessionIsolation',
-  'runId',
-  'leaseId',
   'leaseBackend',
   'sessionLock',
-  'platform',
-  'target',
-  'device',
   'providerApp',
   'providerOsVersion',
   'providerProject',
@@ -79,21 +72,7 @@ export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
   'awsAppArn',
   'awsRegion',
   'awsInteractionMode',
-  'udid',
-  'serial',
-  'iosSimulatorDeviceSet',
-  'iosXctestrunFile',
-  'iosXctestDerivedDataPath',
-  'iosXctestEnvDir',
-  'androidDeviceAllowlist',
-  'session',
-  // `--no-record` is genuinely common: it applies to every recordable command,
-  // mutations included. `--record` is NOT — it only means anything for the
-  // observation-only commands the repair-segment exclusion can drop
-  // (snapshot/get/is/find), so it is scoped per-command via each schema's
-  // `allowedFlags` instead of being accepted everywhere and silently ignored
-  // (#1271 stage 2).
-  'noRecord',
+  ...commonCommandSupportedFlagKeys(),
 );
 
 export const GLOBAL_FLAG_KEYS: ReadonlySet<FlagKey> = new Set([

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -5,6 +5,7 @@ import type {
   InteractionTarget,
 } from '@agent-device/contracts/client';
 import {
+  type CliFlags,
   readOptionalInteger as optionalInteger,
   readOptionalNumber as optionalNumberValue,
 } from '@agent-device/contracts/command';
@@ -17,6 +18,7 @@ import {
 import { AppError } from '@agent-device/kernel/errors';
 import type { RepeatedInput } from '@agent-device/contracts/interaction';
 import type { JsonSchema } from './command-contract.ts';
+import { buildPrimaryEnvVarName } from '../utils/source-value.ts';
 
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 
@@ -55,6 +57,228 @@ export type SelectorSnapshotInput = {
 
 export type PointInput = { x: number; y: number };
 type CommonInputOptions = { readTargetAlias?: boolean };
+type CommonInputKey = keyof CommonCommandInput;
+type CommonFlagKey = keyof CliFlags;
+type CommonInputSchemaPlacement = 'common' | 'mcp-recordable' | 'none';
+type CommonInputAiSdkHidden = 'always' | 'whenPlatformPinned';
+type CommonInputFieldDefinition = {
+  key: string;
+  schema: JsonSchema;
+  audience: Exclude<CommandInputAudience, 'retired'>;
+  schemaPlacement: CommonInputSchemaPlacement;
+  flagKey?: CommonFlagKey;
+  fromCliFlags?: true;
+  read?: (
+    record: Record<string, unknown>,
+    options: CommonInputOptions,
+  ) => [CommonInputKey, unknown];
+  project?: (input: CommonCommandInput) => [string, unknown];
+  aiSdkHidden?: CommonInputAiSdkHidden;
+  envName?: string | false;
+  configKey?: string | false;
+  guidance?: string;
+};
+
+const COMMON_INPUT_FIELDS: readonly CommonInputFieldDefinition[] = [
+  commonStringInput('session', 'Agent-device session name.', {
+    flagKey: 'session',
+    fromCliFlags: true,
+    aiSdkHidden: 'always',
+  }),
+  {
+    key: 'platform',
+    schema: {
+      type: 'string',
+      enum: PLATFORM_SELECTORS,
+      description: 'Platform selector used to resolve a device.',
+    },
+    audience: 'model',
+    schemaPlacement: 'common',
+    flagKey: 'platform',
+    fromCliFlags: true,
+    aiSdkHidden: 'whenPlatformPinned',
+    read: (record) => ['platform', optionalEnum(record, 'platform', PLATFORM_SELECTORS)],
+    project: (input) => ['platform', input.platform],
+  },
+  {
+    key: 'deviceTarget',
+    schema: {
+      type: 'string',
+      enum: DEVICE_TARGETS,
+      description: 'Device target form. Maps to the CLI --target flag.',
+    },
+    audience: 'model',
+    schemaPlacement: 'common',
+    flagKey: 'target',
+    fromCliFlags: true,
+    read: (record, options) => ['deviceTarget', readDeviceTarget(record, options)],
+    project: (input) => ['target', input.deviceTarget],
+  },
+  {
+    key: 'target',
+    schema: {
+      type: 'string',
+      enum: DEVICE_TARGETS,
+      description:
+        'Alias for deviceTarget on commands without a UI target field. Interaction commands reserve target for the UI element.',
+    },
+    audience: 'model',
+    schemaPlacement: 'common',
+  },
+  commonStringInput('device', 'Device name selector.', { flagKey: 'device', fromCliFlags: true }),
+  commonStringInput('udid', 'iOS device UDID selector.', { flagKey: 'udid', fromCliFlags: true }),
+  commonStringInput('serial', 'Android device or Vega VVD serial selector.', {
+    flagKey: 'serial',
+    fromCliFlags: true,
+  }),
+  commonStringInput(
+    'iosSimulatorDeviceSet',
+    'iOS simulator device-set path used for device resolution.',
+    {
+      audience: 'operator',
+      flagKey: 'iosSimulatorDeviceSet',
+      fromCliFlags: true,
+      envName: false,
+    },
+  ),
+  commonStringInput(
+    'iosXctestrunFile',
+    'Externally built iOS XCTest runner .xctestrun artifact path.',
+    {
+      audience: 'operator',
+      flagKey: 'iosXctestrunFile',
+      fromCliFlags: true,
+    },
+  ),
+  commonStringInput(
+    'iosXctestDerivedDataPath',
+    'Derived data path for external iOS XCTest runner execution.',
+    {
+      audience: 'operator',
+      flagKey: 'iosXctestDerivedDataPath',
+      fromCliFlags: true,
+    },
+  ),
+  commonStringInput('iosXctestEnvDir', 'Writable directory for iOS XCTest runner env overlays.', {
+    audience: 'operator',
+    flagKey: 'iosXctestEnvDir',
+    fromCliFlags: true,
+  }),
+  commonStringInput(
+    'androidDeviceAllowlist',
+    'Android serial allowlist used for device resolution.',
+    {
+      flagKey: 'androidDeviceAllowlist',
+      fromCliFlags: true,
+    },
+  ),
+  commonStringInput('daemonBaseUrl', 'Remote daemon base URL.', {
+    audience: 'operator',
+    flagKey: 'daemonBaseUrl',
+  }),
+  commonStringInput('daemonAuthToken', 'Remote daemon auth token.', {
+    audience: 'operator',
+    flagKey: 'daemonAuthToken',
+  }),
+  commonStringInput('tenant', 'Remote tenant identifier.', { flagKey: 'tenant' }),
+  commonStringInput('runId', 'Lease run identifier.', { flagKey: 'runId' }),
+  commonStringInput('leaseId', 'Existing lease identifier.', { flagKey: 'leaseId' }),
+  commonStringInput('cwd', 'Working directory for command execution.', {
+    audience: 'operator',
+    guidance:
+      'cwd is not accepted as a tool argument. Start the process serving these tools in the desired working directory, or pass absolute paths.',
+  }),
+  commonBooleanInput('debug', 'Enable debug diagnostics.'),
+  commonBooleanInput('noRecord', 'Do not record this action.', {
+    flagKey: 'noRecord',
+    fromCliFlags: true,
+    schemaPlacement: 'mcp-recordable',
+  }),
+];
+
+export function commonCommandInputFromFlags(flags: CliFlags): Record<string, unknown> {
+  return compactRecord(
+    Object.fromEntries(
+      COMMON_INPUT_FIELDS.flatMap((field) => {
+        if (!field.fromCliFlags || !field.flagKey || !field.read) return [];
+        const [key] = field.read({}, {});
+        return [[key, flags[field.flagKey]]];
+      }),
+    ),
+  );
+}
+
+export function commonCommandSupportedFlagKeys(): readonly CommonFlagKey[] {
+  return COMMON_INPUT_FIELDS.flatMap((field) => (field.flagKey ? [field.flagKey] : []));
+}
+
+export function commonInputSchemaProperty(key: string): JsonSchema | undefined {
+  return COMMON_INPUT_FIELDS.find((field) => field.key === key)?.schema;
+}
+
+export function commonInputKeysHiddenFromAiSdk(options: {
+  platformPinned: boolean;
+}): readonly string[] {
+  return COMMON_INPUT_FIELDS.flatMap((field) => {
+    if (field.aiSdkHidden === 'always') return [field.key];
+    if (field.aiSdkHidden === 'whenPlatformPinned' && options.platformPinned) return [field.key];
+    return [];
+  });
+}
+
+export function commonOperatorInputGuidance(): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    COMMON_INPUT_FIELDS.flatMap((field) =>
+      field.audience === 'operator' ? [[field.key, operatorInputGuidance(field)]] : [],
+    ),
+  );
+}
+
+function commonStringInput(
+  key: CommonInputKey,
+  description: string,
+  options: Partial<CommonInputFieldDefinition> = {},
+): CommonInputFieldDefinition {
+  return {
+    key,
+    schema: { type: 'string', description },
+    audience: options.audience ?? 'model',
+    schemaPlacement: options.schemaPlacement ?? 'common',
+    ...options,
+    read: (record) => [key, optionalString(record, key)],
+    project: (input) => [key, input[key]],
+  };
+}
+
+function commonBooleanInput(
+  key: CommonInputKey,
+  description: string,
+  options: Partial<CommonInputFieldDefinition> = {},
+): CommonInputFieldDefinition {
+  return {
+    key,
+    schema: { type: 'boolean', description },
+    audience: options.audience ?? 'model',
+    schemaPlacement: options.schemaPlacement ?? 'common',
+    ...options,
+    read: (record) => [key, optionalBoolean(record, key)],
+    project: (input) => [key, input[key]],
+  };
+}
+
+function operatorInputGuidance(field: CommonInputFieldDefinition): string {
+  if (field.guidance) return field.guidance;
+  const envName =
+    field.envName === false ? undefined : (field.envName ?? buildPrimaryEnvVarName(field.key));
+  const configKey = field.configKey === false ? undefined : (field.configKey ?? field.key);
+  const source =
+    envName && configKey
+      ? `the ${envName} environment variable (or ${configKey} in ~/.agent-device/config.json)`
+      : envName
+        ? `the ${envName} environment variable`
+        : `${configKey} in ~/.agent-device/config.json`;
+  return `${field.key} is not accepted as a tool argument. Set ${source} for the process serving these tools.`;
+}
 
 function commandInputSchema(
   properties: Record<string, JsonSchema>,
@@ -129,12 +353,13 @@ export function looseObjectSchema(description?: string): JsonSchema {
 }
 
 type FieldReader<T> = (record: Record<string, unknown>, key: string) => T | undefined;
+export type CommandInputAudience = 'model' | 'operator' | 'retired';
 
 export type CommandField<T> = {
   schema: JsonSchema;
   required: boolean;
   read: FieldReader<T>;
-  retired?: true;
+  audience: CommandInputAudience;
 };
 
 export type CommandFieldMap = Record<string, CommandField<unknown>>;
@@ -176,7 +401,7 @@ export function retiredField(message: string): CommandField<never> {
   return {
     schema: { type: 'null' },
     required: false,
-    retired: true,
+    audience: 'retired',
     read: (record, key) => {
       if (Object.hasOwn(record, key)) {
         throw new AppError('INVALID_ARGS', message);
@@ -312,31 +537,14 @@ export function readCommonInput(
   record: Record<string, unknown>,
   options: CommonInputOptions = {},
 ): CommonCommandInput {
-  return {
-    session: optionalString(record, 'session'),
-    platform: optionalEnum(record, 'platform', PLATFORM_SELECTORS),
-    deviceTarget: readDeviceTarget(record, options),
-    device: optionalString(record, 'device'),
-    udid: optionalString(record, 'udid'),
-    serial: optionalString(record, 'serial'),
-    iosSimulatorDeviceSet: optionalString(record, 'iosSimulatorDeviceSet'),
-    iosXctestrunFile: optionalString(record, 'iosXctestrunFile'),
-    iosXctestDerivedDataPath: optionalString(record, 'iosXctestDerivedDataPath'),
-    iosXctestEnvDir: optionalString(record, 'iosXctestEnvDir'),
-    androidDeviceAllowlist: optionalString(record, 'androidDeviceAllowlist'),
-    // Seam 2 of 3 for `--no-record` (see `commonInputFromFlags`). `readFieldInput`
-    // keeps ONLY declared metadata fields plus this common input, so a flag
-    // absent here is filtered out of every field-based command's input before
-    // the client ever sees it.
-    noRecord: optionalBoolean(record, 'noRecord'),
-    daemonBaseUrl: optionalString(record, 'daemonBaseUrl'),
-    daemonAuthToken: optionalString(record, 'daemonAuthToken'),
-    tenant: optionalString(record, 'tenant'),
-    runId: optionalString(record, 'runId'),
-    leaseId: optionalString(record, 'leaseId'),
-    cwd: optionalString(record, 'cwd'),
-    debug: optionalBoolean(record, 'debug'),
-  };
+  return compactRecord(
+    Object.fromEntries(
+      COMMON_INPUT_FIELDS.flatMap((field) => {
+        const read = field.read?.(record, options);
+        return read && read[1] !== undefined ? [read] : [];
+      }),
+    ),
+  ) as CommonCommandInput;
 }
 
 function readDeviceTarget(
@@ -459,32 +667,14 @@ export function optionalEnum<const T extends readonly string[]>(
 export function commonToClientOptions(
   input: CommonCommandInput,
 ): AgentDeviceRequestOverrides & AgentDeviceSelectionOptions {
-  return compactRecord({
-    // Seam 3 of 3 for `--no-record` (see `commonInputFromFlags`). Every
-    // `to*Options` projection (`toPressOptions`, `toGetOptions`, ...) rebuilds
-    // the client options object from this helper plus its own named fields, so
-    // a flag absent here is dropped even when the reader forwarded it and
-    // `readCommonInput` kept it.
-    noRecord: input.noRecord,
-    session: input.session,
-    platform: input.platform,
-    target: input.deviceTarget,
-    device: input.device,
-    udid: input.udid,
-    serial: input.serial,
-    iosSimulatorDeviceSet: input.iosSimulatorDeviceSet,
-    iosXctestrunFile: input.iosXctestrunFile,
-    iosXctestDerivedDataPath: input.iosXctestDerivedDataPath,
-    iosXctestEnvDir: input.iosXctestEnvDir,
-    androidDeviceAllowlist: input.androidDeviceAllowlist,
-    daemonBaseUrl: input.daemonBaseUrl,
-    daemonAuthToken: input.daemonAuthToken,
-    tenant: input.tenant,
-    runId: input.runId,
-    leaseId: input.leaseId,
-    cwd: input.cwd,
-    debug: input.debug,
-  }) as AgentDeviceRequestOverrides & AgentDeviceSelectionOptions;
+  return compactRecord(
+    Object.fromEntries(
+      COMMON_INPUT_FIELDS.flatMap((field) => {
+        const projected = field.project?.(input);
+        return projected && projected[1] !== undefined ? [projected] : [];
+      }),
+    ),
+  ) as AgentDeviceRequestOverrides & AgentDeviceSelectionOptions;
 }
 
 export function toClientInteractionTarget(target: InteractionTargetInput): InteractionTarget {
@@ -542,7 +732,7 @@ export function compactRecord(record: Record<string, unknown>): Record<string, u
 }
 
 function optionalField<T>(schema: JsonSchema, read: FieldReader<T>): CommandField<T> {
-  return { schema, required: false, read };
+  return { schema, required: false, read, audience: 'model' };
 }
 
 function integerSchemaWithBounds(
@@ -559,7 +749,7 @@ function integerSchemaWithBounds(
 function fieldProperties(fields: CommandFieldMap): Record<string, JsonSchema> {
   return Object.fromEntries(
     Object.entries(fields)
-      .filter(([, field]) => !field.retired)
+      .filter(([, field]) => field.audience !== 'retired')
       .map(([key, field]) => [key, field.schema]),
   );
 }
@@ -570,7 +760,9 @@ function requiredFieldNames(fields: CommandFieldMap): string[] {
 
 /** Names of the retired fields — declared for migration guidance, absent from the schema. */
 export function retiredFieldNames(fields: CommandFieldMap): string[] {
-  return Object.entries(fields).flatMap(([key, field]) => (field.retired ? [key] : []));
+  return Object.entries(fields).flatMap(([key, field]) =>
+    field.audience === 'retired' ? [key] : [],
+  );
 }
 
 function optionalRecord(
@@ -595,55 +787,11 @@ function optionalStringArray(record: Record<string, unknown>, key: string): stri
 }
 
 function commonProperties(): Record<string, JsonSchema> {
-  return {
-    session: { type: 'string', description: 'Agent-device session name.' },
-    platform: {
-      type: 'string',
-      enum: PLATFORM_SELECTORS,
-      description: 'Platform selector used to resolve a device.',
-    },
-    deviceTarget: {
-      type: 'string',
-      enum: DEVICE_TARGETS,
-      description: 'Device target form. Maps to the CLI --target flag.',
-    },
-    target: {
-      type: 'string',
-      enum: DEVICE_TARGETS,
-      description:
-        'Alias for deviceTarget on commands without a UI target field. Interaction commands reserve target for the UI element.',
-    },
-    device: { type: 'string', description: 'Device name selector.' },
-    udid: { type: 'string', description: 'iOS device UDID selector.' },
-    serial: { type: 'string', description: 'Android device or Vega VVD serial selector.' },
-    iosSimulatorDeviceSet: {
-      type: 'string',
-      description: 'iOS simulator device-set path used for device resolution.',
-    },
-    iosXctestrunFile: {
-      type: 'string',
-      description: 'Externally built iOS XCTest runner .xctestrun artifact path.',
-    },
-    iosXctestDerivedDataPath: {
-      type: 'string',
-      description: 'Derived data path for external iOS XCTest runner execution.',
-    },
-    iosXctestEnvDir: {
-      type: 'string',
-      description: 'Writable directory for iOS XCTest runner env overlays.',
-    },
-    androidDeviceAllowlist: {
-      type: 'string',
-      description: 'Android serial allowlist used for device resolution.',
-    },
-    daemonBaseUrl: { type: 'string', description: 'Remote daemon base URL.' },
-    daemonAuthToken: { type: 'string', description: 'Remote daemon auth token.' },
-    tenant: { type: 'string', description: 'Remote tenant identifier.' },
-    runId: { type: 'string', description: 'Lease run identifier.' },
-    leaseId: { type: 'string', description: 'Existing lease identifier.' },
-    cwd: { type: 'string', description: 'Working directory for command execution.' },
-    debug: { type: 'boolean', description: 'Enable debug diagnostics.' },
-  };
+  return Object.fromEntries(
+    COMMON_INPUT_FIELDS.flatMap((field) =>
+      field.schemaPlacement === 'common' ? [[field.key, field.schema]] : [],
+    ),
+  );
 }
 
 function interactionTargetSchema(): JsonSchema {

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -2,6 +2,10 @@ import type { AgentDeviceClientConfig } from '@agent-device/contracts/client';
 import type { AgentDeviceClient } from '../client/client-types.ts';
 import type { JsonSchema } from '../commands/command-contract.ts';
 import type { CommandExecutionResult } from '../commands/command-surface.ts';
+import {
+  commonInputSchemaProperty,
+  commonOperatorInputGuidance,
+} from '../commands/command-input.ts';
 import { RESPONSE_LEVELS, type ResponseLevel } from '@agent-device/kernel/contracts';
 import { formatCliOutput } from '../commands/cli-output.ts';
 import {
@@ -21,6 +25,7 @@ import { formatToolErrorText, normalizeToolError } from './tool-error.ts';
 import { resolveMcpConfigDefaults } from './tool-input-config.ts';
 import { projectStructuredContent } from './tool-result.ts';
 import { createToolRefPinStore, type ToolRefPinStore } from './tool-ref-pins.ts';
+import { buildPrimaryEnvVarName } from '../utils/source-value.ts';
 
 export type ToolResult = {
   isError: boolean;
@@ -65,28 +70,13 @@ type McpToolConfig = {
  * Metro clients fall back to their env vars on their own.
  */
 const OPERATOR_INPUT_GUIDANCE: Readonly<Record<string, string>> = {
+  ...commonOperatorInputGuidance(),
   // Credentials.
-  daemonAuthToken:
-    'daemonAuthToken is not accepted as a tool argument. Set the AGENT_DEVICE_DAEMON_AUTH_TOKEN environment variable (or daemonAuthToken in ~/.agent-device/config.json) for the process serving these tools.',
   bearerToken:
     'bearerToken is not accepted as a tool argument. Set the AGENT_DEVICE_METRO_BEARER_TOKEN or AGENT_DEVICE_DAEMON_AUTH_TOKEN environment variable for the process serving these tools.',
-  // Endpoints the resolved credentials are sent to.
-  daemonBaseUrl:
-    'daemonBaseUrl is not accepted as a tool argument. Set the AGENT_DEVICE_DAEMON_BASE_URL environment variable (or daemonBaseUrl in ~/.agent-device/config.json) for the process serving these tools.',
   proxyBaseUrl:
     'proxyBaseUrl is not accepted as a tool argument. Configure the remote proxy in the remote-config profile or operator config for the process serving these tools.',
-  // Operator infrastructure paths.
-  stateDir:
-    'stateDir is not accepted as a tool argument. Set the AGENT_DEVICE_STATE_DIR environment variable (or stateDir in ~/.agent-device/config.json) for the process serving these tools.',
-  cwd: 'cwd is not accepted as a tool argument. Start the process serving these tools in the desired working directory, or pass absolute paths.',
-  iosSimulatorDeviceSet:
-    'iosSimulatorDeviceSet is not accepted as a tool argument. Set iosSimulatorDeviceSet in ~/.agent-device/config.json for the process serving these tools.',
-  iosXctestrunFile:
-    'iosXctestrunFile is not accepted as a tool argument. Set the AGENT_DEVICE_IOS_XCTESTRUN_FILE environment variable (or iosXctestrunFile in ~/.agent-device/config.json) for the process serving these tools.',
-  iosXctestDerivedDataPath:
-    'iosXctestDerivedDataPath is not accepted as a tool argument. Set the AGENT_DEVICE_IOS_XCTEST_DERIVED_DATA_PATH environment variable (or iosXctestDerivedDataPath in ~/.agent-device/config.json) for the process serving these tools.',
-  iosXctestEnvDir:
-    'iosXctestEnvDir is not accepted as a tool argument. Set the AGENT_DEVICE_IOS_XCTEST_ENV_DIR environment variable (or iosXctestEnvDir in ~/.agent-device/config.json) for the process serving these tools.',
+  stateDir: operatorEnvConfigGuidance('stateDir'),
 };
 
 export function listCommandTools(): Array<{
@@ -364,18 +354,15 @@ function withMcpConfigSchema(
   schema: JsonSchema,
 ): JsonSchema & { properties: Record<string, JsonSchema> } {
   const noRecord = resolveCommandRecordsSessionAction(name);
+  const noRecordSchema = commonInputSchemaProperty('noRecord');
+  if (!noRecordSchema) {
+    throw new Error('Missing common noRecord schema.');
+  }
   return {
     ...schema,
     properties: {
       ...schema.properties,
-      ...(noRecord && !schema.properties?.noRecord
-        ? {
-            noRecord: {
-              type: 'boolean',
-              description: 'Do not record this action.',
-            },
-          }
-        : {}),
+      ...(noRecord && !schema.properties?.noRecord ? { noRecord: noRecordSchema } : {}),
       stateDir: { type: 'string', description: 'Agent-device state directory.' },
       mcpOutputFormat: {
         type: 'string',
@@ -396,6 +383,10 @@ function withMcpConfigSchema(
       },
     },
   };
+}
+
+function operatorEnvConfigGuidance(key: string): string {
+  return `${key} is not accepted as a tool argument. Set the ${buildPrimaryEnvVarName(key)} environment variable (or ${key} in ~/.agent-device/config.json) for the process serving these tools.`;
 }
 
 function renderToolText(params: {


### PR DESCRIPTION
## Summary

Closes #2027. Common command input fields now live in one declarative table that carries schema, reader, client projection, CLI flag key, and surface audience metadata. MCP operator guidance/refusal and AI SDK hidden common fields derive from that same table, and retired command fields use the same `audience` vocabulary.

Scope: 5 files, command input/MCP/AI SDK only.

## Validation

- `pnpm format:check`
- `pnpm check:quick`
- `pnpm exec vitest run --project unit-core src/mcp/__tests__/command-tools-operator-inputs.test.ts src/mcp/__tests__/command-tools.test.ts src/mcp/__tests__/command-tools-parity.test.ts src/ai-sdk/__tests__/index.test.ts src/commands/__tests__/command-surface-metadata.test.ts src/commands/__tests__/command-explain.test.ts src/__tests__/cli-record-flag-delivery.test.ts`
- `PATH=/data00/home/kuanghuangshuo.12/.nvm/versions/node/v22.23.1/bin:$PATH pnpm build`
