### PR TITLE
refactor(layering): remove retired migration scaffolding

### DIFF
--- a/scripts/layering/application-lifecycle-policy.ts
+++ b/scripts/layering/application-lifecycle-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { memberName, visitAst } from './cutover-policy-ast.ts';
+import { memberName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';
 
 type AstNode = Record<string, unknown>;

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -37,8 +37,7 @@
 //   - Over PLATFORM PACKAGE COMPOSITION: six private metadata façades meet at the exact root
 //     composition file; premature implementation loading and forbidden cross-boundary edges fail (R13).
 //   - Over REQUEST-BOUND RUNTIME EXECUTION: facts remain the only admission authority and daemon
-//     code cannot manufacture or repair a narrowed runtime proof (R66). The historical per-command
-//     cutover table was deleted after the last legacy execution shape disappeared.
+//     code cannot manufacture or repair a narrowed runtime proof (R66).
 //   - Over CONTRACTS PRODUCTION SOURCE: contracts owns vocabulary only — host, process, and timer
 //     mechanics belong in capture-kit or an adapter (R18).
 // Only `(root)` is unranked among src/ zones (see `UNRANKED_ZONES` in model.ts):

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -3,7 +3,6 @@ import { test } from 'node:test';
 import {
   checkDaemonModularityRatchets,
   DAEMON_MODULARITY_BASELINE,
-  LOGICAL_MODULE_POLICIES,
   TYPE_CYCLE_BASELINE,
 } from './daemon-modularity.ts';
 import { SESSION_STATE_FIELD_OWNERS } from './session-state.ts';
@@ -28,18 +27,9 @@ function baselineDaemonTypesEdges(): ResolvedImportEdge[] {
   );
 }
 
-function recordedMigrationEdges(): ResolvedImportEdge[] {
-  return LOGICAL_MODULE_POLICIES.flatMap((module) =>
-    (module.recordedMigrationImports ?? []).map((recorded) => {
-      const [file, target] = recorded.split(' -> ');
-      return importEdge(file!, target!);
-    }),
-  );
-}
-
-/** Every recorded import present and nothing else forbidden: the quiet state of the ratchets. */
+/** Every baseline edge is present and nothing else is forbidden: the quiet state of the ratchets. */
 function baselineEdges(): ResolvedImportEdge[] {
-  return [...baselineDaemonTypesEdges(), ...recordedMigrationEdges()];
+  return baselineDaemonTypesEdges();
 }
 
 /** Where a member of `zone` lives, so a zone count can be turned back into file paths. */
@@ -94,14 +84,14 @@ test('external daemon/types.ts importer membership changes require the baseline 
   assert.match(violations[0]!.message, /may only shrink from the recorded 2/);
 
   const removed = checkDaemonModularityRatchets(
-    [...baselineDaemonTypesEdges().slice(1), ...recordedMigrationEdges()],
+    baselineDaemonTypesEdges().slice(1),
     baselineTypeCycleMembers(),
   );
   assert.equal(removed.length, 1);
   assert.match(removed[0]!.message, /delete it from externalDaemonTypesImporters/);
 });
 
