### PR TITLE
perf(harmonyos): memoize gesture viewport dumps

### DIFF
--- a/src/core/__tests__/harmonyos-interactor.test.ts
+++ b/src/core/__tests__/harmonyos-interactor.test.ts
@@ -1,12 +1,19 @@
 import { expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
+const { invalidateHarmonyGestureViewport, runHarmonyHdc } = vi.hoisted(() => ({
+  invalidateHarmonyGestureViewport: vi.fn(),
+  runHarmonyHdc: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+}));
+
+vi.mock('../../platforms/harmonyos/hdc.ts', () => ({ runHarmonyHdc }));
 vi.mock('../../platforms/harmonyos/snapshot.ts', () => ({
   snapshotHarmony: vi.fn(async () => ({
     nodes: [{ index: 0, type: 'Button', label: 'Continue' }],
     truncated: false,
   })),
   readHarmonyGestureViewport: vi.fn(),
+  invalidateHarmonyGestureViewport,
 }));
 
 import { createHarmonyInteractor } from '../interactors/harmonyos.ts';
@@ -25,4 +32,19 @@ test('harmonyos snapshot stamps its channel and producer', async () => {
   expect(result.backend).toBe('harmonyos-arkui');
   expect(result.producer).toBe('harmonyos-uitest');
   expect(result.nodes).toEqual([{ index: 0, type: 'Button', label: 'Continue' }]);
+});
+
+test('harmonyos keyboard dismiss invalidates gesture viewport through the Back route', async () => {
+  await expect(createHarmonyInteractor(device).keyboardDismiss?.()).resolves.toEqual({
+    kind: 'acknowledged',
+  });
+
+  expect(runHarmonyHdc).toHaveBeenCalledWith(device, [
+    'shell',
+    'uitest',
+    'uiInput',
+    'keyEvent',
+    'Back',
+  ]);
+  expect(invalidateHarmonyGestureViewport).toHaveBeenCalledWith(device);
 });

--- a/src/platforms/harmonyos/__tests__/app-lifecycle.test.ts
+++ b/src/platforms/harmonyos/__tests__/app-lifecycle.test.ts
@@ -7,6 +7,15 @@ vi.mock('../../../utils/exec.ts', async (importOriginal) => {
   return { ...actual, runCmd: vi.fn() };
 });
 
+const { invalidateHarmonyGestureViewport } = vi.hoisted(() => ({
+  invalidateHarmonyGestureViewport: vi.fn(),
+}));
+
+vi.mock('../snapshot.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../snapshot.ts')>()),
+  invalidateHarmonyGestureViewport,
+}));
+
 import {
   closeHarmonyApp,
   listHarmonyApps,
@@ -32,6 +41,7 @@ const DEVICE = {
 beforeEach(() => {
   vi.useRealTimers();
   mockRunCmd.mockReset();
+  invalidateHarmonyGestureViewport.mockReset();
 });
 
 afterEach(() => {
@@ -146,6 +156,7 @@ test('HarmonyOS lifecycle commands use HDC bundle and ability primitives', async
       ['-t', 'harmony-1', 'shell', 'aa', 'force-stop', 'com.example.application'],
     ],
   );
+  assert.deepEqual(invalidateHarmonyGestureViewport.mock.calls, [[DEVICE], [DEVICE]]);
 });
 
 test('HarmonyOS app listing filters user-installed bundles through Bundle Manager metadata', async () => {

--- a/src/platforms/harmonyos/__tests__/input-actions.test.ts
+++ b/src/platforms/harmonyos/__tests__/input-actions.test.ts
@@ -3,15 +3,20 @@ import { beforeEach, test, vi } from 'vitest';
 import type { GesturePlan } from '@agent-device/contracts/gesture-plan-types';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
-const { runHarmonyHdc, sleep, readHarmonyGestureViewport } = vi.hoisted(() => ({
-  runHarmonyHdc: vi.fn(),
-  sleep: vi.fn(),
-  readHarmonyGestureViewport: vi.fn(),
-}));
+const { runHarmonyHdc, sleep, readHarmonyGestureViewport, invalidateHarmonyGestureViewport } =
+  vi.hoisted(() => ({
+    runHarmonyHdc: vi.fn(),
+    sleep: vi.fn(),
+    readHarmonyGestureViewport: vi.fn(),
+    invalidateHarmonyGestureViewport: vi.fn(),
+  }));
 
 vi.mock('../hdc.ts', () => ({ runHarmonyHdc }));
 vi.mock('../../../utils/timeouts.ts', () => ({ sleep }));
-vi.mock('../snapshot.ts', () => ({ readHarmonyGestureViewport }));
+vi.mock('../snapshot.ts', () => ({
+  readHarmonyGestureViewport,
+  invalidateHarmonyGestureViewport,
+}));
 
 import {
   appSwitcherHarmony,
@@ -41,6 +46,7 @@ beforeEach(() => {
   runHarmonyHdc.mockReset();
   sleep.mockReset();
   readHarmonyGestureViewport.mockReset();
+  invalidateHarmonyGestureViewport.mockReset();
 });
 
 test('HarmonyOS input primitives use the documented uiInput command names', async () => {

--- a/src/platforms/harmonyos/__tests__/input-actions.test.ts
+++ b/src/platforms/harmonyos/__tests__/input-actions.test.ts
@@ -75,6 +75,7 @@ test('HarmonyOS input primitives use the documented uiInput command names', asyn
     ],
   );
   assert.deepEqual(sleep.mock.calls, [[25], [50]]);
+  assert.deepEqual(invalidateHarmonyGestureViewport.mock.calls, [[DEVICE], [DEVICE], [DEVICE]]);
 });
 
 test('HarmonyOS scroll derives a viewport-aware swipe plan', async () => {

--- a/src/platforms/harmonyos/__tests__/snapshot-viewport-cache.test.ts
+++ b/src/platforms/harmonyos/__tests__/snapshot-viewport-cache.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { beforeEach, test, vi } from 'vitest';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+const { runHarmonyHdc } = vi.hoisted(() => ({ runHarmonyHdc: vi.fn() }));
+
+vi.mock('../hdc.ts', () => ({ runHarmonyHdc }));
+
+import { invalidateHarmonyGestureViewport, readHarmonyGestureViewport } from '../snapshot.ts';
+
+const DEVICE_A: DeviceInfo = {
+  platform: 'harmonyos',
+  id: 'harmony-viewport-a',
+  name: 'HarmonyOS test device A',
+  kind: 'device',
+  target: 'mobile',
+  booted: true,
+};
+
+const DEVICE_B: DeviceInfo = { ...DEVICE_A, id: 'harmony-viewport-b' };
+
+const TALL_LAYOUT = {
+  attributes: { type: 'root', bounds: '[0,0][1080,2340]' },
+};
+
+const WIDE_LAYOUT = {
+  attributes: { type: 'root', bounds: '[0,0][2340,1080]' },
+};
+
+beforeEach(() => {
+  runHarmonyHdc.mockReset();
+  scriptHarmonyLayoutDump(TALL_LAYOUT);
+});
+
+/** Scripts `uitest dumpLayout` + `file recv` so the pulled layout is `layout`. */
+function scriptHarmonyLayoutDump(layout: unknown): void {
+  runHarmonyHdc.mockImplementation(async (_device: unknown, args: string[]) => {
+    if (args[0] === 'file' && args[1] === 'recv') {
+      fs.writeFileSync(args[3] as string, JSON.stringify(layout), 'utf8');
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+}
+
+function dumpLayoutCallCount(): number {
+  return runHarmonyHdc.mock.calls.filter(([, args]) => args.includes('dumpLayout')).length;
+}
+
+test('repeated viewport reads within the TTL trigger a single layout dump', async () => {
+  const first = await readHarmonyGestureViewport(DEVICE_A);
+  const second = await readHarmonyGestureViewport(DEVICE_A);
+
+  assert.deepEqual(first, { x: 0, y: 0, width: 1080, height: 2340 });
+  assert.deepEqual(second, first);
+  assert.equal(dumpLayoutCallCount(), 1);
+});
+
+test('invalidating the viewport cache forces a fresh layout dump', async () => {
+  await readHarmonyGestureViewport(DEVICE_A);
+  assert.equal(dumpLayoutCallCount(), 1);
+
+  scriptHarmonyLayoutDump(WIDE_LAYOUT);
+  invalidateHarmonyGestureViewport(DEVICE_A);
+  const refreshed = await readHarmonyGestureViewport(DEVICE_A);
+
+  assert.deepEqual(refreshed, { x: 0, y: 0, width: 2340, height: 1080 });
+  assert.equal(dumpLayoutCallCount(), 2);
+});
+
+test('viewport cache entries are scoped per device id', async () => {
+  await readHarmonyGestureViewport(DEVICE_A);
+
+  const otherDevice = await readHarmonyGestureViewport(DEVICE_B);
+
+  assert.deepEqual(otherDevice, { x: 0, y: 0, width: 1080, height: 2340 });
+  assert.equal(dumpLayoutCallCount(), 2);
+});

--- a/src/platforms/harmonyos/__tests__/snapshot-viewport-cache.test.ts
+++ b/src/platforms/harmonyos/__tests__/snapshot-viewport-cache.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import { beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
 const { runHarmonyHdc } = vi.hoisted(() => ({ runHarmonyHdc: vi.fn() }));
@@ -33,6 +33,10 @@ beforeEach(() => {
   scriptHarmonyLayoutDump(TALL_LAYOUT);
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 /** Scripts `uitest dumpLayout` + `file recv` so the pulled layout is `layout`. */
 function scriptHarmonyLayoutDump(layout: unknown): void {
   runHarmonyHdc.mockImplementation(async (_device: unknown, args: string[]) => {
@@ -54,6 +58,21 @@ test('repeated viewport reads within the TTL trigger a single layout dump', asyn
   assert.deepEqual(first, { x: 0, y: 0, width: 1080, height: 2340 });
   assert.deepEqual(second, first);
   assert.equal(dumpLayoutCallCount(), 1);
+});
+
+test('viewport cache expires after two seconds without explicit invalidation', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+
+  await readHarmonyGestureViewport(DEVICE_A);
+  assert.equal(dumpLayoutCallCount(), 1);
+
+  scriptHarmonyLayoutDump(WIDE_LAYOUT);
+  await vi.advanceTimersByTimeAsync(2_000);
+  const refreshed = await readHarmonyGestureViewport(DEVICE_A);
+
+  assert.deepEqual(refreshed, { x: 0, y: 0, width: 2340, height: 1080 });
+  assert.equal(dumpLayoutCallCount(), 2);
 });
 
 test('invalidating the viewport cache forces a fresh layout dump', async () => {

--- a/src/platforms/harmonyos/app-lifecycle.ts
+++ b/src/platforms/harmonyos/app-lifecycle.ts
@@ -2,6 +2,7 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { runCmd } from '../../utils/exec.ts';
 import { runHarmonyHdc } from './hdc.ts';
+import { invalidateHarmonyGestureViewport } from './snapshot.ts';
 
 export function parseHarmonyBundleList(rawOutput: string): string[] {
   return rawOutput
@@ -229,8 +230,10 @@ export async function openHarmonyApp(
       details: { output: result.stdout.trim() },
     });
   }
+  invalidateHarmonyGestureViewport(device);
 }
 
 export async function closeHarmonyApp(device: DeviceInfo, bundleId: string): Promise<void> {
   await runHarmonyHdc(device, ['shell', 'aa', 'force-stop', bundleId]);
+  invalidateHarmonyGestureViewport(device);
 }

--- a/src/platforms/harmonyos/input-actions.ts
+++ b/src/platforms/harmonyos/input-actions.ts
@@ -9,7 +9,7 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { sleep } from '../../utils/timeouts.ts';
 import { runHarmonyHdc } from './hdc.ts';
-import { readHarmonyGestureViewport } from './snapshot.ts';
+import { invalidateHarmonyGestureViewport, readHarmonyGestureViewport } from './snapshot.ts';
 
 export async function pressHarmony(device: DeviceInfo, x: number, y: number): Promise<void> {
   await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'click', String(x), String(y)]);
@@ -123,14 +123,17 @@ export async function performHarmonyGesture(
 
 export async function backHarmony(device: DeviceInfo): Promise<void> {
   await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', 'Back']);
+  invalidateHarmonyGestureViewport(device);
 }
 
 export async function homeHarmony(device: DeviceInfo): Promise<void> {
   await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', 'Home']);
+  invalidateHarmonyGestureViewport(device);
 }
 
 export async function appSwitcherHarmony(device: DeviceInfo): Promise<void> {
   await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', 'Recent']);
+  invalidateHarmonyGestureViewport(device);
 }
 
 export async function pressHarmonyKeyboardKey(

--- a/src/platforms/harmonyos/input-actions.ts
+++ b/src/platforms/harmonyos/input-actions.ts
@@ -140,6 +140,10 @@ export async function pressHarmonyKeyboardKey(
   device: DeviceInfo,
   key: 'Enter' | 'Back',
 ): Promise<void> {
+  if (key === 'Back') {
+    await backHarmony(device);
+    return;
+  }
   await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', key]);
 }
 

--- a/src/platforms/harmonyos/snapshot.ts
+++ b/src/platforms/harmonyos/snapshot.ts
@@ -6,9 +6,26 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { RawSnapshotNode, Rect } from '@agent-device/kernel/snapshot';
 import { AppError } from '@agent-device/kernel/errors';
 import type { SnapshotOptions } from '@agent-device/contracts/interactor-types';
+import { createTtlMemo } from '../../utils/ttl-memo.ts';
 import { runHarmonyHdc } from './hdc.ts';
 
 const MAX_NODES = 5_000;
+
+// Gesture planning only reads the Application rect's width/height, but every
+// read paid a full layout dump (`uitest dumpLayout` + `file recv` + `rm`).
+// Edge scrolls run several passes back to back, so a short memo collapses
+// them into one dump while staying far below the cadence where a foreground
+// change between passes would matter. Residual risk: a physical rotation or a
+// split-screen/multi-window transition inside the TTL window that no hook
+// covers yields one stale plan until expiry; agent-device itself cannot
+// rotate HarmonyOS (setHarmonyOrientation throws UNSUPPORTED_OPERATION).
+const HARMONY_GESTURE_VIEWPORT_MEMO_TTL_MS = 2_000;
+const harmonyGestureViewportMemo = createTtlMemo<string, Rect>({
+  ttlMs: HARMONY_GESTURE_VIEWPORT_MEMO_TTL_MS,
+  // Eager expiry so long-lived daemon processes do not accumulate one entry
+  // per device forever.
+  scheduleExpiry: true,
+});
 
 type ArkUiLayoutNode = {
   attributes?: Record<string, unknown>;
@@ -44,6 +61,9 @@ export async function snapshotHarmony(
 
 /** Returns the current ArkUI application viewport for coordinate gestures. */
 export async function readHarmonyGestureViewport(device: DeviceInfo): Promise<Rect> {
+  const memoKey = device.id;
+  const cached = harmonyGestureViewportMemo.get(memoKey);
+  if (cached) return cached;
   const snapshot = await snapshotHarmony(device);
   const viewport = snapshot.nodes.find((node) => node.type === 'Application' && node.rect)?.rect;
   if (!viewport || viewport.width <= 0 || viewport.height <= 0) {
@@ -52,7 +72,17 @@ export async function readHarmonyGestureViewport(device: DeviceInfo): Promise<Re
       'HarmonyOS snapshot did not expose an application viewport',
     );
   }
+  harmonyGestureViewportMemo.set(memoKey, viewport);
   return viewport;
+}
+
+/**
+ * Drop the cached gesture viewport for `device`. Call after anything that can
+ * change the foreground app or window geometry (app open/close, home, back,
+ * app switcher) so the next plan reads a fresh dump.
+ */
+export function invalidateHarmonyGestureViewport(device: DeviceInfo): void {
+  harmonyGestureViewportMemo.delete(device.id);
 }
 
 export function parseHarmonyLayout(raw: string): ArkUiLayoutNode {


### PR DESCRIPTION
## Summary

HarmonyOS coordinate gestures now reuse one device-scoped ArkUI viewport for up to two seconds instead of paying a full layout dump for every adjacent gesture. Foreground-changing actions invalidate the memo, and keyboard dismiss delegates Back through the same invalidating owner as normal navigation.

The previous diagnostics and Apple changes were removed from this PR and preserved as separate ownership slices. This PR changes 7 files and stays within the HarmonyOS interaction family.

## Validation

A planted 20-second TTL made the new exact-expiry regression return the stale portrait viewport after two seconds. Before the production fix, the real interactor keyboard-dismiss route emitted Back but did not invalidate the memo. Both regressions are green on `c604df249e`.

The affected gate passed all runnable checks, including 247 test files / 1,550 tests, format, lint, typecheck, layering, Fallow, build, and provider integration. No HarmonyOS hardware is provisioned locally or in CI; residual live risk is limited to physical rotation or multi-window geometry changes within the two-second TTL.