### PR TITLE
fix(daemon): address cwd-scoped sessions by their store key, not their public name

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -192,7 +192,15 @@
       ]
     }
   ],
-  "usedClassMembers": ["name", "listActiveLeases", "delete", "values", "elapsedMs", "isExpired", "findByDevice"],
+  "usedClassMembers": [
+    "name",
+    "listActiveLeases",
+    "delete",
+    "values",
+    "elapsedMs",
+    "isExpired",
+    "findByDevice"
+  ],
   "rules": {
     "unused-types": "error",
     "duplicate-exports": "off"

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -192,7 +192,7 @@
       ]
     }
   ],
-  "usedClassMembers": ["name", "listActiveLeases", "delete", "values", "elapsedMs", "isExpired"],
+  "usedClassMembers": ["name", "listActiveLeases", "delete", "values", "elapsedMs", "isExpired", "findByDevice"],
   "rules": {
     "unused-types": "error",
     "duplicate-exports": "off"

--- a/packages/contracts/src/client-device-view.ts
+++ b/packages/contracts/src/client-device-view.ts
@@ -68,6 +68,13 @@ export type AgentDeviceSessionDevice = {
 
 export type AgentDeviceSession = {
   name: string;
+  /**
+   * The exact value `--session` must carry to address this session, which is not always `name`:
+   * a session opened without `--session` is named `default` but stored — and addressed — as
+   * `cwd:<hash>:default` (#2031/#1394). Optional only because a daemon older than the field does
+   * not send it.
+   */
+  address?: string;
   createdAt: number;
   sessionStateDir?: string;
   runnerLogPath?: string;

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -369,7 +369,8 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
       const device = { id: 'SIM-001', name: 'iPhone 17 Pro' } as Parameters<
         typeof buildDeviceInUseBySessionError
       >[1];
-      const response = buildDeviceInUseBySessionError(owningSession, device);
+      // An explicitly named session addresses itself, so the sample text is unchanged.
+      const response = buildDeviceInUseBySessionError(owningSession, device, owningSession.name);
       assertErrorResponse(response, 'the by-session conflict');
       return renderErrorResponse(response);
     },

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -365,12 +365,12 @@ export const SAMPLE_PRODUCERS: SampleProducer[] = [
     producer: 'the real session-open by-session conflict producer',
     sample: DEVICE_IN_USE_SAMPLE,
     render: () => {
-      const owningSession = { name: 'checkout' } as SessionState;
+      // An explicitly named session is stored under its own name, so address === name here.
+      const owningSession = { address: 'checkout', session: { name: 'checkout' } as SessionState };
       const device = { id: 'SIM-001', name: 'iPhone 17 Pro' } as Parameters<
         typeof buildDeviceInUseBySessionError
       >[1];
-      // An explicitly named session addresses itself, so the sample text is unchanged.
-      const response = buildDeviceInUseBySessionError(owningSession, device, owningSession.name);
+      const response = buildDeviceInUseBySessionError(owningSession, device);
       assertErrorResponse(response, 'the by-session conflict');
       return renderErrorResponse(response);
     },

--- a/src/client/client-normalizers.ts
+++ b/src/client/client-normalizers.ts
@@ -122,6 +122,7 @@ export function normalizeSession(value: unknown): AgentDeviceSession {
   };
   return {
     name,
+    address: readOptionalString(record, 'address'),
     createdAt: readRequiredNumber(record, 'createdAt'),
     sessionStateDir: readOptionalString(record, 'sessionStateDir'),
     runnerLogPath: readOptionalString(record, 'runnerLogPath'),

--- a/src/daemon/__tests__/request-lock-identity-policy.test.ts
+++ b/src/daemon/__tests__/request-lock-identity-policy.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { AppError } from '@agent-device/kernel/errors';
 import { applyRequestLockPolicy } from '../request-lock-policy.ts';
-import type { DaemonRequest, SessionState } from '../types.ts';
+import type { DaemonRequest, SessionRef, SessionState } from '../types.ts';
 
 /**
  * One table for the device-identity half of the session lock. A device identity selector
@@ -172,6 +172,11 @@ const ROWS: Row[] = [
   },
 ];
 
+/** Every row's session is explicitly named, so it is stored under — and addressed by — its name. */
+function ref(session: SessionState | undefined): SessionRef | undefined {
+  return session ? { address: session.name, session } : undefined;
+}
+
 for (const row of ROWS) {
   test(`session lock: ${row.name}`, () => {
     const request = {
@@ -187,7 +192,7 @@ for (const row of ROWS) {
     } as DaemonRequest;
 
     if (row.expect.kind === 'refused') {
-      const error = assertThrowsAppError(() => applyRequestLockPolicy(request, row.session));
+      const error = assertThrowsAppError(() => applyRequestLockPolicy(request, ref(row.session)));
       assert.equal(error.code, 'INVALID_ARGS');
       assert.ok(
         error.message.includes(row.expect.namesSelector),
@@ -212,7 +217,7 @@ for (const row of ROWS) {
       return;
     }
 
-    const applied = applyRequestLockPolicy(request, row.session);
+    const applied = applyRequestLockPolicy(request, ref(row.session));
     for (const [key, value] of Object.entries(row.expect.keepsSelectors)) {
       assert.equal(
         (applied.flags as Record<string, unknown>)[key],

--- a/src/daemon/__tests__/request-lock-policy.test.ts
+++ b/src/daemon/__tests__/request-lock-policy.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { applyRequestLockPolicy } from '../request-lock-policy.ts';
-import type { SessionState } from '../types.ts';
+import type { SessionRef, SessionState } from '../types.ts';
 
 const IOS_SESSION: SessionState = {
   name: 'qa-ios',
@@ -31,6 +31,11 @@ const ANDROID_SESSION: SessionState = {
     booted: true,
   },
 };
+
+/** Both fixtures are explicitly named, so each is stored under — and addressed by — its name. */
+function ref(session: SessionState): SessionRef {
+  return { address: session.name, session };
+}
 
 test('allows compatible fresh-session selectors under request lock policy', () => {
   const req = applyRequestLockPolicy({
@@ -135,7 +140,7 @@ test('rejects existing-session selector conflicts under request lock policy', ()
             lockPolicy: 'reject',
           },
         },
-        IOS_SESSION,
+        ref(IOS_SESSION),
       ),
     /--serial=emulator-5554/i,
   );
@@ -194,7 +199,7 @@ test('allows matching redundant selectors for existing sessions', () => {
         lockPolicy: 'reject',
       },
     },
-    IOS_SESSION,
+    ref(IOS_SESSION),
   );
 
   assert.equal(req.flags?.udid, 'SIM-001');
@@ -217,7 +222,7 @@ test('rejects mismatching udid selectors for existing sessions', () => {
             lockPolicy: 'reject',
           },
         },
-        IOS_SESSION,
+        ref(IOS_SESSION),
       ),
     /--udid=SIM-999/i,
   );
@@ -238,7 +243,7 @@ test('allows matching serial selectors for existing android sessions', () => {
         lockPolicy: 'reject',
       },
     },
-    ANDROID_SESSION,
+    ref(ANDROID_SESSION),
   );
 
   assert.equal(req.flags?.serial, 'emulator-5554');
@@ -261,7 +266,7 @@ test('rejects mismatching device selectors for existing android sessions', () =>
             lockPolicy: 'reject',
           },
         },
-        ANDROID_SESSION,
+        ref(ANDROID_SESSION),
       ),
     /--device=Pixel 8/i,
   );
@@ -283,7 +288,7 @@ test('rejects mismatching serial selectors for existing android sessions', () =>
             lockPolicy: 'reject',
           },
         },
-        ANDROID_SESSION,
+        ref(ANDROID_SESSION),
       ),
     /--serial=emulator-9999/i,
   );
@@ -306,7 +311,7 @@ test('strips only conflicting scope selectors for existing sessions, keeping mat
         lockPolicy: 'strip',
       },
     },
-    IOS_SESSION,
+    ref(IOS_SESSION),
   );
 
   assert.equal(req.flags?.platform, 'ios');

--- a/src/daemon/__tests__/request-router-session-address.test.ts
+++ b/src/daemon/__tests__/request-router-session-address.test.ts
@@ -1,0 +1,224 @@
+import { createTestDeviceInventoryGateways } from '../../__tests__/test-utils/device-inventory-gateways.ts';
+import { legacyDispatchCapture } from './legacy-snapshot-capture-fixture.ts';
+import { test, expect, vi, beforeEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { getResolveTargetDeviceMock } from './request-router-dispatch-mocks.ts';
+import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
+
+vi.mock('../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('../../utils/host-process.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/host-process.ts')>();
+  return { ...actual, readProcessStartTime: vi.fn(() => 'test-process-start') };
+});
+// Opening a session runs owned-lease cleanup, which pattern-kills stale xcodebuild runners with a
+// real `pkill -f`; the session ids here are fabricated, so stub the tool seam (#1824).
+vi.mock('../../platforms/apple/core/tool-provider.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../platforms/apple/core/tool-provider.ts')>();
+  return {
+    ...actual,
+    runAppleToolCommand: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+  };
+});
+
+import {
+  createRequestHandler,
+  lifecycleDeviceRuntimeGateway,
+} from './test-device-runtime-gateway.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { ensureDeviceReady } from '../device-ready.ts';
+import { awaitFixtureReadiness } from './application-lifecycle-runtime-fixture.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+
+/**
+ * The production route for the #2031/#1394 defect: a request without `--session` resolves the
+ * store key `cwd:<hash>:default`, loads THAT entry, and hands it to a recovery producer whose
+ * record is only named `default`. Every recovery below must name the store key, because
+ * `--session default` marks the session explicit and therefore addresses a different session.
+ *
+ * The address is never hand-written here — it is read back from the store the router wrote, so a
+ * regression that reverts to `SessionState.name` cannot be papered over by an updated constant.
+ */
+const SCOPED_ADDRESS_PATTERN = /^cwd:[0-9a-f]{16}:default$/;
+
+const mockResolveTargetDevice = vi.mocked(getResolveTargetDeviceMock());
+const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
+const mockAwaitFixtureReadiness = vi.mocked(awaitFixtureReadiness);
+
+function makeIosDevice(id: string): DeviceInfo {
+  return {
+    platform: 'apple',
+    id,
+    name: `iPhone ${id}`,
+    kind: 'simulator',
+    target: 'mobile',
+    booted: true,
+  };
+}
+
+function createHandler(sessionStore: ReturnType<typeof makeSessionStore>) {
+  return createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    deviceRuntimeGateway: lifecycleDeviceRuntimeGateway,
+    deviceInventoryGateways: createTestDeviceInventoryGateways(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+/** A request as the CLI sends it when the caller passed no `--session`: named, but not explicit. */
+function implicitRequest(params: {
+  command: string;
+  cwd: string;
+  requestId: string;
+  flags?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'default',
+    command: params.command,
+    positionals: [],
+    flags: params.flags ?? {},
+    meta: { requestId: params.requestId, cwd: params.cwd, ...params.meta },
+  } as DaemonRequest;
+}
+
+/** Opens the implicit session and returns the store key the router filed it under. */
+async function openImplicitSession(
+  handler: ReturnType<typeof createHandler>,
+  sessionStore: ReturnType<typeof makeSessionStore>,
+  cwd: string,
+): Promise<string> {
+  const response = await handler(
+    implicitRequest({ command: 'open', cwd, requestId: 'req-implicit-open' }),
+  );
+  expect(response.ok).toBe(true);
+  const refs = sessionStore.listRefs();
+  expect(refs).toHaveLength(1);
+  const address = refs[0]!.address;
+  // The defect in one line: the record is named `default`, the store key is not.
+  expect(refs[0]!.session.name).toBe('default');
+  expect(address).toMatch(SCOPED_ADDRESS_PATTERN);
+  return address;
+}
+
+function errorHint(response: DaemonResponse): string {
+  expect(response.ok).toBe(false);
+  if (response.ok) return '';
+  return String(response.error.hint ?? '');
+}
+
+function expectAddressableRecovery(hint: string, address: string): void {
+  expect(hint).toContain(`--session ${address}`);
+  expect(hint).not.toMatch(/--session default\b/);
+}
+
+beforeEach(() => {
+  legacyDispatchCapture.mockReset();
+  legacyDispatchCapture.mockResolvedValue({});
+  mockResolveTargetDevice.mockReset();
+  mockEnsureDeviceReady.mockReset();
+  mockEnsureDeviceReady.mockResolvedValue(undefined);
+  mockAwaitFixtureReadiness.mockReset();
+  mockAwaitFixtureReadiness.mockResolvedValue(undefined);
+});
+
+test('device-in-use against an implicit session names its store key, not "default"', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-address-');
+  const cwd = mkdtempForTestSync('agent-device-scope-');
+  const device = makeIosDevice('SIM-IN-USE');
+  mockResolveTargetDevice.mockResolvedValue(device);
+  const handler = createHandler(sessionStore);
+  const address = await openImplicitSession(handler, sessionStore, cwd);
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'checkout',
+    command: 'open',
+    positionals: [],
+    flags: { platform: 'ios' },
+    meta: { requestId: 'req-explicit-open', cwd, sessionExplicit: true },
+  } as DaemonRequest);
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('DEVICE_IN_USE');
+  expect(response.error.message).toContain(`session "${address}"`);
+  expect(response.error.details?.session).toBe(address);
+  expectAddressableRecovery(errorHint(response), address);
+  expect(errorHint(response)).toContain(`agent-device close --session ${address}`);
+});
+
+test('selector conflict on an implicit session names its store key, not "default"', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-address-');
+  const cwd = mkdtempForTestSync('agent-device-scope-');
+  mockResolveTargetDevice.mockResolvedValue(makeIosDevice('SIM-BOUND'));
+  const handler = createHandler(sessionStore);
+  const address = await openImplicitSession(handler, sessionStore, cwd);
+
+  const response = await handler(
+    implicitRequest({
+      command: 'home',
+      cwd,
+      requestId: 'req-selector-conflict',
+      flags: { udid: 'SIM-OTHER' },
+    }),
+  );
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toContain(`Session "${address}"`);
+  expectAddressableRecovery(errorHint(response), address);
+});
+
+test('lock-policy conflict on an implicit session names its store key, not "default"', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-address-');
+  const cwd = mkdtempForTestSync('agent-device-scope-');
+  mockResolveTargetDevice.mockResolvedValue(makeIosDevice('SIM-LOCKED'));
+  const handler = createHandler(sessionStore);
+  const address = await openImplicitSession(handler, sessionStore, cwd);
+
+  const response = await handler(
+    implicitRequest({
+      command: 'home',
+      cwd,
+      requestId: 'req-lock-conflict',
+      flags: { udid: 'SIM-OTHER' },
+      meta: { lockPolicy: 'reject' },
+    }),
+  );
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toContain(`session "${address}"`);
+  expect(response.error.details?.session).toBe(address);
+  expectAddressableRecovery(errorHint(response), address);
+});
+
+test('session list reports the address an implicit session answers to alongside its name', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-address-');
+  const cwd = mkdtempForTestSync('agent-device-scope-');
+  mockResolveTargetDevice.mockResolvedValue(makeIosDevice('SIM-LISTED'));
+  const handler = createHandler(sessionStore);
+  const address = await openImplicitSession(handler, sessionStore, cwd);
+
+  const response = await handler(
+    implicitRequest({ command: 'session_list', cwd, requestId: 'req-session-list' }),
+  );
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  const sessions = response.data?.sessions as { name: string; address: string }[] | undefined;
+  expect(sessions).toHaveLength(1);
+  expect(sessions?.[0]?.name).toBe('default');
+  expect(sessions?.[0]?.address).toBe(address);
+  expect(sessions?.[0]?.address).toMatch(SCOPED_ADDRESS_PATTERN);
+});

