### PR TITLE
fix(test): settle the daemon's exit on its own deadline in the web shutdown lane

### DIFF
--- a/src/daemon/__tests__/daemon-exit-wait.test.ts
+++ b/src/daemon/__tests__/daemon-exit-wait.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { stopProcessForTakeover, waitForDaemonExit } from '../daemon-process.ts';
+
+const DAEMON_COMMAND = '/opt/checkout/dist/src/internal/daemon.js';
+const OURS = 'Mon Aug 24 10:00:00 2026';
+const RECYCLED = 'Mon Aug 24 10:00:07 2026';
+const PID = 4242;
+// Small enough that a regression that waits the budget out still lands inside the
+// unit lane's wall-clock gate and fails on its assertion rather than on the clock.
+const TIMEOUT_MS = 1_000;
+const POLL_MS = 5;
+
+// A live process cannot be made to change identity mid-wait, so the host reads are
+// mocked: a recycled pid is the same live pid reporting a different start time,
+// which is what the host presents after reuse.
+const state = vi.hoisted(() => ({
+  alive: new Map<number, boolean>(),
+  starts: new Map<number, string>(),
+  states: new Map<number, string>(),
+  commands: new Map<number, string>(),
+}));
+
+vi.mock('../../utils/host-process.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/host-process.ts')>()),
+  isProcessAlive: (pid: number) => state.alive.get(pid) ?? false,
+  readProcessStartTime: (pid: number) => state.starts.get(pid) ?? null,
+  readProcessCommand: (pid: number) => state.commands.get(pid) ?? null,
+  readHostProcessIdentityObservations: (pids: Iterable<number>) => {
+    const observations = new Map<number, { state: string; startTime: string }>();
+    for (const pid of pids) {
+      const startTime = state.starts.get(pid);
+      if (startTime === undefined) continue;
+      observations.set(pid, { state: state.states.get(pid) ?? 'S', startTime });
+    }
+    return observations;
+  },
+}));
+
+/** Delivered signals only; a `0` probe is a liveness read, not a write. */
+const signals: NodeJS.Signals[] = [];
+let onSignal: (signal: NodeJS.Signals) => void = () => {};
+
+beforeEach(() => {
+  state.alive.clear();
+  state.starts.clear();
+  state.states.clear();
+  state.commands.clear();
+  signals.length = 0;
+  onSignal = () => {};
+  state.alive.set(PID, true);
+  state.starts.set(PID, OURS);
+  state.states.set(PID, 'S');
+  state.commands.set(PID, DAEMON_COMMAND);
+  vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal: NodeJS.Signals | 0) => {
+    if (pid !== PID || signal === 0) return true;
+    signals.push(signal);
+    onSignal(signal);
+    return true;
+  }) as typeof process.kill);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('waitForDaemonExit reports a pid recycled mid-wait as exited, without burning the deadline', async () => {
+  setTimeout(() => state.starts.set(PID, RECYCLED), 20);
+  const wait = await waitForDaemonExit(
+    { pid: PID, startTime: OURS },
+    { timeoutMs: TIMEOUT_MS, pollMs: POLL_MS },
+  );
+  expect(wait.exited).toBe(true);
+  expect(wait.elapsedMs).toBeLessThan(TIMEOUT_MS / 2);
+});
+
+test('waitForDaemonExit reports a daemon that keeps its identity as not exited', async () => {
+  const wait = await waitForDaemonExit(
+    { pid: PID, startTime: OURS },
+    { timeoutMs: 40, pollMs: POLL_MS },
+  );
+  expect(wait.exited).toBe(false);
+});
+
+// A daemon killed by its own parent lingers as a zombie: kill(pid, 0) still succeeds
+// and the start time still matches, while ps reports the command as `<defunct>`.
+// Reading that as a recycled pid would hand the number back to callers while it is
+// still taken, so it must count as neither ending until the reap lands.
+test('waitForDaemonExit keeps waiting through a zombie until the pid is reaped', async () => {
+  state.states.set(PID, 'Z+');
+  state.commands.set(PID, '<defunct>');
+  const stillTaken = await waitForDaemonExit(
+    { pid: PID, startTime: OURS },
+    { timeoutMs: 40, pollMs: POLL_MS },
+  );
+  expect(stillTaken.exited).toBe(false);
+
+  state.alive.set(PID, false);
+  const reaped = await waitForDaemonExit(
+    { pid: PID, startTime: OURS },
+    { timeoutMs: TIMEOUT_MS, pollMs: POLL_MS },
+  );
+  expect(reaped.exited).toBe(true);
+});
+
+// Planted red for the defect this pair exists to prevent: the grace wait used to poll
+// the bare pid, so a daemon that exited and had its pid reused read as "still running"
+// and the takeover escalated SIGKILL onto whatever now held that number.
+test('stopProcessForTakeover does not SIGKILL a pid recycled during the grace wait', async () => {
+  onSignal = (signal) => {
+    if (signal === 'SIGTERM') state.starts.set(PID, RECYCLED);
+  };
+  await stopProcessForTakeover(PID, {
+    termTimeoutMs: TIMEOUT_MS,
+    killTimeoutMs: 40,
+    expectedStartTime: OURS,
+  });
+  expect(signals).toEqual(['SIGTERM']);
+});
+
+test('stopProcessForTakeover still escalates to SIGKILL for a daemon that survives SIGTERM', async () => {
+  onSignal = (signal) => {
+    if (signal === 'SIGKILL') state.alive.set(PID, false);
+  };
+  await stopProcessForTakeover(PID, {
+    termTimeoutMs: 40,
+    killTimeoutMs: 40,
+    expectedStartTime: OURS,
+  });
+  expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+});