-test('planned logical modules start with zero forbidden imports', () => {
+test('logical modules reject forbidden imports', () => {
   const edges = resolveImportEdges(
     new Map([
       [
@@ -166,22 +156,6 @@ test('replay-test may still import its own files inside the package', () => {
     checkDaemonModularityRatchets([...baselineEdges(), ...edges], baselineTypeCycleMembers()),
     [],
   );
-});
-
-// #1478 P3 cleared every recorded replay-test migration import: the ADR 0012 divergence
-// vocabulary became a neutral contracts leaf, and the reporter tree now reads the progress
-// wire vocabulary from contracts instead of request-global plumbing. The rule enforces
-// unconditionally for replay-test from here on.
-test('replay-test carries no recorded migration imports', () => {
-  assert.equal(
-    LOGICAL_MODULE_POLICIES.find(({ name }) => name === 'replay-test')?.recordedMigrationImports,
-    undefined,
-  );
-  assert.deepEqual(
-    LOGICAL_MODULE_POLICIES.flatMap((module) => module.recordedMigrationImports ?? []),
-    [],
-  );
-  assert.deepEqual(checkDaemonModularityRatchets(baselineEdges(), baselineTypeCycleMembers()), []);
 });
 
 test('internal trees reject deep imports globally, including from daemon', () => {

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -44,14 +44,6 @@ type LogicalModulePolicy = {
   name: string;
   roots: readonly string[];
   forbiddenTargetRoots: readonly string[];
-  /**
-   * Imports that already violate `forbiddenTargetRoots` on the day the rule was written, recorded
-   * as `source -> target`. The rule enforces immediately for everything else, so a new violation
-   * cannot be added while the module waits for its extraction PR; each recorded edge must be
-   * deleted from this list by the change that removes the import, and re-adding one is a diff a
-   * reviewer sees.
-   */
-  recordedMigrationImports?: readonly string[];
 };
 
 /**
@@ -242,7 +234,6 @@ function checkDaemonTypesImporters(edges: readonly ResolvedImportEdge[]): Layeri
 
 function checkLogicalModuleImports(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   const violations: LayeringViolation[] = [];
-  const observedMigrationImports = new Set<string>();
   for (const edge of edges) {
     const sourceModule = moduleForFile(edge.file);
     const targetModule = moduleForFile(edge.target);
@@ -265,33 +256,12 @@ function checkLogicalModuleImports(edges: readonly ResolvedImportEdge[]): Layeri
     // `src/replay/` engine root it may not import from.
     if (sourceModule.roots.some((root) => edge.target.startsWith(root))) continue;
     if (!sourceModule.forbiddenTargetRoots.some((root) => edge.target.startsWith(root))) continue;
-    const migrationImport = `${edge.file} -> ${edge.target}`;
-    if (sourceModule.recordedMigrationImports?.includes(migrationImport)) {
-      observedMigrationImports.add(migrationImport);
-      continue;
-    }
     violations.push({
       rule: 'R10 daemon-modularity',
       file: edge.file,
       line: edge.line,
       message: `${sourceModule.name} must not import ${edge.target}; communicate through its façade and a narrow port with two real adapters.`,
     });
-  }
-  return [...violations, ...checkRecordedMigrationImports(observedMigrationImports)];
-}
-
-function checkRecordedMigrationImports(observed: ReadonlySet<string>): LayeringViolation[] {
-  const violations: LayeringViolation[] = [];
-  for (const module of LOGICAL_MODULE_POLICIES) {
-    for (const migrationImport of module.recordedMigrationImports ?? []) {
-      if (observed.has(migrationImport)) continue;
-      violations.push({
-        rule: 'R10 daemon-modularity',
-        file: 'scripts/layering/daemon-modularity.ts',
-        line: 1,
-        message: `${migrationImport} no longer exists — delete it from ${module.name}'s recordedMigrationImports in the same change so the import cannot return.`,
-      });
-    }
   }
   return violations;
 }
@@ -322,14 +292,10 @@ function groupBy(
 
 export function daemonModularitySummary(): string {
   const session = DAEMON_MODULARITY_BASELINE.sessionState;
-  const recordedMigrationImports = LOGICAL_MODULE_POLICIES.reduce(
-    (sum, module) => sum + (module.recordedMigrationImports?.length ?? 0),
-    0,
-  );
   return (
     `R10 pins R7 at ${session.writerOwnedFields} writer-owned fields / ` +
     `${session.ownerFileClaims} owner claims, R9 at ${TYPE_CYCLE_BASELINE} files with zone ceilings, ` +
     `${DAEMON_MODULARITY_BASELINE.externalDaemonTypesImporters.length} external daemon/types.ts importers, ` +
-    `and zero forbidden logical-module imports beyond ${recordedMigrationImports} recorded migration import(s)`
+    'and zero forbidden logical-module imports'
   );
 }

--- a/scripts/layering/daemon-platform-boundary.ts
+++ b/scripts/layering/daemon-platform-boundary.ts
@@ -4,14 +4,7 @@ import { isProductionSourceFile } from './tracked-sources.ts';
 import type { LayeringViolation } from './model.ts';
 
 /**
- * R65 is the terminal daemon/platform boundary.
- *
- * R3's old platforms seam deliberately tolerated dynamic and type-only edges while the
- * request-bound runtime migration was in flight. That tolerance is not a terminal property:
- * either edge still makes the daemon depend on a concrete platform implementation. This policy
- * closes the boundary completely for tracked production daemon sources. It is kept independent
- * from `check.ts` until the remaining live edges are removed, so the migration can plant and
- * verify the red forms before making the repository-wide gate fail.
+ * R65 rejects every concrete-platform dependency from tracked production daemon sources.
  *
  * The module record supplies static imports and re-exports; the AST supplies dynamic imports and
  * TypeScript import types. Reading syntax through oxc-parser, rather than searching source text,

--- a/scripts/layering/layering-ast.ts
+++ b/scripts/layering/layering-ast.ts
@@ -1,4 +1,4 @@
-/** A production file the cutover policies scan: repo-relative path plus its source. */
+/** Shared AST helpers for permanent layering policies. */
 export type ProductionSource = Readonly<{ path: string; source: string }>;
 
 export function memberName(node: Record<string, unknown>): string | undefined {

--- a/scripts/layering/platform-package-source-policy.ts
+++ b/scripts/layering/platform-package-source-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { memberPath } from './cutover-policy-ast.ts';
+import { memberPath } from './layering-ast.ts';
 import { parseImports, type LayeringViolation } from './model.ts';
 
 const RULE = 'R13 platform-package-substrate';

--- a/scripts/layering/record-runtime-mechanics-policy.ts
+++ b/scripts/layering/record-runtime-mechanics-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { memberName, type ProductionSource, visitAst } from './cutover-policy-ast.ts';
+import { memberName, type ProductionSource, visitAst } from './layering-ast.ts';
 
 const DAEMON_RECORD_MECHANIC_CALLS = new Set([
   'runCmd',

--- a/scripts/layering/record-runtime-registry-policy.ts
+++ b/scripts/layering/record-runtime-registry-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { memberName, type ProductionSource, visitAst } from './cutover-policy-ast.ts';
+import { memberName, type ProductionSource, visitAst } from './layering-ast.ts';
 
 export function recordRuntimeRegistryJoinViolations(
   sources: readonly ProductionSource[],

--- a/scripts/layering/runtime-execution-policy.ts
+++ b/scripts/layering/runtime-execution-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { memberName, propertyName, visitAst } from './cutover-policy-ast.ts';
+import { memberName, propertyName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';
 
 type AstNode = Record<string, unknown>;
@@ -10,15 +10,7 @@ const COMMAND_DESCRIPTOR_MODULE = 'src/core/command-descriptor/registry.ts';
 const RUNTIME_ADMISSION_MODULE = 'src/daemon/runtime-admission.ts';
 const RUNTIME_PROOF_TYPES = new Set(['AdmittedRuntimePlan', 'BoundDeviceRuntime']);
 
-/**
- * Permanent runtime invariants after ADR 0019's command-by-command migration completed.
- *
- * The old cutover table named every retired symbol and every operation owner. Those were useful
- * assertions while two execution systems coexisted, but keeping them after the old system was
- * deleted made handler names and historical routes a second source of truth. The surviving
- * invariant is generic: facts are the only admission authority, and daemon code must not
- * manufacture or repair the proof carried by a narrowed runtime.
- */
+/** Facts are the only admission authority, and daemon code must consume narrowed runtime proofs. */
 export function runtimeExecutionIntegrityViolations(
   sources: ReadonlyMap<string, string>,
 ): LayeringViolation[] {

--- a/scripts/layering/session-resource-ownership.ts
+++ b/scripts/layering/session-resource-ownership.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { propertyName, visitAst } from './cutover-policy-ast.ts';
+import { propertyName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';
 
 type AstNode = Record<string, unknown>;

--- a/scripts/layering/source-execution-policy.ts
+++ b/scripts/layering/source-execution-policy.ts
@@ -1,5 +1,5 @@
 import { parseSync } from 'oxc-parser';
-import { visitAst } from './cutover-policy-ast.ts';
+import { visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';
 
 export const SOURCE_EXECUTION_COMPATIBILITY_RULE = 'R67 source-execution-compatibility';

--- a/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
@@ -3,7 +3,7 @@ import { focusRuntimeUse } from '@agent-device/contracts/platform-runtime-operat
 import { commandDescriptors } from '../registry.ts';
 import { listRuntimeFactCommands } from '../../capabilities.ts';
 
-test('focus descriptor declares its complete runtime use with no legacy projection', () => {
+test('focus descriptor declares its complete runtime use', () => {
   const focus = commandDescriptors.find(({ name }) => name === 'focus');
 
   expect(focus).not.toHaveProperty('capability');
@@ -18,11 +18,9 @@ test('focus descriptor declares its complete runtime use with no legacy projecti
   });
 });
 
-test('focus keeps the traits its retired bucket did not own', () => {
+test('focus preserves command traits outside platform execution', () => {
   const focus = commandDescriptors.find(({ name }) => name === 'focus');
 
-  // The Android blocking-dialog guard is admission-independent: it describes when the command may
-  // run, not which platform executes it.
   expect(focus).toMatchObject({
     daemon: {
       route: 'generic',

--- a/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/focus-runtime-execution.test.ts
@@ -21,8 +21,8 @@ test('focus descriptor declares its complete runtime use with no legacy projecti
 test('focus keeps the traits its retired bucket did not own', () => {
   const focus = commandDescriptors.find(({ name }) => name === 'focus');
 
-  // The Android blocking-dialog guard is admission-independent: it survived the cutover because
-  // it describes when the command may run, not which platform executes it.
+  // The Android blocking-dialog guard is admission-independent: it describes when the command may
+  // run, not which platform executes it.
   expect(focus).toMatchObject({
     daemon: {
       route: 'generic',

--- a/src/core/command-descriptor/__tests__/platform-execution.test.ts
+++ b/src/core/command-descriptor/__tests__/platform-execution.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { commandDescriptors } from '../registry.ts';
 import { deriveDaemonCommandDescriptors } from '../derive.ts';
 
-describe('command platform execution cutover', () => {
+describe('command platform execution declaration', () => {
   test('declares devices through the descriptor-owned inventory use', () => {
     expect(commandDescriptors.find(({ name }) => name === 'devices')?.platformExecution).toEqual({
       kind: 'inventory',
@@ -11,7 +11,7 @@ describe('command platform execution cutover', () => {
     });
   });
 
-  test('keeps the internal cutover discriminant out of daemon/public projections', () => {
+  test('keeps the internal execution discriminant out of daemon/public projections', () => {
     const devices = deriveDaemonCommandDescriptors(commandDescriptors).find(
       ({ command }) => command === 'devices',
     );

--- a/src/core/command-descriptor/types.ts
+++ b/src/core/command-descriptor/types.ts
@@ -201,7 +201,7 @@ type CommandDescriptorBase = {
   catalog: CommandCatalogFacet;
   /** Required iff `catalog.group === 'public'`; see {@link CommandFrameworkTier}. */
   frameworkTier?: CommandFrameworkTier;
-  /** Internal-only ADR 0019 cutover discriminant; public projections must ignore it. */
+  /** Internal-only ADR 0019 execution discriminant; public projections must ignore it. */
   platformExecution: CommandPlatformExecution;
   /** ADR 0012 / #1349: present iff this command's recorded steps can carry `target-v1` evidence. */
   targetIdentityVerification?: TargetIdentityVerification;


### PR DESCRIPTION
## Summary

- Re-audited the completed ADR-0019 state after #1739 and #2089; #2081 had already removed runtime-command-cutover-table and its row-specific callers.
- Removed the empty R10 recordedMigrationImports migration allowance and obsolete test, and renamed the shared AST helper away from cutover terminology.
- Preserved the terminal descriptor execution, R65 daemon/platform, R66 runtime admission/proof, and R68/R69 ownership/lifecycle gates.

## Validation

- Focused layering tests: 34 passing.
- Descriptor and contract tests: 26 passing.
- pnpm check:layering.
- pnpm check:affected --run: all runnable checks passed; native, device, and GitHub-authoritative lanes remain CI-owned.

No production runtime behavior changes. This is follow-up cleanup after #2081/#2089 and is not a merge.