### PR TITLE
fix(ios): retry fill's synthesized replacement once when the value never arrives

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedTextEntry.swift
@@ -103,41 +103,63 @@ extension RunnerTests {
       text: request.text,
       delaySeconds: request.delaySeconds
     )
-    for (index, step) in steps.enumerated() {
-      switch request.synthesizer.enterText(
-        app: request.app,
-        text: step.text,
-        replacingExistingText: step.replacesExistingText
-      ) {
-      case .fallback:
-        NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=verified-fallback reason=synthesis-unavailable")
-        guard let point = request.target.refreshPoint else { return .notApplicable }
-        return .fallback(
-          focusTextInputForTextEntry(app: request.app, x: point.x, y: point.y)
-        )
-      case .raise(let message):
-        NSException(
-          name: NSExceptionName.internalInconsistencyException,
-          reason: message ?? "private XCTest text synthesis failed"
-        ).raise()
-      case .continueTyping:
-        break
+
+    /// Posts the whole replacement once. Returns the route outcome when it could not post at all;
+    /// nil means the events went out and the caller should wait for them.
+    func post() -> SynthesizedReplacementRouteOutcome? {
+      for (index, step) in steps.enumerated() {
+        switch request.synthesizer.enterText(
+          app: request.app,
+          text: step.text,
+          replacingExistingText: step.replacesExistingText
+        ) {
+        case .fallback:
+          NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=verified-fallback reason=synthesis-unavailable")
+          guard let point = request.target.refreshPoint else { return .notApplicable }
+          return .fallback(
+            focusTextInputForTextEntry(app: request.app, x: point.x, y: point.y)
+          )
+        case .raise(let message):
+          NSException(
+            name: NSExceptionName.internalInconsistencyException,
+            reason: message ?? "private XCTest text synthesis failed"
+          ).raise()
+        case .continueTyping:
+          break
+        }
+        if index + 1 < steps.count {
+          sleepFor(request.delaySeconds)
+        }
       }
-      if index + 1 < steps.count {
-        sleepFor(request.delaySeconds)
-      }
+      return nil
     }
+
+    if let blocked = post() { return blocked }
     // The private synthesize call returns at post time, not commit time (same as bare `type`,
     // see awaitSynthesizedFirstResponderCommit) — but this route never resolves an XCUIElement,
     // so without this wait it had no way to notice a dropped or still-in-flight character at all
     // and reported ok purely because the event posted. Wait here, on the same request.target
     // (element nil, refreshPoint set) that gated this route, so each poll re-resolves via the
     // refresh point rather than trusting a stale element handle.
-    let commit = awaitSynthesizedReplacementCommit(
+    var commit = awaitSynthesizedReplacementCommit(
       app: request.app,
       target: request.target,
       expectedText: request.text
     )
+    // Re-post once when the value never arrived. Safe here and nowhere else: this route opens with
+    // select-all, so posting it again replaces the whole field rather than appending to whatever
+    // committed — the double-commit hazard that made #1676 refuse a retry for bare `type` does not
+    // exist. #2080 is the case it exists for: 11 characters posted, 7 observed, frozen for four
+    // polls, which is loss rather than lateness, and the wait has no other move.
+    if commit == .notObserved {
+      NSLog("AGENT_DEVICE_RUNNER_TEXT_ENTRY_ROUTE route=synthesized-first-responder-replacement-retry")
+      if let blocked = post() { return blocked }
+      commit = awaitSynthesizedReplacementCommit(
+        app: request.app,
+        target: request.target,
+        expectedText: request.text
+      )
+    }
     logTextEntryPhase(
       commandId: request.commandId,
       phase: "total",

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+TextEntryPolicyTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+TextEntryPolicyTests.swift
@@ -417,14 +417,17 @@ extension RunnerTests {
       synthesizer: synthesizer
     )
 
-    XCTAssertEqual(
-      synthesizer.steps,
-      [
-        SynthesizedReplacementStep(text: "a", replacesExistingText: true),
-        SynthesizedReplacementStep(text: "b", replacesExistingText: false),
-        SynthesizedReplacementStep(text: "c", replacesExistingText: false),
-      ]
-    )
+    // Posted twice: the fake synthesizer never writes into Springboard, so the wait cannot observe
+    // the value and the route re-posts once (#2080). That retry is safe on this route and nowhere
+    // else — it opens with select-all, so a second post replaces the field rather than appending to
+    // whatever committed, which is the double-commit hazard #1676 refused a retry for on bare
+    // `type`. Each attempt selects once and paces the rest, which is the pacing this pins.
+    let attempt = [
+      SynthesizedReplacementStep(text: "a", replacesExistingText: true),
+      SynthesizedReplacementStep(text: "b", replacesExistingText: false),
+      SynthesizedReplacementStep(text: "c", replacesExistingText: false),
+    ]
+    XCTAssertEqual(synthesizer.steps, attempt + attempt)
     XCTAssertNil(result.verified)
     XCTAssertFalse(result.repaired)
     XCTAssertEqual(result.textEntryRoute, "synthesized-first-responder-replacement")
@@ -441,7 +444,7 @@ extension RunnerTests {
     // `runner-xctest-local-run-gotchas` memory / ios.yml's `-only-testing:` allowlist), where a
     // few extra seconds is a non-issue, and the alternative — asserting `nil` on a wiring path
     // that can never actually observe the expected text — would silently reintroduce the exact
-    // bug this fix closes.
+    // bug this fix closes. Two deadlines now rather than one, since the retry waits again.
     XCTAssertEqual(result.failure, .commitNotObserved)
   }
 


### PR DESCRIPTION
Closes #2080.

## What happens today

`fill id="field-email" ada@example` posts 11 characters. The field settles at **7**, sharing one character with the request, and stays there:

```
route=synthesized-first-responder-replacement
[DEBUG-1874] synthesize posted 11 chars status=0 tookMs=1084
[DEBUG-1874] poll t=1102ms observedLen=7 expectedPrefixLen=1
[DEBUG-1874] poll t=2395ms observedLen=7 expectedPrefixLen=1
[DEBUG-1874] poll t=3717ms observedLen=7 expectedPrefixLen=1
[DEBUG-1874] poll t=5097ms observedLen=7 expectedPrefixLen=1
[DEBUG-1874] wait outcome=notObserved elapsedMs=6293
```

Flat prefix across four polls over ~4 s: the characters are not late, they are gone. The wait reports that honestly (#1995 doing its job) and stops, so `fill` fails and an expensive lane goes red on PRs that touch no iOS code — the #1874 symptom from a third mechanism.

## The change

The route re-posts once before giving up.

**Safe here and nowhere else.** It opens with select-all, so a second post replaces the whole field rather than appending to whatever committed — the double-commit hazard that made #1676 refuse a retry for bare `type` does not exist when the route owns the field. `awaitSynthesizedReplacementCommitOutcome`'s own doc comment already says as much: "`fill` fully owns the field via select-all, so there is no legitimate reason for the settled value to be anything other than exactly what was requested."

It is also what the *other* route has always done. `verifyTextEntryWithRepairIfNeeded` repairs a mismatch with `clearTextInput` + `typeText`; the synthesized replacement route was simply the one without a second chance. This closes that asymmetry rather than inventing a policy.

Bounded at one retry, and the outcome is still reported honestly if the retry fails too.

## What this does not fix

Why the characters are dropped. 11 posted at `typingSpeed: 60`, `status=0`, 7 landed. That stays open on #2080 — this converts a hard failure into a recovery attempt, it does not explain the loss. If the retry turns out to fail as often as the first attempt, that is itself the answer and the issue should say so.

## Validation

- Full `ios.yml` PR `-only-testing:` list on iPhone 17 Pro / iOS 26.2: **76 passed, 0 failures**.
- `testTypeTextReliablyPacesSynthesizedReplacementThroughProductionCaller` pins the retry through the production caller: the fake synthesizer never writes into the app, so the wait cannot observe and the route posts its select-once-then-pace sequence twice. That test now runs two deadlines (~6.7 s, nightly lane only).
- Rebased onto `bf26ab14d6`; applied three-way so #2066's clear-field work on the same test file is preserved rather than reverted, and its `testEmptyReplacementWithoutResolvableTargetFailsClosed` still passes. Empty-text `fill` fails closed before this route, so the retry does not touch that path.

2 files.