### PR TITLE
feat: add symbol-aware depgraph authority overlay

### DIFF
--- a/scripts/depgraph/README.md
+++ b/scripts/depgraph/README.md
@@ -121,8 +121,7 @@ modules and edges, plus 88 dynamic/type-only edges dependency-cruiser fails to r
 
 The report also carries `edgeAuthorities[]`, aligned with `edges[]`. Each entry is a compact list
 of labels, so a collapsed edge may carry more than one label. The labels are derived from exact
-roots and exports in `scripts/layering/architecture-ownership.ts`, plus the named `SessionState`
-and `SessionStore` live-state APIs:
+roots, exports, and named live-state symbols in `scripts/layering/architecture-ownership.ts`:
 
 - `vocabulary` — the target is a declared contract facade root.
 - `capability` — the target is a declared capability root and the import names a declared export.

--- a/scripts/depgraph/README.md
+++ b/scripts/depgraph/README.md
@@ -117,6 +117,43 @@ modules and edges, plus 88 dynamic/type-only edges dependency-cruiser fails to r
   inversion.
 - `cycles[]` — each with `kind` (`value` / `type` / `dynamic`) and its node path.
 
+## Declared-authority overlay
+
+The report also carries `edgeAuthorities[]`, aligned with `edges[]`. Each entry is a compact list
+of labels, so a collapsed edge may carry more than one label. The labels are derived from exact
+roots and exports in `scripts/layering/architecture-ownership.ts`, plus the named `SessionState`
+and `SessionStore` live-state APIs:
+
+- `vocabulary` — the target is a declared contract facade root.
+- `capability` — the target is a declared capability root and the import names a declared export.
+- `live-state-shape` — the edge names the exact `SessionState` type from `src/daemon/types.ts`.
+- `live-state-authority` — the edge names the exact `SessionStore` class from
+  `src/daemon/session-store.ts`.
+- `executable-policy` — the source is under a declared executable-policy root.
+- `ordinary` — no declared authority evidence matches the edge.
+
+`edges[][2]` remains the independent import-kind code (`0` value, `1` type-only, `2` dynamic), and
+`authorityCounts` reports stable counts of labels across the collapsed edges. This is a report-only
+overlay: it reports declared authority, not behavioral ownership quality, safe removability, or a
+composite score/pass threshold.
+
+For reproducible inspection outside the repository's `.tmp` directory:
+
+```sh
+pnpm depgraph --out /tmp/agent-device-2128-depgraph.json
+jq '{generated, authorityCounts}' /tmp/agent-device-2128-depgraph.json
+jq -r '
+  . as $graph
+  | range(0; ($graph.edges | length)) as $i
+  | select($graph.edgeAuthorities[$i] != ["ordinary"])
+  | [($graph.edgeAuthorities[$i] | join("+")),
+     $graph.nodes[$graph.edges[$i][0]].id,
+     $graph.nodes[$graph.edges[$i][1]].id,
+     ["value", "type", "dynamic"][$graph.edges[$i][2]]]
+  | @tsv
+' /tmp/agent-device-2128-depgraph.json
+```
+
 Bit `2` means the target is reachable from the source at distance >= 2 over value edges. That is
 module reachability, not removability — see the caveats above. Treat it as a question ("why is
 this imported directly as well?"), never as an instruction.

--- a/scripts/depgraph/build.ts
+++ b/scripts/depgraph/build.ts
@@ -43,6 +43,9 @@ type Payload = {
    * flags bit0=R5 back-edge, bit1=target also reachable at distance >= 2, bit2=R6 type inversion.
    */
   edges: [number, number, number, number][];
+  /** Labels aligned with `edges`; one edge may carry multiple declared-authority labels. */
+  edgeAuthorities: GraphData['edgeAuthorities'];
+  authorityCounts: GraphData['authorityCounts'];
   cycles: { kind: string; path: number[] }[];
   /** Type-only spine inversions per zone pair, by the gate's counting rule. */
   typeInversions: Record<string, number>;
@@ -102,6 +105,8 @@ function buildPayload(): Payload {
       edgeKindCode(edge.kind),
       edgeFlags(edge),
     ]),
+    edgeAuthorities: graph.edgeAuthorities,
+    authorityCounts: graph.authorityCounts,
     cycles: graph.cycles.map((cycle) => ({
       kind: cycle.kind,
       path: cycle.path.map((file) => nodeIndex.get(file)!),
@@ -130,6 +135,9 @@ async function main(argv: readonly string[]): Promise<number> {
   const backEdges = payload.edges.filter(([, , , flags]) => flags & 1).length;
   const transitivelyReachable = payload.edges.filter(([, , , flags]) => flags & 2).length;
   const typeInversions = Object.values(payload.typeInversions).reduce((sum, n) => sum + n, 0);
+  const authorityCounts = Object.entries(payload.authorityCounts)
+    .map(([label, count]) => `${label}=${count}`)
+    .join(', ');
   process.stdout.write(
     `Dependency graph: ${payload.generated.files} files, ${payload.generated.edges} edges, ` +
       `${payload.zones.length} zones\n` +
@@ -138,6 +146,7 @@ async function main(argv: readonly string[]): Promise<number> {
       `  spine back-edges (R5): ${backEdges}\n` +
       `  type-only spine inversions (R6): ${typeInversions}\n` +
       `  value edges whose target is also reachable at distance >= 2: ${transitivelyReachable}\n` +
+      `  declared-authority labels: ${authorityCounts}\n` +
       `    (reachability only — not a removability claim, see scripts/depgraph/README.md)\n` +
       `  wrote ${path.relative(repoRoot, jsonPath)}\n`,
   );

--- a/scripts/depgraph/model.test.ts
+++ b/scripts/depgraph/model.test.ts
@@ -150,16 +150,16 @@ test('live-state labels follow shared declarations and reject lookalike targets'
         dynamic: false,
         typeOnly: true,
         line: 1,
-        symbols: [declaration.symbol],
+        symbols: [...declaration.exports],
         fromZone: 'core',
         toZone: 'daemon-server',
       }),
-      [declaration.label],
+      [declaration.kind],
     );
   }
 
   const sessionState = ARCHITECTURE_OWNERSHIP.liveState.find(
-    ({ label }) => label === 'live-state-shape',
+    ({ kind }) => kind === 'live-state-shape',
   )!;
   assert.deepEqual(
     authorityLabelsForEdge({
@@ -169,7 +169,7 @@ test('live-state labels follow shared declarations and reject lookalike targets'
       dynamic: false,
       typeOnly: true,
       line: 1,
-      symbols: [sessionState.symbol],
+      symbols: [...sessionState.exports],
       fromZone: 'core',
       toZone: 'daemon-server',
     }),

--- a/scripts/depgraph/model.test.ts
+++ b/scripts/depgraph/model.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { listSourceFiles, TYPE_INVERSION_BASELINE } from '../layering/check.ts';
+import { ARCHITECTURE_OWNERSHIP } from '../layering/architecture-ownership.ts';
 import { resolveImportEdges } from '../layering/model.ts';
 import {
   AUTHORITY_LABELS,
@@ -137,6 +138,43 @@ test('authority overlay uses declared roots and symbols, keeps kind separate, an
     ordinary: 2,
   });
   assert.equal(authorityLabelsForEdge(stateEdges[0]!).includes('live-state-shape'), true);
+});
+
+test('live-state labels follow shared declarations and reject lookalike targets', () => {
+  for (const declaration of ARCHITECTURE_OWNERSHIP.liveState) {
+    assert.deepEqual(
+      authorityLabelsForEdge({
+        file: 'src/core/live-state-consumer.ts',
+        target: declaration.root,
+        spec: `./${declaration.root.split('/').at(-1)}`,
+        dynamic: false,
+        typeOnly: true,
+        line: 1,
+        symbols: [declaration.symbol],
+        fromZone: 'core',
+        toZone: 'daemon-server',
+      }),
+      [declaration.label],
+    );
+  }
+
+  const sessionState = ARCHITECTURE_OWNERSHIP.liveState.find(
+    ({ label }) => label === 'live-state-shape',
+  )!;
+  assert.deepEqual(
+    authorityLabelsForEdge({
+      file: 'src/core/live-state-consumer.ts',
+      target: 'src/daemon/session-state.ts',
+      spec: './session-state.ts',
+      dynamic: false,
+      typeOnly: true,
+      line: 1,
+      symbols: [sessionState.symbol],
+      fromZone: 'core',
+      toZone: 'daemon-server',
+    }),
+    ['ordinary'],
+  );
 });
 
 test('collapseEdges keeps one edge per pair at the strongest kind', () => {

--- a/scripts/depgraph/model.test.ts
+++ b/scripts/depgraph/model.test.ts
@@ -7,6 +7,8 @@ import { test } from 'node:test';
 import { listSourceFiles, TYPE_INVERSION_BASELINE } from '../layering/check.ts';
 import { resolveImportEdges } from '../layering/model.ts';
 import {
+  AUTHORITY_LABELS,
+  authorityLabelsForEdge,
   buildGraph,
   collapseEdges,
   collectCycles,
@@ -17,6 +19,125 @@ import {
 function sources(entries: Record<string, string>): Map<string, string> {
   return new Map(Object.entries(entries));
 }
+
+function authorityWorkspaceTargets(): Map<string, string> {
+  return new Map([
+    ['@agent-device/contracts/client', 'packages/contracts/src/facades/client.ts'],
+    ['@agent-device/contracts/capture', 'packages/contracts/src/facades/capture.ts'],
+    ['@agent-device/contracts/replay', 'packages/contracts/src/facades/replay.ts'],
+    ['@agent-device/contracts/progress', 'packages/contracts/src/facades/progress.ts'],
+  ]);
+}
+
+function authorityFixture(): Map<string, string> {
+  return sources({
+    'src/core/vocabulary-consumer.ts': [
+      "import type { ClientShape } from '@agent-device/contracts/client';",
+      "import type { CaptureShape } from '@agent-device/contracts/capture';",
+      "import type { ReplayShape } from '@agent-device/contracts/replay';",
+      "import type { ProgressShape } from '@agent-device/contracts/progress';",
+    ].join('\n'),
+    'src/daemon/capability-consumer.ts': [
+      "import { createRequestRuntimeBindings } from './request-runtime-binding.ts';",
+      "import { isSessionRecording } from './session-script-publication-capability.ts';",
+    ].join('\n'),
+    'src/daemon/state-consumer.ts': [
+      "import type { SessionState } from './types.ts';",
+      "import { SessionStore } from './session-store.ts';",
+    ].join('\n'),
+    'src/daemon/type-consumer.ts': "import type { SessionStore } from './session-store.ts';\n",
+    'src/snapshot/policy-consumer.ts': [
+      "import type { SessionState } from '../daemon/types.ts';",
+      "import type { SessionRef } from '../daemon/types.ts';",
+      "import './ordinary-target.ts';",
+    ].join('\n'),
+    'src/daemon/ordinary-consumer.ts': [
+      "import { SessionState } from './session-state.ts';",
+      "import { createRequestRuntimeBindingsExtra } from './request-runtime-binding.ts';",
+    ].join('\n'),
+    'src/daemon/types.ts':
+      'export type SessionState = { name: string };\nexport type SessionRef = unknown;\n',
+    'src/daemon/session-store.ts': 'export class SessionStore {}\n',
+    'src/daemon/request-runtime-binding.ts': 'export function createRequestRuntimeBindings() {}\n',
+    'src/daemon/session-script-publication-capability.ts':
+      'export function isSessionRecording() {}\n',
+    'src/daemon/session-state.ts': 'export const SessionState = 1;\n',
+    'src/snapshot/ordinary-target.ts': 'export const ordinary = 1;\n',
+    'packages/contracts/src/facades/client.ts': 'export type ClientShape = string;\n',
+    'packages/contracts/src/facades/capture.ts': 'export type CaptureShape = string;\n',
+    'packages/contracts/src/facades/replay.ts': 'export type ReplayShape = string;\n',
+    'packages/contracts/src/facades/progress.ts': 'export type ProgressShape = string;\n',
+  });
+}
+
+function graphEdge(
+  graph: ReturnType<typeof buildGraph>,
+  from: string,
+  to: string,
+): { kind: string; labels: readonly string[] } {
+  const index = graph.edges.findIndex((edge) => edge.from === from && edge.to === to);
+  assert.notEqual(index, -1, `${from} -> ${to} was not found`);
+  return { kind: graph.edges[index]!.kind, labels: graph.edgeAuthorities[index]! };
+}
+
+test('authority overlay uses declared roots and symbols, keeps kind separate, and collapses labels', () => {
+  const files = authorityFixture();
+  const graph = buildGraph(files, resolveImportEdges(files, authorityWorkspaceTargets()));
+
+  assert.deepEqual(
+    graphEdge(graph, 'src/core/vocabulary-consumer.ts', 'packages/contracts/src/facades/client.ts'),
+    { kind: 'type', labels: ['vocabulary'] },
+  );
+  assert.deepEqual(
+    graphEdge(graph, 'src/daemon/capability-consumer.ts', 'src/daemon/request-runtime-binding.ts'),
+    { kind: 'value', labels: ['capability'] },
+  );
+  assert.deepEqual(graphEdge(graph, 'src/daemon/state-consumer.ts', 'src/daemon/types.ts'), {
+    kind: 'type',
+    labels: ['live-state-shape'],
+  });
+  assert.deepEqual(
+    graphEdge(graph, 'src/daemon/state-consumer.ts', 'src/daemon/session-store.ts'),
+    { kind: 'value', labels: ['live-state-authority'] },
+  );
+  assert.deepEqual(graphEdge(graph, 'src/daemon/type-consumer.ts', 'src/daemon/session-store.ts'), {
+    kind: 'type',
+    labels: ['live-state-authority'],
+  });
+  assert.deepEqual(
+    graphEdge(graph, 'src/snapshot/policy-consumer.ts', 'src/snapshot/ordinary-target.ts'),
+    { kind: 'value', labels: ['executable-policy'] },
+  );
+  assert.deepEqual(
+    graphEdge(graph, 'src/daemon/ordinary-consumer.ts', 'src/daemon/session-state.ts'),
+    { kind: 'value', labels: ['ordinary'] },
+  );
+  assert.deepEqual(
+    graphEdge(graph, 'src/daemon/ordinary-consumer.ts', 'src/daemon/request-runtime-binding.ts'),
+    { kind: 'value', labels: ['ordinary'] },
+  );
+
+  const stateEdges = resolveImportEdges(files, authorityWorkspaceTargets()).filter(
+    (edge) =>
+      edge.file === 'src/snapshot/policy-consumer.ts' && edge.target === 'src/daemon/types.ts',
+  );
+  assert.equal(stateEdges.length, 2, 'the fixture must exercise raw same-pair imports');
+  assert.deepEqual(graphEdge(graph, 'src/snapshot/policy-consumer.ts', 'src/daemon/types.ts'), {
+    kind: 'type',
+    labels: ['live-state-shape', 'executable-policy'],
+  });
+  assert.deepEqual(graph.edgeAuthorities.length, graph.edges.length);
+  assert.deepEqual(Object.keys(graph.authorityCounts), AUTHORITY_LABELS);
+  assert.deepEqual(graph.authorityCounts, {
+    vocabulary: 4,
+    capability: 2,
+    'live-state-shape': 2,
+    'live-state-authority': 2,
+    'executable-policy': 2,
+    ordinary: 2,
+  });
+  assert.equal(authorityLabelsForEdge(stateEdges[0]!).includes('live-state-shape'), true);
+});
 
 test('collapseEdges keeps one edge per pair at the strongest kind', () => {
   const edges = resolveImportEdges(
@@ -235,13 +356,32 @@ test('build.ts writes the default path and a summary consistent with the JSON', 
     zones: { id: string; rank: number | null }[];
     nodes: unknown[];
     edges: [number, number, number, number][];
+    edgeAuthorities: string[][];
+    authorityCounts: Record<string, number>;
     typeInversions: Record<string, number>;
   };
 
   // Wire shape: the fields a consumer queries. A rename here is a breaking change for any script
   // following README.md, so it is pinned rather than assumed.
+  for (const field of [
+    'generated',
+    'zones',
+    'zoneEdges',
+    'nodes',
+    'edges',
+    'cycles',
+    'typeInversions',
+  ]) {
+    assert.ok(field in payload, `legacy payload field ${field} disappeared`);
+  }
   assert.equal(payload.nodes.length, payload.generated.files);
   assert.equal(payload.edges.length, payload.generated.edges);
+  assert.equal(payload.edgeAuthorities.length, payload.edges.length);
+  assert.equal(
+    payload.edges.every((edge) => edge.length === 4),
+    true,
+  );
+  assert.deepEqual(Object.keys(payload.authorityCounts), AUTHORITY_LABELS);
   assert.ok(payload.zones.length > 0);
   assert.ok(Object.keys(payload.typeInversions).length > 0);
 

--- a/scripts/depgraph/model.ts
+++ b/scripts/depgraph/model.ts
@@ -29,6 +29,39 @@ export const AUTHORITY_LABELS = [
 
 export type AuthorityLabel = (typeof AUTHORITY_LABELS)[number];
 export type AuthorityCounts = Record<AuthorityLabel, number>;
+type DeclaredAuthorityLabel = Exclude<AuthorityLabel, 'ordinary'>;
+
+type AuthorityRule = Readonly<{
+  label: DeclaredAuthorityLabel;
+  side: 'source' | 'target';
+  roots: readonly string[];
+  symbols?: readonly string[];
+}>;
+
+const AUTHORITY_RULES: readonly AuthorityRule[] = [
+  ...ARCHITECTURE_OWNERSHIP.vocabulary.map(({ kind, roots }): AuthorityRule => ({
+    label: kind,
+    side: 'target',
+    roots,
+  })),
+  ...ARCHITECTURE_OWNERSHIP.capabilities.map(({ kind, root, exports }): AuthorityRule => ({
+    label: kind,
+    side: 'target',
+    roots: [root],
+    symbols: exports,
+  })),
+  ...ARCHITECTURE_OWNERSHIP.liveState.map(({ kind, root, exports }): AuthorityRule => ({
+    label: kind,
+    side: 'target',
+    roots: [root],
+    symbols: exports,
+  })),
+  ...ARCHITECTURE_OWNERSHIP.executablePolicies.map(({ kind, roots }): AuthorityRule => ({
+    label: kind,
+    side: 'source',
+    roots,
+  })),
+];
 
 export type GraphEdge = {
   from: string;
@@ -42,6 +75,8 @@ export type GraphEdge = {
   /** True when the same pair is also reachable through a longer path of the same weight class. */
   /** Target also reachable at distance >= 2. Reachability only — see the marker function. */
   transitivelyReachable: boolean;
+  /** Declared labels accumulated from every raw import in this collapsed pair. */
+  authorities: readonly DeclaredAuthorityLabel[];
 };
 
 export type GraphNode = {
@@ -81,70 +116,39 @@ export type GraphData = {
   typeInversions: Record<string, number>;
 };
 
-function hasDeclaredCapabilitySymbol(edge: ResolvedImportEdge): boolean {
-  return ARCHITECTURE_OWNERSHIP.capabilities.some(
-    ({ root, exports }) =>
-      edge.target === root &&
-      edge.symbols.some((symbol) => exports.some((name) => name === symbol)),
+function orderedDeclaredAuthorities(
+  labels: Iterable<DeclaredAuthorityLabel>,
+): DeclaredAuthorityLabel[] {
+  const selected = new Set(labels);
+  return AUTHORITY_LABELS.filter(
+    (label): label is DeclaredAuthorityLabel => label !== 'ordinary' && selected.has(label),
   );
 }
 
-function hasDeclaredVocabularyRoot(edge: ResolvedImportEdge): boolean {
-  return ARCHITECTURE_OWNERSHIP.vocabulary.some(({ roots }) =>
-    roots.some((root) => matchesDeclaredRoot(edge.target, root)),
-  );
+function declaredAuthorities(edge: ResolvedImportEdge): DeclaredAuthorityLabel[] {
+  const labels = new Set<DeclaredAuthorityLabel>();
+  for (const rule of AUTHORITY_RULES) {
+    const subject = rule.side === 'source' ? edge.file : edge.target;
+    if (!rule.roots.some((root) => matchesDeclaredRoot(subject, root))) continue;
+    if (rule.symbols && !edge.symbols.some((symbol) => rule.symbols.includes(symbol))) continue;
+    labels.add(rule.label);
+  }
+  return orderedDeclaredAuthorities(labels);
 }
 
-function hasExecutablePolicyOwner(edge: ResolvedImportEdge): boolean {
-  return ARCHITECTURE_OWNERSHIP.executablePolicies.some(({ roots }) =>
-    roots.some((root) => matchesDeclaredRoot(edge.file, root)),
-  );
-}
-
-function declaredLiveStateLabels(edge: ResolvedImportEdge): AuthorityLabel[] {
-  return ARCHITECTURE_OWNERSHIP.liveState
-    .filter(({ root, symbol }) => edge.target === root && edge.symbols.includes(symbol))
-    .map(({ label }) => label);
+function authorityLabelsForDeclared(
+  authorities: readonly DeclaredAuthorityLabel[],
+): AuthorityLabel[] {
+  return authorities.length > 0 ? [...authorities] : ['ordinary'];
 }
 
 /** Labels one resolved edge from exact declared roots and symbols. */
 export function authorityLabelsForEdge(edge: ResolvedImportEdge): AuthorityLabel[] {
-  const labels = new Set<AuthorityLabel>();
-  if (hasDeclaredVocabularyRoot(edge)) labels.add('vocabulary');
-  if (hasDeclaredCapabilitySymbol(edge)) labels.add('capability');
-  for (const label of declaredLiveStateLabels(edge)) labels.add(label);
-  if (hasExecutablePolicyOwner(edge)) labels.add('executable-policy');
-  if (labels.size === 0) labels.add('ordinary');
-  return AUTHORITY_LABELS.filter((label) => labels.has(label));
+  return authorityLabelsForDeclared(declaredAuthorities(edge));
 }
 
 function edgePair(from: string, to: string): string {
   return `${from}\u0000${to}`;
-}
-
-/** Classifications aligned by index with the collapsed graph edges. */
-function classifyEdgeAuthorities(
-  rawEdges: readonly ResolvedImportEdge[],
-  collapsedEdges: readonly GraphEdge[],
-): AuthorityLabel[][] {
-  const rawByPair = new Map<string, ResolvedImportEdge[]>();
-  for (const edge of rawEdges) {
-    const pair = edgePair(edge.file, edge.target);
-    const entries = rawByPair.get(pair) ?? [];
-    entries.push(edge);
-    rawByPair.set(pair, entries);
-  }
-
-  return collapsedEdges.map((edge) => {
-    const labels = new Set<AuthorityLabel>();
-    for (const rawEdge of rawByPair.get(edgePair(edge.from, edge.to)) ?? []) {
-      for (const label of authorityLabelsForEdge(rawEdge)) {
-        if (label !== 'ordinary') labels.add(label);
-      }
-    }
-    if (labels.size === 0) labels.add('ordinary');
-    return AUTHORITY_LABELS.filter((label) => labels.has(label));
-  });
 }
 
 function countAuthorityLabels(edgeAuthorities: readonly AuthorityLabel[][]): AuthorityCounts {
@@ -179,10 +183,17 @@ export function collapseEdges(edges: readonly ResolvedImportEdge[]): GraphEdge[]
   const byPair = new Map<string, GraphEdge>();
   for (const edge of edges) {
     if (edge.file === edge.target) continue;
-    const key = `${edge.file}\u0000${edge.target}`;
+    const key = edgePair(edge.file, edge.target);
     const kind = edgeKind(edge);
     const existing = byPair.get(key);
-    if (existing && strength[existing.kind] >= strength[kind]) continue;
+    const authorities = orderedDeclaredAuthorities([
+      ...(existing?.authorities ?? []),
+      ...declaredAuthorities(edge),
+    ]);
+    if (existing && strength[existing.kind] >= strength[kind]) {
+      byPair.set(key, { ...existing, authorities });
+      continue;
+    }
     byPair.set(key, {
       from: edge.file,
       to: edge.target,
@@ -191,6 +202,7 @@ export function collapseEdges(edges: readonly ResolvedImportEdge[]): GraphEdge[]
       backEdge: backEdgePair(edge),
       typeInversion: typeInversionPair(edge),
       transitivelyReachable: false,
+      authorities,
     });
   }
   return [...byPair.values()].sort(
@@ -425,7 +437,9 @@ export function buildGraph(
 ): GraphData {
   const collapsed = collapseEdges(edges);
   markTransitivelyReachableEdges(collapsed);
-  const edgeAuthorities = classifyEdgeAuthorities(edges, collapsed);
+  const edgeAuthorities = collapsed.map(({ authorities }) =>
+    authorityLabelsForDeclared(authorities),
+  );
   const cycles = collectCycles(edges);
   const nodes = buildNodes(sources, collapsed, indexCyclesByFile(cycles));
 

--- a/scripts/depgraph/model.ts
+++ b/scripts/depgraph/model.ts
@@ -81,9 +81,6 @@ export type GraphData = {
   typeInversions: Record<string, number>;
 };
 
-const SESSION_STATE_ROOT = 'src/daemon/types.ts';
-const SESSION_STORE_ROOT = 'src/daemon/session-store.ts';
-
 function hasDeclaredCapabilitySymbol(edge: ResolvedImportEdge): boolean {
   return ARCHITECTURE_OWNERSHIP.capabilities.some(
     ({ root, exports }) =>
@@ -104,17 +101,18 @@ function hasExecutablePolicyOwner(edge: ResolvedImportEdge): boolean {
   );
 }
 
+function declaredLiveStateLabels(edge: ResolvedImportEdge): AuthorityLabel[] {
+  return ARCHITECTURE_OWNERSHIP.liveState
+    .filter(({ root, symbol }) => edge.target === root && edge.symbols.includes(symbol))
+    .map(({ label }) => label);
+}
+
 /** Labels one resolved edge from exact declared roots and symbols. */
 export function authorityLabelsForEdge(edge: ResolvedImportEdge): AuthorityLabel[] {
   const labels = new Set<AuthorityLabel>();
   if (hasDeclaredVocabularyRoot(edge)) labels.add('vocabulary');
   if (hasDeclaredCapabilitySymbol(edge)) labels.add('capability');
-  if (edge.target === SESSION_STATE_ROOT && edge.symbols.includes('SessionState')) {
-    labels.add('live-state-shape');
-  }
-  if (edge.target === SESSION_STORE_ROOT && edge.symbols.includes('SessionStore')) {
-    labels.add('live-state-authority');
-  }
+  for (const label of declaredLiveStateLabels(edge)) labels.add(label);
   if (hasExecutablePolicyOwner(edge)) labels.add('executable-policy');
   if (labels.size === 0) labels.add('ordinary');
   return AUTHORITY_LABELS.filter((label) => labels.has(label));

--- a/scripts/depgraph/model.ts
+++ b/scripts/depgraph/model.ts
@@ -14,8 +14,21 @@ import {
   typeInversionPair,
   type ResolvedImportEdge,
 } from '../layering/model.ts';
+import { ARCHITECTURE_OWNERSHIP, matchesDeclaredRoot } from '../layering/architecture-ownership.ts';
 
 export type EdgeKind = 'value' | 'type' | 'dynamic';
+
+export const AUTHORITY_LABELS = [
+  'vocabulary',
+  'capability',
+  'live-state-shape',
+  'live-state-authority',
+  'executable-policy',
+  'ordinary',
+] as const;
+
+export type AuthorityLabel = (typeof AUTHORITY_LABELS)[number];
+export type AuthorityCounts = Record<AuthorityLabel, number>;
 
 export type GraphEdge = {
   from: string;
@@ -59,12 +72,90 @@ export type GraphCycle = {
 export type GraphData = {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  edgeAuthorities: AuthorityLabel[][];
+  authorityCounts: AuthorityCounts;
   zones: { id: string; classification: string; files: number; loc: number }[];
   zoneEdges: ZoneEdge[];
   cycles: GraphCycle[];
   /** Type-only spine inversions per zone pair, counted by the gate's rule. */
   typeInversions: Record<string, number>;
 };
+
+const SESSION_STATE_ROOT = 'src/daemon/types.ts';
+const SESSION_STORE_ROOT = 'src/daemon/session-store.ts';
+
+function hasDeclaredCapabilitySymbol(edge: ResolvedImportEdge): boolean {
+  return ARCHITECTURE_OWNERSHIP.capabilities.some(
+    ({ root, exports }) =>
+      edge.target === root &&
+      edge.symbols.some((symbol) => exports.some((name) => name === symbol)),
+  );
+}
+
+function hasDeclaredVocabularyRoot(edge: ResolvedImportEdge): boolean {
+  return ARCHITECTURE_OWNERSHIP.vocabulary.some(({ roots }) =>
+    roots.some((root) => matchesDeclaredRoot(edge.target, root)),
+  );
+}
+
+function hasExecutablePolicyOwner(edge: ResolvedImportEdge): boolean {
+  return ARCHITECTURE_OWNERSHIP.executablePolicies.some(({ roots }) =>
+    roots.some((root) => matchesDeclaredRoot(edge.file, root)),
+  );
+}
+
+/** Labels one resolved edge from exact declared roots and symbols. */
+export function authorityLabelsForEdge(edge: ResolvedImportEdge): AuthorityLabel[] {
+  const labels = new Set<AuthorityLabel>();
+  if (hasDeclaredVocabularyRoot(edge)) labels.add('vocabulary');
+  if (hasDeclaredCapabilitySymbol(edge)) labels.add('capability');
+  if (edge.target === SESSION_STATE_ROOT && edge.symbols.includes('SessionState')) {
+    labels.add('live-state-shape');
+  }
+  if (edge.target === SESSION_STORE_ROOT && edge.symbols.includes('SessionStore')) {
+    labels.add('live-state-authority');
+  }
+  if (hasExecutablePolicyOwner(edge)) labels.add('executable-policy');
+  if (labels.size === 0) labels.add('ordinary');
+  return AUTHORITY_LABELS.filter((label) => labels.has(label));
+}
+
+function edgePair(from: string, to: string): string {
+  return `${from}\u0000${to}`;
+}
+
+/** Classifications aligned by index with the collapsed graph edges. */
+function classifyEdgeAuthorities(
+  rawEdges: readonly ResolvedImportEdge[],
+  collapsedEdges: readonly GraphEdge[],
+): AuthorityLabel[][] {
+  const rawByPair = new Map<string, ResolvedImportEdge[]>();
+  for (const edge of rawEdges) {
+    const pair = edgePair(edge.file, edge.target);
+    const entries = rawByPair.get(pair) ?? [];
+    entries.push(edge);
+    rawByPair.set(pair, entries);
+  }
+
+  return collapsedEdges.map((edge) => {
+    const labels = new Set<AuthorityLabel>();
+    for (const rawEdge of rawByPair.get(edgePair(edge.from, edge.to)) ?? []) {
+      for (const label of authorityLabelsForEdge(rawEdge)) {
+        if (label !== 'ordinary') labels.add(label);
+      }
+    }
+    if (labels.size === 0) labels.add('ordinary');
+    return AUTHORITY_LABELS.filter((label) => labels.has(label));
+  });
+}
+
+function countAuthorityLabels(edgeAuthorities: readonly AuthorityLabel[][]): AuthorityCounts {
+  const counts = Object.fromEntries(AUTHORITY_LABELS.map((label) => [label, 0])) as AuthorityCounts;
+  for (const labels of edgeAuthorities) {
+    for (const label of labels) counts[label]++;
+  }
+  return counts;
+}
 
 function countLines(source: string): number {
   let lines = 1;
@@ -336,12 +427,15 @@ export function buildGraph(
 ): GraphData {
   const collapsed = collapseEdges(edges);
   markTransitivelyReachableEdges(collapsed);
+  const edgeAuthorities = classifyEdgeAuthorities(edges, collapsed);
   const cycles = collectCycles(edges);
   const nodes = buildNodes(sources, collapsed, indexCyclesByFile(cycles));
 
   return {
     nodes: [...nodes.values()].sort((left, right) => left.id.localeCompare(right.id)),
     edges: collapsed,
+    edgeAuthorities,
+    authorityCounts: countAuthorityLabels(edgeAuthorities),
     zones: aggregateZones(nodes),
     zoneEdges: aggregateZoneEdges(nodes, collapsed),
     cycles,

--- a/scripts/layering/architecture-ownership.test.ts
+++ b/scripts/layering/architecture-ownership.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
 import { ARCHITECTURE_OWNERSHIP, matchesDeclaredRoot } from './architecture-ownership.ts';
-import { readDirectNamedExports } from './facade-exports.ts';
+import { readNamedExports } from './facade-exports.ts';
 import { resolveImportEdges } from './model.ts';
 import { workspaceSpecifierTargets } from './package-boundaries.ts';
 import { listTrackedTypeScriptFiles } from './tracked-sources.ts';
@@ -64,7 +64,7 @@ test('capability roots enumerate current exports and have production consumers',
 
   for (const declaration of ARCHITECTURE_OWNERSHIP.capabilities) {
     assert.deepEqual(
-      readDirectNamedExports(sources.get(declaration.root)!),
+      readNamedExports(sources.get(declaration.root)!),
       declaration.exports,
       `${declaration.name} capability exports drifted`,
     );

--- a/scripts/layering/architecture-ownership.test.ts
+++ b/scripts/layering/architecture-ownership.test.ts
@@ -38,12 +38,6 @@ test('architecture ownership roots resolve to tracked owners', () => {
   }
   for (const declaration of ARCHITECTURE_OWNERSHIP.liveState) {
     assert.ok(tracked.has(declaration.root), `${declaration.name} root is not tracked`);
-    assert.ok(
-      readNamedExports(fs.readFileSync(path.join(repoRoot, declaration.root), 'utf8')).includes(
-        declaration.symbol,
-      ),
-      `${declaration.name} symbol is not exported by ${declaration.root}`,
-    );
   }
 });
 
@@ -81,6 +75,20 @@ test('capability roots enumerate current exports and have production consumers',
       edges.some((edge) => edge.target === declaration.root && productionFile(edge.file)),
       `${declaration.name} has no production consumer`,
     );
+  }
+});
+
+test('live-state roots enumerate their declared exports', () => {
+  const files = listTrackedTypeScriptFiles(repoRoot);
+  const sources = new Map(
+    files.map((file) => [file, fs.readFileSync(path.join(repoRoot, file), 'utf8')]),
+  );
+
+  for (const declaration of ARCHITECTURE_OWNERSHIP.liveState) {
+    const actual = new Set(readNamedExports(sources.get(declaration.root)!));
+    for (const name of declaration.exports) {
+      assert.equal(actual.has(name), true, `${declaration.name} export drifted: ${name}`);
+    }
   }
 });
 

--- a/scripts/layering/architecture-ownership.test.ts
+++ b/scripts/layering/architecture-ownership.test.ts
@@ -36,6 +36,15 @@ test('architecture ownership roots resolve to tracked owners', () => {
   for (const declaration of ARCHITECTURE_OWNERSHIP.capabilities) {
     assert.ok(tracked.has(declaration.root), `${declaration.name} root is not tracked`);
   }
+  for (const declaration of ARCHITECTURE_OWNERSHIP.liveState) {
+    assert.ok(tracked.has(declaration.root), `${declaration.name} root is not tracked`);
+    assert.ok(
+      readNamedExports(fs.readFileSync(path.join(repoRoot, declaration.root), 'utf8')).includes(
+        declaration.symbol,
+      ),
+      `${declaration.name} symbol is not exported by ${declaration.root}`,
+    );
+  }
 });
 
 test('vocabulary roots are exported contract facades', () => {

--- a/scripts/layering/architecture-ownership.ts
+++ b/scripts/layering/architecture-ownership.ts
@@ -89,15 +89,15 @@ export const ARCHITECTURE_OWNERSHIP = {
   liveState: [
     {
       name: 'session-state-shape',
-      label: 'live-state-shape',
+      kind: 'live-state-shape',
       root: 'src/daemon/types.ts',
-      symbol: 'SessionState',
+      exports: ['SessionState'],
     },
     {
       name: 'session-store-authority',
-      label: 'live-state-authority',
+      kind: 'live-state-authority',
       root: 'src/daemon/session-store.ts',
-      symbol: 'SessionStore',
+      exports: ['SessionStore'],
     },
   ],
   executablePolicies: [

--- a/scripts/layering/architecture-ownership.ts
+++ b/scripts/layering/architecture-ownership.ts
@@ -86,6 +86,20 @@ export const ARCHITECTURE_OWNERSHIP = {
       ],
     },
   ],
+  liveState: [
+    {
+      name: 'session-state-shape',
+      label: 'live-state-shape',
+      root: 'src/daemon/types.ts',
+      symbol: 'SessionState',
+    },
+    {
+      name: 'session-store-authority',
+      label: 'live-state-authority',
+      root: 'src/daemon/session-store.ts',
+      symbol: 'SessionStore',
+    },
+  ],
   executablePolicies: [
     {
       name: 'snapshot-policy',

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -16,6 +16,7 @@ function importEdge(file: string, target: string): ResolvedImportEdge {
     line: 1,
     dynamic: false,
     typeOnly: true,
+    symbols: [],
     fromZone: targetDagZone(file),
     toZone: targetDagZone(target),
   };

--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -82,6 +82,26 @@ test('parseImports retains named source symbols without changing edge-kind detec
   );
 });
 
+test('parseImports ignores comments inside named bindings', () => {
+  const edges = parseImports(
+    [
+      "import { /* exact, declared */ SessionStore /* authority */ } from './store.ts';",
+      'import /* shape */ {',
+      '  // exact declaration',
+      '  type SessionState as State,',
+      "} from './types.ts';",
+    ].join('\n'),
+  );
+
+  assert.deepEqual(
+    edges.map(({ spec, typeOnly, symbols }) => ({ spec, typeOnly, symbols })),
+    [
+      { spec: './store.ts', typeOnly: false, symbols: ['SessionStore'] },
+      { spec: './types.ts', typeOnly: true, symbols: ['SessionState'] },
+    ],
+  );
+});
+
 test('value cycles fail while type-only and dynamic cycles stay outside the graph', () => {
   const valueCycle = resolveImportEdges(
     new Map([

--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -52,6 +52,36 @@ test('parseImports distinguishes value, type-only, dynamic, and value re-export 
   );
 });
 
+test('parseImports retains named source symbols without changing edge-kind detection', () => {
+  const edges = parseImports(
+    [
+      "import { value as localValue, type TypeA } from './named.ts';",
+      "import type { TypeB as RenamedType } from './types.ts';",
+      "export { reExport as publicName } from './re-export.ts';",
+      "export type { ExportedType } from './exported-types.ts';",
+      "import * as namespace from './namespace.ts';",
+      "void import('./dynamic.ts');",
+    ].join('\n'),
+  );
+
+  assert.deepEqual(
+    edges.map(({ spec, dynamic, typeOnly, symbols }) => ({ spec, dynamic, typeOnly, symbols })),
+    [
+      {
+        spec: './named.ts',
+        dynamic: false,
+        typeOnly: false,
+        symbols: ['value', 'TypeA'],
+      },
+      { spec: './types.ts', dynamic: false, typeOnly: true, symbols: ['TypeB'] },
+      { spec: './re-export.ts', dynamic: false, typeOnly: false, symbols: ['reExport'] },
+      { spec: './exported-types.ts', dynamic: false, typeOnly: true, symbols: ['ExportedType'] },
+      { spec: './namespace.ts', dynamic: false, typeOnly: false, symbols: [] },
+      { spec: './dynamic.ts', dynamic: true, typeOnly: false, symbols: [] },
+    ],
+  );
+});
+
 test('value cycles fail while type-only and dynamic cycles stay outside the graph', () => {
   const valueCycle = resolveImportEdges(
     new Map([

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -124,73 +124,47 @@ function scanSideEffectImport(line: string, lineNo: number): ImportEdge | null {
 }
 
 function withoutImportComments(statement: string): string {
-  let normalized = '';
-  let quote: string | null = null;
-  for (let index = 0; index < statement.length; index++) {
-    const char = statement[index]!;
-    const next = statement[index + 1];
-    if (quote) {
-      normalized += char;
-      if (char === '\\' && next) {
-        normalized += next;
-        index++;
-      } else if (char === quote) {
-        quote = null;
-      }
-    } else if (char === "'" || char === '"') {
-      quote = char;
-      normalized += char;
-    } else if (char === '/' && next === '*') {
-      index += 2;
-      while (
-        index < statement.length &&
-        !(statement[index] === '*' && statement[index + 1] === '/')
-      ) {
-        index++;
-      }
-      index++;
-      normalized += ' ';
-    } else if (char === '/' && next === '/') {
-      while (index < statement.length && statement[index] !== '\n') index++;
-      normalized += '\n';
-    } else {
-      normalized += char;
-    }
+  return statement.replaceAll(
+    /(["'])(?:\\.|(?!\1)[^\\\r\n])*?\1|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g,
+    (match) => (match.startsWith('/*') ? ' ' : match.startsWith('//') ? '\n' : match),
+  );
+}
+
+type NamedSpecifier = { name: string; typeOnly: boolean };
+type ParsedNamedSpecifiers = { index: number; specifiers: NamedSpecifier[] };
+
+function parseNamedSpecifiers(statement: string): ParsedNamedSpecifiers | null {
+  const named = /\{([\s\S]*?)\}/.exec(statement);
+  if (!named) return null;
+
+  const specifiers: NamedSpecifier[] = [];
+  for (const specifier of named[1]!.split(',')) {
+    const trimmed = specifier.trim();
+    const typeOnly = /^type\b/.test(trimmed);
+    const sourceName = trimmed.replace(/^type\s+/, '');
+    const name = /^[A-Za-z_$][\w$]*/.exec(sourceName)?.[0];
+    if (name) specifiers.push({ name, typeOnly });
   }
-  return normalized;
+  return { index: named.index, specifiers };
 }
 
 function importedSymbols(statement: string): string[] {
-  const named = /\{([\s\S]*?)\}/.exec(statement);
-  if (!named) return [];
-  const symbols = new Set<string>();
-  for (const specifier of named[1]!.split(',')) {
-    const sourceName = specifier
-      .trim()
-      .replace(/^type\s+/, '')
-      .split(/\s+as\s+/, 1)[0]
-      ?.trim();
-    if (sourceName) symbols.add(sourceName);
-  }
-  return [...symbols];
+  const parsed = parseNamedSpecifiers(statement);
+  return [...new Set(parsed?.specifiers.map(({ name }) => name) ?? [])];
 }
 
 function statementIsTypeOnly(statement: string): boolean {
   if (/^\s*(?:import|export)\s+type\b/.test(statement)) return true;
-  const named = /\{([\s\S]*?)\}/.exec(statement);
-  if (!named) return false;
+  const parsed = parseNamedSpecifiers(statement);
+  if (!parsed) return false;
   const prefix = statement
-    .slice(0, named.index)
+    .slice(0, parsed.index)
     .replace(/^\s*(?:import|export)\s+/, '')
     .trim()
     .replace(/,$/, '')
     .trim();
   if (prefix.length > 0) return false;
-  const specifiers = named[1]!
-    .split(',')
-    .map((specifier) => specifier.trim())
-    .filter(Boolean);
-  return specifiers.length > 0 && specifiers.every((specifier) => /^type\b/.test(specifier));
+  return parsed.specifiers.length > 0 && parsed.specifiers.every(({ typeOnly }) => typeOnly);
 }
 
 function scanFromImport(lines: string[], index: number): ImportEdge | null {

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -123,6 +123,43 @@ function scanSideEffectImport(line: string, lineNo: number): ImportEdge | null {
     : null;
 }
 
+function withoutImportComments(statement: string): string {
+  let normalized = '';
+  let quote: string | null = null;
+  for (let index = 0; index < statement.length; index++) {
+    const char = statement[index]!;
+    const next = statement[index + 1];
+    if (quote) {
+      normalized += char;
+      if (char === '\\' && next) {
+        normalized += next;
+        index++;
+      } else if (char === quote) {
+        quote = null;
+      }
+    } else if (char === "'" || char === '"') {
+      quote = char;
+      normalized += char;
+    } else if (char === '/' && next === '*') {
+      index += 2;
+      while (
+        index < statement.length &&
+        !(statement[index] === '*' && statement[index + 1] === '/')
+      ) {
+        index++;
+      }
+      index++;
+      normalized += ' ';
+    } else if (char === '/' && next === '/') {
+      while (index < statement.length && statement[index] !== '\n') index++;
+      normalized += '\n';
+    } else {
+      normalized += char;
+    }
+  }
+  return normalized;
+}
+
 function importedSymbols(statement: string): string[] {
   const named = /\{([\s\S]*?)\}/.exec(statement);
   if (!named) return [];
@@ -165,12 +202,13 @@ function scanFromImport(lines: string[], index: number): ImportEdge | null {
   if (start < 0) return null;
 
   const statement = lines.slice(start, index + 1).join('\n');
+  const normalizedStatement = withoutImportComments(statement);
   return {
     spec: fromMatch[1]!,
     dynamic: false,
-    typeOnly: statementIsTypeOnly(statement),
+    typeOnly: statementIsTypeOnly(normalizedStatement),
     line: start + 1,
-    symbols: importedSymbols(statement),
+    symbols: importedSymbols(normalizedStatement),
   };
 }
 

--- a/scripts/layering/model.ts
+++ b/scripts/layering/model.ts
@@ -6,6 +6,8 @@ export type ImportEdge = {
   dynamic: boolean;
   typeOnly: boolean;
   line: number;
+  /** Named symbols imported from the target; empty for side-effect, namespace, and dynamic imports. */
+  symbols: readonly string[];
 };
 
 export type ResolvedImportEdge = ImportEdge & {
@@ -109,14 +111,31 @@ function scanDynamicImports(line: string, lineNo: number): ImportEdge[] {
   const re = /import\s*\(\s*['"]([^'"]+)['"]/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(line))) {
-    edges.push({ spec: match[1]!, dynamic: true, typeOnly: false, line: lineNo });
+    edges.push({ spec: match[1]!, dynamic: true, typeOnly: false, line: lineNo, symbols: [] });
   }
   return edges;
 }
 
 function scanSideEffectImport(line: string, lineNo: number): ImportEdge | null {
   const match = /^\s*import\s+['"]([^'"]+)['"]/.exec(line);
-  return match ? { spec: match[1]!, dynamic: false, typeOnly: false, line: lineNo } : null;
+  return match
+    ? { spec: match[1]!, dynamic: false, typeOnly: false, line: lineNo, symbols: [] }
+    : null;
+}
+
+function importedSymbols(statement: string): string[] {
+  const named = /\{([\s\S]*?)\}/.exec(statement);
+  if (!named) return [];
+  const symbols = new Set<string>();
+  for (const specifier of named[1]!.split(',')) {
+    const sourceName = specifier
+      .trim()
+      .replace(/^type\s+/, '')
+      .split(/\s+as\s+/, 1)[0]
+      ?.trim();
+    if (sourceName) symbols.add(sourceName);
+  }
+  return [...symbols];
 }
 
 function statementIsTypeOnly(statement: string): boolean {
@@ -151,6 +170,7 @@ function scanFromImport(lines: string[], index: number): ImportEdge | null {
     dynamic: false,
     typeOnly: statementIsTypeOnly(statement),
     line: start + 1,
+    symbols: importedSymbols(statement),
   };
 }
 

--- a/scripts/layering/zone-policy.test.ts
+++ b/scripts/layering/zone-policy.test.ts
@@ -18,6 +18,7 @@ function edge(file: string, fromZone: string, toZone: string, kind: Kind = {}) {
       line: 1,
       dynamic: kind.dynamic ?? false,
       typeOnly: kind.typeOnly ?? false,
+      symbols: [],
     },
   };
 }


### PR DESCRIPTION
## Summary

Closes #2128

Adds a tooling-only, report-only, symbol-aware authority overlay to the static dependency graph.
It reuses the existing layering import parser and the central architecture-ownership declarations;
it preserves every existing JSON field and four-position edge tuple, and adds parallel
`edgeAuthorities` plus stable `authorityCounts` fields.

The overlay reports `vocabulary`, `capability`, `live-state-shape`, `live-state-authority`,
`executable-policy`, and `ordinary`. Import kind remains independent. Collapsed edges accumulate
all declared labels from their raw imports, so multi-label edges are retained. The README documents
that this is declared-authority evidence, not proof of behavioral ownership, safe removability, or
a score/threshold.

The authority classifier is a single declaration-derived rule table. Exact `SessionState` and
`SessionStore` roots and declared exports live in `ARCHITECTURE_OWNERSHIP`, with drift coverage;
the old depgraph constants are gone. The shared parser extracts named source symbols once and
handles comments inside bindings. The strict `readNamedExports` reader is used for capability and
live-state declaration checks; `readDirectNamedExports` remains for the R11 source scan, where its
intentional `export *`-tolerant semantics are still required. No second import parser was added.

## Validation

- Fresh implementation base: `f152827447`; merged prerequisite #2126 / PR #2150 commit
  `4244691e1ed0f71c148c412b8e645963f30a02b8` is an ancestor of final head `3e6fdb51ec`.
- Final `origin/main`: `caa3dc23f9f3f6a829e91e8c5f00a1e4a3084f53`. A three-way `git merge-tree`
  is clean; current main's replay/rank edits touch some layering files but introduce no genuine
  conflict or authority-overlay overlap requiring a rebase.
- `pnpm install --frozen-lockfile && pnpm build`: passed on the fresh worktree.
- `pnpm depgraph:test`: 24/24 passed, including all authority classifications, type-only
  SessionState, SessionStore authority/import kind, lookalike files, multi-label collapse, and
  legacy payload shape.
- `pnpm check:layering`: 168/168 tests passed; layering guard OK.
- Planted-red proof: adding a nonexistent `MissingSessionStateExport` to the shared declaration
  made `pnpm check:layering` fail at the live-state drift test (`167 pass, 1 fail`, exit 1).
  Restoring the declaration returned the focused depgraph suite to 24/24.
- `pnpm check:affected --run`: exit 0; all runnable checks passed. The full 56-check set was
  selected; GitHub-authoritative native/device/coverage lanes were skipped locally.
- Final diff adversarial re-audit: review findings on declaration centralization, generic
  classification, collapse alignment, ordinary projection, and shared comment-safe parsing are
  addressed; no remaining valid in-scope findings.

Exact report and jq evidence at final head:

```sh
pnpm depgraph --out /tmp/agent-device-2128-depgraph.json
jq '{generated, authorityCounts}' /tmp/agent-device-2128-depgraph.json
jq -r '. as $graph | range(0; ($graph.edges | length)) as $i | select($graph.edgeAuthorities[$i] != ["ordinary"]) | [($graph.edgeAuthorities[$i] | join("+")), $graph.nodes[$graph.edges[$i][0]].id, $graph.nodes[$graph.edges[$i][1]].id, ["value", "type", "dynamic"][$graph.edges[$i][2]]] | @tsv' /tmp/agent-device-2128-depgraph.json
```

Observed output: generated commit `3e6fdb51ec`, 1,530 files, 7,923 edges; authority counts
`vocabulary=155`, `capability=54`, `live-state-shape=114`, `live-state-authority=82`,
`executable-policy=80`, `ordinary=7441`; the non-ordinary query returned 482 rows and the
multi-label query returned 3 collapsed edges.

## Size

- Touched files: 10, all under `scripts/` or `scripts/depgraph/README.md`.
- Gross diff: +459 / -15.
- Move-adjusted net tooling LOC: +444; there are no file moves.
- Production application LOC: 0; no `src/` or `packages/` files changed.
- Unavoidable net tooling growth: depgraph overlay/payload +115 net lines; shared declaration and
  parser +46; focused regression tests +247; documentation +36. These sum to +444; deletions
  remove the obsolete duplicate authority extraction and parser/object-literal duplication.

## Residual risks

- Labels are deliberately limited to exact declared roots and named exports. Namespace, default,
  side-effect, and dynamic imports do not provide named-symbol evidence and are not inferred into
  a capability/state label.
- The overlay is static declared-authority evidence; it does not establish runtime ownership
  quality, behavioral equivalence, or removability.
- Native/device/provider/full-coverage proof remains GitHub-authoritative.
