### PR TITLE
fix(daemon): let a retried open supersede the claim its aborted attempt abandoned

### DIFF
--- a/src/daemon/__tests__/device-claim-admission.test.ts
+++ b/src/daemon/__tests__/device-claim-admission.test.ts
@@ -9,7 +9,7 @@ import {
   retainOrphanedDeviceClaims,
 } from '../../__tests__/test-utils/device-claim-store.ts';
 import { createDeviceClaimAdmission } from '../device-claim-admission.ts';
-import { acquireDeviceClaim } from '../device-claims.ts';
+import { abandonDeviceClaim, acquireDeviceClaim } from '../device-claims.ts';
 import { inspectDeviceClaims } from '../device-claim-inspection.ts';
 import { createRequestExecutionScope } from '../request-execution-scope.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
@@ -107,6 +107,28 @@ test('a claim already held by this daemon covers the command instead of collidin
 
   // The session claim is untouched: the command neither replaced nor released it.
   expect(claimedSessions()).toEqual(['open-session']);
+});
+
+test("an abandoned claim becomes this command's own transient claim and is released", async () => {
+  const { stateDir } = setup();
+  const aborted = await acquireDeviceClaim({
+    device: ANDROID_EMULATOR,
+    session: 'aborted-open',
+    workspace: '/worktrees/current',
+    stateDir,
+    reconcileOrphanedDeviceClaim: retainOrphanedDeviceClaims,
+  });
+  expect(aborted.status).toBe('acquired');
+  if (aborted.status !== 'acquired') return;
+  expect(await abandonDeviceClaim(aborted.ownership)).toBe('abandoned');
+
+  const admission = makeAdmission('transient-exclusive', stateDir, 'install');
+  await admission.admit(ANDROID_EMULATOR, localAndroid);
+
+  // Coverage would have left the abandoned record owning the device with nothing to release it.
+  expect(claimedSessions()).toEqual(['transient:install']);
+  await admission[Symbol.asyncDispose]();
+  expect(inspectDeviceClaims({})).toEqual([]);
 });
 
 test('a provider-owned device takes no host-local claim', async () => {

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, test, vi } from 'vitest';
 import {
+  abandonDeviceClaim,
   acquireDeviceClaim as acquireProductionDeviceClaim,
   clearDeviceClaim,
 } from '../device-claims.ts';
@@ -527,4 +528,109 @@ test('never treats a claim owned by the inspecting process as superseded', async
   if (second.status !== 'conflict') return;
   assert.equal(second.conflict.classification, 'live');
   assert.equal(reconcile.mock.calls.length, 0);
+});
+
+test('an abandoned claim yields to the next acquire of the daemon that abandoned it', async () => {
+  const root = useClaimsRoot();
+  const aborted = await acquireDeviceClaim({
+    device,
+    session: 'attempt-1',
+    workspace: '/worktrees/suite',
+    stateDir: root,
+  });
+  assert.equal(aborted.status, 'acquired');
+  if (aborted.status !== 'acquired') return;
+  assert.equal(await abandonDeviceClaim(aborted.ownership), 'abandoned');
+  assert.equal(
+    typeof inspectDeviceClaims({ serial: device.id })[0]?.claim?.abandonedAtMs,
+    'number',
+  );
+  const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+  const retry = await acquireDeviceClaim({
+    device,
+    session: 'attempt-2',
+    workspace: '/worktrees/suite',
+    stateDir: root,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(retry.status, 'acquired');
+  const claim = inspectDeviceClaims({ serial: device.id })[0]?.claim;
+  assert.equal(claim?.session, 'attempt-2');
+  assert.equal(claim?.abandonedAtMs, undefined);
+  // Abandonment is an owner's own record, not a proof about a dead owner: it never
+  // routes through orphan reconciliation.
+  assert.equal(reconcile.mock.calls.length, 0);
+  assert.equal(await clearDeviceClaim(aborted.ownership), 'ownership-changed');
+});
+
+test('an abandoned claim keeps fencing a daemon that does not own it', async () => {
+  const root = useClaimsRoot();
+  const stateDir = path.join(root, 'foreign-state');
+  await seedForeignLiveClaim(root, stateDir);
+  const stored = JSON.parse(fs.readFileSync(claimPath(root), 'utf8')) as Record<string, unknown>;
+  fs.writeFileSync(claimPath(root), JSON.stringify({ ...stored, abandonedAtMs: 1 }));
+  const reconcile = vi.fn(async () => ({ status: 'reconciled' as const }));
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'other',
+    workspace: '/w',
+    stateDir,
+    reconcileOrphanedDeviceClaim: reconcile,
+  });
+
+  assert.equal(second.status, 'conflict');
+  if (second.status !== 'conflict') return;
+  assert.equal(second.conflict.classification, 'live');
+  assert.equal(second.conflict.claim?.session, 'cwd:/w:default');
+  assert.equal(reconcile.mock.calls.length, 0);
+});
+
+test("an abandoned claim keeps fencing this process on another daemon's state dir", async () => {
+  const root = useClaimsRoot();
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'attempt-1',
+    workspace: '/worktrees/suite',
+    stateDir: path.join(root, 'owner-state'),
+  });
+  assert.equal(acquired.status, 'acquired');
+  if (acquired.status !== 'acquired') return;
+  assert.equal(await abandonDeviceClaim(acquired.ownership), 'abandoned');
+
+  const second = await acquireDeviceClaim({
+    device,
+    session: 'attempt-2',
+    workspace: '/worktrees/suite',
+    stateDir: path.join(root, 'other-state'),
+  });
+
+  assert.equal(second.status, 'conflict');
+  if (second.status !== 'conflict') return;
+  assert.equal(second.conflict.claim?.session, 'attempt-1');
+});
+
+test('reports the exact outcome of abandoning an owned, missing, and unowned claim', async () => {
+  const root = useClaimsRoot();
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'owner',
+    workspace: '/worktrees/owner',
+    stateDir: root,
+  });
+  assert.equal(acquired.status, 'acquired');
+  if (acquired.status !== 'acquired') return;
+
+  assert.equal(await abandonDeviceClaim(acquired.ownership), 'abandoned');
+  const stored = JSON.parse(fs.readFileSync(claimPath(root), 'utf8')) as Record<string, unknown>;
+  fs.writeFileSync(
+    claimPath(root),
+    JSON.stringify({ ...stored, ownerToken: 'successor-token', session: 'successor' }),
+  );
+  assert.equal(await abandonDeviceClaim(acquired.ownership), 'ownership-changed');
+  fs.rmSync(claimPath(root));
+  assert.equal(await abandonDeviceClaim(acquired.ownership), 'absent');
+  assert.equal(await abandonDeviceClaim(undefined), 'absent');
 });

