### PR TITLE
fix(maestro): measure settle outcomes directly

### DIFF
--- a/packages/maestro/src/internal/engine-types.ts
+++ b/packages/maestro/src/internal/engine-types.ts
@@ -105,6 +105,7 @@ export type MaestroRuntimeMetrics = {
   hierarchyCaptures: number;
   screenshotCaptures: number;
   tapRetries: number;
+  settleLatches: number;
   settleTimeouts: number;
 };
 

--- a/packages/maestro/src/internal/engine-types.ts
+++ b/packages/maestro/src/internal/engine-types.ts
@@ -105,6 +105,7 @@ export type MaestroRuntimeMetrics = {
   hierarchyCaptures: number;
   screenshotCaptures: number;
   tapRetries: number;
+  settleTimeouts: number;
 };
 
 export type MaestroRuntimePort = {

--- a/packages/maestro/src/internal/facade-execution.ts
+++ b/packages/maestro/src/internal/facade-execution.ts
@@ -53,6 +53,7 @@ export type MaestroCompletedActionEvent = MaestroActionEvent & {
     hierarchyCaptures: number;
     screenshotCaptures: number;
     tapRetries: number;
+    settleTimeouts: number;
   };
   readonly data?: Record<string, unknown>;
 };

--- a/packages/maestro/src/internal/facade-execution.ts
+++ b/packages/maestro/src/internal/facade-execution.ts
@@ -7,6 +7,7 @@ import {
   isMaestroControlCommandDescriptor,
   type MaestroEngineEvent,
   type MaestroEngineObserver,
+  type MaestroRuntimeMetrics,
   type MaestroRuntimePort,
 } from './engine-types.ts';
 import { parseMaestroProgram } from './program-ir-parser.ts';
@@ -49,12 +50,7 @@ export type MaestroActionEvent = {
 
 export type MaestroCompletedActionEvent = MaestroActionEvent & {
   readonly durationMs: number;
-  readonly runtimeMetrics?: {
-    hierarchyCaptures: number;
-    screenshotCaptures: number;
-    tapRetries: number;
-    settleTimeouts: number;
-  };
+  readonly runtimeMetrics?: MaestroRuntimeMetrics;
   readonly data?: Record<string, unknown>;
 };
 

--- a/packages/maestro/src/internal/replay-plan-execution.ts
+++ b/packages/maestro/src/internal/replay-plan-execution.ts
@@ -112,6 +112,7 @@ function runtimeMetricsDelta(
       hierarchyCaptures: after.hierarchyCaptures - before.hierarchyCaptures,
       screenshotCaptures: after.screenshotCaptures - before.screenshotCaptures,
       tapRetries: after.tapRetries - before.tapRetries,
+      settleLatches: after.settleLatches - before.settleLatches,
       settleTimeouts: after.settleTimeouts - before.settleTimeouts,
     },
   };

--- a/packages/maestro/src/internal/replay-plan-execution.ts
+++ b/packages/maestro/src/internal/replay-plan-execution.ts
@@ -112,6 +112,7 @@ function runtimeMetricsDelta(
       hierarchyCaptures: after.hierarchyCaptures - before.hierarchyCaptures,
       screenshotCaptures: after.screenshotCaptures - before.screenshotCaptures,
       tapRetries: after.tapRetries - before.tapRetries,
+      settleTimeouts: after.settleTimeouts - before.settleTimeouts,
     },
   };
 }

--- a/packages/maestro/test/conformance/differential/flows/settle-after-tap.yaml
+++ b/packages/maestro/test/conformance/differential/flows/settle-after-tap.yaml
@@ -9,5 +9,6 @@ appId: com.callstack.agentdevicelab
 - assertVisible: Agent Device Tester
 - tapOn:
     text: Settings
+    retryTapIfNoChange: true
 - assertVisible:
     id: open-inert-surface

--- a/packages/maestro/test/conformance/differential/invariants.test.ts
+++ b/packages/maestro/test/conformance/differential/invariants.test.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { MAESTRO_DEFAULT_SETTLE_TIMEOUT_MS, parseMaestroConformanceSource } from '../harness.ts';
+import { parseMaestroProgram } from '../../../src/internal/program-ir-parser.ts';
 import { DIFFERENTIAL_SCENARIOS } from './scenarios.ts';
 import { type Invariant, evaluateInvariant, readTrace } from './invariants.ts';
 
@@ -33,29 +34,59 @@ const SETTLE_TIMEOUT_INVARIANT: Invariant = {
   because: 'test',
 };
 
