### PR TITLE
fix(wait): surface runner restart timeout evidence

### DIFF
--- a/packages/contracts/src/wait.ts
+++ b/packages/contracts/src/wait.ts
@@ -13,6 +13,7 @@
 export const WAIT_REASONS = {
   captureStalled: 'wait_capture_stalled',
   deadlineExceeded: 'wait_deadline_exceeded',
+  runnerRestartExhausted: 'wait_runner_restart_exhausted',
   targetAbsent: 'wait_target_absent',
   stableTimeout: 'wait_stable_timeout',
   landmarkIdentityMismatch: 'wait_landmark_identity_mismatch',

--- a/packages/platform-apple/src/runner/__tests__/runner-recovery-wiring.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-recovery-wiring.test.ts
@@ -27,7 +27,10 @@ import { startFakeRunnerServer, type FakeRunnerServer } from './fake-runner-serv
 
 let server: FakeRunnerServer | undefined;
 
-const ensureRunnerSessionMock = vi.hoisted(() => vi.fn());
+const { ensureRunnerSessionMock, invalidateRunnerSessionMock } = vi.hoisted(() => ({
+  ensureRunnerSessionMock: vi.fn(),
+  invalidateRunnerSessionMock: vi.fn(async () => {}),
+}));
 
 vi.mock('../runner-session.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../runner-session.ts')>();
@@ -36,6 +39,7 @@ vi.mock('../runner-session.ts', async (importOriginal) => {
     // Session creation only. executeRunnerCommandWithSession stays REAL, so
     // the send → classify → recover path under test is production code.
     ensureRunnerSession: ensureRunnerSessionMock,
+    invalidateRunnerSession: invalidateRunnerSessionMock,
   };
 });
 
@@ -67,11 +71,12 @@ afterEach(async () => {
   await server?.close();
   server = undefined;
   ensureRunnerSessionMock.mockReset();
+  invalidateRunnerSessionMock.mockReset();
 });
 
-function seedSession(port: number): RunnerSession {
+function makeRunnerSession(port: number, sessionId = `wiring:${port}`): RunnerSession {
   const session: RunnerSession = {
-    sessionId: `wiring:${port}`,
+    sessionId,
     device: IOS_SIMULATOR,
     deviceId: IOS_SIMULATOR.id,
     port,
@@ -81,6 +86,11 @@ function seedSession(port: number): RunnerSession {
     child: { pid: process.pid, exitCode: null },
     ready: true,
   };
+  return session;
+}
+
+function seedSession(port: number): RunnerSession {
+  const session = makeRunnerSession(port);
   ensureRunnerSessionMock.mockResolvedValue(session);
   return session;
 }
@@ -153,6 +163,42 @@ test('an unrecoverable lifecycle state still reaches recovery and reports the in
     runAppleRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 5, y: 5 }),
   ).rejects.toThrow(/invalidated the runner session/);
   assert.ok(server.requests.some((request) => request.command === 'status'));
