### PR TITLE
fix(daemon): keep the recovery hint on Maestro replay errors

### DIFF
--- a/src/daemon/handlers/__tests__/session-replay-maestro-error-projection.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-error-projection.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+import { stringify } from 'yaml';
+import { runTypedMaestroReplay } from '../session-replay-maestro-runtime.ts';
+import { SessionStore } from '../../session-store.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { maestroScriptSourceBundleFor } from '../../../__tests__/test-utils/replay-script-source.ts';
+import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import type { DaemonRequest } from '../../types.ts';
+
+// A replay error raised before any step runs carries no `failure`, so the route
+// projects the normalized error directly instead of through the divergence
+// transport. `normalizeError` lifts `hint` (and the other diagnostic meta) OUT
+// of `details`, so that projection has to carry the normalized fields — spreading
+// only `details` drops every recovery the throw site wrote.
+test('a typed Maestro replay error keeps its recovery hint', async () => {
+  const root = mkdtempForTestSync('agent-device-maestro-hint-');
+  const flowPath = path.join(root, 'flow.yaml');
+  fs.writeFileSync(flowPath, `${stringify({ appId: 'com.example.app' })}---\n${stringify([])}`);
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  sessionStore.set('default', makeIosSession('default'));
+
+  const req = {
+    token: 'test-token',
+    session: 'default',
+    command: 'replay',
+    positionals: [flowPath],
+    flags: {
+      replayBackend: 'maestro',
+      replayScriptSource: await maestroScriptSourceBundleFor(flowPath),
+      udid: 'SIM-OTHER',
+    },
+    meta: { requestId: 'req-maestro-hint' },
+  } as unknown as DaemonRequest;
+
+  const response = await runTypedMaestroReplay({
+    req,
+    sessionName: 'default',
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('INVALID_ARGS');
+  expect(response.error.hint).toContain('agent-device session list');
+  expect(response.error.hint).toContain('--session default');
+  // The throw site's own details survive beside the projected hint.
+  expect(response.error.details?.session).toBe('default');
+  expect(response.error.details?.conflicts).toEqual(['--udid=SIM-OTHER']);
+  // `hint` is projected, not left behind in `details`.
+  expect(response.error.details?.hint).toBeUndefined();
+});

--- a/src/daemon/handlers/session-replay-maestro-response.ts
+++ b/src/daemon/handlers/session-replay-maestro-response.ts
@@ -5,7 +5,6 @@ import { summarizeSnapshotTimingSamples } from '@agent-device/contracts/capture'
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import { buildTypedMaestroFailureResponse } from './session-replay-maestro-failure.ts';
-import { errorResponse } from './response.ts';
 
 export function buildTypedMaestroSuccessResponse(params: {
   outcome: Extract<MaestroExecutionOutcome, { ok: true }>;
@@ -62,10 +61,10 @@ export async function buildTypedMaestroReplayErrorResponse(params: {
       ),
     });
   }
-  return errorResponse(normalizedError.code, normalizedError.message, {
-    ...(normalizedError.details ?? {}),
-    ...buildErrorDetails(failure),
-  });
+  // The normalized error IS the wire error shape. Returning it whole keeps the
+  // fields `normalizeError` projects out of `details` — `hint`, `diagnosticId`,
+  // `logPath`, `retriable`, `supportedOn` — which re-spreading `details` drops.
+  return { ok: false, error: normalizedError };
 }
 
 function readSnapshotDiagnostics(
@@ -76,17 +75,6 @@ function readSnapshotDiagnostics(
   const samples =
     sessionStore.get(sessionName)?.snapshotDiagnostics?.samples.slice(snapshotStart) ?? [];
   return summarizeSnapshotTimingSamples(samples);
-}
-
-function buildErrorDetails(
-  failure: Extract<MaestroExecutionOutcome, { ok: false }>['failure'],
-): Record<string, unknown> {
-  if (!failure) return {};
-  return {
-    replaySource: failure.source,
-    replayStep: failure.stepIndex,
-    replayStepTotal: failure.stepTotal,
-  };
 }
 
 function replaySuccessMessage(replayed: number, wallClockMs: number): string {


### PR DESCRIPTION
## The defect

`buildTypedMaestroReplayErrorResponse` in `src/daemon/handlers/session-replay-maestro-response.ts` rebuilt the wire error from `normalizeError`'s **stripped** details bag:

```ts
return errorResponse(normalizedError.code, normalizedError.message, {
  ...(normalizedError.details ?? {}),
  ...buildErrorDetails(failure),
});
```

`normalizeError` lifts `hint` out of `details` onto `normalizedError.hint`, and `stripDiagnosticMeta` then deletes it from `details`. So spreading `details` alone discarded the hint. The same loss applied to `diagnosticId`, `logPath`, `logPathUnavailable`, `diagnosticsRecord`, `retriable`, `supportedOn` and `cause` — every field `stripDiagnosticMeta` removes.

Concretely: a session-selector conflict raised in `prepareTypedMaestroReplay` -> `assertSessionSelectorMatches` throws an `AppError` whose details carry the full session recovery:

> Run `agent-device session list` to inspect active sessions. To reuse this device, rerun the command with `--session <address>` and remove conflicting device selectors. To switch devices, first run `agent-device close --session <address>` ...

The response the caller received contained only `code`, `message` and `details: { session, conflicts }`. The recovery was gone. **Every** Maestro replay error raised before the first step took this route — the whole `catch` in `runTypedMaestroReplay` lands here with no `failure`.

## The change

Return the normalized error whole:

```ts
return { ok: false, error: normalizedError };
```

That is the shape nearly every other daemon handler already returns, and it is the wire error shape by construction — so no field can be dropped by omission again.

`buildErrorDetails` is deleted. It was dead: the branch runs only after `if (failure) return ...`, which narrows `failure` to `undefined`, so it always returned `{}`. The now-unused `errorResponse` import goes with it.

## The `failure` branch is not affected

`buildTypedMaestroFailureResponse` does **not** have this defect. It hands the normalized error to `hoistReplayFailureCauseDiagnosticMeta`, and `buildReplayDivergenceFailureResponseFromDescriptor` then writes `hint`, `diagnosticId`, `logPath`, `retriable` and `supportedOn` onto the response as fields. `session-replay-runtime-maestro.test.ts:620` already pins that. It does narrow `details` to a safe-list (`reason`, `recovery`, `retriable`, `supportedOn`), but that is a deliberate scrub of arbitrary cause details, not the same drop.

## Regression

`src/daemon/handlers/__tests__/session-replay-maestro-error-projection.test.ts` drives the production route (`runTypedMaestroReplay` with a conflicting `--udid`) and asserts the hint reaches the caller, that the throw site's own `details` survive beside it, and that `details.hint` stays projected rather than duplicated. Verified red on the old code, green on the new.

## Checks

| Check | Result |
| --- | --- |
| `pnpm vitest run --project unit-core src/daemon/handlers/` | 141 files, 1035 tests passed |
| `pnpm test:output-economy` | 26 tests passed |
| `pnpm vitest run --project unit-core` (full) | 1062 files, 8088 tests passed |
| `tsc --noEmit`, oxlint, oxfmt | clean |

No baseline moved. Restoring the hint changed no golden output.

## Reviewer note — coordinate with #2068

The reference case that documents the current hint-less behavior is `src/daemon/handlers/__tests__/session-replay-maestro-session-address.test.ts`, which exists **only on #2068**, not on `main`. Its closing comment says:

> ... this route's error projection (`buildTypedMaestroReplayErrorResponse`) spreads only `normalizeError`'s stripped `details`, which no longer carries `hint`, so no hint reaches the caller here at all — a separate defect from the address this case pins.

That statement becomes false once this lands. Whichever of the two merges second must remove that comment. If this PR merges first, the #2068 rebase can promote it into a real hint assertion instead.