### PR TITLE
fix(ci): spawn the differential's agent-device CLI as argv, not one option

### DIFF
--- a/.github/workflows/conformance-differential.yml
+++ b/.github/workflows/conformance-differential.yml
@@ -32,7 +32,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AGENT_DEVICE_CLI: '--experimental-strip-types src/bin.ts'
+  # Entry script and node flags are separate on purpose: one variable cannot
+  # encode both without either corrupting a path that contains spaces or
+  # spawning the whole line as a single node option.
+  AGENT_DEVICE_CLI: 'src/bin.ts'
+  AGENT_DEVICE_CLI_NODE_FLAGS: '--experimental-strip-types'
   DIFFERENTIAL_ONLY: ${{ github.event.inputs.only || '' }}
   # CI should not phone home, and it keeps `maestro --version` to just the
   # version instead of prefixing an analytics notice.

--- a/packages/maestro/test/conformance/differential/engine-process.test.ts
+++ b/packages/maestro/test/conformance/differential/engine-process.test.ts
@@ -43,33 +43,24 @@ test('agent-device execution accepts a CLI path containing spaces', () => {
   }
 });
 
-// The regression the nightly ran into for two days: AGENT_DEVICE_CLI carries node
-// flags, and passing that line to node as one argument aborts before the CLI loads
-// ("bad option: --experimental-strip-types src/bin.ts"), which every scenario then
-// reports as an engine infrastructure failure rather than a divergence. Running the
-// workflow's own shape end to end is what pins it — a fixture path with no flag
-// cannot tell an argv from a command line.
-test('agent-device execution spawns node flags as their own arguments', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-engine-argv-'));
-  const cliPath = path.join(root, 'cli.ts');
-  try {
-    fs.writeFileSync(cliPath, 'const code: number = 0;\nprocess.exit(code);\n');
-    assert.deepEqual(
-      runAgentDeviceEngine(resolveAgentDeviceCliArgv(`--experimental-strip-types ${cliPath}`), []),
-      { engine: 'agent-device', outcome: 'pass', exitCode: 0 },
-    );
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('the agent-device CLI argv is the workflow command line, tokenized', () => {
-  // The fallback is the source-CLI line the device workflows pass explicitly, so a
-  // hand run without the variable reproduces CI rather than looking for a dist build.
-  assert.deepEqual(resolveAgentDeviceCliArgv(undefined), [
+test('the CLI argv keeps node flags and the entry script apart', () => {
+  // The default is the source CLI the device workflows name explicitly.
+  assert.deepEqual(resolveAgentDeviceCliArgv(undefined, undefined), [
     '--experimental-strip-types',
     'src/bin.ts',
   ]);
-  assert.deepEqual(resolveAgentDeviceCliArgv('  '), ['--experimental-strip-types', 'src/bin.ts']);
-  assert.deepEqual(resolveAgentDeviceCliArgv(' bin/agent-device.mjs '), ['bin/agent-device.mjs']);
+  // An entry path is never split, so spaces in it survive.
+  assert.deepEqual(resolveAgentDeviceCliArgv('/tmp/agent device.mjs', ''), [
+    '/tmp/agent device.mjs',
+  ]);
+  assert.deepEqual(resolveAgentDeviceCliArgv('/tmp/agent device.mjs', undefined), [
+    '--experimental-strip-types',
+    '/tmp/agent device.mjs',
+  ]);
+  // Flags are split, which is exact because a node flag cannot contain a space.
+  assert.deepEqual(resolveAgentDeviceCliArgv('bin/x.mjs', '--no-warnings  --enable-source-maps'), [
+    '--no-warnings',
+    '--enable-source-maps',
+    'bin/x.mjs',
+  ]);
 });

--- a/packages/maestro/test/conformance/differential/engine-process.test.ts
+++ b/packages/maestro/test/conformance/differential/engine-process.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
-import { classifyAgentDeviceFailure, runAgentDeviceEngine } from './engine-process.ts';
+import {
+  classifyAgentDeviceFailure,
+  resolveAgentDeviceCliArgv,
+  runAgentDeviceEngine,
+} from './engine-process.ts';
 
 test('agent-device JSON distinguishes infrastructure from behavioral failures', () => {
   const result = (infrastructure?: true) =>
@@ -29,7 +33,7 @@ test('agent-device execution accepts a CLI path containing spaces', () => {
   const cliPath = path.join(root, 'agent device.mjs');
   try {
     fs.writeFileSync(cliPath, '');
-    assert.deepEqual(runAgentDeviceEngine(cliPath, []), {
+    assert.deepEqual(runAgentDeviceEngine([cliPath], []), {
       engine: 'agent-device',
       outcome: 'pass',
       exitCode: 0,
@@ -37,4 +41,35 @@ test('agent-device execution accepts a CLI path containing spaces', () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+// The regression the nightly ran into for two days: AGENT_DEVICE_CLI carries node
+// flags, and passing that line to node as one argument aborts before the CLI loads
+// ("bad option: --experimental-strip-types src/bin.ts"), which every scenario then
+// reports as an engine infrastructure failure rather than a divergence. Running the
+// workflow's own shape end to end is what pins it — a fixture path with no flag
+// cannot tell an argv from a command line.
+test('agent-device execution spawns node flags as their own arguments', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-engine-argv-'));
+  const cliPath = path.join(root, 'cli.ts');
+  try {
+    fs.writeFileSync(cliPath, 'const code: number = 0;\nprocess.exit(code);\n');
+    assert.deepEqual(
+      runAgentDeviceEngine(resolveAgentDeviceCliArgv(`--experimental-strip-types ${cliPath}`), []),
+      { engine: 'agent-device', outcome: 'pass', exitCode: 0 },
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the agent-device CLI argv is the workflow command line, tokenized', () => {
+  // The fallback is the source-CLI line the device workflows pass explicitly, so a
+  // hand run without the variable reproduces CI rather than looking for a dist build.
+  assert.deepEqual(resolveAgentDeviceCliArgv(undefined), [
+    '--experimental-strip-types',
+    'src/bin.ts',
+  ]);
+  assert.deepEqual(resolveAgentDeviceCliArgv('  '), ['--experimental-strip-types', 'src/bin.ts']);
+  assert.deepEqual(resolveAgentDeviceCliArgv(' bin/agent-device.mjs '), ['bin/agent-device.mjs']);
 });

--- a/packages/maestro/test/conformance/differential/engine-process.ts
+++ b/packages/maestro/test/conformance/differential/engine-process.ts
@@ -32,28 +32,38 @@ export function classifyAgentDeviceFailure(stdout: string): 'behavioral' | 'infr
   }
 }
 
-/** What the device workflows set AGENT_DEVICE_CLI to, and the default here. */
-const DEFAULT_AGENT_DEVICE_CLI = '--experimental-strip-types src/bin.ts';
-
 /**
- * AGENT_DEVICE_CLI is a command *line* — node flags plus the entry script —
- * mirroring AGENT_DEVICE_PERF_CLI in scripts/perf/config.ts. Tokenizing it here,
- * beside the spawn it feeds, is what keeps `runAgentDeviceEngine`'s precondition
- * satisfiable: no caller downstream holds a string that is neither a path nor an
- * argv. A path with spaces is unreachable through the variable, as in the perf
- * harness; pass it as a single array element instead.
+ * The agent-device CLI the differential drives, as two variables that cannot be
+ * confused for one another:
+ *
+ *   AGENT_DEVICE_CLI            the entry script — ONE path, never split, so a
+ *                               path containing spaces survives verbatim
+ *   AGENT_DEVICE_CLI_NODE_FLAGS node flags — split on whitespace, which is exact
+ *                               because a node flag cannot contain a space
+ *
+ * One variable holding `--experimental-strip-types src/bin.ts` cannot express
+ * both: splitting it corrupts `/tmp/agent device.mjs`, and not splitting it
+ * spawns the whole line as a single node option — the bug that infrastructure-
+ * failed every scenario from 2026-08-25. Set the flags variable to the empty
+ * string to run an entry that needs none (a built `bin/agent-device.mjs`).
  */
-export function resolveAgentDeviceCliArgv(value: string | undefined): string[] {
-  return (value?.trim() || DEFAULT_AGENT_DEVICE_CLI).split(/\s+/);
+const DEFAULT_CLI_ENTRY = 'src/bin.ts';
+const DEFAULT_CLI_NODE_FLAGS = '--experimental-strip-types';
+
+export function resolveAgentDeviceCliArgv(
+  entry: string | undefined,
+  nodeFlags: string | undefined,
+): string[] {
+  const flags = (nodeFlags ?? DEFAULT_CLI_NODE_FLAGS).split(/\s+/).filter(Boolean);
+  return [...flags, entry?.trim() || DEFAULT_CLI_ENTRY];
 }
 
 /**
- * `cliArgv` is a node argv — node flags plus the entry script — never a single
- * command string. AGENT_DEVICE_CLI carries `--experimental-strip-types src/bin.ts`
- * on every device workflow, so a lone `string` here spawns node with that whole
- * line as one option ("bad option: --experimental-strip-types src/bin.ts") and
- * every scenario infrastructure-fails. By the time a path reaches this array it
- * is already its own element, spaces and all.
+ * `cliArgv` is a node argv — flags and entry script as separate elements, built
+ * by `resolveAgentDeviceCliArgv`. Never a command line: spawning one as a single
+ * argument aborts node before the CLI loads ("bad option: --experimental-strip-
+ * types src/bin.ts"), which every scenario then reports as an infrastructure
+ * failure. An entry path reaching this array is already its own element.
  */
 export function runAgentDeviceEngine(cliArgv: readonly string[], args: string[]): EngineResult {
   const result = spawnSync(process.execPath, [...cliArgv, ...args, '--json'], {

--- a/packages/maestro/test/conformance/differential/engine-process.ts
+++ b/packages/maestro/test/conformance/differential/engine-process.ts
@@ -32,8 +32,31 @@ export function classifyAgentDeviceFailure(stdout: string): 'behavioral' | 'infr
   }
 }
 
-export function runAgentDeviceEngine(cliPath: string, args: string[]): EngineResult {
-  const result = spawnSync(process.execPath, [cliPath, ...args, '--json'], {
+/** What the device workflows set AGENT_DEVICE_CLI to, and the default here. */
+const DEFAULT_AGENT_DEVICE_CLI = '--experimental-strip-types src/bin.ts';
+
+/**
+ * AGENT_DEVICE_CLI is a command *line* — node flags plus the entry script —
+ * mirroring AGENT_DEVICE_PERF_CLI in scripts/perf/config.ts. Tokenizing it here,
+ * beside the spawn it feeds, is what keeps `runAgentDeviceEngine`'s precondition
+ * satisfiable: no caller downstream holds a string that is neither a path nor an
+ * argv. A path with spaces is unreachable through the variable, as in the perf
+ * harness; pass it as a single array element instead.
+ */
+export function resolveAgentDeviceCliArgv(value: string | undefined): string[] {
+  return (value?.trim() || DEFAULT_AGENT_DEVICE_CLI).split(/\s+/);
+}
+
+/**
+ * `cliArgv` is a node argv — node flags plus the entry script — never a single
+ * command string. AGENT_DEVICE_CLI carries `--experimental-strip-types src/bin.ts`
+ * on every device workflow, so a lone `string` here spawns node with that whole
+ * line as one option ("bad option: --experimental-strip-types src/bin.ts") and
+ * every scenario infrastructure-fails. By the time a path reaches this array it
+ * is already its own element, spaces and all.
+ */
+export function runAgentDeviceEngine(cliArgv: readonly string[], args: string[]): EngineResult {
+  const result = spawnSync(process.execPath, [...cliArgv, ...args, '--json'], {
     cwd: process.cwd(),
     encoding: 'utf8',
   });

--- a/packages/maestro/test/conformance/differential/run.test.ts
+++ b/packages/maestro/test/conformance/differential/run.test.ts
@@ -174,7 +174,7 @@ test('an ordinary Maestro process failure cannot satisfy a behavioral waiver', (
       {
         dryRun: false,
         maestroBin: `${process.execPath} ${maestroCli}`,
-        agentDeviceCli,
+        agentDeviceCliArgv: [agentDeviceCli],
       },
     );
 

--- a/packages/maestro/test/conformance/differential/run.test.ts
+++ b/packages/maestro/test/conformance/differential/run.test.ts
@@ -186,6 +186,99 @@ test('an ordinary Maestro process failure cannot satisfy a behavioral waiver', (
   }
 });
 
+// The production route the P1 review asked for: environment -> parseRunnerArgs ->
+// runScenario -> spawn. Calling runAgentDeviceEngine with a hand-built argv proves
+// the spawn, but not that the two variables reach it intact — and it is the
+// environment contract that broke the nightly and that a whitespace-split
+// AGENT_DEVICE_CLI would break again in the other direction.
+describe('the agent-device CLI environment route', () => {
+  const ROUTE_SCENARIO = {
+    id: 'cli-env-route',
+    flow: 'differential/flows/settle-after-tap.yaml',
+    comparesAcrossEngines: 'test fixture',
+    expect: 'pass',
+    divergenceMeans: 'test fixture',
+  } as const;
+
+  /** Run one scenario with AGENT_DEVICE_CLI* set, restoring the environment after. */
+  function reportForEnvironment(entry: string, nodeFlags: string, maestroCli: string) {
+    const previous = {
+      entry: process.env.AGENT_DEVICE_CLI,
+      flags: process.env.AGENT_DEVICE_CLI_NODE_FLAGS,
+    };
+    process.env.AGENT_DEVICE_CLI = entry;
+    process.env.AGENT_DEVICE_CLI_NODE_FLAGS = nodeFlags;
+    try {
+      const options = parseRunnerArgs([]);
+      return {
+        argv: options.agentDeviceCliArgv,
+        report: runScenario(ROUTE_SCENARIO, {
+          ...options,
+          maestroBin: `${process.execPath} ${maestroCli}`,
+        }),
+      };
+    } finally {
+      restoreEnv('AGENT_DEVICE_CLI', previous.entry);
+      restoreEnv('AGENT_DEVICE_CLI_NODE_FLAGS', previous.flags);
+    }
+  }
+
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+
+  /**
+   * `spaced` is a subdirectory whose NAME carries the space, so the entry path
+   * holds one whatever the file is called. The maestro stub deliberately stays
+   * out of it: `runMaestroEngine` still splits its command on spaces, and a
+   * spaced stub path would fail this test for the other engine's reason.
+   */
+  function withFixtureRoot(run: (spaced: string, maestroCli: string) => void): void {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-env-route-'));
+    const spaced = path.join(root, 'agent device');
+    fs.mkdirSync(spaced);
+    const maestroCli = path.join(root, 'maestro.mjs');
+    fs.writeFileSync(maestroCli, 'process.exit(0);\n');
+    try {
+      run(spaced, maestroCli);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  test('a CLI path containing spaces reaches the spawn unsplit', () => {
+    withFixtureRoot((spaced, maestroCli) => {
+      const entry = path.join(spaced, 'cli.mjs');
+      fs.writeFileSync(entry, 'process.exit(0);\n');
+
+      const { argv, report } = reportForEnvironment(entry, '', maestroCli);
+
+      assert.deepEqual(argv, [entry], 'the entry path must stay one argument');
+      assert.equal(report.agentDevice.outcome, 'pass');
+      assert.equal(report.failed, false);
+    });
+  });
+
+  test('node flags stay separate arguments alongside a spaced path', () => {
+    withFixtureRoot((spaced, maestroCli) => {
+      const entry = path.join(spaced, 'cli.ts');
+      fs.writeFileSync(entry, 'const code: number = 0;\nprocess.exit(code);\n');
+
+      const { argv, report } = reportForEnvironment(
+        entry,
+        '--experimental-strip-types',
+        maestroCli,
+      );
+
+      // Neither property is expressible in a single whitespace-joined variable.
+      assert.deepEqual(argv, ['--experimental-strip-types', entry]);
+      assert.equal(report.agentDevice.outcome, 'pass');
+      assert.equal(report.failed, false);
+    });
+  });
+});
+
 test('every device flow targets the fixture app the workflow installs', () => {
   for (const scenario of DIFFERENTIAL_SCENARIOS) {
     const flowPath = path.join(CONFORMANCE_DIR, scenario.flow);

--- a/packages/maestro/test/conformance/differential/run.ts
+++ b/packages/maestro/test/conformance/differential/run.ts
@@ -54,7 +54,10 @@ export function parseRunnerArgs(argv: readonly string[]): RunnerOptions {
   const options: RunnerOptions = {
     dryRun: false,
     maestroBin: process.env.MAESTRO_BIN ?? 'maestro',
-    agentDeviceCliArgv: resolveAgentDeviceCliArgv(process.env.AGENT_DEVICE_CLI),
+    agentDeviceCliArgv: resolveAgentDeviceCliArgv(
+      process.env.AGENT_DEVICE_CLI,
+      process.env.AGENT_DEVICE_CLI_NODE_FLAGS,
+    ),
     traceRoot: process.env.AGENT_DEVICE_ARTIFACTS_DIR,
   };
   for (let i = 0; i < argv.length; i += 1) {

--- a/packages/maestro/test/conformance/differential/run.ts
+++ b/packages/maestro/test/conformance/differential/run.ts
@@ -18,7 +18,12 @@ import {
   type DivergenceSignature,
 } from './scenarios.ts';
 import { type InvariantResult, evaluateInvariants, readTrace } from './invariants.ts';
-import { type EngineResult, runAgentDeviceEngine, runMaestroEngine } from './engine-process.ts';
+import {
+  type EngineResult,
+  resolveAgentDeviceCliArgv,
+  runAgentDeviceEngine,
+  runMaestroEngine,
+} from './engine-process.ts';
 import {
   printDryRun,
   printRunSummary,
@@ -38,15 +43,18 @@ export type RunnerOptions = {
   dryRun: boolean;
   only?: string;
   maestroBin: string;
-  agentDeviceCli: string;
+  /**
+   * Node argv for the agent-device CLI — flags and entry script as separate
+   * elements, not one command line. See `resolveAgentDeviceCliArgv`.
+   */
+  agentDeviceCliArgv: readonly string[];
 };
 
 export function parseRunnerArgs(argv: readonly string[]): RunnerOptions {
   const options: RunnerOptions = {
     dryRun: false,
     maestroBin: process.env.MAESTRO_BIN ?? 'maestro',
-    // Mirror the perf harness convention (AGENT_DEVICE_PERF_CLI).
-    agentDeviceCli: process.env.AGENT_DEVICE_CLI ?? '--experimental-strip-types src/bin.ts',
+    agentDeviceCliArgv: resolveAgentDeviceCliArgv(process.env.AGENT_DEVICE_CLI),
     traceRoot: process.env.AGENT_DEVICE_ARTIFACTS_DIR,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -170,7 +178,7 @@ export function runScenario(
   const maestro = runMaestroEngine(options.maestroBin, ['test', flowPath, ...platformArgs]);
   // `--maestro` is required: without it `test` rejects a .yaml flow outright
   // ("test does not support this file type"). Matches scripts/run-test-app-maestro-suite.mjs.
-  const agentDevice = runAgentDeviceEngine(options.agentDeviceCli, [
+  const agentDevice = runAgentDeviceEngine(options.agentDeviceCliArgv, [
     'test',
     flowPath,
     '--maestro',


### PR DESCRIPTION
## What broke

**Conformance Differential** has failed every night since 2026-08-25 ([run 32933263066](https://github.com/callstack/agent-device/actions/runs/32933263066)). All six scenarios reported `infrastructure-failed … maestro=pass agent-device=fail`, each preceded by:

```
/Users/runner/.../node: bad option: --experimental-strip-types src/bin.ts
```

`runAgentDeviceEngine` took the CLI as a single `cliPath` and spawned `[cliPath, ...args]`. But `AGENT_DEVICE_CLI` — set by the workflow, and this runner's own default — is a command *line*: a node flag plus the entry script. Node aborted on the combined token before the CLI loaded, so the oracle compared nothing at all. The lane was red but proving nothing.

Introduced by #1989, which extracted `engine-process.ts` and moved the agent-device side from `command.split(' ')` to `process.execPath` plus one path, to accept paths containing spaces. The maestro side kept splitting; the agent-device side lost it.

## The fix

Tokenize `AGENT_DEVICE_CLI` once, in `resolveAgentDeviceCliArgv` beside the spawn it feeds, and give `runAgentDeviceEngine` an argv array. Both properties now hold at the same time: a flag plus a script cannot collapse into one option, and a path containing spaces stays expressible — as a single array element.

`RunnerOptions.agentDeviceCli: string` becomes `agentDeviceCliArgv: readonly string[]`, so nothing downstream holds a string that is neither a path nor an argv. That ambiguity was the defect.

## Why no test caught it

The existing fixtures passed a bare `.mjs` path, which cannot tell an argv from a command line. The new test runs the workflow's own shape end to end — flag plus script. Verified to have teeth: reverting the fix reproduces the exact CI signature.

```
✖ agent-device execution spawns node flags as their own arguments
  node: bad option: --experimental-strip-types /tmp/.../cli.ts
```

## Verified

`pnpm maestro:conformance` (56/56), `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm check:fallow`.

Device evidence is pending: this lane needs a simulator, so I will dispatch **Conformance Differential** on this branch and post the result here.

## The other two lanes in the report — no change needed

**Mutation Weekly** ([run 32619691689](https://github.com/callstack/agent-device/actions/runs/32619691689), Aug 23) — already fixed on main. The `kernel-errors` shard died in Stryker's dry run on `no test file over the tripwire grows …`, all 26 pins off by one because `disableTypeChecks` prepends `// @ts-nocheck` to every sandbox copy. #1977 moved that test from `src/__tests__/` to `scripts/__tests__/`, outside `KERNEL_TEST_FILE_RE`, and landed at 05:39 UTC — 29 minutes after the weekly started at 05:10. Confirmed against the current tree: the test's address is out of the lane, its old one was in.

**Perf Nightly** — stale by design, not broken. #1822 parked it to `workflow_dispatch` under #1781 A3, because it writes a report and compares nothing. Aug 18 was its last scheduled run before the park. Worth teaching the freshness report about parked lanes so this stops reading as a gap.

## Left open

The differential lane was red for **nine consecutive nights** (Aug 18 → Aug 26) with nobody paged. The three nights before #1989 were real single-scenario reds — `tap-retry-if-no-change` recording zero tap retries (Aug 18), then `settle-after-tap` failing Maestro's `scrollUntilVisible home-open-form` (Aug 23-24, addressed by #1989's flow rewrite). Both look transient or already fixed, but #1989's rewrite has never actually executed: every run since it landed died on the argv bug. The dispatch on this branch is the first real exercise of it.
