### PR TITLE
fix(daemon): refuse host path install sources on the HTTP surface

### DIFF
--- a/src/__tests__/daemon-proxy.test.ts
+++ b/src/__tests__/daemon-proxy.test.ts
@@ -513,3 +513,134 @@ function sendUploadProxyFinalize(
   res.setHeader('content-type', 'application/json');
   res.end(JSON.stringify({ ok: true, uploadId: 'tracked-upload-1' }));
 }
+
+type ProxyRpcOutcome = {
+  status: number;
+  body: { error?: { code?: number; message?: string; data?: { code?: string } } };
+  upstreamCalls: number;
+};
+
+async function postInstallRpcThroughProxy(
+  params: Record<string, unknown>,
+): Promise<ProxyRpcOutcome> {
+  let upstreamCalls = 0;
+  const upstream = http.createServer((req, res) => {
+    upstreamCalls += 1;
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: (JSON.parse(body) as { id?: unknown }).id,
+          result: { ok: true, data: { reached: 'upstream' } },
+        }),
+      );
+    });
+  });
+  const proxy = createDaemonProxyServer({
+    upstreamBaseUrl: `http://127.0.0.1:${await listenOnLoopback(upstream)}`,
+    upstreamToken: 'daemon-secret',
+    clientToken: 'proxy-secret',
+  });
+
+  try {
+    const proxyPort = await listenOnLoopback(proxy);
+    const response = await fetch(`http://127.0.0.1:${proxyPort}/agent-device/rpc`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer proxy-secret' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 'req-1', ...params }),
+    });
+    return {
+      status: response.status,
+      body: (await response.json()) as ProxyRpcOutcome['body'],
+      upstreamCalls,
+    };
+  } finally {
+    await closeLoopbackServer(proxy);
+    await closeLoopbackServer(upstream);
+  }
+}
+
+// #2097: the daemon's own HTTP server binds loopback, so the proxy is the seam between
+// the daemon's host and callers that are not on it. A `path` install source names a file
+// on that host, so it must not cross — through either rpc method that can carry one.
+test('proxy refuses a host path install source on the generic command method', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const { status, body, upstreamCalls } = await postInstallRpcThroughProxy({
+    method: 'agent_device.command',
+    params: {
+      token: 'proxy-secret',
+      command: 'install_source',
+      positionals: [],
+      flags: { platform: 'android' },
+      meta: { installSource: { kind: 'path', path: '/etc/passwd' } },
+    },
+  });
+
+  assert.equal(status, 400);
+  assert.equal(body.error?.code, -32602);
+  assert.equal(body.error?.data?.code, 'INVALID_ARGS');
+  assert.equal(upstreamCalls, 0, 'the daemon must never see a proxied host path source');
+});
+
+test('proxy refuses a host path install source on the install_from_source method', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const { status, body, upstreamCalls } = await postInstallRpcThroughProxy({
+    method: 'agent_device.install_from_source',
+    params: {
+      token: 'proxy-secret',
+      platform: 'android',
+      source: { kind: 'path', path: '/etc/passwd' },
+    },
+  });
+
+  assert.equal(status, 400);
+  assert.equal(body.error?.data?.code, 'INVALID_ARGS');
+  assert.equal(upstreamCalls, 0);
+});
+
+// The sanctioned remote install route: the client uploads the artifact first, and the
+// daemon substitutes the uploaded file for the wire path, so the path is never read.
+test('proxy forwards a path source backed by an uploaded artifact', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const { status, upstreamCalls } = await postInstallRpcThroughProxy({
+    method: 'agent_device.command',
+    params: {
+      token: 'proxy-secret',
+      command: 'install_source',
+      positionals: [],
+      flags: { platform: 'android' },
+      meta: {
+        installSource: { kind: 'path', path: '/Users/dev/Downloads/Sample.apk' },
+        uploadedArtifactId: 'upload-1',
+      },
+    },
+  });
+
+  assert.equal(status, 200);
+  assert.equal(upstreamCalls, 1);
+});
+
+test('proxy forwards url install sources unchanged', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const { status, upstreamCalls } = await postInstallRpcThroughProxy({
+    method: 'agent_device.install_from_source',
+    params: {
+      token: 'proxy-secret',
+      platform: 'android',
+      source: { kind: 'url', url: 'https://example.com/app.apk' },
+    },
+  });
+
+  assert.equal(status, 200);
+  assert.equal(upstreamCalls, 1);
+});

