### PR TITLE
fix(daemon): reconcile device claims held by a replaced daemon

### DIFF
--- a/src/__tests__/cli-device-status.test.ts
+++ b/src/__tests__/cli-device-status.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { test, vi } from 'vitest';
 import { readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
 import { runCliCapture } from './cli-capture.ts';
+import { publishDaemonRegistration } from './test-utils/device-claim-store.ts';
 import { mkdtempForTestSync } from './test-utils/tmp-dir.ts';
 
 vi.mock('../utils/host-process.ts', async (importOriginal) =>
@@ -189,6 +190,53 @@ test('states that nothing is claimed when every claim is stale', async () => {
     assert.match(result.stdout, /No live local device claims found\./);
     assert.match(result.stdout, /1 stale claim hidden/);
     assert.doesNotMatch(result.stdout, /Dead iPhone/);
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});
+
+test('names a replaced-but-running daemon owner as stale rather than a live holder', async () => {
+  const claimsDir = mkdtempForTestSync('agent-device-cli-claims-');
+  const stateDir = path.join(claimsDir, 'state');
+  try {
+    // #2031: the recorded owner still runs, but we are the daemon published for
+    // its state dir, so its session is one `session list` cannot report.
+    publishDaemonRegistration(stateDir, readCurrentOwnerIdentity());
+    fs.writeFileSync(
+      path.join(claimsDir, 'superseded.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        deviceKey: 'local:web:none:agent-browser-chrome',
+        device: {
+          platform: 'web',
+          id: 'agent-browser-chrome',
+          name: 'Chrome',
+          kind: 'device',
+        },
+        session: 'cwd:/w:default',
+        workspace: '/w',
+        stateDir,
+        ownerPid: process.ppid,
+        ownerStartTime: null,
+        ownerToken: 'superseded-token',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    );
+
+    const normal = await runCliCapture(['device', 'status'], {
+      env: { AGENT_DEVICE_CLAIMS_DIR: claimsDir },
+    });
+    assert.match(normal.stdout, /No live local device claims found\./);
+    assert.match(normal.stdout, /1 stale claim hidden/);
+
+    const stale = await runCliCapture(['device', 'status', '--stale', '--json'], {
+      env: { AGENT_DEVICE_CLAIMS_DIR: claimsDir },
+    });
+    const payload = JSON.parse(stale.stdout);
+    assert.equal(payload.data.claims.length, 1);
+    assert.equal(payload.data.claims[0].classification, 'owner-daemon-superseded');
+    assert.equal(payload.data.claims[0].owner.session, 'cwd:/w:default');
   } finally {
     fs.rmSync(claimsDir, { recursive: true, force: true });
   }

--- a/src/__tests__/test-utils/device-claim-store.ts
+++ b/src/__tests__/test-utils/device-claim-store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { afterEach } from 'vitest';
 import { mkdtempForTestSync } from './tmp-dir.ts';
 import type { DeviceClaimReconciler } from '../../daemon/device-claims.ts';
+import type { OwnerIdentity } from '../../utils/owner-identity.ts';
 
 export type IsolatedDeviceClaimStore = {
   /** Temporary root holding both the claim store and the daemon state dir. */
@@ -37,3 +38,23 @@ export const retainOrphanedDeviceClaims: DeviceClaimReconciler = async () => ({
   status: 'retained',
   reason: 'test-live-owner',
 });
+
+/**
+ * Publishes the daemon registration a running daemon writes for its state dir.
+ * Claim ownership is only reachable through the daemon named there, so tests
+ * that exercise reachability have to stand one in.
+ */
+export function publishDaemonRegistration(stateDir: string, owner: OwnerIdentity): void {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'daemon.json'),
+    JSON.stringify({
+      port: 1,
+      transport: 'socket',
+      token: 'test-token',
+      pid: owner.pid,
+      ...(owner.startTime === null ? {} : { processStartTime: owner.startTime }),
+      stateDir,
+    }),
+  );
+}

--- a/src/daemon/__tests__/daemon-registration.test.ts
+++ b/src/daemon/__tests__/daemon-registration.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, test } from 'vitest';
+import { isSupersededDaemonOwner, readRegisteredDaemonIdentity } from '../daemon-registration.ts';
+import { writeInfo } from '../server/server-lifecycle.ts';
+import { publishDaemonRegistration } from '../../__tests__/test-utils/device-claim-store.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function useStateDir(): string {
+  const root = mkdtempForTestSync('agent-device-daemon-registration-');
+  roots.push(root);
+  return root;
+}
+
+function infoPathOf(stateDir: string): string {
+  return path.join(stateDir, 'daemon.json');
+}
+
+test('reads back the identity a running daemon publishes for its state dir', () => {
+  const stateDir = useStateDir();
+  writeInfo(stateDir, infoPathOf(stateDir), path.join(stateDir, 'daemon.log'), {
+    socketPort: 1234,
+    token: 'token',
+    version: '0.0.0-test',
+    codeSignature: 'signature',
+    processStartTime: 'published-start',
+  });
+
+  assert.deepEqual(readRegisteredDaemonIdentity(infoPathOf(stateDir)), {
+    pid: process.pid,
+    startTime: 'published-start',
+  });
+});
+
+test('reads no identity from an absent, corrupt, or pid-less registration', () => {
+  const stateDir = useStateDir();
+  assert.equal(readRegisteredDaemonIdentity(infoPathOf(stateDir)), null);
+
+  fs.writeFileSync(infoPathOf(stateDir), '{not json');
+  assert.equal(readRegisteredDaemonIdentity(infoPathOf(stateDir)), null);
+
+  for (const pid of [0, -1, 1.5, '7', null]) {
+    fs.writeFileSync(infoPathOf(stateDir), JSON.stringify({ pid, token: 'token' }));
+    assert.equal(readRegisteredDaemonIdentity(infoPathOf(stateDir)), null);
+  }
+});
+
+test('a different published pid proves the owner no longer serves its state dir', () => {
+  const stateDir = useStateDir();
+  publishDaemonRegistration(stateDir, { pid: 4242, startTime: 'successor-start' });
+
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4141, startTime: 'owner-start' }), true);
+});
+
+test('a published start time proves supersession only when both sides are readable', () => {
+  const stateDir = useStateDir();
+  publishDaemonRegistration(stateDir, { pid: 4242, startTime: 'successor-start' });
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4242, startTime: 'owner-start' }), true);
+  // An unreadable start time on either side leaves the identity unproven.
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4242, startTime: null }), false);
+  publishDaemonRegistration(stateDir, { pid: 4242, startTime: null });
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4242, startTime: 'owner-start' }), false);
+});
+
+test('the published owner itself is never superseded, and absence is not proof', () => {
+  const stateDir = useStateDir();
+  publishDaemonRegistration(stateDir, { pid: 4242, startTime: 'owner-start' });
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4242, startTime: 'owner-start' }), false);
+
+  fs.rmSync(infoPathOf(stateDir));
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: 4242, startTime: 'owner-start' }), false);
+});
+
+test('the reading process is never superseded by a registration naming someone else', () => {
+  const stateDir = useStateDir();
+  publishDaemonRegistration(stateDir, { pid: 4242, startTime: 'successor-start' });
+
+  assert.equal(isSupersededDaemonOwner({ stateDir, pid: process.pid, startTime: 'ours' }), false);
+});

