### PR TITLE
test: derive unavailable runtime fixtures

### DIFF
--- a/src/__tests__/test-utils/runtime-operation-facts.test.ts
+++ b/src/__tests__/test-utils/runtime-operation-facts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { localRuntimeOwner, providerRuntimeOwner } from '@agent-device/contracts/platform-runtime';
+import { IOS_SIMULATOR } from './device-fixtures.ts';
+import { createUnavailableRuntimeFactsForTest } from './runtime-operation-facts.ts';
+
+describe('createUnavailableRuntimeFactsForTest', () => {
+  it('derives the complete operation surface as unavailable', () => {
+    const facts = createUnavailableRuntimeFactsForTest(IOS_SIMULATOR, localRuntimeOwner('apple'));
+
+    expect(Object.values(facts.operations).every((fact) => !fact.available)).toBe(true);
+    expect(facts.operations).toMatchObject({
+      captureScreenshot: { available: false, reason: 'owner-capability-missing' },
+      typeText: { available: false, reason: 'owner-capability-missing' },
+      finalizeApplicationClose: { available: false, reason: 'owner-capability-missing' },
+    });
+    expect(facts.device.providerMode).toBe('local');
+  });
+
+  it('preserves an exact provider gap across every derived cell', () => {
+    const unsupportedProvider = {
+      available: false,
+      reason: 'unsupported-provider-mode',
+    } as const;
+    const facts = createUnavailableRuntimeFactsForTest(
+      IOS_SIMULATOR,
+      providerRuntimeOwner('test', 'fixtures'),
+      unsupportedProvider,
+    );
+
+    expect(
+      Object.values(facts.operations).every(
+        (fact) => !fact.available && fact.reason === 'unsupported-provider-mode',
+      ),
+    ).toBe(true);
+    expect(facts.device.providerMode).toBe('provider-runtime');
+  });
+});

--- a/src/__tests__/test-utils/runtime-operation-facts.ts
+++ b/src/__tests__/test-utils/runtime-operation-facts.ts
@@ -2,14 +2,19 @@ import { applicationLifecycleOperationFacts } from '@agent-device/contracts/appl
 import { audioProbeRuntimeOperationFacts } from '@agent-device/contracts/audio-probe-runtime';
 import { elementTextRuntimeOperationFacts } from '@agent-device/contracts/element-text-runtime';
 import { gestureRuntimeOperationFacts } from '@agent-device/contracts/gesture-runtime';
-import type { RuntimeOperationFact } from '@agent-device/contracts/platform-runtime';
+import type {
+  RuntimeOperationUnavailability,
+  RuntimeOwnerRef,
+} from '@agent-device/contracts/platform-runtime';
+import { createUnavailablePlatformRuntimeFacts } from '@agent-device/contracts/platform-runtime-unavailable';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { screenshotRuntimeOperationFacts } from '@agent-device/contracts/screenshot-runtime';
 import { scrollRuntimeOperationFacts } from '@agent-device/contracts/scroll-runtime';
 import { snapshotRuntimeOperationFacts } from '@agent-device/contracts/snapshot-runtime';
 import { touchRuntimeOperationFacts } from '@agent-device/contracts/touch-runtime';
 import { perfRuntimeOperationFacts } from '@agent-device/contracts/perf-runtime';
 
-const unavailable: RuntimeOperationFact = Object.freeze({
+const unavailable: RuntimeOperationUnavailability = Object.freeze({
   available: false,
   reason: 'owner-capability-missing',
 });
@@ -95,3 +100,57 @@ export const unavailableApplicationLifecycleOperationFacts = applicationLifecycl
   prepareAppleRunner: unavailable,
   configureProviderPortReverse: unavailable,
 });