--- a/src/__tests__/daemon-proxy.test.ts
+++ b/src/__tests__/daemon-proxy.test.ts
@@ -566,9 +566,6 @@ async function postInstallRpcThroughProxy(
   }
 }
 
-// #2097: the daemon's own HTTP server binds loopback, so the proxy is the seam between
-// the daemon's host and callers that are not on it. A `path` install source names a file
-// on that host, so it must not cross — through either rpc method that can carry one.
 test('proxy refuses a host path install source on the generic command method', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
 
@@ -606,8 +603,6 @@ test('proxy refuses a host path install source on the install_from_source method
   assert.equal(upstreamCalls, 0);
 });
 
-// The sanctioned remote install route: the client uploads the artifact first, and the
-// daemon substitutes the uploaded file for the wire path, so the path is never read.
 test('proxy forwards a path source backed by an uploaded artifact', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
 

--- a/src/daemon/__tests__/http-server-rpc-validation.test.ts
+++ b/src/daemon/__tests__/http-server-rpc-validation.test.ts
@@ -172,8 +172,6 @@ async function withInstallFromSourceRpcServer(
   }
 }
 
-// #2097: honoring `source.kind: "path"` from the wire would hand any authenticated
-// caller a read of whatever the daemon user can read, through the install pipeline.
 test('install_from_source rejects a host path source at the rpc boundary', async (t) => {
   await withInstallFromSourceRpcServer(async (post) => {
     const { status, body, dispatched } = await post({ kind: 'path', path: '/etc/passwd' });

--- a/src/daemon/__tests__/http-server-rpc-validation.test.ts
+++ b/src/daemon/__tests__/http-server-rpc-validation.test.ts
@@ -127,3 +127,88 @@ test('the rpc boundary never accepts internal request fields from the wire', asy
     await closeLoopbackServer(server);
   }
 });
+
+async function withInstallFromSourceRpcServer(
+  run: (
+    post: (source: unknown) => Promise<{
+      status: number;
+      body: RpcErrorResponse;
+      dispatched: DaemonRequest[];
+    }>,
+  ) => Promise<void>,
+  t: { skip(reason?: string): void },
+): Promise<void> {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const dispatched: DaemonRequest[] = [];
+  const handleRequest = async (req: DaemonRequest): Promise<DaemonResponse> => {
+    dispatched.push(req);
+    return { ok: true, data: { ok: true } };
+  };
+  const server = await createDaemonHttpServer({ handleRequest });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const post = async (source: unknown) => {
+      const response = await fetch(`http://127.0.0.1:${port}/rpc`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'req-1',
+          method: 'agent_device.install_from_source',
+          params: { platform: 'android', source },
+        }),
+      });
+      return {
+        status: response.status,
+        body: (await response.json()) as RpcErrorResponse,
+        dispatched,
+      };
+    };
+    await run(post);
+  } finally {
+    await closeLoopbackServer(server);
+  }
+}
+
+// #2097: honoring `source.kind: "path"` from the wire would hand any authenticated
+// caller a read of whatever the daemon user can read, through the install pipeline.
+test('install_from_source rejects a host path source at the rpc boundary', async (t) => {
+  await withInstallFromSourceRpcServer(async (post) => {
+    const { status, body, dispatched } = await post({ kind: 'path', path: '/etc/passwd' });
+
+    assert.equal(status, 400);
+    assert.equal(body.error?.code, -32602);
+    assert.equal(body.error?.data?.code, 'INVALID_ARGS');
+    assert.equal(dispatched.length, 0, 'a host path source must never reach the handler');
+  }, t);
+});
+
+test('install_from_source still admits url sources', async (t) => {
+  await withInstallFromSourceRpcServer(async (post) => {
+    const { status, dispatched } = await post({ kind: 'url', url: 'https://example.com/app.apk' });
+
+    assert.equal(status, 200);
+    assert.equal(dispatched.length, 1);
+    assert.deepEqual(dispatched[0]?.meta?.installSource, {
+      kind: 'url',
+      url: 'https://example.com/app.apk',
+    });
+  }, t);
+});
+
+test('install_from_source still admits github-actions-artifact sources', async (t) => {
+  await withInstallFromSourceRpcServer(async (post) => {
+    const { status, dispatched } = await post({
+      kind: 'github-actions-artifact',
+      owner: 'callstack',
+      repo: 'agent-device',
+      artifactId: 42,
+    });
+
+    assert.equal(status, 200);
+    assert.equal(dispatched.length, 1);
+    assert.equal(dispatched[0]?.meta?.installSource?.kind, 'github-actions-artifact');
+  }, t);
+});