--- a/src/daemon/__tests__/session-selector.test.ts
+++ b/src/daemon/__tests__/session-selector.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { assertSessionSelectorMatches } from '../session-selector.ts';
 import { AppError } from '@agent-device/kernel/errors';
-import type { SessionState } from '../types.ts';
+import type { SessionRef, SessionState } from '../types.ts';
 
 function makeSession(overrides?: Partial<SessionState>): SessionState {
   return {
@@ -21,10 +21,15 @@ function makeSession(overrides?: Partial<SessionState>): SessionState {
   };
 }
 
+/** These sessions are explicitly named, so each is stored under — and addressed by — its name. */
+function ref(session: SessionState): SessionRef {
+  return { address: session.name, session };
+}
+
 test('accepts matching platform and serial selectors', () => {
   const session = makeSession();
   assert.doesNotThrow(() =>
-    assertSessionSelectorMatches(session, {
+    assertSessionSelectorMatches(ref(session), {
       platform: 'android',
       target: 'tv',
       serial: 'emulator-5554',
@@ -44,7 +49,7 @@ test('accepts matching serial selector for a Vega session', () => {
     },
   });
   assert.doesNotThrow(() =>
-    assertSessionSelectorMatches(session, {
+    assertSessionSelectorMatches(ref(session), {
       platform: 'vega',
       target: 'tv',
       serial: 'VirtualDevice',
@@ -55,7 +60,7 @@ test('accepts matching serial selector for a Vega session', () => {
 test('rejects mismatched platform selector', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { platform: 'ios' }),
+    () => assertSessionSelectorMatches(ref(session), { platform: 'ios' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&
@@ -66,7 +71,7 @@ test('rejects mismatched platform selector', () => {
 test('selector mismatch explains session recovery commands', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { platform: 'ios' }),
+    () => assertSessionSelectorMatches(ref(session), { platform: 'ios' }),
     (err: unknown) => {
       assert.ok(err instanceof AppError);
       assert.equal(err.code, 'INVALID_ARGS');
@@ -92,14 +97,14 @@ test('accepts --platform apple alias for ios sessions', () => {
     },
   });
   assert.doesNotThrow(() =>
-    assertSessionSelectorMatches(session, { platform: 'apple', target: 'tv' }),
+    assertSessionSelectorMatches(ref(session), { platform: 'apple', target: 'tv' }),
   );
 });
 
 test('rejects mismatched serial selector', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { serial: 'emulator-9999' }),
+    () => assertSessionSelectorMatches(ref(session), { serial: 'emulator-9999' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&
@@ -110,7 +115,7 @@ test('rejects mismatched serial selector', () => {
 test('rejects udid selector for android session', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { udid: 'ABC-123' }),
+    () => assertSessionSelectorMatches(ref(session), { udid: 'ABC-123' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&
@@ -121,7 +126,7 @@ test('rejects udid selector for android session', () => {
 test('accepts matching device selector (case-insensitive)', () => {
   const session = makeSession();
   assert.doesNotThrow(() =>
-    assertSessionSelectorMatches(session, {
+    assertSessionSelectorMatches(ref(session), {
       device: 'pixel 9',
     }),
   );
@@ -130,7 +135,7 @@ test('accepts matching device selector (case-insensitive)', () => {
 test('rejects mismatched target selector', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { target: 'mobile' }),
+    () => assertSessionSelectorMatches(ref(session), { target: 'mobile' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&
@@ -141,7 +146,7 @@ test('rejects mismatched target selector', () => {
 test('rejects mismatched device selector', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { device: 'thymikee-iphone' }),
+    () => assertSessionSelectorMatches(ref(session), { device: 'thymikee-iphone' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&
@@ -162,14 +167,16 @@ test('accepts matching ios simulator set selector for iOS simulator sessions', (
     },
   });
   assert.doesNotThrow(() =>
-    assertSessionSelectorMatches(session, { iosSimulatorDeviceSet: '/tmp/tenant-a/simulator-set' }),
+    assertSessionSelectorMatches(ref(session), {
+      iosSimulatorDeviceSet: '/tmp/tenant-a/simulator-set',
+    }),
   );
 });
 
 test('rejects android allowlist selector when session device is not allowlisted', () => {
   const session = makeSession();
   assert.throws(
-    () => assertSessionSelectorMatches(session, { androidDeviceAllowlist: 'emulator-9999' }),
+    () => assertSessionSelectorMatches(ref(session), { androidDeviceAllowlist: 'emulator-9999' }),
     (err: unknown) =>
       err instanceof AppError &&
       err.code === 'INVALID_ARGS' &&

--- a/src/daemon/handlers/__tests__/session-doctor-options.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-options.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { sessionChecks } from '../session-doctor-options.ts';
+
+// The doctor's recovery command must carry each session's ADDRESS — the string `close --session`
+// accepts — and dedupe by address: two cwd-scoped implicit sessions both carry the public name
+// `default`, so a name compare hid them from each other and the printed
+// `close --session default` addressed neither (#2031/#1394).
+test('the same-device warning names the other session by its address, not its name', () => {
+  const store = makeSessionStore();
+  const here = 'cwd:aaaaaaaaaaaaaaaa:default';
+  const other = 'cwd:bbbbbbbbbbbbbbbb:default';
+  store.set(here, makeIosSession('default'));
+  store.set(other, makeIosSession('default'));
+
+  const [check] = sessionChecks(store, here, store.get(here));
+
+  expect(check?.status).toBe('warn');
+  expect(check?.summary).toContain(other);
+  expect(check?.command).toContain(`--session ${other}`);
+  expect(check?.command).not.toContain('--session default');
+  expect(check?.evidence).toMatchObject({ session: here, sameDeviceSessions: [other] });
+});
+
+test('a session alone on its device passes with its own address in evidence', () => {
+  const store = makeSessionStore();
+  const here = 'cwd:aaaaaaaaaaaaaaaa:default';
+  store.set(here, makeIosSession('default'));
+
+  const [check] = sessionChecks(store, here, store.get(here));
+
+  expect(check?.status).toBe('pass');
+  expect(check?.command).toBeUndefined();
+  expect(check?.evidence).toMatchObject({ session: here });
+});

--- a/src/daemon/handlers/__tests__/session-inventory-scoped-paths.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-scoped-paths.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from 'vitest';
+import path from 'node:path';
+import { handleSessionInventoryCommands } from '../session-inventory.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
+import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
+
+// A session opened without an explicit --session is NAMED `default` and STORED under
+// `cwd:<hash>:default`. `session list` resolved its paths from the name, so it answered with
+// `<state>/sessions/default` — a directory that does not exist — while the session's real
+// artifacts (runner.log included) sat in `<state>/sessions/cwd_<hash>_default` (#2031/#1394).
+
+const SCOPED_KEY = 'cwd:8bea844ab16aa9b3:default';
+
+function scopedSession(): SessionState {
+  return {
+    name: 'default',
+    sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
+    device: IOS_SIMULATOR,
+    createdAt: Date.now(),
+    actions: [],
+  };
+}
+
+async function runSessionList(): Promise<DaemonResponse | null> {
+  const sessionStore = makeSessionStore('agent-device-inventory-scoped-');
+  sessionStore.set(SCOPED_KEY, scopedSession());
+  const req: DaemonRequest = {
+    token: 't',
+    session: 'default',
+    command: 'session_list',
+    positionals: [],
+    flags: {},
+  };
+  return await handleSessionInventoryCommands({
+    req,
+    sessionName: SCOPED_KEY,
+    sessionStore,
+  });
+}
+
+test('session list resolves a cwd-scoped session directory from its store key', async () => {
+  const response = await runSessionList();
+
+  expect(response?.ok).toBe(true);
+  const sessions = (response?.ok ? response.data?.sessions : undefined) as
+    | { name: string; sessionStateDir: string; runnerLogPath: string }[]
+    | undefined;
+  const session = sessions?.[0];
+  expect(session).toBeDefined();
+  // The public name stays what the caller typed …
+  expect(session?.name).toBe('default');
+  // … while the reported paths point at the directory that actually holds the session.
+  expect(path.basename(session?.sessionStateDir ?? '')).toBe('cwd_8bea844ab16aa9b3_default');
+  expect(session?.runnerLogPath.startsWith(`${session?.sessionStateDir}${path.sep}`)).toBe(true);
+});

--- a/src/daemon/handlers/__tests__/session-inventory-scoped-paths.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-scoped-paths.test.ts
@@ -43,14 +43,17 @@ test('session list resolves a cwd-scoped session directory from its store key', 
   const response = await runSessionList();
 
   expect(response?.ok).toBe(true);
-  const sessions = (response?.ok ? response.data?.sessions : undefined) as
-    | { name: string; sessionStateDir: string; runnerLogPath: string }[]
-    | undefined;
-  const session = sessions?.[0];
-  expect(session).toBeDefined();
+  if (!response?.ok) return;
+  const sessions = response.data?.sessions as {
+    name: string;
+    sessionStateDir: string;
+    runnerLogPath: string;
+  }[];
+  expect(sessions).toHaveLength(1);
+  const session = sessions[0]!;
   // The public name stays what the caller typed …
-  expect(session?.name).toBe('default');
+  expect(session.name).toBe('default');
   // … while the reported paths point at the directory that actually holds the session.
-  expect(path.basename(session?.sessionStateDir ?? '')).toBe('cwd_8bea844ab16aa9b3_default');
-  expect(session?.runnerLogPath.startsWith(`${session?.sessionStateDir}${path.sep}`)).toBe(true);
+  expect(path.basename(session.sessionStateDir)).toBe('cwd_8bea844ab16aa9b3_default');
+  expect(session.runnerLogPath.startsWith(`${session.sessionStateDir}${path.sep}`)).toBe(true);
 });

--- a/src/daemon/handlers/__tests__/session-open-device-in-use.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-device-in-use.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 import { buildDeviceInUseBySessionError } from '../session-open-execution.ts';
-import type { SessionState } from '../../types.ts';
+import type { SessionRef } from '../../types.ts';
 import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
 
 // DEVICE_IN_USE named `SessionState.name`, and for an implicitly cwd-scoped session that is
@@ -10,16 +10,19 @@ import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts'
 
 const SCOPED_ADDRESS = 'cwd:8bea844ab16aa9b3:default';
 
-const scopedSession: SessionState = {
-  name: 'default',
-  sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
-  device: IOS_SIMULATOR,
-  createdAt: 0,
-  actions: [],
+const scopedRef: SessionRef = {
+  address: SCOPED_ADDRESS,
+  session: {
+    name: 'default',
+    sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
+    device: IOS_SIMULATOR,
+    createdAt: 0,
+    actions: [],
+  },
 };
 
 test('the by-session conflict reports the address, in the message, details and hint', () => {
-  const response = buildDeviceInUseBySessionError(scopedSession, IOS_SIMULATOR, SCOPED_ADDRESS);
+  const response = buildDeviceInUseBySessionError(scopedRef, IOS_SIMULATOR);
 
   expect(response.ok).toBe(false);
   if (response.ok) return;

--- a/src/daemon/handlers/__tests__/session-open-device-in-use.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-device-in-use.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from 'vitest';
+import { buildDeviceInUseBySessionError } from '../session-open-execution.ts';
+import type { SessionState } from '../../types.ts';
+import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
+
+// DEVICE_IN_USE named `SessionState.name`, and for an implicitly cwd-scoped session that is
+// `default` while the session is stored — and addressable — as `cwd:<hash>:default`. Both the
+// message and the recovery hint therefore pointed at a session no `--session` value could reach
+// (#2031). The producer now takes the store key and reports that.
+
+const SCOPED_ADDRESS = 'cwd:8bea844ab16aa9b3:default';
+
+const scopedSession: SessionState = {
+  name: 'default',
+  sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
+  device: IOS_SIMULATOR,
+  createdAt: 0,
+  actions: [],
+};
+
+test('the by-session conflict reports the address, in the message, details and hint', () => {
+  const response = buildDeviceInUseBySessionError(scopedSession, IOS_SIMULATOR, SCOPED_ADDRESS);
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error?.message).toBe(`Device is already in use by session "${SCOPED_ADDRESS}".`);
+  expect(response.error?.details?.session).toBe(SCOPED_ADDRESS);
+  expect(String(response.error?.details?.hint)).toContain(
+    `agent-device close --session ${SCOPED_ADDRESS}`,
+  );
+});

--- a/src/daemon/handlers/__tests__/session-replay-maestro-session-address.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-session-address.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+import { stringify } from 'yaml';
+import { runTypedMaestroReplay } from '../session-replay-maestro-runtime.ts';
+import { SessionStore } from '../../session-store.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { maestroScriptSourceBundleFor } from '../../../__tests__/test-utils/replay-script-source.ts';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import type { DaemonRequest } from '../../types.ts';
+
+// The Maestro replay route resolves the store key upstream and then validates the session's
+// selectors, so its conflict recovery must name that key too — an implicitly cwd-scoped session
+// is named `default` but only `--session cwd:<hash>:default` reaches it (#2031/#1394).
+const SCOPED_ADDRESS = 'cwd:8bea844ab16aa9b3:default';
+
+test('a typed Maestro selector conflict names the session store key, not "default"', async () => {
+  const root = mkdtempForTestSync('agent-device-maestro-address-');
+  const flowPath = path.join(root, 'flow.yaml');
+  fs.writeFileSync(flowPath, `${stringify({ appId: 'com.example.app' })}---\n${stringify([])}`);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const session = makeIosSession('default');
+  session.sessionScope = { kind: 'cwd', id: '8bea844ab16aa9b3' };
+  sessionStore.set(SCOPED_ADDRESS, session);
+
+  const req = {
+    token: 'test-token',
+    session: 'default',
+    command: 'replay',
+    positionals: [flowPath],
+    flags: {
+      replayBackend: 'maestro',
+      replayScriptSource: await maestroScriptSourceBundleFor(flowPath),
+      udid: 'SIM-OTHER',
+    },
+    meta: { requestId: 'req-maestro-address' },
+  } as unknown as DaemonRequest;
+
+  const response = await runTypedMaestroReplay({
+    req,
+    sessionName: SCOPED_ADDRESS,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.message).toContain(`Session "${SCOPED_ADDRESS}"`);
+  expect(response.error.message).not.toMatch(/Session "default"/);
+  expect(response.error.details?.session).toBe(SCOPED_ADDRESS);
+  // The recovery hint itself is asserted on the router routes: this route's error projection
+  // (`buildTypedMaestroReplayErrorResponse`) spreads only `normalizeError`'s stripped `details`,
+  // which no longer carries `hint`, so no hint reaches the caller here at all — a separate defect
+  // from the address this case pins.
+});

--- a/src/daemon/handlers/session-doctor-options.ts
+++ b/src/daemon/handlers/session-doctor-options.ts
@@ -87,16 +87,19 @@ export function sessionChecks(
   session: SessionState | undefined,
   options: { remote?: boolean } = {},
 ): DoctorCheck[] {
+  // Candidates report their ADDRESS — the string `close --session` actually accepts — and the
+  // current session is excluded by address too: two cwd-scoped sessions share the name
+  // `default`, so a name compare would hide them from each other (#2031/#1394).
   const sameDeviceSessions = session
     ? sessionStore
-        .toArray()
+        .listRefs()
         .filter(
           (candidate) =>
-            candidate.name !== session.name &&
-            candidate.device.platform === session.device.platform &&
-            candidate.device.id === session.device.id,
+            candidate.address !== sessionName &&
+            candidate.session.device.platform === session.device.platform &&
+            candidate.session.device.id === session.device.id,
         )
-        .map((candidate) => candidate.name)
+        .map((candidate) => candidate.address)
     : [];
 
   if (!session) {
@@ -129,9 +132,9 @@ export function sessionChecks(
           ? `agent-device close --session ${sameDeviceSessions[0]} --platform ${publicPlatformString(session.device)}`
           : undefined,
       evidence: {
-        session: session.name,
+        session: sessionName,
         sameDeviceSessions,
-        sessionStateDir: sessionStore.resolveSessionDir(session.name),
+        sessionStateDir: sessionStore.resolveSessionDir(sessionName),
       },
     },
   ];

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -83,18 +83,27 @@ function sessionListInventoryResponse(
     ok: true,
     data: {
       sessions: sessionStore
-        .toArray()
-        .filter((session) => sessionMatchesScope(session, scope))
-        .map((session) => publicSessionInfo(session, sessionStore)),
+        .entries()
+        .filter(([, session]) => sessionMatchesScope(session, scope))
+        .map(([sessionKey, session]) => publicSessionInfo(sessionKey, session, sessionStore)),
     },
   };
 }
 
+/**
+ * `sessionStateDir`/`runnerLogPath` are resolved from the STORE KEY, not from `session.name`.
+ * An implicitly cwd-scoped session is named `default` and stored under `cwd:<hash>:default`, so
+ * resolving the directory from the name pointed every caller at
+ * `<state>/sessions/default` — a path that does not exist — while the session's real artifacts sat
+ * in `<state>/sessions/cwd_<hash>_default` (#2031/#1394). `open` already answers with the key-derived
+ * path; this is the same directory, from the same source.
+ */
 function publicSessionInfo(
+  sessionKey: string,
   session: ReturnType<SessionStore['toArray']>[number],
   sessionStore: SessionStore,
 ) {
-  const sessionStateDir = sessionStore.resolveSessionDir(session.name);
+  const sessionStateDir = sessionStore.resolveSessionDir(sessionKey);
   return {
     name: session.name,
     sessionStateDir,

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -20,7 +20,7 @@ import {
   resolveAndroidSerialAllowlist,
   resolveIosSimulatorDeviceSetPath,
 } from '../../utils/device-isolation.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import type { DaemonRequest, DaemonResponse, SessionRef } from '../types.ts';
 import { resolveSessionRunnerLogPath, SessionStore } from '../session-store.ts';
 import {
   requireSessionOrExplicitSelector,
@@ -83,29 +83,27 @@ function sessionListInventoryResponse(
     ok: true,
     data: {
       sessions: sessionStore
-        .entries()
-        .filter(([, session]) => sessionMatchesScope(session, scope))
-        .map(([sessionKey, session]) => publicSessionInfo(sessionKey, session, sessionStore)),
+        .listRefs()
+        .filter((ref) => sessionMatchesScope(ref.session, scope))
+        .map((ref) => publicSessionInfo(ref, sessionStore)),
     },
   };
 }
 
 /**
- * `sessionStateDir`/`runnerLogPath` are resolved from the STORE KEY, not from `session.name`.
- * An implicitly cwd-scoped session is named `default` and stored under `cwd:<hash>:default`, so
- * resolving the directory from the name pointed every caller at
- * `<state>/sessions/default` — a path that does not exist — while the session's real artifacts sat
- * in `<state>/sessions/cwd_<hash>_default` (#2031/#1394). `open` already answers with the key-derived
- * path; this is the same directory, from the same source.
+ * `address` is the string `--session` accepts for this session, and `sessionStateDir` /
+ * `runnerLogPath` are resolved from that same key rather than from `session.name`. An implicitly
+ * cwd-scoped session is named `default` and stored under `cwd:<hash>:default`, so reporting only
+ * the name left `session list` — the discovery surface — naming a session no `--session` value
+ * could reach, and pointed its paths at `<state>/sessions/default`, a directory that does not
+ * exist, while the real artifacts sat in `<state>/sessions/cwd_<hash>_default` (#2031/#1394).
+ * `name` stays as the public name the session was opened under.
  */
-function publicSessionInfo(
-  sessionKey: string,
-  session: ReturnType<SessionStore['toArray']>[number],
-  sessionStore: SessionStore,
-) {
-  const sessionStateDir = sessionStore.resolveSessionDir(sessionKey);
+function publicSessionInfo({ address, session }: SessionRef, sessionStore: SessionStore) {
+  const sessionStateDir = sessionStore.resolveSessionDir(address);
   return {
     name: session.name,
+    address,
     sessionStateDir,
     runnerLogPath: resolveSessionRunnerLogPath(sessionStateDir),
     platform: publicPlatformString(session.device),

--- a/src/daemon/handlers/session-open-execution.ts
+++ b/src/daemon/handlers/session-open-execution.ts
@@ -342,8 +342,9 @@ function findNewSessionDeviceConflict(params: {
   sessionStore: SessionStore;
 }): DaemonResponse | undefined {
   const { req, device, sessionStore } = params;
-  const inUse = sessionStore.toArray().find((session) => session.device.id === device.id);
-  if (!inUse) return undefined;
+  const conflict = sessionStore.entries().find(([, session]) => session.device.id === device.id);
+  if (!conflict) return undefined;
+  const [inUseAddress, inUse] = conflict;
   if (isImplicitSessionScopeConflict(req, inUse)) {
     return errorResponse(
       'DEVICE_IN_USE',
@@ -355,7 +356,7 @@ function findNewSessionDeviceConflict(params: {
       },
     );
   }
-  return buildDeviceInUseBySessionError(inUse, device);
+  return buildDeviceInUseBySessionError(inUse, device, inUseAddress);
 }
 
 // Exported as the single by-session DEVICE_IN_USE producer so the help-benchmark sample parity
@@ -364,12 +365,15 @@ function findNewSessionDeviceConflict(params: {
 export function buildDeviceInUseBySessionError(
   inUse: SessionState,
   device: DeviceInfo,
+  // The key the session is stored under — the value `--session` needs. For an implicitly
+  // cwd-scoped session that is `cwd:<hash>:default`, not the `default` it is named (#2031).
+  inUseAddress: string,
 ): DaemonResponse {
-  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUse.name}".`, {
-    session: inUse.name,
+  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUseAddress}".`, {
+    session: inUseAddress,
     deviceId: device.id,
     deviceName: device.name,
-    hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
+    hint: buildSessionRecoveryHint(inUse, 'device-in-use', inUseAddress),
   });
 }
 

--- a/src/daemon/handlers/session-open-execution.ts
+++ b/src/daemon/handlers/session-open-execution.ts
@@ -10,7 +10,7 @@ import {
 import type { BoundDeviceRuntime } from '@agent-device/contracts/platform-runtime';
 import type { SessionSurface } from '@agent-device/contracts/session';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import type { DaemonRequest, DaemonResponse, SessionRef, SessionState } from '../types.ts';
 import {
   abortAuthoringOnSecondOpen,
   armAuthoringOnOpen,
@@ -342,10 +342,9 @@ function findNewSessionDeviceConflict(params: {
   sessionStore: SessionStore;
 }): DaemonResponse | undefined {
   const { req, device, sessionStore } = params;
-  const conflict = sessionStore.entries().find(([, session]) => session.device.id === device.id);
-  if (!conflict) return undefined;
-  const [inUseAddress, inUse] = conflict;
-  if (isImplicitSessionScopeConflict(req, inUse)) {
+  const inUse = sessionStore.findByDevice(device.id);
+  if (!inUse) return undefined;
+  if (isImplicitSessionScopeConflict(req, inUse.session)) {
     return errorResponse(
       'DEVICE_IN_USE',
       'Device is already in use by another workspace session.',
@@ -356,24 +355,21 @@ function findNewSessionDeviceConflict(params: {
       },
     );
   }
-  return buildDeviceInUseBySessionError(inUse, device, inUseAddress);
+  return buildDeviceInUseBySessionError(inUse, device);
 }
 
 // Exported as the single by-session DEVICE_IN_USE producer so the help-benchmark sample parity
 // test renders the exact error this handler returns; a message or hint change here fails that
 // gate instead of drifting past it.
 export function buildDeviceInUseBySessionError(
-  inUse: SessionState,
+  inUse: SessionRef,
   device: DeviceInfo,
-  // The key the session is stored under — the value `--session` needs. For an implicitly
-  // cwd-scoped session that is `cwd:<hash>:default`, not the `default` it is named (#2031).
-  inUseAddress: string,
 ): DaemonResponse {
-  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUseAddress}".`, {
-    session: inUseAddress,
+  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUse.address}".`, {
+    session: inUse.address,
     deviceId: device.id,
     deviceName: device.name,
-    hint: buildSessionRecoveryHint(inUse, 'device-in-use', inUseAddress),
+    hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
   });
 }
 

--- a/src/daemon/handlers/session-replay-maestro-runtime.ts
+++ b/src/daemon/handlers/session-replay-maestro-runtime.ts
@@ -162,8 +162,11 @@ async function prepareTypedMaestroReplay(
   const { req, bundle, sessionName, sessionStore } = params;
   const filePath = bundle.entry;
   const flow = inspectMaestroFlow(readReplayScriptSourceFile(bundle, filePath), filePath);
-  const session = sessionStore.get(sessionName);
-  if (session) assertSessionSelectorMatches(session, req.flags);
+  // `sessionName` is the resolved store key, so the lookup carries the address a selector
+  // conflict must tell the caller to close or reuse.
+  const sessionRef = sessionStore.lookup(sessionName);
+  const session = sessionRef?.session;
+  if (sessionRef) assertSessionSelectorMatches(sessionRef, req.flags);
   const binding = await resolveMaestroReplayBinding({
     req,
     sessionStore,

--- a/src/daemon/request-binding.ts
+++ b/src/daemon/request-binding.ts
@@ -4,13 +4,13 @@ import { applyRequestLockPolicy } from './request-lock-policy.ts';
 import { buildOpenTargetDeviceResolutionOptions } from './open-device-selection.ts';
 import { buildReplayTargetDeviceResolution } from './replay-device-selection.ts';
 import type { SessionStore } from './session-store.ts';
-import type { DaemonRequest, SessionState } from './types.ts';
+import type { DaemonRequest, SessionRef } from './types.ts';
 
 export type RequestExecutionLockKey = `session:${string}` | `device:${string}`;
 
 export type LockedRequestBinding = {
   req: DaemonRequest;
-  existingSession: SessionState | undefined;
+  existingRef: SessionRef | undefined;
 };
 
 export async function resolveRequestExecutionLockKeys(params: {
@@ -48,10 +48,10 @@ export function prepareLockedRequestBinding(params: {
   sessionName: string;
   sessionStore: SessionStore;
 }): LockedRequestBinding {
-  const existingSession = params.sessionStore.get(params.sessionName);
+  const existingRef = params.sessionStore.lookup(params.sessionName);
   return {
-    req: applyRequestLockPolicy(params.req, existingSession),
-    existingSession,
+    req: applyRequestLockPolicy(params.req, existingRef),
+    existingRef,
   };
 }
 

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -394,11 +394,11 @@ export function prepareLockedRequestScope(params: {
   const { scope, sessionStore, trackDownloadableArtifact } = params;
   const logPath = scope.runnerLogPath;
   scope.throwIfCanceled();
-  let existingSession = sessionStore.get(scope.sessionName);
-  if (existingSession) {
+  const seededSession = sessionStore.get(scope.sessionName);
+  if (seededSession) {
     // Called under runLocked: refreshRecordingHealth may mutate session recording state.
-    refreshRecordingHealth(existingSession);
-    sessionStore.set(scope.sessionName, existingSession);
+    refreshRecordingHealth(seededSession);
+    sessionStore.set(scope.sessionName, seededSession);
   }
   const binding = prepareLockedRequestBinding({
     req: scope.req,
@@ -406,7 +406,10 @@ export function prepareLockedRequestScope(params: {
     sessionStore,
   });
   const lockedReq = binding.req;
-  existingSession = binding.existingSession;
+  // `scope.sessionName` is the resolved store key, so `existingRef` carries the address every
+  // recovery producer below must name — `existingRef.session.name` is only the public name.
+  const existingRef = binding.existingRef;
+  const existingSession = existingRef?.session;
   updateDiagnosticsScope({ traceLogPath: existingSession?.trace?.outPath });
   const finalize = (response: DaemonResponse): DaemonResponse => {
     const finalized = finalizeDaemonResponse(lockedReq, response, trackDownloadableArtifact);
@@ -439,12 +442,8 @@ export function prepareLockedRequestScope(params: {
     };
   }
 
-  if (
-    existingSession &&
-    !lockedReq.meta?.lockPolicy &&
-    shouldValidateSessionSelector(scope.command)
-  ) {
-    assertSessionSelectorMatches(existingSession, lockedReq.flags);
+  if (existingRef && !lockedReq.meta?.lockPolicy && shouldValidateSessionSelector(scope.command)) {
+    assertSessionSelectorMatches(existingRef, lockedReq.flags);
   }
 
   const contextFromFlags = (

--- a/src/daemon/request-lock-policy.ts
+++ b/src/daemon/request-lock-policy.ts
@@ -1,6 +1,6 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import type { SessionState, DaemonRequest } from './types.ts';
+import type { SessionRef, SessionState, DaemonRequest } from './types.ts';
 import {
   formatSessionSelectorConflict,
   listSessionSelectorConflicts,
@@ -39,7 +39,7 @@ function isDeviceIdentityConflict(conflict: SessionSelectorConflict): boolean {
 
 export function applyRequestLockPolicy(
   req: DaemonRequest,
-  existingSession?: SessionState,
+  existingRef?: SessionRef,
 ): DaemonRequest {
   const lockPolicy = req.meta?.lockPolicy;
   if (!lockPolicy) {
@@ -50,15 +50,13 @@ export function applyRequestLockPolicy(
   const canOverrideSelector = canOverrideLockPolicySelector(req.command);
   const conflicts = canOverrideSelector
     ? []
-    : existingSession
-      ? listSessionSelectorConflicts(existingSession, nextFlags)
+    : existingRef
+      ? listSessionSelectorConflicts(existingRef.session, nextFlags)
       : listFreshSessionConflicts(nextFlags, req.meta?.lockPlatform);
   const lockPlatform = req.meta?.lockPlatform;
 
   if (conflicts.length === 0) {
-    if (
-      shouldApplyLockPlatformDefault(canOverrideSelector, existingSession, nextFlags, lockPlatform)
-    ) {
+    if (shouldApplyLockPlatformDefault(canOverrideSelector, existingRef, nextFlags, lockPlatform)) {
       nextFlags.platform = lockPlatform;
     }
     return {
@@ -69,23 +67,19 @@ export function applyRequestLockPolicy(
 
   const identityConflicts = conflicts.filter(isDeviceIdentityConflict);
   if (lockPolicy === 'strip' && identityConflicts.length === 0) {
-    applyStripLockPolicy(nextFlags, conflicts, lockPlatform, existingSession);
+    applyStripLockPolicy(nextFlags, conflicts, lockPlatform, existingRef?.session);
     return {
       ...req,
       flags: nextFlags,
     };
   }
 
-  throw new AppError(
-    'INVALID_ARGS',
-    buildLockPolicyConflictMessage(req, conflicts, existingSession),
-    {
-      session: req.session,
-      conflicts: conflicts.map(formatSessionSelectorConflict),
-      ...describeConflictingIdentities(identityConflicts, existingSession),
-      hint: buildLockPolicyConflictHint(req, existingSession, identityConflicts),
-    },
-  );
+  throw new AppError('INVALID_ARGS', buildLockPolicyConflictMessage(req, conflicts, existingRef), {
+    session: existingRef?.address ?? req.session,
+    conflicts: conflicts.map(formatSessionSelectorConflict),
+    ...describeConflictingIdentities(identityConflicts, existingRef?.session),
+    hint: buildLockPolicyConflictHint(req, existingRef, identityConflicts),
+  });
 }
 
 /**
@@ -116,12 +110,12 @@ function describeConflictingIdentities(
 function buildLockPolicyConflictMessage(
   req: DaemonRequest,
   conflicts: SessionSelectorConflict[],
-  existingSession: SessionState | undefined,
+  existingRef: SessionRef | undefined,
 ): string {
   const conflictList = conflicts.map(formatSessionSelectorConflict).join(', ');
-  if (existingSession) {
+  if (existingRef) {
     return (
-      `${req.command} is already bound to session "${existingSession.name}" on ${describeSessionDevice(existingSession)}, ` +
+      `${req.command} is already bound to session "${existingRef.address}" on ${describeSessionDevice(existingRef.session)}, ` +
       `but this request selected ${conflictList}.`
     );
   }
@@ -132,13 +126,13 @@ function buildLockPolicyConflictMessage(
 
 function buildLockPolicyConflictHint(
   req: DaemonRequest,
-  existingSession: SessionState | undefined,
+  existingRef: SessionRef | undefined,
   identityConflicts: SessionSelectorConflict[],
 ): string {
   // `buildSessionRecoveryHint` already states the two recoveries (close the bound session, or drop
   // the selectors) and never mentions --session-lock, so a bound session needs no identity branch.
-  if (existingSession) {
-    return buildSessionRecoveryHint(existingSession, 'selector-conflict', existingSession.name);
+  if (existingRef) {
+    return buildSessionRecoveryHint(existingRef, 'selector-conflict');
   }
   const lockPlatform = req.meta?.lockPlatform;
   const sessionText = req.session ? ` --session ${shellQuoteIfNeeded(req.session)}` : '';
@@ -165,11 +159,11 @@ function buildLockPolicyConflictHint(
 
 function shouldApplyLockPlatformDefault(
   canOverrideSelector: boolean,
-  existingSession: SessionState | undefined,
+  existingRef: SessionRef | undefined,
   flags: CommandFlags,
   lockPlatform: LockPlatform,
 ): boolean {
-  if (!lockPlatform || existingSession || flags.platform !== undefined) {
+  if (!lockPlatform || existingRef || flags.platform !== undefined) {
     return false;
   }
   if (!canOverrideSelector) {

--- a/src/daemon/request-lock-policy.ts
+++ b/src/daemon/request-lock-policy.ts
@@ -138,7 +138,7 @@ function buildLockPolicyConflictHint(
   // `buildSessionRecoveryHint` already states the two recoveries (close the bound session, or drop
   // the selectors) and never mentions --session-lock, so a bound session needs no identity branch.
   if (existingSession) {
-    return buildSessionRecoveryHint(existingSession, 'selector-conflict');
+    return buildSessionRecoveryHint(existingSession, 'selector-conflict', existingSession.name);
   }
   const lockPlatform = req.meta?.lockPlatform;
   const sessionText = req.session ? ` --session ${shellQuoteIfNeeded(req.session)}` : '';

--- a/src/daemon/session-recovery-hints.test.ts
+++ b/src/daemon/session-recovery-hints.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from 'vitest';
+import { buildSessionRecoveryHint } from './session-recovery-hints.ts';
+import type { SessionState } from './types.ts';
+import { IOS_SIMULATOR } from '../__tests__/test-utils/device-fixtures.ts';
+
+// The recovery hint's whole job is to hand back a command that works. For an implicitly
+// cwd-scoped session — named `default`, stored as `cwd:<hash>:default` — building it from the
+// name produced `agent-device close --session default`, which marks the session explicit and so
+// addresses a different, non-existent session: the caller got SESSION_NOT_FOUND from the exact
+// command the previous error told them to run, and the device stayed held (#2031).
+
+const SCOPED_ADDRESS = 'cwd:8bea844ab16aa9b3:default';
+
+function scopedSession(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    name: 'default',
+    sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
+    device: IOS_SIMULATOR,
+    createdAt: Date.now(),
+    actions: [],
+    ...overrides,
+  };
+}
+
+test('device-in-use recovery names the address --session accepts, not the public name', () => {
+  const hint = buildSessionRecoveryHint(scopedSession(), 'device-in-use', SCOPED_ADDRESS);
+
+  expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
+  expect(hint).toContain(`rerun the command with --session ${SCOPED_ADDRESS}`);
+  expect(hint).not.toMatch(/--session default\b/);
+});
+
+test('selector-conflict recovery uses the same address', () => {
+  const hint = buildSessionRecoveryHint(scopedSession(), 'selector-conflict', SCOPED_ADDRESS);
+
+  expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
+  expect(hint).not.toMatch(/--session default\b/);
+});
+
+test('a recording session recovery uses the address for both close and record stop', () => {
+  // Only the presence of an active recording selects this branch; the handle/envelope it carries
+  // is irrelevant to the recovery text, so a marker object keeps the fixture readable.
+  const session = {
+    ...scopedSession(),
+    screenRecording: {} as NonNullable<SessionState['screenRecording']>,
+  };
+
+  const hint = buildSessionRecoveryHint(session, 'device-in-use', SCOPED_ADDRESS);
+
+  expect(hint).toContain(`agent-device record stop --session ${SCOPED_ADDRESS}`);
+  expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
+});
+
+test('an explicitly named session addresses itself unchanged', () => {
+  const hint = buildSessionRecoveryHint(
+    { ...scopedSession(), name: 'checkout', sessionScope: undefined },
+    'device-in-use',
+    'checkout',
+  );
+
+  expect(hint).toContain('agent-device close --session checkout');
+});

--- a/src/daemon/session-recovery-hints.test.ts
+++ b/src/daemon/session-recovery-hints.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 import { buildSessionRecoveryHint } from './session-recovery-hints.ts';
-import type { SessionState } from './types.ts';
+import type { SessionRef, SessionState } from './types.ts';
 import { IOS_SIMULATOR } from '../__tests__/test-utils/device-fixtures.ts';
 
 // The recovery hint's whole job is to hand back a command that works. For an implicitly
@@ -11,19 +11,22 @@ import { IOS_SIMULATOR } from '../__tests__/test-utils/device-fixtures.ts';
 
 const SCOPED_ADDRESS = 'cwd:8bea844ab16aa9b3:default';
 
-function scopedSession(overrides: Partial<SessionState> = {}): SessionState {
+function scopedRef(overrides: Partial<SessionState> = {}): SessionRef {
   return {
-    name: 'default',
-    sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
-    device: IOS_SIMULATOR,
-    createdAt: Date.now(),
-    actions: [],
-    ...overrides,
+    address: SCOPED_ADDRESS,
+    session: {
+      name: 'default',
+      sessionScope: { kind: 'cwd', id: '8bea844ab16aa9b3' },
+      device: IOS_SIMULATOR,
+      createdAt: Date.now(),
+      actions: [],
+      ...overrides,
+    },
   };
 }
 
 test('device-in-use recovery names the address --session accepts, not the public name', () => {
-  const hint = buildSessionRecoveryHint(scopedSession(), 'device-in-use', SCOPED_ADDRESS);
+  const hint = buildSessionRecoveryHint(scopedRef(), 'device-in-use');
 
   expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
   expect(hint).toContain(`rerun the command with --session ${SCOPED_ADDRESS}`);
@@ -31,7 +34,7 @@ test('device-in-use recovery names the address --session accepts, not the public
 });
 
 test('selector-conflict recovery uses the same address', () => {
-  const hint = buildSessionRecoveryHint(scopedSession(), 'selector-conflict', SCOPED_ADDRESS);
+  const hint = buildSessionRecoveryHint(scopedRef(), 'selector-conflict');
 
   expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
   expect(hint).not.toMatch(/--session default\b/);
@@ -40,12 +43,11 @@ test('selector-conflict recovery uses the same address', () => {
 test('a recording session recovery uses the address for both close and record stop', () => {
   // Only the presence of an active recording selects this branch; the handle/envelope it carries
   // is irrelevant to the recovery text, so a marker object keeps the fixture readable.
-  const session = {
-    ...scopedSession(),
+  const ref = scopedRef({
     screenRecording: {} as NonNullable<SessionState['screenRecording']>,
-  };
+  });
 
-  const hint = buildSessionRecoveryHint(session, 'device-in-use', SCOPED_ADDRESS);
+  const hint = buildSessionRecoveryHint(ref, 'device-in-use');
 
   expect(hint).toContain(`agent-device record stop --session ${SCOPED_ADDRESS}`);
   expect(hint).toContain(`agent-device close --session ${SCOPED_ADDRESS}`);
@@ -53,9 +55,11 @@ test('a recording session recovery uses the address for both close and record st
 
 test('an explicitly named session addresses itself unchanged', () => {
   const hint = buildSessionRecoveryHint(
-    { ...scopedSession(), name: 'checkout', sessionScope: undefined },
+    {
+      address: 'checkout',
+      session: { ...scopedRef().session, name: 'checkout', sessionScope: undefined },
+    },
     'device-in-use',
-    'checkout',
   );
 
   expect(hint).toContain('agent-device close --session checkout');

--- a/src/daemon/session-recovery-hints.ts
+++ b/src/daemon/session-recovery-hints.ts
@@ -10,22 +10,33 @@ export function describeSessionDevice(session: SessionState): string {
   return `${platform} device "${name}" (${id})`;
 }
 
+/**
+ * `sessionAddress` is the value a caller must pass to `--session` to reach this session, which is
+ * NOT always `session.name`: an implicitly cwd-scoped session is named `default` and stored under
+ * `cwd:<hash>:default`. Building the recovery commands from the name produced
+ * `agent-device close --session default`, and `--session` marks the session explicit, so that
+ * command addressed a different, non-existent session and answered SESSION_NOT_FOUND while the
+ * device stayed held (#2031). Callers that hold the store key pass it; the rest pass the name and
+ * are unchanged.
+ */
 export function buildSessionRecoveryHint(
   session: SessionState,
   context: SessionRecoveryContext,
+  sessionAddress: string,
 ): string {
   // Active recording state controls user recovery text; record-only ownership controls cleanup.
   if (session.screenRecording) {
-    return buildRecordingSessionRecoveryHint(session, context);
+    return buildRecordingSessionRecoveryHint(session, context, sessionAddress);
   }
-  return buildOpenSessionRecoveryHint(session, context);
+  return buildOpenSessionRecoveryHint(context, sessionAddress);
 }
 
 function buildRecordingSessionRecoveryHint(
   session: SessionState,
   context: SessionRecoveryContext,
+  sessionAddress: string,
 ): string {
-  const sessionArg = shellQuoteIfNeeded(session.name);
+  const sessionArg = shellQuoteIfNeeded(sessionAddress);
   const closeCommand = `agent-device close --session ${sessionArg}`;
   const recordStopCommand = `agent-device record stop --session ${sessionArg}`;
   const reuseText =
@@ -42,10 +53,10 @@ function buildRecordingSessionRecoveryHint(
 }
 
 function buildOpenSessionRecoveryHint(
-  session: SessionState,
   context: SessionRecoveryContext,
+  sessionAddress: string,
 ): string {
-  const sessionArg = shellQuoteIfNeeded(session.name);
+  const sessionArg = shellQuoteIfNeeded(sessionAddress);
   const closeCommand = `agent-device close --session ${sessionArg}`;
   if (context === 'selector-conflict') {
     return (

--- a/src/daemon/session-recovery-hints.ts
+++ b/src/daemon/session-recovery-hints.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from './types.ts';
+import type { SessionRef, SessionState } from './types.ts';
 import { shellQuoteIfNeeded } from '../utils/shell-quote.ts';
 
 export type SessionRecoveryContext = 'device-in-use' | 'selector-conflict';
@@ -11,30 +11,22 @@ export function describeSessionDevice(session: SessionState): string {
 }
 
 /**
- * `sessionAddress` is the value a caller must pass to `--session` to reach this session, which is
- * NOT always `session.name`: an implicitly cwd-scoped session is named `default` and stored under
- * `cwd:<hash>:default`. Building the recovery commands from the name produced
- * `agent-device close --session default`, and `--session` marks the session explicit, so that
- * command addressed a different, non-existent session and answered SESSION_NOT_FOUND while the
- * device stayed held (#2031). Callers that hold the store key pass it; the rest pass the name and
- * are unchanged.
+ * Every command in a recovery hint is addressed by `ref.address`, never by `SessionState.name`:
+ * the hint's whole job is to hand back a command that runs, and for an implicitly cwd-scoped
+ * session those two differ (see {@link SessionRef}). Taking the pair rather than a record is what
+ * keeps an addressless caller from compiling.
  */
-export function buildSessionRecoveryHint(
-  session: SessionState,
-  context: SessionRecoveryContext,
-  sessionAddress: string,
-): string {
+export function buildSessionRecoveryHint(ref: SessionRef, context: SessionRecoveryContext): string {
   // Active recording state controls user recovery text; record-only ownership controls cleanup.
-  if (session.screenRecording) {
-    return buildRecordingSessionRecoveryHint(session, context, sessionAddress);
+  if (ref.session.screenRecording) {
+    return buildRecordingSessionRecoveryHint(ref.address, context);
   }
-  return buildOpenSessionRecoveryHint(context, sessionAddress);
+  return buildOpenSessionRecoveryHint(ref.address, context);
 }
 
 function buildRecordingSessionRecoveryHint(
-  session: SessionState,
-  context: SessionRecoveryContext,
   sessionAddress: string,
+  context: SessionRecoveryContext,
 ): string {
   const sessionArg = shellQuoteIfNeeded(sessionAddress);
   const closeCommand = `agent-device close --session ${sessionArg}`;
@@ -45,7 +37,7 @@ function buildRecordingSessionRecoveryHint(
       : `To keep using this device, reuse --session ${sessionArg} for commands that should attach to the recording session.`;
 
   return (
-    `Recording session "${session.name}" owns this device. ` +
+    `Recording session "${sessionAddress}" owns this device. ` +
     `Run ${recordStopCommand}; if the session still appears in agent-device session list, run ${closeCommand}. ` +
     `${reuseText} ` +
     `Run agent-device session list to inspect active sessions.`
@@ -53,8 +45,8 @@ function buildRecordingSessionRecoveryHint(
 }
 
 function buildOpenSessionRecoveryHint(
-  context: SessionRecoveryContext,
   sessionAddress: string,
+  context: SessionRecoveryContext,
 ): string {
   const sessionArg = shellQuoteIfNeeded(sessionAddress);
   const closeCommand = `agent-device close --session ${sessionArg}`;

--- a/src/daemon/session-selector.ts
+++ b/src/daemon/session-selector.ts
@@ -1,6 +1,6 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
-import type { SessionState } from './types.ts';
+import type { SessionRef, SessionState } from './types.ts';
 import {
   isIosFamily,
   isSerialAddressablePlatform,
@@ -23,19 +23,18 @@ export type SessionSelectorConflict = {
   value: string;
 };
 
-export function assertSessionSelectorMatches(session: SessionState, flags?: CommandFlags): void {
+export function assertSessionSelectorMatches(ref: SessionRef, flags?: CommandFlags): void {
+  const { address, session } = ref;
   const mismatches = listSessionSelectorConflicts(session, flags);
   if (mismatches.length === 0) return;
 
   throw new AppError(
     'INVALID_ARGS',
-    `Session "${session.name}" is already bound to ${describeSessionDevice(session)}, but this request selected ${mismatches.map(formatSessionSelectorConflict).join(', ')}.`,
+    `Session "${address}" is already bound to ${describeSessionDevice(session)}, but this request selected ${mismatches.map(formatSessionSelectorConflict).join(', ')}.`,
     {
-      session: session.name,
+      session: address,
       conflicts: mismatches.map(formatSessionSelectorConflict),
-      // This path has only the session record, whose name is what the caller named on this very
-      // request, so the name IS its address here.
-      hint: buildSessionRecoveryHint(session, 'selector-conflict', session.name),
+      hint: buildSessionRecoveryHint(ref, 'selector-conflict'),
     },
   );
 }

--- a/src/daemon/session-selector.ts
+++ b/src/daemon/session-selector.ts
@@ -33,7 +33,9 @@ export function assertSessionSelectorMatches(session: SessionState, flags?: Comm
     {
       session: session.name,
       conflicts: mismatches.map(formatSessionSelectorConflict),
-      hint: buildSessionRecoveryHint(session, 'selector-conflict'),
+      // This path has only the session record, whose name is what the caller named on this very
+      // request, so the name IS its address here.
+      hint: buildSessionRecoveryHint(session, 'selector-conflict', session.name),
     },
   );
 }

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { AppError, type DiagnosticsRecordRef } from '@agent-device/kernel/errors';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import type { SessionRuntimeHints, SessionState } from './types.ts';
+import type { SessionRef, SessionRuntimeHints, SessionState } from './types.ts';
 import { recordActionEntry, type RecordActionEntry } from './session-action-recorder.ts';
 import { expandSessionPath, isSafeSessionSegment, safeSessionName } from './session-paths.ts';
 import { NO_SCRIPT_PUBLICATION, isRepairCommittable } from './session-script-publication-state.ts';
@@ -97,13 +97,26 @@ export class SessionStore {
   }
 
   /**
-   * Sessions WITH the key each is stored under. `SessionState.name` is the PUBLIC name
-   * (`default`), while an implicitly cwd-scoped session is keyed and stored on disk as
-   * `cwd:<hash>:default` — so anything that turns a session into a path, a `--session` argument,
-   * or a `close` target needs the key, not the name (#2031/#1394).
+   * {@link SessionStore.get}, but returning the session WITH the address it answers to. The store
+   * is the only owner of that mapping, so a caller that needs both never recomputes the key or
+   * falls back to `SessionState.name` (#2031/#1394).
    */
-  entries(): [string, SessionState][] {
-    return Array.from(this.sessions.entries());
+  lookup(address: string): SessionRef | undefined {
+    const session = this.sessions.get(address);
+    return session ? { address, session } : undefined;
+  }
+
+  /** The session currently bound to `deviceId`, with its address, or `undefined` if none is. */
+  findByDevice(deviceId: string): SessionRef | undefined {
+    for (const [address, session] of this.sessions) {
+      if (session.device.id === deviceId) return { address, session };
+    }
+    return undefined;
+  }
+
+  /** Every live session with its address, for surfaces that must report what `--session` accepts. */
+  listRefs(): SessionRef[] {
+    return Array.from(this.sessions, ([address, session]) => ({ address, session }));
   }
 
   getRuntimeHints(name: string): SessionRuntimeHints | undefined {

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -96,6 +96,16 @@ export class SessionStore {
     return Array.from(this.sessions.values());
   }
 
+  /**
+   * Sessions WITH the key each is stored under. `SessionState.name` is the PUBLIC name
+   * (`default`), while an implicitly cwd-scoped session is keyed and stored on disk as
+   * `cwd:<hash>:default` — so anything that turns a session into a path, a `--session` argument,
+   * or a `close` target needs the key, not the name (#2031/#1394).
+   */
+  entries(): [string, SessionState][] {
+    return Array.from(this.sessions.entries());
+  }
+
   getRuntimeHints(name: string): SessionRuntimeHints | undefined {
     return this.runtimeHints.get(name);
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -225,6 +225,20 @@ export type PendingInteractionOutcome = {
   preSignature: InteractionSurfaceEntry[];
 };
 
+/**
+ * A session together with the store key that addresses it: `address` is the exact string
+ * `--session` must carry to reach `session`, and it is NOT always `session.name`. An implicitly
+ * cwd-scoped session is named `default` and stored under `cwd:<hash>:default`, and `--session`
+ * marks the session explicit, so `--session default` addresses a different session entirely
+ * (#2031/#1394). Anything that turns a session into a path, a `--session` argument, or a `close`
+ * target takes this pair rather than a bare record, so it cannot be handed a session whose address
+ * was never resolved.
+ */
+export type SessionRef = {
+  address: string;
+  session: SessionState;
+};
+
 export type SessionState = {
   name: string;
   sessionScope?: {

--- a/src/utils/result-serialization.ts
+++ b/src/utils/result-serialization.ts
@@ -78,6 +78,7 @@ function sessionDeviceSerial(device: AgentDeviceSessionDevice): string | undefin
 export function serializeSessionListEntry(session: AgentDeviceSession): Record<string, unknown> {
   return {
     name: session.name,
+    ...(session.address ? { address: session.address } : {}),
     ...(session.sessionStateDir ? { sessionStateDir: session.sessionStateDir } : {}),
     ...(session.runnerLogPath ? { runnerLogPath: session.runnerLogPath } : {}),
     ...serializeSessionDevice(session.device, { includeSerial: false }),


### PR DESCRIPTION

Refs #2031, #1394 (deliberately not `Closes` — see below)

## Status of #2031

#2031 is **closed**, by b1ee2a77 (#2057), which is in `main`. That fix covers the reported
mechanism: a replaced-but-still-running daemon keeping the device claim, now classified
`owner-daemon-superseded` and reconciled like a dead owner. I re-read that diff; it does what the
issue's headline asks.

The **follow-up comment on the same issue** describes a different mechanism, and that one still
reproduces on `main`. This PR fixes that half.

## Root cause

`resolveEffectiveSessionName` scopes an implicit session to the caller's worktree: a session opened
without `--session` is **named** `default` and **stored** under `cwd:<hash>:default`. The two are
not interchangeable, because passing `--session` sets `sessionExplicit`, which *disables* scoping —
so `--session default` addresses the literal key `default`, a different session.

Three surfaces built caller-facing text from `SessionState.name`:

- `buildDeviceInUseBySessionError` → `Device is already in use by session "default".`
- `buildSessionRecoveryHint` → `agent-device close --session default`
- `publicSessionInfo` (`session list`) → `sessionStateDir: <state>/sessions/default`

Each names something unreachable. Reproduced on `main` (iOS simulator, this clone):

```
$ agent-device open <app> --platform ios --udid <udid>          # cwd-scoped `default`
$ agent-device open <app> --platform ios --udid <udid> --session qa
Error (DEVICE_IN_USE): Device is already in use by session "default".
Hint: ... first run agent-device close --session default.

$ agent-device close --session default                          # follow the hint
Error (SESSION_NOT_FOUND): No active session                    # <- the hint's own command

$ agent-device open ... --session qa                            # retry
Error (DEVICE_IN_USE): ... by session "default".                # still held
```

That is the comment's report exactly: a `DEVICE_IN_USE` naming a session the documented recovery
cannot close. The same mismatch makes `session list` report a `sessionStateDir` and `runnerLogPath`
under `<state>/sessions/default` — a directory that is never created — while the session's real
artifacts, `runner.log` included, sit in `<state>/sessions/cwd_<hash>_default`, which is what `open`
already answers with. An operator following `session list` to read a runner log finds nothing there.

This is the #1394 family: a session's *identity* and its *address* diverged, and the surfaces that
report identity kept publishing it as an address.

## Fix

- `SessionStore.entries()` exposes the key alongside the record.
- `findNewSessionDeviceConflict` reads the conflicting session through it and passes the key to
  `buildDeviceInUseBySessionError`, which reports it in the message, in `details.session`, and in
  the hint.
- `buildSessionRecoveryHint` takes the session's **address** explicitly. The two other callers
  (`session-selector.ts`, `request-lock-policy.ts`) act on the session the current request named,
  where the name *is* the address, so they pass `session.name` and their text is unchanged.
- `session list` resolves `sessionStateDir`/`runnerLogPath` from the store key.

Explicitly named sessions are unaffected everywhere; the `DEVICE_IN_USE` help-conformance sample is
byte-identical (its fixture session is named `checkout`).

## Tests

Three new files; all five assertions were observed red against the pre-fix code.

- `src/daemon/session-recovery-hints.test.ts` — device-in-use, selector-conflict and recording
  recoveries all name the address; an explicitly named session addresses itself unchanged.
- `src/daemon/handlers/__tests__/session-open-device-in-use.test.ts` — the producer reports the
  address in message, details and hint.
- `src/daemon/handlers/__tests__/session-inventory-scoped-paths.test.ts` — `session list` keeps the
  public `name` but resolves paths to `cwd_<hash>_default`.

`pnpm check:quick`, `pnpm test:unit` (8093 passed) and `pnpm check:layering` are green.

## Live check

Same sequence as the repro above, after the fix:

```
Error (DEVICE_IN_USE): Device is already in use by session "cwd:8bea844ab16aa9b3:default".
Hint: ... first run agent-device close --session cwd:8bea844ab16aa9b3:default.

$ agent-device close --session "cwd:8bea844ab16aa9b3:default"
Closed: cwd:8bea844ab16aa9b3:default
$ agent-device open ... --session qa
Opened: <app>
```

`session list` now reports `.../sessions/cwd_8bea844ab16aa9b3_default`, which exists.

The issue's *original* close→plain-open sequence does **not** reproduce on `main` — a plain `close`
followed by a plain `open` in the same worktree succeeds. Its `--device "iPhone 17"` variant now
also raises `AMBIGUOUS_MATCH` when two simulators share that name, which is separate and correct.

## What a maintainer might push back on

- **Exposing the scoped key to users.** `close --session cwd:<hash>:default` is ugly, and it is
  a hash the caller never chose. It is the value that works today, and a hint that works beats a
  hint that reads nicely. The alternative — teaching `close`/`open` to resolve a *public* name
  against scoped keys within the caller's scope — is a bigger change to `resolveEffectiveSessionName`
  and its `sessionExplicit` contract, and belongs in its own PR. Say the word and I will draft it
  instead.
- **`entries()` on `SessionStore`.** The key can also be reconstructed as
  `session.sessionScope ? cwd:<id>:<name> : name`, which needs no new accessor — but that
  reconstruction is wrong for exactly the case #1394 documents, a session whose `sessionScope` was
  never propagated. Reading the key the store actually used cannot be wrong.
- **The two unchanged callers.** They now pass `session.name` explicitly, which looks like
  boilerplate. Making the parameter optional would hide the question at the sites most likely to be
  wrong next; the comment at each site records why the name is the address there.
- **Scope.** This is a follow-up to a closed issue. If the maintainers prefer, it can be re-filed as
  its own issue first — the reproduction above is self-contained.