+
+/**
+ * Complete fail-closed facts for tests that exercise only a small runtime surface.
+ *
+ * Production owners must classify each required family explicitly. Tests instead start from this
+ * single complete record and override only the cells whose behavior they are proving.
+ */
+export function createUnavailableRuntimeFactsForTest(
+  device: DeviceInfo,
+  owner: RuntimeOwnerRef,
+  fact: RuntimeOperationUnavailability = unavailable,
+) {
+  return createUnavailablePlatformRuntimeFacts(device, owner, {
+    appLog: fact,
+    network: fact,
+    screenshot: fact,
+    viewport: fact,
+    focus: fact,
+    gesture: fact,
+    scroll: fact,
+    typeText: fact,
+    touch: fact,
+    elementText: fact,
+    back: fact,
+    home: fact,
+    orientation: fact,
+    tvRemote: fact,
+    keyboardStatus: fact,
+    keyboardDismiss: fact,
+    keyboardEnter: fact,
+    readClipboard: fact,
+    writeClipboard: fact,
+    appSwitcher: fact,
+    triggerAppEvent: fact,
+    setSetting: fact,
+    readAlert: fact,
+    awaitAlert: fact,
+    acceptAlert: fact,
+    dismissAlert: fact,
+    audioProbeCapture: fact,
+    audioProbeQuery: fact,
+    lifecycle: applicationLifecycleOperationFacts({
+      resolveOpenTarget: fact,
+      prepareApplicationOpen: fact,
+      openApplication: fact,
+      applyRuntimeHints: fact,
+      clearRuntimeHints: fact,
+      closeApplication: fact,
+      finalizeApplicationClose: fact,
+      prepareAppleRunner: fact,
+      configureProviderPortReverse: fact,
+    }),
+  });
+}

