### PR TITLE
refactor(registry): flip react-devtools to none (Wave 6 residue, part of #2042)

### DIFF
--- a/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts
@@ -15,7 +15,13 @@ import { commandDescriptors } from '../registry.ts';
  * The registry entry gate inspects one descriptor at a time, so it cannot see a command
  * whose own module holds no platform code while its CLI route injects a *different*
  * command that does. Mode dominance closes that: if a CLI route dispatches command D,
- * the route's command may declare `none` only when D is `none` too.
+ * the route's command may declare `none` only when D is not itself still `legacy`.
+ *
+ * Mode dominance is scoped to hidden *legacy* execution, not to migration mode in general: a
+ * route may declare `none` while its CLI-injected dispatch target is already `device-runtime`,
+ * `inventory`, or `host` — that target's execution is accounted for under its own descriptor,
+ * not hidden behind the route's. Dispatching to a still-`legacy` command is the one shape this
+ * gate rejects, since that really would let unmigrated execution hide behind a `none` label.
  *
  * The dispatched pairs are read from the typed table at the construction seam rather
  * than recovered from syntax. The second test keeps that seam singular, which is what
@@ -48,7 +54,7 @@ function dominanceFailures(
   table: DispatchTable = CLI_INJECTED_DAEMON_DISPATCHES,
 ): string[] {
   return declaredPairs(table)
-    .filter(({ route, dispatched }) => kindOf(route) === 'none' && kindOf(dispatched) !== 'none')
+    .filter(({ route, dispatched }) => kindOf(route) === 'none' && kindOf(dispatched) === 'legacy')
     .map(
       ({ route, dispatched }) =>
         `${route} declares platformExecution none but its CLI route dispatches ${dispatched} (${String(kindOf(dispatched))})`,
@@ -254,16 +260,24 @@ function cliModulePaths(): string[] {
 }
 
 describe('platform-execution coherence across CLI route delegation', () => {
-  test('no none command dispatches a platform-executing command', () => {
+  test('no none command dispatches a still-legacy command', () => {
     expect(dominanceFailures(registryKind)).toEqual([]);
   });
 
-  test('planted red: react-devtools declared none is rejected by the declared pair', () => {
-    const plantedNone: PlatformExecutionKindOf = (command) =>
-      command === 'react-devtools' ? 'none' : registryKind(command);
+  test('a none route dispatching an already-migrated command is not a dominance failure', () => {
+    // react-devtools dispatches `runtime`, which is fully migrated (`device-runtime`, R31) — not
+    // hidden legacy execution — so react-devtools may honestly declare `none`.
+    expect(registryKind('runtime')).toBe('device-runtime');
+    expect(registryKind('react-devtools')).toBe('none');
+    expect(dominanceFailures(registryKind)).toEqual([]);
+  });
 
-    expect(dominanceFailures(plantedNone)).toEqual([
-      'react-devtools declares platformExecution none but its CLI route dispatches runtime (device-runtime)',
+  test('planted red: a route dispatching a still-legacy command is rejected', () => {
+    const plantedLegacyRuntime: PlatformExecutionKindOf = (command) =>
+      command === 'runtime' ? 'legacy' : registryKind(command);
+
+    expect(dominanceFailures(plantedLegacyRuntime)).toEqual([
+      'react-devtools declares platformExecution none but its CLI route dispatches runtime (legacy)',
     ]);
   });
 

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1555,10 +1555,14 @@ export const RAW_COMMAND_DESCRIPTORS = [
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
     mcpExposed: false,
-    // `react-devtools start` on a Limrun Android instance dispatches internal
-    // `runtime port-reverse`, which reaches a provider device runtime. Platform
-    // execution delegated through another command is still platform execution.
-    platformExecution: LEGACY_PLATFORM_EXECUTION,
+    // Wave 6 residue: `react-devtools start` on a Limrun Android instance dispatches internal
+    // `runtime port-reverse` through the CLI-injected dispatch seam. `runtime` is itself fully
+    // migrated (`device-runtime`, R31), so the dispatched execution is accounted for under its
+    // own descriptor rather than hidden behind this one — this route owns no unmigrated platform
+    // execution of its own. The CLI-route dominance gate
+    // (`__tests__/platform-execution-cli-route.test.ts`) still rejects a `none` route whose
+    // CLI-injected dispatch target is still `legacy`.
+    platformExecution: NO_PLATFORM_EXECUTION,
   },
   {
     name: 'web',


### PR DESCRIPTION
Part of #2042 (Flip the residue legacy descriptors: web, replay, test, daemon, react-devtools).

## What lands here

**`react-devtools` → `none`.** Its only platform execution was the CLI-injected dispatch to
`runtime port-reverse` (the sole entry in `CLI_INJECTED_DAEMON_DISPATCHES`). Now that `runtime`
is fully migrated (`device-runtime`, R31), that execution is accounted for under `runtime`'s own
descriptor, not hidden behind `react-devtools`'s `none` label.

This required refining the CLI-route mode-dominance gate
(`src/core/command-descriptor/__tests__/platform-execution-cli-route.test.ts`): it previously
rejected a `none` route whenever its dispatch target was anything other than `none`
(`kindOf(dispatched) !== 'none'`); it now rejects only when the target is still `legacy`
(`kindOf(dispatched) === 'legacy'`). The narrower rule still catches real hidden-legacy
delegation (planted-red test retained/adjusted) while allowing delegation to an already-migrated
command — which matches what the terminal gate actually cares about (the `legacy` count, not
"migration mode in general").

Legacy count: **7 → 6** (`daemon`, `perf`, `replay`, `test`, `trace`, `web` remain), confirmed by
enumerating `platformExecution.kind` directly off the registry, not hand-counted.

## Why the other 4 don't flip in this PR

I investigated all 5 named descriptors before touching anything (findings posted to #1739). None
of `web`, `daemon`, `replay`, or `test` currently qualify for `none` — each has genuine platform
execution that the issue's original assumptions didn't anticipate, and forcing them would violate
the project's own rule that `none` is never a migration target for a command with real execution.

- **`daemon`** (`daemon stop --clean`): unconditionally imports and runs real Apple runner-lease
  cleanup (`src/platforms/apple/core/runner/runner-lease.ts` / `runner-disposal.ts`), which kills
  real runner/xcodebuild process trees via `runXcrun`/`simctl`. Also structurally a poor fit for
  the request-bound `device-runtime` model — the cleanup is global per daemon-owner, not scoped
  to one device/session/request. Needs a design decision, not a unit.
- **`web`** (`web setup`/`web doctor`): both dynamically import
  `src/platforms/web/agent-browser-tool.ts`, which downloads/installs the real `agent-browser`
  npm package and spawns it — the same execution surface that already backs live web sessions
  (`agent-browser-provider.ts`) and that `daemon-runtime.ts` already probes at session-bind time.
  `packages/platform-web` has not absorbed this (no `agentBrowser`/`webBackend` contract exists
  yet), and `setup`'s mutating install doesn't fit the read-only host-diagnostics shape #2038 just
  built for `doctor`'s `ambientChecks` — `web` would need its own facet.
- **`replay`/`test`**: mostly match the `batch` precedent (every `.ad`-script step and Maestro
  public operation re-enters the full per-command admission pipeline as an independent daemon
  request). But `session-replay-maestro-runtime.ts` calls `dispatchGestureViewport`
  (`src/core/dispatch.ts`) directly for Maestro's percentage-based swipe/tap coordinate math — the
  one residue `core/dispatch.ts`'s own comment already flags ("a shared helper stays in place
  until its last consumer can move"). Closing it needs more than a call-site swap: the already-
  migrated `gestureViewport` operation requires admitting a specific gesture tier before binding
  ("one bind per handler," ADR 0019 §9), but Maestro's viewport read happens generically, before a
  tier is chosen, and can serve several operations per replay step. A correct migration means
  restructuring how Maestro's runtime port threads gesture admission through its own operation
  resolution, and touches production coordinate math for live device gesture/swipe execution with
  no low-risk way to verify without device evidence — I did not attempt this live.

Full evidence and a proposed shape for each follow-up unit are posted on #1739.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `node --experimental-strip-types scripts/layering/check.ts` — clean (184 layering tests + the
  aggregate gate all pass, including the parametrized cutover-table gate)
- `npx vitest run src/core/command-descriptor` (27 files / 99 tests) and the react-devtools CLI
  test files — all pass
- Adversarial review pass run on the diff before pushing; two findings (a stale contradictory
  JSDoc sentence, a test that didn't verify its own claim) were fixed in-place.
