### PR TITLE
perf: retain iOS runner across physical relaunch

### DIFF
--- a/docs/adr/0005-ios-runner-interaction-lifecycle.md
+++ b/docs/adr/0005-ios-runner-interaction-lifecycle.md
@@ -62,10 +62,12 @@ root-only payload instead of issuing more flat fallback queries against the same
 the cached `XCUIApplication` handle is cleared so the next command reacquires the target through the
 normal activation path.
 
-An external iOS simulator relaunch also invalidates process-bound target state. After replacing the
-app process, the daemon sends a lifecycle reset to the retained runner so the next command reacquires
-`XCUIApplication`; the reset also clears process-bound snapshot penalty and private-AX depth state. If
-that reset cannot be confirmed, the daemon discards the runner session.
+An external iOS-family Simulator relaunch or physical iOS relaunch also invalidates process-bound
+target state. After replacing the app process, the daemon sends a lifecycle reset to the retained
+runner so the next command reacquires `XCUIApplication`; the reset also clears process-bound snapshot
+penalty and private-AX depth state. If that reset cannot be confirmed, or if relaunch fails before
+reset, the daemon discards the runner session. Other physical Apple OS leaves retain their existing
+runner-restart behavior until separately evidenced.
 
 The snapshot surface intentionally has two AX-failure shapes. Interactive fast snapshots return a
 truncated success payload with `runnerFatal` so agents can still see that AX state is unavailable
@@ -100,9 +102,10 @@ capture. A changed accessibility digest is reported as success with an explicit 
 not blindly repeat a tap that may already have navigated; unchanged, sparse, mismatched, or unavailable
 evidence remains the original failure.
 
-Simulator relaunch keeps the healthy XCTest process warm without carrying an app target across
-process identity. The reset adds one local runner request instead of paying for a runner restart and
-clears the old process's hostile-screen capture penalty before the replacement is reacquired.
+iOS-family Simulator and physical iOS relaunch keep the healthy XCTest process warm without carrying
+an app target across process identity. The reset adds one local runner request instead of paying for a
+runner restart and clears the old process's hostile-screen capture penalty before the replacement is
+reacquired.
 
 Future optimization work should only reduce these preflights after the runner exposes status in a
 way that survives command-induced XCTest teardown and can prove the session is still serving new