--- a/src/daemon/__tests__/install-source-resolution.test.ts
+++ b/src/daemon/__tests__/install-source-resolution.test.ts
@@ -77,9 +77,6 @@ test('resolveInstallSource rejects GitHub Actions artifact sources on the local 
   ).toThrow(/compatible remote daemon/i);
 });
 
-// #2097: the proxy lets a path source cross only when an upload backs it, which is safe
-// solely because an upload id the caller does not own throws here instead of falling
-// back to the path from the wire. A fallback would turn that carve-out into the hole.
 test('resolveInstallSource refuses an unknown upload id rather than reading the wire path', () => {
   expect(() =>
     resolveInstallSource(

--- a/src/daemon/__tests__/install-source-resolution.test.ts
+++ b/src/daemon/__tests__/install-source-resolution.test.ts
@@ -76,3 +76,17 @@ test('resolveInstallSource rejects GitHub Actions artifact sources on the local 
     ),
   ).toThrow(/compatible remote daemon/i);
 });
+
+// #2097: the proxy lets a path source cross only when an upload backs it, which is safe
+// solely because an upload id the caller does not own throws here instead of falling
+// back to the path from the wire. A fallback would turn that carve-out into the hole.
+test('resolveInstallSource refuses an unknown upload id rather than reading the wire path', () => {
+  expect(() =>
+    resolveInstallSource(
+      makeRequest({
+        uploadedArtifactId: 'not-a-real-upload',
+        installSource: { kind: 'path', path: '/etc/passwd' },
+      }),
+    ),
+  ).toThrow();
+});

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -76,11 +76,6 @@ type HttpAuthDecision =
   | { ok: true; tenantId?: string }
   | { ok: false; statusCode: number; response: JsonRpcResponse };
 
-/**
- * The install sources the daemon's HTTP surface admits. A `path` source names a file
- * on the daemon's own host, so it stays an in-process affordance for callers that
- * already carry the daemon's authority (#2097).
- */
 type HttpInstallSource = Exclude<DaemonInstallSource, { kind: 'path' }>;
 
 const MAX_HTTP_RPC_BODY_BYTES = 1024 * 1024;

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -76,6 +76,13 @@ type HttpAuthDecision =
   | { ok: true; tenantId?: string }
   | { ok: false; statusCode: number; response: JsonRpcResponse };
 
+/**
+ * The install sources the daemon's HTTP surface admits. A `path` source names a file
+ * on the daemon's own host, so it stays an in-process affordance for callers that
+ * already carry the daemon's authority (#2097).
+ */
+type HttpInstallSource = Exclude<DaemonInstallSource, { kind: 'path' }>;
+
 const MAX_HTTP_RPC_BODY_BYTES = 1024 * 1024;
 const COMMAND_RPC_METHODS = new Set(['agent_device.command', 'agent-device.command']);
 const INSTALL_FROM_SOURCE_RPC_METHODS = new Set([
@@ -219,7 +226,7 @@ function readGitHubArtifactInteger(record: Record<string, unknown>, key: 'artifa
   return parsed;
 }
 
-function parseGitHubActionsArtifactSource(record: Record<string, unknown>): DaemonInstallSource {
+function parseGitHubActionsArtifactSource(record: Record<string, unknown>): HttpInstallSource {
   const owner = readRequiredGitHubArtifactText(record, 'owner');
   const repo = readRequiredGitHubArtifactText(record, 'repo');
   const hasArtifactId = record.artifactId !== undefined;
@@ -288,7 +295,7 @@ function toLeaseDaemonRequest(
   };
 }
 
-function parseInstallSource(params: Record<string, unknown>): DaemonInstallSource {
+function parseInstallSource(params: Record<string, unknown>): HttpInstallSource {
   const source = params.source;
   if (!source || typeof source !== 'object') {
     throw new AppError('INVALID_ARGS', 'Invalid params: source is required');
@@ -318,21 +325,18 @@ function parseInstallSource(params: Record<string, unknown>): DaemonInstallSourc
     return Object.keys(headers).length > 0 ? { kind: 'url', url, headers } : { kind: 'url', url };
   }
   if (record.kind === 'path') {
-    const artifactPath = typeof record.path === 'string' ? record.path.trim() : '';
-    if (!artifactPath) {
-      throw new AppError(
-        'INVALID_ARGS',
-        'Invalid params: source.path is required for path sources',
-      );
-    }
-    return { kind: 'path', path: artifactPath };
+    throw new AppError(
+      'INVALID_ARGS',
+      'Invalid params: source.kind "path" names a file on the daemon host and is not accepted over HTTP',
+      { hint: 'Use a "url" or "github-actions-artifact" source.' },
+    );
   }
   if (record.kind === 'github-actions-artifact') {
     return parseGitHubActionsArtifactSource(record);
   }
   throw new AppError(
     'INVALID_ARGS',
-    'Invalid params: source.kind must be "url", "path", or "github-actions-artifact"',
+    'Invalid params: source.kind must be "url" or "github-actions-artifact"',
   );
 }
 

--- a/src/remote/daemon-proxy.ts
+++ b/src/remote/daemon-proxy.ts
@@ -80,6 +80,11 @@ async function handleProxyRequest(
     return;
   }
 
+  if (carriesUnbackedHostPathInstallSource(rpcBody)) {
+    sendHostPathInstallSourceRefused(res, readJsonRpcId(rpcBody));
+    return;
+  }
+
   await forwardProxyRequest({ req, res, route, options, rpcBody });
 }
 
@@ -369,6 +374,62 @@ function rewriteRpcToken(body: string, upstreamToken: string): string {
     token: upstreamToken,
   };
   return JSON.stringify(parsed);
+}
+
+/**
+ * A `path` install source names a file on the daemon's own host. The daemon's HTTP
+ * server binds loopback, so this proxy is the seam between that host and callers who
+ * are not on it, and no such source may cross it (#2097). An uploaded artifact backs
+ * the only legitimate crossing: the daemon substitutes the uploaded file and never
+ * reads the path from the wire, and it rejects an upload id that is not the caller's.
+ */
+function carriesUnbackedHostPathInstallSource(rpcBody: string | undefined): boolean {
+  const params = readRpcParams(rpcBody);
+  if (!params) return false;
+  const meta = readRecord(params.meta);
+  if (hasUploadedArtifactId(meta)) return false;
+  return isHostPathInstallSource(params.source) || isHostPathInstallSource(meta?.installSource);
+}
+
+function readRpcParams(rpcBody: string | undefined): Record<string, unknown> | undefined {
+  if (!rpcBody) return undefined;
+  try {
+    return readRecord(readRecord(JSON.parse(rpcBody))?.params);
+  } catch {
+    return undefined;
+  }
+}
+
+function hasUploadedArtifactId(meta: Record<string, unknown> | undefined): boolean {
+  const uploadedArtifactId = meta?.uploadedArtifactId;
+  return typeof uploadedArtifactId === 'string' && uploadedArtifactId.trim().length > 0;
+}
+
+function isHostPathInstallSource(source: unknown): boolean {
+  return readRecord(source)?.kind === 'path';
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function sendHostPathInstallSourceRefused(res: ServerResponse, rpcId: unknown): void {
+  const error = new AppError(
+    'INVALID_ARGS',
+    'Invalid params: an install source of kind "path" names a file on the daemon host and is not accepted through the proxy',
+    { hint: 'Upload the artifact, or use a "url" or "github-actions-artifact" source.' },
+  );
+  res.statusCode = 400;
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: rpcId,
+      error: { code: -32602, message: error.message, data: normalizeError(error) },
+    }),
+  );
 }
 
 function readJsonRpcToken(body: string): string {

--- a/src/remote/daemon-proxy.ts
+++ b/src/remote/daemon-proxy.ts
@@ -12,6 +12,10 @@ import {
   buildDaemonHttpUrl,
 } from '../daemon/http-contract.ts';
 import { buildDaemonHealthPayload } from '../daemon/http-health.ts';
+import {
+  carriesUnbackedHostPathInstallSource,
+  sendHostPathInstallSourceRefused,
+} from './proxy-install-source-admission.ts';
 
 export type DaemonProxyOptions = {
   upstreamBaseUrl: string;
@@ -374,62 +378,6 @@ function rewriteRpcToken(body: string, upstreamToken: string): string {
     token: upstreamToken,
   };
   return JSON.stringify(parsed);
-}
-
-/**
- * A `path` install source names a file on the daemon's own host. The daemon's HTTP
- * server binds loopback, so this proxy is the seam between that host and callers who
- * are not on it, and no such source may cross it (#2097). An uploaded artifact backs
- * the only legitimate crossing: the daemon substitutes the uploaded file and never
- * reads the path from the wire, and it rejects an upload id that is not the caller's.
- */
-function carriesUnbackedHostPathInstallSource(rpcBody: string | undefined): boolean {
-  const params = readRpcParams(rpcBody);
-  if (!params) return false;
-  const meta = readRecord(params.meta);
-  if (hasUploadedArtifactId(meta)) return false;
-  return isHostPathInstallSource(params.source) || isHostPathInstallSource(meta?.installSource);
-}
-
-function readRpcParams(rpcBody: string | undefined): Record<string, unknown> | undefined {
-  if (!rpcBody) return undefined;
-  try {
-    return readRecord(readRecord(JSON.parse(rpcBody))?.params);
-  } catch {
-    return undefined;
-  }
-}
-
-function hasUploadedArtifactId(meta: Record<string, unknown> | undefined): boolean {
-  const uploadedArtifactId = meta?.uploadedArtifactId;
-  return typeof uploadedArtifactId === 'string' && uploadedArtifactId.trim().length > 0;
-}
-
-function isHostPathInstallSource(source: unknown): boolean {
-  return readRecord(source)?.kind === 'path';
-}
-
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function sendHostPathInstallSourceRefused(res: ServerResponse, rpcId: unknown): void {
-  const error = new AppError(
-    'INVALID_ARGS',
-    'Invalid params: an install source of kind "path" names a file on the daemon host and is not accepted through the proxy',
-    { hint: 'Upload the artifact, or use a "url" or "github-actions-artifact" source.' },
-  );
-  res.statusCode = 400;
-  res.setHeader('content-type', 'application/json');
-  res.end(
-    JSON.stringify({
-      jsonrpc: '2.0',
-      id: rpcId,
-      error: { code: -32602, message: error.message, data: normalizeError(error) },
-    }),
-  );
 }
 
 function readJsonRpcToken(body: string): string {

--- a/src/remote/proxy-install-source-admission.ts
+++ b/src/remote/proxy-install-source-admission.ts
@@ -1,0 +1,51 @@
+import type { ServerResponse } from 'node:http';
+import { AppError, normalizeError } from '@agent-device/kernel/errors';
+
+export function carriesUnbackedHostPathInstallSource(rpcBody: string | undefined): boolean {
+  const params = readRpcParams(rpcBody);
+  if (!params) return false;
+  const meta = readRecord(params.meta);
+  if (isBackedByUploadedArtifact(meta)) return false;
+  return isHostPathInstallSource(params.source) || isHostPathInstallSource(meta?.installSource);
+}
+
+export function sendHostPathInstallSourceRefused(res: ServerResponse, rpcId: unknown): void {
+  const error = new AppError(
+    'INVALID_ARGS',
+    'Invalid params: an install source of kind "path" names a file on the daemon host and is not accepted through the proxy',
+    { hint: 'Upload the artifact, or use a "url" or "github-actions-artifact" source.' },
+  );
+  res.statusCode = 400;
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: rpcId,
+      error: { code: -32602, message: error.message, data: normalizeError(error) },
+    }),
+  );
+}
+
+function readRpcParams(rpcBody: string | undefined): Record<string, unknown> | undefined {
+  if (!rpcBody) return undefined;
+  try {
+    return readRecord(readRecord(JSON.parse(rpcBody))?.params);
+  } catch {
+    return undefined;
+  }
+}
+
+function isBackedByUploadedArtifact(meta: Record<string, unknown> | undefined): boolean {
+  const uploadedArtifactId = meta?.uploadedArtifactId;
+  return typeof uploadedArtifactId === 'string' && uploadedArtifactId.trim().length > 0;
+}
+
+function isHostPathInstallSource(source: unknown): boolean {
+  return readRecord(source)?.kind === 'path';
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}


