### PR TITLE
perf(apple): reuse booted simulator memo during open

### DIFF
--- a/src/platforms/apple/core/__tests__/app-launch-device-open.test.ts
+++ b/src/platforms/apple/core/__tests__/app-launch-device-open.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { IOS_SIMULATOR, MACOS_DEVICE } from '../../../../__tests__/test-utils/device-fixtures.ts';
+import { openIosDevice } from '../app-launch.ts';
+import { markSimulatorBooted } from '../simulator.ts';
+import { createLocalAppleToolProvider, withAppleToolProvider } from '../tool-provider.ts';
+
+test('openIosDevice spawns nothing when the booted memo was just seeded', async () => {
+  markSimulatorBooted(IOS_SIMULATOR);
+  const simctlCalls: string[][] = [];
+  const provider = createLocalAppleToolProvider({
+    runCommand: async (cmd, args) => {
+      simctlCalls.push([cmd, ...args]);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    simctl: {
+      run: async (args) => {
+        simctlCalls.push(['simctl', ...args]);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+  });
+
+  await withAppleToolProvider(provider, async () => {
+    await openIosDevice(IOS_SIMULATOR);
+  });
+
+  assert.deepEqual(simctlCalls, []);
+});
+
+test('openIosDevice still boots a simulator that is not observed booted', async () => {
+  const coldSimulator = { ...IOS_SIMULATOR, id: 'open-device-cold-sim' };
+  let booted = false;
+  const provider = createLocalAppleToolProvider({
+    runCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    simctl: {
+      run: async (args) => {
+        if (args.includes('boot')) booted = true;
+        if (args.includes('list')) {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              devices: {
+                'iOS 26.2': [{ udid: coldSimulator.id, state: booted ? 'Booted' : 'Shutdown' }],
+              },
+            }),
+            stderr: '',
+          };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+  });
+
+  await withAppleToolProvider(provider, async () => {
+    await openIosDevice(coldSimulator);
+  });
+
+  assert.equal(booted, true);
+});
+
+test('openIosDevice leaves the macOS desktop target alone', async () => {
+  const simctlCalls: string[][] = [];
+  const provider = createLocalAppleToolProvider({
+    simctl: {
+      run: async (args) => {
+        simctlCalls.push(args);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    },
+  });
+
+  await withAppleToolProvider(provider, async () => {
+    await openIosDevice(MACOS_DEVICE);
+  });
+
+  assert.equal(simctlCalls.length, 0);
+});

--- a/src/platforms/apple/core/app-launch.ts
+++ b/src/platforms/apple/core/app-launch.ts
@@ -24,7 +24,7 @@ import {
   classifyLaunchFailure,
   launchFailureHint,
 } from './launch-diagnostics.ts';
-import { ensureBootedSimulator, getSimulatorState } from './simulator.ts';
+import { ensureBootedSimulator } from './simulator.ts';
 import { runXcrun } from './tool-provider.ts';
 import { closeMacOsApp, openMacOsApp } from '../os/macos/apps.ts';
 import { resolveIosApp } from './app-resolution.ts';
@@ -159,9 +159,10 @@ export async function openIosDevice(device: DeviceInfo): Promise<void> {
     return;
   }
   if (device.kind !== 'simulator') return;
-  const state = await getSimulatorState(device);
-  if (state === 'Booted') return;
-
+  // ensureBootedSimulator consults the recently-booted memo first, so a fresh
+  // Booted observation costs no `simctl list` spawn here. A booted simulator
+  // returns without focusing (focusExisting is unset), matching the old
+  // explicit state check.
   await ensureBootedSimulator(device);
 }
 

--- a/src/platforms/apple/core/app-launch.ts
+++ b/src/platforms/apple/core/app-launch.ts
@@ -159,10 +159,6 @@ export async function openIosDevice(device: DeviceInfo): Promise<void> {
     return;
   }
   if (device.kind !== 'simulator') return;
-  // ensureBootedSimulator consults the recently-booted memo first, so a fresh
-  // Booted observation costs no `simctl list` spawn here. A booted simulator
-  // returns without focusing (focusExisting is unset), matching the old
-  // explicit state check.
   await ensureBootedSimulator(device);
 }
 


### PR DESCRIPTION
## Summary

Let `openIosDevice` delegate simulator readiness directly to `ensureBootedSimulator`, reusing that owner's recent-boot memo instead of performing a second `simctl list`.

The implementation stays at the existing Apple lifecycle owner: no duplicate cache, compatibility path, or explanatory workaround was added. This is the boot-memo slice extracted from #2051.

## Validation

- Focused tests prove a freshly memoized simulator spawns nothing, a cold simulator still boots, and the macOS desktop target remains untouched.
- `pnpm check:affected --run` — all runnable checks passed: 259 files / 1,678 tests plus format, lint, typecheck, layering, Fallow, and build.
- 2 files changed.