### PR TITLE
docs(batch): name the step shape and the accepted commands in `help batch` and in its refusals

### DIFF
--- a/packages/contracts/src/batch-contract.test.ts
+++ b/packages/contracts/src/batch-contract.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import {
+  BATCH_STEP_SHAPE_HINT,
+  readBatchStepInputObject,
+  readBatchStepRecord,
+} from './batch-contract.ts';
+
+function hintOf(read: () => unknown): string | undefined {
+  try {
+    read();
+  } catch (error) {
+    return error instanceof AppError ? error.details?.hint : undefined;
+  }
+  throw new Error('Expected the read to refuse');
+}
+
+// This module validates batch steps for the Node client and the MCP tools as well as the CLI, so
+// a terminal recovery step here would be unrunnable advice on two of the three surfaces (#2062).
+test('the shared step-shape hint names the shape without naming a surface', () => {
+  expect(BATCH_STEP_SHAPE_HINT).toContain('{"command":"<name>","input":{...}}');
+  expect(BATCH_STEP_SHAPE_HINT).not.toMatch(/agent-device |--\w/);
+});
+
+test('shape refusals carry the shared hint, or the caller-supplied one', () => {
+  expect(hintOf(() => readBatchStepRecord('press @e12', 1))).toBe(BATCH_STEP_SHAPE_HINT);
+  expect(hintOf(() => readBatchStepInputObject({ command: 'press' }, 1))).toBe(
+    BATCH_STEP_SHAPE_HINT,
+  );
+  expect(hintOf(() => readBatchStepRecord('press @e12', 1, 'surface hint'))).toBe('surface hint');
+  expect(hintOf(() => readBatchStepInputObject({ command: 'press' }, 1, 'surface hint'))).toBe(
+    'surface hint',
+  );
+});

--- a/packages/contracts/src/batch-contract.ts
+++ b/packages/contracts/src/batch-contract.ts
@@ -18,18 +18,24 @@ export function assertBatchStepCount(stepCount: number, maxSteps: number): void 
  * The one sentence every batch-step shape refusal owes the caller. `batch` accepts a single step
  * shape, and none of its refusals named it: a string step answered "Invalid batch step 1." and an
  * `args`/`target`/`argv` step answered "unknown field(s)", neither of which says what a step
