### PR TITLE
fix: use canonical viewport fallback for rootless touch targeting

### DIFF
--- a/src/commands/interaction/runtime/__tests__/test-utils/index.ts
+++ b/src/commands/interaction/runtime/__tests__/test-utils/index.ts
@@ -295,7 +295,8 @@ export function nonTouchableGroupSnapshot(): SnapshotState {
   return makeSnapshotState([
     {
       index: 0,
-      depth: 0,
+      depth: 1,
+      parentIndex: 2,
       type: 'XCUIElementTypeOther',
       label: 'Clickable group',
       rect: { x: 10, y: 20, width: 300, height: 80 },
@@ -303,12 +304,19 @@ export function nonTouchableGroupSnapshot(): SnapshotState {
     },
     {
       index: 1,
-      depth: 1,
+      depth: 2,
       parentIndex: 0,
       type: 'XCUIElementTypeOther',
       label: 'Decorative group',
       rect: { x: 30, y: 40, width: 60, height: 20 },
       hittable: false,
+    },
+    {
+      index: 2,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+      hittable: true,
     },
   ]);
 }

--- a/src/core/interaction-targeting.fixtures.ts
+++ b/src/core/interaction-targeting.fixtures.ts
@@ -3,7 +3,8 @@ import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
 export const EQUIVALENT_WRAPPER_CHAIN_NODES: RawSnapshotNode[] = [
   {
     index: 0,
-    depth: 0,
+    depth: 1,
+    parentIndex: 3,
     type: 'XCUIElementTypeCell',
     label: 'Chat',
     rect: { x: 10, y: 20, width: 300, height: 60 },
@@ -26,6 +27,13 @@ export const EQUIVALENT_WRAPPER_CHAIN_NODES: RawSnapshotNode[] = [
     label: 'Chat',
     rect: { x: 24, y: 32, width: 80, height: 20 },
     hittable: false,
+  },
+  {
+    index: 3,
+    depth: 0,
+    type: 'XCUIElementTypeApplication',
+    rect: { x: 0, y: 0, width: 390, height: 844 },
+    hittable: true,
   },
 ];
 

--- a/src/core/interaction-targeting.test.ts
+++ b/src/core/interaction-targeting.test.ts
@@ -21,7 +21,10 @@ import {
 test('collapses one same-label wrapper chain to its shared actionable node', () => {
   const snapshot = makeSnapshotState(EQUIVALENT_WRAPPER_CHAIN_NODES);
 
-  const result = classifyActionableTouchCandidates(snapshot.nodes, snapshot.nodes);
+  const result = classifyActionableTouchCandidates(
+    snapshot.nodes,
+    snapshot.nodes.filter((node) => node.label === 'Chat'),
+  );
 
   assert.equal(result.kind, 'equivalent');
   if (result.kind === 'equivalent') assert.equal(result.node.index, 1);
@@ -46,7 +49,8 @@ test('promotes static text inside a hittable row to the row', () => {
   const snapshot = makeSnapshotState([
     {
       index: 0,
-      depth: 0,
+      depth: 1,
+      parentIndex: 2,
       type: 'XCUIElementTypeCell',
       label: 'Account row',
       rect: { x: 10, y: 20, width: 300, height: 60 },
@@ -54,12 +58,19 @@ test('promotes static text inside a hittable row to the row', () => {
     },
     {
       index: 1,
-      depth: 1,
+      depth: 2,
       parentIndex: 0,
       type: 'XCUIElementTypeStaticText',
       label: 'Account',
       rect: { x: 24, y: 32, width: 80, height: 20 },
       hittable: false,
+    },
+    {
+      index: 2,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+      hittable: true,
     },
   ]);
 
@@ -185,6 +196,85 @@ test('prevents full-screen window-like ancestors from stealing taps', () => {
 
   assert.equal(resolution.reason, 'overly-broad-ancestor');
   assert.equal(resolution.node.label, 'Status');
+});
+
+test('prevents a full-screen ancestor from stealing taps in a rootless Android-shaped tree', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'android.widget.FrameLayout',
+      rect: { x: 0, y: 0, width: 1080, height: 2400 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.TextView',
+      label: 'Inbox',
+      rect: { x: 24, y: 200, width: 160, height: 64 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'overly-broad-ancestor');
+  assert.equal(resolution.node.label, 'Inbox');
+});
+
+test('applies the rootless viewport fallback without platform-shaped node types', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Container',
+      rect: { x: 0, y: 0, width: 1080, height: 2400 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Label',
+      label: 'Inbox',
+      rect: { x: 24, y: 200, width: 160, height: 64 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'overly-broad-ancestor');
+  assert.equal(resolution.node.label, 'Inbox');
+});
+
+test('keeps a rootless ancestor when its rectangle matches the target', () => {
+  const targetRect = { x: 24, y: 200, width: 160, height: 64 };
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Container',
+      rect: targetRect,
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Label',
+      label: 'Inbox',
+      rect: targetRect,
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'hittable-ancestor');
+  assert.equal(resolution.node.index, 0);
 });
 
 test('falls back to the original node when no usable touch target exists', () => {

--- a/src/core/interaction-targeting.ts
+++ b/src/core/interaction-targeting.ts
@@ -1,11 +1,10 @@
 import type { Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
-import { centerOfRect } from '@agent-device/kernel/snapshot';
-import { containsPoint, pickLargestRect } from '@agent-device/kernel/rect';
 import {
   findNearestAncestor,
   findSnapshotAncestor,
   normalizeType,
   isViewportRootNode,
+  resolveViewportRect,
 } from '@agent-device/contracts/snapshot';
 import { isSnapshotNodeInteractionBlocked } from '@agent-device/capture-kit/snapshot-occlusion';
 import {
@@ -223,7 +222,7 @@ function isOverlyBroadAncestor(
   if (isScrollingContainer(ancestor) && !areRectsApproximatelyEqual(nodeRect, ancestorRect)) {
     return true;
   }
-  const rootViewportRect = resolveRootViewportRect(nodes, nodeRect, index);
+  const rootViewportRect = resolveViewportRect(nodes, nodeRect, index?.viewportRootRects);
   if (!rootViewportRect) return false;
   if (!isRectViewportSized(ancestorRect, rootViewportRect)) return false;
   return !areRectsApproximatelyEqual(nodeRect, ancestorRect);
@@ -241,26 +240,6 @@ function isScrollingContainer(node: SnapshotNode): boolean {
     type === 'table' ||
     type === 'collection'
   );
-}
-
-function resolveRootViewportRect(
-  nodes: SnapshotNode[],
-  targetRect: Rect,
-  index: ActionableTouchIndex | undefined,
-): Rect | null {
-  const targetCenter = centerOfRect(targetRect);
-  const viewportRects =
-    index?.viewportRootRects ??
-    nodes
-      .filter(isViewportRootNode)
-      .map((node) => normalizeRect(node.rect))
-      .filter((rect): rect is Rect => rect !== null);
-  if (viewportRects.length === 0) return null;
-
-  const containingRects = viewportRects.filter((rect) =>
-    containsPoint(rect, targetCenter.x, targetCenter.y),
-  );
-  return pickLargestRect(containingRects.length > 0 ? containingRects : viewportRects);
 }
 
 function buildActionableTouchIndex(nodes: readonly SnapshotNode[]): ActionableTouchIndex {

--- a/src/core/selector-pipeline.test.ts
+++ b/src/core/selector-pipeline.test.ts
@@ -63,7 +63,8 @@ const COVERED_TREE: RawSnapshotNode[] = [
 const PROMOTABLE_TREE: RawSnapshotNode[] = [
   {
     index: 0,
-    depth: 0,
+    depth: 1,
+    parentIndex: 2,
     type: 'XCUIElementTypeCell',
     label: 'Account row',
     rect: { x: 10, y: 20, width: 300, height: 60 },
@@ -71,12 +72,19 @@ const PROMOTABLE_TREE: RawSnapshotNode[] = [
   },
   {
     index: 1,
-    depth: 1,
+    depth: 2,
     parentIndex: 0,
     type: 'XCUIElementTypeStaticText',
     label: 'Account',
     rect: { x: 24, y: 32, width: 80, height: 20 },
     hittable: false,
+  },
+  {
+    index: 2,
+    depth: 0,
+    type: 'XCUIElementTypeApplication',
+    rect: { x: 0, y: 0, width: 390, height: 844 },
+    hittable: true,
   },
 ];
 

--- a/src/daemon/handlers/__tests__/interaction-touch-press.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-touch-press.test.ts
@@ -137,6 +137,7 @@ test('press @ref promotes a non-hittable node to its hittable ancestor before ta
     nodes: attachRefs([
       {
         index: 0,
+        parentIndex: 2,
         type: 'XCUIElementTypeCell',
         label: 'Settings row',
         rect: { x: 20, y: 100, width: 320, height: 72 },
@@ -151,6 +152,12 @@ test('press @ref promotes a non-hittable node to its hittable ancestor before ta
         rect: { x: 44, y: 124, width: 84, height: 20 },
         enabled: false,
         hittable: false,
+      },
+      {
+        index: 2,
+        type: 'XCUIElementTypeApplication',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+        hittable: true,
       },
     ]),
     createdAt: Date.now(),


### PR DESCRIPTION
## Summary

Rootless snapshot trees now use the canonical `resolveViewportRect` fallback during actionable-touch ancestor resolution. A full-screen structural ancestor no longer steals a touch when no explicit Application/Window viewport node exists. The fallback is universal and does not infer Android from class names, backend names, or other strings.

This PR implements the core slice for #2120 and closes that ordered child of #1609. Fragment fixtures that exercise iOS-shaped promotion now include an honest full-screen Application root, preserving their original assertions without narrowing production semantics.

No Maestro changes, scroll-predicate consolidation, shared resolver semantic changes, or public CLI/wire/response changes.

Closes #2120

## Validation

- Base: `main` @ `f152827447cdd5d1e8de1f4bc0a79153564ef08d`
- Head: `a215a8caf1eeffbd4d5dad3fc15869e607377b56` (rebased onto current `origin/main`)
- Planted red on unmodified base: the rootless Android direct-target test failed 1/14 (`hittable-ancestor` actual vs `overly-broad-ancestor` expected).
- Focused green after the fixture repair and rebase: `pnpm vitest run src/core/selector-pipeline.test.ts src/commands/interaction/runtime/resolution.test.ts src/daemon/handlers/__tests__/interaction-touch-press.test.ts src/core/interaction-targeting.test.ts` passed 57/57.
- `pnpm format` completed successfully. The single final `pnpm check:affected --run` passed format, lint, typecheck, layering, fallow, and build; its related Vitest phase passed 290 files / 2,240 tests and hit one unrelated 5-second timeout in `test/integration/provider-scenarios/ios-lifecycle.test.ts` (`iOS Settings flow uses scripted simctl and runner providers`).
- Fresh exact-head GitHub CI is green: [Android Smoke](https://github.com/callstack/agent-device/actions/runs/33364192539), [iOS Smoke](https://github.com/callstack/agent-device/actions/runs/33364192560), and [CI including Coverage and Repo Guards](https://github.com/callstack/agent-device/actions/runs/33364192586) passed. Linux, macOS, CodeQL, Bundle Size, native fingerprint, Integration Tests, and Typecheck & Package also passed.
- The previous Android Smoke failure on the superseded head booted successfully and produced 17 readable captures, then timed out waiting for fixture text `Alert result: accepted`; it did not fail in actionable-touch targeting. It passed on the fresh rebased head.
- The previous iOS `TEXT_INPUT_COMMIT_NOT_OBSERVED` failure did not reproduce; iOS Smoke passed on the fresh rebased head. No iOS/fill code was changed.
- Live Android rootless RecyclerView evidence remains unavailable: local ADB cannot start its server (`Operation not permitted`), and no non-user-owned emulator was available. No device was disturbed and no live evidence is claimed.

## Duplicate PR disposition

- Compared #2154 (`dcecb3c5cb3046001b41863603b05a8447331ae2`): it implements the same canonical rootless viewport policy and adds two index-shifting test edits because it places new roots at index 0. #2122 keeps roots append-only so existing target/ref indexes remain stable, calls the canonical resolver directly, and is the narrower reviewed implementation. No code was borrowed from #2154.
- #2154 was closed as fully superseded by this PR: [disposition comment](https://github.com/callstack/agent-device/pull/2154#issuecomment-5474597548).

Touched files: 6. No docs or skills changed. No merge was performed.

Residual risk is limited to the missing live Android RecyclerView evidence and the unrelated local provider timeout. #2121 remains blocked behind this prerequisite.
