### PR TITLE
feat(apple): reclaim retained runners under device-claim authority

### DIFF
--- a/packages/platform-apple/src/core/runner-host.ts
+++ b/packages/platform-apple/src/core/runner-host.ts
@@ -88,5 +88,5 @@ export const appleRunnerHost: AppleRunnerHost = {
   resolveIosPhysicalDeviceControl,
   visitXmlPlistEntries,
   leaseOwnerStateDir: getRunnerLeaseOwnerStateDir,
-  hasDeviceClaimAuthority: (deviceId) => getRunnerDeviceClaimAuthorityProbe()?.(deviceId) ?? false,
+  hasDeviceClaimAuthority: (device) => getRunnerDeviceClaimAuthorityProbe()?.(device) ?? false,
 };

--- a/packages/platform-apple/src/core/runner-host.ts
+++ b/packages/platform-apple/src/core/runner-host.ts
@@ -36,7 +36,10 @@ import {
 import { bootFailureHint, classifyBootFailure } from '@agent-device/provision-kit/boot-diagnostics';
 import { resolveIosPhysicalDeviceControl } from './physical-device-control.ts';
 import { visitXmlPlistEntries } from './plist-xml.ts';
-import { getRunnerLeaseOwnerStateDir } from './runner-owner-state.ts';
+import {
+  getRunnerDeviceClaimAuthorityProbe,
+  getRunnerLeaseOwnerStateDir,
+} from './runner-owner-state.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
 import { readApplePlistJson, runAppleToolCommand, runXcrun } from './tool-provider.ts';
 
@@ -85,4 +88,5 @@ export const appleRunnerHost: AppleRunnerHost = {
   resolveIosPhysicalDeviceControl,
   visitXmlPlistEntries,
   leaseOwnerStateDir: getRunnerLeaseOwnerStateDir,
+  hasDeviceClaimAuthority: (deviceId) => getRunnerDeviceClaimAuthorityProbe()?.(deviceId) ?? false,
 };

--- a/packages/platform-apple/src/core/runner-owner-state.ts
+++ b/packages/platform-apple/src/core/runner-owner-state.ts
@@ -13,3 +13,23 @@ export function setRunnerLeaseOwnerStateDir(stateDir: string | undefined): void 
 export function getRunnerLeaseOwnerStateDir(): string | undefined {
   return runnerLeaseOwnerStateDir;
 }
+
+/**
+ * Daemon-owned device-claim arbitration probe: does the embedding process hold
+ * the host-global local device claim for this device id right now? Unbound (in
+ * embedders that run no claim store, such as package tests) it answers false,
+ * which keeps runner-lease takeover disabled there.
+ */
+export type RunnerDeviceClaimAuthorityProbe = (deviceId: string) => boolean;
+
+let runnerDeviceClaimAuthorityProbe: RunnerDeviceClaimAuthorityProbe | undefined;
+
+export function setRunnerDeviceClaimAuthorityProbe(
+  probe: RunnerDeviceClaimAuthorityProbe | undefined,
+): void {
+  runnerDeviceClaimAuthorityProbe = probe;
+}
+
+export function getRunnerDeviceClaimAuthorityProbe(): RunnerDeviceClaimAuthorityProbe | undefined {
+  return runnerDeviceClaimAuthorityProbe;
+}

--- a/packages/platform-apple/src/core/runner-owner-state.ts
+++ b/packages/platform-apple/src/core/runner-owner-state.ts
@@ -1,3 +1,5 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
 /**
  * Daemon-owned lease-owner state directory for the Apple runner. Kept in a
  * dedicated tiny module so daemon startup can set it without loading the
@@ -16,11 +18,13 @@ export function getRunnerLeaseOwnerStateDir(): string | undefined {
 
 /**
  * Daemon-owned device-claim arbitration probe: does the embedding process hold
- * the host-global local device claim for this device id right now? Unbound (in
- * embedders that run no claim store, such as package tests) it answers false,
- * which keeps runner-lease takeover disabled there.
+ * the host-global local device claim for exactly this device right now? The
+ * probe receives the full device so the claim owner can match its canonical
+ * platform-family/OS/id key — a bare id is ambiguous across families. Unbound
+ * (in embedders that run no claim store, such as package tests) it answers
+ * false, which keeps runner-lease takeover disabled there.
  */
-export type RunnerDeviceClaimAuthorityProbe = (deviceId: string) => boolean;
+export type RunnerDeviceClaimAuthorityProbe = (device: DeviceInfo) => boolean;
 
 let runnerDeviceClaimAuthorityProbe: RunnerDeviceClaimAuthorityProbe | undefined;
 

--- a/packages/platform-apple/src/runner-owner-facade.ts
+++ b/packages/platform-apple/src/runner-owner-facade.ts
@@ -1,1 +1,5 @@
-export { setRunnerLeaseOwnerStateDir } from './core/runner-owner-state.ts';
+export {
+  setRunnerDeviceClaimAuthorityProbe,
+  setRunnerLeaseOwnerStateDir,
+  type RunnerDeviceClaimAuthorityProbe,
+} from './core/runner-owner-state.ts';

--- a/packages/platform-apple/src/runner/__tests__/runner-disposal.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-disposal.test.ts
@@ -16,7 +16,12 @@ vi.mock('../runner-io.ts', async (importOriginal) => {
 });
 
 import { abortRunnerSessionsAndPrepProcesses, disposeRunnerSession } from '../runner-disposal.ts';
-import { writeRunnerLease } from '../runner-lease.ts';
+import {
+  currentRunnerLeaseOwnerToken,
+  releaseRunnerLease,
+  withRunnerLeaseLock,
+  writeRunnerLease,
+} from '../runner-lease.ts';
 
 const mockIsProcessAlive = vi.fn();
 const mockIsProcessGroupAlive = vi.fn();
@@ -140,6 +145,41 @@ test('simulator disposal skips container-app termination after a foreign takeove
 
   expect(simulatorTerminateCalls()).toEqual([]);
   expect(mockCleanupTempFile).toHaveBeenCalledWith(session.xctestrunPath);
+});
+
+test('disposal serializes behind a successor reclaim window and never terminates its runner', async () => {
+  vi.useRealTimers();
+  mockIsProcessAlive.mockReturnValue(false);
+  const loserLease = makeRunnerLease({
+    deviceId: IOS_SIMULATOR.id,
+    ownerToken: 'owner-toctou-loser',
+  });
+  const session = makeRunnerSession(IOS_SIMULATOR, Promise.resolve(execResult()), {
+    lease: loserLease,
+  });
+  writeRunnerLease(loserLease);
+
+  let disposal: Promise<void> | undefined;
+  let disposalSettled = false;
+  await withRunnerLeaseLock(IOS_SIMULATOR.id, async () => {
+    // The successor's critical section: loser disposal starting now must not
+    // pass its ownership check inside this window — the on-disk lease still
+    // names the loser, but the takeover below is already in flight.
+    disposal = disposeRunnerSession(session, { graceful: false, waitTimeoutMs: 1 }).then(() => {
+      disposalSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(disposalSettled).toBe(false);
+    expect(simulatorTerminateCalls()).toEqual([]);
+    releaseRunnerLease(loserLease);
+    writeRunnerLease(
+      makeRunnerLease({ deviceId: IOS_SIMULATOR.id, ownerToken: 'owner-toctou-successor' }),
+    );
+  });
+  await disposal;
+
+  expect(simulatorTerminateCalls()).toEqual([]);
+  expect(currentRunnerLeaseOwnerToken(IOS_SIMULATOR.id)).toBe('owner-toctou-successor');
 });
 
 function simulatorTerminateCalls(): unknown[] {

--- a/packages/platform-apple/src/runner/__tests__/runner-disposal.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-disposal.test.ts
@@ -3,6 +3,8 @@ import { IOS_SIMULATOR, MACOS_DEVICE, TVOS_SIMULATOR } from './device-fixtures.t
 import type { ExecResult } from '../host.ts';
 import type { RunnerSession } from '../runner-session-types.ts';
 import { appleRunnerTestHost } from '../test-host.ts';
+import { makeRunnerLease } from './runner-session-fixtures.ts';
+import { mkdtempForTestSync } from './tmp-dir.ts';
 
 const { mockCleanupTempFile } = vi.hoisted(() => ({
   mockCleanupTempFile: vi.fn(),
@@ -13,7 +15,8 @@ vi.mock('../runner-io.ts', async (importOriginal) => {
   return { ...actual, cleanupTempFile: mockCleanupTempFile };
 });
 
-import { abortRunnerSessionsAndPrepProcesses } from '../runner-disposal.ts';
+import { abortRunnerSessionsAndPrepProcesses, disposeRunnerSession } from '../runner-disposal.ts';
+import { writeRunnerLease } from '../runner-lease.ts';
 
 const mockIsProcessAlive = vi.fn();
 const mockIsProcessGroupAlive = vi.fn();
@@ -23,6 +26,9 @@ const mockSignalPidsBestEffort = vi.fn();
 const mockSignalProcessGroupBestEffort = vi.fn();
 
 beforeEach(() => {
+  process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = mkdtempForTestSync(
+    'agent-device-runner-disposal-test-',
+  );
   appleRunnerTestHost.update({
     isProcessAlive: mockIsProcessAlive,
     isProcessGroupAlive: mockIsProcessGroupAlive,
@@ -106,9 +112,44 @@ test.each([IOS_SIMULATOR, TVOS_SIMULATOR])(
   },
 );
 
+test('simulator disposal terminates runner container apps while it still owns the on-disk lease', async () => {
+  vi.useRealTimers();
+  mockIsProcessAlive.mockReturnValue(false);
+  const lease = makeRunnerLease({ deviceId: IOS_SIMULATOR.id, ownerToken: 'owner-disposal-own' });
+  const session = makeRunnerSession(IOS_SIMULATOR, Promise.resolve(execResult()), { lease });
+  writeRunnerLease(lease);
+
+  await disposeRunnerSession(session, { graceful: false, waitTimeoutMs: 1 });
+
+  expect(simulatorTerminateCalls()).not.toEqual([]);
+});
+
+test('simulator disposal skips container-app termination after a foreign takeover replaced the lease', async () => {
+  vi.useRealTimers();
+  mockIsProcessAlive.mockReturnValue(false);
+  const session = makeRunnerSession(IOS_SIMULATOR, Promise.resolve(execResult()), {
+    lease: makeRunnerLease({ deviceId: IOS_SIMULATOR.id, ownerToken: 'owner-disposal-loser' }),
+  });
+  // The successor's runner lives in the same container bundles on the shared
+  // simulator; terminating them here would stop the new owner's runner.
+  writeRunnerLease(
+    makeRunnerLease({ deviceId: IOS_SIMULATOR.id, ownerToken: 'owner-disposal-successor' }),
+  );
+
+  await disposeRunnerSession(session, { graceful: false, waitTimeoutMs: 1 });
+
+  expect(simulatorTerminateCalls()).toEqual([]);
+  expect(mockCleanupTempFile).toHaveBeenCalledWith(session.xctestrunPath);
+});
+
+function simulatorTerminateCalls(): unknown[] {
+  return mockRunXcrun.mock.calls.filter(([args]) => (args as string[]).includes('terminate'));
+}
+
 function makeRunnerSession(
   device: RunnerSession['device'],
   testPromise: Promise<ExecResult>,
+  overrides: Partial<RunnerSession> = {},
 ): RunnerSession {
   return {
     sessionId: `${device.id}:8123:test`,
@@ -120,6 +161,7 @@ function makeRunnerSession(
     testPromise,
     child: { pid: 42, exitCode: null },
     ready: true,
+    ...overrides,
   };
 }
 

--- a/packages/platform-apple/src/runner/__tests__/runner-lease-claim-takeover.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-lease-claim-takeover.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { afterEach, beforeEach, test } from 'vitest';
+import { appleRunnerTestHost } from '../test-host.ts';
+import {
+  prepareRunnerLeaseForStartup,
+  runnerOwnerStartTime,
+  writeRunnerLease,
+  type RunnerLease,
+  type RunnerLeaseCleanupAdapter,
+} from '../runner-lease.ts';
+import { makeRunnerLease } from './runner-session-fixtures.ts';
+import { mkdtempForTestSync } from './tmp-dir.ts';
+
+// #1320 retained-runner rule, tested at the lease seam directly: device claims
+// are exclusive per device, so claim authority proves a busy lease's owner
+// released the device and merely kept its runner warm.
+
+let ownerStateDir: string;
+
+beforeEach(() => {
+  process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = mkdtempForTestSync(
+    'agent-device-claim-takeover-lease-',
+  );
+  // The owner state dir must exist on disk: an owner whose state dir is gone
+  // classifies as stale (reclaimable) instead of busy.
+  ownerStateDir = mkdtempForTestSync('agent-device-claim-takeover-owner-');
+});
+
+afterEach(() => {
+  fs.rmSync(ownerStateDir, { recursive: true, force: true });
+});
+
+function liveForeignLease(deviceId: string, overrides: Partial<RunnerLease> = {}): RunnerLease {
+  return makeRunnerLease({
+    deviceId,
+    ownerToken: 'owner-foreign-live',
+    ownerPid: process.pid,
+    ownerStartTime: runnerOwnerStartTime(),
+    ownerStateDir,
+    ...overrides,
+  });
+}
+
+function recordingCleanupAdapter(): RunnerLeaseCleanupAdapter & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    cleanupRunnerProcessTree: async (_pid, signal) => {
+      calls.push(`process-tree:${signal}`);
+    },
+    cleanupRunnerXcodebuildProcesses: async (_deviceId, ownerToken) => {
+      calls.push(`xcodebuild:${ownerToken ?? 'any'}`);
+    },
+    cleanupTempFile: (filePath) => {
+      calls.push(`temp:${filePath}`);
+    },
+  };
+}
+
+test('device-claim authority reclaims a live foreign claim-aware lease', async () => {
+  const deviceId = 'claim-takeover-sim';
+  writeRunnerLease(liveForeignLease(deviceId, { deviceClaimProtocol: 1 }));
+  appleRunnerTestHost.update({ hasDeviceClaimAuthority: (id) => id === deviceId });
+  const cleanup = recordingCleanupAdapter();
+
+  await prepareRunnerLeaseForStartup(deviceId, cleanup);
+
+  assert.ok(cleanup.calls.includes('xcodebuild:owner-foreign-live'));
+  // The lease was released as part of the takeover, so the next classification
+  // sees an empty store instead of the foreign owner.
+  const emptyCleanup = recordingCleanupAdapter();
+  await prepareRunnerLeaseForStartup(deviceId, emptyCleanup);
+  assert.ok(emptyCleanup.calls.includes('xcodebuild:any'));
+});
+
+test('a claim-aware lease still refuses without device-claim authority', async () => {
+  const deviceId = 'claim-no-authority-sim';
+  writeRunnerLease(liveForeignLease(deviceId, { deviceClaimProtocol: 1 }));
+  const cleanup = recordingCleanupAdapter();
+
+  await assert.rejects(
+    async () => await prepareRunnerLeaseForStartup(deviceId, cleanup),
+    /already owned by another agent-device daemon/,
+  );
+  assert.deepEqual(cleanup.calls, []);
+});
+
+test('a pre-claims lease is never preempted despite device-claim authority', async () => {
+  // A lease without deviceClaimProtocol was written by a build that never
+  // arbitrates through device claims, so its owner may be actively using the
+  // runner without holding any claim.
+  const deviceId = 'legacy-lease-sim';
+  writeRunnerLease(liveForeignLease(deviceId));
+  appleRunnerTestHost.update({ hasDeviceClaimAuthority: () => true });
+  const cleanup = recordingCleanupAdapter();
+
+  await assert.rejects(
+    async () => await prepareRunnerLeaseForStartup(deviceId, cleanup),
+    /already owned by another agent-device daemon/,
+  );
+  assert.deepEqual(cleanup.calls, []);
+});

--- a/packages/platform-apple/src/runner/__tests__/runner-lease-claim-takeover.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-lease-claim-takeover.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { afterEach, beforeEach, test } from 'vitest';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { appleRunnerTestHost } from '../test-host.ts';
 import {
   prepareRunnerLeaseForStartup,
@@ -9,6 +10,7 @@ import {
   type RunnerLease,
   type RunnerLeaseCleanupAdapter,
 } from '../runner-lease.ts';
+import { IOS_SIMULATOR } from './device-fixtures.ts';
 import { makeRunnerLease } from './runner-session-fixtures.ts';
 import { mkdtempForTestSync } from './tmp-dir.ts';
 
@@ -30,6 +32,10 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(ownerStateDir, { recursive: true, force: true });
 });
+
+function takeoverDevice(id: string): DeviceInfo {
+  return { ...IOS_SIMULATOR, id };
+}
 
 function liveForeignLease(deviceId: string, overrides: Partial<RunnerLease> = {}): RunnerLease {
   return makeRunnerLease({
@@ -59,28 +65,40 @@ function recordingCleanupAdapter(): RunnerLeaseCleanupAdapter & { calls: string[
 }
 
 test('device-claim authority reclaims a live foreign claim-aware lease', async () => {
-  const deviceId = 'claim-takeover-sim';
-  writeRunnerLease(liveForeignLease(deviceId, { deviceClaimProtocol: 1 }));
-  appleRunnerTestHost.update({ hasDeviceClaimAuthority: (id) => id === deviceId });
+  const device = takeoverDevice('claim-takeover-sim');
+  writeRunnerLease(liveForeignLease(device.id, { deviceClaimProtocol: 1 }));
+  const probedDevices: DeviceInfo[] = [];
+  appleRunnerTestHost.update({
+    hasDeviceClaimAuthority: (probed) => {
+      probedDevices.push(probed);
+      return probed.id === device.id;
+    },
+  });
   const cleanup = recordingCleanupAdapter();
 
-  await prepareRunnerLeaseForStartup(deviceId, cleanup);
+  await prepareRunnerLeaseForStartup(device, cleanup);
 
   assert.ok(cleanup.calls.includes('xcodebuild:owner-foreign-live'));
+  // The probe must receive the full device identity, never a bare id: claim
+  // ownership is canonical family/OS/id, and a same-id claim from another
+  // platform family grants nothing.
+  assert.equal(probedDevices[0]?.platform, 'apple');
+  assert.equal(probedDevices[0]?.appleOs, 'ios');
+  assert.equal(probedDevices[0]?.id, device.id);
   // The lease was released as part of the takeover, so the next classification
   // sees an empty store instead of the foreign owner.
   const emptyCleanup = recordingCleanupAdapter();
-  await prepareRunnerLeaseForStartup(deviceId, emptyCleanup);
+  await prepareRunnerLeaseForStartup(device, emptyCleanup);
   assert.ok(emptyCleanup.calls.includes('xcodebuild:any'));
 });
 
 test('a claim-aware lease still refuses without device-claim authority', async () => {
-  const deviceId = 'claim-no-authority-sim';
-  writeRunnerLease(liveForeignLease(deviceId, { deviceClaimProtocol: 1 }));
+  const device = takeoverDevice('claim-no-authority-sim');
+  writeRunnerLease(liveForeignLease(device.id, { deviceClaimProtocol: 1 }));
   const cleanup = recordingCleanupAdapter();
 
   await assert.rejects(
-    async () => await prepareRunnerLeaseForStartup(deviceId, cleanup),
+    async () => await prepareRunnerLeaseForStartup(device, cleanup),
     /already owned by another agent-device daemon/,
   );
   assert.deepEqual(cleanup.calls, []);
@@ -90,13 +108,13 @@ test('a pre-claims lease is never preempted despite device-claim authority', asy
   // A lease without deviceClaimProtocol was written by a build that never
   // arbitrates through device claims, so its owner may be actively using the
   // runner without holding any claim.
-  const deviceId = 'legacy-lease-sim';
-  writeRunnerLease(liveForeignLease(deviceId));
+  const device = takeoverDevice('legacy-lease-sim');
+  writeRunnerLease(liveForeignLease(device.id));
   appleRunnerTestHost.update({ hasDeviceClaimAuthority: () => true });
   const cleanup = recordingCleanupAdapter();
 
   await assert.rejects(
-    async () => await prepareRunnerLeaseForStartup(deviceId, cleanup),
+    async () => await prepareRunnerLeaseForStartup(device, cleanup),
     /already owned by another agent-device daemon/,
   );
   assert.deepEqual(cleanup.calls, []);

--- a/packages/platform-apple/src/runner/__tests__/runner-session.test.ts
+++ b/packages/platform-apple/src/runner/__tests__/runner-session.test.ts
@@ -1182,7 +1182,7 @@ test('stale-lease cleanup does not signal a recycled runner pid (start time mism
   );
   const { adapter, treeKills, xcodebuildCleanups } = makeRecordingCleanupAdapter();
 
-  await prepareRunnerLeaseForStartup(device.id, adapter);
+  await prepareRunnerLeaseForStartup(device, adapter);
 
   assert.deepEqual(treeKills, [
     { pid: undefined, signal: 'SIGTERM' },
@@ -1201,7 +1201,7 @@ test('stale-lease cleanup signals the runner pid when its start time still match
   );
   const { adapter, treeKills } = makeRecordingCleanupAdapter();
 
-  await prepareRunnerLeaseForStartup(device.id, adapter);
+  await prepareRunnerLeaseForStartup(device, adapter);
 
   assert.deepEqual(treeKills, [
     { pid: 55_555, signal: 'SIGTERM' },
@@ -1221,7 +1221,7 @@ test('stale-lease cleanup re-verifies the pid before the SIGKILL escalation', as
   );
   const { adapter, treeKills } = makeRecordingCleanupAdapter();
 
-  await prepareRunnerLeaseForStartup(device.id, adapter);
+  await prepareRunnerLeaseForStartup(device, adapter);
 
   assert.deepEqual(treeKills, [
     { pid: 55_555, signal: 'SIGTERM' },
@@ -1237,7 +1237,7 @@ test('stale-lease cleanup without a recorded start time trusts only runner-shape
     pid === 55_555 ? 'node /usr/local/bin/opencode run --model gpt-high' : null,
   );
   const foreign = makeRecordingCleanupAdapter();
-  await prepareRunnerLeaseForStartup(device.id, foreign.adapter);
+  await prepareRunnerLeaseForStartup(device, foreign.adapter);
   assert.deepEqual(foreign.treeKills, [
     { pid: undefined, signal: 'SIGTERM' },
     { pid: undefined, signal: 'SIGKILL' },
@@ -1250,7 +1250,7 @@ test('stale-lease cleanup without a recorded start time trusts only runner-shape
       : null,
   );
   const runner = makeRecordingCleanupAdapter();
-  await prepareRunnerLeaseForStartup(device.id, runner.adapter);
+  await prepareRunnerLeaseForStartup(device, runner.adapter);
   assert.deepEqual(runner.treeKills, [
     { pid: 55_555, signal: 'SIGTERM' },
     { pid: 55_555, signal: 'SIGKILL' },
@@ -1263,7 +1263,7 @@ test('stale-lease cleanup skips a dead runner pid entirely', async () => {
   mockIsProcessAlive.mockImplementation((pid) => pid !== 999_999_999 && pid !== 55_555);
   const { adapter, treeKills } = makeRecordingCleanupAdapter();
 
-  await prepareRunnerLeaseForStartup(device.id, adapter);
+  await prepareRunnerLeaseForStartup(device, adapter);
 
   assert.deepEqual(treeKills, [
     { pid: undefined, signal: 'SIGTERM' },

--- a/packages/platform-apple/src/runner/host.ts
+++ b/packages/platform-apple/src/runner/host.ts
@@ -237,8 +237,9 @@ export type AppleRunnerHost = {
   leaseOwnerStateDir(): string | undefined;
   // Daemon-owned device-claim arbitration probe (packages/platform-apple/src/core/runner-owner-state.ts):
   // true only while the embedding process holds the host-global local device
-  // claim for the device. Embedders without a claim store answer false.
-  hasDeviceClaimAuthority(deviceId: string): boolean;
+  // claim for exactly this device (matched by canonical family/OS/id, never a
+  // bare id). Embedders without a claim store answer false.
+  hasDeviceClaimAuthority(device: DeviceInfo): boolean;
 };
 
 let boundHost: AppleRunnerHost | undefined;
@@ -354,8 +355,8 @@ export const visitXmlPlistEntries: AppleRunnerHost['visitXmlPlistEntries'] = (no
   requireHost().visitXmlPlistEntries(nodes, visitor);
 export const leaseOwnerStateDir: AppleRunnerHost['leaseOwnerStateDir'] = () =>
   requireHost().leaseOwnerStateDir();
-export const hasDeviceClaimAuthority: AppleRunnerHost['hasDeviceClaimAuthority'] = (deviceId) =>
-  requireHost().hasDeviceClaimAuthority(deviceId);
+export const hasDeviceClaimAuthority: AppleRunnerHost['hasDeviceClaimAuthority'] = (device) =>
+  requireHost().hasDeviceClaimAuthority(device);
 
 /**
  * Deadline keeps its root call-site shape (`Deadline.fromTimeoutMs(...)`);

--- a/packages/platform-apple/src/runner/host.ts
+++ b/packages/platform-apple/src/runner/host.ts
@@ -235,6 +235,10 @@ export type AppleRunnerHost = {
   visitXmlPlistEntries(nodes: XmlNode[], visitor: (key: string, valueNode: XmlNode) => void): void;
   // Daemon-owned lease owner state directory (packages/platform-apple/src/core/runner-owner-state.ts)
   leaseOwnerStateDir(): string | undefined;
+  // Daemon-owned device-claim arbitration probe (packages/platform-apple/src/core/runner-owner-state.ts):
+  // true only while the embedding process holds the host-global local device
+  // claim for the device. Embedders without a claim store answer false.
+  hasDeviceClaimAuthority(deviceId: string): boolean;
 };
 
 let boundHost: AppleRunnerHost | undefined;
@@ -350,6 +354,8 @@ export const visitXmlPlistEntries: AppleRunnerHost['visitXmlPlistEntries'] = (no
   requireHost().visitXmlPlistEntries(nodes, visitor);
 export const leaseOwnerStateDir: AppleRunnerHost['leaseOwnerStateDir'] = () =>
   requireHost().leaseOwnerStateDir();
+export const hasDeviceClaimAuthority: AppleRunnerHost['hasDeviceClaimAuthority'] = (deviceId) =>
+  requireHost().hasDeviceClaimAuthority(deviceId);
 
 /**
  * Deadline keeps its root call-site shape (`Deadline.fromTimeoutMs(...)`);

--- a/packages/platform-apple/src/runner/runner-disposal.ts
+++ b/packages/platform-apple/src/runner/runner-disposal.ts
@@ -15,6 +15,7 @@ import { waitForRunner } from './runner-startup-transport.ts';
 import { withRunnerCommandId, type RunnerCommand } from './runner-contract.ts';
 import {
   cleanupOwnedRunnerLease,
+  currentRunnerLeaseOwnerToken,
   releaseRunnerLease,
   type RunnerLeaseCleanupAdapter,
 } from './runner-lease.ts';
@@ -172,7 +173,13 @@ async function runnerSessionsStillAlive(
 }
 
 async function cleanupRunnerSessionResources(session: RunnerSession): Promise<void> {
-  await terminateRunnerSimulatorApps(session.device);
+  // Terminating the runner container bundles acts on the whole device, so it is
+  // only this session's to do while the on-disk lease is still its own. After a
+  // takeover (device-claim or logical-lease) the successor's runner lives in the
+  // same bundles; killing them here would stop the new owner's runner.
+  if (!runnerLeaseOwnedElsewhere(session)) {
+    await terminateRunnerSimulatorApps(session.device);
+  }
   cleanupTempFile(session.xctestrunPath);
   cleanupTempFile(session.jsonPath);
   try {
@@ -180,6 +187,11 @@ async function cleanupRunnerSessionResources(session: RunnerSession): Promise<vo
   } finally {
     releaseRunnerLease(session.lease);
   }
+}
+
+function runnerLeaseOwnedElsewhere(session: RunnerSession): boolean {
+  const onDiskToken = currentRunnerLeaseOwnerToken(session.deviceId);
+  return onDiskToken !== null && onDiskToken !== session.lease?.ownerToken;
 }
 
 async function terminateRunnerSimulatorApps(device: DeviceInfo): Promise<void> {

--- a/packages/platform-apple/src/runner/runner-disposal.ts
+++ b/packages/platform-apple/src/runner/runner-disposal.ts
@@ -17,6 +17,7 @@ import {
   cleanupOwnedRunnerLease,
   currentRunnerLeaseOwnerToken,
   releaseRunnerLease,
+  withRunnerLeaseLock,
   type RunnerLeaseCleanupAdapter,
 } from './runner-lease.ts';
 import { IOS_RUNNER_CONTAINER_BUNDLE_IDS, runnerPrepProcesses } from './runner-xctestrun.ts';
@@ -37,16 +38,27 @@ export const runnerLeaseCleanupAdapter: RunnerLeaseCleanupAdapter = {
   cleanupTempFile,
 };
 
+export type RunnerDisposalOptions = {
+  graceful?: boolean;
+  waitTimeoutMs?: number;
+  /**
+   * The caller already executes inside {@link withRunnerLeaseLock} for this
+   * device, so the ownership-fenced device-wide teardown must not re-acquire
+   * the (non-reentrant) lease lock.
+   */
+  leaseLockHeld?: boolean;
+};
+
 export async function disposeRunnerSession(
   session: RunnerSession,
-  options: { graceful?: boolean; waitTimeoutMs?: number } = {},
+  options: RunnerDisposalOptions = {},
 ): Promise<void> {
   let processExitHandled = false;
   if (options.graceful !== false) {
     processExitHandled = await shutdownRunnerSessionGracefully(session);
   } else if (isMacOs(session.device)) {
     await interruptMacOsRunnerSessions([session]);
-    await cleanupRunnerSessionResources(session);
+    await cleanupRunnerSessionResources(session, options);
     return;
   } else {
     await killRunnerProcessTree(session.child.pid, 'SIGTERM');
@@ -58,7 +70,7 @@ export async function disposeRunnerSession(
       await killRunnerProcessTree(session.child.pid, 'SIGKILL');
     }
   }
-  await cleanupRunnerSessionResources(session);
+  await cleanupRunnerSessionResources(session, options);
 }
 
 export async function cleanupOwnedIosRunnerLease(deviceId: string): Promise<void> {
@@ -172,20 +184,54 @@ async function runnerSessionsStillAlive(
   return sessions.filter((_, index) => !exited[index]);
 }
 
-async function cleanupRunnerSessionResources(session: RunnerSession): Promise<void> {
-  // Terminating the runner container bundles acts on the whole device, so it is
-  // only this session's to do while the on-disk lease is still its own. After a
-  // takeover (device-claim or logical-lease) the successor's runner lives in the
-  // same bundles; killing them here would stop the new owner's runner.
-  if (!runnerLeaseOwnedElsewhere(session)) {
-    await terminateRunnerSimulatorApps(session.device);
-  }
+async function cleanupRunnerSessionResources(
+  session: RunnerSession,
+  options: Pick<RunnerDisposalOptions, 'leaseLockHeld'> = {},
+): Promise<void> {
+  await settleOwnedRunnerDeviceState(session, options);
   cleanupTempFile(session.xctestrunPath);
   cleanupTempFile(session.jsonPath);
+  await session.simulatorSetRedirect?.release();
+}
+
+/**
+ * Terminating the runner container bundles acts on the whole device, and the
+ * lease file names whose runner lives in them; a takeover (device-claim or
+ * logical-lease) can change that between a check and the termination. The
+ * ownership check, the termination, and the lease release therefore run as one
+ * operation under the runner-lease lock — the same lock a successor holds for
+ * its entire reclaim-and-publish window. If the lock cannot be acquired, all
+ * device-wide teardown is skipped: whoever owns the lease settles that state,
+ * and an unreleased own lease turns stale once this process exits.
+ */
+async function settleOwnedRunnerDeviceState(
+  session: RunnerSession,
+  options: Pick<RunnerDisposalOptions, 'leaseLockHeld'>,
+): Promise<void> {
+  const settle = async () => {
+    if (runnerLeaseOwnedElsewhere(session)) return;
+    try {
+      await terminateRunnerSimulatorApps(session.device);
+    } finally {
+      releaseRunnerLease(session.lease);
+    }
+  };
+  if (options.leaseLockHeld) {
+    await settle();
+    return;
+  }
   try {
-    await session.simulatorSetRedirect?.release();
-  } finally {
-    releaseRunnerLease(session.lease);
+    await withRunnerLeaseLock(session.deviceId, settle);
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'ios_runner_disposal_lease_lock_unavailable',
+      data: {
+        deviceId: session.deviceId,
+        sessionId: session.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
   }
 }
 

--- a/packages/platform-apple/src/runner/runner-lease.ts
+++ b/packages/platform-apple/src/runner/runner-lease.ts
@@ -14,6 +14,7 @@ import {
   leaseOwnerStateDir,
 } from './host.ts';
 import { AppError } from '@agent-device/kernel/errors';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { RunnerLogicalLeaseContext } from '@agent-device/contracts/runner-lease-context';
 
 const RUNNER_LEASE_SCHEMA_VERSION = 1;
@@ -155,10 +156,11 @@ function classifyRunnerLease(lease: RunnerLease | null): RunnerLeaseState {
 }
 
 export async function prepareRunnerLeaseForStartup(
-  deviceId: string,
+  device: DeviceInfo,
   cleanup: RunnerLeaseCleanupAdapter,
   logicalLeaseContext?: RunnerLogicalLeaseContext,
 ): Promise<void> {
+  const deviceId = device.id;
   const state = classifyRunnerLease(readRunnerLease(deviceId));
   if (state.type === 'empty') {
     await cleanup.cleanupRunnerXcodebuildProcesses(deviceId, undefined);
@@ -169,7 +171,7 @@ export async function prepareRunnerLeaseForStartup(
       await cleanupLeasedRunnerProcesses(state.lease, 'same-state-dir', cleanup);
       return;
     }
-    if (canDeviceClaimReclaimRunner(state.lease)) {
+    if (canDeviceClaimReclaimRunner(state.lease, device)) {
       await cleanupLeasedRunnerProcesses(state.lease, 'device-claim-takeover', cleanup);
       return;
     }
@@ -211,10 +213,17 @@ function isSameStateDirRunnerLease(lease: RunnerLease): boolean {
  * retained warm runner, not an active one. Stop-and-recreate is safe because
  * every owner-side cleanup path no-ops once the lease token changes. Gated on
  * the lease declaring claim arbitration, so owners from builds that predate
- * device claims (and therefore never hold one) keep today's refusal.
+ * device claims (and therefore never hold one) keep today's refusal. The probe
+ * receives the full device: claim ownership is canonical family/OS/id, and a
+ * bare id could let a same-id claim from another platform family authorize a
+ * destructive takeover.
  */
-function canDeviceClaimReclaimRunner(lease: RunnerLease): boolean {
-  return lease.deviceClaimProtocol === 1 && hasDeviceClaimAuthority(lease.deviceId);
+function canDeviceClaimReclaimRunner(lease: RunnerLease, device: DeviceInfo): boolean {
+  return (
+    lease.deviceClaimProtocol === 1 &&
+    lease.deviceId === device.id &&
+    hasDeviceClaimAuthority(device)
+  );
 }
 
 function canLogicalLeaseReclaimRunner(

--- a/packages/platform-apple/src/runner/runner-lease.ts
+++ b/packages/platform-apple/src/runner/runner-lease.ts
@@ -6,6 +6,7 @@ import {
   emitDiagnostic,
   publishFileSync,
   acquireProcessLock,
+  hasDeviceClaimAuthority,
   isProcessAlive,
   readProcessCommand,
   readProcessStartTime,
@@ -48,6 +49,14 @@ export type RunnerLease = {
   xctestrunPath: string;
   jsonPath: string;
   createdAtMs: number;
+  /**
+   * The owner arbitrates device ownership through host-global device claims
+   * (#1320): while it wants the device it holds the claim, so a daemon that
+   * holds the claim instead may stop and replace this runner. Absent on leases
+   * written before claim arbitration existed — those owners never signal
+   * ownership through claims, so claim authority must not preempt them.
+   */
+  deviceClaimProtocol?: 1;
 };
 
 // Why a foreign lease classifies as stale (reclaimable). The distinction is
@@ -99,6 +108,7 @@ export function buildRunnerLease(params: {
     xctestrunPath: params.xctestrunPath,
     jsonPath: params.jsonPath,
     createdAtMs: Date.now(),
+    deviceClaimProtocol: 1,
   };
 }
 
@@ -159,6 +169,10 @@ export async function prepareRunnerLeaseForStartup(
       await cleanupLeasedRunnerProcesses(state.lease, 'same-state-dir', cleanup);
       return;
     }
+    if (canDeviceClaimReclaimRunner(state.lease)) {
+      await cleanupLeasedRunnerProcesses(state.lease, 'device-claim-takeover', cleanup);
+      return;
+    }
     if (canLogicalLeaseReclaimRunner(state.lease, logicalLeaseContext)) {
       await cleanupLeasedRunnerProcesses(state.lease, 'logical-lease-takeover', cleanup);
       return;
@@ -189,6 +203,18 @@ function isSameStateDirRunnerLease(lease: RunnerLease): boolean {
   const currentStateDir = readCurrentStateDir();
   if (!currentStateDir || !lease.ownerStateDir) return false;
   return path.resolve(currentStateDir) === path.resolve(lease.ownerStateDir);
+}
+
+/**
+ * #1320 retained-runner rule: device claims are exclusive per device, so this
+ * process holding the claim proves the lease owner released or lost it — a
+ * retained warm runner, not an active one. Stop-and-recreate is safe because
+ * every owner-side cleanup path no-ops once the lease token changes. Gated on
+ * the lease declaring claim arbitration, so owners from builds that predate
+ * device claims (and therefore never hold one) keep today's refusal.
+ */
+function canDeviceClaimReclaimRunner(lease: RunnerLease): boolean {
+  return lease.deviceClaimProtocol === 1 && hasDeviceClaimAuthority(lease.deviceId);
 }
 
 function canLogicalLeaseReclaimRunner(
@@ -305,6 +331,15 @@ export async function cleanupRunnerLeasesForOwner(
   );
 }
 
+/**
+ * The owner token of the lease currently on disk for this device, or null when
+ * none is readable. Lets disposal recognize that a foreign owner (a device-claim
+ * or logical-lease takeover) has replaced the runner it is cleaning up after.
+ */
+export function currentRunnerLeaseOwnerToken(deviceId: string): string | null {
+  return readRunnerLease(deviceId)?.ownerToken ?? null;
+}
+
 export function releaseRunnerLease(lease: RunnerLease | undefined): void {
   if (!lease) return;
   removeRunnerLease({
@@ -395,6 +430,7 @@ function normalizeRunnerLease(value: unknown, deviceId: string): RunnerLease | n
     ownerStateDir: readOptionalString(raw.ownerStateDir) ?? undefined,
     runnerPid: readPositiveInteger(raw.runnerPid),
     runnerStartTime: readOptionalString(raw.runnerStartTime),
+    ...(raw.deviceClaimProtocol === 1 ? { deviceClaimProtocol: 1 as const } : {}),
   };
 }
 
@@ -441,14 +477,11 @@ function readFiniteNumber(value: unknown): number | null {
 // liveness only.
 async function cleanupLeasedRunnerProcesses(
   lease: RunnerLease,
-  reason: 'owned' | 'stale' | 'same-state-dir' | 'logical-lease-takeover',
+  reason: 'owned' | 'stale' | 'same-state-dir' | 'logical-lease-takeover' | 'device-claim-takeover',
   cleanup: RunnerLeaseCleanupAdapter,
 ): Promise<void> {
   emitDiagnostic({
-    level:
-      reason === 'stale' || reason === 'same-state-dir' || reason === 'logical-lease-takeover'
-        ? 'warn'
-        : 'debug',
+    level: reason === 'owned' ? 'debug' : 'warn',
     phase: 'ios_runner_lease_cleanup',
     data: {
       deviceId: lease.deviceId,

--- a/packages/platform-apple/src/runner/runner-session.ts
+++ b/packages/platform-apple/src/runner/runner-session.ts
@@ -54,6 +54,7 @@ import {
   runnerLeaseCleanupAdapter,
   RUNNER_INVALIDATE_WAIT_TIMEOUT_MS,
   stopRunnerPrepProcesses,
+  type RunnerDisposalOptions,
 } from './runner-disposal.ts';
 import { enrichRunnerFailureFromLog } from './runner-failure-diagnostics.ts';
 import {
@@ -263,6 +264,7 @@ async function startRunnerSessionWithLease(
     await disposeRunnerSession(session, {
       graceful: false,
       waitTimeoutMs: RUNNER_INVALIDATE_WAIT_TIMEOUT_MS,
+      leaseLockHeld: true,
     });
     throw createRequestCanceledError();
   }
@@ -272,6 +274,7 @@ async function startRunnerSessionWithLease(
     await stopRunnerSessionInternal(device.id, session, {
       graceful: false,
       waitTimeoutMs: RUNNER_INVALIDATE_WAIT_TIMEOUT_MS,
+      leaseLockHeld: true,
     });
     throw error;
   }
@@ -452,7 +455,7 @@ export async function invalidateRunnerSession(
 async function stopRunnerSessionInternal(
   deviceId: string,
   sessionOverride?: RunnerSession,
-  options: { graceful?: boolean; waitTimeoutMs?: number } = {},
+  options: RunnerDisposalOptions = {},
 ): Promise<void> {
   const session = sessionOverride ?? runnerSessions.get(deviceId);
   if (!session) return;
@@ -521,7 +524,7 @@ export async function stopIosRunnerSession(deviceId: string): Promise<void> {
   cancelIosRunnerIdleStop(deviceId);
   await withRunnerSessionLock(deviceId, async () => {
     await withRunnerLeaseLock(deviceId, async () => {
-      await stopRunnerSessionInternal(deviceId);
+      await stopRunnerSessionInternal(deviceId, undefined, { leaseLockHeld: true });
       await cleanupOwnedIosRunnerLease(deviceId);
     });
   });

--- a/packages/platform-apple/src/runner/runner-session.ts
+++ b/packages/platform-apple/src/runner/runner-session.ts
@@ -162,7 +162,7 @@ async function startRunnerSessionWithLease(
   }
   assertRunnerSessionMayStart(options.expectedRunnerSessionId);
   await measureRunnerStartupStep(startupTimings, 'cleanup_stale_xcodebuild', async () => {
-    await prepareRunnerLeaseForStartup(device.id, runnerLeaseCleanupAdapter, logicalLeaseContext);
+    await prepareRunnerLeaseForStartup(device, runnerLeaseCleanupAdapter, logicalLeaseContext);
   });
   await measureRunnerStartupStep(startupTimings, 'ensure_booted', async () => {
     await ensureBootedIfNeeded(device);

--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -175,7 +175,10 @@ test('help physical-device documents the runner/daemon lifecycle detail moved ou
     result.stdout,
     /a stale iOS runner lease — its owner process dead, or its AGENT_DEVICE_STATE_DIR deleted — is reclaimed automatically/i,
   );
-  assert.match(result.stdout, /genuinely live owner whose state dir still exists still rejects/);
+  assert.match(
+    result.stdout,
+    /A live owner's runner is also reclaimed when the requesting daemon holds the host-global device claim/,
+  );
 });
 
 test('help workflow documents ref lifetime and snapshot diff guarantees (#1051)', async () => {

--- a/src/cli-schema/cli-help-topics.test.ts
+++ b/src/cli-schema/cli-help-topics.test.ts
@@ -511,7 +511,11 @@ test('usageForCommand resolves physical-device help topic', async () => {
     help,
     /a stale iOS runner lease — its owner process dead, or its AGENT_DEVICE_STATE_DIR deleted — is reclaimed automatically/i,
   );
-  assert.match(help, /genuinely live owner whose state dir still exists still rejects/);
+  assert.match(
+    help,
+    /A live owner's runner is also reclaimed when the requesting daemon holds the host-global device claim/,
+  );
+  assert.match(help, /owners outside claim arbitration/);
 });
 
 test('usageForCommand resolves ios-system-ui help topic', async () => {

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -179,7 +179,7 @@ Validation and evidence:
 
 React Native: help react-native for Metro/Re.Pack reload, DevTools, RN overlays. JS-only change: metro reload, find "Home"; open --relaunch for native reset.
 
-Lifecycle facts (trust these instead of probing): open without --relaunch is idempotent-foreground; --relaunch restarts it. close keeps a healthy iOS runner warm by default; runners and daemons both self-idle after 5 minutes, and a stale lease reclaims automatically -- a live owner still rejects with "already owned by another agent-device daemon". Env vars: help physical-device.
+Lifecycle facts (trust these instead of probing): open without --relaunch is idempotent-foreground; --relaunch restarts it. close keeps a healthy iOS runner warm by default; runners and daemons both self-idle after 5 minutes, and a stale lease reclaims automatically. The device claim taken by open also reclaims another worktree's retained warm runner; "already owned by another agent-device daemon" = owner outside claim arbitration. Env vars: help physical-device.
 
 Escalate:
   help manual-qa scripted manual QA
@@ -684,7 +684,7 @@ Runner and daemon lifecycle (applies to simulators too):
   open without --relaunch is idempotent-foreground for an already-running app (it brings the process forward; it does not restart it). open --relaunch restarts the app; on iOS simulators this collapses to one simctl launch --terminate-running-process call instead of a separate terminate-then-launch.
   close keeps a healthy iOS simulator XCTest runner warm by default so the next open on that device skips the runner build, unless --shutdown was requested, the session was recording, the session held a device lease, or the device used a scoped (non-default) simulator set. A retained runner auto-stops after an idle window (default 5 minutes); set AGENT_DEVICE_IOS_RUNNER_IDLE_STOP_MS to override, or 0 to disable idle stop and retain until daemon exit.
   Each AGENT_DEVICE_STATE_DIR runs its own daemon. It self-exits after an idle window (default 5 minutes, matching the runner idle-stop default) once it has no open sessions, no in-flight requests, and no active recording; set AGENT_DEVICE_DAEMON_IDLE_TIMEOUT_MS to override, or 0 to disable idle reap.
-  A stale iOS runner lease — its owner process dead, or its AGENT_DEVICE_STATE_DIR deleted — is reclaimed automatically instead of failing with "is already owned by another agent-device daemon"; a genuinely live owner whose state dir still exists still rejects with that error.
+  A stale iOS runner lease — its owner process dead, or its AGENT_DEVICE_STATE_DIR deleted — is reclaimed automatically instead of failing with "is already owned by another agent-device daemon". A live owner's runner is also reclaimed when the requesting daemon holds the host-global device claim for that device: claims are exclusive, so holding one proves the runner's owner released the device and merely kept the runner warm. The error remains only for owners outside claim arbitration (a pre-claims build, or daemons pointed at different claim stores).
 
 For iOS SpringBoard, widget, or other system-UI surfaces, read agent-device help ios-system-ui.`,
   },

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -638,7 +638,7 @@ test('reports the exact outcome of abandoning an owned, missing, and unowned cla
 
 test('answers the runner authority probe only for a claim this process actively holds', async () => {
   const root = useClaimsRoot();
-  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
+  assert.equal(processOwnsActiveDeviceClaim(device), false);
 
   const acquired = await acquireDeviceClaim({
     device,
@@ -648,11 +648,44 @@ test('answers the runner authority probe only for a claim this process actively 
   });
   assert.equal(acquired.status, 'acquired');
   if (acquired.status !== 'acquired') return;
-  assert.equal(processOwnsActiveDeviceClaim(device.id), true);
-  assert.equal(processOwnsActiveDeviceClaim('some-other-device'), false);
+  assert.equal(processOwnsActiveDeviceClaim(device), true);
+  assert.equal(processOwnsActiveDeviceClaim({ ...device, id: 'some-other-device' }), false);
 
   assert.equal(await abandonDeviceClaim(acquired.ownership), 'abandoned');
-  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
+  assert.equal(processOwnsActiveDeviceClaim(device), false);
+});
+
+test('a same-id claim from another platform family grants no runner authority', async () => {
+  const root = useClaimsRoot();
+  // An Android claim whose serial happens to equal an Apple runner's device id
+  // must not authorize destructive takeover of that runner: authority matches
+  // the canonical family/OS/id key, never the bare id.
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'android-owner',
+    workspace: '/worktrees/android',
+    stateDir: root,
+  });
+  assert.equal(acquired.status, 'acquired');
+  const sameIdAppleSimulator: DeviceInfo = {
+    platform: 'apple',
+    appleOs: 'ios',
+    id: device.id,
+    name: 'Colliding iPhone',
+    kind: 'simulator',
+    booted: true,
+  };
+  assert.equal(processOwnsActiveDeviceClaim(sameIdAppleSimulator), false);
+  assert.equal(processOwnsActiveDeviceClaim(device), true);
+
+  const appleAcquired = await acquireDeviceClaim({
+    device: sameIdAppleSimulator,
+    session: 'apple-owner',
+    workspace: '/worktrees/apple',
+    stateDir: root,
+  });
+  assert.equal(appleAcquired.status, 'acquired');
+  assert.equal(processOwnsActiveDeviceClaim(sameIdAppleSimulator), true);
 });
 
 test('denies the runner authority probe for a claim held by another process', async () => {
@@ -669,5 +702,5 @@ test('denies the runner authority probe for a claim held by another process', as
     claimPath(root),
     JSON.stringify({ ...stored, ownerPid: 999_999, ownerStartTime: 'other-start' }),
   );
-  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
+  assert.equal(processOwnsActiveDeviceClaim(device), false);
 });

--- a/src/daemon/__tests__/device-claims.test.ts
+++ b/src/daemon/__tests__/device-claims.test.ts
@@ -7,6 +7,7 @@ import {
   abandonDeviceClaim,
   acquireDeviceClaim as acquireProductionDeviceClaim,
   clearDeviceClaim,
+  processOwnsActiveDeviceClaim,
 } from '../device-claims.ts';
 import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
 import { inspectDeviceClaims } from '../device-claim-inspection.ts';
@@ -633,4 +634,40 @@ test('reports the exact outcome of abandoning an owned, missing, and unowned cla
   fs.rmSync(claimPath(root));
   assert.equal(await abandonDeviceClaim(acquired.ownership), 'absent');
   assert.equal(await abandonDeviceClaim(undefined), 'absent');
+});
+
+test('answers the runner authority probe only for a claim this process actively holds', async () => {
+  const root = useClaimsRoot();
+  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
+
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'probe-owner',
+    workspace: '/worktrees/probe',
+    stateDir: root,
+  });
+  assert.equal(acquired.status, 'acquired');
+  if (acquired.status !== 'acquired') return;
+  assert.equal(processOwnsActiveDeviceClaim(device.id), true);
+  assert.equal(processOwnsActiveDeviceClaim('some-other-device'), false);
+
+  assert.equal(await abandonDeviceClaim(acquired.ownership), 'abandoned');
+  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
+});
+
+test('denies the runner authority probe for a claim held by another process', async () => {
+  const root = useClaimsRoot();
+  const acquired = await acquireDeviceClaim({
+    device,
+    session: 'foreign-owner',
+    workspace: '/worktrees/foreign',
+    stateDir: root,
+  });
+  assert.equal(acquired.status, 'acquired');
+  const stored = JSON.parse(fs.readFileSync(claimPath(root), 'utf8')) as Record<string, unknown>;
+  fs.writeFileSync(
+    claimPath(root),
+    JSON.stringify({ ...stored, ownerPid: 999_999, ownerStartTime: 'other-start' }),
+  );
+  assert.equal(processOwnsActiveDeviceClaim(device.id), false);
 });

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -16,7 +16,6 @@ import { publishFileSync, acquireProcessLock } from '@agent-device/host-kit/file
 import {
   deviceClaimOwnerCannotRelease,
   inspectDeviceClaimFile,
-  inspectDeviceClaims,
   type DeviceClaimClassification,
   type InspectedDeviceClaim,
 } from './device-claim-inspection.ts';
@@ -199,23 +198,26 @@ function isAbandonedDeviceClaim(claim: DeviceClaim): boolean {
 }
 
 /**
- * Does this process hold a claim for a local device with this id right now?
- * The Apple runner's device-claim arbitration probe (#1320 retained-runner
- * rule): claim authority lets a daemon stop and replace a warm runner whose
- * owner no longer holds the device. Ownership is proven by process identity
+ * Does this process hold the claim for exactly this device right now? The
+ * Apple runner's device-claim arbitration probe (#1320 retained-runner rule):
+ * claim authority lets a daemon stop and replace a warm runner whose owner no
+ * longer holds the device. Matching is by the canonical local device key —
+ * family, Apple OS, and id — never by bare id, so a same-id claim from another
+ * platform family grants nothing. Ownership is proven by process identity
  * alone — one process serves one daemon — and an abandoned claim holds the
  * device for nobody, so it grants no authority either.
  */
-export function processOwnsActiveDeviceClaim(deviceId: string): boolean {
-  const owner = readCurrentOwnerIdentity();
-  return inspectDeviceClaims({ udid: deviceId }).some(
-    (entry) =>
-      entry.claim &&
-      !isAbandonedDeviceClaim(entry.claim) &&
-      ownerIdentityMatches(
-        { pid: entry.claim.ownerPid, startTime: entry.claim.ownerStartTime },
-        owner,
-      ),
+export function processOwnsActiveDeviceClaim(device: DeviceInfo): boolean {
+  const deviceKey = canonicalLocalDeviceKey(deviceClaimIdentity(device));
+  const claim = inspectDeviceClaimFile(resolveDeviceClaimPath(deviceKey))?.claim;
+  return (
+    claim !== undefined &&
+    claim.deviceKey === deviceKey &&
+    !isAbandonedDeviceClaim(claim) &&
+    ownerIdentityMatches(
+      { pid: claim.ownerPid, startTime: claim.ownerStartTime },
+      readCurrentOwnerIdentity(),
+    )
   );
 }
 

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -16,6 +16,7 @@ import { publishFileSync, acquireProcessLock } from '@agent-device/host-kit/file
 import {
   deviceClaimOwnerCannotRelease,
   inspectDeviceClaimFile,
+  inspectDeviceClaims,
   type DeviceClaimClassification,
   type InspectedDeviceClaim,
 } from './device-claim-inspection.ts';
@@ -195,6 +196,27 @@ function isClaimOwnedByThisDaemon(
 
 function isAbandonedDeviceClaim(claim: DeviceClaim): boolean {
   return claim.abandonedAtMs !== undefined;
+}
+
+/**
+ * Does this process hold a claim for a local device with this id right now?
+ * The Apple runner's device-claim arbitration probe (#1320 retained-runner
+ * rule): claim authority lets a daemon stop and replace a warm runner whose
+ * owner no longer holds the device. Ownership is proven by process identity
+ * alone — one process serves one daemon — and an abandoned claim holds the
+ * device for nobody, so it grants no authority either.
+ */
+export function processOwnsActiveDeviceClaim(deviceId: string): boolean {
+  const owner = readCurrentOwnerIdentity();
+  return inspectDeviceClaims({ udid: deviceId }).some(
+    (entry) =>
+      entry.claim &&
+      !isAbandonedDeviceClaim(entry.claim) &&
+      ownerIdentityMatches(
+        { pid: entry.claim.ownerPid, startTime: entry.claim.ownerStartTime },
+        owner,
+      ),
+  );
 }
 
 function isAbandonedClaimOfThisDaemon(

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -27,7 +27,11 @@ import { closeDaemonServers } from './server-shutdown.ts';
 import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';
 import { finalizeDaemonSessionLease } from './daemon-session-lease-finalizer.ts';
-import { reconcileOrphanedDeviceClaims, type DeviceClaimReconciler } from '../device-claims.ts';
+import {
+  processOwnsActiveDeviceClaim,
+  reconcileOrphanedDeviceClaims,
+  type DeviceClaimReconciler,
+} from '../device-claims.ts';
 import { createDeviceClaimReconciler } from '../device-claim-reconciliation.ts';
 import { createDaemonShutdownClaimLedger } from './daemon-shutdown-claims.ts';
 import { createPerfCaptureAdmissionLedger } from '../perf-capture-admission-ledger.ts';
@@ -61,7 +65,10 @@ import {
 } from './transport.ts';
 import { prewarmPngWorker, terminatePngWorker } from '@agent-device/capture-kit/png-worker-client';
 
-import { configureAppleRunnerLeaseOwnerStateDir } from '../../platform-runtime-apple-runner-owner.ts';
+import {
+  configureAppleRunnerDeviceClaimAuthorityProbe,
+  configureAppleRunnerLeaseOwnerStateDir,
+} from '../../platform-runtime-apple-runner-owner.ts';
 import {
   cleanupManagedWebRuntimeOrphans,
   platformResourceCleanup,
@@ -253,6 +260,7 @@ export async function startDaemonRuntime(
   const daemonServerMode = resolveDaemonServerMode(env.AGENT_DEVICE_DAEMON_SERVER_MODE);
   const retainArtifacts = isEnvTruthy(env.AGENT_DEVICE_RETAIN_ARTIFACTS);
   await configureAppleRunnerLeaseOwnerStateDir(baseDir);
+  await configureAppleRunnerDeviceClaimAuthorityProbe(processOwnsActiveDeviceClaim);
 
   const sessionStore = new SessionStore(sessionsDir);
   const ownedProcessRecords = createOwnedProcessRecordStore({
@@ -489,6 +497,7 @@ export async function startDaemonRuntime(
   if (!acquireDaemonLock(baseDir, lockPath, lockData)) {
     stderr.write('Daemon lock is held by another process; exiting.\n');
     await configureAppleRunnerLeaseOwnerStateDir(undefined);
+    await configureAppleRunnerDeviceClaimAuthorityProbe(undefined);
     exit(0);
     return null;
   }
@@ -570,6 +579,7 @@ export async function startDaemonRuntime(
     removeInfo(infoPath);
     releaseDaemonLock(lockPath);
     await configureAppleRunnerLeaseOwnerStateDir(undefined);
+    await configureAppleRunnerDeviceClaimAuthorityProbe(undefined);
     exit(1);
     return null;
   }
@@ -635,6 +645,7 @@ export async function startDaemonRuntime(
     removeInfo(infoPath);
     releaseDaemonLock(lockPath);
     await configureAppleRunnerLeaseOwnerStateDir(undefined);
+    await configureAppleRunnerDeviceClaimAuthorityProbe(undefined);
     exit(shutdownOptions.exitCode ?? 0);
   };
 

--- a/src/platform-runtime-apple-runner-owner.ts
+++ b/src/platform-runtime-apple-runner-owner.ts
@@ -1,7 +1,17 @@
-/** Root-composed daemon ownership input consumed by the Apple runner host. */
+import type { RunnerDeviceClaimAuthorityProbe } from '@agent-device/platform-apple/runner-owner';
+
+/** Root-composed daemon ownership inputs consumed by the Apple runner host. */
 export async function configureAppleRunnerLeaseOwnerStateDir(
   stateDir: string | undefined,
 ): Promise<void> {
   const { setRunnerLeaseOwnerStateDir } = await import('@agent-device/platform-apple/runner-owner');
   setRunnerLeaseOwnerStateDir(stateDir);
+}
+
+export async function configureAppleRunnerDeviceClaimAuthorityProbe(
+  probe: RunnerDeviceClaimAuthorityProbe | undefined,
+): Promise<void> {
+  const { setRunnerDeviceClaimAuthorityProbe } =
+    await import('@agent-device/platform-apple/runner-owner');
+  setRunnerDeviceClaimAuthorityProbe(probe);
 }


### PR DESCRIPTION
## Summary

Implements the #1320 retained-runner rule (the issue's v1 stop-and-recreate decision): a daemon that holds the host-global device claim may stop and replace a warm XCTest runner whose owner no longer holds that claim.

Before this, the worst remaining cross-worktree failure on iOS was: worktree A closes its session (claim released, runner kept warm by default), worktree B wins the claim at `open`, then dies in runner preparation with an unstructured `COMMAND_FAILED` / `IOS_RUNNER_OWNED_BY_OTHER_DAEMON` for up to ~5 minutes until A's daemon idled out — exactly the late runner-prep contention #1320 set out to remove.

## How it works

- **Claim authority proves release.** Device claims are exclusive per device, so the requesting daemon holding the claim proves the lease owner released the device and merely kept its runner warm. `prepareRunnerLeaseForStartup`'s busy branch gains a third takeover rule (`device-claim-takeover`) alongside same-state-dir and proxy logical-lease.
- **Trust boundary respected.** The probe is not request metadata: it is daemon-bound through the existing runner-owner seam (`@agent-device/platform-apple/runner-owner`, same pattern as `setRunnerLeaseOwnerStateDir`) and answers from the claim store by process identity (`processOwnsActiveDeviceClaim`). Unbound embedders (package tests, non-daemon use) answer false and keep today's refusal. Abandoned claims grant no authority.
- **Mixed-version safety.** Leases now record `deviceClaimProtocol: 1`; takeover is gated on the lease declaring claim arbitration, so a runner owned by a pre-claims build — which can legitimately be mid-session without holding any claim — is never preempted.
- **Loser-side safety.** `cleanupRunnerSessionResources` now skips the device-wide `simctl terminate` of the runner container bundles when the on-disk lease is owned by someone else. Without this, the losing daemon's delayed idle-stop or shutdown would kill the successor's active runner on the shared simulator (this also closes the same latent hazard for the proxy logical-lease takeover path). Lease release and token-scoped xcodebuild cleanup already no-op on token mismatch.
- Help topics (`workflow`, `physical-device`) updated: the live-owner rejection now names claim arbitration instead of being unconditional.

## Validation

`pnpm check:affected --run` passed (format, lint, typecheck, layering, fallow, affected tests).

Live two-daemon validation against a throwaway `iPhone 17 Pro` simulator with a shared claim store and shared lease dir:
1. **Protection intact:** while daemon A's session held the claim, daemon B's `open` was rejected with non-retriable `DEVICE_IN_USE`, reason `DEVICE_CLAIM_LIVE_OWNER`, owner session/workspace/stateDir, and the exact `device status` recovery command.
2. **Takeover works:** after A's `close` (claim gone, lease retained with `deviceClaimProtocol: 1`, daemon A still alive), B's `open` succeeded in ~8s and the on-disk lease flipped to B's daemon pid while A was still running — the live-owner path, not stale reclaim.
3. **Guard works:** `daemon stop` on A afterwards left B's session fully functional (`appstate` healthy).

Part of #1320.