-const settleStep = (command: string, durationMs: number, settleTimeouts: number, step = 1) => ({
+const SETTLE_LATCH_INVARIANT: Invariant = {
+  kind: 'metricAtLeast',
+  command: 'tapOn',
+  metric: 'settleLatches',
+  min: 1,
+  because: 'test',
+};
+
+const settleStep = (
+  command: string,
+  durationMs: number,
+  metrics: { settleLatches: number; settleTimeouts: number },
+  step = 1,
+) => ({
   type: 'replay_action_stop',
   step,
   command,
   ok: true,
   durationMs,
-  resultTiming: { hierarchyCaptures: 1, screenshotCaptures: 0, tapRetries: 0, settleTimeouts },
+  resultTiming: { hierarchyCaptures: 1, screenshotCaptures: 0, tapRetries: 0, ...metrics },
 });
 
 test('a stability loop that latched holds the settle invariant however slow the step', () => {
-  const result = evaluateInvariant([settleStep('tapOn', 3344, 0)], SETTLE_TIMEOUT_INVARIANT);
+  const result = evaluateInvariant(
+    [settleStep('tapOn', 3344, { settleLatches: 1, settleTimeouts: 0 })],
+    SETTLE_TIMEOUT_INVARIANT,
+  );
   assert.equal(result.status, 'held');
 });
 
 test('a stability loop that never latched violates it however fast the step', () => {
-  const result = evaluateInvariant([settleStep('tapOn', 120, 1)], SETTLE_TIMEOUT_INVARIANT);
+  const result = evaluateInvariant(
+    [settleStep('tapOn', 120, { settleLatches: 0, settleTimeouts: 1 })],
+    SETTLE_TIMEOUT_INVARIANT,
+  );
   assert.equal(result.status, 'violated');
   assert.match(result.detail, /settleTimeouts was 1/);
 });
 
+test('a tap that did not run the loop violates the settle proof-of-life invariant', () => {
+  const result = evaluateInvariant(
+    [settleStep('tapOn', 120, { settleLatches: 0, settleTimeouts: 0 })],
+    SETTLE_LATCH_INVARIANT,
+  );
+  assert.equal(result.status, 'violated');
+});
+
 test('another command running out of settle budget does not implicate the tap', () => {
   const result = evaluateInvariant(
-    [settleStep('scroll', 900, 2), settleStep('tapOn', 3344, 0, 2)],
+    [
+      settleStep('scroll', 900, { settleLatches: 0, settleTimeouts: 2 }),
+      settleStep('tapOn', 3344, { settleLatches: 1, settleTimeouts: 0 }, 2),
+    ],
     SETTLE_TIMEOUT_INVARIANT,
   );
   assert.equal(result.status, 'held');
@@ -122,14 +153,20 @@ test('readTrace on a missing file returns no events', () => {
 
 test('bug class 4 has a machine-checkable invariant, not just outcome parity', () => {
   const settle = DIFFERENTIAL_SCENARIOS.find((scenario) => scenario.bugClass === 4);
-  const invariant = settle?.engineInvariants?.[0];
-  assert.ok(invariant, 'settle scenario must carry an engine-side invariant');
-  assert.equal(invariant?.kind, 'metricAtMost');
+  const invariants = settle?.engineInvariants;
+  assert.ok(invariants, 'settle scenario must carry engine-side invariants');
   assert.deepEqual(
-    invariant?.kind === 'metricAtMost'
-      ? { metric: invariant.metric, max: invariant.max }
-      : undefined,
-    { metric: 'settleTimeouts', max: 0 },
+    invariants.map((invariant) =>
+      invariant.kind === 'metricAtLeast'
+        ? { kind: invariant.kind, metric: invariant.metric, min: invariant.min }
+        : invariant.kind === 'metricAtMost'
+          ? { kind: invariant.kind, metric: invariant.metric, max: invariant.max }
+          : { kind: invariant.kind },
+    ),
+    [
+      { kind: 'metricAtLeast', metric: 'settleLatches', min: 1 },
+      { kind: 'metricAtMost', metric: 'settleTimeouts', max: 0 },
+    ],
   );
 });
 
@@ -137,6 +174,7 @@ const SETTLE_FLOW_PATH = path.join(import.meta.dirname, 'flows/settle-after-tap.
 
 function assertSettleFlowSemantics(source: string): void {
   const parsed = parseMaestroConformanceSource(source, SETTLE_FLOW_PATH);
+  const program = parseMaestroProgram(source, { sourcePath: SETTLE_FLOW_PATH });
   assert.equal(
     parsed.commands.some(
       (command) => command.kind === 'scroll' || command.kind === 'scrollUntilVisible',
@@ -147,7 +185,9 @@ function assertSettleFlowSemantics(source: string): void {
     parsed.commands.filter((command) => command.kind === 'tap'),
     [{ kind: 'tap', longPress: false, repeat: 1, target: { selector: { text: 'Settings' } } }],
   );
-  assert.match(source, /retryTapIfNoChange: true/);
+  const tap = program.commands.find((command) => command.kind === 'tapOn');
+  assert.equal(tap?.kind, 'tapOn');
+  assert.equal(tap?.retryTapIfNoChange, true);
   assert.equal(
     parsed.commands.some(
       (command) =>
@@ -163,9 +203,10 @@ test('the settle detector reaches its tap without an unrelated setup command', (
   assertSettleFlowSemantics(fs.readFileSync(SETTLE_FLOW_PATH, 'utf8'));
 });
 
-test('the settle flow guard rejects a changed tap target or inserted scroll', () => {
+test('the settle flow guard rejects a changed tap target, disabled retry, or inserted scroll', () => {
   const flow = fs.readFileSync(SETTLE_FLOW_PATH, 'utf8');
   assert.throws(() => assertSettleFlowSemantics(flow.replace('text: Settings', 'text: Home')));
+  assert.throws(() => assertSettleFlowSemantics(flow.replace(/\n\s*retryTapIfNoChange: true/, '')));
   assert.throws(() => assertSettleFlowSemantics(flow.replace('- tapOn:', '- scroll\n- tapOn:')));
 });
 

--- a/packages/maestro/test/conformance/differential/invariants.test.ts
+++ b/packages/maestro/test/conformance/differential/invariants.test.ts
@@ -25,6 +25,47 @@ const stop = (command: string, durationMs: number, step = 1) => ({
   durationMs,
 });
 
+const SETTLE_TIMEOUT_INVARIANT: Invariant = {
+  kind: 'metricAtMost',
+  command: 'tapOn',
+  metric: 'settleTimeouts',
+  max: 0,
+  because: 'test',
+};
+
+const settleStep = (command: string, durationMs: number, settleTimeouts: number, step = 1) => ({
+  type: 'replay_action_stop',
+  step,
+  command,
+  ok: true,
+  durationMs,
+  resultTiming: { hierarchyCaptures: 1, screenshotCaptures: 0, tapRetries: 0, settleTimeouts },
+});
+
+test('a stability loop that latched holds the settle invariant however slow the step', () => {
+  const result = evaluateInvariant([settleStep('tapOn', 3344, 0)], SETTLE_TIMEOUT_INVARIANT);
+  assert.equal(result.status, 'held');
+});
+
+test('a stability loop that never latched violates it however fast the step', () => {
+  const result = evaluateInvariant([settleStep('tapOn', 120, 1)], SETTLE_TIMEOUT_INVARIANT);
+  assert.equal(result.status, 'violated');
+  assert.match(result.detail, /settleTimeouts was 1/);
+});
+
+test('another command running out of settle budget does not implicate the tap', () => {
+  const result = evaluateInvariant(
+    [settleStep('scroll', 900, 2), settleStep('tapOn', 3344, 0, 2)],
+    SETTLE_TIMEOUT_INVARIANT,
+  );
+  assert.equal(result.status, 'held');
+});
+
+test('a trace with no settle metric reports no-data rather than passing', () => {
+  const result = evaluateInvariant([stop('tapOn', 350)], SETTLE_TIMEOUT_INVARIANT);
+  assert.equal(result.status, 'no-data');
+});
+
 test('a tap that latches early holds the settle invariant', () => {
   // Healthy: Android ~350ms, iOS ~800-1100ms — well under the 2000ms budget.
   const result = evaluateInvariant([stop('tapOn', 350)], SETTLE_INVARIANT);
@@ -83,10 +124,12 @@ test('bug class 4 has a machine-checkable invariant, not just outcome parity', (
   const settle = DIFFERENTIAL_SCENARIOS.find((scenario) => scenario.bugClass === 4);
   const invariant = settle?.engineInvariants?.[0];
   assert.ok(invariant, 'settle scenario must carry an engine-side invariant');
-  assert.equal(invariant?.kind, 'stepDurationBelow');
-  assert.equal(
-    invariant?.kind === 'stepDurationBelow' ? invariant.maxMs : undefined,
-    MAESTRO_DEFAULT_SETTLE_TIMEOUT_MS,
+  assert.equal(invariant?.kind, 'metricAtMost');
+  assert.deepEqual(
+    invariant?.kind === 'metricAtMost'
+      ? { metric: invariant.metric, max: invariant.max }
+      : undefined,
+    { metric: 'settleTimeouts', max: 0 },
   );
 });
 
@@ -104,6 +147,7 @@ function assertSettleFlowSemantics(source: string): void {
     parsed.commands.filter((command) => command.kind === 'tap'),
     [{ kind: 'tap', longPress: false, repeat: 1, target: { selector: { text: 'Settings' } } }],
   );
+  assert.match(source, /retryTapIfNoChange: true/);
   assert.equal(
     parsed.commands.some(
       (command) =>

--- a/packages/maestro/test/conformance/differential/invariants.ts
+++ b/packages/maestro/test/conformance/differential/invariants.ts
@@ -7,9 +7,7 @@
 //
 // These invariants read the `replay-timing.ndjson` written by the test runtime
 // (src/daemon/handlers/session-test-runtime.ts) and assert engine-side facts —
-// e.g. a tap must not burn the entire settle budget, which is the signature of a
-// stability loop that never latches (a full-budget tap measures ~2093-2117ms
-// against a 2000ms budget; a healthy Android tap is ~350ms, iOS ~800-1100ms).
+// e.g. a tap's stability loop must latch rather than run out of settle budget.
 //
 // The evaluator is pure and unit-tested against synthetic traces; the device run
 // that produces a real trace happens only on the scheduled workflow.
@@ -25,6 +23,12 @@ export type TraceEvent = {
   resultTiming?: Record<string, unknown>;
 };
 
+export type MetricKey =
+  | 'tapRetries'
+  | 'hierarchyCaptures'
+  | 'screenshotCaptures'
+  | 'settleTimeouts';
+
 export type Invariant =
   | {
       kind: 'stepDurationBelow';
@@ -38,8 +42,15 @@ export type Invariant =
       kind: 'metricAtLeast';
       command: string;
       /** MaestroRuntimeMetrics key, recorded per step as a delta. */
-      metric: 'tapRetries' | 'hierarchyCaptures' | 'screenshotCaptures';
+      metric: MetricKey;
       min: number;
+      because: string;
+    }
+  | {
+      kind: 'metricAtMost';
+      command: string;
+      metric: MetricKey;
+      max: number;
       because: string;
     }
   | {
@@ -76,69 +87,81 @@ function completedSteps(events: TraceEvent[], command: string): TraceEvent[] {
   return events.filter((event) => event.type === 'replay_action_stop' && event.command === command);
 }
 
-export function evaluateInvariant(events: TraceEvent[], invariant: Invariant): InvariantResult {
-  const steps = completedSteps(events, invariant.command);
-  if (steps.length === 0) {
+type MetricBound = Extract<Invariant, { kind: 'metricAtLeast' | 'metricAtMost' }>;
+
+function metricBoundTerms(invariant: MetricBound) {
+  return invariant.kind === 'metricAtMost'
+    ? {
+        broken: (peak: number) => peak > invariant.max,
+        failed: `> ${invariant.max}`,
+        held: (peak: number) => `stayed at ${peak} (<= ${invariant.max})`,
+      }
+    : {
+        broken: (peak: number) => peak < invariant.min,
+        failed: `< ${invariant.min}`,
+        held: (peak: number) => `reached ${peak} (>= ${invariant.min})`,
+      };
+}
+
+function evaluateMetricBound(steps: TraceEvent[], invariant: MetricBound): InvariantResult {
+  const values = steps
+    .map((step) => step.resultTiming?.[invariant.metric])
+    .filter((value): value is number => typeof value === 'number');
+  if (values.length === 0) {
     return {
       invariant,
       status: 'no-data',
-      detail: `no completed ${invariant.command} steps in the trace`,
+      detail: `no ${invariant.command} step recorded a ${invariant.metric} metric`,
     };
   }
-
-  if (invariant.kind === 'metricAtLeast') {
-    const values = steps
-      .map((step) => step.resultTiming?.[invariant.metric])
-      .filter((value): value is number => typeof value === 'number');
-    if (values.length === 0) {
-      return {
-        invariant,
-        status: 'no-data',
-        detail: `no ${invariant.command} step recorded a ${invariant.metric} metric`,
-      };
-    }
-    // Per-step deltas: the strongest single step is what proves the path ran.
-    const best = Math.max(...values);
-    if (best < invariant.min) {
-      return {
+  const peak = Math.max(...values);
+  const terms = metricBoundTerms(invariant);
+  return terms.broken(peak)
+    ? {
         invariant,
         status: 'violated',
-        detail: `highest ${invariant.command} ${invariant.metric} was ${best} (< ${invariant.min}): ${invariant.because}`,
+        detail: `highest ${invariant.command} ${invariant.metric} was ${peak} (${terms.failed}): ${invariant.because}`,
+      }
+    : {
+        invariant,
+        status: 'held',
+        detail: `${invariant.command} ${invariant.metric} ${terms.held(peak)}`,
       };
-    }
+}
+
+function evaluateGestureProfile(
+  steps: TraceEvent[],
+  invariant: Extract<Invariant, { kind: 'gestureExecutionProfile' }>,
+): InvariantResult {
+  const profiles = steps
+    .map((step) => step.resultTiming?.executionProfile)
+    .filter((value): value is string => typeof value === 'string');
+  if (profiles.length === 0) {
     return {
       invariant,
-      status: 'held',
-      detail: `${invariant.command} ${invariant.metric} reached ${best} (>= ${invariant.min})`,
+      status: 'no-data',
+      detail: `no ${invariant.command} step recorded an executionProfile`,
     };
   }
-
-  if (invariant.kind === 'gestureExecutionProfile') {
-    const profiles = steps
-      .map((step) => step.resultTiming?.executionProfile)
-      .filter((value): value is string => typeof value === 'string');
-    if (profiles.length === 0) {
-      return {
-        invariant,
-        status: 'no-data',
-        detail: `no ${invariant.command} step recorded an executionProfile`,
-      };
-    }
-    const firstMismatch = profiles.find((profile) => profile !== invariant.profile);
-    if (firstMismatch !== undefined) {
-      return {
-        invariant,
-        status: 'violated',
-        detail: `${invariant.command} executionProfile was ${firstMismatch} (expected ${invariant.profile}): ${invariant.because}`,
-      };
-    }
+  const firstMismatch = profiles.find((profile) => profile !== invariant.profile);
+  if (firstMismatch !== undefined) {
     return {
       invariant,
-      status: 'held',
-      detail: `${invariant.command} executionProfile is ${invariant.profile} on ${profiles.length} step(s)`,
+      status: 'violated',
+      detail: `${invariant.command} executionProfile was ${firstMismatch} (expected ${invariant.profile}): ${invariant.because}`,
     };
   }
+  return {
+    invariant,
+    status: 'held',
+    detail: `${invariant.command} executionProfile is ${invariant.profile} on ${profiles.length} step(s)`,
+  };
+}
 
+function evaluateStepDuration(
+  steps: TraceEvent[],
+  invariant: Extract<Invariant, { kind: 'stepDurationBelow' }>,
+): InvariantResult {
   const timed = steps.filter((step) => typeof step.durationMs === 'number');
   if (timed.length === 0) {
     return {
@@ -160,6 +183,22 @@ export function evaluateInvariant(events: TraceEvent[], invariant: Invariant): I
     status: 'held',
     detail: `slowest ${invariant.command} took ${worst}ms (< ${invariant.maxMs}ms)`,
   };
+}
+
+export function evaluateInvariant(events: TraceEvent[], invariant: Invariant): InvariantResult {
+  const steps = completedSteps(events, invariant.command);
+  if (steps.length === 0) {
+    return {
+      invariant,
+      status: 'no-data',
+      detail: `no completed ${invariant.command} steps in the trace`,
+    };
+  }
+  if (invariant.kind === 'metricAtMost' || invariant.kind === 'metricAtLeast') {
+    return evaluateMetricBound(steps, invariant);
+  }
+  if (invariant.kind === 'gestureExecutionProfile') return evaluateGestureProfile(steps, invariant);
+  return evaluateStepDuration(steps, invariant);
 }
 
 export function evaluateInvariants(

--- a/packages/maestro/test/conformance/differential/invariants.ts
+++ b/packages/maestro/test/conformance/differential/invariants.ts
@@ -12,6 +12,7 @@
 // The evaluator is pure and unit-tested against synthetic traces; the device run
 // that produces a real trace happens only on the scheduled workflow.
 import fs from 'node:fs';
+import type { MaestroRuntimeMetrics } from '../../../src/internal/engine-types.ts';
 
 export type TraceEvent = {
   type: string;
@@ -19,15 +20,11 @@ export type TraceEvent = {
   command?: string;
   ok?: boolean;
   durationMs?: number;
-  /** Per-step MaestroRuntimeMetrics delta (hierarchyCaptures/screenshotCaptures/tapRetries). */
+  /** Per-step MaestroRuntimeMetrics delta. */
   resultTiming?: Record<string, unknown>;
 };
 
-export type MetricKey =
-  | 'tapRetries'
-  | 'hierarchyCaptures'
-  | 'screenshotCaptures'
-  | 'settleTimeouts';
+export type MetricKey = keyof MaestroRuntimeMetrics;
 
 export type Invariant =
   | {

--- a/packages/maestro/test/conformance/differential/scenarios.ts
+++ b/packages/maestro/test/conformance/differential/scenarios.ts
@@ -17,7 +17,6 @@
 // we do it engine-side via `engineInvariants` over agent-device's own replay
 // timing trace. Scenarios without invariants prove outcome parity ONLY; do not
 // read more into them than that.
-import { MAESTRO_DEFAULT_SETTLE_TIMEOUT_MS } from '../harness.ts';
 import type { Invariant } from './invariants.ts';
 
 /** Bundle id of the fixture app the workflow installs before running scenarios. */
@@ -98,11 +97,12 @@ export const DIFFERENTIAL_SCENARIOS: DifferentialScenario[] = [
     // budget still passes. This invariant is the actual bug-class-4 detector.
     engineInvariants: [
       {
-        kind: 'stepDurationBelow',
+        kind: 'metricAtMost',
         command: 'tapOn',
-        maxMs: MAESTRO_DEFAULT_SETTLE_TIMEOUT_MS,
+        metric: 'settleTimeouts',
+        max: 0,
         because:
-          'a tap consuming the entire settle budget means the stability loop never latched — the signature of a sleep-before-capture ordering regression',
+          'a tap whose stability loop ran out of settle budget without the UI going quiet is the sleep-before-capture ordering signature',
       },
     ],
     divergenceMeans:

--- a/packages/maestro/test/conformance/differential/scenarios.ts
+++ b/packages/maestro/test/conformance/differential/scenarios.ts
@@ -97,6 +97,13 @@ export const DIFFERENTIAL_SCENARIOS: DifferentialScenario[] = [
     // budget still passes. This invariant is the actual bug-class-4 detector.
     engineInvariants: [
       {
+        kind: 'metricAtLeast',
+        command: 'tapOn',
+        metric: 'settleLatches',
+        min: 1,
+        because: 'the scenario must execute and latch its inline stability loop',
+      },
+      {
         kind: 'metricAtMost',
         command: 'tapOn',
         metric: 'settleTimeouts',

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-observation.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-observation.test.ts
@@ -235,6 +235,27 @@ test('compares snapshots before sleeping and captures once beyond a zero settle 
   expect(result.snapshot.nodes[0]?.value).toBe('settled');
 });
 
+test('reports which exit the stability loop took', async () => {
+  const clock = { value: 0 };
+
+  const latched = await waitForTypedSnapshotStability({
+    timeoutMs: 1_000,
+    context: { generation: 0, env: {} },
+    snapshot: async () => makeSnapshot([{ index: 0, type: 'Text', value: 'stable' }]),
+    dependencies: makeDependencies(clock),
+  });
+  expect(latched.settled).toBe(true);
+
+  let value = 0;
+  const exhausted = await waitForTypedSnapshotStability({
+    timeoutMs: 1_000,
+    context: { generation: 0, env: {} },
+    snapshot: async () => makeSnapshot([{ index: 0, type: 'Text', value: `moving ${++value}` }]),
+    dependencies: makeDependencies(clock),
+  });
+  expect(exhausted.settled).toBe(false);
+});
+
 test('confirms an unchanged hierarchy across one polling interval', async () => {
   const clock = { value: 0 };
   let captures = 0;

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-targets.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-targets.test.ts
@@ -235,6 +235,7 @@ test('retries an iOS non-hittable coordinate fallback when the hierarchy does no
     hierarchyCaptures: 5,
     screenshotCaptures: 2,
     tapRetries: 1,
+    settleTimeouts: 0,
   });
 });
 
@@ -298,6 +299,7 @@ test('does not retry an iOS tap when only the rendered surface changes', async (
     hierarchyCaptures: 3,
     screenshotCaptures: 2,
     tapRetries: 0,
+    settleTimeouts: 0,
   });
 });
 
@@ -344,6 +346,7 @@ test('uses screenshot evidence without a redundant hierarchy baseline for iOS po
     hierarchyCaptures: 4,
     screenshotCaptures: 2,
     tapRetries: 1,
+    settleTimeouts: 0,
   });
 });
 

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-targets.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port-targets.test.ts
@@ -235,6 +235,7 @@ test('retries an iOS non-hittable coordinate fallback when the hierarchy does no
     hierarchyCaptures: 5,
     screenshotCaptures: 2,
     tapRetries: 1,
+    settleLatches: 2,
     settleTimeouts: 0,
   });
 });
@@ -299,6 +300,7 @@ test('does not retry an iOS tap when only the rendered surface changes', async (
     hierarchyCaptures: 3,
     screenshotCaptures: 2,
     tapRetries: 0,
+    settleLatches: 1,
     settleTimeouts: 0,
   });
 });
@@ -346,8 +348,52 @@ test('uses screenshot evidence without a redundant hierarchy baseline for iOS po
     hierarchyCaptures: 4,
     screenshotCaptures: 2,
     tapRetries: 1,
+    settleLatches: 2,
     settleTimeouts: 0,
   });
+});
+
+test('records an exhausted inline tap settle', async () => {
+  const clock = { value: 0 };
+  let snapshots = 0;
+  const port = createDaemonMaestroRuntimePort({
+    baseReq: makeBaseRequest({ flags: { platform: 'android', replayBackend: 'maestro' } }),
+    invoke: async (request) => {
+      if (request.command !== 'snapshot') return { ok: true, data: {} };
+      snapshots += 1;
+      return {
+        ok: true,
+        data: {
+          nodes: [
+            { index: 0, type: 'Application' },
+            {
+              index: 1,
+              parentIndex: 0,
+              type: snapshots === 1 ? 'Button' : 'Text',
+              ...(snapshots === 1 ? { identifier: 'continue' } : { value: String(snapshots) }),
+              rect: { x: 20, y: 40, width: 120, height: 44 },
+            },
+          ],
+        },
+      };
+    },
+    dependencies: makeDependencies(clock),
+    platform: 'android',
+  });
+
+  await port.execute({
+    command: {
+      kind: 'tapOn',
+      source: { line: 2 },
+      target: { space: 'target', selector: { id: 'continue' } },
+      retryTapIfNoChange: true,
+    },
+    generation: 0,
+    env: {},
+    invalidateObservation() {},
+  });
+
+  expect(port.readMetrics?.()).toMatchObject({ settleTimeouts: 1 });
 });
 
 function solidPng(value: number): Buffer {

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port.test.ts
@@ -249,6 +249,7 @@ test('uses an observation as the baseline for a later mutation barrier', async (
     hierarchyCaptures: 2,
     screenshotCaptures: 0,
     tapRetries: 0,
+    settleLatches: 1,
     settleTimeouts: 0,
   });
   expect(clock.value).toBe(MAESTRO_OBSERVATION_POLL_MS);

--- a/src/daemon/adapters/maestro/__tests__/daemon-runtime-port.test.ts
+++ b/src/daemon/adapters/maestro/__tests__/daemon-runtime-port.test.ts
@@ -249,6 +249,7 @@ test('uses an observation as the baseline for a later mutation barrier', async (
     hierarchyCaptures: 2,
     screenshotCaptures: 0,
     tapRetries: 0,
+    settleTimeouts: 0,
   });
   expect(clock.value).toBe(MAESTRO_OBSERVATION_POLL_MS);
 });

--- a/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
@@ -49,6 +49,7 @@ export type MaestroSnapshotSource = {
 export type StableMaestroSnapshot = {
   readonly snapshot: SnapshotState;
   readonly signature: string;
+  readonly settled: boolean;
 };
 
 type MaestroTargetResolutionMode = 'tap' | 'swipe' | 'observe';
@@ -237,12 +238,12 @@ export async function waitForTypedSnapshotStability(params: {
     );
     const snapshot = await captureRetriableMaestroSnapshot(params, deadline);
     const signature = maestroSnapshotSignature(snapshot);
-    if (signature === previousSignature) return { snapshot, signature };
+    if (signature === previousSignature) return { snapshot, signature, settled: true };
     previous = snapshot;
     previousSignature = signature;
 
     if (params.dependencies.now() >= deadline) {
-      return { snapshot: previous, signature: previousSignature };
+      return { snapshot: previous, signature: previousSignature, settled: false };
     }
   }
 }

--- a/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-observation.ts
@@ -43,7 +43,9 @@ export type MaestroSnapshotSource = {
   readonly requireStability: (generation: number) => void;
   readonly consumeStabilityFromVisualWait: (context: MaestroRuntimeReadContext) => void;
   readonly prime: (generation: number, snapshot: SnapshotState) => void;
-  readonly settlePending: (context: MaestroRuntimeReadContext) => Promise<void>;
+  readonly settlePending: (
+    context: MaestroRuntimeReadContext,
+  ) => Promise<StableMaestroSnapshot | undefined>;
 };
 
 export type StableMaestroSnapshot = {

--- a/src/daemon/adapters/maestro/daemon-runtime-port-snapshot-source.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port-snapshot-source.ts
@@ -101,7 +101,7 @@ export function createDaemonMaestroSnapshotSource(
       primed = { generation, snapshot };
     },
     settlePending: async (context) => {
-      if (stabilityRequiredGeneration === undefined) return;
+      if (stabilityRequiredGeneration === undefined) return undefined;
       if (stabilityRequiredGeneration !== context.generation) {
         throw new AppError(
           'COMMAND_FAILED',
@@ -120,6 +120,7 @@ export function createDaemonMaestroSnapshotSource(
       stabilityRequiredGeneration = undefined;
       stabilityBaseline = undefined;
       primed = { generation: context.generation, snapshot: stable.snapshot };
+      return stable;
     },
   };
 }

--- a/src/daemon/adapters/maestro/daemon-runtime-port.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port.ts
@@ -43,7 +43,7 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
   readMetrics: () => MaestroRuntimeMetrics;
 } {
   const snapshots = createDaemonMaestroSnapshotSource(options);
-  const metrics = { screenshotCaptures: 0, tapRetries: 0 };
+  const metrics = { screenshotCaptures: 0, tapRetries: 0, settleTimeouts: 0 };
   const platform = options.platform;
   const invoke = <Operation extends MaestroPublicOperation>(operation: Operation) => {
     if (operation.kind === 'screenshot') metrics.screenshotCaptures += 1;
@@ -78,6 +78,7 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
       snapshot: snapshots.capture,
       dependencies: options.dependencies,
     });
+    if (!stable.settled) metrics.settleTimeouts += 1;
     snapshots.prime(context.generation, stable.snapshot);
   };
 
@@ -216,14 +217,14 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
                 },
             context,
           );
-          return (
-            await waitForTypedSnapshotStability({
-              timeoutMs: Math.min(MAESTRO_RUNTIME_ADAPTER_POLICY.settleTimeoutMs, remainingMs),
-              context,
-              snapshot: snapshots.capture,
-              dependencies: options.dependencies,
-            })
-          ).snapshot;
+          const stable = await waitForTypedSnapshotStability({
+            timeoutMs: Math.min(MAESTRO_RUNTIME_ADAPTER_POLICY.settleTimeoutMs, remainingMs),
+            context,
+            snapshot: snapshots.capture,
+            dependencies: options.dependencies,
+          });
+          if (!stable.settled) metrics.settleTimeouts += 1;
+          return stable.snapshot;
         },
       });
       if (match.visiblePercentage !== MAESTRO_RUNTIME_ADAPTER_POLICY.scrollUntilVisiblePercentage) {

--- a/src/daemon/adapters/maestro/daemon-runtime-port.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-port.ts
@@ -16,6 +16,7 @@ import {
   observeTypedMaestroCondition,
   scrollUntilTypedMaestroTarget,
   waitForTypedSnapshotStability,
+  type StableMaestroSnapshot,
   type MaestroSnapshotSource,
 } from './daemon-runtime-port-observation.ts';
 import { createDaemonMaestroSnapshotSource } from './daemon-runtime-port-snapshot-source.ts';
@@ -41,9 +42,19 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
   operations: MaestroRuntimeOperations;
   snapshots: MaestroSnapshotSource;
   readMetrics: () => MaestroRuntimeMetrics;
+  recordSettle: (stable: StableMaestroSnapshot) => void;
 } {
   const snapshots = createDaemonMaestroSnapshotSource(options);
-  const metrics = { screenshotCaptures: 0, tapRetries: 0, settleTimeouts: 0 };
+  const metrics: Omit<MaestroRuntimeMetrics, 'hierarchyCaptures'> = {
+    screenshotCaptures: 0,
+    tapRetries: 0,
+    settleLatches: 0,
+    settleTimeouts: 0,
+  };
+  const recordSettle = (stable: StableMaestroSnapshot) => {
+    if (stable.settled) metrics.settleLatches += 1;
+    else metrics.settleTimeouts += 1;
+  };
   const platform = options.platform;
   const invoke = <Operation extends MaestroPublicOperation>(operation: Operation) => {
     if (operation.kind === 'screenshot') metrics.screenshotCaptures += 1;
@@ -78,7 +89,7 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
       snapshot: snapshots.capture,
       dependencies: options.dependencies,
     });
-    if (!stable.settled) metrics.settleTimeouts += 1;
+    recordSettle(stable);
     snapshots.prime(context.generation, stable.snapshot);
   };
 
@@ -223,7 +234,6 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
             snapshot: snapshots.capture,
             dependencies: options.dependencies,
           });
-          if (!stable.settled) metrics.settleTimeouts += 1;
           return stable.snapshot;
         },
       });
@@ -280,17 +290,20 @@ function createDaemonMaestroRuntimeParts(options: CreateDaemonMaestroRuntimeOper
     operations,
     snapshots,
     readMetrics: () => ({ ...snapshots.readMetrics(), ...metrics }),
+    recordSettle,
   };
 }
 
 export function createDaemonMaestroRuntimePort(
   options: CreateDaemonMaestroRuntimeOperationsOptions,
 ): MaestroRuntimePort {
-  const { operations, snapshots, readMetrics } = createDaemonMaestroRuntimeParts(options);
+  const { operations, snapshots, readMetrics, recordSettle } =
+    createDaemonMaestroRuntimeParts(options);
   return createMaestroRuntimePort(operations, {
     beforeExecute: async ({ context, requiresSettledPredecessor }) => {
       if (requiresSettledPredecessor) {
-        await snapshots.settlePending(context);
+        const stable = await snapshots.settlePending(context);
+        if (stable) recordSettle(stable);
       }
     },
     afterExecute: ({ context, visualStabilityReached }) => {

--- a/src/daemon/adapters/maestro/daemon-runtime-tap.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-tap.ts
@@ -71,7 +71,7 @@ export async function resolveDaemonMaestroTarget(params: {
 export async function tapTargetAndSettle(
   options: CreateDaemonMaestroRuntimeOperationsOptions,
   snapshots: MaestroSnapshotSource,
-  metrics: { screenshotCaptures: number; tapRetries: number },
+  metrics: { screenshotCaptures: number; tapRetries: number; settleTimeouts: number },
   target: Parameters<MaestroRuntimeOperations['tapOn']>[0]['target'],
   context: MaestroRuntimeOperationContext,
   policy: { click: MaestroClickOptions; retryIfNoChange: boolean },
@@ -119,7 +119,7 @@ export async function tapTargetAndSettle(
 async function tapTargetWithRetry(
   options: CreateDaemonMaestroRuntimeOperationsOptions,
   snapshots: MaestroSnapshotSource,
-  metrics: { screenshotCaptures: number; tapRetries: number },
+  metrics: { screenshotCaptures: number; tapRetries: number; settleTimeouts: number },
   target: Parameters<MaestroRuntimeOperations['tapOn']>[0]['target'],
   context: MaestroRuntimeOperationContext,
   flags: MaestroClickOptions,
@@ -129,13 +129,16 @@ async function tapTargetWithRetry(
   const baselineSignature =
     target.resolution?.surfaceSignature ??
     (screenshotBaseline ? undefined : maestroSnapshotSignature(await snapshots.capture(context)));
-  const settle = async () =>
-    await waitForTypedSnapshotStability({
+  const settle = async () => {
+    const stable = await waitForTypedSnapshotStability({
       timeoutMs: MAESTRO_RUNTIME_ADAPTER_POLICY.settleTimeoutMs,
       context,
       snapshot: snapshots.capture,
       dependencies: options.dependencies,
     });
+    if (!stable.settled) metrics.settleTimeouts += 1;
+    return stable;
+  };
 
   try {
     const observed = await executeTapRetryLoop({

--- a/src/daemon/adapters/maestro/daemon-runtime-tap.ts
+++ b/src/daemon/adapters/maestro/daemon-runtime-tap.ts
@@ -6,6 +6,7 @@ import {
   type MaestroDispatchSelector,
   type MaestroRuntimeOperationContext,
   type MaestroRuntimeOperations,
+  type MaestroRuntimeMetrics,
   type MaestroRuntimeReadContext,
   type MaestroTargetMatch,
   type MaestroTargetQuery,
@@ -71,7 +72,7 @@ export async function resolveDaemonMaestroTarget(params: {
 export async function tapTargetAndSettle(
   options: CreateDaemonMaestroRuntimeOperationsOptions,
   snapshots: MaestroSnapshotSource,
-  metrics: { screenshotCaptures: number; tapRetries: number; settleTimeouts: number },
+  metrics: Omit<MaestroRuntimeMetrics, 'hierarchyCaptures'>,
   target: Parameters<MaestroRuntimeOperations['tapOn']>[0]['target'],
   context: MaestroRuntimeOperationContext,
   policy: { click: MaestroClickOptions; retryIfNoChange: boolean },
@@ -119,7 +120,7 @@ export async function tapTargetAndSettle(
 async function tapTargetWithRetry(
   options: CreateDaemonMaestroRuntimeOperationsOptions,
   snapshots: MaestroSnapshotSource,
-  metrics: { screenshotCaptures: number; tapRetries: number; settleTimeouts: number },
+  metrics: Omit<MaestroRuntimeMetrics, 'hierarchyCaptures'>,
   target: Parameters<MaestroRuntimeOperations['tapOn']>[0]['target'],
   context: MaestroRuntimeOperationContext,
   flags: MaestroClickOptions,
@@ -136,7 +137,8 @@ async function tapTargetWithRetry(
       snapshot: snapshots.capture,
       dependencies: options.dependencies,
     });
-    if (!stable.settled) metrics.settleTimeouts += 1;
+    if (stable.settled) metrics.settleLatches += 1;
+    else metrics.settleTimeouts += 1;
     return stable;
   };
 

--- a/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
@@ -24,7 +24,12 @@ test('forwards command labels to progress and replay trace projection', () => {
   observer.actionCompleted?.({
     ...event,
     durationMs: 5,
-    runtimeMetrics: { hierarchyCaptures: 1, screenshotCaptures: 0, tapRetries: 0 },
+    runtimeMetrics: {
+      hierarchyCaptures: 1,
+      screenshotCaptures: 0,
+      tapRetries: 0,
+      settleTimeouts: 0,
+    },
   });
 
   expect(onStep).toHaveBeenCalledWith({

--- a/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-maestro-label.test.ts
@@ -28,6 +28,7 @@ test('forwards command labels to progress and replay trace projection', () => {
       hierarchyCaptures: 1,
       screenshotCaptures: 0,
       tapRetries: 0,
+      settleLatches: 0,
       settleTimeouts: 0,
     },
   });

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -312,7 +312,12 @@ test('typed Maestro writes source-aware redacted step timing traces', async () =
       command: 'inputText',
       ok: true,
       durationMs: expect.any(Number),
-      resultTiming: { hierarchyCaptures: 2, screenshotCaptures: 0, tapRetries: 0 },
+      resultTiming: {
+        hierarchyCaptures: 2,
+        screenshotCaptures: 0,
+        tapRetries: 0,
+        settleTimeouts: 0,
+      },
     }),
   ]);
   expect(fs.readFileSync(tracePath, 'utf8')).not.toContain('highly-sensitive');

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -316,6 +316,7 @@ test('typed Maestro writes source-aware redacted step timing traces', async () =
         hierarchyCaptures: 2,
         screenshotCaptures: 0,
         tapRetries: 0,
+        settleLatches: 1,
         settleTimeouts: 0,
       },
     }),


### PR DESCRIPTION
## Summary

Replace the differential settle detector’s tap-duration proxy with the stability loop’s own outcome. The `settle-after-tap` flow now exercises the retry/settle path and fails only when that loop exhausts its budget.

This removes the cold-simulator false failure where target resolution and dispatch made a healthy tap exceed the settle timeout.

## Validation

- `pnpm test:maestro-compat`
- `pnpm maestro:conformance`
- `pnpm check:affected --run`

The device-backed differential remains GitHub-authoritative. A local iOS attempt was blocked by a pre-existing simulator-session claim, which was closed after the check.

15 files changed; scope is limited to Maestro settle outcome instrumentation, its differential flow, and trace coverage.