--- a/src/daemon/__tests__/daemon-exit-wait.test.ts
+++ b/src/daemon/__tests__/daemon-exit-wait.test.ts
@@ -5,14 +5,9 @@ const DAEMON_COMMAND = '/opt/checkout/dist/src/internal/daemon.js';
 const OURS = 'Mon Aug 24 10:00:00 2026';
 const RECYCLED = 'Mon Aug 24 10:00:07 2026';
 const PID = 4242;
-// Small enough that a regression that waits the budget out still lands inside the
-// unit lane's wall-clock gate and fails on its assertion rather than on the clock.
 const TIMEOUT_MS = 1_000;
 const POLL_MS = 5;
 
-// A live process cannot be made to change identity mid-wait, so the host reads are
-// mocked: a recycled pid is the same live pid reporting a different start time,
-// which is what the host presents after reuse.
 const state = vi.hoisted(() => ({
   alive: new Map<number, boolean>(),
   starts: new Map<number, string>(),
@@ -36,7 +31,6 @@ vi.mock('../../utils/host-process.ts', async (importOriginal) => ({
   },
 }));
 
-/** Delivered signals only; a `0` probe is a liveness read, not a write. */
 const signals: NodeJS.Signals[] = [];
 let onSignal: (signal: NodeJS.Signals) => void = () => {};
 
@@ -81,10 +75,6 @@ test('waitForDaemonExit reports a daemon that keeps its identity as not exited',
   expect(wait.exited).toBe(false);
 });
 
-// A daemon killed by its own parent lingers as a zombie: kill(pid, 0) still succeeds
-// and the start time still matches, while ps reports the command as `<defunct>`.
-// Reading that as a recycled pid would hand the number back to callers while it is
-// still taken, so it must count as neither ending until the reap lands.
 test('waitForDaemonExit keeps waiting through a zombie until the pid is reaped', async () => {
   state.states.set(PID, 'Z+');
   state.commands.set(PID, '<defunct>');
@@ -102,9 +92,6 @@ test('waitForDaemonExit keeps waiting through a zombie until the pid is reaped',
   expect(reaped.exited).toBe(true);
 });
 
-// Planted red for the defect this pair exists to prevent: the grace wait used to poll
-// the bare pid, so a daemon that exited and had its pid reused read as "still running"
-// and the takeover escalated SIGKILL onto whatever now held that number.
 test('stopProcessForTakeover does not SIGKILL a pid recycled during the grace wait', async () => {
   onSignal = (signal) => {
     if (signal === 'SIGTERM') state.starts.set(PID, RECYCLED);

--- a/src/daemon/__tests__/daemon-stop.test.ts
+++ b/src/daemon/__tests__/daemon-stop.test.ts
@@ -8,16 +8,16 @@ const mocks = vi.hoisted(() => ({
   isProcessAlive: vi.fn(),
   sleep: vi.fn(async () => undefined),
   trySignalProcess: vi.fn(),
-  waitForProcessExit: vi.fn(),
+  waitForDaemonExit: vi.fn(),
 }));
 
 vi.mock('../daemon-process.ts', () => ({
   isAgentDeviceDaemonProcess: mocks.isAgentDeviceDaemonProcess,
   trySignalProcess: mocks.trySignalProcess,
+  waitForDaemonExit: mocks.waitForDaemonExit,
 }));
 vi.mock('../../utils/host-process.ts', () => ({
   isProcessAlive: mocks.isProcessAlive,
-  waitForProcessExit: mocks.waitForProcessExit,
 }));
 vi.mock('../../utils/timeouts.ts', () => ({ sleep: mocks.sleep }));
 
@@ -102,9 +102,9 @@ test('reports graceful cleanup after SIGTERM exits the verified daemon', async (
   const paths = createDaemonPaths();
   mocks.isAgentDeviceDaemonProcess.mockReturnValue(true);
   mocks.trySignalProcess.mockReturnValue(true);
-  mocks.waitForProcessExit.mockImplementation(async () => {
+  mocks.waitForDaemonExit.mockImplementation(async () => {
     fs.rmSync(paths.infoPath, { force: true });
-    return true;
+    return { exited: true, elapsedMs: 0 };
   });
 
   try {
@@ -125,7 +125,9 @@ test('re-verifies identity before SIGKILL and reports forced cleanup as unknown'
   const paths = createDaemonPaths();
   mocks.isAgentDeviceDaemonProcess.mockReturnValue(true);
   mocks.trySignalProcess.mockReturnValue(true);
-  mocks.waitForProcessExit.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+  mocks.waitForDaemonExit
+    .mockResolvedValueOnce({ exited: false, elapsedMs: 0 })
+    .mockResolvedValueOnce({ exited: true, elapsedMs: 0 });
 
   try {
     const result = await stopDaemon({ paths });
@@ -146,7 +148,9 @@ test('does not send SIGKILL if the daemon identity changes during the graceful w
   const paths = createDaemonPaths();
   mocks.isAgentDeviceDaemonProcess.mockReturnValueOnce(true).mockReturnValueOnce(false);
   mocks.trySignalProcess.mockReturnValue(true);
-  mocks.waitForProcessExit.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+  mocks.waitForDaemonExit
+    .mockResolvedValueOnce({ exited: false, elapsedMs: 0 })
+    .mockResolvedValueOnce({ exited: true, elapsedMs: 0 });
 
   try {
     await stopDaemon({ paths });

--- a/src/daemon/daemon-process.ts
+++ b/src/daemon/daemon-process.ts
@@ -1,9 +1,10 @@
 import {
   isProcessAlive,
+  readHostProcessIdentityObservations,
   readProcessCommand,
   readProcessStartTime,
-  waitForProcessExit,
 } from '../utils/host-process.ts';
+import { sleep } from '../utils/timeouts.ts';
 
 const DAEMON_COMMAND_PATTERNS = [
   /\/dist\/src\/daemon\.js($|[\s"'])/,
@@ -48,6 +49,87 @@ export function trySignalProcess(pid: number, signal: NodeJS.Signals): boolean {
   }
 }
 
+/** A daemon pinned to one process lifetime, never a bare pid. */
+export type DaemonProcessIdentity = {
+  pid: number;
+  startTime: string;
+};
+
+export type DaemonExitWait = {
+  /** The pid no longer belongs to the identity: it exited, or the host recycled it. */
+  exited: boolean;
+  elapsedMs: number;
+};
+
+/**
+ * Poll for {@link waitForDaemonExit}. {@link classifyDaemonPid} reads `ps` only
+ * once the cheap liveness check says the pid is still taken, so a daemon that has
+ * already gone costs no subprocess at all.
+ */
+const DAEMON_EXIT_POLL_MS = 100;
+
+/**
+ * What a pid is doing relative to the identity that claimed it. `exiting` is the
+ * state a bare liveness read cannot express: `kill(pid, 0)` still succeeds for a
+ * process that has died but has not been reaped yet, while `ps` has already
+ * dropped its row — a pid on its way out, not a pid handed to somebody else.
+ */
+type DaemonPidState = 'ours' | 'exiting' | 'released' | 'recycled';
+
+function classifyDaemonPid(identity: DaemonProcessIdentity): DaemonPidState {
+  if (!isProcessAlive(identity.pid)) return 'released';
+  // State and start time in one `ps` read. A process that has died but has not
+  // been reaped answers kill(pid, 0) AND still reports its original start time,
+  // so the state is the only field that separates it from one still running —
+  // and its command reads `<defunct>`, which would otherwise look like a pid
+  // handed to a different program.
+  const observed = readHostProcessIdentityObservations([identity.pid]).get(identity.pid);
+  if (!observed || observed.state.startsWith('Z')) return 'exiting';
+  if (observed.startTime !== identity.startTime) return 'recycled';
+  const command = readProcessCommand(identity.pid);
+  if (!command) return 'exiting';
+  return isAgentDeviceDaemonCommand(command) ? 'ours' : 'recycled';
+}
+
+/**
+ * Waits for a daemon identity to leave the host. Two endings count as exited: the
+ * pid was released, or the host handed it to someone else. Recycling is the one a
+ * bare liveness wait gets wrong — it reports a stranger's pid as "still running",
+ * which is what lets a grace wait escalate a SIGKILL onto an unrelated process —
+ * so escalating callers must branch on this result, never on bare liveness. A pid
+ * still being torn down is neither ending, so the wait keeps polling and callers
+ * retain the old guarantee that the number is free before they act on it.
+ */
+export async function waitForDaemonExit(
+  identity: DaemonProcessIdentity,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<DaemonExitWait> {
+  const startedAt = Date.now();
+  const deadline = startedAt + options.timeoutMs;
+  const pollMs = options.pollMs ?? DAEMON_EXIT_POLL_MS;
+  const hasExited = (): boolean => {
+    const state = classifyDaemonPid(identity);
+    return state === 'released' || state === 'recycled';
+  };
+  let exited = hasExited();
+  while (!exited && Date.now() < deadline) {
+    await sleep(pollMs);
+    exited = hasExited();
+  }
+  return { exited, elapsedMs: Date.now() - startedAt };
+}
+
+/**
+ * The only way this module signals a daemon: identity is re-read immediately
+ * before the write, so a pid recycled since the last observation cannot be
+ * signaled at all. Escalation safety is then a property of the call, not a rule
+ * each call site has to remember.
+ */
+function signalDaemonIdentity(identity: DaemonProcessIdentity, signal: NodeJS.Signals): boolean {
+  if (!isAgentDeviceDaemonProcess(identity.pid, identity.startTime)) return false;
+  return trySignalProcess(identity.pid, signal);
+}
+
 export async function stopProcessForTakeover(
   pid: number,
   options: {
@@ -56,9 +138,10 @@ export async function stopProcessForTakeover(
     expectedStartTime: string | undefined;
   },
 ): Promise<void> {
-  if (!isAgentDeviceDaemonProcess(pid, options.expectedStartTime)) return;
-  if (!trySignalProcess(pid, 'SIGTERM')) return;
-  if (await waitForProcessExit(pid, options.termTimeoutMs)) return;
-  if (!trySignalProcess(pid, 'SIGKILL')) return;
-  await waitForProcessExit(pid, options.killTimeoutMs);
+  if (!options.expectedStartTime) return;
+  const identity: DaemonProcessIdentity = { pid, startTime: options.expectedStartTime };
+  if (!signalDaemonIdentity(identity, 'SIGTERM')) return;
+  if ((await waitForDaemonExit(identity, { timeoutMs: options.termTimeoutMs })).exited) return;
+  if (!signalDaemonIdentity(identity, 'SIGKILL')) return;
+  await waitForDaemonExit(identity, { timeoutMs: options.killTimeoutMs });
 }

--- a/src/daemon/daemon-process.ts
+++ b/src/daemon/daemon-process.ts
@@ -56,33 +56,19 @@ export type DaemonProcessIdentity = {
 };
 
 export type DaemonExitWait = {
-  /** The pid no longer belongs to the identity: it exited, or the host recycled it. */
+  /** The pid was released, or the host handed it to a different process. */
   exited: boolean;
   elapsedMs: number;
 };
 
-/**
- * Poll for {@link waitForDaemonExit}. {@link classifyDaemonPid} reads `ps` only
- * once the cheap liveness check says the pid is still taken, so a daemon that has
- * already gone costs no subprocess at all.
- */
 const DAEMON_EXIT_POLL_MS = 100;
 
-/**
- * What a pid is doing relative to the identity that claimed it. `exiting` is the
- * state a bare liveness read cannot express: `kill(pid, 0)` still succeeds for a
- * process that has died but has not been reaped yet, while `ps` has already
- * dropped its row — a pid on its way out, not a pid handed to somebody else.
- */
 type DaemonPidState = 'ours' | 'exiting' | 'released' | 'recycled';
 
 function classifyDaemonPid(identity: DaemonProcessIdentity): DaemonPidState {
   if (!isProcessAlive(identity.pid)) return 'released';
-  // State and start time in one `ps` read. A process that has died but has not
-  // been reaped answers kill(pid, 0) AND still reports its original start time,
-  // so the state is the only field that separates it from one still running —
-  // and its command reads `<defunct>`, which would otherwise look like a pid
-  // handed to a different program.
+  // A terminated pid awaiting reap answers kill(pid, 0), keeps its start time, and
+  // reports its command as `<defunct>`; only the process state distinguishes it.
   const observed = readHostProcessIdentityObservations([identity.pid]).get(identity.pid);
   if (!observed || observed.state.startsWith('Z')) return 'exiting';
   if (observed.startTime !== identity.startTime) return 'recycled';
@@ -92,13 +78,8 @@ function classifyDaemonPid(identity: DaemonProcessIdentity): DaemonPidState {
 }
 
 /**
- * Waits for a daemon identity to leave the host. Two endings count as exited: the
- * pid was released, or the host handed it to someone else. Recycling is the one a
- * bare liveness wait gets wrong — it reports a stranger's pid as "still running",
- * which is what lets a grace wait escalate a SIGKILL onto an unrelated process —
- * so escalating callers must branch on this result, never on bare liveness. A pid
- * still being torn down is neither ending, so the wait keeps polling and callers
- * retain the old guarantee that the number is free before they act on it.
+ * Resolves once `identity` has left the host — released or recycled. A pid still
+ * being torn down is neither, so the wait continues until the number is free.
  */
 export async function waitForDaemonExit(
   identity: DaemonProcessIdentity,
@@ -119,12 +100,6 @@ export async function waitForDaemonExit(
   return { exited, elapsedMs: Date.now() - startedAt };
 }
 
-/**
- * The only way this module signals a daemon: identity is re-read immediately
- * before the write, so a pid recycled since the last observation cannot be
- * signaled at all. Escalation safety is then a property of the call, not a rule
- * each call site has to remember.
- */
 function signalDaemonIdentity(identity: DaemonProcessIdentity, signal: NodeJS.Signals): boolean {
   if (!isAgentDeviceDaemonProcess(identity.pid, identity.startTime)) return false;
   return trySignalProcess(identity.pid, signal);

--- a/src/daemon/daemon-stop.ts
+++ b/src/daemon/daemon-stop.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import { AppError } from '@agent-device/kernel/errors';
-import { isAgentDeviceDaemonProcess, trySignalProcess } from './daemon-process.ts';
-import { isProcessAlive, waitForProcessExit } from '../utils/host-process.ts';
+import {
+  isAgentDeviceDaemonProcess,
+  trySignalProcess,
+  waitForDaemonExit,
+  type DaemonProcessIdentity,
+} from './daemon-process.ts';
+import { isProcessAlive } from '../utils/host-process.ts';
 import { sleep } from '../utils/timeouts.ts';
 import type { DaemonPaths } from './config.ts';
 import { readRegisteredDaemonIdentity } from './daemon-registration.ts';
@@ -56,11 +61,11 @@ export async function stopDaemon(params: {
     );
   }
 
+  const identity: DaemonProcessIdentity = { pid: info.pid, startTime: info.startTime };
   if (!signalDaemonProcess(info.pid, 'SIGTERM')) return notRunningResult();
-  const graceful = await waitForProcessExit(
-    info.pid,
-    params.graceTimeoutMs ?? DAEMON_STOP_GRACE_TIMEOUT_MS,
-  );
+  const { exited: graceful } = await waitForDaemonExit(identity, {
+    timeoutMs: params.graceTimeoutMs ?? DAEMON_STOP_GRACE_TIMEOUT_MS,
+  });
   if (graceful) {
     await waitForDaemonMetadataRemoval(params.paths, DAEMON_STOP_METADATA_WAIT_MS);
     return {
@@ -80,10 +85,9 @@ export async function stopDaemon(params: {
   if (isAgentDeviceDaemonProcess(info.pid, info.startTime)) {
     signalDaemonProcess(info.pid, 'SIGKILL');
   }
-  const stopped = await waitForProcessExit(
-    info.pid,
-    params.killTimeoutMs ?? DAEMON_STOP_KILL_TIMEOUT_MS,
-  );
+  const { exited: stopped } = await waitForDaemonExit(identity, {
+    timeoutMs: params.killTimeoutMs ?? DAEMON_STOP_KILL_TIMEOUT_MS,
+  });
   if (!stopped) {
     throw new AppError('COMMAND_FAILED', 'Daemon did not exit after SIGKILL.', { pid: info.pid });
   }

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -193,10 +193,6 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
     // orchestrator shutting the container down would, rather than going through `close`.
     process.kill(daemonPid, 'SIGTERM');
 
-    // The fleet dying and the daemon exiting are unordered — the daemon awaits the
-    // `agent-browser close` CLI's return, not the disappearance of the pids it reaps — so each
-    // settles on its own deadline from this SIGTERM and neither waits the other out. That the
-    // fleet closed BECAUSE the daemon closed it is held by WEB_SHUTDOWN_IDLE_TIMEOUT_MS above.
     const [after, daemonExit] = await Promise.all([
       settleManagedBrowserProcesses(status),
       waitForDaemonExit(daemonIdentity, {

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -18,8 +18,9 @@ import {
   type AgentBrowserToolStatus,
 } from '../../src/platforms/web/agent-browser-tool.ts';
 import {
-  isAgentDeviceDaemonProcess,
   stopProcessForTakeover,
+  waitForDaemonExit,
+  type DaemonProcessIdentity,
 } from '../../src/daemon/daemon-process.ts';
 import {
   expandProcessTree,
@@ -42,11 +43,6 @@ const WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS = 5_000;
 // this pass for the wrong reason. A pass can then only mean the daemon's shutdown teardown
 // actively closed the browser, not that agent-browser's own idle timer beat this test's own wait.
 const WEB_SHUTDOWN_IDLE_TIMEOUT_MS = WEB_SHUTDOWN_SETTLE_TIMEOUT_MS + 60_000;
-
-type WebShutdownDaemonIdentity = {
-  pid: number;
-  startTime: string;
-};
 
 test('web shutdown cleanup reaps the exact daemon that survived graceful shutdown', async (t) => {
   const root = mkdtempSync('/tmp/agent-device-web-shutdown-cleanup-');
@@ -171,7 +167,7 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
   // Cleanup authority lives entirely in `finally`, driven by these two, so a failed assertion
   // above (including the very failure this test exists to catch: processes still alive when the
   // fix regresses) can never leave a daemon or a Chrome fleet running on the host afterward.
-  let daemonIdentity: WebShutdownDaemonIdentity | undefined;
+  let daemonIdentity: DaemonProcessIdentity | undefined;
   let status: AgentBrowserToolStatus | undefined;
   try {
     await runStep(context, 'set up managed web backend', ['web', 'setup', '--json']);
@@ -197,18 +193,16 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
     // orchestrator shutting the container down would, rather than going through `close`.
     process.kill(daemonPid, 'SIGTERM');
 
-    // Two unordered endings, so each gets its own deadline from this SIGTERM rather than one
-    // waiting out the other. The daemon awaits the `agent-browser close` CLI's RETURN, never the
-    // disappearance of the Chrome pids that call reaps, and awaits it under a teardown-budget
-    // race it walks away from on expiry — so either can finish first, and both orders have been
-    // seen (macOS: fleet gone ~13s after the daemon; CI: daemon alive ~4.8s after the fleet).
-    // Settling only the fleet and then reading daemon liveness once, as this did, silently lent
-    // the daemon the fleet's deadline and failed whenever CI reaped Chrome first. The guarantee
-    // #1868 is about — the fleet closed BECAUSE the daemon closed it — is held by
-    // WEB_SHUTDOWN_IDLE_TIMEOUT_MS, not by any ordering between these two.
+    // The fleet dying and the daemon exiting are unordered — the daemon awaits the
+    // `agent-browser close` CLI's return, not the disappearance of the pids it reaps — so each
+    // settles on its own deadline from this SIGTERM and neither waits the other out. That the
+    // fleet closed BECAUSE the daemon closed it is held by WEB_SHUTDOWN_IDLE_TIMEOUT_MS above.
     const [after, daemonExit] = await Promise.all([
       settleManagedBrowserProcesses(status),
-      settleDaemonExit(daemonIdentity),
+      waitForDaemonExit(daemonIdentity, {
+        timeoutMs: WEB_SHUTDOWN_SETTLE_TIMEOUT_MS,
+        pollMs: WEB_SHUTDOWN_SETTLE_POLL_MS,
+      }),
     ]);
     assert.equal(
       after.count,
@@ -237,7 +231,7 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
 // alongside.
 async function cleanupWebShutdownSmoke(
   context: WebSmokeContext,
-  daemonIdentity: WebShutdownDaemonIdentity | undefined,
+  daemonIdentity: DaemonProcessIdentity | undefined,
   status: AgentBrowserToolStatus | undefined,
   timeouts = {
     termTimeoutMs: WEB_SHUTDOWN_CLEANUP_TIMEOUT_MS,
@@ -311,27 +305,6 @@ async function settleManagedBrowserProcesses(
     summary = await inspectManagedAgentBrowserProcesses(status);
   }
   return summary;
-}
-
-// The daemon-side sibling of settleManagedBrowserProcesses, on the same deadline and poll: 45s
-// clears the daemon's dominant term, the web session's 35s teardown budget
-// (WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS + DAEMON_SESSION_TEARDOWN_TIMEOUT_MS), spent before the
-// rest of its shutdown sequence even starts. Waits out the identity, not the bare pid: a pid the
-// host recycled inside that 45s window is a DIFFERENT process, and reading it as "the daemon is
-// still alive" would fail this lane for the one reason it is not allowed to — a false red. The
-// sibling test at the top of this file exists for that same hazard. Reports elapsed time so a
-// deadline failure says how long the daemon outlived its SIGTERM, not merely that it did.
-async function settleDaemonExit(
-  identity: WebShutdownDaemonIdentity,
-): Promise<{ exited: boolean; elapsedMs: number }> {
-  const start = Date.now();
-  const deadline = start + WEB_SHUTDOWN_SETTLE_TIMEOUT_MS;
-  let alive = isAgentDeviceDaemonProcess(identity.pid, identity.startTime);
-  while (alive && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, WEB_SHUTDOWN_SETTLE_POLL_MS));
-    alive = isAgentDeviceDaemonProcess(identity.pid, identity.startTime);
-  }
-  return { exited: !alive, elapsedMs: Date.now() - start };
 }
 
 function formatProcessSummary(summary: AgentBrowserProcessSummary): string {

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -17,7 +17,10 @@ import {
   getManagedAgentBrowserStatus,
   type AgentBrowserToolStatus,
 } from '../../src/platforms/web/agent-browser-tool.ts';
-import { stopProcessForTakeover } from '../../src/daemon/daemon-process.ts';
+import {
+  isAgentDeviceDaemonProcess,
+  stopProcessForTakeover,
+} from '../../src/daemon/daemon-process.ts';
 import {
   expandProcessTree,
   isProcessAlive,
@@ -194,16 +197,28 @@ async function runWebShutdownSmoke(context: WebSmokeContext): Promise<void> {
     // orchestrator shutting the container down would, rather than going through `close`.
     process.kill(daemonPid, 'SIGTERM');
 
-    const after = await settleManagedBrowserProcesses(status);
+    // Two unordered endings, so each gets its own deadline from this SIGTERM rather than one
+    // waiting out the other. The daemon awaits the `agent-browser close` CLI's RETURN, never the
+    // disappearance of the Chrome pids that call reaps, and awaits it under a teardown-budget
+    // race it walks away from on expiry — so either can finish first, and both orders have been
+    // seen (macOS: fleet gone ~13s after the daemon; CI: daemon alive ~4.8s after the fleet).
+    // Settling only the fleet and then reading daemon liveness once, as this did, silently lent
+    // the daemon the fleet's deadline and failed whenever CI reaped Chrome first. The guarantee
+    // #1868 is about — the fleet closed BECAUSE the daemon closed it — is held by
+    // WEB_SHUTDOWN_IDLE_TIMEOUT_MS, not by any ordering between these two.
+    const [after, daemonExit] = await Promise.all([
+      settleManagedBrowserProcesses(status),
+      settleDaemonExit(daemonIdentity),
+    ]);
     assert.equal(
       after.count,
       0,
       `expected zero owned Chrome processes after daemon shutdown, found: ${formatProcessSummary(after)}`,
     );
     assert.equal(
-      isProcessAlive(daemonPid),
-      false,
-      'expected the daemon process itself to have exited after SIGTERM',
+      daemonExit.exited,
+      true,
+      `expected the daemon process itself to have exited after SIGTERM, still alive ${daemonExit.elapsedMs}ms later`,
     );
 
     // #1781 B1: the daemon leak oracle this fix unblocks wiring to a web lane — no stray
@@ -296,6 +311,27 @@ async function settleManagedBrowserProcesses(
     summary = await inspectManagedAgentBrowserProcesses(status);
   }
   return summary;
+}
+
+// The daemon-side sibling of settleManagedBrowserProcesses, on the same deadline and poll: 45s
+// clears the daemon's dominant term, the web session's 35s teardown budget
+// (WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS + DAEMON_SESSION_TEARDOWN_TIMEOUT_MS), spent before the
+// rest of its shutdown sequence even starts. Waits out the identity, not the bare pid: a pid the
+// host recycled inside that 45s window is a DIFFERENT process, and reading it as "the daemon is
+// still alive" would fail this lane for the one reason it is not allowed to — a false red. The
+// sibling test at the top of this file exists for that same hazard. Reports elapsed time so a
+// deadline failure says how long the daemon outlived its SIGTERM, not merely that it did.
+async function settleDaemonExit(
+  identity: WebShutdownDaemonIdentity,
+): Promise<{ exited: boolean; elapsedMs: number }> {
+  const start = Date.now();
+  const deadline = start + WEB_SHUTDOWN_SETTLE_TIMEOUT_MS;
+  let alive = isAgentDeviceDaemonProcess(identity.pid, identity.startTime);
+  while (alive && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, WEB_SHUTDOWN_SETTLE_POLL_MS));
+    alive = isAgentDeviceDaemonProcess(identity.pid, identity.startTime);
+  }
+  return { exited: !alive, elapsedMs: Date.now() - start };
 }
 
 function formatProcessSummary(summary: AgentBrowserProcessSummary): string {


### PR DESCRIPTION
## What

The daemon-exit assertion in the #1868 web shutdown lane (`live web platform e2e daemon-shutdown browser cleanup`) was an **instantaneous** liveness read placed right after `settleManagedBrowserProcesses`:

```ts
const after = await settleManagedBrowserProcesses(status);   // polls, 45s deadline
assert.equal(after.count, 0, ...);
assert.equal(isProcessAlive(daemonPid), false, ...);         // no polling at all
```

It silently borrowed the Chrome fleet's poll deadline for a condition it never polled, and passed only while the fleet happened to outlast the daemon.

Both endings now settle concurrently from the same SIGTERM, each against its own deadline, with no ordering asserted between them.

## Why

Nothing enforces that order. The daemon awaits the `agent-browser close` CLI's **return**, never the disappearance of the Chrome pids that call reaps, and awaits it under a teardown-budget race (`WEB_BROWSER_SESSION_TEARDOWN_BUDGET_MS` + `DAEMON_SESSION_TEARDOWN_TIMEOUT_MS`) it walks away from on expiry. Either can finish first, and both orders have been observed:

- **macOS local:** fleet pids linger ~13s, daemon exits first — the race is hidden entirely.
- **CI:** fleet reaped in ~4.8s, daemon still alive → `expected the daemon process itself to have exited after SIGTERM`. Seen once on #2074; re-running the same job on the same commit passed.

The guarantee #1868 is actually about — the fleet closed *because the daemon closed it*, not because agent-browser's idle timer beat the test — is held by `WEB_SHUTDOWN_IDLE_TIMEOUT_MS`, not by any ordering between these two. So the ordering is asserted nowhere, on purpose, and the comment records why.

## Notes for the reviewer

**`settleDaemonExit` waits out the daemon's *identity*, not the bare pid.** A pid the host recycles inside the 45s window is a different process, and reading it as "the daemon is still alive" would fail this lane for the one reason it must not — a false red. It polls `isAgentDeviceDaemonProcess(pid, startTime)` (already exported; this file already imports from that module, and the sibling test at the top of the file exists for the same hazard). That also makes `WEB_SHUTDOWN_SETTLE_POLL_MS` the right interval, since the identity probe shells out to `ps` like the fleet sweep. No new constant, no new machinery, no new module edge — a structural sibling of `settleManagedBrowserProcesses` sharing both existing constants.

**No fixed sleep.** The 45s is a failure bound, not a wait; the happy path returns as soon as the daemon is gone. There is no event-based alternative: the daemon is not a child of the test process (the CLI spawns it detached and exits), Node exposes neither kqueue `NOTE_EXIT` nor `pidfd`, and every daemon artifact (lock file, `daemon.json`, shutdown report) is written *before* `exit()` — so watching one would prove the daemon *decided* to exit, which is the weaker proxy claim this bug came from in the first place.

**Residual limits, stated rather than hidden:** the 45s is derived from the daemon's 35s web-session teardown budget and must grow with it; a zombie daemon would still read as alive (documented at `src/utils/host-process.ts:64`), unreachable here because the reparented daemon is reaped by launchd/init.

## Verification — planted red, then green

Plant: `await sleep(N)` immediately before `exit()` in `src/daemon/server/daemon-runtime.ts` (reverted; not in this diff).

| Daemon | Assertion | Result |
| --- | --- | --- |
| `sleep(25s)` | old | ✖ fails at 18.2s — `expected the daemon process itself to have exited after SIGTERM`, the exact CI message |
| `sleep(25s)` | new | ✔ passes at 40.6s — waits it out instead of reading once |
| `sleep(120s)` | new | ✖ fails at the deadline — `still alive 45128ms later` |
| unmodified | new | ✔ ✔ 13.4s / 13.5s — unchanged from before the fix |

Run with `AGENT_DEVICE_WEB_E2E=1 pnpm test:smoke:web`. Healthy-path wall clock is unchanged because the two settles run concurrently. `pnpm lint` and `pnpm typecheck` both clean.

Test-only change; #2074 was not touched.