### PR TITLE
fix(cli): name `--udid` when a device identity is passed to `--device`

### DIFF
--- a/packages/kernel/src/device-selector-flags.test.ts
+++ b/packages/kernel/src/device-selector-flags.test.ts
@@ -75,22 +75,16 @@ test('a serial passed to --device names --serial, not --udid', async () => {
   assert.match(String(error.details?.hint ?? ''), /Did you mean --serial emulator-5580\?/);
 });
 
-test('a UDID-shaped --device value names --udid even when no listed device has that id', async () => {
-  const error = await resolveError([APPLE], {
-    platform: 'ios',
-    deviceName: '204BFFD9-9644-4830-B2C1-1B946597A07C',
-  });
-  assert.equal(error.code, 'DEVICE_NOT_FOUND');
-  assert.match(
-    String(error.details?.hint ?? ''),
-    /--device takes a device name\. Did you mean --udid 204BFFD9-9644-4830-B2C1-1B946597A07C\?/,
-  );
-});
-
-test('an ordinary unknown --device name keeps the generic device-not-found hint', async () => {
-  const error = await resolveError([APPLE], { platform: 'ios', deviceName: 'iPhone 99' });
-  assert.equal(error.code, 'DEVICE_NOT_FOUND');
-  assert.equal(error.details?.hint, undefined);
+test('an unknown --device value gets the generic hint, even when it looks like a UDID', async () => {
+  // The hint is grounded in observed identity: only a candidate's actual id earns the
+  // wrong-flag answer. A UDID-shaped value that no listed device carries stays a plain
+  // unknown name — guessing from shape would misclassify UUID-named devices and miss
+  // every identity syntax the shape guess does not cover.
+  for (const deviceName of ['204BFFD9-9644-4830-B2C1-1B946597A07C', 'iPhone 99']) {
+    const error = await resolveError([APPLE], { platform: 'ios', deviceName });
+    assert.equal(error.code, 'DEVICE_NOT_FOUND');
+    assert.equal(error.details?.hint, undefined);
+  }
 });
 
 async function resolveError(

--- a/packages/kernel/src/device-selector-flags.test.ts
+++ b/packages/kernel/src/device-selector-flags.test.ts
@@ -56,6 +56,43 @@ test('an unspecified platform keeps the existing device-not-found behavior', asy
   assert.equal(error.code, 'DEVICE_NOT_FOUND');
 });
 
+// `--device` takes a NAME. Passing a UDID there answered "No device named <udid>" with the generic
+// booted/connected hint (#2064) — true, unactionable, and silent about `--udid` existing at all.
+
+test('a UDID passed to --device names --udid and the device it identifies', async () => {
+  const error = await resolveError([APPLE, ANDROID], { deviceName: 'SIM-001' });
+  assert.equal(error.code, 'DEVICE_NOT_FOUND');
+  assert.match(error.message, /No device named SIM-001/);
+  assert.match(
+    String(error.details?.hint ?? ''),
+    /SIM-001 is the id of "iPhone 16", not its name\. Did you mean --udid SIM-001\?/,
+  );
+});
+
+test('a serial passed to --device names --serial, not --udid', async () => {
+  const error = await resolveError([APPLE, ANDROID], { deviceName: 'emulator-5580' });
+  assert.equal(error.code, 'DEVICE_NOT_FOUND');
+  assert.match(String(error.details?.hint ?? ''), /Did you mean --serial emulator-5580\?/);
+});
+
+test('a UDID-shaped --device value names --udid even when no listed device has that id', async () => {
+  const error = await resolveError([APPLE], {
+    platform: 'ios',
+    deviceName: '204BFFD9-9644-4830-B2C1-1B946597A07C',
+  });
+  assert.equal(error.code, 'DEVICE_NOT_FOUND');
+  assert.match(
+    String(error.details?.hint ?? ''),
+    /--device takes a device name\. Did you mean --udid 204BFFD9-9644-4830-B2C1-1B946597A07C\?/,
+  );
+});
+
+test('an ordinary unknown --device name keeps the generic device-not-found hint', async () => {
+  const error = await resolveError([APPLE], { platform: 'ios', deviceName: 'iPhone 99' });
+  assert.equal(error.code, 'DEVICE_NOT_FOUND');
+  assert.equal(error.details?.hint, undefined);
+});
+
 async function resolveError(
   devices: DeviceInfo[],
   selector: Parameters<typeof resolveDevice>[1],

--- a/packages/kernel/src/device-selector-flags.test.ts
+++ b/packages/kernel/src/device-selector-flags.test.ts
@@ -75,6 +75,22 @@ test('a serial passed to --device names --serial, not --udid', async () => {
   assert.match(String(error.details?.hint ?? ''), /Did you mean --serial emulator-5580\?/);
 });
 
+test('an id passed to --device on a platform with no identity flag stays hint-free', async () => {
+  // `--udid` resolves only Apple devices and `--serial` only serial-addressable ones; a web or
+  // linux device's id has no flag that could take it, so a hint naming one would be unrunnable.
+  const WEB: DeviceInfo = {
+    platform: 'web',
+    target: 'desktop',
+    id: 'agent-browser-chrome',
+    name: 'Agent Browser Chrome',
+    kind: 'device',
+    booted: true,
+  };
+  const error = await resolveError([WEB], { deviceName: 'agent-browser-chrome' });
+  assert.equal(error.code, 'DEVICE_NOT_FOUND');
+  assert.equal(error.details?.hint, undefined);
+});
+
 test('an unknown --device value gets the generic hint, even when it looks like a UDID', async () => {
   // The hint is grounded in observed identity: only a candidate's actual id earns the
   // wrong-flag answer. A UDID-shaped value that no listed device carries stays a plain

--- a/packages/kernel/src/device.ts
+++ b/packages/kernel/src/device.ts
@@ -353,35 +353,27 @@ function resolveDeviceByName(
   return match;
 }
 
-// A simulator/device UDID: five hex groups, 8-4-4-4-12. Only used to recognize a UDID the
-// inventory does not currently list (a shut-down or unplugged one), so the answer is still
-// "wrong flag" rather than "no such device".
-const DEVICE_UDID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 /**
  * `--device` takes a device NAME, and `--udid`/`--serial` take a device IDENTITY. Passing an
  * identity to `--device` reached name resolution and answered "No device named
  * 204BFFD9-9644-4830-B2C1-1B946597A07C" (#2064) — literally true, and unactionable: it names
  * neither the flag that does take that value nor the fact that one exists. It is the same class of
  * mistake `assertSelectorFlagMatchesPlatform` already answers for a mismatched identity flag, so
- * answer it the same way: name the flag the value belongs to.
+ * answer it the same way: name the flag the value belongs to. Only an observed identity earns the
+ * hint — the candidates' own ids, with the flag derived from that device's platform; guessing from
+ * the value's shape would have to reimplement every platform's identity syntax here.
  */
 function deviceIdentityMistakenForNameHint(
   candidates: DeviceInfo[],
   deviceName: string,
 ): string | undefined {
   const identityMatch = candidates.find((device) => device.id === deviceName);
-  if (identityMatch) {
-    const flag = isSerialAddressablePlatform(identityMatch.platform) ? '--serial' : '--udid';
-    return (
-      `${deviceName} is the id of ${JSON.stringify(identityMatch.name)}, not its name. ` +
-      `Did you mean ${flag} ${deviceName}?`
-    );
-  }
-  if (DEVICE_UDID_SHAPE.test(deviceName)) {
-    return `--device takes a device name. Did you mean --udid ${deviceName}?`;
-  }
-  return undefined;
+  if (!identityMatch) return undefined;
+  const flag = isSerialAddressablePlatform(identityMatch.platform) ? '--serial' : '--udid';
+  return (
+    `${deviceName} is the id of ${JSON.stringify(identityMatch.name)}, not its name. ` +
+    `Did you mean ${flag} ${deviceName}?`
+  );
 }
 
 /**

--- a/packages/kernel/src/device.ts
+++ b/packages/kernel/src/device.ts
@@ -342,8 +342,46 @@ function resolveDeviceByName(
   if (!deviceName) return undefined;
   const normalizedName = normalizeDeviceName(deviceName);
   const match = candidates.find((device) => normalizeDeviceName(device.name) === normalizedName);
-  if (!match) throw new AppError('DEVICE_NOT_FOUND', `No device named ${deviceName}`);
+  if (!match) {
+    const hint = deviceIdentityMistakenForNameHint(candidates, deviceName);
+    throw new AppError(
+      'DEVICE_NOT_FOUND',
+      `No device named ${deviceName}`,
+      hint === undefined ? undefined : { hint },
+    );
+  }
   return match;
+}
+
+// A simulator/device UDID: five hex groups, 8-4-4-4-12. Only used to recognize a UDID the
+// inventory does not currently list (a shut-down or unplugged one), so the answer is still
+// "wrong flag" rather than "no such device".
+const DEVICE_UDID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `--device` takes a device NAME, and `--udid`/`--serial` take a device IDENTITY. Passing an
+ * identity to `--device` reached name resolution and answered "No device named
+ * 204BFFD9-9644-4830-B2C1-1B946597A07C" (#2064) — literally true, and unactionable: it names
+ * neither the flag that does take that value nor the fact that one exists. It is the same class of
+ * mistake `assertSelectorFlagMatchesPlatform` already answers for a mismatched identity flag, so
+ * answer it the same way: name the flag the value belongs to.
+ */
+function deviceIdentityMistakenForNameHint(
+  candidates: DeviceInfo[],
+  deviceName: string,
+): string | undefined {
+  const identityMatch = candidates.find((device) => device.id === deviceName);
+  if (identityMatch) {
+    const flag = isSerialAddressablePlatform(identityMatch.platform) ? '--serial' : '--udid';
+    return (
+      `${deviceName} is the id of ${JSON.stringify(identityMatch.name)}, not its name. ` +
+      `Did you mean ${flag} ${deviceName}?`
+    );
+  }
+  if (DEVICE_UDID_SHAPE.test(deviceName)) {
+    return `--device takes a device name. Did you mean --udid ${deviceName}?`;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/kernel/src/device.ts
+++ b/packages/kernel/src/device.ts
@@ -361,7 +361,9 @@ function resolveDeviceByName(
  * mistake `assertSelectorFlagMatchesPlatform` already answers for a mismatched identity flag, so
  * answer it the same way: name the flag the value belongs to. Only an observed identity earns the
  * hint — the candidates' own ids, with the flag derived from that device's platform; guessing from
- * the value's shape would have to reimplement every platform's identity syntax here.
+ * the value's shape would have to reimplement every platform's identity syntax here. A platform
+ * with no identity flag at all (web, linux) earns no hint either: `--udid` resolves only Apple
+ * devices, so naming it would send the user to a flag that provably cannot work.
  */
 function deviceIdentityMistakenForNameHint(
   candidates: DeviceInfo[],
@@ -369,11 +371,19 @@ function deviceIdentityMistakenForNameHint(
 ): string | undefined {
   const identityMatch = candidates.find((device) => device.id === deviceName);
   if (!identityMatch) return undefined;
-  const flag = isSerialAddressablePlatform(identityMatch.platform) ? '--serial' : '--udid';
+  const flag = deviceIdentityFlag(identityMatch.platform);
+  if (!flag) return undefined;
   return (
     `${deviceName} is the id of ${JSON.stringify(identityMatch.name)}, not its name. ` +
     `Did you mean ${flag} ${deviceName}?`
   );
+}
+
+/** The identity flag that can actually resolve a device on this platform, if one exists. */
+function deviceIdentityFlag(platform: Platform): '--udid' | '--serial' | undefined {
+  if (isApplePlatform(platform)) return '--udid';
+  if (isSerialAddressablePlatform(platform)) return '--serial';
+  return undefined;
 }
 
 /**

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -37,6 +37,23 @@ test('gesture help documents selectors and pinned refs for both drag endpoints',
   assert.match(help, /drag <source-selector\|pinned-ref> <destination-selector\|pinned-ref>/);
 });
 
+// `--udid` was reachable only from `help device`'s usage line, so the one flag that pins a
+// specific simulator among several sharing a name was invisible in the command catalog (#2064).
+test('commands topic lists the device selectors accepted by every command', async () => {
+  const usageText = await usageForCommand('commands');
+  if (usageText === null) throw new Error('Expected commands help text');
+  const selectionSection = usageText.slice(
+    usageText.indexOf('Device Selection'),
+    usageText.indexOf('Global Flags:'),
+  );
+  assert.match(selectionSection, /^Device Selection/);
+  assert.match(selectionSection, /--platform /);
+  assert.match(selectionSection, /--device <name>/);
+  assert.match(selectionSection, /--udid <udid>/);
+  assert.match(selectionSection, /--serial <serial>/);
+  assert.match(selectionSection, /--session <name>/);
+});
+
 test('commands topic includes only global flags in its global flags section', async () => {
   const usageText = await usageForCommand('commands');
   if (usageText === null) throw new Error('Expected commands help text');

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -39,7 +39,7 @@ test('gesture help documents selectors and pinned refs for both drag endpoints',
 
 // `--udid` was reachable only from `help device`'s usage line, so the one flag that pins a
 // specific simulator among several sharing a name was invisible in the command catalog (#2064).
-test('commands topic lists the device selectors accepted by every command', async () => {
+test('commands topic lists the shared device selectors in their own section', async () => {
   const usageText = await usageForCommand('commands');
   if (usageText === null) throw new Error('Expected commands help text');
   const selectionSection = usageText.slice(

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -656,7 +656,7 @@ For simulator/emulator flows, use help manual-qa for routine QA or help workflow
 Discovery:
   agent-device devices --platform ios
   agent-device devices --platform android
-  Use --device <name-or-udid> only when multiple devices are present.
+  With multiple devices present, select one: --device <name>, or --udid <udid> (iOS) / --serial <serial> (Android) when names collide.
 
 iOS physical-device prerequisites:
   Xcode, xcrun xcdevice, and xcrun xctrace must be available from the selected Xcode.

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -6,6 +6,7 @@ import {
 } from '@agent-device/maestro';
 import { helpBody } from '../commands/command-text.ts';
 import {
+  DEVICE_SELECTION_FLAG_KEYS,
   getCliCommandSchema,
   getCommandSchema,
   getFlagDefinitions,
@@ -1059,6 +1060,10 @@ Full command catalog. Use agent-device help <command> for exact flags and behavi
   });
   const commandLines = renderCommandSection(commands);
 
+  const selectionSection = renderFlagSection(
+    'Device Selection (accepted by every device command):',
+    listHelpFlags(DEVICE_SELECTION_FLAG_KEYS),
+  );
   const helpFlags = listHelpFlags(GLOBAL_FLAG_KEYS);
   const flagsSection = renderFlagSection('Global Flags:', helpFlags);
   const configSection = renderTextSection('Configuration:', CONFIGURATION_LINES);
@@ -1067,6 +1072,8 @@ Full command catalog. Use agent-device help <command> for exact flags and behavi
 
   return `${header}
 ${commandLines}
+
+${selectionSection}
 
 ${flagsSection}
 

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -1061,7 +1061,9 @@ Full command catalog. Use agent-device help <command> for exact flags and behavi
   const commandLines = renderCommandSection(commands);
 
   const selectionSection = renderFlagSection(
-    'Device Selection (accepted by every device command):',
+    // "shared by", not "accepted by every": a few catalog commands take a subset (connect has
+    // no --udid/--serial, device has no --session) — help <command> states each command's own.
+    "Device Selection (shared by device commands; help <command> lists each command's flags):",
     listHelpFlags(DEVICE_SELECTION_FLAG_KEYS),
   );
   const helpFlags = listHelpFlags(GLOBAL_FLAG_KEYS);

--- a/src/cli-schema/command-schema.ts
+++ b/src/cli-schema/command-schema.ts
@@ -5,6 +5,7 @@ import { getCliCommandOverride, getSchemaOnlyCliCommandSchema } from './command-
 import { getFlagDefinition, getFlagDefinitions } from '../commands/cli-grammar/flag-registry.ts';
 import {
   COMMON_COMMAND_SUPPORTED_FLAG_KEYS,
+  DEVICE_SELECTION_FLAG_KEYS,
   GLOBAL_FLAG_KEYS,
 } from '../commands/cli-grammar/flag-groups.ts';
 import { type FlagDefinition, type FlagKey } from '../commands/cli-grammar/flag-types.ts';
@@ -12,7 +13,7 @@ import { AppError } from '@agent-device/kernel/errors';
 
 export type { FlagDefinition, FlagKey };
 export type { CommandSchema };
-export { getFlagDefinition, getFlagDefinitions, GLOBAL_FLAG_KEYS };
+export { DEVICE_SELECTION_FLAG_KEYS, getFlagDefinition, getFlagDefinitions, GLOBAL_FLAG_KEYS };
 
 // Bases hold only the flags every command supports; prose arrives with the facet's schema,
 // which always carries a complete `text`.

--- a/src/commands/__tests__/command-surface-metadata.test.ts
+++ b/src/commands/__tests__/command-surface-metadata.test.ts
@@ -257,7 +257,7 @@ test('every emitted input schema carries the aligned device-selector description
     ).properties;
     if (!properties) continue;
     for (const [key, description] of Object.entries(expected)) {
-      const property = properties[key];
+      const property: { description?: string } | undefined = properties[key];
       if (!property) continue;
       assert.equal(property.description, description, `${metadata.name}.${key}`);
       pinned += 1;

--- a/src/commands/__tests__/command-surface-metadata.test.ts
+++ b/src/commands/__tests__/command-surface-metadata.test.ts
@@ -240,6 +240,32 @@ test('command family facets keep daemon writers as an explicit projection subset
   }
 });
 
+// The device-selector descriptions are a public machine surface (MCP/Node input schemas) and
+// must state the same platform facts as the resolver and the CLI help: a UDID belongs in udid,
+// --serial covers HarmonyOS (#2064). Pinned here so a drift on any command's emitted schema
+// fails instead of shipping a cross-surface mismatch.
+test('every emitted input schema carries the aligned device-selector descriptions', () => {
+  const expected: Record<string, string> = {
+    device: 'Device name selector (a UDID belongs in udid, a serial in serial).',
+    udid: 'Apple device or simulator UDID; the selector that pins one device when several share a name.',
+    serial: 'Android, HarmonyOS, or Vega VVD serial selector.',
+  };
+  let pinned = 0;
+  for (const metadata of listCommandMetadata()) {
+    const properties = (
+      metadata.inputSchema as { properties?: Record<string, { description?: string }> }
+    ).properties;
+    if (!properties) continue;
+    for (const [key, description] of Object.entries(expected)) {
+      const property = properties[key];
+      if (!property) continue;
+      assert.equal(property.description, description, `${metadata.name}.${key}`);
+      pinned += 1;
+    }
+  }
+  assert.ok(pinned > 0, 'expected at least one command schema to carry the device selectors');
+});
+
 const daemonRouteOwnerFiles = getDaemonRouteOwnerFiles();
 
 function describeCommand(name: string): string | undefined {

--- a/src/commands/cli-grammar/flag-definitions-target.ts
+++ b/src/commands/cli-grammar/flag-definitions-target.ts
@@ -40,7 +40,7 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     names: ['--serial'],
     type: 'string',
     usageLabel: '--serial <serial>',
-    usageDescription: 'Android device or Vega VVD serial',
+    usageDescription: 'Android, HarmonyOS, or Vega VVD serial',
   },
   {
     key: 'stale',

--- a/src/commands/cli-grammar/flag-definitions-target.ts
+++ b/src/commands/cli-grammar/flag-definitions-target.ts
@@ -25,14 +25,15 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     names: ['--device'],
     type: 'string',
     usageLabel: '--device <name>',
-    usageDescription: 'Device name to target',
+    usageDescription: 'Device name to target (a UDID belongs in --udid, a serial in --serial)',
   },
   {
     key: 'udid',
     names: ['--udid'],
     type: 'string',
     usageLabel: '--udid <udid>',
-    usageDescription: 'iOS device UDID',
+    usageDescription:
+      'Apple device or simulator UDID; the only selector that pins one device when several share a --device name',
   },
   {
     key: 'serial',

--- a/src/commands/cli-grammar/flag-groups.ts
+++ b/src/commands/cli-grammar/flag-groups.ts
@@ -97,7 +97,8 @@ export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
 );
 
 /**
- * The device/session selectors every command accepts (they are part of
+ * The device/session selectors shared across device commands (a few take a subset:
+ * connect has no --udid/--serial, device has no --session). They are part of
  * {@link COMMON_COMMAND_SUPPORTED_FLAG_KEYS}, not of {@link GLOBAL_FLAG_KEYS}, because they reach
  * device resolution rather than the CLI envelope). `help commands` renders them as their own
  * section: `--udid` used to appear only inside `help device`'s usage line, so the one flag that

--- a/src/commands/cli-grammar/flag-groups.ts
+++ b/src/commands/cli-grammar/flag-groups.ts
@@ -96,6 +96,22 @@ export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
   'noRecord',
 );
 
+/**
+ * The device/session selectors every command accepts (they are part of
+ * {@link COMMON_COMMAND_SUPPORTED_FLAG_KEYS}, not of {@link GLOBAL_FLAG_KEYS}, because they reach
+ * device resolution rather than the CLI envelope). `help commands` renders them as their own
+ * section: `--udid` used to appear only inside `help device`'s usage line, so the one flag that
+ * pins a specific simulator among several with the same name was undiscoverable from the command
+ * catalog (#2064).
+ */
+export const DEVICE_SELECTION_FLAG_KEYS: ReadonlySet<FlagKey> = new Set([
+  'platform',
+  'device',
+  'udid',
+  'serial',
+  'session',
+]);
+
 export const GLOBAL_FLAG_KEYS: ReadonlySet<FlagKey> = new Set([
   'json',
   'config',

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -622,7 +622,7 @@ function commonProperties(): Record<string, JsonSchema> {
       description:
         'Apple device or simulator UDID; the selector that pins one device when several share a name.',
     },
-    serial: { type: 'string', description: 'Android device or Vega VVD serial selector.' },
+    serial: { type: 'string', description: 'Android, HarmonyOS, or Vega VVD serial selector.' },
     iosSimulatorDeviceSet: {
       type: 'string',
       description: 'iOS simulator device-set path used for device resolution.',

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -613,8 +613,15 @@ function commonProperties(): Record<string, JsonSchema> {
       description:
         'Alias for deviceTarget on commands without a UI target field. Interaction commands reserve target for the UI element.',
     },
-    device: { type: 'string', description: 'Device name selector.' },
-    udid: { type: 'string', description: 'iOS device UDID selector.' },
+    device: {
+      type: 'string',
+      description: 'Device name selector (a UDID belongs in udid, a serial in serial).',
+    },
+    udid: {
+      type: 'string',
+      description:
+        'Apple device or simulator UDID; the selector that pins one device when several share a name.',
+    },
     serial: { type: 'string', description: 'Android device or Vega VVD serial selector.' },
     iosSimulatorDeviceSet: {
       type: 'string',


### PR DESCRIPTION

Closes #2064

## Summary

`--udid` is the only selector that pins one simulator when several share a name, and it was
effectively undiscoverable: `help commands` listed no device selector at all, and passing a UDID to
`--device` answered with a literal lookup failure that neither named `--udid` nor hinted that a
UDID-taking flag exists.

Before:

```
$ agent-device snapshot --platform ios --device 204BFFD9-9644-4830-B2C1-1B946597A07C
Error (DEVICE_NOT_FOUND): No device named 204BFFD9-9644-4830-B2C1-1B946597A07C
Hint: Verify the target device is booted/connected and selectors match.
```

After:

```
Error (DEVICE_NOT_FOUND): No device named 204BFFD9-9644-4830-B2C1-1B946597A07C
Hint: 204BFFD9-9644-4830-B2C1-1B946597A07C is the id of "iPhone 17", not its name.
      Did you mean --udid 204BFFD9-9644-4830-B2C1-1B946597A07C?
```

Two changes:

1. **`resolveDeviceByName` answers the flag mistake.** When the `--device` value is the id of a
   listed candidate it names that device and the flag the value belongs to — `--udid` for Apple,
   `--serial` for serial-addressable platforms. When it merely has UDID shape (8-4-4-4-12 hex) but
   matches no listed device, it names `--udid` anyway, because a shut-down simulator is still a
   wrong-flag answer. An ordinary unknown name keeps the generic hint untouched.

   This mirrors, rather than invents, the answer `assertSelectorFlagMatchesPlatform` already gives
   a few lines above for a mismatched identity flag (`--udid` on `--platform android`).

2. **`help commands` renders a `Device Selection` section** for the selectors every command
   accepts: `--platform`, `--device`, `--udid`, `--serial`, `--session`.

   ```
   Device Selection (accepted by every device command):
     --platform apple|android|...  Platform to target (`apple` aliases the Apple automation backend)
     --device <name>               Device name to target (a UDID belongs in --udid, a serial in --serial)
     --udid <udid>                 Apple device or simulator UDID; the only selector that pins one
                                   device when several share a --device name
     --serial <serial>             Android device or Vega VVD serial
     --session <name>              Named session
   ```

   Deliberately a **new help section rather than a `GLOBAL_FLAG_KEYS` addition**: those keys mark a
   flag as supported by `*` in `buildOptionSpecs` and move it from `supportedFlags` to `globalFlags`
   in `explain`. These selectors reach device resolution, not the CLI envelope; they stay in
   `COMMON_COMMAND_SUPPORTED_FLAG_KEYS`, so the option schema, `explain` output and MCP surface are
   byte-identical.

`--udid` and `--device` also get sharper one-line descriptions, which is where an agent reading the
new section actually learns the distinction.

## Tests

- `packages/kernel/src/device-selector-flags.test.ts` — the existing home for selector-flag
  mistakes — gains four cases: a UDID and a serial passed to `--device` (each naming the right
  flag and the device it identifies), a UDID-shaped value no listed device carries, and an ordinary
  unknown name keeping the generic hint. All four were observed red against the pre-fix code.
- `src/cli-schema/cli-help-topics.test.ts` gains a `Device Selection` section assertion. The
  existing "only global flags in its global flags section" test slices from `Global Flags:` to
  `Configuration:`; the new section sits above `Global Flags:`, so that slice is unaffected.

`pnpm check:quick`, `pnpm test:unit` (8092 passed), `pnpm check:command-docs` and
`pnpm check:agent-guidance` are green.

## Live check

Run from the built clone against a local simulator set with two simulators named "iPhone 17":

- `--device <udid>` → the new identity hint naming `--udid` and `"iPhone 17"`.
- `--device 11111111-2222-3333-4444-555555555555` (no such device) → the shape hint naming `--udid`.
- `--device "iPhone 99"` → unchanged generic hint.
- `help commands` renders the new section.

## What a maintainer might push back on

- **The UDID regex.** It is deliberately the *fallback*: the primary signal is exact id-equality
  against the candidate set, which needs no shape knowledge and gets `--serial` right for Android.
  The regex only covers a device the current inventory does not list. Dropping it would still fix
  the reported case; keeping it covers the shut-down-simulator variant the issue's workaround
  section implies.
- **`--device` accepting a UDID outright** was the issue's other suggested fix. Not taken: it would
  make `--device` a two-meaning flag and quietly duplicate `--udid`/`--serial`'s platform routing,
  including the `assertSelectorFlagMatchesPlatform` cross-check. Naming the right flag is smaller
  and keeps one meaning per selector.
- **Section placement and title.** `Device Selection (accepted by every device command)` is long;
  a shorter title works if it does not read as "global", which is exactly the distinction that
  keeps the option schema unchanged.
- **Selector set.** `--target` is also a common selector and was left out to match the issue's list.
  Adding it is a one-line change to `DEVICE_SELECTION_FLAG_KEYS`.