### PR DESCRIPTION
Closes #2097.

Two gates, because two RPC methods can carry an install source and they do not share a trust boundary.

## The vulnerability

`install_from_source` accepted `source.kind: "path"` behind nothing but a non-empty check, then handed the string to `materializeLocalSource`, which expands `~` and reads it as-is. Any caller reaching `/rpc` with a valid token could name a file the daemon user can read and have its bytes flow back through the install pipeline.

## Gate 1 — the daemon's `install_from_source` method

`parseInstallSource` now refuses `kind: "path"` outright rather than confining it. The `url` kind already declares its trust boundary (credential rejection, blocked hostnames, non-public-address rejection, redirect caps); the `path` kind has no host-side equivalent and does not need one — it is an affordance for callers that already carry the daemon's authority. No opt-in and no allowlist-root config surface, per the triage note.

`HttpInstallSource = Exclude<DaemonInstallSource, { kind: 'path' }>` carries the narrowed contract, so re-adding a path return fails to compile. Verified by planting one: `TS2322: Type '"path"' is not assignable to type '"github-actions-artifact" | "url"'`.

## Gate 2 — the proxy, for the method the client actually uses

That first gate covers the wrong route on its own. The generic `agent_device.command` method copies `params.meta` wholesale and `commandRpcParamsSchema` types `meta` as an opaque object, so `meta.installSource` reached the install handler unparsed — and `buildHttpRpcPayload` always sends `agent_device.command`. Before this PR:

```
POST /rpc  {"method":"agent_device.command",
            "params":{"command":"install_source","flags":{"platform":"android"},
                      "meta":{"installSource":{"kind":"path","path":"/etc/passwd"}}}}
→ 200, handler receives {"kind":"path","path":"/etc/passwd"}
```

**Refusing that at the daemon's HTTP boundary would take local callers with it.** The daemon's HTTP server binds `127.0.0.1` (`listenLoopbackServer`), and `agent-device proxy` puts the local daemon into HTTP-only mode — so on any host running a proxy, a plain local `agent-device install <path>` crosses that same boundary with the same wire shape (`prepareRemoteRequestArtifacts` uploads only when `info.baseUrl` is set, which a loopback daemon has not). Gating there would break local installs to fix a remote hole.

The proxy is the seam that actually separates the daemon's host from callers who are not on it — it is the component whose entire job is exposing the daemon off-host, and it already reads and re-serializes the RPC body to swap tokens. So the refusal lives there, where it covers **both** methods at once because it inspects the payload before the method is dispatched. It also cannot be dodged by parser divergence: the daemon receives the very body the proxy parsed, re-serialized by `rewriteRpcToken`.

**Carve-out:** a path source still crosses when the request carries `meta.uploadedArtifactId` — the sanctioned remote install route, where `resolveInstallSource` substitutes the uploaded file and never reads the wire path. A forged id cannot smuggle a path through it: `prepareUploadedArtifact` → `requireTenantOwnedEntry` throws on an unknown or cross-tenant id rather than falling back. That no-fallback property is the carve-out's whole safety argument, so it is now pinned by its own test — verified to go red when a fallback is introduced.

