### PR TITLE
fix: address security scanner findings

### DIFF
--- a/.github/actions/setup-fixture-app/resolve-artifact-name.sh
+++ b/.github/actions/setup-fixture-app/resolve-artifact-name.sh
@@ -15,7 +15,13 @@ case "$PLATFORM" in
     ;;
 esac
 
-FINGERPRINT_JSON="$(pnpm --dir examples/test-app exec fingerprint fingerprint:generate --platform "$PLATFORM")"
+FINGERPRINT_BIN="examples/test-app/node_modules/.bin/fingerprint"
+if [ ! -x "$FINGERPRINT_BIN" ]; then
+  echo "fingerprint binary is missing; run the test-app dependency setup first" >&2
+  exit 1
+fi
+
+FINGERPRINT_JSON="$("$FINGERPRINT_BIN" fingerprint:generate --platform "$PLATFORM")"
 if ! HASH="$(
   printf '%s\n' "$FINGERPRINT_JSON" |
     jq -ser '

--- a/examples/test-app/package.json
+++ b/examples/test-app/package.json
@@ -7,7 +7,8 @@
     "start": "expo start --dev-client",
     "ios": "expo run:ios",
     "android": "expo run:android",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "security:test": "node --test security/image-size-security.test.mjs"
   },
   "dependencies": {
     "@expo/dom-webview": "~56.0.5",

--- a/examples/test-app/patches/image-size@1.2.1.patch
+++ b/examples/test-app/patches/image-size@1.2.1.patch
@@ -11,3 +11,25 @@ index f2bfafef3723cb423b110304815e56e3f97f81e0..1379f55b63656b52913462790bf6393b
              imageOffset += imageHeader[1];
              result.images.push(imageSize);
          }