--- a/packages/platform-apple/src/lifecycle.test.ts
+++ b/packages/platform-apple/src/lifecycle.test.ts
@@ -1,0 +1,160 @@
+import { expect, test, vi } from 'vitest';
+import type { OpenApplicationInput } from '@agent-device/contracts/application-lifecycle-runtime';
+import type { Interactor } from '@agent-device/contracts/interactor-types';
+import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { bindAppleApplicationLifecycle } from './lifecycle.ts';
+import { platformRuntimeHostFixture } from './runtime.fixtures.ts';
+
+const device: DeviceInfo = {
+  platform: 'apple',
+  appleOs: 'ios',
+  id: 'ios-device',
+  name: 'iPhone',
+  kind: 'device',
+  target: 'mobile',
+  booted: true,
+  iosPhysicalDeviceBackend: 'coredevice',
+};
+
+test.each(['coredevice', 'xctest'] as const)(
+  'retains a physical iOS runner through relaunch and resets its target with the %s backend',
+  async (iosPhysicalDeviceBackend) => {
+    const selectedDevice = { ...device, iosPhysicalDeviceBackend };
+    const signal = new AbortController().signal;
+    const events: string[] = [];
+    const interactor = {
+      close: vi.fn(async () => {
+        events.push('close');
+      }),
+      open: vi.fn(async () => {
+        events.push('open');
+      }),
+    } as unknown as Interactor;
+    const baseHost = platformRuntimeHostFixture();
+    const stopRunnerSession = vi.fn(async () => {
+      events.push('stop');
+    });
+    const prewarmRunnerSession = vi.fn(async () => {
+      events.push('prewarm');
+    });
+    const notifyRunnerAppRelaunched = vi.fn(async () => {
+      events.push('reset');
+    });
+    const host = {
+      ...baseHost,
+      localInteractors: { resolve: async () => interactor },
+      appleApplications: {
+        ...baseHost.appleApplications,
+        stopRunnerSession,
+        prewarmRunnerSession,
+        notifyRunnerAppRelaunched,
+      },
+    } as unknown as PlatformRuntimeHost;
+    const lifecycle = bindAppleApplicationLifecycle({ host, device: selectedDevice, signal });
+
+    await lifecycle.openApplication(openInput());
+
+    expect(events).toEqual(['close', 'open', 'prewarm', 'reset']);
+    expect(stopRunnerSession).not.toHaveBeenCalled();
+    expect(notifyRunnerAppRelaunched).toHaveBeenCalledWith(selectedDevice, {}, signal);
+  },
+);
+
+test.each(['ipados', 'tvos', 'visionos'] as const)(
+  'preserves runner restart semantics for a physical %s target',
+  async (appleOs) => {
+    const selectedDevice = { ...device, appleOs };
+    const signal = new AbortController().signal;
+    const events: string[] = [];
+    const interactor = {
+      close: vi.fn(async () => {
+        events.push('close');
+      }),
+      open: vi.fn(async () => {
+        events.push('open');
+      }),
+    } as unknown as Interactor;
+    const baseHost = platformRuntimeHostFixture();
+    const stopRunnerSession = vi.fn(async () => {
+      events.push('stop');
+    });
+    const prewarmRunnerSession = vi.fn(async () => {
+      events.push('prewarm');
+    });
+    const notifyRunnerAppRelaunched = vi.fn(async () => {
+      events.push('reset');
+    });
+    const host = {
+      ...baseHost,
+      localInteractors: { resolve: async () => interactor },
+      appleApplications: {
+        ...baseHost.appleApplications,
+        stopRunnerSession,
+        prewarmRunnerSession,
+        notifyRunnerAppRelaunched,
+      },
+    } as unknown as PlatformRuntimeHost;
+    const lifecycle = bindAppleApplicationLifecycle({ host, device: selectedDevice, signal });
+
+    await lifecycle.openApplication(openInput());
+
+    expect(events).toEqual(['stop', 'close', 'open', 'prewarm']);
+    expect(notifyRunnerAppRelaunched).not.toHaveBeenCalled();
+  },
+);
+
+test('discards a retained physical iOS runner when relaunch fails and preserves the failure', async () => {
+  const signal = new AbortController().signal;
+  const events: string[] = [];
+  const relaunchFailure = new Error('app failed to reopen');
+  const interactor = {
+    close: vi.fn(async () => {
+      events.push('close');
+    }),
+    open: vi.fn(async () => {
+      events.push('open');
+      throw relaunchFailure;
+    }),
+  } as unknown as Interactor;
+  const baseHost = platformRuntimeHostFixture();
+  const stopRunnerSession = vi.fn(async () => {
+    events.push('stop');
+    throw new Error('runner cleanup failed');
+  });
+  const notifyRunnerAppRelaunched = vi.fn(async () => {
+    events.push('reset');
+  });
+  const host = {
+    ...baseHost,
+    localInteractors: { resolve: async () => interactor },
+    appleApplications: {
+      ...baseHost.appleApplications,
+      stopRunnerSession,
+      notifyRunnerAppRelaunched,
+    },
+  } as unknown as PlatformRuntimeHost;
+  const lifecycle = bindAppleApplicationLifecycle({ host, device, signal });
+
+  await expect(lifecycle.openApplication(openInput())).rejects.toBe(relaunchFailure);
+
+  expect(events).toEqual(['close', 'open', 'stop']);
+  expect(stopRunnerSession).toHaveBeenCalledWith(device.id);
+  expect(notifyRunnerAppRelaunched).not.toHaveBeenCalled();
+});
+
+function openInput(): OpenApplicationInput {
+  return {
+    target: 'com.example.app',
+    positionals: ['com.example.app'],
+    appBundleId: 'com.example.app',
+    surface: 'app',
+    hasExistingSession: true,
+    relaunch: true,
+    prewarmRunnerBeforeOpen: false,
+    enableTestIme: false,
+    stateDir: '/tmp/agent-device-lifecycle-test',
+    runtimeHints: {},
+    execution: {},
+  };
+}