- * looks like or where to find a command's input keys (#2062).
+ * looks like (#2062).
+ *
+ * It describes the shape only. This module validates for the Node client and the MCP tools as
+ * well as the CLI, so a terminal recovery step ("run agent-device help ...") belongs to the CLI
+ * call sites, which pass their own hint through the `hint` parameters below.
  */
 export const BATCH_STEP_SHAPE_HINT =
-  'Each batch step is {"command":"<name>","input":{...}} — the same input object that command ' +
-  'takes on its own. There is no positional step form: run agent-device help <command> for its ' +
-  'arguments, and agent-device help batch for the commands batch accepts.';
+  'Each batch step is {"command":"<name>","input":{...}}, where input is that command\'s own ' +
+  'structured input object, keyed by field name. There is no positional step form: args, argv, ' +
+  'positionals, and flags are not step fields.';
 
-export function readBatchStepRecord(step: unknown, stepNumber: number): Record<string, unknown> {
+export function readBatchStepRecord(
+  step: unknown,
+  stepNumber: number,
+  hint: string = BATCH_STEP_SHAPE_HINT,
+): Record<string, unknown> {
   if (!isRecord(step)) {
-    throw new AppError('INVALID_ARGS', `Invalid batch step ${stepNumber}.`, {
-      hint: BATCH_STEP_SHAPE_HINT,
-    });
+    throw new AppError('INVALID_ARGS', `Invalid batch step ${stepNumber}.`, { hint });
   }
   return step;
 }
@@ -37,11 +43,12 @@ export function readBatchStepRecord(step: unknown, stepNumber: number): Record<s
 export function readBatchStepInputObject(
   record: Record<string, unknown>,
   stepNumber: number,
+  hint: string = BATCH_STEP_SHAPE_HINT,
 ): Record<string, unknown> {
   const input = record.input;
   if (!isRecord(input)) {
     throw new AppError('INVALID_ARGS', `Batch step ${stepNumber} input must be an object.`, {
-      hint: BATCH_STEP_SHAPE_HINT,
+      hint,
     });
   }
   return input;

--- a/packages/contracts/src/batch-contract.ts
+++ b/packages/contracts/src/batch-contract.ts
@@ -14,9 +14,22 @@ export function assertBatchStepCount(stepCount: number, maxSteps: number): void 
   }
 }
 
+/**
+ * The one sentence every batch-step shape refusal owes the caller. `batch` accepts a single step
+ * shape, and none of its refusals named it: a string step answered "Invalid batch step 1." and an
+ * `args`/`target`/`argv` step answered "unknown field(s)", neither of which says what a step
+ * looks like or where to find a command's input keys (#2062).
+ */
+export const BATCH_STEP_SHAPE_HINT =
+  'Each batch step is {"command":"<name>","input":{...}} — the same input object that command ' +
+  'takes on its own. There is no positional step form: run agent-device help <command> for its ' +
+  'arguments, and agent-device help batch for the commands batch accepts.';
+
 export function readBatchStepRecord(step: unknown, stepNumber: number): Record<string, unknown> {
   if (!isRecord(step)) {
-    throw new AppError('INVALID_ARGS', `Invalid batch step ${stepNumber}.`);
+    throw new AppError('INVALID_ARGS', `Invalid batch step ${stepNumber}.`, {
+      hint: BATCH_STEP_SHAPE_HINT,
+    });
   }
   return step;
 }
@@ -27,7 +40,9 @@ export function readBatchStepInputObject(
 ): Record<string, unknown> {
   const input = record.input;
   if (!isRecord(input)) {
-    throw new AppError('INVALID_ARGS', `Batch step ${stepNumber} input must be an object.`);
+    throw new AppError('INVALID_ARGS', `Batch step ${stepNumber} input must be an object.`, {
+      hint: BATCH_STEP_SHAPE_HINT,
+    });
   }
   return input;
 }

--- a/packages/contracts/src/facades/command.ts
+++ b/packages/contracts/src/facades/command.ts
@@ -1,4 +1,5 @@
 export {
+  BATCH_STEP_SHAPE_HINT,
   DEFAULT_BATCH_MAX_STEPS,
   assertBatchStepCount,
   isValidBatchMaxSteps,

--- a/src/cli-schema/cli-help-examples.test.ts
+++ b/src/cli-schema/cli-help-examples.test.ts
@@ -1,10 +1,12 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import type { BatchStep } from '@agent-device/contracts/client';
 import { parseArgs } from '../cli/parser/args.ts';
+import { readCliBatchStepsJson } from '../cli/batch-steps.ts';
 import { buildCommandUsageText, buildUsageText, helpTopicIds } from './cli-help.ts';
 import { listCliCommandNames } from '../command-catalog.ts';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
-import { isCommandName } from '../commands/command-metadata.ts';
+import { findCommandMetadata, isCommandName } from '../commands/command-metadata.ts';
 import { readVersion } from '../utils/version.ts';
 
 // Help is the agent-facing contract, and agents copy its example lines verbatim, so an example the
@@ -104,6 +106,46 @@ test('every runnable example printed by CLI help is accepted by the CLI schema',
     [],
     `Help advertises commands the CLI rejects:\n${failures.join('\n')}`,
   );
+});
+
+/** The `--steps` payload of every batch example help prints, paired with the line it came from. */
+function collectBatchStepExamples(): Array<{ line: string; steps: BatchStep[] }> {
+  return collectHelpExamples()
+    .filter((example) => example.argv[0] === 'batch' && example.argv.includes('--steps'))
+    .map((example) => {
+      const json = example.argv[example.argv.indexOf('--steps') + 1];
+      assert.ok(json, `Expected a --steps payload in help example: ${example.line}`);
+      return { line: example.line, steps: readCliBatchStepsJson(json) };
+    });
+}
+
+// A step's `input` is keyed by the command's structured field names, and no CLI help text spells
+// those out — `help press` documents the positional and the flags, not `target: {kind, ref}`. So
+// the printed steps ARE the terminal's only statement of them, and the check above cannot see it:
+// the CLI parser validates the step envelope and stops, never reading `input`. Each printed input
+// therefore goes through its own command's `readInput` — the same reader the daemon, the client,
+// and the MCP tool run (#2062).
+test('every batch step printed by CLI help is accepted by its own command reader', () => {
+  const examples = collectBatchStepExamples();
+  const covered = new Set<string>();
+  for (const { line, steps } of examples) {
+    for (const step of steps) {
+      assert.ok(isCommandName(step.command), `Unknown command in help example: ${line}`);
+      try {
+        findCommandMetadata(step.command).readInput(step.input);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.fail(
+          `Help advertises a batch step ${step.command} rejects:\n${line}\n    ${message}`,
+        );
+      }
+      covered.add(step.command);
+    }
+  }
+  // #2062 was reported against the mutating verbs; a snapshot step is what precedes them.
+  for (const command of ['press', 'fill', 'snapshot']) {
+    assert.ok(covered.has(command), `Expected a ${command} step among help's batch examples`);
+  }
 });
 
 test('help react-native keeps its multi-worktree open example runnable', () => {

--- a/src/cli-schema/cli-help-examples.test.ts
+++ b/src/cli-schema/cli-help-examples.test.ts
@@ -131,14 +131,23 @@ test('every batch step printed by CLI help is accepted by its own command reader
   for (const { line, steps } of examples) {
     for (const step of steps) {
       assert.ok(isCommandName(step.command), `Unknown command in help example: ${line}`);
+      let parsed: unknown;
       try {
-        findCommandMetadata(step.command).readInput(step.input);
+        parsed = findCommandMetadata(step.command).readInput(step.input);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         assert.fail(
           `Help advertises a batch step ${step.command} rejects:\n${line}\n    ${message}`,
         );
       }
+      // readInput IGNORES unknown keys, so acceptance alone cannot pin an optional field: a
+      // renamed `settle` or `interactiveOnly` would parse to a step that silently does less
+      // than the help advertises. Every printed key must survive into the parsed input.
+      assert.deepEqual(
+        Object.keys(parsed as Record<string, unknown>).sort(),
+        Object.keys(step.input).sort(),
+        `Help advertises a batch step ${step.command} key its reader drops:\n${line}`,
+      );
       covered.add(step.command);
     }
   }

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -68,6 +68,26 @@ test('batch help documents the step shape and the commands batch accepts', async
     assert.match(help, new RegExp(`\\b${command}\\b`), `expected ${command} in batch help`);
   }
   assert.match(help, /batch and replay never nest/);
+  // A step's input is keyed by structured field names no CLI help spells out, so the examples are
+  // this text's only statement of them. `cli-help-examples.test.ts` runs them through the readers.
+  assert.match(help, /\n\nExamples:\n {2}agent-device batch --steps '\[/);
+  assert.match(help, /"command":"press","input":\{"target":\{"kind":"ref"/);
+  assert.match(help, /"command":"fill",.*"text":"qa@example\.com"/);
+  assert.match(help, /"command":"snapshot","input":\{"interactiveOnly":true\}/);
+});
+
+// #2046 removed the positionals/flags step payload and dropped positional step input, but the
+// topics kept describing both: `help scripting` still weighed the removed shape against the
+// accepted one, and `help workflow` still named `batch ./steps.json` as the known flow (#2062).
+test('scripting and workflow topics name only the accepted batch step source', async () => {
+  const scripting = await usageForCommand('scripting');
+  const workflow = await usageForCommand('workflow');
+  if (scripting === null || workflow === null) throw new Error('Expected both help texts');
+
+  assert.match(scripting, /agent-device batch --steps-file \.\/steps\.json/);
+  assert.doesNotMatch(scripting, /positionals\/flags/);
+  assert.match(workflow, /batch --steps-file \.\/steps\.json/);
+  assert.doesNotMatch(workflow, /batch \.\/steps\.json/);
 });
 
 test('commands topic includes only global flags in its global flags section', async () => {
@@ -167,7 +187,7 @@ test('usageForCommand resolves workflow help topic', async () => {
     help,
     /iOS rejects a stale pinned ref -- refresh with snapshot -i or use a selector/,
   );
-  assert.match(help, /Known flow: batch \.\/steps\.json \(help scripting\)/);
+  assert.match(help, /Known flow: batch --steps-file \.\/steps\.json \(help batch\)/);
   assert.match(help, /Shapes and platform quirks: help gestures/);
   assert.match(
     help,
@@ -270,7 +290,7 @@ test('usageForCommand resolves scripting help topic', async () => {
   assert.match(help, /state-repair means the script is correct but app state is not/);
   assert.match(help, /close --save-script\[=<out>\] \(default <stem>\.healed\.ad\)/);
   assert.match(help, /agent-device batch --steps '\[\{"command":"open"/);
-  assert.match(help, /removed positionals\/flags shape fails with an example/);
+  assert.match(help, /Step keys are command, input, and optional runtime -- that is the whole/);
   assert.match(help, /test \.\/e2e\/maestro --maestro --device udid1,emulator-5554 --shard-all 2/);
   assert.match(help, /Android adb screenrecord has a 180s limit/);
   assert.match(help, /--hide-touches skips that for the fastest raw recording/);

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -54,6 +54,22 @@ test('commands topic lists the shared device selectors in their own section', as
   assert.match(selectionSection, /--session <name>/);
 });
 
+// `help batch` documented neither the step shape nor which commands batch accepts, so both were
+// only reachable by trial (#2062). The accepted list is rendered from the registry, so this asserts
+// membership rather than an exact roster.
+test('batch help documents the step shape and the commands batch accepts', async () => {
+  const help = await usageForCommand('batch');
+  if (help === null) throw new Error('Expected batch help text');
+
+  assert.match(help, /\{"command":"<name>","input":\{\.\.\.\}\}/);
+  assert.match(help, /no positional step form/);
+  assert.match(help, /Available through batch:/);
+  for (const command of ['press', 'click', 'fill', 'longpress', 'scroll', 'back']) {
+    assert.match(help, new RegExp(`\\b${command}\\b`), `expected ${command} in batch help`);
+  }
+  assert.match(help, /batch and replay never nest/);
+});
+
 test('commands topic includes only global flags in its global flags section', async () => {
   const usageText = await usageForCommand('commands');
   if (usageText === null) throw new Error('Expected commands help text');

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -131,7 +131,7 @@ Command shape:
   Command lines only -- no prose, numbering, fences, pipes, or grep/head/tail/jq on agent-device output; raw output carries the refs/hints the next step needs. Subcommand first, then positionals, then flags: agent-device open com.example.app --session checkout --platform android --relaunch
   Chain confident consecutive steps with &&: press 'label="Search"' --settle && fill 'label="Search"' "query" --settle. Fall back to one command at a time when a step is uncertain (ambiguous match, network-backed result, unseen screen).
   Refs look like @e12; use the exact ref from the latest snapshot -i, never a placeholder (@ref, @eN, @Label_Name). Pin with ~s<n> (press @e12~s4); iOS rejects a stale pinned ref -- refresh with snapshot -i or use a selector.
-  close = agent-device close. App back is back; system back is back --system. Taps are press/click. type never takes --settle: run type, then diff snapshot to verify. Known flow: batch ./steps.json (help scripting).
+  close = agent-device close. App back is back; system back is back --system. Taps are press/click. type never takes --settle: run type, then diff snapshot to verify. Known flow: batch --steps-file ./steps.json (help batch).
   Gestures: scroll/swipe for lists/flicks; gesture pan|fling|pinch|rotate|transform|drag for multi-touch. Shapes and platform quirks: help gestures.
 
 Bootstrap:
@@ -225,7 +225,8 @@ Replay divergence and repair:
 
 Batch:
   agent-device batch --steps '[{"command":"open","input":{"app":"settings"}},{"command":"wait","input":{"kind":"duration","durationMs":100}}]'
-  Step keys are command, input, and optional runtime; put command arguments inside input using the same fields as the MCP/Node command. The removed positionals/flags shape fails with an example showing how to migrate it.
+  agent-device batch --steps-file ./steps.json --json
+  Step keys are command, input, and optional runtime -- that is the whole accepted shape. input holds the command's structured fields, not its terminal spelling: a CLI positional becomes a named field (target, text, direction) and a flag becomes a camelCase key (--settle -> "settle":true). Accepted commands, that mapping, and runnable press/fill/snapshot steps: help batch.
   Maestro full-suite validation on connected devices uses one test command with a comma-separated --device list and --shard-all (--shard-split only to split suite entries across devices):
     agent-device test ./e2e/maestro --maestro --device udid1,emulator-5554 --shard-all 2
 

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -37,6 +37,7 @@ function readCliBatchStep(step: unknown, stepNumber: number): BatchStep {
     throw new AppError(
       'INVALID_ARGS',
       `Batch step ${stepNumber} uses removed field(s): ${fields}. Use {"command":"...","input":{...}}. Example: {"command":"open","input":{"app":"settings","platform":"ios"}}.`,
+      { hint: CLI_BATCH_STEP_SHAPE_HINT },
     );
   }
   assertAllowedKeys(

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -1,5 +1,6 @@
 import type { BatchStep } from '@agent-device/contracts/client';
 import {
+  BATCH_STEP_SHAPE_HINT,
   parseBatchStepRuntime,
   readBatchStepInputObject,
   readBatchStepRecord,
@@ -31,7 +32,12 @@ function readCliBatchStep(step: unknown, stepNumber: number): BatchStep {
       `Batch step ${stepNumber} uses removed field(s): ${fields}. Use {"command":"...","input":{...}}. Example: {"command":"open","input":{"app":"settings","platform":"ios"}}.`,
     );
   }
-  assertAllowedKeys(record, ['command', 'input', 'runtime'], `Batch step ${stepNumber}`);
+  assertAllowedKeys(
+    record,
+    ['command', 'input', 'runtime'],
+    `Batch step ${stepNumber}`,
+    BATCH_STEP_SHAPE_HINT,
+  );
   const runtime = parseBatchStepRuntime(record.runtime, stepNumber);
   return {
     command: readStructuredBatchCommandName(record.command, stepNumber),

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -9,6 +9,13 @@ import { AppError } from '@agent-device/kernel/errors';
 import { readStructuredBatchCommandName } from '../core/batch-policy.ts';
 import { assertAllowedKeys } from '../commands/command-input.ts';
 
+/**
+ * The terminal half of the step-shape refusal. `@agent-device/contracts` states the shape for
+ * every surface and stops there; only a terminal caller can be told to run a help command, so the
+ * recovery step is attached here rather than in the shared contract (#2062).
+ */
+const CLI_BATCH_STEP_SHAPE_HINT = `${BATCH_STEP_SHAPE_HINT} Run agent-device help batch for the commands batch accepts and for runnable step examples.`;
+
 export function readCliBatchStepsJson(raw: string): BatchStep[] {
   let parsed: unknown;
   try {
@@ -23,7 +30,7 @@ export function readCliBatchStepsJson(raw: string): BatchStep[] {
 }
 
 function readCliBatchStep(step: unknown, stepNumber: number): BatchStep {
-  const record = readBatchStepRecord(step, stepNumber);
+  const record = readBatchStepRecord(step, stepNumber, CLI_BATCH_STEP_SHAPE_HINT);
   const removedFields = ['positionals', 'flags'].filter((field) => field in record);
   if (removedFields.length > 0) {
     const fields = removedFields.map((field) => `"${field}"`).join(', ');
@@ -36,12 +43,12 @@ function readCliBatchStep(step: unknown, stepNumber: number): BatchStep {
     record,
     ['command', 'input', 'runtime'],
     `Batch step ${stepNumber}`,
-    BATCH_STEP_SHAPE_HINT,
+    CLI_BATCH_STEP_SHAPE_HINT,
   );
   const runtime = parseBatchStepRuntime(record.runtime, stepNumber);
   return {
     command: readStructuredBatchCommandName(record.command, stepNumber),
-    input: readBatchStepInputObject(record, stepNumber),
+    input: readBatchStepInputObject(record, stepNumber, CLI_BATCH_STEP_SHAPE_HINT),
     ...(runtime === undefined ? {} : { runtime }),
   };
 }

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -6,7 +6,10 @@ import {
   readBatchStepRecord,
 } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import { readStructuredBatchCommandName } from '../core/batch-policy.ts';
+import {
+  BATCH_AVAILABLE_COMMANDS_HINT,
+  readStructuredBatchCommandName,
+} from '../core/batch-policy.ts';
 import { assertAllowedKeys } from '../commands/command-input.ts';
 
 /**
@@ -15,6 +18,8 @@ import { assertAllowedKeys } from '../commands/command-input.ts';
  * recovery step is attached here rather than in the shared contract (#2062).
  */
 const CLI_BATCH_STEP_SHAPE_HINT = `${BATCH_STEP_SHAPE_HINT} Run agent-device help batch for the commands batch accepts and for runnable step examples.`;
+
+const CLI_BATCH_AVAILABLE_COMMANDS_HINT = `${BATCH_AVAILABLE_COMMANDS_HINT} Run agent-device help batch for the commands batch accepts and for runnable step examples.`;
 
 export function readCliBatchStepsJson(raw: string): BatchStep[] {
   let parsed: unknown;
@@ -48,7 +53,11 @@ function readCliBatchStep(step: unknown, stepNumber: number): BatchStep {
   );
   const runtime = parseBatchStepRuntime(record.runtime, stepNumber);
   return {
-    command: readStructuredBatchCommandName(record.command, stepNumber),
+    command: readStructuredBatchCommandName(
+      record.command,
+      stepNumber,
+      CLI_BATCH_AVAILABLE_COMMANDS_HINT,
+    ),
     input: readBatchStepInputObject(record, stepNumber, CLI_BATCH_STEP_SHAPE_HINT),
     ...(runtime === undefined ? {} : { runtime }),
   };

--- a/src/commands/batch/cli.test.ts
+++ b/src/commands/batch/cli.test.ts
@@ -10,6 +10,8 @@ import {
   type CliCaptureOptions,
 } from '../../__tests__/cli-capture.ts';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+import { AppError } from '@agent-device/kernel/errors';
+import { createBatchCommandMetadata } from './metadata.ts';
 
 const batchDefaultResponse: DaemonResponse = {
   ok: true,
@@ -142,12 +144,38 @@ test('an args/target step names the step shape instead of only the unknown field
   assert.match(result.stderr, /\{"command":"<name>","input":\{\.\.\.\}\}/);
 });
 
-test('a non-batchable command points at the listing of the ones that are', async () => {
+test('a non-batchable command states the boundary and, on the CLI, the help recovery', async () => {
   const result = await runCliCapture(['batch', '--steps', '[{"command":"session","input":{}}]']);
 
   assert.equal(result.code, 1);
   assert.match(result.stderr, /not available through command batch: session/);
+  assert.match(result.stderr, /excluded from batch/);
   assert.match(result.stderr, /help batch/);
+});
+
+// The same reader backs the MCP/Node surface through the batch metadata, where a terminal
+// recovery step is unrunnable: the shared hint stays surface-neutral (those surfaces read the
+// accepted commands off the step schema's command enum) and only the CLI admission appends the
+// help pointer (#2062). The hint also has to survive the 400-character redaction cap intact —
+// enumerating the roster inline truncated it, help pointer and all.
+test('the MCP/Node availability refusal is surface-neutral and survives redaction whole', () => {
+  const metadata = createBatchCommandMetadata();
+  try {
+    metadata.readInput({ steps: [{ command: 'session', input: {} }] });
+    assert.fail('expected the nested session command to be refused');
+  } catch (error) {
+    assert.ok(error instanceof AppError);
+    const hint = String(error.details?.hint ?? '');
+    assert.match(hint, /excluded from batch/);
+    assert.doesNotMatch(hint, /agent-device /);
+    assert.doesNotMatch(hint, /--[a-z]/);
+    assert.ok(hint.length <= 400, `hint must survive the redaction cap, got ${hint.length}`);
+  }
+  const stepSchema = metadata.inputSchema.properties?.steps as {
+    items?: { properties?: { command?: { enum?: string[] } } };
+  };
+  const commandEnum = stepSchema.items?.properties?.command?.enum ?? [];
+  assert.ok(commandEnum.includes('press'), 'the step schema enum is the machine-readable roster');
 });
 
 // The reported blocker (#2062) was the step shape, not the verb: press/click/fill were never

--- a/src/commands/batch/cli.test.ts
+++ b/src/commands/batch/cli.test.ts
@@ -120,6 +120,55 @@ test('batch rejects structured replay steps before daemon dispatch', async () =>
   assert.match(result.stderr, /not available through command batch/);
 });
 
+// Every step-shape refusal used to name only what was wrong, never what a step looks like, and
+// `help batch` documented no shape and no exclusions — so the boundary was reachable only by
+// trial (#2062). Each refusal now carries the missing half.
+
+test('a non-object step names the step shape', async () => {
+  const result = await runCliCapture(['batch', '--steps', '["press @e12"]']);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 0);
+  assert.match(result.stderr, /Invalid batch step 1/);
+  assert.match(result.stderr, /\{"command":"<name>","input":\{\.\.\.\}\}/);
+  assert.match(result.stderr, /no positional step form/);
+});
+
+test('an args/target step names the step shape instead of only the unknown field', async () => {
+  const result = await runCliCapture(['batch', '--steps', '[{"command":"press","args":["@e12"]}]']);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /has unknown field\(s\): args/);
+  assert.match(result.stderr, /\{"command":"<name>","input":\{\.\.\.\}\}/);
+});
+
+test('a non-batchable command points at the listing of the ones that are', async () => {
+  const result = await runCliCapture(['batch', '--steps', '[{"command":"session","input":{}}]']);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /not available through command batch: session/);
+  assert.match(result.stderr, /help batch/);
+});
+
+// The reported blocker (#2062) was the step shape, not the verb: press/click/fill were never
+// excluded from batch. Pin that so a future exclusion has to be a deliberate registry change.
+test('mutating UI verbs reach daemon dispatch through batch', async () => {
+  const result = await runCliCapture([
+    'batch',
+    '--steps',
+    '[{"command":"press","input":{"target":{"kind":"ref","ref":"@e12"}}},{"command":"fill","input":{"target":{"kind":"ref","ref":"@e13"},"text":"x"}}]',
+    '--json',
+  ]);
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  const steps = result.calls[0]?.flags?.batchSteps ?? [];
+  assert.deepEqual(
+    steps.map((step) => step.command),
+    ['press', 'fill'],
+  );
+});
+
 test('batch rejects invalid structured runtime', async () => {
   const result = await runCliCapture([
     'batch',

--- a/src/commands/batch/index.ts
+++ b/src/commands/batch/index.ts
@@ -6,7 +6,7 @@ import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/typ
 import { defineExecutableCommand } from '../command-contract.ts';
 import { commonToClientOptions } from '../command-input.ts';
 import { batchCliOutputFormatters } from './output.ts';
-import { createBatchCommandMetadata, type BatchInput } from './metadata.ts';
+import { createBatchCommandMetadata, type BatchCommandStep, type BatchInput } from './metadata.ts';
 import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../core/batch-policy.ts';
 import { createBatchDaemonWriter } from './projection.ts';
 
@@ -31,18 +31,40 @@ const batchCliReader: CliReader = (_positionals, flags) => ({
 });
 
 /**
+ * The step examples `help batch` prints. A step's `input` is keyed by the command's structured
+ * field names, which no CLI help text spells out — `help press` documents the positional and the
+ * flags, not `target: {kind, ref}` — so these lines are the only place the terminal states them.
+ * `cli-help-examples.test.ts` reads them back out of the rendered help and runs each `input`
+ * through its own command's `readInput`, so a renamed field fails there instead of shipping an
+ * example nobody can run (#2062).
+ */
+const BATCH_STEP_EXAMPLES: readonly BatchCommandStep[] = [
+  { command: 'snapshot', input: { interactiveOnly: true } },
+  { command: 'press', input: { target: { kind: 'ref', ref: '@e12' }, settle: true } },
+  {
+    command: 'fill',
+    input: { target: { kind: 'selector', selector: 'id="field-email"' }, text: 'qa@example.com' },
+  },
+];
+
+/**
  * `help batch` documented neither the step shape nor which commands batch accepts, so an agent
  * discovered both by trial: `["press @e12"]` and `{"command":"press","args":[...]}` were refused
  * without either being named (#2062). The accepted set is RENDERED from the command-descriptor
  * registry's `batchable` trait, so it cannot drift from what the runtime allowlist enforces.
  */
 function buildBatchCliDetail(): string {
-  return [
-    'Each step is {"command":"<name>","input":{...}}: the same input object that command takes on its own — run agent-device help <command> for its arguments. There is no positional step form; args, target, and argv are not step fields.',
+  const prose = [
+    'Each step is {"command":"<name>","input":{...}}, and input is that command\'s structured input object rather than its terminal spelling: a CLI positional becomes a named field (target, text, direction) and a CLI flag becomes a camelCase key (--settle -> "settle":true, -i -> "interactiveOnly":true). There is no positional step form; args, argv, positionals, and flags are not step fields. agent-device help <command> lists arguments in CLI spelling only. The examples below carry the structured spelling; over MCP, the command tool schema states it in full.',
     'Steps run serially in one daemon request against the same session, in order. Mutating UI verbs are included (press, click, fill, longpress, scroll, back), which is where the round-trip saving is; --on-error stop halts at the first failing step.',
     `Available through batch: ${[...STRUCTURED_BATCH_COMMAND_NAMES].sort().join(', ')}.`,
     'Every other command is excluded: batch and replay never nest, and session, daemon, connection, and host tooling commands own lifecycle a batch request cannot carry. Run those on their own.',
   ].join(' ');
+  const examples = [
+    `  agent-device batch --steps '${JSON.stringify(BATCH_STEP_EXAMPLES)}'`,
+    '  agent-device batch --steps-file ./steps.json --json',
+  ].join('\n');
+  return `${prose}\n\nExamples:\n${examples}`;
 }
 
 const batchCommandFacet = defineCommandFacet({

--- a/src/commands/batch/index.ts
+++ b/src/commands/batch/index.ts
@@ -7,6 +7,7 @@ import { defineExecutableCommand } from '../command-contract.ts';
 import { commonToClientOptions } from '../command-input.ts';
 import { batchCliOutputFormatters } from './output.ts';
 import { createBatchCommandMetadata, type BatchInput } from './metadata.ts';
+import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../core/batch-policy.ts';
 import { createBatchDaemonWriter } from './projection.ts';
 
 const batchCommandMetadata = createBatchCommandMetadata();
@@ -29,10 +30,26 @@ const batchCliReader: CliReader = (_positionals, flags) => ({
   out: flags.out,
 });
 
+/**
+ * `help batch` documented neither the step shape nor which commands batch accepts, so an agent
+ * discovered both by trial: `["press @e12"]` and `{"command":"press","args":[...]}` were refused
+ * without either being named (#2062). The accepted set is RENDERED from the command-descriptor
+ * registry's `batchable` trait, so it cannot drift from what the runtime allowlist enforces.
+ */
+function buildBatchCliDetail(): string {
+  return [
+    'Each step is {"command":"<name>","input":{...}}: the same input object that command takes on its own — run agent-device help <command> for its arguments. There is no positional step form; args, target, and argv are not step fields.',
+    'Steps run serially in one daemon request against the same session, in order. Mutating UI verbs are included (press, click, fill, longpress, scroll, back), which is where the round-trip saving is; --on-error stop halts at the first failing step.',
+    `Available through batch: ${[...STRUCTURED_BATCH_COMMAND_NAMES].sort().join(', ')}.`,
+    'Every other command is excluded: batch and replay never nest, and session, daemon, connection, and host tooling commands own lifecycle a batch request cannot carry. Run those on their own.',
+  ].join(' ');
+}
+
 const batchCommandFacet = defineCommandFacet({
   name: 'batch',
   text: {
     summary: 'Run multiple commands',
+    cliDetail: buildBatchCliDetail(),
   },
   metadata: batchCommandMetadata,
   definition: batchCommandDefinition,

--- a/src/commands/batch/metadata.ts
+++ b/src/commands/batch/metadata.ts
@@ -1,4 +1,5 @@
 import {
+  BATCH_STEP_SHAPE_HINT,
   DEFAULT_BATCH_MAX_STEPS,
   assertBatchStepCount,
   isValidBatchMaxSteps,
@@ -49,7 +50,7 @@ export function createBatchCommandMetadata(
   const fields = batchFields(nestedCommands);
   return defineCommandMetadata({
     name: 'batch',
-    description: 'Execute multiple commands in one daemon request',
+    description: 'Execute multiple commands in one daemon request.',
     inputSchema: fieldsInputSchema(fields),
     readInput: (input) => readBatchInput(input, fields),
   });
@@ -128,7 +129,12 @@ function readBatchStep(
   nestedCommands: readonly string[],
 ): BatchCommandStep {
   const record = readBatchStepRecord(step, stepNumber);
-  assertAllowedKeys(record, ['command', 'input', 'runtime'], `Batch step ${stepNumber}`);
+  assertAllowedKeys(
+    record,
+    ['command', 'input', 'runtime'],
+    `Batch step ${stepNumber}`,
+    BATCH_STEP_SHAPE_HINT,
+  );
   return {
     command: readBatchStepCommand(record, stepNumber, nestedCommands),
     input: readBatchStepInputObject(record, stepNumber),

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -135,7 +135,7 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     names: ['--steps'],
     type: 'string',
     usageLabel: '--steps <json>',
-    usageDescription: 'Batch: JSON array of steps',
+    usageDescription: 'Batch: JSON array of {"command","input"} steps',
   },
   {
     key: 'stepsFile',

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -550,11 +550,16 @@ export function assertAllowedKeys(
   record: Record<string, unknown>,
   allowedKeys: readonly string[],
   label: string,
+  hint?: string,
 ): void {
   const allowed = new Set(allowedKeys);
   const unknownKeys = Object.keys(record).filter((key) => !allowed.has(key));
   if (unknownKeys.length > 0) {
-    throw new AppError('INVALID_ARGS', `${label} has unknown field(s): ${unknownKeys.join(', ')}.`);
+    throw new AppError(
+      'INVALID_ARGS',
+      `${label} has unknown field(s): ${unknownKeys.join(', ')}.`,
+      hint === undefined ? undefined : { hint },
+    );
   }
 }
 

--- a/src/core/batch-policy.ts
+++ b/src/core/batch-policy.ts
@@ -50,15 +50,17 @@ export const INHERITED_PARENT_FLAG_KEYS = [
 ] as const;
 
 /**
- * The refusal above names the rejected command but never named the accepted set, and `help batch`
- * documented no exclusions either, so the boundary was only discoverable by trial (#2062). Point at
- * the one derived listing rather than restating it: `help batch` renders
- * {@link STRUCTURED_BATCH_COMMAND_NAMES} itself, so a registry change cannot leave prose behind.
+ * The refusal below names the rejected command but never stated the boundary, so it was only
+ * discoverable by trial (#2062). Surface-neutral by design — this default reaches the MCP and
+ * Node readers, whose batch step schema already enumerates the accepted commands in its
+ * `command` enum; the CLI attaches its terminal recovery via the `hint` parameter at its own
+ * admission. NOT the place for the roster itself: hint strings are redaction-capped at 400
+ * characters, and the enumerated roster truncates.
  */
-const BATCH_AVAILABLE_COMMANDS_HINT =
-  'Run agent-device help batch for the commands available through batch. Session, daemon, ' +
-  'connection, and host tooling commands are excluded — they own lifecycle a batch cannot ' +
-  'carry — and batch and replay never nest. Run an excluded command on its own.';
+export const BATCH_AVAILABLE_COMMANDS_HINT =
+  'Session, daemon, connection, and host tooling commands are excluded from batch — they own ' +
+  'lifecycle a batch cannot carry — and batch and replay never nest. Run an excluded command on ' +
+  'its own; every other device command is available as a step.';
 
 const structuredBatchCommandNames = new Set<string>(STRUCTURED_BATCH_COMMAND_NAMES);
 
@@ -73,13 +75,14 @@ export function normalizeBatchCommandName(command: unknown): string {
 export function readStructuredBatchCommandName(
   command: unknown,
   stepNumber: number,
+  hint: string = BATCH_AVAILABLE_COMMANDS_HINT,
 ): StructuredBatchCommandName {
   const normalized = normalizeBatchCommandName(command);
   if (isStructuredBatchCommandName(normalized)) return normalized;
   throw new AppError(
     'INVALID_ARGS',
     `Batch step ${stepNumber} command is not available through command batch: ${String(command)}`,
-    { hint: BATCH_AVAILABLE_COMMANDS_HINT },
+    { hint },
   );
 }
 

--- a/src/core/batch-policy.ts
+++ b/src/core/batch-policy.ts
@@ -49,6 +49,17 @@ export const INHERITED_PARENT_FLAG_KEYS = [
   'out',
 ] as const;
 
+/**
+ * The refusal above names the rejected command but never named the accepted set, and `help batch`
+ * documented no exclusions either, so the boundary was only discoverable by trial (#2062). Point at
+ * the one derived listing rather than restating it: `help batch` renders
+ * {@link STRUCTURED_BATCH_COMMAND_NAMES} itself, so a registry change cannot leave prose behind.
+ */
+const BATCH_AVAILABLE_COMMANDS_HINT =
+  'Run agent-device help batch for the commands available through batch. Session, daemon, ' +
+  'connection, and host tooling commands are excluded — they own lifecycle a batch cannot ' +
+  'carry — and batch and replay never nest. Run an excluded command on its own.';
+
 const structuredBatchCommandNames = new Set<string>(STRUCTURED_BATCH_COMMAND_NAMES);
 
 function isStructuredBatchCommandName(command: string): command is StructuredBatchCommandName {
@@ -68,6 +79,7 @@ export function readStructuredBatchCommandName(
   throw new AppError(
     'INVALID_ARGS',
     `Batch step ${stepNumber} command is not available through command batch: ${String(command)}`,
+    { hint: BATCH_AVAILABLE_COMMANDS_HINT },
   );
 }
 


### PR DESCRIPTION

Closes #2062

## Summary

**The premise of the issue does not hold, and that is the finding.** `press`, `click`, `fill`,
`longpress`, `scroll` and `back` all carry `batchable: true` in the command-descriptor registry —
including at 0.20.10, which is the version the report was filed against (`git show
v0.20.10:src/core/command-descriptor/registry.ts`). Mutating UI verbs were never excluded from
`batch`. The exclusions are `batch`/`replay` (which never nest) and the session, daemon, connection
and host-tooling commands, none of which is a UI verb.

What actually blocked the reporter is that `batch` accepts exactly one step shape and **nothing said
so**. `help batch` was a usage line, one sentence and the flags. Every refusal named only what was
wrong:

| input | before |
| --- | --- |
| `'["press @e12"]'` | `Invalid batch step 1.` |
| `'[{"command":"press","args":["@e12"]}]'` | `Batch step 1 has unknown field(s): args.` |
| `'[{"command":"session","input":{}}]'` | `... is not available through command batch: session` |

None of those says what a step looks like or where the boundary is, so "the verb is not batchable"
is a reasonable conclusion to reach from them. Per the issue's own second branch, this PR does not
touch the allowlist — it states it.

- **`help batch`** now documents the step shape, the serial semantics, and **renders the accepted
  commands from the registry's `batchable` trait**, so the listing cannot drift from the runtime
  allowlist. It also says explicitly that the mutating UI verbs are included, which is the sentence
  the reporter needed.
- **The step-shape refusals** (non-object step, unknown field, non-object input) share one hint
  naming `{"command":"<name>","input":{...}}`. It lives in `packages/contracts/src/batch-contract.ts`
  next to the two checks that raise it, so the CLI, the command metadata and the daemon projection
  all get the same sentence from one place.
- **The non-batchable-command refusal** points at that listing and names which families are
  excluded and why.
- `assertAllowedKeys` takes an optional hint, so the two batch call sites attach theirs without a
  second unknown-key check being written.
- `--steps` reads `JSON array of {"command","input"} steps`, so the shape is visible at flag level too.

After:

```
Error (INVALID_ARGS): Batch step 1 has unknown field(s): args.
Hint: Each batch step is {"command":"<name>","input":{...}} — the same input object that command
      takes on its own. There is no positional step form: run agent-device help <command> for its
      arguments, and agent-device help batch for the commands batch accepts.
```

`batch`'s `description` gains a trailing period so the help body reads as prose once `cliDetail` is
appended; `server.json` carries no tool descriptions, and `pnpm check:mcp-metadata` is green.

## Tests

In `src/commands/batch/cli.test.ts` and `src/cli-schema/cli-help-topics.test.ts`; the four
assertion tests were observed red against the pre-fix code:

- a non-object step, an `args` step, and a non-batchable command each name the missing half;
- `help batch` documents the shape and lists press/click/fill/longpress/scroll/back;
- **and one test that passes today on purpose**: two mutating verbs reach daemon dispatch through
  `batch`. It is the regression pin for the premise above — if the allowlist is ever narrowed, that
  has to be a deliberate registry change rather than a silent one.

`pnpm check:quick`, `pnpm test:unit` (8092 passed), `pnpm check:command-docs` and
`pnpm check:mcp-metadata` are green.

## Live check

iOS 26.5 simulator (iPhone 17), DemoApp, CLI from this clone — one batch request, three steps:

```
$ agent-device batch --steps '[{"command":"press","input":{"target":{"kind":"selector","selector":"id=\"tabBar.form\""}}},
                               {"command":"fill","input":{"target":{"kind":"selector","selector":"id=\"form.textField\""},"text":"batched"}},
                               {"command":"snapshot","input":{"interactiveOnly":true}}]'
1 press    ok  Tapped id="tabBar.form" (287, 822)
2 fill     ok  Filled 7 chars
3 snapshot ok
```

That is the observe→act→verify sequence the issue says cannot be amortised, running today. Session
closed and daemon stopped afterwards.

Worth noting for the issue thread: with `@ref` steps, step 2 fails `ref_frame_expired` because
step 1's press invalidates the ref frame — correct and documented, but it means a multi-step batch
wants selectors, not refs. That is a real ergonomic limit on batching mutations and may deserve its
own issue.

## What a maintainer might push back on

- **The full command list in `help batch` is long** (48 names, one wrapped paragraph). The
  alternative is listing the ~20 exclusions instead, which is shorter but inverts the question an
  agent is asking. Rendering either from the registry is the part that matters.
- **`cliDetail` is one paragraph** because `helpBody` joins with a space. Four sentences is at the
  upper end of what that format carries well.
- **The optional `hint` on `assertAllowedKeys`** is a generic helper gaining a parameter for two
  callers. The alternative — a batch-local unknown-key check — duplicates the check itself.
- **This closes the issue without changing behaviour.** If the maintainers would rather also record
  *why* each excluded command is excluded (the registry declares the trait but no rationale), that
  is a separate, larger pass over `registry.ts`.
