### PR TITLE
perf(diagnostics): reuse redaction and directory work per scope

### DIFF
--- a/src/utils/__tests__/diagnostics.test.ts
+++ b/src/utils/__tests__/diagnostics.test.ts
@@ -151,3 +151,26 @@ test('appendDiagnosticLine ensures the log directory once across appended lines'
     mkdirSpy.mockRestore();
   }
 });
+
+test('a later diagnostics scope recreates a removed log directory', async () => {
+  const rootDir = mkdtempForTestSync('agent-device-diag-recreate-');
+  const logDir = path.join(rootDir, 'nested');
+  const logPath = path.join(logDir, 'request.ndjson');
+  const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
+  try {
+    await withDiagnosticsScope({ command: 'first', logPath, debug: true }, () => {
+      emitDiagnostic({ phase: 'first_scope' });
+    });
+    fs.rmSync(logDir, { recursive: true, force: true });
+
+    await withDiagnosticsScope({ command: 'second', logPath, debug: true }, () => {
+      emitDiagnostic({ phase: 'second_scope' });
+    });
+
+    const callsForLogDir = mkdirSpy.mock.calls.filter(([dir]) => dir === logDir);
+    assert.equal(callsForLogDir.length, 2);
+    assert.match(fs.readFileSync(logPath, 'utf8'), /second_scope/);
+  } finally {
+    mkdirSpy.mockRestore();
+  }
+});

--- a/src/utils/__tests__/diagnostics.test.ts
+++ b/src/utils/__tests__/diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -88,4 +88,66 @@ test('diagnostics scrubs caller-declared recorded input literals regardless of f
   const diagnostics = fs.readFileSync(outputPath, 'utf8');
   assert.equal(diagnostics.includes(secret), false);
   assert.match(diagnostics, /Backend echoed \[REDACTED\]/);
+});
+
+test('overlapping sensitive values replace longest-first even when registered out of order', async () => {
+  const outputPath = path.join(mkdtempForTestSync('agent-device-diag-overlap-'), 'request.ndjson');
+  const shortLiteral = 'secret-value';
+  const longLiteral = `${shortLiteral}-extended`;
+
+  await withDiagnosticsScope({ command: 'fill', logPath: outputPath }, async () => {
+    registerDiagnosticSensitiveValue(shortLiteral);
+    registerDiagnosticSensitiveValue(longLiteral);
+    emitDiagnostic({
+      phase: 'platform_failure',
+      data: { message: `echoed ${longLiteral} tail` },
+    });
+    flushDiagnosticsToSessionFile({ force: true });
+  });
+
+  const diagnostics = fs.readFileSync(outputPath, 'utf8');
+  assert.equal(diagnostics.includes(longLiteral), false);
+  assert.equal(diagnostics.includes(shortLiteral), false);
+  // Shortest-first replacement would leave '[REDACTED]-extended' behind.
+  assert.match(diagnostics, /echoed \[REDACTED\] tail/);
+});
+
+test('a value registered after an emit but before flush is replaced in the flushed file', async () => {
+  const outputPath = path.join(
+    mkdtempForTestSync('agent-device-diag-late-register-'),
+    'request.ndjson',
+  );
+  const lateSecret = 'late-registered-opaque-literal';
+
+  await withDiagnosticsScope({ command: 'fill', logPath: outputPath }, async () => {
+    emitDiagnostic({
+      phase: 'platform_failure',
+      data: { message: `captured ${lateSecret}` },
+    });
+    registerDiagnosticSensitiveValue(lateSecret);
+    flushDiagnosticsToSessionFile({ force: true });
+  });
+
+  const diagnostics = fs.readFileSync(outputPath, 'utf8');
+  assert.equal(diagnostics.includes(lateSecret), false);
+  assert.match(diagnostics, /captured \[REDACTED\]/);
+});
+
+test('appendDiagnosticLine ensures the log directory once across appended lines', () => {
+  const logDir = mkdtempForTestSync('agent-device-diag-mkdir-');
+  const logPath = path.join(logDir, 'nested', 'request.ndjson');
+  const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
+  try {
+    withDiagnosticsScope({ command: 'fill', logPath, debug: true }, () => {
+      for (let index = 0; index < 3; index += 1) {
+        emitDiagnostic({ phase: `iteration_${index}`, data: { index } });
+      }
+    });
+
+    const callsForLogDir = mkdirSpy.mock.calls.filter(([dir]) => dir === path.dirname(logPath));
+    assert.equal(callsForLogDir.length, 1);
+    assert.equal(fs.readFileSync(logPath, 'utf8').trim().split('\n').length, 3);
+  } finally {
+    mkdirSpy.mockRestore();
+  }
 });

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -46,6 +46,7 @@ type DiagnosticsScope = DiagnosticsScopeOptions & {
   // events are streamed out and reset mid-flight.
   phaseCounts: Map<string, number>;
   sensitiveValues: Set<string>;
+  ensuredDirectories: Set<string>;
   // Sorted-longest-first view of `sensitiveValues`, recomputed lazily after a
   // registration invalidates it so replacement order stays deterministic.
   sortedSensitiveValues?: string[];
@@ -72,6 +73,7 @@ export async function withDiagnosticsScope<T>(
     liveWrittenEventCount: 0,
     phaseCounts: new Map(),
     sensitiveValues: new Set(),
+    ensuredDirectories: new Set(),
   };
   return await diagnosticsStorage.run(scope, fn);
 }
