### PR TITLE
refactor(test): derive provider gateway facts from runtime builder

### DIFF
--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -19,7 +19,10 @@ import type {
 import type { PlatformRequestScope } from '@agent-device/contracts/platform-runtime-host';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { LimrunRuntimeDependencies } from '@agent-device/provider-limrun';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from './__tests__/test-utils/runtime-operation-facts.ts';
+import {
+  createUnavailableRuntimeFactsForTest,
+  unavailableDeploymentSnapshotAndShutdownOperationFacts,
+} from './__tests__/test-utils/runtime-operation-facts.ts';
 import {
   createComposedPlatformRuntimeGateway,
   type PlatformRuntimeProviderRegistration,
@@ -134,32 +137,12 @@ function binding(options: {
 function unavailableFacts() {
   const unavailable = { available: false, reason: 'unsupported-provider-mode' } as const;
   return {
+    ...createUnavailableRuntimeFactsForTest(
+      gatewayFixtureDevice,
+      providerRuntimeOwner('limrun', 'fixtures'),
+      unavailable,
+    ).operations,
     ...unavailableDeploymentSnapshotAndShutdownOperationFacts,
-    appLogInspect: unavailable,
-    appLogDoctor: unavailable,
-    appLogStart: unavailable,
-    appLogReattach: unavailable,
-    appLogCleanup: unavailable,
-    appState: unavailable,
-    networkDump: unavailable,
-    screenRecordingStart: unavailable,
-    screenRecordingReattach: unavailable,
-    screenRecordingCleanup: unavailable,
-    ensureReady: unavailable,
-    bootTarget: unavailable,
-    bootTargetHeadless: unavailable,
-    listApps: unavailable,
-    ...applicationLifecycleOperationFacts({
-      resolveOpenTarget: unavailable,
-      prepareApplicationOpen: unavailable,
-      openApplication: unavailable,
-      applyRuntimeHints: unavailable,
-      clearRuntimeHints: unavailable,
-      closeApplication: unavailable,
-      finalizeApplicationClose: unavailable,
-      prepareAppleRunner: unavailable,
-      configureProviderPortReverse: unavailable,
-    }),
   };
 }
 

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -499,6 +499,14 @@ describe('composed platform runtime gateway', () => {
       });
 
       const facts = await runtimeGateway.inspectFacts(device);
+      expect(facts.operations.captureScreenshot).toMatchObject({
+        available: false,
+        reason: 'owner-capability-missing',
+      });
+      expect(facts.operations.appLogInspect).toMatchObject({
+        available: false,
+        reason: 'unsupported-provider-mode',
+      });
       for (const operation of operations) {
         expect(facts.operations[operation].available).toBe(false);
       }


### PR DESCRIPTION
## Summary

Derive the provider runtime-gateway fixture from the canonical runtime-facts builder while retaining the specialized owner-capability overrides.

- Remove the repeated provider operation and lifecycle literal map.
- Preserve provider-mode versus owner-capability refusal reasons with focused assertions.
- Keep the four already-canonical historical fixtures behavior-specific and unchanged.

## Validation

- Focused Vitest: 7 files, 45 tests passed.
- pnpm check:affected --run: all runnable checks passed; device lanes remain GitHub-authoritative.
- pnpm format

Docs and skills unchanged; test-fixture-only scope.