### PR TITLE
test(perf): raise local Vitest worker cap to four

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -179,5 +179,5 @@ or remove flakes.
   family before adding tests; never raise the pin.
 - Keep isolation enabled and the pool on forks — both alternatives were measured and did not help.
   The useful optimization is importing the module under test, not a platform barrel.
-- Raise the two-worker local cap only for a solo run: `AGENT_DEVICE_VITEST_MAX_WORKERS=<n>`
-  (clamped to host CPUs, ignored in CI).
+- Local Vitest runs use a four-worker cap. Override it when a run needs a different host share:
+  `AGENT_DEVICE_VITEST_MAX_WORKERS=<n>` (clamped to host CPUs, ignored in CI).

--- a/scripts/lib/vitest-concurrency.ts
+++ b/scripts/lib/vitest-concurrency.ts
@@ -1,11 +1,12 @@
 import os from 'node:os';
 
 /**
- * Keep one Vitest invocation modest enough to coexist with two other Codex
- * worktrees on a 12-core development host: 3 agents + (3 suites * 2 workers)
- * leaves roughly 3 cores for runners, subprocesses, simulators, and the OS.
+ * Keep one Vitest invocation below Vitest's 11-worker host default while using
+ * enough of a typical development machine to overlap the suite's I/O and timer
+ * waits. Measured 2026-08-25 on coverage shard 1/2: four workers took 74s,
+ * versus 128s with two and 217s with one.
  */
-export const DEFAULT_VITEST_MAX_WORKERS = 2;
+export const DEFAULT_VITEST_MAX_WORKERS = 4;
 
 /**
  * Opt-in escape hatch for a solo local run that owns the whole machine (see

--- a/src/__tests__/hermetic-env-setup.test.ts
+++ b/src/__tests__/hermetic-env-setup.test.ts
@@ -20,7 +20,8 @@ type ProjectShape = { test?: { name?: string; setupFiles?: readonly string[] } }
 
 test('vitest caps aggregate worker concurrency for parallel worktrees', () => {
   assert.equal(vitestConfig.test?.maxWorkers, resolveVitestMaxWorkers());
-  assert.equal(resolveVitestMaxWorkers({}), DEFAULT_VITEST_MAX_WORKERS);
+  assert.equal(DEFAULT_VITEST_MAX_WORKERS, 4);
+  assert.equal(resolveVitestMaxWorkers({}), 4);
   assert.equal(resolveVitestMaxWorkers({ CI: 'true' }), undefined);
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,12 +98,9 @@ export default defineConfig({
     // --no-isolate = 205s wall vs 48s (module state thrashes across files),
     // threads = no change.
     slowTestThreshold: 500,
-    // Vitest otherwise derives 11 workers from this 12-core host. Three
-    // concurrent Codex worktrees can then request 33 workers and starve the
-    // subprocess/test-server paths behind exact timeout budgets. Two workers
-    // per local invocation preserves useful parallelism while leaving host
-    // headroom. CI stays uncapped so Vitest derives the runner-appropriate
-    // worker count from the isolated machine's available CPU pool.
+    // Four workers gave a worthwhile solo-run speedup without approaching
+    // Vitest's 11-worker default on a 12-core host. CI stays uncapped so Vitest
+    // derives the runner-appropriate worker count from its available CPU pool.
     maxWorkers: resolveVitestMaxWorkers(),
     // hermetic-env-setup clears worker-scoped device claims after every case.
     // Capping explicit `test.concurrent` work at one enforces that teardown


### PR DESCRIPTION
## Summary

Raise the default local Vitest worker ceiling from 2 to 4 while preserving the existing environment override and leaving CI runner-derived concurrency unchanged.

The adaptive load-balancer experiment is intentionally excluded: its roughly five-second median improvement under concurrent load did not justify coordination complexity.

Touched 4 files; scope stayed within Vitest test tooling and its documentation.

## Validation

- Focused Vitest configuration test: 6/6 passed.
- `pnpm check:affected --run`: all runnable checks passed. GitHub remains authoritative for CI-only coverage and device lanes.