@@ -145,11 +147,11 @@ export function emitDiagnostic(event: {
   const fileLine = `${JSON.stringify(payload)}\n`;
   try {
     if (scope.debug && scope.logPath) {
-      appendDiagnosticLine(scope.logPath, fileLine);
+      appendDiagnosticLine(scope, scope.logPath, fileLine);
       scope.liveWrittenEventCount = scope.events.length;
     }
     if (scope.traceLogPath) {
-      appendDiagnosticLine(scope.traceLogPath, fileLine);
+      appendDiagnosticLine(scope, scope.traceLogPath, fileLine);
     }
     if (scope.debug && !scope.logPath && !scope.traceLogPath) {
       process.stderr.write(`[agent-device][diag] ${fileLine}`);
@@ -221,7 +223,7 @@ export function flushDiagnosticsToSessionFile(
         const lines = pendingEvents.map((entry) =>
           JSON.stringify(replaceSensitiveValues(entry, values)),
         );
-        appendDiagnosticLine(scope.logPath, `${lines.join('\n')}\n`);
+        appendDiagnosticLine(scope, scope.logPath, `${lines.join('\n')}\n`);
       }
       const logRecord = scope.logRecord;
       scope.events = [];
@@ -283,14 +285,11 @@ function sanitizePathPart(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-// Directories already ensured by appendDiagnosticLine; debug mode would mkdir per line otherwise.
-const ensuredDiagnosticDirs = new Set<string>();
-
-function appendDiagnosticLine(logPath: string, line: string): void {
+function appendDiagnosticLine(scope: DiagnosticsScope, logPath: string, line: string): void {
   const dir = path.dirname(logPath);
-  if (!ensuredDiagnosticDirs.has(dir)) {
+  if (!scope.ensuredDirectories.has(dir)) {
     fs.mkdirSync(dir, { recursive: true });
-    ensuredDiagnosticDirs.add(dir);
+    scope.ensuredDirectories.add(dir);
   }
   fs.appendFileSync(logPath, line, 'utf8');
 }

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -92,14 +92,8 @@ export function getDiagnosticsMeta(): {
 } {
   const scope = diagnosticsStorage.getStore();
   if (!scope) return {};
-  return {
-    diagnosticId: scope.diagnosticId,
-    requestId: scope.requestId,
-    session: scope.session,
-    command: scope.command,
-    debug: scope.debug,
-    flushOnSuccess: scope.flushOnSuccess,
-  };
+  const { diagnosticId, requestId, session, command, debug, flushOnSuccess } = scope;
+  return { diagnosticId, requestId, session, command, debug, flushOnSuccess };
 }
 
 /** Register a caller-declared literal that must not reach this request's diagnostics. */
@@ -212,27 +206,27 @@ export function flushDiagnosticsToSessionFile(
   if (!scope) return null;
   if (!options.force && !scope.debug && !scope.flushOnSuccess) return null;
   if (scope.events.length === 0) return null;
+  const values = sortedScopeSensitiveValues(scope);
 
   try {
     if (scope.logPath) {
       const pendingEvents = scope.events.slice(scope.liveWrittenEventCount);
       if (pendingEvents.length > 0) {
-        // Entries were fully redacted at emit time. `redactDiagnosticData` is
-        // idempotent over its own output (its replacements cannot re-match its
-        // patterns and strings stay length-bounded), so re-running it here
-        // cannot change bytes; only the caller-declared value replacement is
-        // repeated, so literals registered after an emit are still scrubbed.
-        const values = sortedScopeSensitiveValues(scope);
+        // Data payloads are fully redacted once at emit time; this flush pass
+        // repeats only the caller-declared literal replacement so literals
+        // registered after an emit are still scrubbed. Metadata fields are
+        // generated identifiers and internal phase names, deliberately no
+        // longer re-normalized here. Replacement output is not length-bounded:
+        // a short literal can grow past `[REDACTED]`.
         const lines = pendingEvents.map((entry) =>
           JSON.stringify(replaceSensitiveValues(entry, values)),
         );
         appendDiagnosticLine(scope.logPath, `${lines.join('\n')}\n`);
       }
-      const logPath = scope.logPath;
       const logRecord = scope.logRecord;
       scope.events = [];
       scope.liveWrittenEventCount = 0;
-      return { path: logPath, ...(logRecord ? { ref: logRecord } : {}) };
+      return { path: scope.logPath, ...(logRecord ? { ref: logRecord } : {}) };
     }
 
     const sessionDir = sanitizePathPart(scope.session ?? 'default');
@@ -242,7 +236,6 @@ export function flushDiagnosticsToSessionFile(
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const filePath = path.join(baseDir, `${timestamp}-${scope.diagnosticId}.ndjson`);
     // Same single-value-replacement re-pass as the logPath branch above.
-    const values = sortedScopeSensitiveValues(scope);
     const lines = scope.events.map((entry) =>
       JSON.stringify(replaceSensitiveValues(entry, values)),
     );
@@ -256,11 +249,9 @@ export function flushDiagnosticsToSessionFile(
 
 /** Longest-first so an overlapping shorter literal cannot truncate a longer one. */
 function sortedScopeSensitiveValues(scope: DiagnosticsScope): readonly string[] {
-  if (!scope.sortedSensitiveValues) {
-    scope.sortedSensitiveValues = [...scope.sensitiveValues].sort(
-      (left, right) => right.length - left.length,
-    );
-  }
+  scope.sortedSensitiveValues ??= [...scope.sensitiveValues].sort(
+    (left, right) => right.length - left.length,
+  );
   return scope.sortedSensitiveValues;
 }
 
@@ -292,8 +283,7 @@ function sanitizePathPart(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-// Directories already ensured by appendDiagnosticLine. Debug-mode scopes
-// append one line per event, so without this memo every line pays a mkdir.
+// Directories already ensured by appendDiagnosticLine; debug mode would mkdir per line otherwise.
 const ensuredDiagnosticDirs = new Set<string>();
 
 function appendDiagnosticLine(logPath: string, line: string): void {

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -46,6 +46,9 @@ type DiagnosticsScope = DiagnosticsScopeOptions & {
   // events are streamed out and reset mid-flight.
   phaseCounts: Map<string, number>;
   sensitiveValues: Set<string>;
+  // Sorted-longest-first view of `sensitiveValues`, recomputed lazily after a
+  // registration invalidates it so replacement order stays deterministic.
+  sortedSensitiveValues?: string[];
 };
 
 const diagnosticsStorage = new AsyncLocalStorage<DiagnosticsScope>();
@@ -102,7 +105,10 @@ export function getDiagnosticsMeta(): {
 /** Register a caller-declared literal that must not reach this request's diagnostics. */
 export function registerDiagnosticSensitiveValue(value: string): void {
   if (!value) return;
-  diagnosticsStorage.getStore()?.sensitiveValues.add(value);
+  const scope = diagnosticsStorage.getStore();
+  if (!scope) return;
+  scope.sensitiveValues.add(value);
+  scope.sortedSensitiveValues = undefined;
 }
 
 /**
@@ -211,7 +217,15 @@ export function flushDiagnosticsToSessionFile(
     if (scope.logPath) {
       const pendingEvents = scope.events.slice(scope.liveWrittenEventCount);
       if (pendingEvents.length > 0) {
-        const lines = pendingEvents.map((entry) => JSON.stringify(redactScopeData(scope, entry)));
+        // Entries were fully redacted at emit time. `redactDiagnosticData` is
+        // idempotent over its own output (its replacements cannot re-match its
+        // patterns and strings stay length-bounded), so re-running it here
+        // cannot change bytes; only the caller-declared value replacement is
+        // repeated, so literals registered after an emit are still scrubbed.
+        const values = sortedScopeSensitiveValues(scope);
+        const lines = pendingEvents.map((entry) =>
+          JSON.stringify(replaceSensitiveValues(entry, values)),
+        );
         appendDiagnosticLine(scope.logPath, `${lines.join('\n')}\n`);
       }
       const logPath = scope.logPath;
@@ -227,7 +241,11 @@ export function flushDiagnosticsToSessionFile(
     fs.mkdirSync(baseDir, { recursive: true });
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const filePath = path.join(baseDir, `${timestamp}-${scope.diagnosticId}.ndjson`);
-    const lines = scope.events.map((entry) => JSON.stringify(redactScopeData(scope, entry)));
+    // Same single-value-replacement re-pass as the logPath branch above.
+    const values = sortedScopeSensitiveValues(scope);
+    const lines = scope.events.map((entry) =>
+      JSON.stringify(replaceSensitiveValues(entry, values)),
+    );
     fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
     scope.events = [];
     return { path: filePath };
@@ -236,10 +254,19 @@ export function flushDiagnosticsToSessionFile(
   }
 }
 
+/** Longest-first so an overlapping shorter literal cannot truncate a longer one. */
+function sortedScopeSensitiveValues(scope: DiagnosticsScope): readonly string[] {
+  if (!scope.sortedSensitiveValues) {
+    scope.sortedSensitiveValues = [...scope.sensitiveValues].sort(
+      (left, right) => right.length - left.length,
+    );
+  }
+  return scope.sortedSensitiveValues;
+}
+
 function redactScopeData<T>(scope: DiagnosticsScope, input: T): T {
   const redacted = redactDiagnosticData(input);
-  const values = [...scope.sensitiveValues].sort((left, right) => right.length - left.length);
-  return replaceSensitiveValues(redacted, values) as T;
+  return replaceSensitiveValues(redacted, sortedScopeSensitiveValues(scope)) as T;
 }
 
 function replaceSensitiveValues(value: unknown, sensitiveValues: readonly string[]): unknown {
@@ -265,7 +292,15 @@ function sanitizePathPart(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
+// Directories already ensured by appendDiagnosticLine. Debug-mode scopes
+// append one line per event, so without this memo every line pays a mkdir.
+const ensuredDiagnosticDirs = new Set<string>();
+
 function appendDiagnosticLine(logPath: string, line: string): void {
-  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const dir = path.dirname(logPath);
+  if (!ensuredDiagnosticDirs.has(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    ensuredDiagnosticDirs.add(dir);
+  }
   fs.appendFileSync(logPath, line, 'utf8');
 }


### PR DESCRIPTION
## Summary

Redact structured event data once at emit time, reuse sorted redaction literals within a diagnostics scope, and memoize ensured log directories per scope.

The scope boundary remains explicit: a new diagnostics scope recreates a deleted log directory rather than inheriting stale process-global state. This is the diagnostics-only slice extracted from #2051.

## Validation

- Planted-red regression proved that a second scope must recreate a deleted directory.
- `pnpm check:affected --run` — 593 files / 4,307 tests passed; format, lint, typecheck, layering, Fallow, and build passed.
- 2 files changed.