### PR TITLE
fix(ci): stop ten artifact uploads discarding their hidden paths

### DIFF
--- a/.github/workflows/1874-diagnose.yml
+++ b/.github/workflows/1874-diagnose.yml
@@ -106,6 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: stall-evidence-${{ matrix.arch }}-${{ matrix.mode }}
+          include-hidden-files: true
           path: |
             stall-summary.txt
             .tmp/stall-failure-*.log

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -122,6 +122,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: xctest-host-results-${{ github.run_id }}-${{ github.run_attempt }}
+          include-hidden-files: true
           path: .tmp/xctest-host
           if-no-files-found: warn
 

--- a/.github/workflows/mutation-affected.yml
+++ b/.github/workflows/mutation-affected.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-affected-select
+          include-hidden-files: true
           path: .tmp/mutation/lane-envelope.json
           if-no-files-found: warn
 
@@ -122,6 +123,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-affected-shard-${{ matrix.name }}
+          include-hidden-files: true
           path: |
             .tmp/mutation/mutation.json
             .tmp/mutation/mutation.html
@@ -175,6 +177,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-affected
+          include-hidden-files: true
           path: |
             .tmp/mutation/shards
             .tmp/mutation/lane-envelope.json

--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-shard-${{ matrix.name }}
+          include-hidden-files: true
           path: |
             .tmp/mutation/mutation.json
             .tmp/mutation/lane-envelope.json
@@ -160,6 +161,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-decision-kernels
+          include-hidden-files: true
           path: |
             .tmp/mutation/shards
             .tmp/mutation/lane-envelope.json

--- a/.github/workflows/replays-nightly.yml
+++ b/.github/workflows/replays-nightly.yml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: parser-fuzz-run-${{ github.run_id }}-${{ github.run_attempt }}
+          include-hidden-files: true
           path: .tmp/fuzz
           if-no-files-found: warn
 

--- a/.github/workflows/test-app-build-cache.yml
+++ b/.github/workflows/test-app-build-cache.yml
@@ -230,6 +230,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.artifactName }}
+          include-hidden-files: true
           path: .tmp/test-app-artifact/binary.tar.gz
           if-no-files-found: error
           compression-level: 0 # already gzipped

--- a/.github/workflows/xctest-nightly.yml
+++ b/.github/workflows/xctest-nightly.yml
@@ -186,5 +186,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: xctest-nightly-results-${{ github.run_id }}-${{ github.run_attempt }}
+          include-hidden-files: true
           path: .tmp/xctest-nightly
           if-no-files-found: warn

--- a/test/ci/upload-artifact-hidden-paths.test.ts
+++ b/test/ci/upload-artifact-hidden-paths.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+import { parse } from 'yaml';
+
+// `actions/upload-artifact` excludes hidden files and directories unless `include-hidden-files` is
+// set (default since v4.4); this repository writes most of its diagnostics under `.tmp`.
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+
+type Step = { uses?: unknown; with?: Record<string, unknown> };
+
+function uploadSteps(node: unknown): Step[] {
+  if (Array.isArray(node)) return node.flatMap(uploadSteps);
+  if (node === null || typeof node !== 'object') return [];
+  const record = node as Record<string, unknown>;
+  const self =
+    typeof record.uses === 'string' && record.uses.startsWith('actions/upload-artifact@')
+      ? [record as Step]
+      : [];
+  return [...self, ...Object.values(record).flatMap(uploadSteps)];
+}
+
+function isHidden(entry: string): boolean {
+  return entry
+    .split('/')
+    .some((segment) => segment.startsWith('.') && segment !== '.' && segment !== '..');
+}
+
+function configuredFiles(): string[] {
+  const workflows = path.join(repoRoot, '.github/workflows');
+  const actions = path.join(repoRoot, '.github/actions');
+  return [
+    ...fs.readdirSync(workflows).map((name) => `.github/workflows/${name}`),
+    ...fs.readdirSync(actions).map((name) => `.github/actions/${name}/action.yml`),
+  ].filter((file) => file.endsWith('.yml') && fs.existsSync(path.join(repoRoot, file)));
+}
+
+test('every artifact upload that writes a hidden path opts into hidden files', () => {
+  const offenders = configuredFiles().flatMap((file) =>
+    uploadSteps(parse(fs.readFileSync(path.join(repoRoot, file), 'utf8')))
+      .filter((step) => {
+        const paths = String(step.with?.path ?? '')
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        return paths.some(isHidden) && step.with?.['include-hidden-files'] !== true;
+      })
+      .map((step) => `${file}: ${step.with?.name ?? '(unnamed)'}`),
+  );
+
+  expect(offenders, 'these uploads silently discard their hidden paths').toEqual([]);
+});

--- a/test/ci/upload-artifact-hidden-paths.test.ts
+++ b/test/ci/upload-artifact-hidden-paths.test.ts
@@ -1,10 +1,8 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { expect, test } from 'vitest';
 import { parse } from 'yaml';
-
-// `actions/upload-artifact` excludes hidden files and directories unless `include-hidden-files` is
-// set (default since v4.4); this repository writes most of its diagnostics under `.tmp`.
 
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 
@@ -27,27 +25,53 @@ function isHidden(entry: string): boolean {
     .some((segment) => segment.startsWith('.') && segment !== '.' && segment !== '..');
 }
 