+});
+
+test('a failed restart preserves the invalidated runner evidence', async () => {
+  const restartedServer = await startFakeRunnerServer({
+    tap: [{ kind: 'hangUp' }],
+    status: [{ kind: 'ok', data: { lifecycleState: 'zombie' } }],
+  });
+  try {
+    server = await startFakeRunnerServer({
+      uptime: [{ kind: 'runnerError', code: 'COMMAND_FAILED', message: 'fetch failed' }],
+    });
+    const staleSession = makeRunnerSession(server.port, 'session-stale');
+    const restartedSession = makeRunnerSession(restartedServer.port, 'session-restarted');
+    ensureRunnerSessionMock
+      .mockResolvedValueOnce(staleSession)
+      .mockResolvedValueOnce(restartedSession);
+
+    await expect(
+      runAppleRunnerCommand(
+        IOS_SIMULATOR,
+        { command: 'tap', x: 5, y: 5 },
+        { logPath: '/tmp/restart.ndjson' },
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        runnerRestarted: true,
+        runnerRestartReason: 'runner_readiness_preflight_failed_before_command_send',
+        runnerRestartCommand: 'tap',
+        runnerInvalidatedSessionId: staleSession.sessionId,
+        runnerRestartSessionId: restartedSession.sessionId,
+        logPath: '/tmp/restart.ndjson',
+      },
+    });
+  } finally {
+    await restartedServer.close();
+  }
 });
 
 test('an exact-session command never dispatches to a replacement runner', async () => {

--- a/packages/platform-apple/src/runner/runner-lifecycle.ts
+++ b/packages/platform-apple/src/runner/runner-lifecycle.ts
@@ -359,6 +359,8 @@ async function restartSessionAndRunCommand(params: {
   const restartedSession = await ensureRunnerSession(device, {
     ...options,
     cleanStaleBundles: true,
+  }).catch((error: unknown) => {
+    throw markRunnerRestartError(error, params);
   });
   commitRunnerRecycle(recycleKey);
   try {
@@ -386,19 +388,51 @@ async function restartSessionAndRunCommand(params: {
   } catch (retryErr) {
     const retryAppErr = asAppError(retryErr, 'COMMAND_FAILED');
     if (isRetryableRunnerError(retryAppErr)) {
-      return await handleRunnerTransportErrorAfterCommandSend({
-        device,
-        session: restartedSession,
-        command,
-        transportError: retryAppErr,
-        options,
-        signal,
-        invalidationReason: 'transport_error_after_retry_command_send',
-        invalidateSession: invalidateRunnerSession,
-      });
+      try {
+        return await handleRunnerTransportErrorAfterCommandSend({
+          device,
+          session: restartedSession,
+          command,
+          transportError: retryAppErr,
+          options,
+          signal,
+          invalidationReason: 'transport_error_after_retry_command_send',
+          invalidateSession: invalidateRunnerSession,
+        });
+      } catch (recoveryErr) {
+        throw markRunnerRestartError(recoveryErr, params, restartedSession);
+      }
     }
-    throw retryErr;
+    throw markRunnerRestartError(retryErr, params, restartedSession);
   }
+}
+
+function markRunnerRestartError(
+  error: unknown,
+  params: Pick<
+    Parameters<typeof restartSessionAndRunCommand>[0],
+    'session' | 'command' | 'options' | 'restartReason'
+  >,
+  restartedSession?: RunnerSession,
+): unknown {
+  if (!(error instanceof AppError)) return error;
+  return new AppError(
+    error.code,
+    error.message,
+    {
+      ...(error.details ?? {}),
+      runnerRestarted: true,
+      runnerRestartReason: params.restartReason,
+      runnerRestartCommand: params.command.command,
+      ...(params.command.commandId ? { runnerRestartCommandId: params.command.commandId } : {}),
+      runnerInvalidatedSessionId: params.session.sessionId,
+      ...(restartedSession ? { runnerRestartSessionId: restartedSession.sessionId } : {}),
+      ...(error.details?.logPath === undefined && params.options.logPath
+        ? { logPath: params.options.logPath }
+        : {}),
+    },
+    error.cause ?? error,
+  );
 }
 
 async function runPrepareHealthCheck(

--- a/src/commands/interaction/runtime/wait-deadline.ts
+++ b/src/commands/interaction/runtime/wait-deadline.ts
@@ -1,4 +1,6 @@
-export type WaitDeadlineResult<T> = { timedOut: false; value: T } | { timedOut: true };
+export type WaitDeadlineResult<T> =
+  | { timedOut: false; value: T }
+  | { timedOut: true; error?: unknown };
 
 type AbortSignalSource = { signal?: AbortSignal };
 
@@ -37,7 +39,7 @@ export async function runWithinWaitDeadline<T>(
     return { timedOut: false, value };
   } catch (error) {
     if (deadlineExpired && !parentSignals.some((parent) => parent.aborted)) {
-      return { timedOut: true };
+      return { timedOut: true, error };
     }
     throw error;
   } finally {

--- a/src/commands/interaction/runtime/wait-polling.ts
+++ b/src/commands/interaction/runtime/wait-polling.ts
@@ -1,5 +1,5 @@
-import { AppError } from '@agent-device/kernel/errors';
-import { WAIT_REASONS } from '@agent-device/contracts/wait';
+import { AppError, type AppErrorDetails } from '@agent-device/kernel/errors';
+import { WAIT_REASONS, type WaitReason } from '@agent-device/contracts/wait';
 import { isUnreadableCaptureContentError } from '@agent-device/contracts/android-snapshot-quality';
 import { selectorPollBudget } from '../../../core/selector-pipeline.ts';
 import {
@@ -15,12 +15,20 @@ import { runWithinWaitDeadline } from './wait-deadline.ts';
  */
 export const DEFAULT_WAIT_TIMEOUT_MS = SELECTOR_PIPELINE_POLICIES.wait.poll.defaultTimeoutMs;
 
-export type WaitPollDeadline = 'capture-stalled' | 'capture-truncated';
+export type WaitPollDeadline = 'capture-stalled' | 'capture-truncated' | 'runner-restart-exhausted';
 
 export type WaitFailureEvidence = {
   timeoutMs: number;
   readableCaptures: number;
   waitedMs: number;
+  runnerRestarted?: true;
+  runnerRestartReason?: string;
+  runnerRestartCommand?: string;
+  runnerRestartCommandId?: string;
+  runnerInvalidatedSessionId?: string;
+  runnerRestartSessionId?: string;
+  logPath?: string;
+  diagnosticId?: string;
 };
 
 type WaitPollingRuntime = {
@@ -62,6 +70,7 @@ export function createWaitPolling(
   const timeoutMs = requestedTimeoutMs ?? budget.defaultTimeoutMs;
   const startedAtMs = now(runtime);
   const unreadable = createUnreadablePollTracker();
+  let timeoutEvidence: Partial<WaitFailureEvidence> = {};
   const remainingMs = () => Math.max(0, timeoutMs - (now(runtime) - startedAtMs));
 
   return {
@@ -82,6 +91,8 @@ export function createWaitPolling(
         if (captureWasReadable) unreadable.recordReadableCapture();
         return result;
       }
+      const runnerRestart = runnerRestartTimeoutEvidence(result.error);
+      timeoutEvidence = runnerRestart ?? {};
       // A capture that only becomes readable after its deadline is not evidence for this wait.
       // Count only captures that completed before runWithinWaitDeadline returned a timeout.
       return {
@@ -90,9 +101,11 @@ export function createWaitPolling(
         // the poll index is not evidence. This remains true after one or more unreadable content
         // verdicts followed by a capture that consumes the remaining budget.
         deadline:
-          unreadable.readableCaptures() === 0
-            ? ('capture-stalled' as const)
-            : ('capture-truncated' as const),
+          runnerRestart !== undefined
+            ? ('runner-restart-exhausted' as const)
+            : unreadable.readableCaptures() === 0
+              ? ('capture-stalled' as const)
+              : ('capture-truncated' as const),
       };
     },
     hasTimeRemaining: () => remainingMs() > 0,
@@ -100,6 +113,7 @@ export function createWaitPolling(
       timeoutMs,
       readableCaptures: unreadable.readableCaptures(),
       waitedMs: now(runtime) - startedAtMs,
+      ...timeoutEvidence,
     }),
     rethrowIfNeverReadable: unreadable.rethrowIfNeverReadable,
     sleepUntilNextPoll: async () =>
@@ -116,6 +130,16 @@ function waitCaptureStalledError(message: string, evidence: WaitFailureEvidence)
     ...evidence,
     retriable: true,
     hint: 'No readable snapshot capture completed before the wait timeout. Retry, or use screenshot to inspect the current surface.',
+  });
+}
+
+function waitRunnerRestartExhaustedError(message: string, evidence: WaitFailureEvidence): AppError {
+  return new AppError('COMMAND_FAILED', message, {
+    reason: WAIT_REASONS.runnerRestartExhausted satisfies WaitReason,
+    waitRunnerRestartExhausted: true,
+    ...evidence,
+    retriable: true,
+    hint: 'An iOS runner restart consumed the wait timeout before a readable snapshot completed. Inspect the diagnostics log for the runner invalidation/restart sequence, then retry.',
   });
 }
 
@@ -140,6 +164,9 @@ export function waitTimeoutError(
   deadline: WaitPollDeadline | undefined,
 ): AppError {
   const evidence = polling.failureEvidence();
+  if (deadline === 'runner-restart-exhausted') {
+    return waitRunnerRestartExhaustedError(message, evidence);
+  }
   if (deadline === 'capture-stalled') return waitCaptureStalledError(message, evidence);
   if (deadline === 'capture-truncated') return waitDeadlineExceededError(message, evidence);
 
@@ -147,6 +174,30 @@ export function waitTimeoutError(
   return evidence.readableCaptures === 0
     ? waitCaptureStalledError(message, evidence)
     : waitTargetAbsentError(message, evidence);
+}
+
+function runnerRestartTimeoutEvidence(error: unknown): Partial<WaitFailureEvidence> | undefined {
+  if (!(error instanceof AppError)) return undefined;
+  const details = error.details;
+  if (details?.runnerRestarted !== true) return undefined;
+  return {
+    runnerRestarted: true,
+    ...copyStringDetail(details, 'runnerRestartReason'),
+    ...copyStringDetail(details, 'runnerRestartCommand'),
+    ...copyStringDetail(details, 'runnerRestartCommandId'),
+    ...copyStringDetail(details, 'runnerInvalidatedSessionId'),
+    ...copyStringDetail(details, 'runnerRestartSessionId'),
+    ...copyStringDetail(details, 'logPath'),
+    ...copyStringDetail(details, 'diagnosticId'),
+  };
+}
+
+function copyStringDetail<Key extends keyof WaitFailureEvidence>(
+  details: AppErrorDetails | undefined,
+  key: Key,
+): Pick<WaitFailureEvidence, Key> | {} {
+  const value = details?.[key];
+  return typeof value === 'string' ? ({ [key]: value } as Pick<WaitFailureEvidence, Key>) : {};
 }
 
 function createUnreadablePollTracker(): UnreadablePollTracker {

--- a/src/daemon/__tests__/wait-runtime.test.ts
+++ b/src/daemon/__tests__/wait-runtime.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import { WAIT_REASONS } from '@agent-device/contracts/wait';
+import { AppError } from '@agent-device/kernel/errors';
 import {
   type DeviceBinding,
   type RuntimeFacts,
@@ -530,6 +531,47 @@ test('a stalled capture reports capture-stalled with no readable captures', asyn
   expect(response.error.details?.reason).toBe(WAIT_REASONS.captureStalled);
   expect(response.error.details?.captureStalled).toBe(true);
   expect(response.error.details?.readableCaptures).toBe(0);
+});
+
+test('a runner restart that exhausts the wait reports typed restart evidence', async () => {
+  const captureSnapshot = vi.fn(async (input: CaptureSnapshotInput) => {
+    const signal = input.signal;
+    if (!signal) throw new Error('the poll deadline never reached the platform');
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) return resolve();
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    throw new AppError('COMMAND_FAILED', 'request canceled', {
+      runnerRestarted: true,
+      runnerRestartReason: 'runner_readiness_preflight_failed_before_command_send',
+      runnerRestartCommand: 'snapshot',
+      runnerRestartCommandId: 'snapshot-1',
+      runnerInvalidatedSessionId: 'session-old',
+      runnerRestartSessionId: 'session-new',
+      diagnosticId: 'diag-restart',
+      logPath: '/tmp/restart.ndjson',
+    });
+  });
+  const harness = waitRuntimeHarness({ captureSnapshot });
+
+  const { response } = await runWait(['text', 'Ready', '50'], harness);
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.details).toMatchObject({
+    reason: WAIT_REASONS.runnerRestartExhausted,
+    waitRunnerRestartExhausted: true,
+    runnerRestarted: true,
+    runnerRestartReason: 'runner_readiness_preflight_failed_before_command_send',
+    runnerRestartCommand: 'snapshot',
+    runnerRestartCommandId: 'snapshot-1',
+    runnerInvalidatedSessionId: 'session-old',
+    runnerRestartSessionId: 'session-new',
+    diagnosticId: 'diag-restart',
+    logPath: '/tmp/restart.ndjson',
+    readableCaptures: 0,
+  });
+  expect(response.error.details?.captureStalled).toBeUndefined();
 });
 
 test('a readable capture that lacks the target stays target-absent, not capture-stalled', async () => {


### PR DESCRIPTION
## Summary

Closes #2103. Keep the caller-supplied wait deadline hard, but preserve an iOS runner restart cause when the capture is cancelled after the restart consumes the wait budget. The wait timeout now reports `wait_runner_restart_exhausted` with restart/session/log evidence instead of `wait_capture_stalled`.

## Validation

Added a daemon wait regression for the typed restart-exhaustion error and an Apple runner recovery wiring regression for marking failed restart paths. PR-head CI is green, including iOS runner smoke.