--- a/src/daemon/__tests__/test-device-runtime-gateway.ts
+++ b/src/daemon/__tests__/test-device-runtime-gateway.ts
@@ -19,7 +19,7 @@ import {
 import type { BindDeviceRuntime, BindExactDeviceRuntime } from '../request-runtime-binding.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { applicationLifecycleRuntimeFixture } from './application-lifecycle-runtime-fixture.ts';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../__tests__/test-utils/runtime-operation-facts.ts';
+import { createUnavailableRuntimeFactsForTest } from '../../__tests__/test-utils/runtime-operation-facts.ts';
 import { withClientReplayScriptSources } from '../../__tests__/test-utils/replay-script-source.ts';
 import type { DaemonInvokeFn } from '../types.ts';
 import { clearAndroidObservationFixture } from './android-observation-fixture.ts';
@@ -47,36 +47,14 @@ function lifecycleFactsForTest(device: DeviceInfo): ApplicationLifecycleOperatio
 
 async function lifecycleBindingForTest(device: DeviceInfo) {
   const lifecycleFacts = lifecycleFactsForTest(device);
+  const base = createUnavailableRuntimeFactsForTest(device, localRuntimeOwner(device.platform));
   return {
     device,
     owner: localRuntimeOwner(device.platform),
     facts: {
-      device: {
-        family: device.platform,
-        kind: device.kind,
-        providerMode: 'local' as const,
-        ...(device.appleOs === undefined ? {} : { appleOs: device.appleOs }),
-        ...(device.target === undefined ? {} : { target: device.target }),
-        ...(device.iosPhysicalDeviceBackend === undefined
-          ? {}
-          : { iosPhysicalDeviceBackend: device.iosPhysicalDeviceBackend }),
-      },
+      device: base.device,
       operations: {
-        ...unavailableDeploymentSnapshotAndShutdownOperationFacts,
-        appLogInspect: unavailable,
-        appLogDoctor: unavailable,
-        appLogStart: unavailable,
-        appLogReattach: unavailable,
-        appLogCleanup: unavailable,
-        appState: unavailable,
-        networkDump: unavailable,
-        screenRecordingStart: unavailable,
-        screenRecordingReattach: unavailable,
-        screenRecordingCleanup: unavailable,
-        ensureReady: unavailable,
-        bootTarget: unavailable,
-        bootTargetHeadless: unavailable,
-        listApps: unavailable,
+        ...base.operations,
         ...lifecycleFacts,
         ...admittedGestureFamilyFacts,
         ...admittedSystemFamilyFacts,
@@ -109,52 +87,16 @@ export const lifecycleDeviceRuntimeGateway: DeviceRuntimeGateway<PlatformRuntime
 export const unavailableDeviceRuntimeGateway: DeviceRuntimeGateway<PlatformRuntimeOperations> =
   Object.freeze({
     inspectFacts: async (device) => (await unavailableBinding(device)).facts,
-    bind: async ({ device }) => ({
-      device,
-      owner: localRuntimeOwner(device.platform),
-      facts: {
-        device: {
-          family: device.platform,
-          kind: device.kind,
-          providerMode: 'local',
-          ...(device.appleOs === undefined ? {} : { appleOs: device.appleOs }),
-          ...(device.target === undefined ? {} : { target: device.target }),
-          ...(device.iosPhysicalDeviceBackend === undefined
-            ? {}
-            : { iosPhysicalDeviceBackend: device.iosPhysicalDeviceBackend }),
-        },
-        operations: {
-          ...unavailableDeploymentSnapshotAndShutdownOperationFacts,
-          appLogInspect: unavailable,
-          appLogDoctor: unavailable,
-          appLogStart: unavailable,
-          appLogReattach: unavailable,
-          appLogCleanup: unavailable,
-          appState: unavailable,
-          networkDump: unavailable,
-          screenRecordingStart: unavailable,
-          screenRecordingReattach: unavailable,
-          screenRecordingCleanup: unavailable,
-          ensureReady: unavailable,
-          bootTarget: unavailable,
-          bootTargetHeadless: unavailable,
-          listApps: unavailable,
-          ...applicationLifecycleOperationFacts({
-            resolveOpenTarget: unavailable,
-            prepareApplicationOpen: unavailable,
-            openApplication: unavailable,
-            applyRuntimeHints: unavailable,
-            clearRuntimeHints: unavailable,
-            closeApplication: unavailable,
-            finalizeApplicationClose: unavailable,
-            prepareAppleRunner: unavailable,
-            configureProviderPortReverse: unavailable,
-          }),
-        },
-      },
-      operations: {},
-      [Symbol.asyncDispose]: async () => {},
-    }),
+    bind: async ({ device }) => {
+      const owner = localRuntimeOwner(device.platform);
+      return {
+        device,
+        owner,
+        facts: createUnavailableRuntimeFactsForTest(device, owner),
+        operations: {},
+        [Symbol.asyncDispose]: async () => {},
+      };
+    },
     shutdown: async () => {},
   });
 

--- a/src/daemon/handlers/__tests__/interaction-get-runtime-fixture.ts
+++ b/src/daemon/handlers/__tests__/interaction-get-runtime-fixture.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
 import type { TypeTextBackendResult } from '@agent-device/contracts/interactor-types';
-import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import type {
   ElementTextReadOutcome,
   ReadTextAtPointInput,
@@ -13,7 +12,6 @@ import {
   narrowDeviceBinding,
 } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { createUnavailablePlatformRuntimeFacts } from '@agent-device/contracts/platform-runtime-unavailable';
 import type { CaptureSnapshotInput } from '@agent-device/contracts/snapshot-runtime';
 import type { TypeTextInput } from '@agent-device/contracts/type-text-runtime';
 import {
@@ -34,6 +32,7 @@ import type {
 } from '../../request-runtime-binding.ts';
 import { captureSnapshotWithInteractor } from '../snapshot-interactor-capture.ts';
 import { androidObservationFixture } from '../../__tests__/android-observation-fixture.ts';
+import { createUnavailableRuntimeFactsForTest } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
 
 /**
  * The request-bound runtime seam `get` consumes, faked at `inspectFacts` / `bindDevice` — never
@@ -154,47 +153,7 @@ const unavailable = Object.freeze({
 } as const);
 
 function elementReadFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperations> {
-  const base = createUnavailablePlatformRuntimeFacts(device, localRuntimeOwner('apple'), {
-    appLog: unavailable,
-    network: unavailable,
-    viewport: unavailable,
-    focus: unavailable,
-    gesture: unavailable,
-    scroll: unavailable,
-    typeText: unavailable,
-    touch: unavailable,
-    elementText: unavailable,
-    back: unavailable,
-    home: unavailable,
-    orientation: unavailable,
-    tvRemote: unavailable,
-    keyboardStatus: unavailable,
-    keyboardDismiss: unavailable,
-    keyboardEnter: unavailable,
-    readClipboard: unavailable,
-    writeClipboard: unavailable,
-    appSwitcher: unavailable,
-    triggerAppEvent: unavailable,
-    setSetting: unavailable,
-    readAlert: unavailable,
-    awaitAlert: unavailable,
-    acceptAlert: unavailable,
-    dismissAlert: unavailable,
-    screenshot: unavailable,
-    audioProbeCapture: unavailable,
-    audioProbeQuery: unavailable,
-    lifecycle: applicationLifecycleOperationFacts({
-      resolveOpenTarget: unavailable,
-      prepareApplicationOpen: unavailable,
-      openApplication: unavailable,
-      applyRuntimeHints: unavailable,
-      clearRuntimeHints: unavailable,
-      closeApplication: unavailable,
-      finalizeApplicationClose: unavailable,
-      prepareAppleRunner: unavailable,
-      configureProviderPortReverse: unavailable,
-    }),
-  });
+  const base = createUnavailableRuntimeFactsForTest(device, localRuntimeOwner('apple'));
   return Object.freeze({
     device: base.device,
     operations: {

--- a/src/daemon/handlers/__tests__/session-capabilities-install-projection.test.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities-install-projection.test.ts
@@ -107,6 +107,37 @@ test('capabilities fails closed for every fact-owned command when facts inspecti
   expect(runtime.uses).toEqual([]);
 });
 
+test('capabilities fixture preserves transport mode and owner-specific refusal reasons', async () => {
+  const device = makeAndroidSession('fixture-semantics').device;
+  const transport = createCapabilitiesAdmissionRuntime({
+    appLogAvailable: false,
+    networkAvailable: false,
+    providerMode: 'transport-composed',
+  });
+  const provider = createCapabilitiesAdmissionRuntime({
+    appLogAvailable: false,
+    networkAvailable: false,
+    providerMode: 'provider-runtime',
+  });
+
+  const transportFacts = await transport.inspectFacts(device);
+  const providerFacts = await provider.inspectFacts(device);
+
+  expect(transportFacts.device.providerMode).toBe('transport-composed');
+  expect(providerFacts.operations.networkDump).toMatchObject({
+    available: false,
+    reason: 'unsupported-provider-mode',
+  });
+  expect(providerFacts.operations.tapRef).toEqual({
+    available: false,
+    reason: 'owner-capability-missing',
+  });
+  expect(providerFacts.operations.finalizeApplicationClose).toEqual({
+    available: false,
+    reason: 'owner-capability-missing',
+  });
+});
+
 function createAndroidCapabilitiesSession(suffix: string) {
   const sessionName = `android-capabilities-${suffix}`;
   const sessionStore = makeSessionStore(`agent-device-capabilities-${suffix}-`);

--- a/src/daemon/handlers/__tests__/session-capabilities.fixtures.ts
+++ b/src/daemon/handlers/__tests__/session-capabilities.fixtures.ts
@@ -1,4 +1,4 @@
-import { deviceShape, type DeviceInfo } from '@agent-device/kernel/device';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import {
   type DeviceBinding,
   type RuntimeFacts,
@@ -7,19 +7,21 @@ import {
   narrowDeviceBinding,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
-import { audioProbeRuntimeOperationFacts } from '@agent-device/contracts/audio-probe-runtime';
-import { perfRuntimeOperationFacts } from '@agent-device/contracts/perf-runtime';
-import { gestureRuntimeOperationFacts } from '@agent-device/contracts/gesture-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { screenshotRuntimeOperationFacts } from '@agent-device/contracts/screenshot-runtime';
-import { scrollRuntimeOperationFacts } from '@agent-device/contracts/scroll-runtime';
-import { snapshotRuntimeOperationFacts } from '@agent-device/contracts/snapshot-runtime';
-import { touchRuntimeOperationFacts } from '@agent-device/contracts/touch-runtime';
+import { HOVER_UNAVAILABLE_HINT } from '@agent-device/contracts/touch-runtime';
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
 } from '../../request-runtime-binding.ts';
-import { unavailableApplicationLifecycleOperationFacts } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+import {
+  createUnavailableRuntimeFactsForTest,
+  unavailableApplicationLifecycleOperationFacts,
+} from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+
+const nativeRefUnavailable = Object.freeze({
+  available: false,
+  reason: 'owner-capability-missing',
+} as const);
 
 export type CapabilitiesAdmissionRuntimeOptions = Readonly<{
   appLogAvailable: boolean;
@@ -69,79 +71,29 @@ function createAdmissionFacts(
   const cell = (enabled: boolean | undefined) => (enabled ? available : unavailable);
   const appsFact = cell(options.appsAvailable);
   const screenshotFact = cell(options.screenshotAvailable !== false);
+  const base = createUnavailableRuntimeFactsForTest(
+    device,
+    runtimeOwnerFor(device, options.providerMode),
+    unavailable,
+  );
   return {
-    device: { ...deviceShape(device), providerMode: options.providerMode },
+    device: { ...base.device, providerMode: options.providerMode },
     operations: {
+      ...base.operations,
+      // Ref support is a native-owner capability, independent of provider transport support.
+      tapRef: nativeRefUnavailable,
+      hoverRef: Object.freeze({ ...nativeRefUnavailable, hint: HOVER_UNAVAILABLE_HINT }),
+      fillRef: nativeRefUnavailable,
+      // This fake historically keeps lifecycle ownership local and independently fail-closed.
       ...unavailableApplicationLifecycleOperationFacts,
       appLogInspect: cell(options.appLogAvailable),
-      appLogDoctor: unavailable,
-      appLogStart: unavailable,
-      appLogReattach: unavailable,
-      appLogCleanup: unavailable,
-      appState: unavailable,
-      ...snapshotRuntimeOperationFacts({
-        capture: unavailable,
-        customActions: unavailable,
-        withoutActiveApp: unavailable,
-      }),
-      ...screenshotRuntimeOperationFacts({ capture: screenshotFact }),
-      findText: unavailable,
-      findSelector: unavailable,
-      setViewport: unavailable,
-      focusPoint: unavailable,
-      typeText: unavailable,
-      back: unavailable,
-      home: unavailable,
-      setOrientation: unavailable,
-      tvRemote: unavailable,
-      keyboardStatus: unavailable,
-      keyboardDismiss: unavailable,
-      keyboardEnter: unavailable,
-      readClipboard: unavailable,
-      writeClipboard: unavailable,
-      appSwitcher: unavailable,
-      triggerAppEvent: unavailable,
-      setSetting: unavailable,
-      readAlert: unavailable,
-      awaitAlert: unavailable,
-      acceptAlert: unavailable,
-      dismissAlert: unavailable,
-      ...touchRuntimeOperationFacts({
-        tap: unavailable,
-        longPress: unavailable,
-        hover: unavailable,
-        fill: unavailable,
-        tapElementSelector: unavailable,
-      }),
-      ...gestureRuntimeOperationFacts({
-        plan: unavailable,
-        directionalFling: unavailable,
-        multiTouch: unavailable,
-        targetAuthoredDrag: unavailable,
-        viewport: unavailable,
-      }),
-      ...scrollRuntimeOperationFacts({ scroll: unavailable }),
+      captureScreenshot: screenshotFact,
       deployApp: cell(options.deployAvailable),
       materializeAppSource: cell(options.sourceAvailable),
       deployMaterializedApp: cell(options.sourceAvailable),
       sendPushNotification: cell(options.pushAvailable),
       networkDump: cell(options.networkAvailable),
-      readTextAtPoint: unavailable,
-      screenRecordingStart: unavailable,
-      screenRecordingReattach: unavailable,
-      screenRecordingCleanup: unavailable,
-      ...audioProbeRuntimeOperationFacts({ capture: unavailable, query: unavailable }),
-      ...perfRuntimeOperationFacts({
-        frames: unavailable,
-        memorySample: unavailable,
-        memorySnapshot: unavailable,
-        nativeCapture: unavailable,
-        profileReport: unavailable,
-      }),
       ensureReady: options.readinessAvailable ? available : appsFact,
-      bootTarget: unavailable,
-      bootTargetHeadless: unavailable,
-      shutdownTarget: unavailable,
       listApps: appsFact,
     },
   };
@@ -153,10 +105,7 @@ function createAdmissionBinding(
 ): DeviceBinding<PlatformRuntimeOperations> {
   return {
     device,
-    owner:
-      options.providerMode === 'provider-runtime'
-        ? providerRuntimeOwner('test', 'capabilities')
-        : localRuntimeOwner(device.platform),
+    owner: runtimeOwnerFor(device, options.providerMode),
     facts: createAdmissionFacts(device, options),
     operations: {
       ...(options.appLogAvailable ? { appLogInspect: inspectAndroidAppLog } : {}),
@@ -164,6 +113,12 @@ function createAdmissionBinding(
     },
     [Symbol.asyncDispose]: async () => {},
   };
+}
+
+function runtimeOwnerFor(device: DeviceInfo, providerMode: RuntimeProviderMode) {
+  return providerMode === 'provider-runtime'
+    ? providerRuntimeOwner('test', 'capabilities')
+    : localRuntimeOwner(device.platform);
 }
 
 function unavailableOperationFact(providerMode: RuntimeProviderMode) {

--- a/src/daemon/handlers/__tests__/session-command-harness.ts
+++ b/src/daemon/handlers/__tests__/session-command-harness.ts
@@ -20,18 +20,13 @@ import {
   localRuntimeOwner,
   narrowDeviceBinding,
 } from '@agent-device/contracts/platform-runtime';
-import { gestureRuntimeOperationFacts } from '@agent-device/contracts/gesture-runtime';
-import { perfRuntimeOperationFacts } from '@agent-device/contracts/perf-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { screenshotRuntimeOperationFacts } from '@agent-device/contracts/screenshot-runtime';
-import { scrollRuntimeOperationFacts } from '@agent-device/contracts/scroll-runtime';
-import { snapshotRuntimeOperationFacts } from '@agent-device/contracts/snapshot-runtime';
-import { touchRuntimeOperationFacts } from '@agent-device/contracts/touch-runtime';
 import type { TargetShutdownResult } from '@agent-device/contracts/device';
-import { deviceShape, isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
+import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { beforeEach, vi } from 'vitest';
 import { applicationLifecycleRuntimeFixture } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
 import { withClientReplayScriptSources } from '../../../__tests__/test-utils/replay-script-source.ts';
+import { createUnavailableRuntimeFactsForTest } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
 import { platformResourceCleanup } from '../../../platform-runtime-resource-cleanup.ts';
 
 const unavailable = Object.freeze({
@@ -132,85 +127,24 @@ function readinessFacts(device: DeviceInfo): RuntimeFacts<PlatformRuntimeOperati
   const headlessAvailable = device.platform === 'android' && device.kind === 'emulator';
   const shutdownAvailable = isShutdownDevice(device);
   const deployment = deploymentAvailability(device);
+  const base = createUnavailableRuntimeFactsForTest(device, localRuntimeOwner(device.platform));
   return {
-    device: { ...deviceShape(device), providerMode: 'local' },
+    device: base.device,
     operations: {
-      appLogInspect: unavailable,
-      appLogDoctor: unavailable,
-      appLogStart: unavailable,
-      appLogReattach: unavailable,
-      appLogCleanup: unavailable,
-      ...snapshotRuntimeOperationFacts({
-        capture: unavailable,
-        customActions: unavailable,
-        withoutActiveApp: unavailable,
-      }),
-      ...perfRuntimeOperationFacts({
-        frames: unavailable,
-        memorySample: unavailable,
-        memorySnapshot: unavailable,
-        nativeCapture: unavailable,
-        profileReport: unavailable,
-      }),
+      ...base.operations,
       // Mirrors the real owners: every kind this harness models except an Apple `simulator`-shaped
       // Android placeholder can capture pixels, and `capabilities` now reads this cell.
-      ...screenshotRuntimeOperationFacts({
-        capture: operationAvailability(device.kind !== 'simulator' || device.platform === 'apple'),
-      }),
-      findText: unavailable,
-      findSelector: unavailable,
-      setViewport: unavailable,
-      focusPoint: unavailable,
-      typeText: unavailable,
-      ...touchRuntimeOperationFacts({
-        tap: unavailable,
-        longPress: unavailable,
-        hover: unavailable,
-        fill: unavailable,
-        tapElementSelector: unavailable,
-      }),
-      ...gestureRuntimeOperationFacts({
-        plan: unavailable,
-        directionalFling: unavailable,
-        multiTouch: unavailable,
-        targetAuthoredDrag: unavailable,
-        viewport: unavailable,
-      }),
-      ...scrollRuntimeOperationFacts({ scroll: unavailable }),
-      readTextAtPoint: unavailable,
-      back: unavailable,
-      home: unavailable,
-      setOrientation: unavailable,
-      tvRemote: unavailable,
-      keyboardStatus: unavailable,
-      keyboardDismiss: unavailable,
-      keyboardEnter: unavailable,
-      readClipboard: unavailable,
-      writeClipboard: unavailable,
-      appSwitcher: unavailable,
-      triggerAppEvent: unavailable,
-      setSetting: unavailable,
-      readAlert: unavailable,
-      awaitAlert: unavailable,
-      acceptAlert: unavailable,
-      dismissAlert: unavailable,
-      audioProbeStart: unavailable,
-      audioProbeReattach: unavailable,
-      audioProbeCleanup: unavailable,
-      audioProbeQuery: unavailable,
+      captureScreenshot: operationAvailability(
+        device.kind !== 'simulator' || device.platform === 'apple',
+      ),
       deployApp: operationAvailability(deployment.deploy),
       materializeAppSource: operationAvailability(deployment.source),
       deployMaterializedApp: operationAvailability(deployment.source),
       sendPushNotification: operationAvailability(deployment.push),
       appState: operationAvailability(device.platform === 'android'),
-      networkDump: unavailable,
-      screenRecordingStart: unavailable,
-      screenRecordingReattach: unavailable,
-      screenRecordingCleanup: unavailable,
       ensureReady: operationAvailability(device.appleOs !== 'watchos'),
       bootTarget: operationAvailability(normalAvailable),
       bootTargetHeadless: operationAvailability(headlessAvailable),
-      listApps: unavailable,
       shutdownTarget: shutdownAvailable ? available : unavailable,
       ...applicationLifecycleOperationFacts({
         resolveOpenTarget: available,


### PR DESCRIPTION
## Summary

Derive complete fail-closed runtime facts for tests through one fixture interface instead of restating the operation surface in four daemon harnesses.

- keep each harness's behavior-specific available operations and spies independent
- preserve transport-composed projection plus provider-specific ref and lifecycle refusal reasons
- make future runtime-operation additions flow into unrelated tests by construction

Stacked on #2081. This PR contains 7 files and stays within test fixtures and tests.

## Validation

- `pnpm check:affected --run`
- `pnpm test:coverage -- --runInBand` (1,171 files, 8,731 tests; 88.6% statements, 80.63% branches, 91.68% functions, 90.58% lines)
- Luna-max adversarial review found and regression-pinned transport mode, native-ref reason, and lifecycle-reason drift