## Behavior change worth your attention

**`install remote:<path>` is now refused through a proxy.** Naming a file on the daemon's host from a remote client *is* the reported vulnerability, so the affordance cannot survive the fix. I left the client-side `remote:` prefix handling in place (it still applies to a remote daemon reached without the proxy) — say the word if you'd rather retire the client surface too.

## Tests

Both refusals were **observed red** before the fix.

- `src/daemon/__tests__/http-server-rpc-validation.test.ts` — a path source over `/rpc` is rejected `400` / `-32602` / `INVALID_ARGS` and never dispatched; `url` and `github-actions-artifact` still reach the handler with their payload intact.
- `src/__tests__/daemon-proxy.test.ts` — the proxy refuses a path source on *both* methods and the upstream daemon is never called; it still forwards an upload-backed path source and a url source.
- `src/daemon/__tests__/install-source-resolution.test.ts` — an unknown upload id throws instead of reading the wire path.

Local in-process callers are untouched: `admin.ts` and `diff-screenshot.ts` build path sources without crossing either gate, and their existing coverage is unchanged and green.

## One thing left for your call

**No `DAEMON_RPC_PROTOCOL_VERSION` bump.** This removes wire input a released daemon accepted, and `test/wire-compat/README.md` says removal is always the breaking case. The gate stays green only because `surface.ts` declares the `DaemonInstallSource` *type*, not these parsers. I left the version alone deliberately: an old client now fails clearly with `INVALID_ARGS` rather than misparsing anything, which is the distinction ADR 0006 draws, and a bump would sever otherwise-compatible peers over a change that already fails loudly. Happy to take the bump if you read it the other way.

## Validation

`pnpm format:check`, `oxlint --deny-warnings`, `pnpm typecheck`, `pnpm check:layering`, `pnpm check:fallow`, `test/wire-compat`, `pnpm test:integration:provider` (54 files / 161 tests) — all green. Full `pnpm test:unit`: 1074 files / 8158 tests green.

No docs or skills changed: neither RPC method has user-facing documentation, and both refusals carry their own message and hint.