--- a/src/daemon/device-claim-inspection.ts
+++ b/src/daemon/device-claim-inspection.ts
@@ -278,10 +278,15 @@ function decodeClaimOwner(
 
 function decodeClaimTimestamps(
   raw: Record<string, unknown>,
-): Pick<DeviceClaim, 'createdAtMs' | 'updatedAtMs'> | null {
-  const { createdAtMs, updatedAtMs } = raw;
+): Pick<DeviceClaim, 'createdAtMs' | 'updatedAtMs' | 'abandonedAtMs'> | null {
+  const { createdAtMs, updatedAtMs, abandonedAtMs } = raw;
   if (!isFiniteNumber(createdAtMs) || !isFiniteNumber(updatedAtMs)) return null;
-  return { createdAtMs, updatedAtMs };
+  if (abandonedAtMs !== undefined && !isFiniteNumber(abandonedAtMs)) return null;
+  return {
+    createdAtMs,
+    updatedAtMs,
+    ...(isFiniteNumber(abandonedAtMs) ? { abandonedAtMs } : {}),
+  };
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -40,7 +40,7 @@ export type DeviceClaim = {
   ownerToken: string;
   createdAtMs: number;
   updatedAtMs: number;
-  /** Set by {@link abandonDeviceClaim}; absent while a session owns the claim. */
+  /** Set by {@link abandonDeviceClaim}; absent while the claim still holds the device for its owner. */
   abandonedAtMs?: number;
 };
 
@@ -104,10 +104,11 @@ export async function acquireDeviceClaim(params: {
 /**
  * #1320 `transient-exclusive`: exclusive ownership for the duration of one
  * sessionless device mutation. Identical to a session claim except that a claim
- * already held by this daemon process covers the command instead of colliding
- * with it — the claim file itself, not the in-memory session table, is the
- * authority for that, so a claim acquired earlier in the same request (`open`'s,
- * for instance) can never lock the daemon out of its own device.
+ * this daemon still holds covers the command instead of colliding with it — the
+ * claim file itself, not the in-memory session table, is the authority for that,
+ * so a claim acquired earlier in the same request (`open`'s, for instance) can
+ * never lock the daemon out of its own device. An abandoned claim holds nothing,
+ * so it is superseded into this command's own transient claim instead.
  */
 export async function acquireTransientDeviceClaim(params: {
   device: DeviceInfo;
@@ -122,6 +123,7 @@ export async function acquireTransientDeviceClaim(params: {
     const existing = inspectDeviceClaimFile(resolveDeviceClaimPath(deviceKey));
     if (
       existing?.claim &&
+      !isAbandonedDeviceClaim(existing.claim) &&
       isClaimOwnedByThisDaemon(existing.claim, params.stateDir, readCurrentOwnerIdentity())
     ) {
       return { status: 'covered-by-owned-claim' };
@@ -191,17 +193,16 @@ function isClaimOwnedByThisDaemon(
   );
 }
 
-/**
- * An abandoned claim binds no session, so the daemon that abandoned it takes the device back
- * instead of colliding with a record only it can account for. Every other owner still reads a
- * live claim.
- */
+function isAbandonedDeviceClaim(claim: DeviceClaim): boolean {
+  return claim.abandonedAtMs !== undefined;
+}
+
 function isAbandonedClaimOfThisDaemon(
   claim: DeviceClaim,
   stateDir: string,
   owner: ReturnType<typeof readCurrentOwnerIdentity>,
 ): boolean {
-  return claim.abandonedAtMs !== undefined && isClaimOwnedByThisDaemon(claim, stateDir, owner);
+  return isAbandonedDeviceClaim(claim) && isClaimOwnedByThisDaemon(claim, stateDir, owner);
 }
 
 function deviceClaimIdentity(device: DeviceInfo): DeviceIdentity {
@@ -292,19 +293,17 @@ export async function clearDeviceClaim(
 }
 
 /**
- * What abandoning a claim did, in the same terms {@link DeviceClaimClearOutcome} reports:
+ * What abandoning a claim did, in the terms {@link DeviceClaimClearOutcome} uses:
  *
- *  - `abandoned`        — the claim we acquired now binds no session.
+ *  - `abandoned`        — the claim we acquired now holds the device for nobody.
  *  - `absent`           — no claim remains for the device; nothing to mark.
  *  - `ownership-changed`— a claim remains, but it is not the one we acquired.
  */
 export type DeviceClaimAbandonOutcome = 'abandoned' | 'absent' | 'ownership-changed';
 
 /**
- * Keeps a device fenced while recording that no session can release the claim any more, for an
- * owner whose command ended without establishing one. Releasing instead would hand a device whose
- * effects are unproven to any process on the host; the claim stays live to everyone except this
- * daemon, which supersedes it on its next acquire.
+ * Keeps the device fenced against every other owner while recording that this claim holds it for
+ * nobody. Only the daemon that abandoned it may take it back.
  */
 export async function abandonDeviceClaim(
   ownership: DeviceClaimSessionOwnership | undefined,

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -40,6 +40,8 @@ export type DeviceClaim = {
   ownerToken: string;
   createdAtMs: number;
   updatedAtMs: number;
+  /** Set by {@link abandonDeviceClaim}; absent while a session owns the claim. */
+  abandonedAtMs?: number;
 };
 
 export type DeviceClaimReconciliationResult =
@@ -189,6 +191,19 @@ function isClaimOwnedByThisDaemon(
   );
 }
 
+/**
+ * An abandoned claim binds no session, so the daemon that abandoned it takes the device back
+ * instead of colliding with a record only it can account for. Every other owner still reads a
+ * live claim.
+ */
+function isAbandonedClaimOfThisDaemon(
+  claim: DeviceClaim,
+  stateDir: string,
+  owner: ReturnType<typeof readCurrentOwnerIdentity>,
+): boolean {
+  return claim.abandonedAtMs !== undefined && isClaimOwnedByThisDaemon(claim, stateDir, owner);
+}
+
 function deviceClaimIdentity(device: DeviceInfo): DeviceIdentity {
   return deviceIdentity({
     ...device,
@@ -206,6 +221,13 @@ async function resolveExistingClaim(params: {
 }): Promise<DeviceClaimAcquireResult | { status: 'available' }> {
   const existing = inspectDeviceClaimFile(resolveDeviceClaimPath(params.deviceKey));
   if (!existing) return { status: 'available' };
+  if (
+    existing.claim &&
+    isAbandonedClaimOfThisDaemon(existing.claim, params.stateDir, params.owner)
+  ) {
+    emitClaimSupersede(params.deviceKey, existing.claim);
+    return { status: 'available' };
+  }
   if (existing.claim && isCurrentClaimOwner(existing.claim, params, params.owner)) {
     return { status: 'acquired', ownership: ownershipFromClaim(existing.claim) };
   }
@@ -258,16 +280,7 @@ export async function clearDeviceClaim(
     const inspected = inspectDeviceClaimFile(claimPath);
     if (!inspected) return 'absent';
     const claim = inspected.claim;
-    if (
-      !claim ||
-      claim.ownerToken !== ownership.ownerToken ||
-      !ownerIdentityMatches(
-        { pid: claim.ownerPid, startTime: claim.ownerStartTime },
-        { pid: ownership.ownerPid, startTime: ownership.ownerStartTime },
-      )
-    ) {
-      return 'ownership-changed';
-    }
+    if (!claim || !claimMatchesOwnership(claim, ownership)) return 'ownership-changed';
     try {
       fs.unlinkSync(claimPath);
     } catch (error) {
@@ -276,6 +289,49 @@ export async function clearDeviceClaim(
     }
     return 'deleted';
   });
+}
+
+/**
+ * What abandoning a claim did, in the same terms {@link DeviceClaimClearOutcome} reports:
+ *
+ *  - `abandoned`        — the claim we acquired now binds no session.
+ *  - `absent`           — no claim remains for the device; nothing to mark.
+ *  - `ownership-changed`— a claim remains, but it is not the one we acquired.
+ */
+export type DeviceClaimAbandonOutcome = 'abandoned' | 'absent' | 'ownership-changed';
+
+/**
+ * Keeps a device fenced while recording that no session can release the claim any more, for an
+ * owner whose command ended without establishing one. Releasing instead would hand a device whose
+ * effects are unproven to any process on the host; the claim stays live to everyone except this
+ * daemon, which supersedes it on its next acquire.
+ */
+export async function abandonDeviceClaim(
+  ownership: DeviceClaimSessionOwnership | undefined,
+): Promise<DeviceClaimAbandonOutcome> {
+  if (!ownership) return 'absent';
+  return await withDeviceClaimLock(ownership.deviceKey, async () => {
+    const inspected = inspectDeviceClaimFile(resolveDeviceClaimPath(ownership.deviceKey));
+    if (!inspected) return 'absent';
+    const claim = inspected.claim;
+    if (!claim || !claimMatchesOwnership(claim, ownership)) return 'ownership-changed';
+    const now = Date.now();
+    writeClaim({ ...claim, abandonedAtMs: now, updatedAtMs: now });
+    return 'abandoned';
+  });
+}
+
+function claimMatchesOwnership(
+  claim: DeviceClaim,
+  ownership: DeviceClaimSessionOwnership,
+): boolean {
+  return (
+    claim.ownerToken === ownership.ownerToken &&
+    ownerIdentityMatches(
+      { pid: claim.ownerPid, startTime: claim.ownerStartTime },
+      { pid: ownership.ownerPid, startTime: ownership.ownerStartTime },
+    )
+  );
 }
 
 /**
@@ -383,6 +439,18 @@ function emitClaimConflict(
       ownerSession: existing.claim?.session,
       ownerStateDir: existing.claim?.stateDir,
       ...(reconciliationReason ? { reconciliationReason } : {}),
+    },
+  });
+}
+
+function emitClaimSupersede(deviceKey: string, abandoned: DeviceClaim): void {
+  emitDiagnostic({
+    level: 'info',
+    phase: 'device_claim_abandoned_superseded',
+    data: {
+      deviceKey,
+      abandonedSession: abandoned.session,
+      abandonedAtMs: abandoned.abandonedAtMs,
     },
   });
 }

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -181,7 +181,9 @@ test('failed local open after dispatch retains its device claim for recovery', a
       }),
     (error: unknown) => error === rejectionError,
   );
-  assert.equal(inspectDeviceClaims({ serial: android.id })[0]?.classification, 'live');
+  const retained = inspectDeviceClaims({ serial: android.id })[0];
+  assert.equal(retained?.classification, 'live');
+  assert.equal(typeof retained?.claim?.abandonedAtMs, 'number');
 });
 
 test('failed local runtime-hint setup retains its device claim before open dispatch', async () => {
@@ -269,6 +271,55 @@ test('cancellation after local device setup retains the device claim for recover
   } finally {
     clearRequestCanceled(requestId);
   }
+});
+
+test('a canceled attempt lets the next attempt of the same suite open the device', async () => {
+  const { store, stateDir } = setup();
+  const requestId = 'suite:1-gesture-pan-duration:attempt:1';
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockResolvedValue(undefined);
+  markRequestCanceled(requestId);
+  try {
+    const timedOut = await handleOpenCommand({
+      req: {
+        command: 'open',
+        token: 'test',
+        session: 'suite:1-gesture-pan-duration:attempt-1',
+        positionals: ['Demo'],
+        flags: { platform: 'android' },
+        meta: { requestId },
+      },
+      sessionName: 'suite:1-gesture-pan-duration:attempt-1',
+      logPath: path.join(stateDir, 'daemon.log'),
+      sessionStore: store,
+    });
+    assert.equal(timedOut.ok, false);
+  } finally {
+    clearRequestCanceled(requestId);
+  }
+  assert.equal(store.get('suite:1-gesture-pan-duration:attempt-1'), undefined);
+
+  const retry = await handleOpenCommand({
+    req: {
+      command: 'open',
+      token: 'test',
+      session: 'suite:1-gesture-pan-duration:attempt-2',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+    },
+    sessionName: 'suite:1-gesture-pan-duration:attempt-2',
+    logPath: path.join(stateDir, 'daemon.log'),
+    sessionStore: store,
+  });
+
+  assert.equal(retry.ok, true);
+  const claim = inspectDeviceClaims({ serial: android.id })[0]?.claim;
+  assert.equal(claim?.session, 'suite:1-gesture-pan-duration:attempt-2');
+  assert.equal(claim?.abandonedAtMs, undefined);
+  assert.equal(
+    store.get('suite:1-gesture-pan-duration:attempt-2')?.deviceClaim?.ownerToken,
+    claim?.ownerToken,
+  );
 });
 
 test('provider-owned open creates no host-local device claim from its selected owner', async () => {

--- a/src/daemon/handlers/session-open-execution.ts
+++ b/src/daemon/handlers/session-open-execution.ts
@@ -46,6 +46,7 @@ import {
 import { resolveSessionLeaseForRequest } from '../lease-lifecycle.ts';
 import { applicationLifecycleExecutionFromRequest } from '../application-lifecycle-execution.ts';
 import {
+  abandonDeviceClaim,
   acquireDeviceClaim,
   clearDeviceClaim,
   isLocalDeviceClaimTarget,
@@ -438,6 +439,13 @@ export async function openNewSessionWithDeviceClaim(params: {
   }
   const deviceClaim = localClaim.status === 'acquired' ? localClaim.ownership : undefined;
   const effects: NewSessionOpenEffects = { mayHaveStarted: false };
+  const rollbackClaim = async () =>
+    await rollbackNewSessionClaim({
+      ownership: deviceClaim,
+      effects,
+      sessionName,
+      sessionStore,
+    });
   try {
     const details = await prepareOpenCommandDetails({
       req,
@@ -450,7 +458,7 @@ export async function openNewSessionWithDeviceClaim(params: {
       foreground: req.flags?.foreground === true && openTarget === undefined,
     });
     if (details.type === 'response') {
-      await rollbackNewSessionClaim(deviceClaim, effects);
+      await rollbackClaim();
       return details.response;
     }
     // Preparation can boot the device or warm caches, but it cannot establish session ownership.
@@ -484,26 +492,37 @@ export async function openNewSessionWithDeviceClaim(params: {
       deviceClaim,
       selection,
     });
-    if (!response.ok) await rollbackNewSessionClaim(deviceClaim, effects);
+    if (!response.ok) await rollbackClaim();
     return response;
   } catch (error) {
-    await rollbackNewSessionClaim(deviceClaim, effects);
+    await rollbackClaim();
     throw error;
   }
 }
 
-async function rollbackNewSessionClaim(
-  ownership: DeviceClaimSessionOwnership | undefined,
-  effects: NewSessionOpenEffects,
-): Promise<void> {
+/**
+ * A claim outlives its request only while a session owns it. An open that proved no device effect
+ * releases the device outright; one that may have started effects keeps the fence, but a claim no
+ * session holds is abandoned so this daemon's next open supersedes it instead of inheriting a
+ * device nothing left alive can release.
+ */
+async function rollbackNewSessionClaim(params: {
+  ownership: DeviceClaimSessionOwnership | undefined;
+  effects: NewSessionOpenEffects;
+  sessionName: string;
+  sessionStore: SessionStore;
+}): Promise<void> {
+  const { ownership, effects, sessionName, sessionStore } = params;
   if (!ownership) return;
-  if (effects.mayHaveStarted) {
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'device_claim_open_effects_unconfirmed',
-      data: { deviceKey: ownership.deviceKey },
-    });
+  if (!effects.mayHaveStarted) {
+    await clearDeviceClaim(ownership);
     return;
   }
-  await clearDeviceClaim(ownership);
+  if (sessionStore.get(sessionName)?.deviceClaim?.ownerToken === ownership.ownerToken) return;
+  const outcome = await abandonDeviceClaim(ownership);
+  emitDiagnostic({
+    level: 'warn',
+    phase: 'device_claim_open_effects_unconfirmed',
+    data: { deviceKey: ownership.deviceKey, outcome },
+  });
 }

--- a/src/daemon/handlers/session-open-execution.ts
+++ b/src/daemon/handlers/session-open-execution.ts
@@ -500,12 +500,6 @@ export async function openNewSessionWithDeviceClaim(params: {
   }
 }
 
-/**
- * A claim outlives its request only while a session owns it. An open that proved no device effect
- * releases the device outright; one that may have started effects keeps the fence, but a claim no
- * session holds is abandoned so this daemon's next open supersedes it instead of inheriting a
- * device nothing left alive can release.
- */
 async function rollbackNewSessionClaim(params: {
   ownership: DeviceClaimSessionOwnership | undefined;
   effects: NewSessionOpenEffects;


### PR DESCRIPTION
## Summary

`--retries` was worthless for a timed-out replay attempt: the failed attempt kept the simulator, so
every retry died at step 1 with `ios device <UDID> is owned by session "…:attempt-1"`.

The claim, not the scheduler, was the hole. An `open` that fails **after** preparation deliberately
keeps its claim — the effects it may have started are unproven, and releasing the device would hand
an unknown state to the next session. But nothing recorded that the retained claim binds no session,
so it stayed on disk for the daemon's whole life: no session could release it, no sweep could settle
it (its owner is alive), and every later `open` of that device failed with `DEVICE_IN_USE` naming a
session `session list` does not report and `close --session` cannot reach. A replay-test retry is
just the loudest victim — a plain `agent-device open` that fails mid-launch blocked that device until
the daemon was restarted.

A rollback that finds no session owning the claim now **abandons** it rather than leaving it
untouched:

- the claim file stays, so the host-global fence is unchanged — every other process still reads a
  live claim and still refuses the device;
- the daemon that abandoned it supersedes it on its next acquire, because it is the only owner that
  can account for the effects in question (it owns the runner processes involved).

A `transient-exclusive` command (`install`, `push`, `prepare`, `boot`, `shutdown`) treats a claim this
daemon still holds as coverage and adds none of its own. An abandoned claim holds nothing, so it is
superseded into that command's own transient claim instead — otherwise the command would run unowned
and leave the abandoned record behind.

Retention stays exactly where it was earned. `session close` still retains a claim when teardown
*proved* a resource is unsettled (`device_claim_close_effects_unconfirmed`) — that device has known
outstanding work, and the suite's `infrastructure` stop is the designed response. Abandonment is for
the other case: a claim with nothing left alive to release it.

Before/after, same command, same simulator, same daemon (`test --retries 1`, attempt 1 timed out
mid-`open`):

```
before: ⨯ attempt-2 — Replay failed at step 1 (open "com.apple.Preferences"):
        ios device 524AC9DA… is owned by session "…:1-claim-timeout:attempt-1"
after:  ✓ claim-timeout.ad after 2 attempts (passed attempt 1.27s, total 3.40s)
```

Reported from the iOS smoke lane on [#2100](https://github.com/callstack/agent-device/pull/2100) CI
(run 33091927274, job 98587070677, head 15ec144): attempt-1's request log ends in
`device_claim_open_effects_unconfirmed` after the runner connect exhausted its retries and the
attempt timeout aborted the open, and the scheduler's `cleanupSession` was a 0 ms no-op because no
session had ever been stored.

Two new diagnostics: `device_claim_open_effects_unconfirmed` now carries the abandon `outcome`, and
`device_claim_abandoned_superseded` (info) records the takeover with the abandoned session name.

## Validation

- Live iOS simulator, on `examples/test-app/replays/gesture-pan-duration.ad` itself: dedicated
  throwaway device with the fixture app, real daemon over the repo CLI, host-global claims dir, at
  the shipped head. `--timeout 3400` puts the attempt deadline inside step 1's `open`, which is the
  CI shape. Pre-fix that reproduces the reported failure exactly (`… is owned by session
  "…:1-gesture-pan-duration:attempt-1"`); on this head, 3/3 runs have attempt 2 run its own `open`
  and fail on its own timeout, with `device_claim_open_effects_unconfirmed {outcome: "abandoned"}`
  followed by `device_claim_abandoned_superseded` in attempt-2's request log. Full evidence and the
  cleanup record are in a PR comment. Validation simulator deleted, scratch daemon stopped.
- `session-device-claims.test.ts`: a canceled attempt-1 through the real `open` handler and the real
  claim store, then attempt-2 opening the same device. Reverting `session-open-execution.ts` +
  `device-claims.ts` makes it fail on `retry.ok`, with the same `DEVICE_IN_USE` cause as CI.
- `device-claims.test.ts`: abandon → same-daemon supersede (and no orphan reconciliation), abandoned
  claims still fencing a foreign state dir and a foreign owner, and the three abandon outcomes.
- `pnpm check:affected --run` green (187 files / 1237 tests), plus `check:layering` and
  `check:fallow`.

## Notes

Six files, all in the daemon claim lifecycle; no CLI, MCP, or help surface changes. `device status`
still reports an abandoned claim as `live` with its original owner session — accurate (it is still
fenced) but not self-explanatory; surfacing the abandoned state there is a follow-up, not a
prerequisite. This does not touch the underlying `gesture-pan-duration` runner flake that triggered
the CI timeout; it makes the retry a real retry.
