### PR TITLE
feat(interaction): accept `fill <target> ""` as the clear-field primitive

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -144,6 +144,7 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPenalizedCoordinateTapOnNonTextControlDoesNotAuthorizeBareType \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBareDelayedTypeFailsWhenTappedInputDisappearsMidCommand \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSynthesizedTextCommitProgressWalksExpectedPrefixOnly \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testEmptyReplacementWithoutResolvableTargetFailsClosed \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextEntryTapWitnessIsBoundToTargetIdentity \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCoordinateTapTextInputProbeSkipsPenalizedXCTestChannel \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCoordinateTextInputCandidateMustBeEnabledAndContainTheTouchPoint \

--- a/android/snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/AccessibilityTreeXml.java
+++ b/android/snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/AccessibilityTreeXml.java
@@ -35,6 +35,13 @@ final class AccessibilityTreeXml {
       appendWindowMetadata(xml, windowMetadata);
     }
     appendNonEmptyAttribute(xml, "text", node.getText());
+    // getText() returns the HINT for an empty field on modern Android, so `text` alone cannot
+    // distinguish a cleared field from one whose value equals its hint; only this flag can
+    // (#2063 empty-fill verification).
+    appendTrueAttribute(
+        xml,
+        "hint-showing",
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && node.isShowingHintText());
     appendNonEmptyAttribute(xml, "resource-id", node.getViewIdResourceName());
     appendAttribute(xml, "class", node.getClassName());
     appendNonEmptyAttribute(xml, "package", node.getPackageName());

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -15,6 +15,23 @@ extension RunnerTests {
   ) -> TextEntryResult {
     let totalStartedAt = Date()
     guard !text.isEmpty else {
+      // Replacing a field WITH the empty string is the clear-field primitive (#2063): the typing
+      // is vacuous but the clear is not. Returning here unconditionally left the old value in
+      // place while the response reported "typed". Append (`type`) and unrepaired entry stay
+      // no-ops, which is what an empty payload means for them.
+      if repairMode == .replacement, let clearTarget = resolveTextEntryElement(app: app, target: target) {
+        clearTextInput(clearTarget)
+        // nil means the value is unreadable (secure fields), not "not empty": leave `verified`
+        // nil there rather than reporting a mismatch the runner cannot actually observe.
+        let observed = editableTextValue(for: clearTarget, treatingPlaceholderAsEmpty: true)
+        logTextEntryPhase(commandId: commandId, phase: "total", startedAt: totalStartedAt, chars: 0, mode: repairMode)
+        return TextEntryResult(
+          verified: observed.map { $0.isEmpty },
+          repaired: false,
+          expectedText: "",
+          observedText: observed
+        )
+      }
       logTextEntryPhase(commandId: commandId, phase: "total", startedAt: totalStartedAt, chars: 0, mode: repairMode)
       return TextEntryResult(verified: true, repaired: false, expectedText: "", observedText: "")
     }

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+TextTyping.swift
@@ -19,7 +19,20 @@ extension RunnerTests {
       // is vacuous but the clear is not. Returning here unconditionally left the old value in
       // place while the response reported "typed". Append (`type`) and unrepaired entry stay
       // no-ops, which is what an empty payload means for them.
-      if repairMode == .replacement, let clearTarget = resolveTextEntryElement(app: app, target: target) {
+      if repairMode == .replacement {
+        guard let clearTarget = resolveTextEntryElement(app: app, target: target) else {
+          // No resolvable input means no clear happened — including the synthesized
+          // first-responder route, whose target carries no element. Success here would claim a
+          // clear the runner never performed.
+          logTextEntryPhase(commandId: commandId, phase: "total", startedAt: totalStartedAt, chars: 0, mode: repairMode)
+          return TextEntryResult(
+            verified: nil,
+            repaired: false,
+            expectedText: "",
+            observedText: nil,
+            failure: .notFocused
+          )
+        }
         clearTextInput(clearTarget)
         // nil means the value is unreadable (secure fields), not "not empty": leave `verified`
         // nil there rather than reporting a mismatch the runner cannot actually observe.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+TextEntryPolicyTests.swift
@@ -445,6 +445,26 @@ extension RunnerTests {
     XCTAssertEqual(result.failure, .commitNotObserved)
   }
 
+  // `fill <target> ""` is the clear-field primitive (#2063). When no clear target resolves —
+  // Springboard's home screen has no focused text input — the empty-text replacement path must
+  // fail closed: it used to fall through to the vacuous-typing early return and report
+  // `verified: true` for a clear that never ran.
+  func testEmptyReplacementWithoutResolvableTargetFailsClosed() {
+    let result = typeTextReliably(
+      app: springboard,
+      target: TextEntryTarget(element: nil, refreshPoint: nil, prefersFocusedElement: false),
+      text: "",
+      delaySeconds: 0,
+      repairMode: .replacement,
+      xCTestChannelPenalized: false,
+      synthesizer: RecordingTextEntrySynthesizer()
+    )
+
+    XCTAssertEqual(result.failure, .notFocused)
+    XCTAssertNil(result.verified)
+    XCTAssertNil(result.observedText)
+  }
+
   // Companion to the above: text carrying a submit key must skip the wait entirely, same as the
   // append route (`awaitSynthesizedFirstResponderCommit`) — the app may clear or rewrite the field
   // on submit, so there is nothing meaningful to poll toward.

--- a/packages/contracts/src/interactor-types.ts
+++ b/packages/contracts/src/interactor-types.ts
@@ -285,6 +285,12 @@ export type Interactor = {
   hoverRef?(ref: string): Promise<Record<string, unknown> | void>;
   focus(x: number, y: number): Promise<Record<string, unknown> | void>;
   type(text: string, delayMs?: number): Promise<TypeTextBackendResult | void>;
+  /**
+   * Replace the target's text with `text`. The empty string is the clear request (#2063), not a
+   * no-op: an implementation must empty the field or fail — never report success over an
+   * untouched value. A backend with no clear mechanism refuses the empty text up front (see the
+   * webdriver interactor).
+   */
   fill(
     x: number,
     y: number,

--- a/packages/maestro/src/internal/export-flow.ts
+++ b/packages/maestro/src/internal/export-flow.ts
@@ -266,6 +266,20 @@ function convertFillAction(
   }
   const tapTarget = readTapTarget(target, undefined, resolveSelector);
   if (!tapTarget) return { kind: 'unsupported', message: 'fill target is not Maestro-compatible' };
+  if (text.length === 0) {
+    // The clear request (#2063): `inputText: ""` types nothing in Maestro, so the recorded
+    // clear would silently become a no-op. `eraseText` is Maestro's clear verb; without a
+    // count it erases up to its 50-character default, which is a bound this export cannot
+    // recover the real length for.
+    return {
+      kind: 'commands',
+      commands: [{ tapOn: tapTarget }, 'eraseText'],
+      warnings: [
+        ...readLabelSelectorWarnings(target),
+        'fill "" exports as tapOn + eraseText; Maestro erases at most its 50-character default',
+      ],
+    };
+  }
   return {
     kind: 'commands',
     commands: [{ tapOn: tapTarget }, { inputText: text }],

--- a/packages/provider-webdriver/src/webdriver-interactor.test.ts
+++ b/packages/provider-webdriver/src/webdriver-interactor.test.ts
@@ -228,6 +228,27 @@ test('fill caps each probe timeout by the readiness budget remaining', async () 
  * past the whole readiness budget is safe for every case — once readiness
  * resolves there are no pending timers left to fire.
  */
+// `fill <target> ""` is the clear-field primitive (#2063). This backend's fill is tap +
+// sendKeys and owns no clear mechanism, so an empty fill must refuse up front — sending zero
+// keys and reporting success would claim a clear that never ran, before even touching the
+// device.
+test('fill refuses empty text as an unsupported clear rather than a vacuous success', async () => {
+  const world = createTextEntryWorld();
+  const interactor = createWebDriverInteractor({
+    client: world.client,
+    backend: 'xctest',
+    capabilities: createCloudWebDriverCapabilities({ provider: 'test', platform: 'ios' }),
+  });
+
+  await assert.rejects(interactor.fill(12, 24, ''), (error: AppError) => {
+    assert.equal(error.code, 'UNSUPPORTED_OPERATION');
+    assert.match(error.message, /clear field/);
+    return true;
+  });
+  // Fail-closed means untouched: no tap, no keys, no probes reached the device.
+  assert.deepEqual(world.transcript, []);
+});
+
 async function runFill(world: ReturnType<typeof createTextEntryWorld>) {
   vi.useFakeTimers();
   try {

--- a/packages/provider-webdriver/src/webdriver-interactor.ts
+++ b/packages/provider-webdriver/src/webdriver-interactor.ts
@@ -215,6 +215,18 @@ class WebDriverInteractor implements Interactor {
     _delayMs?: number,
   ): Promise<Record<string, unknown>> {
     this.requireSupport('fill');
+    // This backend's fill is tap + sendKeys: it never clears the existing value, so the
+    // clear-field request (`fill <target> ""`, #2063) has no mechanism here — sending zero keys
+    // and reporting success would claim a clear that never ran.
+    if (text.length === 0) {
+      throw new AppError(
+        'UNSUPPORTED_OPERATION',
+        'fill with empty text (clear field) is not supported on the webdriver backend',
+        {
+          hint: 'Use a visible clear/reset control in the app, or fill the field with the intended replacement text directly.',
+        },
+      );
+    }
     // #1658: both readings are taken BEFORE the tap, because each is only
     // evidence as a change. A keyboard that was already up says nothing about
     // which field owns first responder now, and a focused element is only

--- a/packages/selectors/src/internal/find.ts
+++ b/packages/selectors/src/internal/find.ts
@@ -234,7 +234,15 @@ export function parseFindArgs(args: string[]): ParsedFindArgs {
     return { locator, query, action: 'wait', timeoutMs: timeoutMs ?? undefined };
   }
   if (action === 'fill' || action === 'type') {
-    return { locator, query, action, value: actionTokens.slice(1).join(' ') };
+    // `undefined` when NO value token followed, `''` when an empty one did: `find <q> fill ""`
+    // is the clear request (#2063) and must stay distinguishable from a forgotten argument.
+    const valueTokens = actionTokens.slice(1);
+    return {
+      locator,
+      query,
+      action,
+      value: valueTokens.length === 0 ? undefined : valueTokens.join(' '),
+    };
   }
   throw new AppError('INVALID_ARGS', `Unsupported find action: ${actionTokens[0]}`, {
     hint: UNSUPPORTED_FIND_ACTION_HINT,

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -159,10 +159,7 @@ test('usageForCommand resolves workflow help topic', async () => {
   assert.match(help, /geometry never chooses a winner/);
   assert.match(help, /iOS AX flags are unreliable on deep RN trees/);
   assert.match(help, /targetHittable: false plus a hint -- verify or re-target, not a failure/);
-  assert.match(
-    help,
-    /Empty replacement is not a clear-field command \(do not plan fill <target> ""\)/,
-  );
+  assert.match(help, /fill <target> "" clears the field \(replace with nothing\)/);
   assert.match(help, /retry with --delay-ms before clipboard paste/);
   assert.match(
     help,

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -153,7 +153,7 @@ Selectors:
 
 Text entry:
   fill replaces; type appends to an already-focused field: fill 'id="field-email"' "qa@example.com"; type "Handle with care" --delay-ms 80
-  Empty replacement is not a clear-field command (do not plan fill <target> ""); use a visible clear/reset control, or report the gap.
+  fill <target> "" clears the field (replace with nothing); the empty argument must be present -- fill <target> alone is a missing argument.
   Plain fill/type first; if an iOS debounced/search-as-you-type field drops characters, retry with --delay-ms before clipboard paste.
   The keyboard usually does not block interactions -- press the next target directly. keyboard dismiss taps its own dismiss key when one exists, else UNSUPPORTED_OPERATION. Android: try dismiss before back. iOS: when both fail, do not tap a static text/heading hoping it is safe; prefer type "\\n" to submit.
   iOS paste-prompt limits and Android IME/handwriting capture quirks: help debugging.

--- a/src/cli/commands/__tests__/replay-maestro-export.test.ts
+++ b/src/cli/commands/__tests__/replay-maestro-export.test.ts
@@ -45,6 +45,26 @@ screenshot "./artifacts/checkout"
     ]);
   });
 
+  test('exports the empty-fill clear as eraseText, never a vacuous inputText', () => {
+    // `fill <target> ""` is the clear-field primitive (#2063); Maestro's `inputText: ""` types
+    // nothing, so the recorded clear must become its clear verb.
+    const result = exportReplayScriptToMaestro(`context platform=ios target=mobile
+open com.example.app
+fill id="email" ""
+`);
+
+    const docs = parseYamlDocs(result.yaml);
+    expect(docs[1]).toEqual(['launchApp', { tapOn: { id: 'email' } }, 'eraseText']);
+    expect(result.warnings).toEqual([
+      {
+        line: 3,
+        action: 'fill id="email"',
+        message:
+          'fill "" exports as tapOn + eraseText; Maestro erases at most its 50-character default',
+      },
+    ]);
+  });
+
   test('exports coordinate gestures and sleep waits with warnings', () => {
     const result = exportReplayScriptToMaestro(`open com.example.app
 click 120 240

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -162,8 +162,14 @@ export function requiredField<T>(
   };
 }
 
-export function stringField(description?: string): CommandField<string> {
-  return optionalField(stringSchema(description), optionalString);
+export function stringField(
+  description?: string,
+  options: { allowEmpty?: boolean } = {},
+): CommandField<string> {
+  return optionalField(
+    stringSchema(description),
+    options.allowEmpty === true ? optionalAnyString : optionalString,
+  );
 }
 
 /**
@@ -401,6 +407,21 @@ function requiredString(record: Record<string, unknown>, key: string): string {
   const value = record[key];
   if (typeof value !== 'string' || value.length === 0) {
     throw new AppError('INVALID_ARGS', `Expected ${key} to be a non-empty string.`);
+  }
+  return value;
+}
+
+/**
+ * Opt-in reader for the one field where the empty string is a VALUE, not a missing input:
+ * `fill <target> ""` is the clear-field primitive (#2063). `requiredField` still refuses a
+ * missing key, so "" and absent stay distinguishable; every other string field keeps
+ * {@link optionalString}'s non-empty rule.
+ */
+function optionalAnyString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a string.`);
   }
   return value;
 }

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -249,7 +249,7 @@ const fillCommandFacet = defineCommandFacet({
   text: {
     summary: 'Replace text in a UI input',
     cliDetail:
-      'When visible label text also matches a non-input element, constrain the target with editable=true, for example fill \'label="Email" editable=true\' "qa@example.com".',
+      'Clear a field with an empty text argument: fill @e57 "" (the argument must be present — fill @e57 alone is a missing argument, not a clear). When visible label text also matches a non-input element, constrain the target with editable=true, for example fill \'label="Email" editable=true\' "qa@example.com".',
   },
   metadata: metadata('fill'),
   definition: fillCommandDefinition,

--- a/src/commands/interaction/interactions.test.ts
+++ b/src/commands/interaction/interactions.test.ts
@@ -49,3 +49,25 @@ test('fill projects recordAs through the typed daemon flags', () => {
   expect(request.positionals).toEqual(['id="password"', 'live-secret']);
   expect(request.options.recordAs).toBe('PASSWORD');
 });
+
+// The empty text has to survive the CLI grammar AND the daemon projection for `fill @e57 ""` to
+// reach the runner as a clear (#2063); a missing text argument must still read as missing, so the
+// reader distinguishes "no text positional" from "an empty one".
+
+test('fill reads an empty text positional as an empty text, not a missing one', () => {
+  const input = interactionCliReaders.fill(['@e57', ''], BASE_FLAGS);
+
+  expect(input.text).toBe('');
+});
+
+test('fill reads a missing text positional as undefined so required validation fires', () => {
+  expect(interactionCliReaders.fill(['@e57'], BASE_FLAGS).text).toBeUndefined();
+  expect(interactionCliReaders.fill(['label="Email"'], BASE_FLAGS).text).toBeUndefined();
+  expect(interactionCliReaders.fill(['10', '20'], BASE_FLAGS).text).toBeUndefined();
+});
+
+test('fill projects an empty text as its own positional', () => {
+  const request = interactionDaemonWriters.fill({ ref: '@e57', text: '' });
+
+  expect(request.positionals).toEqual(['@e57', '']);
+});

--- a/src/commands/interaction/interactions.test.ts
+++ b/src/commands/interaction/interactions.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { interactionCliReaders, interactionDaemonWriters } from './interactions.ts';
+import { selectorCliReaders } from './selectors.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import type { CliFlags } from '@agent-device/contracts/command';
 
@@ -70,4 +71,16 @@ test('fill projects an empty text as its own positional', () => {
   const request = interactionDaemonWriters.fill({ ref: '@e57', text: '' });
 
   expect(request.positionals).toEqual(['@e57', '']);
+});
+
+// `find <q> fill ""` is the same clear request through the find grammar (#2063): the empty
+// value reaches the typed options, while a missing value is refused at the reader so the typed
+// `value: string` contract stays intact.
+test('find fill reads an empty value as the clear request and refuses a missing one', () => {
+  const cleared = selectorCliReaders.find(['text', 'Save', 'fill', ''], BASE_FLAGS);
+  expect(cleared).toMatchObject({ action: 'fill', value: '' });
+
+  expect(() => selectorCliReaders.find(['text', 'Save', 'fill'], BASE_FLAGS)).toThrow(
+    /find fill requires text \(use "" to clear the field\)/,
+  );
 });

--- a/src/commands/interaction/metadata.test.ts
+++ b/src/commands/interaction/metadata.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { interactionCommandMetadata } from './metadata.ts';
+
+// `fill <target> ""` is the clear-field primitive (#2063): before it existed, emptying an input
+// was not expressible at all — `fill` refused the empty string and `keyboard` had no delete verb.
+// The empty string therefore has to survive input validation, while a MISSING text argument must
+// still be refused: otherwise a forgotten argument silently erases the field.
+const fillMetadata = interactionCommandMetadata.find((metadata) => metadata.name === 'fill');
+
+test('fill accepts an empty text as the clear request', () => {
+  if (!fillMetadata) throw new Error('expected fill metadata');
+  const input = fillMetadata.readInput({
+    target: { kind: 'ref', ref: '@e57' },
+    text: '',
+  }) as { text: unknown };
+
+  expect(input.text).toBe('');
+});
+
+test('fill still refuses a missing text', () => {
+  if (!fillMetadata) throw new Error('expected fill metadata');
+  try {
+    fillMetadata.readInput({ target: { kind: 'ref', ref: '@e57' } });
+    expect.unreachable('fill should refuse input without text');
+  } catch (error) {
+    expect(error).toBeInstanceOf(AppError);
+    expect((error as AppError).code).toBe('INVALID_ARGS');
+    expect((error as AppError).message).toMatch(/text to be set/);
+  }
+});
+
+test('fill refuses a non-string text', () => {
+  if (!fillMetadata) throw new Error('expected fill metadata');
+  try {
+    fillMetadata.readInput({ target: { kind: 'ref', ref: '@e57' }, text: 42 });
+    expect.unreachable('fill should refuse a non-string text');
+  } catch (error) {
+    expect((error as AppError).code).toBe('INVALID_ARGS');
+  }
+});
+
+test('type keeps refusing an empty text: appending nothing is not a clear', () => {
+  const typeMetadata = interactionCommandMetadata.find((metadata) => metadata.name === 'type');
+  if (!typeMetadata) throw new Error('expected type metadata');
+  try {
+    typeMetadata.readInput({ text: '' });
+    expect.unreachable('type should refuse an empty text');
+  } catch (error) {
+    expect((error as AppError).code).toBe('INVALID_ARGS');
+  }
+});

--- a/src/commands/interaction/metadata.ts
+++ b/src/commands/interaction/metadata.ts
@@ -61,7 +61,7 @@ const interactionCommandDescriptions = {
     'Activate a UI target by snapshot ref, selector, or coordinates. Prefer a ref or selector after a snapshot; use coordinates only when semantic targeting is unavailable. This can change app state; use settle or verify to confirm the result without a follow-up snapshot.',
   press:
     'Short-press a UI target by snapshot ref, selector, or coordinates. Use longpress instead when the target requires a context-menu or hold gesture.',
-  fill: 'Replace text in a UI input selected by snapshot ref, selector, or coordinates. Prefer refs or selectors after snapshot; use recordAs to keep sensitive text out of a recorded replay while sending it to the live app.',
+  fill: 'Replace text in a UI input selected by snapshot ref, selector, or coordinates. Pass an empty text to clear the field. Prefer refs or selectors after snapshot; use recordAs to keep sensitive text out of a recorded replay while sending it to the live app.',
   longpress:
     'Hold a UI target by snapshot ref, selector, or coordinates to open a context menu or perform another hold gesture. Set durationMs when the default hold duration is unsuitable.',
   hover:
@@ -98,7 +98,11 @@ const pressFields = {
 
 const fillFields = {
   target: requiredField(interactionTargetField()),
-  text: requiredField(stringField('Text to enter into the target.')),
+  // "" is accepted and means "replace with nothing", i.e. clear the field (#2063). The key
+  // must still be present: omitting it is a missing argument, not a clear.
+  text: requiredField(
+    stringField('Text to enter into the target. Pass "" to clear it.', { allowEmpty: true }),
+  ),
   delayMs: integerField('Delay between typed characters.', { min: 0 }),
   recordAs: stringField(
     'When script recording is armed, send text to the live app but publish it as ${VAR}. Use an uppercase replay variable name such as PASSWORD.',

--- a/src/commands/interaction/metadata.ts
+++ b/src/commands/interaction/metadata.ts
@@ -188,7 +188,9 @@ const findFields = {
   locator: enumField(FIND_LOCATORS),
   query: requiredField(stringField()),
   action: enumField(FIND_ACTION_VALUES),
-  value: stringField(),
+  // `find <q> fill ""` is the clear request (#2063); the daemon handler still refuses a MISSING
+  // value, and an empty `type` value.
+  value: stringField(undefined, { allowEmpty: true }),
   timeoutMs: integerField(),
   first: booleanField(),
   last: booleanField(),

--- a/src/commands/interaction/runtime/interactions.ts
+++ b/src/commands/interaction/runtime/interactions.ts
@@ -79,7 +79,11 @@ export const fillCommand: RuntimeCommand<FillCommandOptions, FillCommandResult> 
   runtime,
   options,
 ): Promise<FillCommandResult> => {
-  if (!options.text) throw new AppError('INVALID_ARGS', 'fill requires text');
+  // `''` is a VALUE here — `fill <target> ""` is the clear-field primitive (#2063) — so this
+  // runtime guard for untyped callers checks presence, not truthiness.
+  if (typeof options.text !== 'string') {
+    throw new AppError('INVALID_ARGS', 'fill requires text');
+  }
   const observation = planPostActionObservation(options);
   const nativeRefFill = observation.needsPreActionBaseline
     ? null

--- a/src/commands/interaction/selectors.ts
+++ b/src/commands/interaction/selectors.ts
@@ -97,12 +97,23 @@ function readFindOptionsFromPositionals(positionals: string[], flags: CliFlags):
     };
   }
   if (action === 'fill' || action === 'type') {
+    // An empty value positional is the clear request (#2063); only a MISSING one is refused,
+    // here, so `value` stays present on the typed options.
+    const valuePositionals = positionals.slice(actionOffset + 1);
+    if (valuePositionals.length === 0) {
+      throw new AppError(
+        'INVALID_ARGS',
+        action === 'fill'
+          ? 'find fill requires text (use "" to clear the field)'
+          : 'find type requires text',
+      );
+    }
     return {
       ...base,
       locator,
       query: readRequiredQuery(query),
       action,
-      value: positionals.slice(actionOffset + 1).join(' '),
+      value: valuePositionals.join(' '),
     };
   }
   if (action === 'click' || action === 'focus' || action === 'exists' || action === 'list') {

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -16,10 +16,16 @@ type PositionalInteractionTarget =
   | { ref: string; label?: string }
   | { selector: string };
 
+/**
+ * `text` is `undefined` when the grammar supplied NO text argument at all, and `''` when it
+ * supplied an empty one. `fill <target> ""` is the clear-field primitive (#2063), so the two
+ * cannot collapse: without the distinction a forgotten argument (`fill @e57`) would silently
+ * erase the field instead of being refused.
+ */
 export type DecodedFillTarget =
-  | { kind: 'ref'; target: { ref: string; label?: string }; text: string }
-  | { kind: 'selector'; target: { selector: string }; text: string }
-  | { kind: 'point'; target: { x: number; y: number }; text: string };
+  | { kind: 'ref'; target: { ref: string; label?: string }; text: string | undefined }
+  | { kind: 'selector'; target: { selector: string }; text: string | undefined }
+  | { kind: 'point'; target: { x: number; y: number }; text: string | undefined };
 
 const BARE_SNAPSHOT_REF_PATTERN = /^e\d+$/;
 
@@ -52,8 +58,8 @@ export function readInteractionTargetFromPositionals(
 export function readFillTargetFromPositionals(positionals: string[]): DecodedFillTarget {
   const firstPositional = positionals[0];
   if (firstPositional?.startsWith('@')) {
-    const text =
-      positionals.length >= 3 ? positionals.slice(2).join(' ') : positionals.slice(1).join(' ');
+    const textPositionals = positionals.length >= 3 ? positionals.slice(2) : positionals.slice(1);
+    const text = textPositionals.length === 0 ? undefined : textPositionals.join(' ');
     return {
       kind: 'ref',
       target: {
@@ -74,13 +80,14 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
     return {
       kind: 'selector',
       target: { selector: selectorArgs.selectorExpression },
-      text: selectorArgs.rest.join(' '),
+      text: selectorArgs.rest.length === 0 ? undefined : selectorArgs.rest.join(' '),
     };
   }
+  const pointText = positionals.slice(2);
   return {
     kind: 'point',
     target: readPointTarget(positionals.slice(0, 2)),
-    text: positionals.slice(2).join(' '),
+    text: pointText.length === 0 ? undefined : pointText.join(' '),
   };
 }
 

--- a/src/daemon/__tests__/session-action-recorder.test.ts
+++ b/src/daemon/__tests__/session-action-recorder.test.ts
@@ -238,6 +238,48 @@ test.each(['', '   '])(
   },
 );
 
+test('an empty parameterized clear rewrites only its own text, never other empty fields', () => {
+  // `fill <target> "" --record-as VAR` (#2063): the empty literal matches inside every string,
+  // so it must redact nothing beyond the fill's own semantic text — an unrelated empty field or
+  // empty evidence label is not an echo of the (empty) value.
+  const session = makeIosSession('default');
+  recordActionEntry(session, {
+    command: 'fill',
+    positionals: ['id="search"', ''],
+    flags: { recordAs: 'QUERY' },
+    result: {
+      text: '',
+      message: 'Filled 0 chars',
+      selector: 'id="search"',
+      backend: { detail: '' },
+    },
+    targetEvidence: {
+      role: 'textinput',
+      label: '',
+      ancestry: [{ role: 'form', label: '' }],
+      sibling: 0,
+      viewportOrder: 0,
+      verification: 'verified',
+    },
+  });
+
+  expect(session.actions[0]).toMatchObject({
+    positionals: ['id="search"', '${QUERY}'],
+    result: {
+      text: '${QUERY}',
+      message: 'Filled 0 chars',
+      selector: 'id="search"',
+      backend: { detail: '' },
+    },
+    targetEvidence: {
+      label: '',
+      ancestry: [{ role: 'form', label: '' }],
+    },
+  });
+  // The empty literal is never registered for session-wide echo protection either.
+  expect(session.recordedFillLiterals?.has('') ?? false).toBe(false);
+});
+
 test('whitespace-only fills collapse ambiguous recorder output and keys', () => {
   const session = makeIosSession('default');
   const whitespace = '   ';

--- a/src/daemon/handlers/__tests__/find-args.test.ts
+++ b/src/daemon/handlers/__tests__/find-args.test.ts
@@ -100,6 +100,18 @@ test('parseFindSelectorExpression only treats bare selector-shaped queries as se
   expect(parseFindSelectorExpression('any', 'a=b')).toBeNull();
 });
 
+// `find <q> fill ""` is the clear request (#2063): an EMPTY value token must survive the parse,
+// while NO value token reads as undefined so the handler's missing-text refusal still fires —
+// the parse used to collapse both to ''.
+test('parseFindArgs distinguishes an empty fill value from a missing one', () => {
+  const cleared = parseFindArgs(['text', 'Save', 'fill', '']);
+  expect(cleared).toMatchObject({ action: 'fill', value: '' });
+
+  const missing = parseFindArgs(['text', 'Save', 'fill']);
+  expect(missing.action).toBe('fill');
+  expect(missing.value).toBeUndefined();
+});
+
 // #1271 stage 2: `--record` is statically scoped to snapshot/get/is via each
 // command schema's `allowedFlags`, but `find`'s observe-vs-mutate split is a
 // POSITIONAL, so it is validated dynamically against this shared predicate.

--- a/src/daemon/handlers/__tests__/interaction-touch-targets.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-targets.test.ts
@@ -156,3 +156,39 @@ test('parseFillTarget rejects a malformed pinned ref before reading text', () =>
     });
   }
 });
+
+// `fill <target> ""` is the clear-field primitive (#2063). Empty text is a VALUE here; only a
+// missing text argument is an error. Whitespace-only text keeps its established per-shape rule:
+// payload on ref/coordinate fills, refused on selector fills.
+
+test('parseFillTarget accepts an empty text after a ref as the clear request', () => {
+  const parsed = parseFillTarget(['@e57', '']);
+  expect(parsed.ok).toBe(true);
+  if (!parsed.ok) return;
+  expect(parsed.text).toBe('');
+});
+
+test('parseFillTarget accepts an empty text after a selector and after coordinates', () => {
+  const selectorParsed = parseFillTarget(['label="Email"', '']);
+  expect(selectorParsed.ok).toBe(true);
+  if (selectorParsed.ok) expect(selectorParsed.text).toBe('');
+
+  const pointParsed = parseFillTarget(['10', '20', '']);
+  expect(pointParsed.ok).toBe(true);
+  if (pointParsed.ok) expect(pointParsed.text).toBe('');
+});
+
+test('parseFillTarget still refuses a missing text argument on every target shape', () => {
+  for (const positionals of [['@e57'], ['label="Email"'], ['10', '20']]) {
+    expect(parseFillTarget(positionals).ok, positionals.join(' ')).toBe(false);
+  }
+});
+
+test('parseFillTarget keeps the established whitespace-only rules', () => {
+  // Payload whitespace on a ref fill (Maestro/keyboard-enter newlines) is preserved …
+  const refParsed = parseFillTarget(['@e57', '   ']);
+  expect(refParsed.ok).toBe(true);
+  if (refParsed.ok) expect(refParsed.text).toBe('   ');
+  // … while a blank selector-fill argument stays a mistake.
+  expect(parseFillTarget(['label="Email"', '   ']).ok).toBe(false);
+});

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -267,8 +267,9 @@ async function handleFindFill(
   value: string | undefined,
 ): Promise<DaemonResponse> {
   const { req, sessionName, sessionStore, session, invoke, command, publicFlags } = ctx;
-  if (!value) {
-    return errorResponse('INVALID_ARGS', 'find fill requires text');
+  // `''` is the clear request (#2063); only a MISSING value is an error.
+  if (value === undefined) {
+    return errorResponse('INVALID_ARGS', 'find fill requires text (use "" to clear the field)');
   }
   const response = await invoke({
     token: req.token,

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -104,13 +104,6 @@ export type ParsedFillTarget =
   | { ok: true; target: InteractionTarget; refGeneration?: number; text: string }
   | { ok: false; response: DaemonResponse };
 
-// An empty text argument is the clear-field primitive (#2063): only a MISSING one is an error.
-// Whitespace-only text keeps its per-shape rule below — ref/coordinate fills accept it as payload
-// (Maestro/keyboard-enter newlines), selector fills refuse it.
-function hasFillText(text: string | undefined): text is string {
-  return text !== undefined;
-}
-
 function missingFillTextResponse(place: 'ref' | 'coordinates' | 'selector'): ParsedFillTarget {
   return {
     ok: false,
@@ -121,43 +114,15 @@ function missingFillTextResponse(place: 'ref' | 'coordinates' | 'selector'): Par
   };
 }
 
+/**
+ * One decode, then per-shape admission. `readFillTargetFromPositionals` owns shape detection and
+ * the missing-vs-empty text rule (`''` is the clear request, `undefined` a forgotten argument —
+ * see {@link DecodedFillTarget}); this layer adds only what the wire owns: versioned-ref
+ * admission, the selector whitespace rule, and the daemon error responses.
+ */
 export function parseFillTarget(positionals: string[]): ParsedFillTarget {
-  const first = positionals[0] ?? '';
-  if (first.startsWith('@')) return parseRefFillTarget(first, positionals);
-  const coordinates = parseCoordinateTarget(positionals);
-  if (coordinates) return parsePointFillTarget(coordinates, positionals);
-  return parseSelectorFillTarget(positionals);
-}
-
-function parseRefFillTarget(first: string, positionals: string[]): ParsedFillTarget {
-  const versioned = parseVersionedRefPositional(first);
-  if (!versioned.ok) return { ok: false, response: versioned.response };
-  const text = readFillTargetFromPositionals(positionals).text;
-  if (!hasFillText(text)) return missingFillTextResponse('ref');
-  return {
-    ok: true,
-    target: {
-      kind: 'ref',
-      ref: versioned.ref,
-      fallbackLabel: readRefFallbackLabel(positionals),
-    },
-    refGeneration: versioned.generation,
-    text,
-  };
-}
-
-function parsePointFillTarget(
-  coordinates: { x: number; y: number },
-  positionals: string[],
-): ParsedFillTarget {
-  const text = positionals.length >= 3 ? positionals.slice(2).join(' ') : undefined;
-  if (!hasFillText(text)) return missingFillTextResponse('coordinates');
-  return { ok: true, target: { kind: 'point', x: coordinates.x, y: coordinates.y }, text };
-}
-
-function parseSelectorFillTarget(positionals: string[]): ParsedFillTarget {
-  const parsed = tryReadFillSelectorTarget(positionals);
-  if (!parsed || parsed.kind !== 'selector') {
+  const decoded = decodeFillTarget(positionals);
+  if (!decoded) {
     return {
       ok: false,
       response: errorResponse(
@@ -166,22 +131,49 @@ function parseSelectorFillTarget(positionals: string[]): ParsedFillTarget {
       ),
     };
   }
-  // Preserve payload whitespace (for example Maestro/keyboard-enter newlines) while still
-  // rejecting selector fills that contain only whitespace. `''` is exempt: it is the explicit
-  // clear request (#2063), not an accidentally blank argument.
-  if (!hasFillText(parsed.text) || (parsed.text.length > 0 && !parsed.text.trim())) {
-    return missingFillTextResponse('selector');
+  switch (decoded.kind) {
+    case 'ref': {
+      const versioned = parseVersionedRefPositional(positionals[0] ?? '');
+      if (!versioned.ok) return { ok: false, response: versioned.response };
+      if (decoded.text === undefined) return missingFillTextResponse('ref');
+      return {
+        ok: true,
+        target: {
+          kind: 'ref',
+          ref: versioned.ref,
+          fallbackLabel: readRefFallbackLabel(positionals),
+        },
+        refGeneration: versioned.generation,
+        text: decoded.text,
+      };
+    }
+    case 'point': {
+      if (decoded.text === undefined) return missingFillTextResponse('coordinates');
+      return {
+        ok: true,
+        target: { kind: 'point', x: decoded.target.x, y: decoded.target.y },
+        text: decoded.text,
+      };
+    }
+    case 'selector': {
+      // Preserve payload whitespace (for example Maestro/keyboard-enter newlines) while still
+      // rejecting selector fills that contain only whitespace. `''` is exempt: it is the
+      // explicit clear request, not an accidentally blank argument.
+      if (decoded.text === undefined || (decoded.text.length > 0 && !decoded.text.trim())) {
+        return missingFillTextResponse('selector');
+      }
+      return {
+        ok: true,
+        target: { kind: 'selector', selector: decoded.target.selector },
+        text: decoded.text,
+      };
+    }
   }
-  return {
-    ok: true,
-    target: { kind: 'selector', selector: parsed.target.selector },
-    text: parsed.text,
-  };
 }
 
-// Valid points and @refs are handled above, so a parse failure here only means
-// "not a selector either" — fold it into this handler's uniform INVALID_ARGS response.
-function tryReadFillSelectorTarget(positionals: string[]): DecodedFillTarget | null {
+// A decode failure only means "no recognizable target shape" — fold it into this handler's
+// uniform INVALID_ARGS response.
+function decodeFillTarget(positionals: string[]): DecodedFillTarget | null {
   try {
     return readFillTargetFromPositionals(positionals);
   } catch {

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -119,7 +119,13 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
     const parsed = readFillTargetFromPositionals(positionals);
     const text = parsed.text;
     if (!hasFillText(text))
-      return { ok: false, response: errorResponse('INVALID_ARGS', 'fill requires text after ref') };
+      return {
+        ok: false,
+        response: errorResponse(
+          'INVALID_ARGS',
+          'fill requires text after ref (use "" to clear the field)',
+        ),
+      };
     return {
       ok: true,
       target: {
@@ -138,7 +144,10 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
     if (!hasFillText(text))
       return {
         ok: false,
-        response: errorResponse('INVALID_ARGS', 'fill requires text after coordinates'),
+        response: errorResponse(
+          'INVALID_ARGS',
+          'fill requires text after coordinates (use "" to clear the field)',
+        ),
       };
     return { ok: true, target: { kind: 'point', x: coordinates.x, y: coordinates.y }, text };
   }
@@ -159,7 +168,10 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
   if (!hasFillText(parsed.text) || (parsed.text.length > 0 && !parsed.text.trim())) {
     return {
       ok: false,
-      response: errorResponse('INVALID_ARGS', 'fill requires text after selector'),
+      response: errorResponse(
+        'INVALID_ARGS',
+        'fill requires text after selector (use "" to clear the field)',
+      ),
     };
   }
   return {

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -104,6 +104,13 @@ export type ParsedFillTarget =
   | { ok: true; target: InteractionTarget; refGeneration?: number; text: string }
   | { ok: false; response: DaemonResponse };
 
+// An empty text argument is the clear-field primitive (#2063): only a MISSING one is an error.
+// Whitespace-only text keeps its per-shape rule below — ref/coordinate fills accept it as payload
+// (Maestro/keyboard-enter newlines), selector fills refuse it.
+function hasFillText(text: string | undefined): text is string {
+  return text !== undefined;
+}
+
 export function parseFillTarget(positionals: string[]): ParsedFillTarget {
   const first = positionals[0] ?? '';
   if (first.startsWith('@')) {
@@ -111,7 +118,7 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
     if (!versioned.ok) return { ok: false, response: versioned.response };
     const parsed = readFillTargetFromPositionals(positionals);
     const text = parsed.text;
-    if (!text)
+    if (!hasFillText(text))
       return { ok: false, response: errorResponse('INVALID_ARGS', 'fill requires text after ref') };
     return {
       ok: true,
@@ -127,8 +134,8 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
 
   const coordinates = parseCoordinateTarget(positionals);
   if (coordinates) {
-    const text = positionals.slice(2).join(' ');
-    if (!text)
+    const text = positionals.length >= 3 ? positionals.slice(2).join(' ') : undefined;
+    if (!hasFillText(text))
       return {
         ok: false,
         response: errorResponse('INVALID_ARGS', 'fill requires text after coordinates'),
@@ -146,9 +153,10 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
       ),
     };
   }
-  // Preserve payload whitespace (for example Maestro/keyboard-enter newlines)
-  // while still rejecting selector fills that contain only whitespace.
-  if (!parsed.text.trim()) {
+  // Preserve payload whitespace (for example Maestro/keyboard-enter newlines) while still
+  // rejecting selector fills that contain only whitespace. `''` is exempt: it is the explicit
+  // clear request (#2063), not an accidentally blank argument.
+  if (!hasFillText(parsed.text) || (parsed.text.length > 0 && !parsed.text.trim())) {
     return {
       ok: false,
       response: errorResponse('INVALID_ARGS', 'fill requires text after selector'),

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -111,47 +111,51 @@ function hasFillText(text: string | undefined): text is string {
   return text !== undefined;
 }
 
+function missingFillTextResponse(place: 'ref' | 'coordinates' | 'selector'): ParsedFillTarget {
+  return {
+    ok: false,
+    response: errorResponse(
+      'INVALID_ARGS',
+      `fill requires text after ${place} (use "" to clear the field)`,
+    ),
+  };
+}
+
 export function parseFillTarget(positionals: string[]): ParsedFillTarget {
   const first = positionals[0] ?? '';
-  if (first.startsWith('@')) {
-    const versioned = parseVersionedRefPositional(first);
-    if (!versioned.ok) return { ok: false, response: versioned.response };
-    const parsed = readFillTargetFromPositionals(positionals);
-    const text = parsed.text;
-    if (!hasFillText(text))
-      return {
-        ok: false,
-        response: errorResponse(
-          'INVALID_ARGS',
-          'fill requires text after ref (use "" to clear the field)',
-        ),
-      };
-    return {
-      ok: true,
-      target: {
-        kind: 'ref',
-        ref: versioned.ref,
-        fallbackLabel: readRefFallbackLabel(positionals),
-      },
-      refGeneration: versioned.generation,
-      text,
-    };
-  }
-
+  if (first.startsWith('@')) return parseRefFillTarget(first, positionals);
   const coordinates = parseCoordinateTarget(positionals);
-  if (coordinates) {
-    const text = positionals.length >= 3 ? positionals.slice(2).join(' ') : undefined;
-    if (!hasFillText(text))
-      return {
-        ok: false,
-        response: errorResponse(
-          'INVALID_ARGS',
-          'fill requires text after coordinates (use "" to clear the field)',
-        ),
-      };
-    return { ok: true, target: { kind: 'point', x: coordinates.x, y: coordinates.y }, text };
-  }
+  if (coordinates) return parsePointFillTarget(coordinates, positionals);
+  return parseSelectorFillTarget(positionals);
+}
 
+function parseRefFillTarget(first: string, positionals: string[]): ParsedFillTarget {
+  const versioned = parseVersionedRefPositional(first);
+  if (!versioned.ok) return { ok: false, response: versioned.response };
+  const text = readFillTargetFromPositionals(positionals).text;
+  if (!hasFillText(text)) return missingFillTextResponse('ref');
+  return {
+    ok: true,
+    target: {
+      kind: 'ref',
+      ref: versioned.ref,
+      fallbackLabel: readRefFallbackLabel(positionals),
+    },
+    refGeneration: versioned.generation,
+    text,
+  };
+}
+
+function parsePointFillTarget(
+  coordinates: { x: number; y: number },
+  positionals: string[],
+): ParsedFillTarget {
+  const text = positionals.length >= 3 ? positionals.slice(2).join(' ') : undefined;
+  if (!hasFillText(text)) return missingFillTextResponse('coordinates');
+  return { ok: true, target: { kind: 'point', x: coordinates.x, y: coordinates.y }, text };
+}
+
+function parseSelectorFillTarget(positionals: string[]): ParsedFillTarget {
   const parsed = tryReadFillSelectorTarget(positionals);
   if (!parsed || parsed.kind !== 'selector') {
     return {
@@ -166,13 +170,7 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
   // rejecting selector fills that contain only whitespace. `''` is exempt: it is the explicit
   // clear request (#2063), not an accidentally blank argument.
   if (!hasFillText(parsed.text) || (parsed.text.length > 0 && !parsed.text.trim())) {
-    return {
-      ok: false,
-      response: errorResponse(
-        'INVALID_ARGS',
-        'fill requires text after selector (use "" to clear the field)',
-      ),
-    };
+    return missingFillTextResponse('selector');
   }
   return {
     ok: true,

--- a/src/daemon/parameterized-recorded-fill.ts
+++ b/src/daemon/parameterized-recorded-fill.ts
@@ -258,6 +258,9 @@ export function parameterizeRecordedFillTargetEvidence(
   placeholder: string,
 ): TargetAnnotationV1 | undefined {
   if (!evidence) return evidence;
+  // An empty literal (#2063) would equate every EMPTY label with the fill value; an empty
+  // label is not an echo of anything, so the evidence stays untouched.
+  if (!literal) return evidence;
   return {
     ...evidence,
     ...(evidence.label === literal ? { label: placeholder } : {}),
@@ -360,7 +363,10 @@ function filterSensitiveSelectorCandidates(
 }
 
 function parameterizeSensitiveString(value: string, literal: string, placeholder: string): string {
-  if (!literal) return value === literal ? placeholder : value;
+  // The empty literal (`fill <target> "" --record-as VAR`, #2063) matches inside every string:
+  // it reveals nothing if echoed, so it redacts nothing. Only the fill's own semantic `text`
+  // field is force-parameterized, by `parameterizeRecordedFillPayload`, not here.
+  if (!literal) return value;
 
   const unparameterizedSegments = placeholder ? value.split(placeholder) : [value];
   if (unparameterizedSegments.every((segment) => !segment.includes(literal))) return value;

--- a/src/platforms/android/__tests__/text-input-fill.test.ts
+++ b/src/platforms/android/__tests__/text-input-fill.test.ts
@@ -506,6 +506,49 @@ test('verifyAndroidFilledTextInHierarchy does not ignore broader case mismatches
   assert.equal(verification.ok, false);
 });
 
+// The delete burst used to be sized from the INCOMING text, so the empty clear (#2063) sent the
+// 12/24-delete minimums and could never empty a field longer than 36 characters — leaving residue
+// after reporting failure. The clear must be sized from the value being removed.
+test('fillAndroid sizes the empty clear from the field content, not the empty text', async () => {
+  let value = 'a'.repeat(70);
+  let deletes = 0;
+  await withFillAdb(
+    async (args) => {
+      if (args[0] === 'shell' && args[1] === 'input' && args[2] === 'keyevent') {
+        const count = args.filter((arg) => arg === 'KEYCODE_DEL').length;
+        deletes += count;
+        value = value.slice(0, Math.max(0, value.length - count));
+      }
+      return adbResult('');
+    },
+    () => androidInputXml({ text: value }),
+    async () => {
+      await fillAndroid(ANDROID_EMULATOR, 10, 10, '');
+    },
+  );
+  assert.equal(value, '');
+  assert.ok(deletes >= 70, `expected the clear to cover the 70-char value, sent ${deletes}`);
+});
+
+// A masked value only ever compares by length, and the empty expectation (#2063) accepts an
+// observed masked node with no dump text: a masked field WITH content dumps its bullet run.
+// Matches iOS, where clearing a secure field succeeds unverified instead of failing after the
+// clear worked.
+test('verifyAndroidFilledTextInHierarchy accepts a cleared masked field for an empty expectation', () => {
+  const cleared = verifyAndroidFilledTextInHierarchy(passwordHierarchy(''), 10, 10, '');
+  assert.equal(cleared.ok, true);
+  assert.equal(cleared.masked, true);
+
+  const residue = verifyAndroidFilledTextInHierarchy(
+    passwordHierarchy(maskBullets('Test@123')),
+    10,
+    10,
+    '',
+  );
+  assert.equal(residue.ok, false);
+  assert.equal(residue.reason, 'masked_unverified');
+});
+
 test('fillAndroid accepts matching-length masked password verification', async () => {
   let typed = '';
   await withFillAdb(

--- a/src/platforms/android/__tests__/text-input-fill.test.ts
+++ b/src/platforms/android/__tests__/text-input-fill.test.ts
@@ -375,6 +375,28 @@ test('verifyAndroidFilledTextInHierarchy accepts a cleared field for an empty ex
   assert.equal(clearedWithoutAttribute.ok, true);
 });
 
+test('verifyAndroidFilledTextInHierarchy refuses an empty expectation when no input is observed at all', () => {
+  // `actual` is null both for a cleared field and for NO field: a wrong point or lost focus
+  // must not satisfy the empty expectation, or three such samples become a stable success for
+  // a clear that never touched an app input.
+  const noInputAnywhere = verifyAndroidFilledTextInHierarchy(
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.FrameLayout" bounds="[0,0][1080,1920]"/></hierarchy>',
+    10,
+    10,
+    '',
+  );
+  assert.equal(noInputAnywhere.ok, false);
+  assert.equal(noInputAnywhere.actualInput, null);
+
+  const inputElsewhere = verifyAndroidFilledTextInHierarchy(
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" bounds="[500,500][700,600]"/></hierarchy>',
+    10,
+    10,
+    '',
+  );
+  assert.equal(inputElsewhere.ok, false);
+});
+
 test('verifyAndroidFilledTextInHierarchy still refuses a non-empty field for an empty expectation', () => {
   const verification = verifyAndroidFilledTextInHierarchy(
     androidInputXml({ text: 'still here' }),

--- a/src/platforms/android/__tests__/text-input-fill.test.ts
+++ b/src/platforms/android/__tests__/text-input-fill.test.ts
@@ -397,6 +397,40 @@ test('verifyAndroidFilledTextInHierarchy refuses an empty expectation when no in
   assert.equal(inputElsewhere.ok, false);
 });
 
+// Live Pixel 9 emulator (Settings search, adb-shell channel): a CLEARED EditText dumps its hint
+// as `text` ("Search settings"), because getText() returns the hint for an empty field on
+// modern Android. The helper's hint-showing fact is the only way to tell that apart from a
+// field whose VALUE equals the hint string.
+test('verifyAndroidFilledTextInHierarchy accepts hint-only text for an empty expectation', () => {
+  const hintShowing = verifyAndroidFilledTextInHierarchy(
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" text="Search settings" hint-showing="true" focused="true" bounds="[0,0][200,100]"/></hierarchy>',
+    10,
+    10,
+    '',
+  );
+  assert.equal(hintShowing.ok, true);
+
+  // Without the fact, identical text is a real value and the clear must NOT verify.
+  const valueEqualsHint = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: 'Search settings' }),
+    10,
+    10,
+    '',
+  );
+  assert.equal(valueEqualsHint.ok, false);
+});
+
+test('verifyAndroidFilledTextInHierarchy treats hint-only text as an empty value for a non-empty expectation', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" text="Search settings" hint-showing="true" focused="true" bounds="[0,0][200,100]"/></hierarchy>',
+    10,
+    10,
+    'battery saver',
+  );
+  assert.equal(verification.ok, false);
+  assert.equal(verification.actual, 'Search settings');
+});
+
 test('verifyAndroidFilledTextInHierarchy still refuses a non-empty field for an empty expectation', () => {
   const verification = verifyAndroidFilledTextInHierarchy(
     androidInputXml({ text: 'still here' }),

--- a/src/platforms/android/__tests__/text-input-fill.test.ts
+++ b/src/platforms/android/__tests__/text-input-fill.test.ts
@@ -354,6 +354,39 @@ test('verifyAndroidFilledTextInHierarchy accepts Android sentence autocapitaliza
   assert.equal(verification.ok, true);
 });
 
+// `fill <target> ""` is the clear-field primitive (#2063). A cleared EditText carries no `text`
+// attribute at all, so the dump reads back as null while the expectation is "": without an
+// explicit empty rule the clear succeeds on the device and is still reported as text_mismatch.
+test('verifyAndroidFilledTextInHierarchy accepts a cleared field for an empty expectation', () => {
+  const clearedByAttribute = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: '' }),
+    10,
+    10,
+    '',
+  );
+  assert.equal(clearedByAttribute.ok, true);
+
+  const clearedWithoutAttribute = verifyAndroidFilledTextInHierarchy(
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" focused="true" bounds="[0,0][200,100]"/></hierarchy>',
+    10,
+    10,
+    '',
+  );
+  assert.equal(clearedWithoutAttribute.ok, true);
+});
+
+test('verifyAndroidFilledTextInHierarchy still refuses a non-empty field for an empty expectation', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: 'still here' }),
+    10,
+    10,
+    '',
+  );
+
+  assert.equal(verification.ok, false);
+  assert.equal(verification.actual, 'still here');
+});
+
 test('verifyAndroidFilledTextInHierarchy rejects near-complete prefixes', () => {
   const verification = verifyAndroidFilledTextInHierarchy(
     androidInputXml({ text: 'filed the expens' }),

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -24,11 +24,13 @@ export type { AndroidFillVerification } from './fill-diagnostics.ts';
 
 type AndroidFillVerificationCandidate = AndroidFillVerificationNode & {
   editText: boolean;
+  // Helper-only fact: the node's dump text is its HINT, so the field itself is empty.
+  hintShowing: boolean;
 };
 
 type AndroidTextAtPointInspection = {
-  targetInput: AndroidFillVerificationNode | null;
-  actualInput: AndroidFillVerificationNode | null;
+  targetInput: AndroidFillVerificationCandidate | null;
+  actualInput: AndroidFillVerificationCandidate | null;
 };
 
 type AndroidTextAtPointScan = {
@@ -309,12 +311,16 @@ function textAndroidFillVerification(
 ): AndroidFillVerification {
   const actualInput = inspection.actualInput;
   const actual = actualInput?.text ?? null;
+  // An empty field's dump text is its HINT on modern Android (the placeholder-as-value trap the
+  // Apple runner solves with treatingPlaceholderAsEmpty): match against the field's VALUE, which
+  // the helper's hint-showing fact says is absent. `actual` keeps the raw text for diagnostics.
+  const valueText = actualInput?.hintShowing === true ? null : actual;
   return {
-    // An observed input node is required before any match: `actual` is also null when the scan
-    // found NO input at all (wrong point, lost focus), and an empty expectation accepts null —
-    // without the gate, three empty samples of nothing would report a clear that never touched
-    // an app field.
-    ok: actualInput !== null && isAcceptableAndroidFillMatch(actual, expected),
+    // An observed input node is required before any match: `valueText` is also null when the
+    // scan found NO input at all (wrong point, lost focus), and an empty expectation accepts
+    // null — without the gate, three empty samples of nothing would report a clear that never
+    // touched an app field.
+    ok: actualInput !== null && isAcceptableAndroidFillMatch(valueText, expected),
     actual,
     reason: 'text_mismatch',
     targetInput: inspection.targetInput,
@@ -384,6 +390,7 @@ function androidFillCandidateFromNode(
     }),
     area,
     editText: isEditTextClass(node.className ?? ''),
+    hintShowing: node.hintShowing === true,
   };
 }
 

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -321,6 +321,13 @@ function isAcceptableAndroidFillMatch(actual: string | null, expected: string): 
   if (actual === expected) {
     return true;
   }
+  // `fill <target> ""` is the clear-field primitive (#2063). A cleared input has no text in the
+  // hierarchy dump, which reads back as `null` rather than `''` — without this the clear would
+  // succeed on the device and still be reported as `text_mismatch`. The normalization below
+  // cannot cover it: it treats both sides as empty and refuses on the emptiness check.
+  if (expected.length === 0) {
+    return actual === null || actual.length === 0;
+  }
   const normalizedActual = normalizeFillVerificationText(actual);
   const normalizedExpected = normalizeFillVerificationText(expected);
   if (!normalizedActual || !normalizedExpected) {

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -154,6 +154,10 @@ export function buildAndroidFillUnconfirmedVerification(
   const afterTarget = verification.targetInput;
   const actualInput = verification.actualInput;
   if (
+    // The unconfirmed soft-success exists for app-owned formatting that prevents raw equality.
+    // Nothing formats the EMPTY value (#2063): residual text after a clear is a failed clear,
+    // and the soft-success would also skip the second, bigger delete burst.
+    requested.length === 0 ||
     verification.reason === 'ime_capture' ||
     !beforeTarget ||
     !afterTarget ||
@@ -293,8 +297,14 @@ function maskedAndroidFillVerification(
   const actual = actualInput.text ?? null;
   const actualLength = Array.from(actual ?? '').length;
   const expectedLength = Array.from(expected).length;
+  // A masked value only ever compares by length. The empty expectation (#2063) accepts an
+  // observed masked node with no dump text: a masked field WITH content dumps its bullet run,
+  // so absence is honest evidence of emptiness — matching iOS, where clearing a secure field
+  // succeeds unverified rather than failing after the clear worked.
   const matched =
-    actual !== null && actualLength > 0 && expectedLength > 0 && actualLength === expectedLength;
+    expectedLength === 0
+      ? actualLength === 0
+      : actual !== null && actualLength > 0 && actualLength === expectedLength;
   return {
     ok: matched,
     actual,

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -295,16 +295,14 @@ function maskedAndroidFillVerification(
   const actualInput = inspection.actualInput;
   if (!actualInput || !isMaskedAndroidInput(actualInput)) return null;
   const actual = actualInput.text ?? null;
-  const actualLength = Array.from(actual ?? '').length;
+  const valueLength = Array.from(observedAndroidValue(actualInput)).length;
   const expectedLength = Array.from(expected).length;
-  // A masked value only ever compares by length. The empty expectation (#2063) accepts an
-  // observed masked node with no dump text: a masked field WITH content dumps its bullet run,
-  // so absence is honest evidence of emptiness — matching iOS, where clearing a secure field
-  // succeeds unverified rather than failing after the clear worked.
+  // A masked value only ever compares by length. The empty expectation accepts an observed
+  // masked node with an empty VALUE: a masked field WITH content dumps its bullet run, so
+  // emptiness is honest evidence — matching iOS, where clearing a secure field succeeds
+  // unverified rather than failing after the clear worked.
   const matched =
-    expectedLength === 0
-      ? actualLength === 0
-      : actual !== null && actualLength > 0 && actualLength === expectedLength;
+    expectedLength === 0 ? valueLength === 0 : valueLength > 0 && valueLength === expectedLength;
   return {
     ok: matched,
     actual,
@@ -320,51 +318,58 @@ function textAndroidFillVerification(
   expected: string,
 ): AndroidFillVerification {
   const actualInput = inspection.actualInput;
-  const actual = actualInput?.text ?? null;
-  // An empty field's dump text is its HINT on modern Android (the placeholder-as-value trap the
-  // Apple runner solves with treatingPlaceholderAsEmpty): match against the field's VALUE, which
-  // the helper's hint-showing fact says is absent. `actual` keeps the raw text for diagnostics.
-  const valueText = actualInput?.hintShowing === true ? null : actual;
   return {
-    // An observed input node is required before any match: `valueText` is also null when the
-    // scan found NO input at all (wrong point, lost focus), and an empty expectation accepts
-    // null — without the gate, three empty samples of nothing would report a clear that never
-    // touched an app field.
-    ok: actualInput !== null && isAcceptableAndroidFillMatch(valueText, expected),
-    actual,
+    // An observed input node is required before any match: an empty expectation accepts an
+    // empty VALUE, and "no input at all" (wrong point, lost focus) must never read as one —
+    // three empty samples of nothing would report a clear that never touched an app field.
+    ok:
+      actualInput !== null &&
+      isAcceptableAndroidFillMatch(observedAndroidValue(actualInput), expected),
+    // Raw dump text, for diagnostics — the hint-collapsed VALUE is only for matching.
+    actual: actualInput?.text ?? null,
     reason: 'text_mismatch',
     targetInput: inspection.targetInput,
     actualInput,
   };
 }
 
-function isAcceptableAndroidFillMatch(actual: string | null, expected: string): boolean {
-  if (actual === expected) {
+/**
+ * An observed input's VALUE. The dump `text` is not it in two cases the verifiers must agree
+ * on: an absent attribute is the empty value, and hint-only text is too — an empty field's
+ * `getText()` returns its HINT on modern Android (the placeholder-as-value trap the Apple
+ * runner solves with `treatingPlaceholderAsEmpty`); the helper's hint-showing fact is the only
+ * way to tell that apart from a real value equal to the hint string (#2063).
+ */
+function observedAndroidValue(input: AndroidFillVerificationCandidate): string {
+  if (input.hintShowing) return '';
+  return input.text ?? '';
+}
+
+function isAcceptableAndroidFillMatch(value: string, expected: string): boolean {
+  if (value === expected) {
     return true;
   }
-  // `fill <target> ""` is the clear-field primitive (#2063). A cleared input has no text in the
-  // hierarchy dump, which reads back as `null` rather than `''` — without this the clear would
-  // succeed on the device and still be reported as `text_mismatch`. The normalization below
-  // cannot cover it: it treats both sides as empty and refuses on the emptiness check.
   if (expected.length === 0) {
-    return actual === null || actual.length === 0;
-  }
-  const normalizedActual = normalizeFillVerificationText(actual);
-  const normalizedExpected = normalizeFillVerificationText(expected);
-  if (!normalizedActual || !normalizedExpected) {
+    // The clear request (#2063) matched exactly above or not at all; whitespace never
+    // normalizes into emptiness.
     return false;
   }
-  if (normalizedActual === normalizedExpected) {
+  const normalizedValue = normalizeFillVerificationText(value);
+  const normalizedExpected = normalizeFillVerificationText(expected);
+  if (!normalizedValue || !normalizedExpected) {
+    return false;
+  }
+  if (normalizedValue === normalizedExpected) {
     return true;
   }
-  if (isSentenceAutocapitalizeMatch(normalizedActual, normalizedExpected)) {
+  if (isSentenceAutocapitalizeMatch(normalizedValue, normalizedExpected)) {
     return true;
   }
   return false;
 }
 
-function normalizeFillVerificationText(value: string | null): string {
-  return (value ?? '').replace(/\s+/g, ' ').trim();
+function normalizeFillVerificationText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
 }
 
 function isSentenceAutocapitalizeMatch(actual: string, expected: string): boolean {

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -307,13 +307,18 @@ function textAndroidFillVerification(
   inspection: AndroidTextAtPointInspection,
   expected: string,
 ): AndroidFillVerification {
-  const actual = inspection.actualInput?.text ?? null;
+  const actualInput = inspection.actualInput;
+  const actual = actualInput?.text ?? null;
   return {
-    ok: isAcceptableAndroidFillMatch(actual, expected),
+    // An observed input node is required before any match: `actual` is also null when the scan
+    // found NO input at all (wrong point, lost focus), and an empty expectation accepts null —
+    // without the gate, three empty samples of nothing would report a clear that never touched
+    // an app field.
+    ok: actualInput !== null && isAcceptableAndroidFillMatch(actual, expected),
     actual,
     reason: 'text_mismatch',
     targetInput: inspection.targetInput,
-    actualInput: inspection.actualInput,
+    actualInput,
   };
 }
 

--- a/src/platforms/android/text-input.ts
+++ b/src/platforms/android/text-input.ts
@@ -122,11 +122,17 @@ export async function fillAndroid(
       );
       return completeAndroidFillVerification(text, beforeTarget, verification);
     }
-    const clearCount = clampCount(
-      textCodePointLength + attempt.clearPadding,
-      attempt.minClear,
-      attempt.maxClear,
-    );
+    // The delete burst must cover the OLD value. Sizing the empty clear (#2063) from the
+    // incoming text would send the minimum burst and leave residue in any longer field, so it
+    // sizes from the pre-mutation read instead — and assumes the attempt's worst case when
+    // that read could not see the field.
+    const clearBase =
+      textCodePointLength > 0
+        ? textCodePointLength + attempt.clearPadding
+        : beforeTarget?.text
+          ? Array.from(beforeTarget.text).length + attempt.clearPadding
+          : attempt.maxClear;
+    const clearCount = clampCount(clearBase, attempt.minClear, attempt.maxClear);
     await clearFocusedText(device, clearCount);
     await typeAndroidShell(device, {
       action: 'fill',

--- a/src/platforms/android/text-input.ts
+++ b/src/platforms/android/text-input.ts
@@ -81,14 +81,50 @@ export async function fillAndroid(
     const verification = await verifyAndroidFilledText(device, x, y, text, helper);
     return completeAndroidFillVerification(text, beforeTarget, verification);
   }
-  const textCodePointLength = Array.from(text).length;
-  const attempts: Array<{
-    clearPadding: number;
-    minClear: number;
-    maxClear: number;
-    chunkSize: number;
-    inputDelayMs: number;
-  }> = [
+  let lastVerification: AndroidFillVerification | null = null;
+
+  for (const attempt of buildAndroidShellFillAttempts(delayMs)) {
+    await focusAndroid(device, x, y);
+    const channel = await admitAndroidTextChannel(device, 'fill', text);
+    if (channel.backend === 'test-ime') {
+      const verification = await fillAndroidImeHelper(
+        device,
+        channel.packageName,
+        x,
+        y,
+        text,
+        beforeTarget,
+        helper,
+      );
+      return completeAndroidFillVerification(text, beforeTarget, verification);
+    }
+    const verification = await runAndroidShellFillAttempt(
+      device,
+      { x, y, text, beforeTarget, attempt },
+      helper,
+    );
+    lastVerification = verification;
+    if (verification.ok) return;
+    if (verification.reason === 'ime_capture') {
+      return completeAndroidFillVerification(text, beforeTarget, verification);
+    }
+    const unconfirmed = buildAndroidFillUnconfirmedVerification(text, beforeTarget, verification);
+    if (unconfirmed) return unconfirmed;
+  }
+
+  return completeAndroidFillVerification(text, beforeTarget, lastVerification);
+}
+
+type AndroidShellFillAttempt = {
+  clearPadding: number;
+  minClear: number;
+  maxClear: number;
+  chunkSize: number;
+  inputDelayMs: number;
+};
+
+function buildAndroidShellFillAttempts(delayMs: number): AndroidShellFillAttempt[] {
+  return [
     {
       clearPadding: 12,
       minClear: 8,
@@ -104,53 +140,50 @@ export async function fillAndroid(
       inputDelayMs: delayMs > 0 ? delayMs : 15,
     },
   ];
+}
 
-  let lastVerification: AndroidFillVerification | null = null;
+/** One clear-then-type pass on the adb-shell channel, verified against the requested text. */
+async function runAndroidShellFillAttempt(
+  device: DeviceInfo,
+  input: {
+    x: number;
+    y: number;
+    text: string;
+    beforeTarget: AndroidFillVerification['targetInput'];
+    attempt: AndroidShellFillAttempt;
+  },
+  helper: AndroidHelperSessionOptions,
+): Promise<AndroidFillVerification> {
+  const { x, y, text, beforeTarget, attempt } = input;
+  await clearFocusedText(device, androidShellClearCount(text, beforeTarget, attempt));
+  await typeAndroidShell(device, {
+    action: 'fill',
+    text,
+    chunkSize: attempt.chunkSize,
+    delayMs: attempt.inputDelayMs,
+  });
+  return verifyAndroidFilledText(device, x, y, text, helper);
+}
 
-  for (const attempt of attempts) {
-    await focusAndroid(device, x, y);
-    const channel = await admitAndroidTextChannel(device, 'fill', text);
-    if (channel.backend === 'test-ime') {
-      const verification = await fillAndroidImeHelper(
-        device,
-        channel.packageName,
-        x,
-        y,
-        text,
-        beforeTarget,
-        helper,
-      );
-      return completeAndroidFillVerification(text, beforeTarget, verification);
-    }
-    // The delete burst must cover the OLD value. Sizing the empty clear (#2063) from the
-    // incoming text would send the minimum burst and leave residue in any longer field, so it
-    // sizes from the pre-mutation read instead — and assumes the attempt's worst case when
-    // that read could not see the field.
-    const clearBase =
-      textCodePointLength > 0
-        ? textCodePointLength + attempt.clearPadding
-        : beforeTarget?.text
-          ? Array.from(beforeTarget.text).length + attempt.clearPadding
-          : attempt.maxClear;
-    const clearCount = clampCount(clearBase, attempt.minClear, attempt.maxClear);
-    await clearFocusedText(device, clearCount);
-    await typeAndroidShell(device, {
-      action: 'fill',
-      text,
-      chunkSize: attempt.chunkSize,
-      delayMs: attempt.inputDelayMs,
-    });
-    const verification = await verifyAndroidFilledText(device, x, y, text, helper);
-    lastVerification = verification;
-    if (verification.ok) return;
-    if (verification.reason === 'ime_capture') {
-      return completeAndroidFillVerification(text, beforeTarget, verification);
-    }
-    const unconfirmed = buildAndroidFillUnconfirmedVerification(text, beforeTarget, verification);
-    if (unconfirmed) return unconfirmed;
-  }
-
-  return completeAndroidFillVerification(text, beforeTarget, lastVerification);
+/**
+ * The delete burst must cover the OLD value. Sizing the empty clear (#2063) from the incoming
+ * text would send the minimum burst and leave residue in any longer field, so it sizes from the
+ * pre-mutation read instead — and assumes the attempt's worst case when that read could not see
+ * the field.
+ */
+function androidShellClearCount(
+  text: string,
+  beforeTarget: AndroidFillVerification['targetInput'],
+  attempt: AndroidShellFillAttempt,
+): number {
+  const textCodePointLength = Array.from(text).length;
+  const clearBase =
+    textCodePointLength > 0
+      ? textCodePointLength + attempt.clearPadding
+      : beforeTarget?.text
+        ? Array.from(beforeTarget.text).length + attempt.clearPadding
+        : attempt.maxClear;
+  return clampCount(clearBase, attempt.minClear, attempt.maxClear);
 }
 
 /**

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -35,6 +35,11 @@ export type AndroidUiNodeMetadata = {
   focusable?: boolean;
   focused?: boolean;
   password?: boolean;
+  /**
+   * Helper-only: the `text` attribute is the field's HINT, not its value (an empty input's
+   * `getText()` returns the hint on modern Android). Absent in raw uiautomator dumps.
+   */
+  hintShowing?: boolean;
   scrollable?: boolean;
   canScrollForward?: boolean;
   canScrollBackward?: boolean;
@@ -142,6 +147,7 @@ function readNodeAttributes(node: string): Omit<AndroidUiNodeMetadata, 'rect'> {
     focusable: boolAttr('focusable'),
     focused: boolAttr('focused'),
     password: boolAttr('password'),
+    ...optionalBoolAttr('hintShowing', 'hint-showing'),
     ...optionalBoolAttr('visibleToUser', 'visible-to-user'),
     ...optionalNumberAttr('drawingOrder', 'drawing-order'),
     ...optionalBoolAttr('scrollable', 'scrollable'),

--- a/src/platforms/linux/__tests__/input-actions.test.ts
+++ b/src/platforms/linux/__tests__/input-actions.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../../utils/exec.ts', async (importOriginal) => {
 
 import { runCmd, whichCmd } from '../../../utils/exec.ts';
 import { resetInputToolCache } from '../linux-env.ts';
-import { pressLinux, scrollLinux, typeLinux, sendKey } from '../input-actions.ts';
+import { fillLinux, pressLinux, scrollLinux, typeLinux, sendKey } from '../input-actions.ts';
 
 const mockRunCmd = vi.mocked(runCmd);
 const mockWhichCmd = vi.mocked(whichCmd);
@@ -59,6 +59,19 @@ test('typeLinux omits --delay when delayMs is 0', async () => {
   const typeCall = c.find(([cmd, args]) => cmd === 'xdotool' && args.includes('type'));
   assert.ok(typeCall);
   assert.ok(!typeCall[1].includes('--delay'));
+});
+
+// `fill <target> ""` is the clear-field primitive (#2063). Typing zero characters over the
+// Ctrl+A selection leaves the old value selected but intact, so the empty fill must delete
+// the selection instead.
+test('fillLinux deletes the select-all selection for an empty text', async () => {
+  setupXdotool();
+  await fillLinux(10, 20, '');
+  const c = calls();
+  const backspaceCall = c.find(([cmd, args]) => cmd === 'xdotool' && args.includes('BackSpace'));
+  assert.ok(backspaceCall);
+  const typeCall = c.find(([cmd, args]) => cmd === 'xdotool' && args.includes('type'));
+  assert.equal(typeCall, undefined);
 });
 
 test('scrollLinux preserves xdotool repeat count for non-paced scroll', async () => {

--- a/src/platforms/linux/input-actions.ts
+++ b/src/platforms/linux/input-actions.ts
@@ -305,6 +305,12 @@ export async function fillLinux(x: number, y: number, text: string, delayMs = 0)
   // Select all existing text (Ctrl+A scancodes: Ctrl=29, A=30)
   await sendKey('ctrl+a', ['29:1', '30:1', '30:0', '29:0']);
   await sleep(50);
+  if (text.length === 0) {
+    // The clear-field request (#2063): typing zero characters over the selection would leave
+    // the old value selected but intact, so delete the selection instead (BackSpace=14).
+    await sendKey('BackSpace', ['14:1', '14:0']);
+    return;
+  }
   // Type replacement text
   await typeLinux(text, delayMs);
 }

--- a/src/platforms/web/agent-browser-provider.test.ts
+++ b/src/platforms/web/agent-browser-provider.test.ts
@@ -49,6 +49,7 @@ test('agent-browser provider maps supported operations to session-scoped JSON co
       await provider.hover?.(30.2, 40.7);
       await provider.hoverRef?.('@e5');
       await provider.fill(11, 22, 'Ada');
+      await provider.fill(11, 22, '');
       await provider.fillRef?.('@e2', 'Grace');
       await provider.typeText('hello');
       await provider.scroll('down', { pixels: 400 });
@@ -80,6 +81,13 @@ test('agent-browser provider maps supported operations to session-scoped JSON co
         ['mouse', 'up', '--json', '--session', 'web-session'],
         ['press', expectedSelectAllShortcut(), '--json', '--session', 'web-session'],
         ['keyboard', 'type', 'Ada', '--json', '--session', 'web-session'],
+        // The empty fill (#2063) deletes the select-all selection instead of typing zero
+        // characters over it, which would leave the old value intact.
+        ['mouse', 'move', '11', '22', '--json', '--session', 'web-session'],
+        ['mouse', 'down', '--json', '--session', 'web-session'],
+        ['mouse', 'up', '--json', '--session', 'web-session'],
+        ['press', expectedSelectAllShortcut(), '--json', '--session', 'web-session'],
+        ['press', 'Backspace', '--json', '--session', 'web-session'],
         ['fill', '@e2', 'Grace', '--json', '--session', 'web-session'],
         ['keyboard', 'type', 'hello', '--json', '--session', 'web-session'],
         ['scroll', 'down', '400', '--json', '--session', 'web-session'],

--- a/src/platforms/web/agent-browser-provider.ts
+++ b/src/platforms/web/agent-browser-provider.ts
@@ -90,6 +90,12 @@ export function createAgentBrowserWebProvider(
       // browser input until a future ref-targeted web path can call native fill.
       await clickCoordinates(runJson, x, y);
       await runJson(['press', selectAllShortcut()]);
+      if (text.length === 0) {
+        // The clear-field request (#2063): typing zero characters over the selection would
+        // leave the old value selected but intact, so the selection must be deleted instead.
+        await runJson(['press', 'Backspace']);
+        return;
+      }
       await runJson(['keyboard', 'type', text]);
     },
     async fillRef(ref, text) {


### PR DESCRIPTION

Closes #2063

## Summary

Emptying a text input was not expressible. `fill` refused the empty string, `type` only appends,
`keyboard` has no delete verb, and `get value` is not a thing — so clearing a field before typing,
a routine QA step, was reachable only through the app's own clear button or N presses of a
locale-dependent keyboard delete key read out of a snapshot first.

```
$ agent-device fill @e57 ""
Error (INVALID_ARGS): Expected text to be a non-empty string.
```

`fill <target> ""` now means "replace with nothing". **Both platforms already own the clear half of
replace** — this change is mostly the validation and reporting standing in front of it, not a new
interaction:

- **Input validation.** `stringField` takes an opt-in `allowEmpty`, used by exactly one field:
  `fill`'s `text`. `type` keeps refusing an empty text (appending nothing is not a clear), and every
  other string field keeps the non-empty rule.
- **Missing vs empty.** `requiredField` still refuses a missing `text`, and
  `readFillTargetFromPositionals` now reports `undefined` for "no text argument" instead of
  collapsing it to `''`. So `fill @e57` stays `Expected text to be set.` rather than silently
  erasing the field — the one hazard in relaxing this check.
- **Apple runner.** `typeTextReliably` early-returned on empty text and reported `verified: true`,
  which would have made the whole feature a no-op that *claims* success. For `repairMode ==
  .replacement` it now runs the existing `clearTextInput` and verifies the field came back empty;
  secure fields, whose value is unreadable, stay unverified rather than reporting a mismatch.
  `type` (append) and unrepaired entry keep the old no-op return.
- **Android.** `fillAndroid` already clears before typing and already skips an empty shell/IME
  write, so the device behaviour was correct — but `isAcceptableAndroidFillMatch` read a cleared
  `EditText`'s absent `text` attribute (`null`) as a mismatch against `''`, so a successful clear
  would have been reported `text_mismatch`. An empty expectation now accepts `null` or `""`.

Whitespace-only text keeps its established per-shape rules (payload on ref/coordinate fills,
refused on selector fills); only `''` is new.

```
$ agent-device fill 'id="form.textField"' ""
Filled 0 chars
```

## Tests

New/updated, each observed red against the pre-fix code:

- `src/commands/interaction/metadata.test.ts` (new) — `fill` accepts `''`, still refuses a missing
  `text` and a non-string `text`; `type` still refuses `''`.
- `src/commands/interaction/interactions.test.ts` — the CLI reader distinguishes an empty text
  positional from an absent one on all three target shapes, and the daemon writer projects `''` as
  its own positional.
- `src/daemon/handlers/__tests__/interaction-touch-targets.test.ts` — `parseFillTarget` accepts
  `''` after a ref, a selector and coordinates; still refuses a missing text on all three; keeps
  the per-shape whitespace rules.
- `src/platforms/android/__tests__/text-input-fill.test.ts` — a cleared field verifies against an
  empty expectation whether the dump carries `text=""` or no `text` attribute, and a non-empty
  field still fails one.

`pnpm check:quick`, `pnpm test:unit` (8100 passed) and `pnpm check:command-docs` are green.

## Live check

iOS 26.5 simulator (iPhone 17), DemoApp with a text field, runner rebuilt via
`pnpm build:xcuitest:ios`, CLI from this clone:

| step | field value |
| --- | --- |
| `fill @e53 "hello world"` | `"hello world"` |
| `fill @e53 ""` | `"Text input"` (placeholder — empty) |
| `fill @e53 ""` again | still empty, no error |
| `fill @e53` | `INVALID_ARGS: Expected text to be set.` |
| `fill 'id="form.textField"' "second value"` | `"second value"` |
| `fill 'id="form.textField"' ""` | empty |

Session closed and daemon stopped afterwards.

**Android is not live-verified** — no emulator was available. Its half is a verification-predicate
fix plus paths that already short-circuit on empty text, and it carries unit coverage, but a
maintainer should run one `fill <target> ""` on an emulator (both the adb-shell and test-IME
channels) before merging.

## What a maintainer might push back on

- **`clear` as its own command** was the issue's other option. Not taken: it would add a registry
  descriptor, a capability admission entry, an MCP tool, help, and recording/replay handling for
  behaviour `fill` already performs. `fill <target> ""` is the same primitive with no new surface.
- **The Swift change is the risky part.** It sits entirely inside the existing empty-text guard and
  reuses `clearTextInput`; the non-replacement path is byte-identical. It is the one piece with no
  unit coverage (the runner has none), so the live table above is its only evidence.
- **`"Filled 0 chars"`** is accurate but reads oddly for a clear. Changing it means touching two
  message builders in different daemon modules (`touch-runtime.ts`,
  `handlers/interaction-touch-payload.ts`); left out to keep the diff on the primitive. Happy to add
  it if preferred.
- **Whitespace asymmetry.** `""` is accepted where `"   "` is still refused on selector fills. That
  is deliberate — an explicit clear versus an accidentally blank argument — but it is a rule worth
  agreeing on.
- **Recording.** `optimizeFillAction` skips the selector optimisation for empty text, so a recorded
  clear falls back to the ref form. Out of scope here; flag it if it should be part of this change.
