### PR TITLE
refactor: extract daemon session lifecycle inventory facade

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -189,7 +189,7 @@
         "count": 2
       }
     },
-    "src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts": {
+    "src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts": {
       "crap_moderate": {
         "count": 1
       }
@@ -230,7 +230,7 @@
         "count": 1
       }
     },
-    "src/daemon/handlers/session-inventory.ts": {
+    "src/daemon/session-lifecycle/internal/inventory.ts": {
       "complexity_moderate": {
         "count": 1
       }

--- a/scripts/layering/architecture-ownership.test.ts
+++ b/scripts/layering/architecture-ownership.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
-import { ARCHITECTURE_OWNERSHIP, matchesDeclaredRoot } from './architecture-ownership.ts';
+import {
+  ARCHITECTURE_OWNERSHIP,
+  matchesDeclaredRoot,
+  SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS,
+} from './architecture-ownership.ts';
 import { readNamedExports } from './facade-exports.ts';
 import { resolveImportEdges } from './model.ts';
 import { workspaceSpecifierTargets } from './package-boundaries.ts';
@@ -41,7 +45,7 @@ test('architecture ownership roots resolve to tracked owners', () => {
   }
 });
 
-test('daemon replay façade pins its named command surface', () => {
+test('logical module façades pin their named command surfaces', () => {
   const tracked = new Set(listTrackedTypeScriptFiles(repoRoot));
 
   for (const declaration of ARCHITECTURE_OWNERSHIP.facades) {
@@ -52,6 +56,13 @@ test('daemon replay façade pins its named command surface', () => {
       declaration.exports,
       `${declaration.name} façade exports drifted`,
     );
+  }
+});
+
+test('session lifecycle retires its handler-owned helper paths', () => {
+  const tracked = new Set(listTrackedTypeScriptFiles(repoRoot));
+  for (const retiredPath of SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS) {
+    assert.equal(tracked.has(retiredPath), false, `retired path was restored: ${retiredPath}`);
   }
 });
 

--- a/scripts/layering/architecture-ownership.ts
+++ b/scripts/layering/architecture-ownership.ts
@@ -15,6 +15,16 @@ const DAEMON_REPLAY_FACADE = {
   exports: ['ReplaySession', 'ReplayTestVideoOwner', 'runReplayCommand', 'runReplayTestCommand'],
 } as const;
 
+const DAEMON_SESSION_LIFECYCLE_FACADE = {
+  root: 'src/daemon/session-lifecycle/index.ts',
+  exports: ['SessionInventoryCommandInput', 'handleSessionInventoryCommands'],
+} as const;
+
+export const SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS = [
+  'src/daemon/handlers/session-device-utils.ts',
+  'src/daemon/handlers/session-runtime-admission.ts',
+] as const;
+
 export const LOGICAL_MODULE_POLICIES = [
   {
     name: 'ad-replay',
@@ -47,6 +57,12 @@ export const LOGICAL_MODULE_POLICIES = [
       'src/daemon/session-store.ts',
     ],
     facade: DAEMON_REPLAY_FACADE,
+  },
+  {
+    name: 'daemon-session-lifecycle',
+    roots: ['src/daemon/session-lifecycle/'],
+    forbiddenTargetRoots: ['src/daemon/handlers/'],
+    facade: DAEMON_SESSION_LIFECYCLE_FACADE,
   },
 ] as const satisfies readonly LogicalModulePolicy[];
 

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -74,7 +74,11 @@ import {
   type LayeringViolation,
   type ResolvedImportEdge,
 } from './model.ts';
-import { checkDaemonModularityRatchets, daemonModularitySummary } from './daemon-modularity.ts';
+import {
+  checkDaemonModularityRatchets,
+  checkRetiredSessionLifecyclePaths,
+  daemonModularitySummary,
+} from './daemon-modularity.ts';
 import {
   checkPackageBoundaries,
   packageBoundariesSummary,
@@ -578,8 +582,10 @@ export const LAYERING_RULES: Readonly<Record<LayeringRuleId, LayeringRule>> = {
   'back-edges': (context) => checkBackEdges(context.edges),
   'type-spine-inversions': (context) => checkTypeInversions(context.edges),
   'session-state-ownership': (context) => checkSessionStateOwnership(context.sources),
-  'daemon-modularity-ratchets': (context) =>
-    checkDaemonModularityRatchets(context.edges, context.typeCycleMembers),
+  'daemon-modularity-ratchets': (context) => [
+    ...checkDaemonModularityRatchets(context.edges, context.typeCycleMembers),
+    ...checkRetiredSessionLifecyclePaths(context.sourceFiles),
+  ],
   'daemon-platform-boundary': (context) =>
     checkDaemonPlatformBoundary([...context.sources].map(([path, source]) => ({ path, source }))),
   'bin-alias-fast-path': (context) => checkBinAliasFastPath(context.sources),

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   checkDaemonModularityRatchets,
+  checkRetiredSessionLifecyclePaths,
   DAEMON_MODULARITY_BASELINE,
   TYPE_CYCLE_BASELINE,
 } from './daemon-modularity.ts';
@@ -215,6 +216,54 @@ test('daemon replay rejects handler, owner, session-store, and engine deep edges
       'daemon-replay must not import src/daemon/handlers/session-close.ts',
       'daemon-replay must not import src/daemon/session-store.ts',
       "packages/ad-replay/src/internal/step-loop.ts must not import daemon-replay's internal tree (src/daemon/replay/internal/native-command.ts)",
+    ],
+  );
+});
+
+test('session lifecycle rejects handler deep imports in both directions', () => {
+  const edges = resolveImportEdges(
+    new Map([
+      [
+        'src/daemon/handlers/session.ts',
+        "import { handleSessionInventoryCommands } from '../session-lifecycle/internal/inventory.ts';",
+      ],
+      [
+        'src/daemon/session-lifecycle/internal/inventory.ts',
+        "import { handleCloseCommand } from '../../handlers/session-close.ts';",
+      ],
+      [
+        'src/daemon/session-lifecycle/index.ts',
+        'export function handleSessionInventoryCommands() {}',
+      ],
+      ['src/daemon/handlers/session-close.ts', 'export function handleCloseCommand() {}'],
+    ]),
+  );
+
+  const violations = checkDaemonModularityRatchets(
+    [...baselineEdges(), ...edges],
+    baselineTypeCycleMembers(),
+  );
+  assert.deepEqual(
+    violations.map(({ message }) => message.replace(/;.*/, '')),
+    [
+      "src/daemon/handlers/session.ts must not import daemon-session-lifecycle's internal tree (src/daemon/session-lifecycle/internal/inventory.ts)",
+      'daemon-session-lifecycle must not import src/daemon/handlers/session-close.ts',
+    ],
+  );
+});
+
+test('session lifecycle rejects restored neutral helper paths', () => {
+  const violations = checkRetiredSessionLifecyclePaths([
+    'src/daemon/session-device-resolution.ts',
+    'src/daemon/handlers/session-device-utils.ts',
+    'src/daemon/handlers/session-runtime-admission.ts',
+  ]);
+
+  assert.deepEqual(
+    violations.map(({ message }) => message),
+    [
+      'retired session lifecycle helper path was restored: src/daemon/handlers/session-device-utils.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+      'retired session lifecycle helper path was restored: src/daemon/handlers/session-runtime-admission.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
     ],
   );
 });

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import {
   LOGICAL_MODULE_POLICIES,
   matchesDeclaredRoot,
+  SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS,
   type LogicalModulePolicy,
 } from './architecture-ownership.ts';
 import { targetDagZone, type LayeringViolation, type ResolvedImportEdge } from './model.ts';
@@ -51,6 +52,21 @@ export function checkDaemonModularityRatchets(
     ...checkDaemonTypesImporters(edges),
     ...checkLogicalModuleImports(edges),
   ];
+}
+
+export function checkRetiredSessionLifecyclePaths(
+  sourceFiles: readonly string[],
+): LayeringViolation[] {
+  return SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS.filter((file) => sourceFiles.includes(file)).map(
+    (file) => ({
+      rule: 'R10 daemon-modularity',
+      file,
+      line: 1,
+      message:
+        `retired session lifecycle helper path was restored: ${file}. ` +
+        'Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+    }),
+  );
 }
 
 function checkSessionStateBaseline(): LayeringViolation[] {

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -516,7 +516,7 @@ export const RAW_COMMAND_DESCRIPTORS = [
     name: 'session_list',
     deviceClaimPolicy: 'none',
     ...(ownerFilesEnabled
-      ? { ownerFiles: ['src/daemon/handlers/session-inventory.ts'] as const }
+      ? { ownerFiles: ['src/daemon/session-lifecycle/internal/inventory.ts'] as const }
       : {}),
     catalog: { group: 'internal', key: 'sessionList' },
     recordsSessionAction: false,

--- a/src/daemon/__tests__/session-device-resolution.test.ts
+++ b/src/daemon/__tests__/session-device-resolution.test.ts
@@ -1,25 +1,25 @@
 import { test, expect, vi, beforeEach } from 'vitest';
-import type { SessionState } from '../../types.ts';
+import type { SessionState } from '../types.ts';
 
 import {
   resolveCommandDevice,
   refreshSessionDeviceIfNeeded,
   selectorTargetsSessionDevice,
-} from '../session-device-utils.ts';
+} from '../session-device-resolution.ts';
 import { getRunnerSessionSnapshot } from '@agent-device/platform-apple/runner/operations';
-import { resolveTargetDevice } from '../../../core/dispatch-resolve.ts';
-import { isActiveProviderDevice } from '../../../provider-device-runtime.ts';
+import { resolveTargetDevice } from '../../core/dispatch-resolve.ts';
+import { isActiveProviderDevice } from '../../provider-device-runtime.ts';
 
 vi.mock('@agent-device/platform-apple/runner/operations', () => ({
   getRunnerSessionSnapshot: vi.fn(async () => null),
 }));
-vi.mock('../../../core/dispatch-resolve.ts', () => ({
+vi.mock('../../core/dispatch-resolve.ts', () => ({
   resolveTargetDevice: vi.fn(),
 }));
-vi.mock('../../../provider-device-runtime.ts', () => ({
+vi.mock('../../provider-device-runtime.ts', () => ({
   isActiveProviderDevice: vi.fn(() => false),
 }));
-vi.mock('../../device-ready.ts', () => ({
+vi.mock('../device-ready.ts', () => ({
   ensureDeviceReady: vi.fn(async () => {}),
 }));
 

--- a/src/daemon/__tests__/session-runtime-admission.test.ts
+++ b/src/daemon/__tests__/session-runtime-admission.test.ts
@@ -1,7 +1,7 @@
 import { resolveSnapshotRuntimePlan } from '@agent-device/contracts/platform-runtime-operations';
 import { expect, test } from 'vitest';
-import { ANDROID_EMULATOR, IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
-import { snapshotRuntimeFixture } from '../../__tests__/snapshot-runtime-fixture.ts';
+import { ANDROID_EMULATOR, IOS_SIMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
+import { snapshotRuntimeFixture } from './snapshot-runtime-fixture.ts';
 import {
   admitRuntimePlan,
   unwrapAdmittedRuntimePlan,

--- a/src/daemon/handlers/session-app-deployment.ts
+++ b/src/daemon/handlers/session-app-deployment.ts
@@ -16,13 +16,16 @@ import { resolveDeployResultTarget } from '../../utils/result-serialization.ts';
 import { withSuccessText } from '@agent-device/kernel/success-text';
 import { recordSessionAction } from './handler-utils.ts';
 import { errorResponse } from './response.ts';
-import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
+import {
+  requireSessionOrExplicitSelector,
+  resolveCommandDevice,
+} from '../session-device-resolution.ts';
 import {
   requireRuntimeBinding,
   requireRuntimeFacts,
   type RuntimeCommandHandlerParams,
   unavailableRuntimeOperationResponse,
-} from './session-runtime-admission.ts';
+} from '../session-runtime-admission.ts';
 
 type DeployCommand = 'install' | 'reinstall';
 

--- a/src/daemon/handlers/session-app-source-deployment.ts
+++ b/src/daemon/handlers/session-app-source-deployment.ts
@@ -19,12 +19,12 @@ import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { resolveInstallFromSourceResultTarget } from '../../utils/result-serialization.ts';
 import { withSuccessText } from '@agent-device/kernel/success-text';
 import { recordSessionAction } from './handler-utils.ts';
-import { resolveCommandDevice } from './session-device-utils.ts';
+import { resolveCommandDevice } from '../session-device-resolution.ts';
 import {
   requireRuntimeBinding,
   requireRuntimeFacts,
   unavailableRuntimeOperationResponse,
-} from './session-runtime-admission.ts';
+} from '../session-runtime-admission.ts';
 
 type Retention = Readonly<{ enabled: boolean; ttlMs?: number }>;
 type InstallFromSourceResult = Readonly<{

--- a/src/daemon/handlers/session-clipboard.ts
+++ b/src/daemon/handlers/session-clipboard.ts
@@ -19,7 +19,10 @@ import { runtimeExecutionFromContext } from '../snapshot-runtime-capture-input.t
 import { successText } from '@agent-device/kernel/success-text';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import { recordSessionAction } from './handler-utils.ts';
-import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
+import {
+  requireSessionOrExplicitSelector,
+  resolveCommandDevice,
+} from '../session-device-resolution.ts';
 
 type ClipboardAction = 'read' | 'write';
 

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -4,7 +4,7 @@ import type { LeaseLifecycleProvider, TargetShutdownResult } from '@agent-device
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { successText, withSuccessText } from '@agent-device/kernel/success-text';
-import { resolveCommandDevice } from './session-device-utils.ts';
+import { resolveCommandDevice } from '../session-device-resolution.ts';
 import { errorResponse } from './response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import type { LeaseRegistry } from '../lease-registry.ts';

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -9,7 +9,7 @@ import {
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
-import { refreshSessionDeviceIfNeeded } from './session-device-utils.ts';
+import { refreshSessionDeviceIfNeeded } from '../session-device-resolution.ts';
 import { withKeyedLock } from '@agent-device/kernel/keyed-lock';
 import { buildOpenTargetDeviceResolutionOptions } from '../open-device-selection.ts';
 import {

--- a/src/daemon/handlers/session-perf-runtime.ts
+++ b/src/daemon/handlers/session-perf-runtime.ts
@@ -35,7 +35,7 @@ import {
   unavailableRuntimeOperationResponse,
   unwrapAdmittedRuntimePlan,
   type AdmittedRuntimePlan,
-} from './session-runtime-admission.ts';
+} from '../session-runtime-admission.ts';
 
 export type PerfRuntimeHandlerParams = Readonly<{
   req: DaemonRequest;

--- a/src/daemon/handlers/session-prepare.ts
+++ b/src/daemon/handlers/session-prepare.ts
@@ -8,7 +8,10 @@ import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { admitRuntimeUse } from '../runtime-admission.ts';
-import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
+import {
+  requireSessionOrExplicitSelector,
+  resolveCommandDevice,
+} from '../session-device-resolution.ts';
 import { errorResponse } from './response.ts';
 
 const PREPARE_IOS_RUNNER_TIMING_NOTE =

--- a/src/daemon/handlers/session-runtime-port-reverse.ts
+++ b/src/daemon/handlers/session-runtime-port-reverse.ts
@@ -5,7 +5,10 @@ import type { SessionStore } from '../session-store.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { admitRuntimeUse } from '../runtime-admission.ts';
 import { errorResponse } from './response.ts';
-import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
+import {
+  requireSessionOrExplicitSelector,
+  resolveCommandDevice,
+} from '../session-device-resolution.ts';
 
 type PortReverseParseResult =
   | { ok: true; options: ProviderPortReverseOptions }

--- a/src/daemon/handlers/session-selector-dispatch.ts
+++ b/src/daemon/handlers/session-selector-dispatch.ts
@@ -3,7 +3,10 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
-import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
+import {
+  requireSessionOrExplicitSelector,
+  resolveCommandDevice,
+} from '../session-device-resolution.ts';
 import { errorResponse } from './response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { resolveBoundAppEventRuntime } from '../app-event-runtime.ts';

--- a/src/daemon/handlers/session-state.ts
+++ b/src/daemon/handlers/session-state.ts
@@ -21,7 +21,7 @@ import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,
   selectorTargetsSessionDevice,
-} from './session-device-utils.ts';
+} from '../session-device-resolution.ts';
 import { errorResponse } from './response.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import {
@@ -29,7 +29,7 @@ import {
   admitRuntimeUse,
   type UnavailableRuntimeResponse,
 } from '../runtime-admission.ts';
-import type { RuntimeCommandHandlerParams } from './session-runtime-admission.ts';
+import type { RuntimeCommandHandlerParams } from '../session-runtime-admission.ts';
 
 const IOS_APPSTATE_SESSION_REQUIRED_MESSAGE =
   'iOS appstate requires an active session on the target device. Run open first (for example: open --session sim --platform ios --device "<name>" <app>).';

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -1,14 +1,14 @@
 import type { DaemonResponse } from '../types.ts';
 import { handleReleaseMaterializedPathsCommand } from './session-app-source-deployment.ts';
 import { handleRuntimeCommand } from './session-runtime-command.ts';
-import { requireRuntimeBinding, requireRuntimeFacts } from './session-runtime-admission.ts';
+import { requireRuntimeBinding, requireRuntimeFacts } from '../session-runtime-admission.ts';
 import { handleOpenCommand } from './session-open.ts';
 import { composeOpenWithInitialSnapshot } from './session-open-foreground.ts';
 import { handleKeyboardCommand, handleAppEventCommand } from './session-selector-dispatch.ts';
 import { handleCloseCommand } from './session-close.ts';
 import { handleSessionAppDeploymentCommand } from './session-app-deployment-route.ts';
 import { runBatchCommands } from './session-batch.ts';
-import { handleSessionInventoryCommands } from './session-inventory.ts';
+import { handleSessionInventoryCommands } from '../session-lifecycle/index.ts';
 import { handleSessionStateCommands } from './session-state.ts';
 import { handleSessionObservabilityCommands } from './session-observability.ts';
 import { handleReplayCommand, handleReplayTestCommand } from './session-replay-command.ts';
@@ -16,26 +16,18 @@ import { handleSessionScriptPublication } from './session-script-publication.ts'
 import { handleSessionClipboardCommand } from './session-clipboard.ts';
 import { handleDoctorCommand } from './session-doctor.ts';
 import { handlePrepareCommand } from './session-prepare.ts';
-import type { SessionCommandHandler, SessionCommandInput } from './session-command-input.ts';
+import type {
+  SessionCommandHandler,
+  SessionCommandInput,
+  SessionCommandParams,
+} from './session-command-input.ts';
+import type { SessionInventoryCommandInput } from '../session-lifecycle/index.ts';
 import type { DescriptorSessionRouteCommandName } from '../../core/command-descriptor/registry.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 
-const handleSessionInventoryCommandGroup: SessionCommandHandler = async ({
-  req,
-  sessionName,
-  sessionStore,
-  inspectFacts,
-  bindDevice,
-  providerAppCatalog,
-}) =>
-  await handleSessionInventoryCommands({
-    req,
-    sessionName,
-    sessionStore,
-    inspectFacts,
-    bindDevice,
-    providerAppCatalog,
-  });
+const handleSessionInventoryCommandGroup: SessionCommandHandler = (
+  params: SessionCommandParams & SessionInventoryCommandInput,
+) => handleSessionInventoryCommands(params);
 
 const handleSessionStateCommandGroup: SessionCommandHandler = async ({
   req,

--- a/src/daemon/screenshot-runtime-binding.ts
+++ b/src/daemon/screenshot-runtime-binding.ts
@@ -20,7 +20,7 @@ import {
   unavailableRuntimeOperationResponse,
   unwrapAdmittedRuntimePlan,
   type AdmittedRuntimePlan,
-} from './handlers/session-runtime-admission.ts';
+} from './session-runtime-admission.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from './request-runtime-binding.ts';
 import type { DaemonResponse } from './types.ts';
 

--- a/src/daemon/session-device-resolution.ts
+++ b/src/daemon/session-device-resolution.ts
@@ -1,13 +1,13 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import { isActiveProviderDevice } from '../../provider-device-runtime.ts';
-import { ensureDeviceReady } from '../device-ready.ts';
-import { inspectAppleRunnerSession } from '../../platform-runtime-apple-resources.ts';
-import { resolveTargetDevice } from '../../core/dispatch-resolve.ts';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { hasDeviceSelectionInput, hasExplicitDeviceSelector } from '../device-selector-intent.ts';
-import { listSessionSelectorConflicts } from '../session-selector.ts';
-import { errorResponse } from './response.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
+import { ensureDeviceReady } from './device-ready.ts';
+import { inspectAppleRunnerSession } from '../platform-runtime-apple-resources.ts';
+import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
+import { hasDeviceSelectionInput, hasExplicitDeviceSelector } from './device-selector-intent.ts';
+import { listSessionSelectorConflicts } from './session-selector.ts';
+import { errorResponse } from './handlers/response.ts';
 
 export function requireSessionOrExplicitSelector(
   command: string,

--- a/src/daemon/session-lifecycle/__tests__/application.test.ts
+++ b/src/daemon/session-lifecycle/__tests__/application.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+
+vi.mock('../../../request/device-inventory-context.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../request/device-inventory-context.ts')>();
+  return { ...actual, listDeviceInventory: vi.fn(async () => []) };
+});
+
+vi.mock('../index.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../index.ts')>();
+  return {
+    ...actual,
+    handleSessionInventoryCommands: vi.fn(actual.handleSessionInventoryCommands),
+  };
+});
+
+import { handleSessionCommands } from '../../handlers/session.ts';
+import { handleSessionInventoryCommands } from '../index.ts';
+
+const mockHandleSessionInventoryCommands = vi.mocked(handleSessionInventoryCommands);
+
+beforeEach(() => {
+  mockHandleSessionInventoryCommands.mockClear();
+});
+
+function request(command: DaemonRequest['command']): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'default',
+    command,
+    positionals: [],
+    flags: {},
+  };
+}
+
+async function run(command: DaemonRequest['command']): Promise<DaemonResponse | null> {
+  return await handleSessionCommands({
+    req: request(command),
+    sessionName: 'default',
+    logPath: '/tmp/agent-device-session-lifecycle-route.log',
+    sessionStore: makeSessionStore('agent-device-session-lifecycle-route-'),
+    invoke: async () => ({ ok: true, data: {} }),
+    reconcileOrphanedDeviceClaim: async () => ({
+      status: 'retained' as const,
+      reason: 'test-harness',
+    }),
+  });
+}
+
+test('inventory commands retain their route responses and typed failures', async () => {
+  const expected: Record<string, DaemonResponse> = {
+    session_list: { ok: true, data: { sessions: [] } },
+    devices: { ok: true, data: { devices: [] } },
+    capabilities: {
+      ok: false,
+      error: {
+        code: 'INVALID_ARGS',
+        message:
+          'capabilities requires an active session or an explicit device selector (e.g. --platform ios).',
+      },
+    },
+    apps: {
+      ok: false,
+      error: {
+        code: 'INVALID_ARGS',
+        message:
+          'apps requires an active session or an explicit device selector (e.g. --platform ios).',
+      },
+    },
+  };
+
+  for (const command of ['session_list', 'devices', 'capabilities', 'apps'] as const) {
+    await expect(run(command)).resolves.toEqual(expected[command]);
+    expect(mockHandleSessionInventoryCommands).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        req: expect.objectContaining({ command }),
+        sessionName: 'default',
+      }),
+    );
+  }
+});

--- a/src/daemon/session-lifecycle/index.ts
+++ b/src/daemon/session-lifecycle/index.ts
@@ -1,0 +1,2 @@
+export { handleSessionInventoryCommands } from './internal/inventory.ts';
+export type { SessionInventoryCommandInput } from './internal/inventory.ts';

--- a/src/daemon/session-lifecycle/internal/__tests__/session-capabilities-install-projection.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-capabilities-install-projection.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
-import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
-import { makeAndroidSession } from '../../../__tests__/test-utils/session-factories.ts';
-import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import { PUBLIC_COMMANDS } from '../../../../command-catalog.ts';
+import { makeAndroidSession } from '../../../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
+} from '../../../request-runtime-binding.ts';
 import { createCapabilitiesAdmissionRuntime } from './session-capabilities.fixtures.ts';
-import { handleSessionCommands } from './session-command-harness.ts';
+import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
 
 test('capabilities projects the install family from exactly one facts inspection', async () => {
   const { sessionName, sessionStore } = createAndroidCapabilitiesSession('install-family');

--- a/src/daemon/session-lifecycle/internal/__tests__/session-capabilities.fixtures.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-capabilities.fixtures.ts
@@ -12,11 +12,11 @@ import { HOVER_UNAVAILABLE_HINT } from '@agent-device/contracts/touch-runtime';
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
+} from '../../../request-runtime-binding.ts';
 import {
   createUnavailableRuntimeFactsForTest,
   unavailableApplicationLifecycleOperationFacts,
-} from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+} from '../../../../__tests__/test-utils/runtime-operation-facts.ts';
 
 const nativeRefUnavailable = Object.freeze({
   available: false,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-capabilities.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-capabilities.test.ts
@@ -1,15 +1,18 @@
 import { test, expect, vi } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
-import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
-import { LINUX_DEVICE, WEB_DESKTOP_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
+import { PUBLIC_COMMANDS } from '../../../../command-catalog.ts';
+import {
+  LINUX_DEVICE,
+  WEB_DESKTOP_DEVICE,
+} from '../../../../__tests__/test-utils/device-fixtures.ts';
 import {
   makeAndroidSession,
   makeSession,
-} from '../../../__tests__/test-utils/session-factories.ts';
-import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import { withTestDeviceInventoryProvider as withTargetDeviceResolutionScope } from '../../../__tests__/test-utils/device-inventory-gateways.ts';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+} from '../../../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
+import { withTestDeviceInventoryProvider as withTargetDeviceResolutionScope } from '../../../../__tests__/test-utils/device-inventory-gateways.ts';
+import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../../__tests__/test-utils/runtime-operation-facts.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
@@ -26,8 +29,8 @@ import { perfRuntimeOperationFacts } from '@agent-device/contracts/perf-runtime'
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
-import { handleSessionCommands } from './session-command-harness.ts';
+} from '../../../request-runtime-binding.ts';
+import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
 
 /** The system leaves this owner refuses: the retired fallback listed them unconditionally. */
 const ANDROID_REFUSED_SYSTEM_COMMANDS = ['clipboard', 'alert', 'settings', 'app-switcher'];

--- a/src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts
@@ -2,17 +2,17 @@ import { test, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { retainMaterializedPaths } from '../../materialized-path-registry.ts';
+import { retainMaterializedPaths } from '../../../materialized-path-registry.ts';
 import {
   mockCleanupRetainedMaterializedPaths,
   makeSessionStore,
   makeSession,
   noopInvoke,
-} from './session-test-harness.ts';
-import type { DaemonRequest } from '../../types.ts';
-import { handleSessionCommands } from './session-command-harness.ts';
-import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
-import { withTestDeviceInventory } from '../../../__tests__/test-utils/device-inventory-gateways.ts';
+} from '../../../handlers/__tests__/session-test-harness.ts';
+import type { DaemonRequest } from '../../../types.ts';
+import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
+import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
+import { withTestDeviceInventory } from '../../../../__tests__/test-utils/device-inventory-gateways.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { readCurrentOwnerIdentity } from '@agent-device/host-kit/process';
 
@@ -442,8 +442,8 @@ test('close clears retained materialized install paths bound to the session', as
 
   // Use real cleanup implementation so retained paths are actually removed
   const { cleanupRetainedMaterializedPathsForSession: realCleanup } = await vi.importActual<
-    typeof import('../../materialized-path-registry.ts')
-  >('../../materialized-path-registry.ts');
+    typeof import('../../../materialized-path-registry.ts')
+  >('../../../materialized-path-registry.ts');
   mockCleanupRetainedMaterializedPaths.mockImplementation(realCleanup);
 
   const response = await handleSessionCommands({

--- a/src/daemon/session-lifecycle/internal/__tests__/session-inventory-appleos.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-inventory-appleos.test.ts
@@ -3,16 +3,16 @@ import { test, expect, vi, beforeEach } from 'vitest';
 // The `devices` handler resolves its inventory through listDeviceInventory; mocking it
 // lets us drive the additive `appleOs` projection off the shared device fixtures without
 // touching real local discovery.
-vi.mock('../../../request/device-inventory-context.ts', async (importOriginal) => {
+vi.mock('../../../../request/device-inventory-context.ts', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('../../../request/device-inventory-context.ts')>();
+    await importOriginal<typeof import('../../../../request/device-inventory-context.ts')>();
   return { ...actual, listDeviceInventory: vi.fn(async () => []) };
 });
 
-import { handleSessionInventoryCommands } from '../session-inventory.ts';
-import { listDeviceInventory } from '../../../request/device-inventory-context.ts';
-import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import { handleSessionInventoryCommands } from '../inventory.ts';
+import { listDeviceInventory } from '../../../../request/device-inventory-context.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
+import type { DaemonRequest, DaemonResponse } from '../../../types.ts';
 import type { AppleOS, DeviceInfo } from '@agent-device/kernel/device';
 import {
   ANDROID_EMULATOR,
@@ -21,7 +21,7 @@ import {
   MACOS_DEVICE,
   TVOS_SIMULATOR,
   VISIONOS_SIMULATOR,
-} from '../../../__tests__/test-utils/device-fixtures.ts';
+} from '../../../../__tests__/test-utils/device-fixtures.ts';
 
 const mockListDeviceInventory = vi.mocked(listDeviceInventory);
 

--- a/src/daemon/session-lifecycle/internal/__tests__/session-inventory-appleos.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-inventory-appleos.test.ts
@@ -14,6 +14,7 @@ import { listDeviceInventory } from '../../../../request/device-inventory-contex
 import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
 import type { DaemonRequest, DaemonResponse } from '../../../types.ts';
 import type { AppleOS, DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
 import {
   ANDROID_EMULATOR,
   IOS_SIMULATOR,
@@ -111,4 +112,21 @@ test('devices drops a stray appleOs on a non-Apple device (gated to Apple platfo
   const android = devices.find((device) => device.id === ANDROID_EMULATOR.id);
   expect(android?.platform).toBe('android');
   expect(android && 'appleOs' in android).toBe(false);
+});
+
+test('devices preserves the typed inventory failure response', async () => {
+  mockListDeviceInventory.mockRejectedValue(
+    new AppError('COMMAND_FAILED', 'device inventory unavailable', {
+      reason: 'inventory-failed',
+    }),
+  );
+
+  await expect(runDevices()).resolves.toEqual({
+    ok: false,
+    error: {
+      code: 'COMMAND_FAILED',
+      message: 'device inventory unavailable',
+      details: { reason: 'inventory-failed' },
+    },
+  });
 });

--- a/src/daemon/session-lifecycle/internal/__tests__/session-inventory-apps-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-inventory-apps-runtime.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { DaemonRequest } from '../../types.ts';
-import { makeSession, makeSessionStore } from './session-test-harness.ts';
-import { handleSessionInventoryCommands } from '../session-inventory.ts';
+import type { DaemonRequest } from '../../../types.ts';
+import { makeSession, makeSessionStore } from '../../../handlers/__tests__/session-test-harness.ts';
+import { handleSessionInventoryCommands } from '../inventory.ts';
 import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
   type RuntimeFacts,
@@ -9,11 +9,11 @@ import {
   narrowDeviceBinding,
 } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../../__tests__/test-utils/runtime-operation-facts.ts';
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
+} from '../../../request-runtime-binding.ts';
 import {
   clearRequestAbortRegistration,
   registerRequestAbort,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-inventory-harmonyos.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { DaemonRequest, DaemonResponse } from '../../types.ts';
-import { makeSession, makeSessionStore } from './session-test-harness.ts';
-import { handleSessionInventoryCommands } from '../session-inventory.ts';
+import type { DaemonRequest, DaemonResponse } from '../../../types.ts';
+import { makeSession, makeSessionStore } from '../../../handlers/__tests__/session-test-harness.ts';
+import { handleSessionInventoryCommands } from '../inventory.ts';
 import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
   type RuntimeFacts,
@@ -9,11 +9,11 @@ import {
   narrowDeviceBinding,
 } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../../__tests__/test-utils/runtime-operation-facts.ts';
 import type {
   BindDeviceRuntime,
   InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
+} from '../../../request-runtime-binding.ts';
 
 const HARMONY_DEVICE = {
   platform: 'harmonyos' as const,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-inventory-scoped-paths.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-inventory-scoped-paths.test.ts
@@ -1,11 +1,11 @@
 import { test, expect } from 'vitest';
 import path from 'node:path';
-import { handleSessionInventoryCommands } from '../session-inventory.ts';
-import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
-import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
-import { resolveImplicitSessionScope } from '../../session-routing.ts';
-import { tenantScopedSessionName } from '../../session-tenant-scope.ts';
+import { handleSessionInventoryCommands } from '../inventory.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../../../types.ts';
+import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/device-fixtures.ts';
+import { resolveImplicitSessionScope } from '../../../session-routing.ts';
+import { tenantScopedSessionName } from '../../../session-tenant-scope.ts';
 
 // A session opened without an explicit --session is NAMED `default` and STORED under
 // `cwd:<hash>:default`. `session list` resolved its paths from the name, so it answered with

--- a/src/daemon/session-lifecycle/internal/inventory.ts
+++ b/src/daemon/session-lifecycle/internal/inventory.ts
@@ -1,8 +1,8 @@
 import {
   commandRuntimeUseRequirements,
   listRuntimeFactCommands,
-} from '../../core/command-descriptor/registry.ts';
-import { listDeviceInventory } from '../../request/device-inventory-context.ts';
+} from '../../../core/command-descriptor/registry.ts';
+import { listDeviceInventory } from '../../../request/device-inventory-context.ts';
 import { assertResolvedAppsFilter } from '@agent-device/contracts/device';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import {
@@ -19,18 +19,20 @@ import {
   resolveAndroidSerialAllowlist,
   resolveIosSimulatorDeviceSetPath,
 } from '@agent-device/kernel/device-isolation';
-import { deviceClaimOwnerCannotRelease, inspectDeviceClaims } from '../device-claim-inspection.ts';
-import { canonicalLocalDeviceKey } from '../device-claim-paths.ts';
-import { deviceClaimIdentity } from '../device-claims.ts';
-import type { DaemonRequest, DaemonResponse, SessionRef } from '../types.ts';
-import { resolveSessionRunnerLogPath, SessionStore } from '../session-store.ts';
+import {
+  deviceClaimOwnerCannotRelease,
+  inspectDeviceClaims,
+} from '../../device-claim-inspection.ts';
+import { canonicalLocalDeviceKey } from '../../device-claim-paths.ts';
+import { deviceClaimIdentity } from '../../device-claims.ts';
+import type { DaemonRequest, DaemonResponse, SessionRef } from '../../types.ts';
+import { resolveSessionRunnerLogPath, SessionStore } from '../../session-store.ts';
 import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,
   selectorTargetsSessionDevice,
-} from './session-device-utils.ts';
-import { errorResponse } from './response.ts';
-import { resolveSessionScope, sessionMatchesInventoryScope } from '../session-routing.ts';
+} from '../../session-device-resolution.ts';
+import { resolveSessionScope, sessionMatchesInventoryScope } from '../../session-routing.ts';
 import type {
   BoundDeviceRuntime,
   RuntimeFacts,
@@ -40,20 +42,27 @@ import {
   type PlatformRuntimeOperations,
   appsRuntimeUse,
 } from '@agent-device/contracts/platform-runtime-operations';
-import { ensureAppsRuntimeReady, listAppsFromRuntime } from '../apps-runtime.ts';
-import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
+import { ensureAppsRuntimeReady, listAppsFromRuntime } from '../../apps-runtime.ts';
+import type {
+  BindDeviceRuntime,
+  InspectDeviceRuntimeFacts,
+} from '../../request-runtime-binding.ts';
 import type { ProviderAppCatalog, ProviderAppCatalogQuery } from '@agent-device/contracts/device';
-import { resolveLeaseScope } from '../lease-context.ts';
+import { resolveLeaseScope } from '../../lease-context.ts';
 import { getRequestSignal } from '@agent-device/host-kit/request';
 
-export async function handleSessionInventoryCommands(params: {
+export type SessionInventoryCommandInput = Readonly<{
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
   inspectFacts?: InspectDeviceRuntimeFacts;
   bindDevice?: BindDeviceRuntime;
   providerAppCatalog?: ProviderAppCatalog;
-}): Promise<DaemonResponse | null> {
+}>;
+
+export async function handleSessionInventoryCommands(
+  params: SessionInventoryCommandInput,
+): Promise<DaemonResponse | null> {
   const { req, sessionName, sessionStore } = params;
   switch (req.command) {
     case 'session_list':
@@ -97,15 +106,6 @@ function sessionListInventoryResponse(
   };
 }
 
-/**
- * `address` is the string `--session` accepts for this session, and `sessionStateDir` /
- * `runnerLogPath` are resolved from that same key rather than from `session.name`. An implicitly
- * cwd-scoped session is named `default` and stored under `cwd:<hash>:default`, so reporting only
- * the name left `session list` — the discovery surface — naming a session no `--session` value
- * could reach, and pointed its paths at `<state>/sessions/default`, a directory that does not
- * exist, while the real artifacts sat in `<state>/sessions/cwd_<hash>_default` (#2031/#1394).
- * `name` stays as the public name the session was opened under.
- */
 function publicSessionInfo({ address, session }: SessionRef, sessionStore: SessionStore) {
   const sessionStateDir = sessionStore.resolveSessionDir(address);
   return {
@@ -145,19 +145,17 @@ async function devicesInventoryResponse(req: DaemonRequest): Promise<DaemonRespo
     };
   } catch (error) {
     const appErr = asAppError(error);
-    return errorResponse(appErr.code, appErr.message, appErr.details);
+    return {
+      ok: false,
+      error: {
+        code: appErr.code,
+        message: appErr.message,
+        ...(appErr.details ? { details: appErr.details } : {}),
+      },
+    };
   }
 }
 
-/**
- * #1320 ownership projection (`observe` policy): device rows name the claim
- * owner that would block a foreign `open` right now, so an agent told a device
- * is busy can pick a free one from the same listing. Provably dead owners are
- * excluded — the next open reconciles and replaces them automatically. Both
- * sides key by the canonical local device key (family, Apple OS, id): distinct
- * platform devices may share a bare id, and a claim must never project onto
- * another family's row.
- */
 function blockingClaimOwnersByDevice(): Map<string, { session: string; workspace: string }> {
   const owners = new Map<string, { session: string; workspace: string }>();
   for (const entry of inspectDeviceClaims({})) {
@@ -250,13 +248,6 @@ async function capabilitiesInventoryResponse(params: {
     params.sessionStore.get(params.sessionName),
     params.req.flags,
   );
-  // Capability projection is admission-only: every fact-owned command reads this one
-  // side-effect-free exact-device snapshot, never a deleted descriptor capability bucket, and
-  // never a binding. R63 retired the three `bindDevice` probes that used to answer
-  // `logs`/`network`/`record`: every owner composes a binding's facts with the same function
-  // `inspectFacts` calls, so the probes read back values this snapshot already carries while
-  // costing a device claim on a read-only query. ADR 0019 §6 requires a `none` descriptor to bind
-  // nothing, and `capabilities` is one.
   const facts = await inspectCapabilityFacts(device, params.inspectFacts);
   return {
     ok: true,
@@ -299,15 +290,6 @@ function hasMacSessionSurface(
   );
 }
 
-/**
- * Whether the exact device admits any of `command`'s declared runtime uses, or `undefined` when
- * the command is not fact-owned at all.
- *
- * R63 reads the requirement straight off the descriptor (`commandRuntimeUseRequirements`), so a
- * command cannot be migrated in one place and left projecting from a stale list in another —
- * which is precisely how a real Vega VVD came to advertise `snapshot diff get is wait focus` it
- * cannot run.
- */
 function factOwnedCapabilityAvailable(
   command: string,
   facts: RuntimeFacts<PlatformRuntimeOperations> | undefined,
@@ -437,12 +419,14 @@ async function resolveAppsRuntime(params: {
   );
   if (unavailable && !unavailable.available) {
     return {
-      response: errorResponse(
-        'UNSUPPORTED_OPERATION',
-        'apps is not supported on this device',
-        undefined,
-        unavailable.hint ? { hint: unavailable.hint } : undefined,
-      ),
+      response: {
+        ok: false,
+        error: {
+          code: 'UNSUPPORTED_OPERATION',
+          message: 'apps is not supported on this device',
+          ...(unavailable.hint ? { hint: unavailable.hint } : {}),
+        },
+      },
     };
   }
   if (!params.bindDevice) {

--- a/src/daemon/session-runtime-admission.ts
+++ b/src/daemon/session-runtime-admission.ts
@@ -5,10 +5,10 @@ import type {
 } from '@agent-device/contracts/platform-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import type { SessionStore } from '../session-store.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
-import { errorResponse } from './response.ts';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from './request-runtime-binding.ts';
+import type { SessionStore } from './session-store.ts';
+import type { DaemonRequest, DaemonResponse } from './types.ts';
+import { errorResponse } from './handlers/response.ts';
 
 export type RuntimeCommandHandlerParams = Readonly<{
   req: DaemonRequest;

--- a/src/daemon/snapshot-runtime-binding.ts
+++ b/src/daemon/snapshot-runtime-binding.ts
@@ -21,7 +21,7 @@ import {
   unavailableRuntimeOperationResponse,
   unwrapAdmittedRuntimePlan,
   type AdmittedRuntimePlan,
-} from './handlers/session-runtime-admission.ts';
+} from './session-runtime-admission.ts';
 import { errorResponse } from './handlers/response.ts';
 import { resolveSnapshotScope } from './handlers/snapshot-capture.ts';
 import { resolveSessionDevice } from './handlers/snapshot-session.ts';

--- a/test/integration/macos-e2e/coverage-manifest.ts
+++ b/test/integration/macos-e2e/coverage-manifest.ts
@@ -66,7 +66,7 @@ export const MACOS_PLATFORM_COVERAGE = {
     'Apple inventory projects the local macOS host as a desktop device',
   ),
   [C.capabilities]: contract(
-    'src/daemon/handlers/__tests__/session-capabilities.test.ts',
+    'src/daemon/session-lifecycle/internal/__tests__/session-capabilities.test.ts',
     'capabilities preserves session-owned appstate for an active %s session',
     'the capabilities response projects exact runtime facts plus active macOS session state',
   ),

--- a/test/integration/web-e2e/coverage-manifest.ts
+++ b/test/integration/web-e2e/coverage-manifest.ts
@@ -76,7 +76,7 @@ export const WEB_PLATFORM_COVERAGE = {
     'web inventory returns the established browser target',
   ),
   [C.capabilities]: contract(
-    'src/daemon/handlers/__tests__/session-capabilities.test.ts',
+    'src/daemon/session-lifecycle/internal/__tests__/session-capabilities.test.ts',
     'capabilities omits apps when $label runtime facts deny the operation',
     'web capability projection reflects runtime-owned unsupported operations',
   ),
@@ -86,7 +86,7 @@ export const WEB_PLATFORM_COVERAGE = {
     'web doctor reports managed browser lifecycle evidence',
   ),
   [C.apps]: contract(
-    'src/daemon/handlers/__tests__/session-capabilities.test.ts',
+    'src/daemon/session-lifecycle/internal/__tests__/session-capabilities.test.ts',
     'capabilities omits apps when $label runtime facts deny the operation',
     'web runtime facts keep native app inventory unavailable',
   ),
@@ -171,7 +171,7 @@ export const WEB_PLATFORM_COVERAGE = {
     'web runtime facts keep Apple runner preparation unavailable',
   ),
   [C.batch]: contract(
-    'src/daemon/handlers/__tests__/session-devices-batch-runtime.test.ts',
+    'src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts',
     'batch step forwards the parent web platform selector to each invoked step',
     'batch re-invokes each step through the normal dispatcher with no platform branch, so a web selector threads through unchanged',
   ),


### PR DESCRIPTION
## Summary

Moves neutral session device resolution and runtime admission to daemon-owned seams, moves inventory implementation/tests under the session-lifecycle internal owner, and routes session_list/devices/capabilities/apps through the two-export facade. Adds ownership/deep-import/retired-path enforcement while preserving response data, typed errors, runtime admission, and SessionState ownership.

Closes #2173

## Validation

- `pnpm check:layering`, `pnpm check:fallow --base origin/main`, typecheck, format, lint, build, package, and coverage-manifest checks passed.
- Focused lifecycle suite: 58 tests passed; related selection exercised 3,119 tests, with four unrelated timeout-budget failures under broad host load. The four cases passed in isolated diagnostics with `--testTimeout=15000`; no test budgets were changed.
- Observed planted-red failures for both forbidden-import directions and both retired helper paths.
- Final staged-diff adversarial review passed; production source is net -7 LOC after move accounting.