### PR TITLE
fix(build): silence TS2883 dts noise in the Apple runner client shim

### DIFF
--- a/src/platforms/apple/core/runner-client.ts
+++ b/src/platforms/apple/core/runner-client.ts
@@ -1,4 +1,7 @@
-import { createAppleRunnerClient } from '@agent-device/platform-apple/runner/client';
+import {
+  createAppleRunnerClient,
+  type AppleRunnerClient,
+} from '@agent-device/platform-apple/runner/client';
 import { appleRunnerHost } from './runner-host.ts';
 
 /**
@@ -7,26 +10,47 @@ import { appleRunnerHost } from './runner-host.ts';
  * host capabilities from `runner-host.ts` and re-exposes the bound operations
  * under their historical names for daemon, platform, and CLI consumers. Types
  * and host-free helpers come from the package façade directly.
+ *
+ * Each export below carries an explicit `AppleRunnerClient[...]` annotation
+ * (rather than a destructuring re-export) because the package's operation
+ * types resolve through its private modules; without an annotation naming
+ * the public `AppleRunnerClient` type, dts emit cannot print a portable type
+ * for the inferred signature (TS2883).
  */
-const client = createAppleRunnerClient(appleRunnerHost);
+const client: AppleRunnerClient = createAppleRunnerClient(appleRunnerHost);
 
-export const {
-  runAppleRunnerCommand,
-  notifyIosRunnerAppRelaunched,
-  prewarmAppleRunnerCache,
-  prewarmIosRunnerSession,
-  prepareIosRunner,
-  resolveRunnerAppBundleId,
-  hasCachedAppleRunnerArtifact,
-  detachIosSimulatorRunnerSessionsForShutdown,
-  getRunnerSessionSnapshot,
-  scheduleIosRunnerIdleStop,
-  stopIosRunnerSession,
-  stopAllIosRunnerSessions,
-  runApplePressSeries,
-  cleanupRunnerLeasesForOwner,
-  readStaleRunnerLease,
-  verifyLeaseRunnerPidIdentity,
-  runnerLeaseCleanupAdapter,
-  applyXctestRunnerAppIconFromDerivedPath,
-} = client;
+export const runAppleRunnerCommand: AppleRunnerClient['runAppleRunnerCommand'] =
+  client.runAppleRunnerCommand;
+export const notifyIosRunnerAppRelaunched: AppleRunnerClient['notifyIosRunnerAppRelaunched'] =
+  client.notifyIosRunnerAppRelaunched;
+export const prewarmAppleRunnerCache: AppleRunnerClient['prewarmAppleRunnerCache'] =
+  client.prewarmAppleRunnerCache;
+export const prewarmIosRunnerSession: AppleRunnerClient['prewarmIosRunnerSession'] =
+  client.prewarmIosRunnerSession;
+export const prepareIosRunner: AppleRunnerClient['prepareIosRunner'] = client.prepareIosRunner;
+export const resolveRunnerAppBundleId: AppleRunnerClient['resolveRunnerAppBundleId'] =
+  client.resolveRunnerAppBundleId;
+export const hasCachedAppleRunnerArtifact: AppleRunnerClient['hasCachedAppleRunnerArtifact'] =
+  client.hasCachedAppleRunnerArtifact;
+export const detachIosSimulatorRunnerSessionsForShutdown: AppleRunnerClient['detachIosSimulatorRunnerSessionsForShutdown'] =
+  client.detachIosSimulatorRunnerSessionsForShutdown;
+export const getRunnerSessionSnapshot: AppleRunnerClient['getRunnerSessionSnapshot'] =
+  client.getRunnerSessionSnapshot;
+export const scheduleIosRunnerIdleStop: AppleRunnerClient['scheduleIosRunnerIdleStop'] =
+  client.scheduleIosRunnerIdleStop;
+export const stopIosRunnerSession: AppleRunnerClient['stopIosRunnerSession'] =
+  client.stopIosRunnerSession;
+export const stopAllIosRunnerSessions: AppleRunnerClient['stopAllIosRunnerSessions'] =
+  client.stopAllIosRunnerSessions;
+export const runApplePressSeries: AppleRunnerClient['runApplePressSeries'] =
+  client.runApplePressSeries;
+export const cleanupRunnerLeasesForOwner: AppleRunnerClient['cleanupRunnerLeasesForOwner'] =
+  client.cleanupRunnerLeasesForOwner;
+export const readStaleRunnerLease: AppleRunnerClient['readStaleRunnerLease'] =
+  client.readStaleRunnerLease;
+export const verifyLeaseRunnerPidIdentity: AppleRunnerClient['verifyLeaseRunnerPidIdentity'] =
+  client.verifyLeaseRunnerPidIdentity;
+export const runnerLeaseCleanupAdapter: AppleRunnerClient['runnerLeaseCleanupAdapter'] =
+  client.runnerLeaseCleanupAdapter;
+export const applyXctestRunnerAppIconFromDerivedPath: AppleRunnerClient['applyXctestRunnerAppIconFromDerivedPath'] =
+  client.applyXctestRunnerAppIconFromDerivedPath;


### PR DESCRIPTION
## Summary
- Every ubuntu `pnpm build` prints 18 non-fatal `TS2883` diagnostics for `src/platforms/apple/core/runner-client.ts` (tsdown 0.22.14's experimental TypeScript 7 dts API can't portably print the type it infers for each destructured re-export, since those types resolve through `@agent-device/platform-apple`'s private internal modules). The build still succeeds, but GitHub renders these as `##[error]` annotations on every CI run, burying real failures under 18 fake ones during triage.
- Replaces the single destructuring re-export (`export const { a, b, ... } = client;`) with 18 individually-typed statements (`export const a: AppleRunnerClient['a'] = client.a;`), giving dts emission an explicit, portable type to print for each export instead of having to infer and name one through private modules. This mirrors the identical pattern already used for the `AppleRunnerHost` port in [`packages/platform-apple/src/runner/host.ts`](https://github.com/callstack/agent-device/blob/main/packages/platform-apple/src/runner/host.ts).
- No behavior change: same object built once at module load, same bound function references, same export names — confirmed via the full local build + typecheck + the 39 test files (321 tests) that import or `vi.mock` this module.

## Test plan
- [x] `pnpm build` — zero `TS2883` lines in output, build still completes
- [x] `pnpm check:quick` (lint + full-repo typecheck) — green
- [x] `oxfmt --check` on the changed file — clean
- [x] Targeted `vitest run` across the 39 test files that import/mock `core/runner-client` — 321/321 passing
- [x] Adversarial multi-angle code review (correctness, cross-file consumers, reuse/simplification/efficiency, altitude, conventions) — no findings