-function configuredFiles(): string[] {
-  const workflows = path.join(repoRoot, '.github/workflows');
-  const actions = path.join(repoRoot, '.github/actions');
-  return [
-    ...fs.readdirSync(workflows).map((name) => `.github/workflows/${name}`),
-    ...fs.readdirSync(actions).map((name) => `.github/actions/${name}/action.yml`),
-  ].filter((file) => file.endsWith('.yml') && fs.existsSync(path.join(repoRoot, file)));
+/** Every YAML GitHub reads under a `.github` tree: both extensions, local actions at any depth. */
+function offenders(root: string): string[] {
+  return fs
+    .readdirSync(root, { recursive: true, encoding: 'utf8' })
+    .map((entry) => path.join(root, entry))
+    .filter((file) => /\.ya?ml$/.test(file) && fs.statSync(file).isFile())
+    .flatMap((file) =>
+      uploadSteps(parse(fs.readFileSync(file, 'utf8')))
+        .filter((step) => {
+          const paths = String(step.with?.path ?? '')
+            .split('\n')
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+          return paths.some(isHidden) && step.with?.['include-hidden-files'] !== true;
+        })
+        .map((step) => `${path.relative(root, file)}: ${step.with?.name ?? '(unnamed)'}`),
+    );
 }
 
 test('every artifact upload that writes a hidden path opts into hidden files', () => {
-  const offenders = configuredFiles().flatMap((file) =>
-    uploadSteps(parse(fs.readFileSync(path.join(repoRoot, file), 'utf8')))
-      .filter((step) => {
-        const paths = String(step.with?.path ?? '')
-          .split('\n')
-          .map((entry) => entry.trim())
-          .filter(Boolean);
-        return paths.some(isHidden) && step.with?.['include-hidden-files'] !== true;
-      })
-      .map((step) => `${file}: ${step.with?.name ?? '(unnamed)'}`),
-  );
+  expect(
+    offenders(path.join(repoRoot, '.github')),
+    'these uploads silently discard their hidden paths',
+  ).toEqual([]);
+});
 
-  expect(offenders, 'these uploads silently discard their hidden paths').toEqual([]);
+test('the scan reaches every shape GitHub accepts', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hidden-uploads-'));
+  const plant = (file: string, name: string) => {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, file),
+      `jobs:\n  j:\n    steps:\n      - uses: actions/upload-artifact@v4\n` +
+        `        with:\n          name: ${name}\n          path: .tmp/out\n`,
+    );
+  };
+  try {
+    plant('workflows/dotyaml.yaml', 'yaml-extension');
+    plant('actions/nested/inner/action.yaml', 'nested-action');
+    plant('actions/shallow/action.yml', 'shallow-action');
+
+    expect(offenders(root).sort()).toEqual([
+      'actions/nested/inner/action.yaml: nested-action',
+      'actions/shallow/action.yml: shallow-action',
+      'workflows/dotyaml.yaml: yaml-extension',
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -152,6 +152,7 @@ export default defineConfig({
             'scripts/__tests__/size-report-package.test.ts',
             // Parses CI configuration only, so this action guard needs no device or subprocess lane.
             'test/ci/upload-agent-device-artifacts.test.ts',
+            'test/ci/upload-artifact-hidden-paths.test.ts',
             // The size reporter is preserved across a base checkout; its entrypoint and imported
             // modules must move as one directory or the Bundle Size lane fails before measuring.
             'test/ci/size-workflow.test.ts',


### PR DESCRIPTION
`actions/upload-artifact` has excluded hidden files and directories by default since v4.4, and this repository pins v4.6.2 and writes most of its diagnostics under `.tmp`. Ten upload steps across seven files were therefore uploading nothing from those paths.

| workflow | artifact | `if-no-files-found` |
|---|---|---|
| `macos.yml` | host XCTest xcresult bundle | `warn` |
| `mutation-affected.yml` ×3 | report, shards, lane envelope | `warn` / unset |
| `mutation-weekly.yml` ×2 | report, shards | `warn` / unset |
| `replays-nightly.yml` | fuzz output | `ignore` |
| `xctest-nightly.yml` | results | `warn` |
| `test-app-build-cache.yml` | fixture tarball | **`error`** |
| `1874-diagnose.yml` | per-iteration logs | `ignore` |

Most pair the omission with `warn` or `ignore`, so they fail silently. `test-app-build-cache` sets `error`, so that one does not.

## How it surfaced

The #1874 diagnose loop was dispatched to collect per-iteration logs. The summary arrived with its cadence excerpt and **none of the logs it points at** — `.tmp` is hidden, so every per-iteration log that workflow has ever kept had been discarded. Checking whether anything else did the same found nine more.

## Why a guard rather than a wrapper

A shared upload wrapper would be a shallow mirror of the action's options across artifacts with genuinely different owners — mutation reports, fixture caches, XCTest bundles, session diagnostics. The policy question is one rule ("a hidden path needs the flag") and belongs in one place; the artifact itself belongs to the workflow that produces it. `test/ci/upload-artifact-hidden-paths.test.ts` centralises the policy and leaves each workflow declaring its own artifact.

## Validation

Parse-only, no device lane. The guard walks every workflow and composite action; dropping any single flag turns it red (verified against `xctest-nightly.yml`). Format, lint, typecheck and `test/ci` green.

Not claimed: that this explains any specific past failure. The last eight `Test App Build Cache` runs on `main` are green, and the most recent published zero artifacts — consistent with no rebuild being selected, which proves nothing either way about the upload path.

Split out of #2059 on review; that PR keeps the diagnose-loop behaviour and will drop its duplicate of these changes once this lands.