--- a/packages/platform-apple/src/lifecycle.ts
+++ b/packages/platform-apple/src/lifecycle.ts
@@ -96,22 +96,42 @@ async function openAppleApplication(
     input.surface === 'app' &&
     input.positionals.length > 0 &&
     Boolean(input.appBundleId);
-  if (localIosSimulator && shouldPrewarmRunner && !input.prewarmRunnerBeforeOpen) runner.schedule();
-  await closeAppleApplicationForRelaunch(host, binding, input, localIosSimulator, timing);
-  await applyAppleOpenRuntimeHints(input, timing);
-  await prewarmAppleRunnerBeforeOpen(runner, shouldPrewarmRunner, input.prewarmRunnerBeforeOpen);
-  const runnerTargetPredatesOpen = runner.wasAwaited();
-  await dispatchAppleOpen(binding, input, localIosSimulator, timing);
-  await finishAppleRunnerPrewarm(runner, shouldPrewarmRunner, input.relaunch);
-  await notifyAppleRunnerRelaunch(
-    host,
-    binding,
+  const retainRunnerForRelaunch = shouldRetainRunnerForRelaunch(
+    binding.device,
     input,
     localIosSimulator,
-    runnerTargetPredatesOpen,
   );
-  await settleAppleOpen(host, binding, localIosSimulator, timing);
-  return { appBundleId: input.appBundleId, timing };
+  if (localIosSimulator && shouldPrewarmRunner && !input.prewarmRunnerBeforeOpen) runner.schedule();
+  try {
+    await closeAppleApplicationForRelaunch(
+      host,
+      binding,
+      input,
+      localIosSimulator,
+      retainRunnerForRelaunch,
+      timing,
+    );
+    await applyAppleOpenRuntimeHints(input, timing);
+    await prewarmAppleRunnerBeforeOpen(runner, shouldPrewarmRunner, input.prewarmRunnerBeforeOpen);
+    const runnerTargetPredatesOpen = runner.wasAwaited();
+    await dispatchAppleOpen(binding, input, localIosSimulator, timing);
+    await finishAppleRunnerPrewarm(runner, shouldPrewarmRunner, input.relaunch);
+    await notifyAppleRunnerRelaunch(
+      host,
+      binding,
+      input,
+      localIosSimulator,
+      runnerTargetPredatesOpen,
+      retainRunnerForRelaunch,
+    );
+    await settleAppleOpen(host, binding, localIosSimulator, timing);
+    return { appBundleId: input.appBundleId, timing };
+  } catch (error) {
+    if (retainRunnerForRelaunch) {
+      await host.appleApplications.stopRunnerSession(binding.device.id).catch(() => {});
+    }
+    throw error;
+  }
 }
 
 async function closeAppleApplicationForRelaunch(
@@ -119,11 +139,12 @@ async function closeAppleApplicationForRelaunch(
   binding: BoundAppleInteractor,
   input: OpenApplicationInput,
   localIosSimulator: boolean,
+  retainRunnerForRelaunch: boolean,
   timing: MutableOpenTiming,
 ): Promise<void> {
   if (!shouldCloseForAppleRelaunch(input, localIosSimulator) || !input.target) return;
   const startedAtMs = Date.now();
-  if (isApplePlatform(binding.device.platform) && !localIosSimulator) {
+  if (isApplePlatform(binding.device.platform) && !localIosSimulator && !retainRunnerForRelaunch) {
     await host.appleApplications.stopRunnerSession(binding.device.id);
   }
   await invokeApplicationClose({
@@ -225,8 +246,15 @@ async function notifyAppleRunnerRelaunch(
   input: OpenApplicationInput,
   localIosSimulator: boolean,
   runnerTargetPredatesOpen: boolean,
+  retainRunnerForRelaunch: boolean,
 ): Promise<void> {
-  if (!localIosSimulator || (!input.relaunch && !runnerTargetPredatesOpen)) return;
+  if (
+    !isIosFamily(binding.device) ||
+    (!localIosSimulator && !retainRunnerForRelaunch) ||
+    (!input.relaunch && !runnerTargetPredatesOpen)
+  ) {
+    return;
+  }
   await host.appleApplications.notifyRunnerAppRelaunched(
     binding.device,
     input.execution,
@@ -252,6 +280,18 @@ function shouldCloseForAppleRelaunch(
   return (
     Boolean(input.relaunch && input.target) &&
     !(localIosSimulator && !input.execution.clearAppState)
+  );
+}
+
+function shouldRetainRunnerForRelaunch(
+  device: DeviceInfo,
+  input: OpenApplicationInput,
+  localIosSimulator: boolean,
+): boolean {
+  return (
+    device.kind === 'device' &&
+    device.appleOs === 'ios' &&
+    shouldCloseForAppleRelaunch(input, localIosSimulator)
   );
 }
 

--- a/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
+++ b/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
@@ -157,12 +157,13 @@ test('open --relaunch does not let an ambient provider claim suppress a local pr
   }
 });
 
-test('open --relaunch on iOS stops runner before close/open', async () => {
+test('open --relaunch on physical iOS retains runner through close/open', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'ios-session';
   sessionStore.set(sessionName, {
     ...makeSession(sessionName, {
       platform: 'apple',
+      appleOs: 'ios',
       id: 'ios-device-1',
       name: 'My iPhone',
       kind: 'device',
@@ -174,6 +175,7 @@ test('open --relaunch on iOS stops runner before close/open', async () => {
   const calls: string[] = [];
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
+    appleOs: 'ios',
     id: 'ios-device-1',
     name: 'My iPhone',
     kind: 'device',
@@ -181,6 +183,9 @@ test('open --relaunch on iOS stops runner before close/open', async () => {
   });
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
+  });
+  mockNotifyIosRunnerAppRelaunched.mockImplementation(async () => {
+    calls.push('reset-runner-target');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
     calls.push(`${command}:${positionals.join(' ')}`);
@@ -203,7 +208,8 @@ test('open --relaunch on iOS stops runner before close/open', async () => {
 
   expect(response).toBeTruthy();
   expect(response?.ok).toBe(true);
-  expect(calls).toEqual(['stop-runner', 'close:com.example.app', 'open:com.example.app']);
+  expect(calls).toEqual(['close:com.example.app', 'open:com.example.app', 'reset-runner-target']);
+  expect(mockStopIosRunner).not.toHaveBeenCalled();
 });
 
 test('open --relaunch on iOS simulator collapses into one terminate-running open dispatch', async () => {
@@ -368,6 +374,7 @@ test('open --relaunch includes timing and waits for iOS runner prewarm after ope
   sessionStore.set(sessionName, {
     ...makeSession(sessionName, {
       platform: 'apple',
+      appleOs: 'ios',
       id: 'ios-device-1',
       name: 'My iPhone',
       kind: 'device',
@@ -413,13 +420,8 @@ test('open --relaunch includes timing and waits for iOS runner prewarm after ope
   const response = await responsePromise;
 
   expect(response?.ok).toBe(true);
-  expect(events).toEqual([
-    'stop-runner',
-    'dispatch:close',
-    'dispatch:open',
-    'prewarm-start',
-    'prewarm-finish',
-  ]);
+  expect(events).toEqual(['dispatch:close', 'dispatch:open', 'prewarm-start', 'prewarm-finish']);
+  expect(mockStopIosRunner).not.toHaveBeenCalled();
   expect((response as any).data?.timing).toMatchObject({
     runnerPrewarmKind: 'session',
     runnerPrewarmScheduled: true,
@@ -434,6 +436,7 @@ test('open --relaunch on iOS without existing session closes then opens target a
   const sessionName = 'ios-new-session';
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
+    appleOs: 'ios',
     id: 'ios-device-1',
     name: 'My iPhone',
     kind: 'device',
@@ -443,6 +446,9 @@ test('open --relaunch on iOS without existing session closes then opens target a
   const calls: string[] = [];
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
+  });
+  mockNotifyIosRunnerAppRelaunched.mockImplementation(async () => {
+    calls.push('reset-runner-target');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
     calls.push(`${command}:${positionals.join(' ')}`);
@@ -465,7 +471,8 @@ test('open --relaunch on iOS without existing session closes then opens target a
 
   expect(response).toBeTruthy();
   expect(response?.ok).toBe(true);
-  expect(calls).toEqual(['stop-runner', 'close:com.example.app', 'open:com.example.app']);
+  expect(calls).toEqual(['close:com.example.app', 'open:com.example.app', 'reset-runner-target']);
+  expect(mockStopIosRunner).not.toHaveBeenCalled();
 });
 
 test('close on macOS session stops runner and dismisses automation alert before delete', async () => {


### PR DESCRIPTION
## Summary

Keep a healthy XCTest runner alive while `open --relaunch` replaces an app process on a physical iOS device, then reset the runner's process-bound target state before the next command. A failed relaunch or unconfirmed target reset still discards the runner, preserving the original typed failure and existing cancellation/deadline behavior. Physical iPadOS, tvOS, and visionOS retain their existing restart behavior until separately evidenced.

This removes repeated runner startup from the physical-device relaunch critical path; it does not prewarm accessibility or weaken snapshot correctness. The initial runner startup is still paid, and the retained runner remains owned until normal session close/idle cleanup.

Matched CoreDevice iPhone samples on production-equivalent pre-rebase commit `c3bede63dc` showed:

| Relaunch metric | Before | After |
| --- | ---: | ---: |
| runner prewarm wait median | 6,583 ms | 13 ms |
| runner command send median | 6,441.5 ms | 8.5 ms |
| runner retries median | 5 | 0 |
| successful command total median | 11,755 ms | 9,803 ms (-16.6%) |
| successful CLI wall median | 13,866 ms | 13,043 ms (-5.9%) |
| successful CLI wall p95 | 39,362 ms | 36,916 ms (-6.2%) |
| observed open failures | 2/8 | 0/8 |

The mechanism evidence is stronger than the aggregate wall-time delta: post-change relaunches emitted no runner-startup timing and had zero runner retries, while CoreDevice terminate/process discovery remained the dominant variable. Snapshot acquisition stayed around 0.2 seconds, so the 65-91 second tails were not attributed to AX warmup. Semantic dev-client readiness was separately Metro-dependent and is not claimed as improved here.

The benchmark used dedicated worktree-owned daemon/session state, a freshly signed fixture app, a fresh LAN Metro server, the discovered USB-connected iPhone, retained raw command/runner logs, and eight matched relaunch cycles per side. It was sequential rather than randomized, so the small failure-rate and end-to-end deltas are observational; the two cold-cold samples are descriptive only and not a reliable p95 estimate.

ADR 0005 now records the physical-device lifecycle rule. Four files changed; scope stayed within Apple application/runner lifecycle and its daemon regression seam.

## Validation

- Live physical iPhone on production-equivalent pre-rebase commit `c3bede63dc` (iOS 26.6, CoreDevice, Xcode 26.2): fresh build/install/signing, LAN Metro bundle load, snapshots/interactions, eight before and eight after relaunch cycles, and final session/daemon cleanup. Final head `e8cdd87f5c` preserves that physical-iOS path while narrowing unmeasured physical Apple OS leaves to their existing restart behavior; exact-head local and CI gates validate the final tree.
- Planted-red lifecycle regression: reverting runner retention produces `stop -> close -> open -> prewarm` instead of the required `close -> open -> prewarm -> targetReset` sequence.
- Focused lifecycle/daemon/runner suites pass, including both CoreDevice and XCTest physical backends plus relaunch-failure cleanup/error precedence.
- `pnpm check:quick` and `pnpm check:affected --run` pass on `e8cdd87f5c` (format, lint, typecheck, layering, fallow, build, unit, interaction-contract, and provider-integration green). GitHub is authoritative for coverage and hosted Apple lanes; the workflow's physical-device step was skipped, so the local device run above supplies physical proof.

Raw local measurements and per-command logs:

- `/private/tmp/agent-device-physical-perf-baseline-20260831-valid2/`
- `/private/tmp/agent-device-physical-perf-warm-20260831-retry2/`
- `/private/tmp/agent-device-physical-perf-relaunch-after-20260831/`