+diff --git a/dist/types/utils.js b/dist/types/utils.js
+index 5224bbafe87551ac415cb3de234820ccc0ff6e2c..2a487ca78ee269aea9c82a00314b0c12646c360c 100644
+--- a/dist/types/utils.js
++++ b/dist/types/utils.js
+@@ -52,6 +52,8 @@ function readBox(input, offset) {
+     if (input.length - offset < 4)
+         return;
+     const boxSize = (0, exports.readUInt32BE)(input, offset);
++    if (boxSize < 8)
++        return;
+     if (input.length - offset < boxSize)
+         return;
+     return {
+@@ -61,7 +63,7 @@ function readBox(input, offset) {
+     };
+ }
+ function findBox(input, boxName, offset) {
+-    while (offset < input.length) {
++    while (offset + 8 <= input.length) {
+         const box = readBox(input, offset);
+         if (!box)
+             break;

--- a/examples/test-app/patches/image-size@1.2.1.patch
+++ b/examples/test-app/patches/image-size@1.2.1.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/types/icns.js b/dist/types/icns.js
+index f2bfafef3723cb423b110304815e56e3f97f81e0..1379f55b63656b52913462790bf6393bebd4a4fc 100644
+--- a/dist/types/icns.js
++++ b/dist/types/icns.js
+@@ -93,6 +93,8 @@ exports.ICNS = {
+         while (imageOffset < fileLength && imageOffset < inputLength) {
+             imageHeader = readImageHeader(input, imageOffset);
+             imageSize = getImageSize(imageHeader[0]);
++            if (imageHeader[1] < 8)
++                break;
+             imageOffset += imageHeader[1];
+             result.images.push(imageSize);
+         }

--- a/examples/test-app/pnpm-lock.yaml
+++ b/examples/test-app/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   '@babel/core@7': ^7.29.6
 
 patchedDependencies:
-  image-size@1.2.1: 2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae
+  image-size@1.2.1: 6544266162325551c6f85c53ca52e5b3b25ccf96127a57a4ebcc3553e89584bb
 
 importers:
 
@@ -1143,6 +1143,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -5144,7 +5145,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-size@1.2.1(patch_hash=2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae):
+  image-size@1.2.1(patch_hash=6544266162325551c6f85c53ca52e5b3b25ccf96127a57a4ebcc3553e89584bb):
     dependencies:
       queue: 6.0.2
 
@@ -5471,7 +5472,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.35.0
-      image-size: 1.2.1(patch_hash=2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae)
+      image-size: 1.2.1(patch_hash=6544266162325551c6f85c53ca52e5b3b25ccf96127a57a4ebcc3553e89584bb)
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4

--- a/examples/test-app/pnpm-lock.yaml
+++ b/examples/test-app/pnpm-lock.yaml
@@ -12,8 +12,12 @@ overrides:
   ws@7: ^7.5.11
   brace-expansion@5: ^5.0.9
   shell-quote: ^1.9.0
-  js-yaml@4: ^4.3.0
+  js-yaml@4: ^4.3.1
+  nanoid@3: ^3.3.18
   '@babel/core@7': ^7.29.6
+
+patchedDependencies:
+  image-size@1.2.1: 2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae
 
 importers:
 
@@ -1945,8 +1949,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -2213,13 +2217,8 @@ packages:
   multitars@1.0.0:
     resolution: {integrity: sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3906,7 +3905,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -4675,7 +4674,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -4926,7 +4925,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.3
       react-fast-compare: 3.2.2
@@ -5145,7 +5144,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-size@1.2.1:
+  image-size@1.2.1(patch_hash=2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae):
     dependencies:
       queue: 6.0.2
 
@@ -5217,7 +5216,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5472,7 +5471,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.35.0
-      image-size: 1.2.1
+      image-size: 1.2.1(patch_hash=2da0b17cf650b529201c0fc84157668d8873e8c2c440d60d33499568e174b3ae)
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
@@ -5538,9 +5537,7 @@ snapshots:
 
   multitars@1.0.0: {}
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -5645,7 +5642,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/examples/test-app/pnpm-workspace.yaml
+++ b/examples/test-app/pnpm-workspace.yaml
@@ -15,5 +15,8 @@ overrides:
   ws@7: ^7.5.11
   brace-expansion@5: ^5.0.9
   shell-quote: ^1.9.0
-  js-yaml@4: ^4.3.0
+  js-yaml@4: ^4.3.1
+  nanoid@3: ^3.3.18
   '@babel/core@7': ^7.29.6
+patchedDependencies:
+  image-size@1.2.1: patches/image-size@1.2.1.patch

--- a/examples/test-app/security/image-size-security.test.mjs
+++ b/examples/test-app/security/image-size-security.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const packageStore = path.join(process.cwd(), 'node_modules', '.pnpm');
+const patchedStoreEntry = fs
+  .readdirSync(packageStore)
+  .find((entry) => entry.startsWith('image-size@1.2.1_patch_hash='));
+assert.ok(patchedStoreEntry, 'the patched image-size package must be installed');
+const imageSizePath = path.join(packageStore, patchedStoreEntry, 'node_modules', 'image-size');
+
+test('zero-length image records and boxes return within the parser budget', () => {
+  const fixtures = [
+    ['ICNS entry', Buffer.concat([box(16, 'icns'), Buffer.from('icm#'), uint32(0)])],
+    ['HEIF box', Buffer.concat([box(16, 'ftyp'), Buffer.from('heic'), box(8, 'junk')])],
+    [
+      'JXL box',
+      Buffer.concat([box(8, 'JXL '), box(8, 'junk'), box(16, 'ftyp'), Buffer.from('jxl ')]),
+    ],
+  ];
+
+  for (const [name, input] of fixtures) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        `const imageSize = require(${JSON.stringify(imageSizePath)}); try { imageSize.imageSize(Buffer.from(${JSON.stringify(input.toString('base64'))}, 'base64')); } catch {}`,
+      ],
+      { encoding: 'utf8', timeout: 1000 },
+    );
+    assert.equal(result.error, undefined, `${name} exceeded the parser budget`);
+    assert.equal(result.signal, null, `${name} was terminated instead of returning`);
+  }
+});
+
+function box(size, type) {
+  return Buffer.concat([uint32(size), Buffer.from(type)]);
+}
+
+function uint32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value);
+  return buffer;
+}

--- a/examples/test-app/security/image-size-security.test.mjs
+++ b/examples/test-app/security/image-size-security.test.mjs
@@ -5,38 +5,66 @@ import path from 'node:path';
 import test from 'node:test';
 
 const packageStore = path.join(process.cwd(), 'node_modules', '.pnpm');
-const patchedStoreEntry = fs
-  .readdirSync(packageStore)
-  .find((entry) => entry.startsWith('image-size@1.2.1_patch_hash='));
-assert.ok(patchedStoreEntry, 'the patched image-size package must be installed');
-const imageSizePath = path.join(packageStore, patchedStoreEntry, 'node_modules', 'image-size');
+const imageSizePath =
+  process.env.IMAGE_SIZE_PACKAGE_DIR ??
+  path.join(
+    packageStore,
+    fs.readdirSync(packageStore).find((entry) => entry.startsWith('image-size@1.2.1_patch_hash=')),
+    'node_modules',
+    'image-size',
+  );
+assert.ok(fs.existsSync(imageSizePath), 'the image-size package must be installed');
 
 test('zero-length image records and boxes return within the parser budget', () => {
   const fixtures = [
-    ['ICNS entry', Buffer.concat([box(16, 'icns'), Buffer.from('icm#'), uint32(0)])],
-    ['HEIF box', Buffer.concat([box(16, 'ftyp'), Buffer.from('heic'), box(8, 'junk')])],
+    [
+      'ICNS entry',
+      Buffer.concat([Buffer.from('icns'), uint32(16), Buffer.from('icm#'), uint32(0)]),
+      'icns',
+    ],
+    [
+      'HEIF box',
+      Buffer.concat([box(16, 'ftyp'), Buffer.from('heic'), Buffer.alloc(4), zeroBox('junk')]),
+      'Invalid HEIF, no size found',
+    ],
     [
       'JXL box',
-      Buffer.concat([box(8, 'JXL '), box(8, 'junk'), box(16, 'ftyp'), Buffer.from('jxl ')]),
+      Buffer.concat([
+        box(8, 'JXL '),
+        box(16, 'ftyp'),
+        Buffer.from('jxl '),
+        Buffer.alloc(4),
+        zeroBox('junk'),
+      ]),
+      'No codestream found in JXL container',
     ],
   ];
+  const selectedFixtures = process.env.IMAGE_SIZE_FIXTURE
+    ? fixtures.filter(([name]) => name === process.env.IMAGE_SIZE_FIXTURE)
+    : fixtures;
+  assert.equal(selectedFixtures.length > 0, true, 'the selected fixture must exist');
 
-  for (const [name, input] of fixtures) {
+  for (const [name, input, expected] of selectedFixtures) {
     const result = spawnSync(
       process.execPath,
       [
         '-e',
-        `const imageSize = require(${JSON.stringify(imageSizePath)}); try { imageSize.imageSize(Buffer.from(${JSON.stringify(input.toString('base64'))}, 'base64')); } catch {}`,
+        `const imageSize = require(${JSON.stringify(imageSizePath)}); const input = Buffer.from(${JSON.stringify(input.toString('base64'))}, 'base64'); try { const result = imageSize.imageSize(input); if (${JSON.stringify(expected)} !== 'icns' || result.type !== 'icns' || result.width !== 16 || result.height !== 16) process.exitCode = 1; } catch (error) { if (${JSON.stringify(expected)} === 'icns' || error.message !== ${JSON.stringify(expected)}) process.exitCode = 1; }`,
       ],
       { encoding: 'utf8', timeout: 1000 },
     );
     assert.equal(result.error, undefined, `${name} exceeded the parser budget`);
     assert.equal(result.signal, null, `${name} was terminated instead of returning`);
+    assert.equal(result.status, 0, `${name} did not take the expected parser route`);
   }
 });
 
 function box(size, type) {
   return Buffer.concat([uint32(size), Buffer.from(type)]);
+}
+
+function zeroBox(type) {
+  return Buffer.concat([uint32(0), Buffer.from(type)]);
 }
 
 function uint32(value) {

--- a/packages/platform-android/src/__tests__/app-lifecycle-parse.test.ts
+++ b/packages/platform-android/src/__tests__/app-lifecycle-parse.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import { parseAndroidLaunchComponent } from '../app-lifecycle.ts';
+import { isAmStartError, parseAndroidLaunchComponent } from '../app-lifecycle.ts';
+
+test('isAmStartError only matches an error line with a known launch failure', () => {
+  assert.equal(isAmStartError('', 'Error: Activity not started'), true);
+  assert.equal(isAmStartError('warning\nError: unable to resolve Intent', ''), true);
+  assert.equal(isAmStartError('notice: Activity not started', ''), false);
+  assert.equal(isAmStartError('Activity not started', ''), false);
+});
 
 test('parseAndroidLaunchComponent extracts final resolved components', () => {
   const stdout = [

--- a/packages/platform-android/src/__tests__/app-parsers.test.ts
+++ b/packages/platform-android/src/__tests__/app-parsers.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { parseAndroidLaunchablePackages } from '../app-parsers.ts';
+import { parseAndroidLaunchablePackages, readAndroidBlockingDialogFocus } from '../app-parsers.ts';
 
 test('parseAndroidLaunchablePackages ignores cmd package query metadata lines', () => {
   assert.deepEqual(
@@ -14,5 +14,21 @@ test('parseAndroidLaunchablePackages ignores cmd package query metadata lines', 
       ].join('\n'),
     ),
     ['com.google.android.apps.maps', 'org.mozilla.firefox'],
+  );
+});
+
+test('readAndroidBlockingDialogFocus preserves responding window text without regex backtracking', () => {
+  assert.deepEqual(
+    readAndroidBlockingDialogFocus(
+      'mCurrentFocus=Window{123 u0 com.example.app/com.example.MainActivity Demo is not responding}',
+    ),
+    {
+      focusObserved: true,
+      focus: {
+        package: 'com.example.app',
+        focusedWindow: '123 u0 com.example.app/com.example.MainActivity Demo is not responding',
+        raw: 'mCurrentFocus=Window{123 u0 com.example.app/com.example.MainActivity Demo is not responding}',
+      },
+    },
   );
 });

--- a/packages/platform-android/src/alert-detection.ts
+++ b/packages/platform-android/src/alert-detection.ts
@@ -125,7 +125,11 @@ function findNativeDialogNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
 }
 
 function isAndroidDialogType(type: string): boolean {
-  return /(?:^|[.$])[^.]*Dialog$/i.test(type);
+  const lastSeparator = Math.max(type.lastIndexOf('.'), type.lastIndexOf('$'));
+  return type
+    .slice(lastSeparator + 1)
+    .toLowerCase()
+    .endsWith('dialog');
 }
 
 function correlatedAndroidAlertIdNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {

--- a/packages/platform-android/src/app-lifecycle.ts
+++ b/packages/platform-android/src/app-lifecycle.ts
@@ -460,8 +460,14 @@ async function resolveAndroidLaunchComponent(
 }
 
 export function isAmStartError(stdout: string, stderr: string): boolean {
-  const output = `${stdout}\n${stderr}`;
-  return /Error:.*(?:Activity not started|unable to resolve Intent)/i.test(output);
+  return `${stdout}\n${stderr}`.split('\n').some((line) => {
+    const normalized = line.toLowerCase();
+    return (
+      normalized.startsWith('error:') &&
+      (normalized.includes('activity not started') ||
+        normalized.includes('unable to resolve intent'))
+    );
+  });
 }
 
 export function parseAndroidLaunchComponent(stdout: string): string | null {

--- a/packages/platform-android/src/app-parsers.ts
+++ b/packages/platform-android/src/app-parsers.ts
@@ -20,7 +20,6 @@ export const ANDROID_FOCUS_MARKERS = [
   'ResumedActivity:',
 ] as const;
 const ANDROID_ANR_TITLE_PATTERN = /\bApplication Not Responding:\s*([A-Za-z0-9_.]+)/i;
-const ANDROID_RESPONDING_TITLE_PATTERN = /([^{}]*\bis(?:n't| not)\s+responding[^{}]*)/i;
 const ANDROID_PACKAGE_PATTERN = /\b([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)\b/;
 
 export function parseAndroidLaunchablePackages(stdout: string): string[] {
@@ -106,12 +105,14 @@ function parseAndroidBlockingDialogFromSegment(
     };
   }
 
-  const respondingMatch = ANDROID_RESPONDING_TITLE_PATTERN.exec(windowText);
-  if (!respondingMatch) return null;
-
-  const focusedWindowTitle = respondingMatch[1];
-  if (focusedWindowTitle === undefined) return null;
-  const focusedWindow = focusedWindowTitle.trim().replaceAll(/\s+/g, ' ');
+  const normalizedWindowText = windowText.toLowerCase();
+  if (
+    !normalizedWindowText.includes("isn't responding") &&
+    !normalizedWindowText.includes('is not responding')
+  ) {
+    return null;
+  }
+  const focusedWindow = windowText.trim().replaceAll(/\s+/g, ' ');
   const packageName = ANDROID_PACKAGE_PATTERN.exec(focusedWindow)?.[1];
   return {
     ...(packageName ? { package: packageName } : {}),

--- a/packages/platform-android/src/observation.ts
+++ b/packages/platform-android/src/observation.ts
@@ -25,7 +25,6 @@ const ACTIVITY_DUMPS = [
 ] as const;
 const FOCUS_LINE = new RegExp(`(?:${FOCUS_MARKERS.map(escapeRegExp).join('|')})(.*)$`, 'gm');
 const ANR_TITLE = /\bApplication Not Responding:\s*([A-Za-z0-9_.]+)/i;
-const RESPONDING_TITLE = /([^{}]*\bis(?:n't| not)\s+responding[^{}]*)/i;
 const PACKAGE_NAME = /\b([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)\b/;
 const PERMISSION_PACKAGES = new Set([
   'com.android.permissioncontroller',
@@ -186,8 +185,14 @@ function parseDialogFocus(segment: string, raw: string): AndroidBlockingDialogFo
       raw,
     };
   }
-  const responding = RESPONDING_TITLE.exec(segment)?.[1]?.trim().replaceAll(/\s+/g, ' ');
-  if (!responding) return null;
+  const normalizedSegment = segment.toLowerCase();
+  if (
+    !normalizedSegment.includes("isn't responding") &&
+    !normalizedSegment.includes('is not responding')
+  ) {
+    return null;
+  }
+  const responding = segment.trim().replaceAll(/\s+/g, ' ');
   const packageName = PACKAGE_NAME.exec(responding)?.[1];
   return {
     ...(packageName ? { package: packageName } : {}),

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -413,13 +413,30 @@ test('artifact name resolver scopes both platforms and rejects invalid output', 
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-artifact-name-'));
   t.after(() => fs.rmSync(tempRoot, { force: true, recursive: true }));
   const callLog = path.join(tempRoot, 'calls');
+  const actionDir = path.join(tempRoot, '.github/actions/setup-fixture-app');
+  const fingerprintBinDir = path.join(tempRoot, 'examples/test-app/node_modules/.bin');
   const pnpmStub = path.join(tempRoot, 'pnpm');
+  fs.mkdirSync(actionDir, { recursive: true });
+  fs.mkdirSync(fingerprintBinDir, { recursive: true });
+  fs.copyFileSync(
+    '.github/actions/setup-fixture-app/resolve-artifact-name.sh',
+    path.join(actionDir, 'resolve-artifact-name.sh'),
+  );
   fs.writeFileSync(
     pnpmStub,
     [
       '#!/bin/sh',
+      'echo "pnpm must not mediate machine-readable fingerprint output" >&2',
+      'exit 91',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(fingerprintBinDir, 'fingerprint'),
+    [
+      '#!/bin/sh',
       String.raw`printf "%s\n" "$*" >> "$TEST_CALL_LOG"`,
-      'if [ "$TEST_PNPM_EXIT" -ne 0 ]; then exit "$TEST_PNPM_EXIT"; fi',
+      'if [ "$TEST_FINGERPRINT_EXIT" -ne 0 ]; then exit "$TEST_FINGERPRINT_EXIT"; fi',
       'if [ -n "$TEST_RAW_OUTPUT" ]; then',
       String.raw`  printf "%s\n" "$TEST_RAW_OUTPUT"`,
       'else',
@@ -429,17 +446,18 @@ test('artifact name resolver scopes both platforms and rejects invalid output', 
     ].join('\n'),
   );
   fs.chmodSync(pnpmStub, 0o755);
+  fs.chmodSync(path.join(fingerprintBinDir, 'fingerprint'), 0o755);
   const resolver = '.github/actions/setup-fixture-app/resolve-artifact-name.sh';
-  const runResolver = (platform, hash, pnpmExit = 0, rawOutput = '') =>
+  const runResolver = (platform, hash, fingerprintExit = 0, rawOutput = '') =>
     spawnSync('sh', platform === undefined ? [resolver] : [resolver, platform], {
-      cwd: process.cwd(),
+      cwd: tempRoot,
       encoding: 'utf8',
       env: {
         ...process.env,
         PATH: `${tempRoot}:${process.env.PATH}`,
         TEST_CALL_LOG: callLog,
         TEST_HASH: hash,
-        TEST_PNPM_EXIT: String(pnpmExit),
+        TEST_FINGERPRINT_EXIT: String(fingerprintExit),
         TEST_RAW_OUTPUT: rawOutput,
       },
     });
@@ -453,13 +471,13 @@ test('artifact name resolver scopes both platforms and rejects invalid output', 
   assert.equal(android.stdout, 'fingerprint.android-hash.android\n');
 
   assert.deepEqual(fs.readFileSync(callLog, 'utf8').trim().split('\n'), [
-    '--dir examples/test-app exec fingerprint fingerprint:generate --platform ios',
-    '--dir examples/test-app exec fingerprint fingerprint:generate --platform android',
+    'fingerprint:generate --platform ios',
+    'fingerprint:generate --platform android',
   ]);
   assert.equal(runResolver(undefined, 'unused').status, 2);
   assert.equal(
     spawnSync('sh', [resolver, 'ios', 'extra'], {
-      cwd: process.cwd(),
+      cwd: tempRoot,
       encoding: 'utf8',
       env: process.env,
     }).status,

--- a/test/scripts/setup-fixture-app-fallback-smoke.sh
+++ b/test/scripts/setup-fixture-app-fallback-smoke.sh
@@ -20,12 +20,20 @@ pnpm test:fixture-cache
 
 export TEST_WAIT_SECONDS=0
 
-# pnpm yields a fixed fingerprint so the step has a name to look up without
-# installing the app. The real selector uses the deliberately unavailable API.
+# The installed fingerprint binary yields a fixed value so the step has a name
+# to look up without installing the app. pnpm is a tripwire: machine-readable
+# fingerprint output must not pass through package-manager status output.
 mkdir -p "$WORK/bin"
+WORKSPACE="$WORK/workspace"
+mkdir -p "$WORKSPACE/examples/test-app/node_modules/.bin"
 REAL_NODE="$(command -v node)"
 export REAL_NODE
 cat > "$WORK/bin/pnpm" <<'STUB'
+#!/bin/sh
+echo "pnpm must not mediate machine-readable fingerprint output" >&2
+exit 91
+STUB
+cat > "$WORKSPACE/examples/test-app/node_modules/.bin/fingerprint" <<'STUB'
 #!/bin/sh
 printf '%s\n' "$*" >> "$WORK/fingerprint-calls"
 echo '{"hash":"deadbeefcafe"}'
@@ -35,7 +43,10 @@ cat > "$WORK/bin/node" <<'STUB'
 printf '%s\n' "$*" >> "$WORK/node-calls"
 exec "$REAL_NODE" "$@"
 STUB
-chmod +x "$WORK/bin/pnpm" "$WORK/bin/node"
+chmod +x \
+  "$WORK/bin/pnpm" \
+  "$WORK/bin/node" \
+  "$WORKSPACE/examples/test-app/node_modules/.bin/fingerprint"
 
 GITHUB_OUTPUT="$WORK/out"
 : > "$GITHUB_OUTPUT"
@@ -50,9 +61,11 @@ run_lookup_outage() {
   PLATFORM="$1"
   : > "$GITHUB_OUTPUT"
   set +e
-  PATH="$WORK/bin:$PATH" bash "$ACTION_PATH/fetch-artifact.sh" \
-    "$PLATFORM" "$WORK/fixture" "$TEST_WAIT_SECONDS" octo/repo current-head "$ACTION_PATH" \
-    > "$WORK/log-outage-$PLATFORM" 2>&1
+  (
+    cd "$WORKSPACE"
+    PATH="$WORK/bin:$PATH" bash "$ACTION_PATH/fetch-artifact.sh" \
+      "$PLATFORM" "$WORK/fixture" "$TEST_WAIT_SECONDS" octo/repo current-head "$ACTION_PATH"
+  ) > "$WORK/log-outage-$PLATFORM" 2>&1
   RC=$?
   set -e
 
@@ -71,7 +84,7 @@ run_lookup_outage() {
     echo "FAIL: $PLATFORM expected a warning that it is building inline." >&2
     FAIL=1
   fi
-  if ! grep -qx -- "--dir examples/test-app exec fingerprint fingerprint:generate --platform $PLATFORM" "$WORK/fingerprint-calls"; then
+  if ! grep -qx -- "fingerprint:generate --platform $PLATFORM" "$WORK/fingerprint-calls"; then
     echo "FAIL: fixture consumer did not request the $PLATFORM-scoped fingerprint." >&2
     FAIL=1
   fi
@@ -118,9 +131,11 @@ run_terminal_producer_case() {
   TEST_WAIT_SECONDS=1800
   export TEST_WAIT_SECONDS
   : > "$GITHUB_OUTPUT"
-  if ! PATH="$WORK/bin:$PATH" bash "$ACTION_PATH/fetch-artifact.sh" \
-    "$PLATFORM" "$WORK/fixture" "$TEST_WAIT_SECONDS" octo/repo current-head "$ACTION_PATH" \
-    > "$WORK/log-$TEST_PRODUCER_STATE-$PLATFORM" 2>&1; then
+  if ! (
+    cd "$WORKSPACE"
+    PATH="$WORK/bin:$PATH" bash "$ACTION_PATH/fetch-artifact.sh" \
+      "$PLATFORM" "$WORK/fixture" "$TEST_WAIT_SECONDS" octo/repo current-head "$ACTION_PATH"
+  ) > "$WORK/log-$TEST_PRODUCER_STATE-$PLATFORM" 2>&1; then
     echo "FAIL: $PLATFORM $TEST_PRODUCER_STATE producer state did not fall back cleanly." >&2
     FAIL=1
     return


### PR DESCRIPTION
## Summary

Address the repository's current security findings:

- replace polynomial-ReDoS regexes in Android lifecycle, alert, and observation parsing with linear string operations;
- pin patched `js-yaml` and `nanoid` transitives in the isolated Expo test app;
- apply a local `image-size` 1.2.1 patch at the shared box parser so zero-sized or undersized ICNS, HEIF, and JXL records terminate safely;
- keep native fixture fingerprint resolution machine-readable by invoking the installed fingerprint binary directly, outside pnpm's dependency-status output.

The `image-size` Dependabot alerts remain open because upstream has no patched release; the pnpm patch is the repository remediation until one exists.

Scope expanded from Android and security paths into the existing fixture-cache resolver only to repair the exact CI failure exposed by the dependency patch.

## Validation

- Observed red: zero-size HEIF/JXL fixtures timed out with the shared `image-size` guard bypassed; green on the patched head.
- Observed red: the fixture resolver regression rejected pnpm mediation with exit 91; green after direct installed-binary ownership.
- `node --test security/image-size-security.test.mjs` from `examples/test-app`: 1/1 passed.
- Focused Android parser suites: 9/9 passed.
- `node --test test/ci/trusted-fixture-artifact.test.mjs`: 11/11 passed.
- `CI=true sh .github/actions/setup-fixture-app/resolve-artifact-name.sh ios`: emitted a valid iOS-scoped fingerprint name.
- `CI=true sh .github/actions/setup-fixture-app/resolve-artifact-name.sh android`: emitted a valid Android-scoped fingerprint name.
- `pnpm check:affected --run`: format, lint, typecheck, layering, DI seams, fallow, metadata, build, package verification, integration-node, and macOS coverage passed; the related-test phase was host-contention limited, with 36 unrelated fixed-budget timeouts across interaction, provider, fuzz, daemon, and help-conformance suites.
- Exact-head GitHub CI is authoritative for native, device, provider, and coverage lanes.
