### PR TITLE
docs+ux: make device ownership discoverable end to end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,10 @@ cross-language rules change through golden tables under `contracts/fixtures/`.
   regenerate baselines to accept unrelated findings.
 - The first Node process after a newly signed Apple runner launches may block during Gatekeeper
   verification. Warm it with a throwaway `node -e 0` before measuring.
-- `DEVICE_IN_USE` normally means another session still owns the device. Follow the error's targeted
-  `close --session` hint instead of debugging the daemon.
+- `DEVICE_IN_USE` has two flavors. "already in use by session X" is this daemon — follow its
+  `close --session` hint. "owned by session X in workspace Y" is another worktree's device
+  claim — non-retriable; run the error's `device status`/`device release --stale` recovery,
+  never PID hunting.
 - A changing timeout failure set that passes in isolation is host contention. Reproduce the same
   test on `origin/main` under the same load before treating it as a regression.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The same session and evidence model works at every step: the agent explores the 
 
 Support depth varies by target. Newer backends such as HarmonyOS and Vega OS cover a subset of commands; run `agent-device capabilities --platform <platform>` to see what a target supports.
 
-Sessions are scoped to the caller's git worktree, and host-local device claims stop parallel agents from taking over each other's simulators and emulators. The same commands drive hosted devices on [BrowserStack, AWS Device Farm, and Limrun](https://oss.callstack.com/agent-device/docs/device-clouds).
+Sessions are scoped to the caller's git worktree, and host-local device claims stop parallel agents from taking over each other's simulators and emulators. Inspect ownership without a daemon via `agent-device device status`, and settle provably dead owners with `agent-device device release --stale`. The same commands drive hosted devices on [BrowserStack, AWS Device Farm, and Limrun](https://oss.callstack.com/agent-device/docs/device-clouds).
 
 `agent-device` uses the inspect-act-verify process from Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser) for mobile, TV, and desktop apps. Basic `--platform web` support runs `agent-browser` in the same session and replay system.
 

--- a/docs/adr/0010-error-system.md
+++ b/docs/adr/0010-error-system.md
@@ -28,7 +28,8 @@ agent failures (selector/ref misses), and consumers that drop fields (MCP tool e
    `err instanceof AppError ? err : new AppError(...)`.
 2. **Code selection.** Use the most specific `KnownAppErrorCode`; `COMMAND_FAILED` is for genuine
    runtime failures of a well-formed request, never a catch-all for capability gaps
-   (`UNSUPPORTED_OPERATION`), contention (`DEVICE_IN_USE`, the only retriable code), or ambiguity
+   (`UNSUPPORTED_OPERATION`), contention (`DEVICE_IN_USE`, the only code retriable by default;
+   the cross-worktree device-claim path overrides it to `retriable: false`), or ambiguity
    (`AMBIGUOUS_MATCH`). New codes are added to the union deliberately; machine-dispatchable
    sub-classification rides in `details.reason` (the lease registry is the model).
 3. **Hints answer "what should the agent run next".** A hint is required wherever the per-code

--- a/docs/agents/device-verification.md
+++ b/docs/agents/device-verification.md
@@ -38,11 +38,13 @@ failed verification attempts.
 - Use a purpose-specific session name for experiments, and an isolated `--state-dir` under
   `/private/tmp` when you need cleanup isolation beyond the current worktree's default daemon.
 - Track opened sessions in working notes; close each one before the final response.
-- If `close` is blocked by stale daemon metadata, inspect processes first with
-  `ps -ax | rg "agent-device|xcodebuild test-without-building"`. Stop only exact stale PIDs belonging
-  to this verification run, then `pnpm clean:daemon`.
-- If cleanup cannot be completed, report the remaining session name, state dir, PIDs, and metadata
-  paths as a blocker.
+- If `close` is blocked or ownership looks stuck, inspect it with
+  `agent-device device status --stale` (daemonless), stop the owning daemon with
+  `agent-device daemon stop --state-dir <dir>` (add `--clean` to remove retained runners), and
+  release provably dead owners with `agent-device device release --stale`. Do not hunt PIDs with
+  `ps`/`kill`.
+- If cleanup cannot be completed, report the remaining session name, state dir, and the
+  `device status --stale` output as a blocker.
 
 ## Sandboxed environments
 

--- a/packages/contracts/src/client-device-view.ts
+++ b/packages/contracts/src/client-device-view.ts
@@ -21,6 +21,15 @@ export type AgentDeviceDevice = {
    */
   appleOs?: AppleOS;
   identifiers: AgentDeviceIdentifiers;
+  /**
+   * Present when a host-local device claim currently blocks foreign use of
+   * this device (#1320). Provably dead owners are not projected — the next
+   * open reconciles and replaces them automatically.
+   */
+  claimedBy?: {
+    session: string;
+    workspace: string;
+  };
   ios?: {
     udid: string;
   };

--- a/scripts/help-conformance-cases.mjs
+++ b/scripts/help-conformance-cases.mjs
@@ -2,6 +2,7 @@ import {
   AMBIGUOUS_MATCH_SAMPLE,
   APP_NOT_INSTALLED_SAMPLE,
   BROWSERSTACK_CONNECT_SAMPLE,
+  DEVICE_CLAIM_IN_USE_SAMPLE,
   DEVICE_IN_USE_SAMPLE,
   FOREGROUND_SNAPSHOT_FAILURE_SAMPLE,
   MERGED_CARD_ACTIONS_SAMPLE,
@@ -573,6 +574,28 @@ Use the output already shown to determine whether the feed-search UI is present,
       { id: 'noClose', pattern: /(?:^|\n)agent-device\s+close\b/i },
       { id: 'noReopen', pattern: /(?:^|\n)agent-device\s+open\b/i },
       { id: 'noRawCoordinateTarget', pattern: RAW_COORDINATE_TARGET },
+    ],
+  },
+  {
+    id: 'sample-output-device-claim-inspects-owner',
+    docs: ['--help:first30', 'debugging'],
+    recovery: { code: 'DEVICE_IN_USE', sample: DEVICE_CLAIM_IN_USE_SAMPLE },
+    task: quiz(
+      DEVICE_CLAIM_IN_USE_SAMPLE,
+      'A different worktree owns this device and you must not interrupt it. What command should run next?',
+    ),
+    expectations: ['validPlanCommands', 'fullPrefix'],
+    matchers: [
+      {
+        id: 'runsDeviceStatus',
+        pattern:
+          /(?:^|\n)agent-device\s+device\s+status\s+--platform\s+android\s+--serial\s+emulator-5554\b/i,
+      },
+    ],
+    forbidden: [
+      { id: 'noRetryOpen', pattern: /(?:^|\n)agent-device\s+open\b/i },
+      { id: 'noForeignClose', pattern: /(?:^|\n)agent-device\s+close\b/i },
+      { id: 'noPidHunting', pattern: /(?:^|\n)\s*(?:ps|kill|pkill)\b/i },
     ],
   },
   {

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -512,6 +512,11 @@ Example:
   agent-device react-devtools profile report @c5
   agent-device network dump --include headers
 
+Device busy and ownership:
+  DEVICE_IN_USE has two flavors. "already in use by session X" is this daemon: reuse it with --session X, or run close --session X first. "owned by session X in workspace Y" is another worktree's daemon holding the host-global device claim: it is never retriable — run the error's exact recovery command instead of retrying.
+  Inspect ownership without any daemon: agent-device device status (add --stale for proven-dead owners; settle and release those with agent-device device release --stale). devices marks rows that are claimed, so pick an unclaimed device instead of contending.
+  A live foreign owner is released only by closing its session from its own workspace or stopping its daemon: agent-device daemon stop --state-dir <owner state dir> (the error names the state dir). Never recover by hunting PIDs with ps/kill. boot/install/shutdown take the same claims as open and refuse foreign-claimed devices identically.
+
 Use snapshot, screenshot, logs, network, perf frames, and perf memory for device/app runtime evidence. Use react-devtools when component internals or React rendering behavior matters.`,
   },
   cdp: {

--- a/src/client/client-normalizers.test.ts
+++ b/src/client/client-normalizers.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { test } from 'vitest';
-import { normalizeOpenForegroundComposition } from './client-normalizers.ts';
+import { expect, test } from 'vitest';
+import { normalizeDevice, normalizeOpenForegroundComposition } from './client-normalizers.ts';
 
 test('embedded daemon errors sanitize an untrusted cause before client exposure', () => {
   const secret = 'adc_live_remote-secret';
@@ -26,4 +26,23 @@ test('embedded daemon errors sanitize an untrusted cause before client exposure'
   assert.match(cause.code ?? '', /^token=\[REDACTED\]/);
   assert.equal(cause.code?.length, 400);
   assert.match(cause.code ?? '', /<truncated>$/);
+});
+
+test('device normalization preserves the projected claim owner and drops malformed ones', () => {
+  const base = {
+    platform: 'ios',
+    target: 'mobile',
+    kind: 'simulator',
+    id: 'sim-1',
+    name: 'iPhone 17 Pro',
+    booted: true,
+  };
+  const claimed = normalizeDevice({
+    ...base,
+    claimedBy: { session: 'qa', workspace: '/worktrees/qa' },
+  });
+  expect(claimed.claimedBy).toEqual({ session: 'qa', workspace: '/worktrees/qa' });
+
+  expect(normalizeDevice(base).claimedBy).toBeUndefined();
+  expect(normalizeDevice({ ...base, claimedBy: { session: 42 } }).claimedBy).toBeUndefined();
 });

--- a/src/client/client-normalizers.ts
+++ b/src/client/client-normalizers.ts
@@ -108,8 +108,19 @@ export function normalizeDevice(value: unknown): AgentDeviceDevice {
     // a non-Apple record with a stray appleOs value is not preserved.
     ...(isApplePlatform(platform) && appleOs ? { appleOs } : {}),
     identifiers: buildDeviceIdentifiers(platform, id, name),
+    ...readClaimedBy(record),
     ...buildClientDevicePlatformFields(platform, id),
   };
+}
+
+function readClaimedBy(record: Record<string, unknown>): Pick<AgentDeviceDevice, 'claimedBy'> {
+  const value = record.claimedBy;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const claimedBy = value as Record<string, unknown>;
+  const session = claimedBy.session;
+  const workspace = claimedBy.workspace;
+  if (typeof session !== 'string' || typeof workspace !== 'string') return {};
+  return { claimedBy: { session, workspace } };
 }
 
 export function normalizeSession(value: unknown): AgentDeviceSession {

--- a/src/commands/management/output.test.ts
+++ b/src/commands/management/output.test.ts
@@ -313,3 +313,45 @@ describe('doctorCliOutput', () => {
     expect(output.text).toBe(['Doctor: pass', 'No blockers found.'].join('\n'));
   });
 });
+
+describe('devices output', () => {
+  test('carries the projected claim owner through JSON data and the text line', () => {
+    const output = managementCliOutputFormatters.devices({
+      input: {},
+      result: [
+        {
+          platform: 'ios',
+          appleOs: 'ios',
+          target: 'mobile',
+          kind: 'simulator',
+          id: 'sim-free',
+          name: 'Free iPhone',
+          booted: true,
+          identifiers: { deviceId: 'sim-free', deviceName: 'Free iPhone', udid: 'sim-free' },
+        },
+        {
+          platform: 'ios',
+          appleOs: 'ios',
+          target: 'mobile',
+          kind: 'simulator',
+          id: 'sim-claimed',
+          name: 'Claimed iPhone',
+          booted: true,
+          identifiers: {
+            deviceId: 'sim-claimed',
+            deviceName: 'Claimed iPhone',
+            udid: 'sim-claimed',
+          },
+          claimedBy: { session: 'qa', workspace: '/worktrees/qa' },
+        },
+      ],
+    });
+
+    const devices = (output.data as { devices: Record<string, unknown>[] }).devices;
+    expect(devices[0]).not.toHaveProperty('claimedBy');
+    expect(devices[1]?.claimedBy).toEqual({ session: 'qa', workspace: '/worktrees/qa' });
+    const lines = (output.text ?? '').split('\n');
+    expect(lines[0]).not.toContain('claimed by');
+    expect(lines[1]).toContain('claimed by session "qa" in /worktrees/qa');
+  });
+});

--- a/src/commands/management/output.ts
+++ b/src/commands/management/output.ts
@@ -232,7 +232,10 @@ function formatDeviceLine(device: AgentDeviceDevice): string {
   const kind = device.kind ? ` ${device.kind}` : '';
   const target = device.target ? ` target=${device.target}` : '';
   const booted = typeof device.booted === 'boolean' ? ` booted=${device.booted}` : '';
-  return `${device.name} (${device.platform}${kind}${target})${booted}`;
+  const claimed = device.claimedBy
+    ? ` claimed by session "${device.claimedBy.session}" in ${device.claimedBy.workspace}`
+    : '';
+  return `${device.name} (${device.platform}${kind}${target})${booted}${claimed}`;
 }
 
 function formatCloudArtifactLine(artifact: CloudArtifactsResult['cloudArtifacts'][number]): string {

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -231,7 +231,8 @@ function isAbandonedClaimOfThisDaemon(
   return isAbandonedDeviceClaim(claim) && isClaimOwnedByThisDaemon(claim, stateDir, owner);
 }
 
-function deviceClaimIdentity(device: DeviceInfo): DeviceIdentity {
+/** The canonical claim-facing identity of a local device: family, Apple OS, and id. */
+export function deviceClaimIdentity(device: DeviceInfo): DeviceIdentity {
   return deviceIdentity({
     ...device,
     ...(isApplePlatform(device.platform) ? { appleOs: resolveDeviceAppleOs(device) } : {}),

--- a/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
@@ -14,6 +14,7 @@ import { handleSessionCommands } from './session-command-harness.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 import { withTestDeviceInventory } from '../../../__tests__/test-utils/device-inventory-gateways.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import { readCurrentOwnerIdentity } from '@agent-device/host-kit/process';
 
 test('devices filters Apple-family platform selectors', async () => {
   const sessionStore = makeSessionStore();
@@ -497,3 +498,80 @@ test('release_materialized_paths removes retained install artifacts', async () =
   expect(fs.existsSync(retained.installablePath)).toBe(false);
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
+
+test('devices projects the blocking claim owner and hides provably dead owners', async () => {
+  const claimsDir = mkdtempForTestSync('agent-device-devices-claims-');
+  const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const owner = readCurrentOwnerIdentity();
+  const writeClaim = (id: string, ownerPid: number, ownerStartTime: string | null) => {
+    fs.writeFileSync(
+      path.join(claimsDir, `${id}.json`),
+      JSON.stringify({
+        schemaVersion: 1,
+        deviceKey: `local:android:none:${id}`,
+        device: { platform: 'android', id, name: id, kind: 'emulator' },
+        session: `${id}-session`,
+        workspace: `/worktrees/${id}`,
+        stateDir: process.cwd(),
+        ownerPid,
+        ownerStartTime,
+        ownerToken: `${id}-token`,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      }),
+    );
+  };
+  writeClaim('emulator-5554', owner.pid, owner.startTime);
+  writeClaim('emulator-5556', 999_999_999, 'long-gone');
+  const sessionStore = makeSessionStore();
+  const inventory: DeviceInfo[] = [
+    makeAndroidInventoryDevice('emulator-5554'),
+    makeAndroidInventoryDevice('emulator-5556'),
+  ];
+  try {
+    const response = await withTestDeviceInventory(
+      { local: async () => inventory },
+      async () =>
+        await handleSessionCommands({
+          req: {
+            token: 't',
+            session: 'default',
+            command: 'devices',
+            positionals: [],
+            flags: { platform: 'android' },
+          },
+          sessionName: 'default',
+          logPath: path.join(os.tmpdir(), 'daemon.log'),
+          sessionStore,
+          invoke: noopInvoke,
+        }),
+    );
+    expect(response?.ok).toBeTruthy();
+    if (response?.ok) {
+      const devices = response.data?.devices as Array<Record<string, unknown>> | undefined;
+      expect(devices).toHaveLength(2);
+      expect(devices?.[0]?.claimedBy).toEqual({
+        session: 'emulator-5554-session',
+        workspace: '/worktrees/emulator-5554',
+      });
+      // The dead owner is not projected: the next open reconciles and replaces it.
+      expect(devices?.[1]?.claimedBy).toBeUndefined();
+    }
+  } finally {
+    if (previousClaimsDir === undefined) delete process.env.AGENT_DEVICE_CLAIMS_DIR;
+    else process.env.AGENT_DEVICE_CLAIMS_DIR = previousClaimsDir;
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});
+
+function makeAndroidInventoryDevice(id: string): DeviceInfo {
+  return {
+    platform: 'android',
+    id,
+    name: id,
+    kind: 'emulator',
+    target: 'mobile',
+    booted: true,
+  };
+}

--- a/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts
@@ -575,3 +575,75 @@ function makeAndroidInventoryDevice(id: string): DeviceInfo {
     booted: true,
   };
 }
+
+test('a claim never projects onto a same-id device from another platform family', async () => {
+  const claimsDir = mkdtempForTestSync('agent-device-devices-claims-');
+  const previousClaimsDir = process.env.AGENT_DEVICE_CLAIMS_DIR;
+  process.env.AGENT_DEVICE_CLAIMS_DIR = claimsDir;
+  const owner = readCurrentOwnerIdentity();
+  fs.writeFileSync(
+    path.join(claimsDir, 'shared-id.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      deviceKey: 'local:android:none:shared-id',
+      device: { platform: 'android', id: 'shared-id', name: 'Claimed Pixel', kind: 'emulator' },
+      session: 'android-session',
+      workspace: '/worktrees/android',
+      stateDir: process.cwd(),
+      ownerPid: owner.pid,
+      ownerStartTime: owner.startTime,
+      ownerToken: 'shared-id-token',
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    }),
+  );
+  const sessionStore = makeSessionStore();
+  const inventory: DeviceInfo[] = [
+    {
+      platform: 'apple',
+      appleOs: 'ios',
+      id: 'shared-id',
+      name: 'Colliding iPhone',
+      kind: 'simulator',
+      target: 'mobile',
+      booted: true,
+    },
+    makeAndroidInventoryDevice('shared-id'),
+  ];
+  try {
+    const response = await withTestDeviceInventory(
+      { local: async () => inventory },
+      async () =>
+        await handleSessionCommands({
+          req: {
+            token: 't',
+            session: 'default',
+            command: 'devices',
+            positionals: [],
+            flags: {},
+          },
+          sessionName: 'default',
+          logPath: path.join(os.tmpdir(), 'daemon.log'),
+          sessionStore,
+          invoke: noopInvoke,
+        }),
+    );
+    expect(response?.ok).toBeTruthy();
+    if (response?.ok) {
+      const devices = response.data?.devices as Array<Record<string, unknown>> | undefined;
+      expect(devices).toHaveLength(2);
+      const byPlatform = new Map(devices?.map((row) => [row.platform, row]));
+      // Claim ownership is canonical family/OS/id: the Android claim must not
+      // appear on the Apple row that happens to share the bare id.
+      expect(byPlatform.get('ios')?.claimedBy).toBeUndefined();
+      expect(byPlatform.get('android')?.claimedBy).toEqual({
+        session: 'android-session',
+        workspace: '/worktrees/android',
+      });
+    }
+  } finally {
+    if (previousClaimsDir === undefined) delete process.env.AGENT_DEVICE_CLAIMS_DIR;
+    else process.env.AGENT_DEVICE_CLAIMS_DIR = previousClaimsDir;
+    fs.rmSync(claimsDir, { recursive: true, force: true });
+  }
+});

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -20,6 +20,8 @@ import {
   resolveIosSimulatorDeviceSetPath,
 } from '@agent-device/kernel/device-isolation';
 import { deviceClaimOwnerCannotRelease, inspectDeviceClaims } from '../device-claim-inspection.ts';
+import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
+import { deviceClaimIdentity } from '../device-claims.ts';
 import type { DaemonRequest, DaemonResponse, SessionRef } from '../types.ts';
 import { resolveSessionRunnerLogPath, SessionStore } from '../session-store.ts';
 import {
@@ -146,16 +148,17 @@ async function devicesInventoryResponse(req: DaemonRequest): Promise<DaemonRespo
  * #1320 ownership projection (`observe` policy): device rows name the claim
  * owner that would block a foreign `open` right now, so an agent told a device
  * is busy can pick a free one from the same listing. Provably dead owners are
- * excluded — the next open reconciles and replaces them automatically.
+ * excluded — the next open reconciles and replaces them automatically. Both
+ * sides key by the canonical local device key (family, Apple OS, id): distinct
+ * platform devices may share a bare id, and a claim must never project onto
+ * another family's row.
  */
 function blockingClaimOwnersByDevice(): Map<string, { session: string; workspace: string }> {
   const owners = new Map<string, { session: string; workspace: string }>();
   for (const entry of inspectDeviceClaims({})) {
     const claim = entry.claim;
     if (!claim || deviceClaimOwnerCannotRelease(entry.classification)) continue;
-    // Keyed by device id alone: udids and serials do not collide across the
-    // platform families a claim can name, and the claim's own id is canonical.
-    owners.set(claim.device.id, {
+    owners.set(claim.deviceKey, {
       session: claim.session,
       workspace: claim.workspace,
     });
@@ -167,7 +170,7 @@ function claimedByProjection(
   device: DeviceInfo,
   owners: Map<string, { session: string; workspace: string }>,
 ): { claimedBy?: { session: string; workspace: string } } {
-  const owner = owners.get(device.id);
+  const owner = owners.get(canonicalLocalDeviceKey(deviceClaimIdentity(device)));
   return owner ? { claimedBy: owner } : {};
 }
 

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -19,6 +19,7 @@ import {
   resolveAndroidSerialAllowlist,
   resolveIosSimulatorDeviceSetPath,
 } from '@agent-device/kernel/device-isolation';
+import { deviceClaimOwnerCannotRelease, inspectDeviceClaims } from '../device-claim-inspection.ts';
 import type { DaemonRequest, DaemonResponse, SessionRef } from '../types.ts';
 import { resolveSessionRunnerLogPath, SessionStore } from '../session-store.ts';
 import {
@@ -125,14 +126,49 @@ function publicSessionInfo({ address, session }: SessionRef, sessionStore: Sessi
 
 async function devicesInventoryResponse(req: DaemonRequest): Promise<DaemonResponse> {
   try {
+    const blockingClaims = blockingClaimOwnersByDevice();
     return {
       ok: true,
-      data: { devices: (await resolveInventoryDevices(req)).map(publicDeviceInfo) },
+      data: {
+        devices: (await resolveInventoryDevices(req)).map((device) => ({
+          ...publicDeviceInfo(device),
+          ...claimedByProjection(device, blockingClaims),
+        })),
+      },
     };
   } catch (error) {
     const appErr = asAppError(error);
     return errorResponse(appErr.code, appErr.message, appErr.details);
   }
+}
+
+/**
+ * #1320 ownership projection (`observe` policy): device rows name the claim
+ * owner that would block a foreign `open` right now, so an agent told a device
+ * is busy can pick a free one from the same listing. Provably dead owners are
+ * excluded — the next open reconciles and replaces them automatically.
+ */
+function blockingClaimOwnersByDevice(): Map<string, { session: string; workspace: string }> {
+  const owners = new Map<string, { session: string; workspace: string }>();
+  for (const entry of inspectDeviceClaims({})) {
+    const claim = entry.claim;
+    if (!claim || deviceClaimOwnerCannotRelease(entry.classification)) continue;
+    // Keyed by device id alone: udids and serials do not collide across the
+    // platform families a claim can name, and the claim's own id is canonical.
+    owners.set(claim.device.id, {
+      session: claim.session,
+      workspace: claim.workspace,
+    });
+  }
+  return owners;
+}
+
+function claimedByProjection(
+  device: DeviceInfo,
+  owners: Map<string, { session: string; workspace: string }>,
+): { claimedBy?: { session: string; workspace: string } } {
+  const owner = owners.get(device.id);
+  return owner ? { claimedBy: owner } : {};
 }
 
 async function resolveInventoryDevices(req: DaemonRequest): Promise<DeviceInfo[]> {

--- a/src/utils/result-serialization.ts
+++ b/src/utils/result-serialization.ts
@@ -95,6 +95,7 @@ export function serializeDevice(device: AgentDeviceDevice): Record<string, unkno
     kind: device.kind,
     target: device.target,
     ...(typeof device.booted === 'boolean' ? { booted: device.booted } : {}),
+    ...(device.claimedBy ? { claimedBy: device.claimedBy } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Stacked on #2162 (which stacks on #2160). The last slice of #1320: make the `busy? → inspect → choose another device or release` loop discoverable from every surface an agent actually reads, and retire the Stage-5 PID-hunting guidance.

- **`devices` now projects ownership**: each row that a foreign `open` would be refused on carries `claimedBy: { session, workspace }` (text output: `claimed by session "x" in /worktrees/y`). Provably dead owners are deliberately not projected — the next open reconciles and replaces them automatically, so showing them would only scare agents off free devices. This is the `observe`-policy projection the #1320 design explicitly permitted, and it completes the third recovery path ("choose another device") that previously required guesswork.
- **`help debugging`** gains a "Device busy and ownership" section separating the two `DEVICE_IN_USE` flavors (same-daemon session vs cross-worktree claim) with their exact recoveries, including "never recover by hunting PIDs".
- **AGENTS.md** documents both flavors (previously described only the same-daemon one, whose `close --session` advice is wrong for a foreign claim).
- **docs/agents/device-verification.md** retires the last `ps`/`kill` recovery guidance in favor of `device status --stale`, `daemon stop --state-dir`, and `device release --stale` — the Stage 5 deliverable of #1320.
- **ADR-0010** no longer calls `DEVICE_IN_USE` "the only retriable code" without naming the claim path's `retriable: false` override.
- **help-conformance**: the rendered cross-worktree claim error sample (`DEVICE_CLAIM_IN_USE_SAMPLE`) was validated but bound to no quiz case; it now has one (`sample-output-device-claim-inspects-owner`) checking the model runs the exact `device status` recovery and forbidding retry-open/foreign-close/PID-hunting.
- **README** points at `device status` / `device release --stale`.

## Validation

All non-vitest gate checks green (format, lint, typecheck, layering, di-seams, fallow, mcp-metadata, build, package, node-integration, macos-coverage). The vitest step flaked on 9 load-timeout failures while a parallel agent session ran a full suite on this host (load avg 35–42); all 9 files pass when re-run at low concurrency, and the failures were 5s-timeouts in files this PR does not touch.

Live real-binary validation: planted a live foreign claim for the booted `iPhone 17 Pro` in an isolated claim store — `devices` rendered `claimed by session "other-worktree-session" in /worktrees/other` and `--json` carried `claimedBy`; a dead-owner claim was correctly not projected.

Closes #1320.