--- a/src/daemon/__tests__/device-claim-prune.test.ts
+++ b/src/daemon/__tests__/device-claim-prune.test.ts
@@ -7,6 +7,7 @@ import { reconcileOrphanedDeviceClaims } from '../device-claims.ts';
 import { resolveDeviceClaimPath } from '../device-claim-paths.ts';
 import { acquireProcessLock } from '../../utils/process-lock.ts';
 import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
+import { publishDaemonRegistration } from '../../__tests__/test-utils/device-claim-store.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 
 vi.mock('../../utils/host-process.ts', async (importOriginal) =>
@@ -63,7 +64,10 @@ test('reconciles claims whose owner is gone and keeps every other claim', async 
     });
     fs.writeFileSync(path.join(claimsDir, 'garbage.json'), 'not json');
 
-    const summary = await reconcileOrphanedDeviceClaims(async () => ({ status: 'reconciled' }));
+    const summary = await reconcileOrphanedDeviceClaims(
+      async () => ({ status: 'reconciled' }),
+      process.cwd(),
+    );
 
     const claimPathFor = (name: string) => resolveDeviceClaimPath(`local:android:none:${name}`);
     assert.deepEqual(summary, { examined: 1, reconciled: 1, retained: 0, changed: 0 });
@@ -81,12 +85,15 @@ test('reconciles nothing when the claim store does not exist', async () => {
     os.tmpdir(),
     'agent-device-reconciliation-absent-store',
   );
-  assert.deepEqual(await reconcileOrphanedDeviceClaims(async () => ({ status: 'reconciled' })), {
-    examined: 0,
-    reconciled: 0,
-    retained: 0,
-    changed: 0,
-  });
+  assert.deepEqual(
+    await reconcileOrphanedDeviceClaims(async () => ({ status: 'reconciled' }), process.cwd()),
+    {
+      examined: 0,
+      reconciled: 0,
+      retained: 0,
+      changed: 0,
+    },
+  );
 });
 
 test('leaves a live successor written while the reconciliation waited for the claim lock', async () => {
@@ -128,7 +135,10 @@ test('leaves a live successor written while the reconciliation waited for the cl
       description: 'test-held device claim lock',
     });
 
-    const reconciliation = reconcileOrphanedDeviceClaims(async () => ({ status: 'reconciled' }));
+    const reconciliation = reconcileOrphanedDeviceClaims(
+      async () => ({ status: 'reconciled' }),
+      process.cwd(),
+    );
     // The reconciliation is now blocked on the lock; stand in the live successor.
     writeContested(owner.pid, owner.startTime, 'live-token');
     await release();
@@ -141,6 +151,64 @@ test('leaves a live successor written while the reconciliation waited for the cl
     });
     assert.equal(fs.existsSync(claimPath), true);
     assert.equal(JSON.parse(fs.readFileSync(claimPath, 'utf8')).ownerToken, 'live-token');
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});
+
+test('reconciles a claim whose owning daemon was replaced while still running', async () => {
+  const claimsDir = mkdtempForTestSync('agent-device-reconciliation-superseded-');
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const stateDir = path.join(claimsDir, 'state');
+  try {
+    // #2031: the daemon-startup scan a replaced daemon leaves behind. Our own
+    // registration serves the state dir, so the still-running owner recorded in
+    // the claim can never be asked to release it.
+    publishDaemonRegistration(stateDir, readCurrentOwnerIdentity());
+    writeClaim(claimsDir, 'superseded.json', {
+      ownerPid: process.ppid,
+      ownerStartTime: null,
+      stateDir,
+    });
+
+    const summary = await reconcileOrphanedDeviceClaims(
+      async () => ({ status: 'reconciled' }),
+      stateDir,
+    );
+
+    assert.deepEqual(summary, { examined: 1, reconciled: 1, retained: 0, changed: 0 });
+    assert.equal(
+      fs.existsSync(resolveDeviceClaimPath('local:android:none:superseded.json')),
+      false,
+    );
+  } finally {
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});
+
+test('leaves a superseded owner in another state dir to the device that asks for it', async () => {
+  const claimsDir = mkdtempForTestSync('agent-device-reconciliation-foreign-superseded-');
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const stateDir = path.join(claimsDir, 'other-state');
+  try {
+    // The owner still runs, so finalizing the durable resources attributed to it
+    // is only the business of the daemon that now serves ITS state dir.
+    publishDaemonRegistration(stateDir, readCurrentOwnerIdentity());
+    writeClaim(claimsDir, 'foreign.json', {
+      ownerPid: process.ppid,
+      ownerStartTime: null,
+      stateDir,
+    });
+    const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+    const summary = await reconcileOrphanedDeviceClaims(
+      reconcile,
+      path.join(claimsDir, 'our-state'),
+    );
+
+    assert.deepEqual(summary, { examined: 0, reconciled: 0, retained: 0, changed: 0 });
+    assert.equal(reconcile.mock.calls.length, 0);
+    assert.equal(fs.existsSync(resolveDeviceClaimPath('local:android:none:foreign.json')), true);
   } finally {
     fs.rmSync(claimsDir, { recursive: true, force: true });
   }

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -11,6 +11,8 @@ import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
 import { inspectDeviceClaims } from '../device-claim-inspection.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { publishDaemonRegistration } from '../../__tests__/test-utils/device-claim-store.ts';
+import { readCurrentOwnerIdentity } from '../../utils/owner-identity.ts';
 
 vi.mock('../../utils/host-process.ts', async (importOriginal) =>
   (await import('../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
@@ -406,3 +408,123 @@ test.each([
     assert.equal(second.conflict.classification, 'live');
   },
 );
+
+/**
+ * A live owner that is not this process. The mocked host-process module reads a
+ * start time only for our own pid, so a claim recorded against our parent is a
+ * genuinely-alive foreign owner — what a running daemon looks like on disk.
+ */
+function rewriteClaimOwner(root: string, ownerPid: number): void {
+  const stored = JSON.parse(fs.readFileSync(claimPath(root), 'utf8')) as Record<string, unknown>;
+  fs.writeFileSync(claimPath(root), JSON.stringify({ ...stored, ownerPid, ownerStartTime: null }));
+}
+
+async function seedForeignLiveClaim(root: string, stateDir: string): Promise<void> {
+  fs.mkdirSync(stateDir, { recursive: true });
+  const seeded = await acquireDeviceClaim({
+    device,
+    session: 'cwd:/w:default',
+    workspace: '/w',
+    stateDir,
+  });
+  assert.equal(seeded.status, 'acquired');
+  rewriteClaimOwner(root, process.ppid);
+}
+
+test('reconciles a live claim whose owner is no longer the daemon published for its state dir', async () => {
+  const root = useClaimsRoot();
+  const stateDir = path.join(root, 'orphaned-state');
+  await seedForeignLiveClaim(root, stateDir);
+  // #2031: the recorded owner is a replaced-but-still-running daemon. We are the
+  // successor published for the same state dir, so its session is absent from
+  // `session list` and no close can ever reach it.
+  publishDaemonRegistration(stateDir, readCurrentOwnerIdentity());
+  let reconciledSession: string | undefined;
+  const reconcile = vi.fn(async (claim: { session: string }) => {
+    reconciledSession = claim.session;
+    return { status: 'reconciled' as const };
+  });
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'cwd:/w:default',
+    workspace: '/w',
+    stateDir,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(second.status, 'acquired');
+  assert.equal(reconciledSession, 'cwd:/w:default');
+  assert.equal(inspectDeviceClaims({ serial: device.id })[0]?.claim?.ownerPid, process.pid);
+});
+
+test('keeps a live claim blocking while its owner is still the daemon published for its state dir', async () => {
+  const root = useClaimsRoot();
+  const stateDir = path.join(root, 'served-state');
+  await seedForeignLiveClaim(root, stateDir);
+  publishDaemonRegistration(stateDir, { pid: process.ppid, startTime: null });
+  const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'other',
+    workspace: '/w',
+    stateDir,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(second.status, 'conflict');
+  if (second.status !== 'conflict') return;
+  assert.equal(second.conflict.classification, 'live');
+  assert.equal(reconcile.mock.calls.length, 0);
+});
+
+test('never supersedes a live claim owner on a state dir with no published daemon', async () => {
+  const root = useClaimsRoot();
+  const stateDir = path.join(root, 'unpublished-state');
+  await seedForeignLiveClaim(root, stateDir);
+  const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'other',
+    workspace: '/w',
+    stateDir,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(second.status, 'conflict');
+  if (second.status !== 'conflict') return;
+  assert.equal(second.conflict.classification, 'live');
+  assert.equal(reconcile.mock.calls.length, 0);
+});
+
+test('never treats a claim owned by the inspecting process as superseded', async () => {
+  const root = useClaimsRoot();
+  const stateDir = path.join(root, 'self-state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const first = await acquireDeviceClaim({
+    device,
+    session: 'ours',
+    workspace: '/w',
+    stateDir,
+  });
+  assert.equal(first.status, 'acquired');
+  // A registration naming someone else cannot make us unreachable: a caller had
+  // to reach this process to ask, so our own sessions stay closeable.
+  publishDaemonRegistration(stateDir, { pid: process.ppid, startTime: 'other-start' });
+  const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'another',
+    workspace: '/w',
+    stateDir,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(second.status, 'conflict');
+  if (second.status !== 'conflict') return;
+  assert.equal(second.conflict.classification, 'live');
+  assert.equal(reconcile.mock.calls.length, 0);
+});

--- a/src/daemon/daemon-registration.ts
+++ b/src/daemon/daemon-registration.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import { ownerIdentityDiffers, type OwnerIdentity } from '../utils/owner-identity.ts';
+import { resolveDaemonPaths } from './config.ts';
+
+/**
+ * The daemon identity published in a state dir's `daemon.json`. It is the only
+ * answer to "which process serves this state dir": clients discover a daemon
+ * through this record, so a process that is not named here receives no request
+ * however alive it is.
+ */
+export function readRegisteredDaemonIdentity(infoPath: string): OwnerIdentity | null {
+  try {
+    const { pid, processStartTime } = JSON.parse(fs.readFileSync(infoPath, 'utf8')) as {
+      pid?: unknown;
+      processStartTime?: unknown;
+    };
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return null;
+    return { pid, startTime: readableStartTime(processStartTime) };
+  } catch {
+    return null;
+  }
+}
+
+function readableStartTime(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * #2031: positive proof that `owner` is no longer the daemon serving its own
+ * state dir, and so can never be asked to release what it holds — its sessions
+ * are unreachable and `session list` cannot even report them.
+ *
+ * Proof runs one way only, on top of the one-way comparison in
+ * {@link ownerIdentityDiffers}. The reading process is never superseded: a
+ * caller had to reach it to ask. Nor is a missing or unreadable registration
+ * proof, because a daemon publishes its record only after startup recovery, so
+ * absence equally describes one that is about to be reachable.
+ */
+export function isSupersededDaemonOwner(owner: OwnerIdentity & { stateDir: string }): boolean {
+  if (owner.pid === process.pid) return false;
+  const registered = readRegisteredDaemonIdentity(resolveDaemonPaths(owner.stateDir).infoPath);
+  return registered !== null && ownerIdentityDiffers(registered, owner);
+}

--- a/src/daemon/daemon-stop.ts
+++ b/src/daemon/daemon-stop.ts
@@ -4,16 +4,12 @@ import { isAgentDeviceDaemonProcess, trySignalProcess } from './daemon-process.t
 import { isProcessAlive, waitForProcessExit } from '../utils/host-process.ts';
 import { sleep } from '../utils/timeouts.ts';
 import type { DaemonPaths } from './config.ts';
+import { readRegisteredDaemonIdentity } from './daemon-registration.ts';
 import type { DeviceClaimRecord, ProviderReleaseRecord } from './daemon-shutdown-report.ts';
 
 const DAEMON_STOP_GRACE_TIMEOUT_MS = 10_000;
 const DAEMON_STOP_KILL_TIMEOUT_MS = 2_000;
 const DAEMON_STOP_METADATA_WAIT_MS = 1_000;
-
-type DaemonInfo = {
-  pid?: unknown;
-  processStartTime?: unknown;
-};
 
 export type DaemonStopResult = {
   stopped: boolean;
@@ -41,9 +37,9 @@ export async function stopDaemon(params: {
   graceTimeoutMs?: number;
   killTimeoutMs?: number;
 }): Promise<DaemonStopResult> {
-  const info = readDaemonInfo(params.paths.infoPath);
+  const info = readRegisteredDaemonIdentity(params.paths.infoPath);
   if (!info) return notRunningResult();
-  if (!info.processStartTime) {
+  if (!info.startTime) {
     if (!isProcessAlive(info.pid)) return notRunningResult();
     throw new AppError(
       'COMMAND_FAILED',
@@ -51,12 +47,12 @@ export async function stopDaemon(params: {
       { pid: info.pid },
     );
   }
-  if (!isAgentDeviceDaemonProcess(info.pid, info.processStartTime)) {
+  if (!isAgentDeviceDaemonProcess(info.pid, info.startTime)) {
     if (!isProcessAlive(info.pid)) return notRunningResult();
     throw new AppError(
       'COMMAND_FAILED',
       'Refusing to stop a daemon whose PID or start-time identity could not be verified.',
-      { pid: info.pid, processStartTime: info.processStartTime },
+      { pid: info.pid, processStartTime: info.startTime },
     );
   }
 
@@ -81,7 +77,7 @@ export async function stopDaemon(params: {
 
   // Re-verify immediately before escalation so a PID cannot be reused between
   // the graceful wait and SIGKILL.
-  if (isAgentDeviceDaemonProcess(info.pid, info.processStartTime)) {
+  if (isAgentDeviceDaemonProcess(info.pid, info.startTime)) {
     signalDaemonProcess(info.pid, 'SIGKILL');
   }
   const stopped = await waitForProcessExit(
@@ -117,29 +113,9 @@ function signalDaemonProcess(pid: number, signal: NodeJS.Signals): boolean {
 export function readDaemonStopIdentity(
   infoPath: string,
 ): { pid: number; processStartTime: string } | null {
-  const info = readDaemonInfo(infoPath);
-  if (!info?.processStartTime) return null;
-  return { pid: info.pid, processStartTime: info.processStartTime };
-}
-
-function readDaemonInfo(infoPath: string): { pid: number; processStartTime?: string } | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(infoPath, 'utf8')) as DaemonInfo;
-    const pid = parsed.pid;
-    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return null;
-    return {
-      pid,
-      ...(hasProcessStartTime(parsed.processStartTime)
-        ? { processStartTime: parsed.processStartTime }
-        : {}),
-    };
-  } catch {
-    return null;
-  }
-}
-
-function hasProcessStartTime(value: unknown): value is string {
-  return typeof value === 'string' && value.trim().length > 0;
+  const info = readRegisteredDaemonIdentity(infoPath);
+  if (!info?.startTime) return null;
+  return { pid: info.pid, processStartTime: info.startTime };
 }
 
 async function waitForDaemonMetadataRemoval(paths: DaemonPaths, timeoutMs: number): Promise<void> {

--- a/src/daemon/device-claim-conflict.ts
+++ b/src/daemon/device-claim-conflict.ts
@@ -100,6 +100,7 @@ function conflictReason(classification: DeviceClaimClassification): DeviceClaimC
     case 'live':
       return 'DEVICE_CLAIM_LIVE_OWNER';
     case 'owner-process-dead':
+    case 'owner-daemon-superseded':
       return 'DEVICE_CLAIM_RECOVERY_PENDING';
     case 'owner-process-reused':
     case 'owner-state-dir-gone':

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -13,12 +13,13 @@ import {
   type OwnerLiveness,
 } from '../utils/owner-identity.ts';
 import { readHostProcessIdentityObservations } from '../utils/host-process.ts';
+import { isSupersededDaemonOwner } from './daemon-registration.ts';
 import { canonicalLocalDeviceKey, resolveDeviceClaimRoot } from './device-claim-paths.ts';
 import type { DeviceClaim } from './device-claims.ts';
 
 const DEVICE_CLAIM_SCHEMA_VERSION = 2;
 
-export type DeviceClaimClassification = OwnerLiveness | 'inconsistent';
+export type DeviceClaimClassification = OwnerLiveness | 'inconsistent' | 'owner-daemon-superseded';
 
 export type InspectedDeviceClaim = {
   fileName: string;
@@ -137,17 +138,20 @@ function classifyInspectedClaim(
   entry: InspectedDeviceClaim,
   observation: Parameters<typeof classifyOwnerLivenessFromObservation>[1],
 ): InspectedDeviceClaim {
-  if (!entry.claim) return entry;
-  return {
-    ...entry,
-    classification: classifyOwnerLivenessFromObservation(
-      {
-        owner: { pid: entry.claim.ownerPid, startTime: entry.claim.ownerStartTime },
-        stateDir: entry.claim.stateDir,
-      },
-      observation,
-    ),
-  };
+  const claim = entry.claim;
+  if (!claim) return entry;
+  const owner = { pid: claim.ownerPid, startTime: claim.ownerStartTime };
+  const liveness = classifyOwnerLivenessFromObservation(
+    { owner, stateDir: claim.stateDir },
+    observation,
+  );
+  // A live owner holds a device exclusively only while it can still be asked to
+  // release it. #2031: a replaced daemon keeps running and keeps its claim, but
+  // clients reach the successor published for its state dir instead, so the
+  // claim names a session no `session list` reports and no `close` can reach.
+  const superseded =
+    liveness === 'live' && isSupersededDaemonOwner({ ...owner, stateDir: claim.stateDir });
+  return { ...entry, classification: superseded ? 'owner-daemon-superseded' : liveness };
 }
 
 /** Claims hidden by the default status view and exposed through `device status --stale`. */
@@ -158,8 +162,31 @@ export function deviceClaimRequiresStaleInspection(
     case 'owner-process-dead':
     case 'owner-process-reused':
     case 'owner-state-dir-gone':
+    case 'owner-daemon-superseded':
       return true;
     case 'live':
+    case 'unknown':
+    case 'inconsistent':
+      return false;
+  }
+}
+
+/**
+ * Claims whose recorded owner can no longer release them, and which
+ * reconciliation may therefore settle once exact-owner resource recovery
+ * reaches a terminal state. Both members are proofs about the owner, never
+ * about the resource: `owner-process-dead` is a process that exited,
+ * `owner-daemon-superseded` one that still runs but no longer serves the state
+ * dir its claim was taken in.
+ */
+export function deviceClaimOwnerCannotRelease(classification: DeviceClaimClassification): boolean {
+  switch (classification) {
+    case 'owner-process-dead':
+    case 'owner-daemon-superseded':
+      return true;
+    case 'live':
+    case 'owner-process-reused':
+    case 'owner-state-dir-gone':
     case 'unknown':
     case 'inconsistent':
       return false;

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -13,7 +13,12 @@ import type { RuntimeOwnerRef } from '@agent-device/contracts/platform-runtime';
 import { publishFileSync } from '../utils/atomic-file.ts';
 import { acquireProcessLock } from '../utils/process-lock.ts';
 import { ownerIdentityMatches, readCurrentOwnerIdentity } from '../utils/owner-identity.ts';
-import { inspectDeviceClaimFile, type InspectedDeviceClaim } from './device-claim-inspection.ts';
+import {
+  deviceClaimOwnerCannotRelease,
+  inspectDeviceClaimFile,
+  type DeviceClaimClassification,
+  type InspectedDeviceClaim,
+} from './device-claim-inspection.ts';
 import {
   canonicalLocalDeviceKey,
   resolveDeviceClaimPath,
@@ -204,7 +209,7 @@ async function resolveExistingClaim(params: {
   if (existing.claim && isCurrentClaimOwner(existing.claim, params, params.owner)) {
     return { status: 'acquired', ownership: ownershipFromClaim(existing.claim) };
   }
-  if (existing.classification !== 'owner-process-dead' || !existing.claim) {
+  if (!existing.claim || !deviceClaimOwnerCannotRelease(existing.classification)) {
     emitClaimConflict(params.deviceKey, existing);
     return { status: 'conflict', conflict: existing };
   }
@@ -274,23 +279,27 @@ export async function clearDeviceClaim(
 }
 
 /**
- * Reconciles claims whose owning process is provably gone and clears only
+ * Reconciles claims whose owner can no longer release them and clears only
  * claims whose attributable durable resources reached a safe terminal state.
  *
  * Claims are released on session close and daemon shutdown, but a process that
- * dies abruptly leaves its file behind for proof-oriented recovery.
+ * dies abruptly leaves its file behind for proof-oriented recovery, and #2031 a
+ * daemon that was replaced while still running leaves one no client can reach.
  *
- * The liveness check is repeated under the per-device lock immediately before
+ * The owner check is repeated under the per-device lock immediately before
  * reconciliation: claim paths are derived from the device key, so a concurrent
- * daemon can replace the same dead claim while this scan is still running.
+ * daemon can replace the same orphaned claim while this scan is still running.
  * Acting on the first read could clear the successor.
  *
  * Deliberately narrower than the CLI's stale filter: `owner-state-dir-gone`
  * describes a LIVE process whose state dir vanished, and deleting that claim
- * could hand its device to a second session.
+ * could hand its device to a second session. Narrower again for owners that are
+ * still running, which this sweep settles only inside `daemonStateDir` — see
+ * {@link sweepMayReconcile}.
  */
 export async function reconcileOrphanedDeviceClaims(
   reconcile: DeviceClaimReconciler,
+  daemonStateDir: string,
 ): Promise<{ examined: number; reconciled: number; retained: number; changed: number }> {
   const root = resolveDeviceClaimRoot();
   let entries: fs.Dirent[];
@@ -307,7 +316,12 @@ export async function reconcileOrphanedDeviceClaims(
     if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
     const filePath = path.join(root, entry.name);
     const scanned = inspectDeviceClaimFile(filePath);
-    if (scanned?.classification !== 'owner-process-dead' || !scanned.claim) continue;
+    if (
+      !scanned?.claim ||
+      !sweepMayReconcile(scanned.classification, scanned.claim.stateDir, daemonStateDir)
+    ) {
+      continue;
+    }
     examined += 1;
     const { deviceKey, ownerToken } = scanned.claim;
     // A file whose name is not the hash of its own device key is not the file
@@ -319,8 +333,9 @@ export async function reconcileOrphanedDeviceClaims(
     await withDeviceClaimLock(deviceKey, async () => {
       const current = inspectDeviceClaimFile(filePath);
       if (
-        current?.classification !== 'owner-process-dead' ||
-        current.claim?.ownerToken !== ownerToken
+        !current?.claim ||
+        !sweepMayReconcile(current.classification, current.claim.stateDir, daemonStateDir) ||
+        current.claim.ownerToken !== ownerToken
       ) {
         changed += 1;
         return;
@@ -334,6 +349,24 @@ export async function reconcileOrphanedDeviceClaims(
     });
   }
   return { examined, reconciled, retained, changed };
+}
+
+/**
+ * What the unattended startup sweep may settle. A proven-dead owner is
+ * reconciled wherever the host-global store holds it, but a superseded owner is
+ * still running: finalizing the durable resources attributed to it is only this
+ * daemon's business inside the state dir it now serves. A superseded owner
+ * elsewhere is settled by {@link acquireDeviceClaim} instead, at the one device
+ * a caller actually asked for.
+ */
+function sweepMayReconcile(
+  classification: DeviceClaimClassification,
+  ownerStateDir: string,
+  daemonStateDir: string,
+): boolean {
+  if (!deviceClaimOwnerCannotRelease(classification)) return false;
+  if (classification !== 'owner-daemon-superseded') return true;
+  return path.resolve(ownerStateDir) === path.resolve(daemonStateDir);
 }
 
 function emitClaimConflict(

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -537,6 +537,7 @@ export async function startDaemonRuntime(
         gateway: deviceRuntimeGateway,
         scope: createDaemonRecoveryPlatformScope(),
       }),
+      baseDir,
     );
     // Arms the initial idle-reap timer: a daemon that starts and never
     // receives a request must still be able to reap itself.
@@ -650,6 +651,7 @@ export async function startDaemonRuntime(
 async function reconcileDeviceClaimsForDaemonStartup(
   logPath: string,
   reconcile: DeviceClaimReconciler,
+  stateDir: string,
 ): Promise<void> {
   // Startup runs outside any diagnostics scope, where emitDiagnostic is a no-op,
   // so reconciliation has to open one of its own for its events to be recorded.
@@ -657,7 +659,7 @@ async function reconcileDeviceClaimsForDaemonStartup(
     { command: 'daemon', session: 'daemon', logPath, debug: true },
     async () => {
       try {
-        const summary = await reconcileOrphanedDeviceClaims(reconcile);
+        const summary = await reconcileOrphanedDeviceClaims(reconcile, stateDir);
         if (summary.examined > 0) {
           emitDiagnostic({ phase: 'device_claim_reconcile', data: summary });
           flushDiagnosticsToSessionFile({ force: true });

--- a/src/utils/__tests__/owner-identity.test.ts
+++ b/src/utils/__tests__/owner-identity.test.ts
@@ -3,7 +3,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
-import { classifyOwnerLiveness } from '../owner-identity.ts';
+import {
+  classifyOwnerLiveness,
+  ownerIdentityDiffers,
+  ownerIdentityMatches,
+  type OwnerIdentity,
+} from '../owner-identity.ts';
 import { readProcessStartTime } from '../host-process.ts';
 
 afterEach(() => {
@@ -37,5 +42,20 @@ test('distinguishes a gone state directory from permission and transient I/O fai
   assert.equal(
     classifyOwnerLiveness({ owner: { pid: process.pid, startTime }, stateDir: '/protected' }),
     'unknown',
+  );
+});
+
+test('proves two owners differ only when the evidence is there', () => {
+  const differs = (left: OwnerIdentity, right: OwnerIdentity) => ownerIdentityDiffers(left, right);
+  assert.equal(differs({ pid: 1, startTime: 'a' }, { pid: 2, startTime: 'a' }), true);
+  assert.equal(differs({ pid: 1, startTime: 'a' }, { pid: 1, startTime: 'b' }), true);
+  assert.equal(differs({ pid: 1, startTime: 'a' }, { pid: 1, startTime: 'a' }), false);
+  // An unreadable start time on either side leaves equal pids unproven, never
+  // different — the inverse mistake would hand a held resource to a second owner.
+  assert.equal(differs({ pid: 1, startTime: null }, { pid: 1, startTime: 'b' }), false);
+  assert.equal(differs({ pid: 1, startTime: 'a' }, { pid: 1, startTime: null }), false);
+  assert.equal(
+    ownerIdentityMatches({ pid: 1, startTime: null }, { pid: 1, startTime: 'b' }),
+    false,
   );
 });

--- a/src/utils/owner-identity.ts
+++ b/src/utils/owner-identity.ts
@@ -30,6 +30,21 @@ export function ownerIdentityMatches(
 }
 
 /**
+ * Positive proof that two records name DIFFERENT processes. Deliberately not
+ * the negation of {@link ownerIdentityMatches}: equal pids with an unreadable
+ * start time on either side are unproven rather than different, so a caller
+ * that acts on this can never mistake one owner for two and hand its resource
+ * away.
+ */
+export function ownerIdentityDiffers(
+  left: Pick<OwnerIdentity, 'pid' | 'startTime'>,
+  right: Pick<OwnerIdentity, 'pid' | 'startTime'>,
+): boolean {
+  if (left.pid !== right.pid) return true;
+  return Boolean(left.startTime && right.startTime && left.startTime !== right.startTime);
+}
+
+/**
  * This is deliberately proof-oriented, in both directions. A filesystem read
  * error is not proof that an owner state directory disappeared, so callers
  * must surface it as an unknown owner rather than treating the resource as


### PR DESCRIPTION
## Summary

A daemon that is replaced but keeps running keeps the device claim it took. Its sessions are reachable
only through the `daemon.json` its state dir publishes, and that record now names the successor — so the
claim named a session no `session list` could report and no `close` could release. The only documented
recovery was to find and kill the orphaned daemon by hand.

Claim classification now proves that case. A live owner that is **not** the daemon published for its own
state dir classifies as `owner-daemon-superseded`, and reconciliation settles it exactly like a dead
owner: through the same exact-owner durable-resource recovery, which still retains the claim when cleanup
is pending.

Before / after, on the same staged state (a live daemon holding the web claim after losing its
registration):

```
$ agent-device session list --json
{ "success": true, "data": { "sessions": [] } }

# before
$ agent-device open "about:blank" --platform web
Error (DEVICE_IN_USE): web device agent-browser-chrome is owned by session "cwd:2489af30c8e017d8:default" …
$ agent-device device status --platform web --serial agent-browser-chrome
web Agent Browser Chrome: live session=cwd:2489af30c8e017d8:default …

# after
$ agent-device device status --platform web --serial agent-browser-chrome --stale
web Agent Browser Chrome: owner-daemon-superseded session=cwd:2489af30c8e017d8:default …
$ agent-device open "about:blank" --platform web
Opened: about:blank
```

Proof runs one way only, so the change cannot hand a held device to a second owner:

- an absent, unreadable, or pid-less registration is **not** proof — a daemon publishes its record after
  startup recovery, so absence equally describes one about to be reachable;
- equal pids prove supersession only when both start times are readable and differ;
- the process reading a registration never supersedes itself — a caller had to reach it to ask, so a
  daemon can never disown its own live sessions;
- the unattended daemon-startup sweep settles a still-running owner only inside the state dir it now
  serves. A superseded owner in another state dir is left to the acquisition path, which a caller drove
  at that exact device.

Shapes and comparisons stay canonical rather than bespoke. `daemon.json`'s identity fields had two
readers; the daemon-side one moves to `daemon-registration.ts` — returning the existing `OwnerIdentity`
rather than a new type — and `daemon-stop.ts` now shares it, so this adds a use instead of a third
parser. The daemon-client reader stays put: `daemon-server` may not import `daemon-client` (R5). The
comparison itself is a pure `ownerIdentityDiffers` sitting next to its mirror `ownerIdentityMatches`,
which leaves `isSupersededDaemonOwner` as three lines whose only real contribution is the I/O.

Closes #2031

## Validation

Reproduced and fixed live on macOS against the managed `agent-browser` backend in an isolated state dir,
with a real orphaned daemon (alive, holding `local:web:none:agent-browser-chrome`, registration removed).
The pre-fix build produced the reported `DEVICE_IN_USE` verbatim while `session list` returned
`{"sessions": []}`; the post-fix build on the identical staged state classified the claim
`owner-daemon-superseded` and reconciled it on the next `open`. Evidence gathered at `3fdbc7b`. The
verification session was closed and both orphaned daemons stopped.

Three regression tests were each observed red against the pre-fix code and cover a different seam:
acquisition (`device-claims`), the daemon-startup sweep (`device-claim-prune`), and the CLI status
surface (`cli-device-status`). Four fail-closed guards — no registration, matching registration,
self-ownership, and a superseded owner in another state dir — pass in both states, which is what they are
for; each was separately confirmed to fail when its guard is removed.

Full `unit-core` bundle green on an idle host: 1048 files, 8053 tests. An earlier run under concurrent
load tripped the slow-test budget on `gesture-admission-parity`, which is already over budget on
`origin/main` (2.89s against 2.5s, same file, same host) and stubs `admitDeviceClaim` with a no-op, so no
line of this diff executes in it — host contention, per the AGENTS.md rule. Also green: `typecheck`,
`oxlint`, `oxfmt --check`, `check:layering`, `check:fallow --base origin/main`, `check:mcp-metadata`.
`check:production-exports` reports the same 50 pre-existing findings on `origin/main` as on this
branch.

`check:affected` could not run in this worktree — it refuses on a `node_modules` / `pnpm-lock.yaml`
mismatch that predates this branch. The gates above were run directly instead; CI on the head is the
authority.

## Notes

13 files: 7 production and 6 test. Scope stayed inside the device-claim module group;
`owner-identity.ts` gains one pure helper, `daemon-runtime.ts` changes only to thread its state dir into
the startup sweep, and `daemon-stop.ts` only to drop its private copy of the registration reader.

No docs or skills changed. No user doc enumerates claim classifications, and `device status`'s help
already says reclamation happens "during open or daemon startup after exact-owner resource
reconciliation" — this widens when that applies without changing the sentence.

Residual risk, unchanged in kind by this PR but worth naming: durable-resource recovery
(`readRecoveryCandidate`) has no owner-liveness guard, so reconciling a superseded owner that is still
running can finalize a capture that owner is writing. The startup sweep is scoped to the daemon's own
state dir to bound this, and daemon startup already reaps that state dir's orphaned web browsers and
app-log resources on the same reasoning. Adding an owner-liveness gate to durable recovery is a
worthwhile follow-up, but belongs to that seam rather than this one.
