### PR TITLE
refactor(daemon): move open lifecycle behind session facade

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -199,7 +199,7 @@
         "count": 1
       }
     },
-    "src/daemon/handlers/__tests__/session-open-runtime.test.ts": {
+    "src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.test.ts": {
       "crap_moderate": {
         "count": 1
       }
@@ -240,12 +240,12 @@
         "count": 2
       }
     },
-    "src/daemon/handlers/session-open-surface.ts": {
+    "src/daemon/session-lifecycle/internal/session-open-surface.ts": {
       "crap_moderate": {
         "count": 1
       }
     },
-    "src/daemon/handlers/session-open.ts": {
+    "src/daemon/session-lifecycle/internal/session-open.ts": {
       "crap_moderate": {
         "count": 1
       }
@@ -255,7 +255,7 @@
         "count": 1
       }
     },
-    "src/daemon/handlers/session-runtime.ts": {
+    "src/daemon/session-runtime.ts": {
       "crap_moderate": {
         "count": 1
       }

--- a/scripts/__tests__/help-conformance-sample-producers.ts
+++ b/scripts/__tests__/help-conformance-sample-producers.ts
@@ -21,7 +21,7 @@ import { openCliOutput } from '../../src/commands/management/output.ts';
 import { NEVER_SETTLED_HINT } from '../../src/commands/interaction/runtime/settle.ts';
 import { buildAmbiguousMatchError } from '../../src/daemon/handlers/find-match-resolution.ts';
 import { refMutationAdmissionResponse } from '../../src/daemon/handlers/interaction-ref-policy.ts';
-import { buildDeviceInUseBySessionError } from '../../src/daemon/handlers/session-open.ts';
+import { buildDeviceInUseBySessionError } from '../../src/daemon/session-recovery-hints.ts';
 import { buildDeviceClaimConflictError } from '../../src/daemon/device-claim-conflict.ts';
 import { resolveRefStalenessWarning } from '../../src/daemon/session-snapshot.ts';
 import type { SessionState } from '../../src/daemon/types.ts';

--- a/scripts/help-conformance-sample-outputs.mjs
+++ b/scripts/help-conformance-sample-outputs.mjs
@@ -83,8 +83,7 @@ Detected an overly complex or slow accessibility tree. Fell back to the private-
 };
 
 // DEVICE_IN_USE from buildDeviceInUseBySessionError
-// (src/daemon/handlers/session-open.ts) — the parity test drives that exact
-// producer.
+// (src/daemon/session-recovery-hints.ts) — the parity test drives that exact producer.
 export const DEVICE_IN_USE_SAMPLE = {
   command: `agent-device press 'label="Place order"' --settle`,
   output: `Error (DEVICE_IN_USE): Device is already in use by session "checkout".

--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -342,7 +342,7 @@ function summarizeProviderScenarioFlagExclusions() {
     },
     {
       name: 'open foreground auto-resolution (RFC prototype)',
-      owner: 'daemon session-open-foreground handler unit tests',
+      owner: 'daemon session-open-foreground lifecycle unit tests',
       keys: ['foreground'],
     },
     {

--- a/scripts/layering/architecture-ownership.ts
+++ b/scripts/layering/architecture-ownership.ts
@@ -17,12 +17,23 @@ const DAEMON_REPLAY_FACADE = {
 
 const DAEMON_SESSION_LIFECYCLE_FACADE = {
   root: 'src/daemon/session-lifecycle/index.ts',
-  exports: ['SessionInventoryCommandInput', 'handleSessionInventoryCommands'],
+  exports: [
+    'SessionInventoryCommandInput',
+    'SessionOpenCommandInput',
+    'handleSessionInventoryCommands',
+    'handleSessionOpenCommands',
+  ],
 } as const;
 
 export const SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS = [
   'src/daemon/handlers/session-device-utils.ts',
   'src/daemon/handlers/session-runtime-admission.ts',
+  'src/daemon/handlers/session-open.ts',
+  'src/daemon/handlers/session-open-prepare.ts',
+  'src/daemon/handlers/session-open-execution.ts',
+  'src/daemon/handlers/session-open-foreground.ts',
+  'src/daemon/handlers/session-open-surface.ts',
+  'src/daemon/handlers/session-startup-metrics.ts',
 ] as const;
 
 export const LOGICAL_MODULE_POLICIES = [

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -262,10 +262,26 @@ test('session lifecycle rejects restored neutral helper paths', () => {
   assert.deepEqual(
     violations.map(({ message }) => message),
     [
-      'retired session lifecycle helper path was restored: src/daemon/handlers/session-device-utils.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
-      'retired session lifecycle helper path was restored: src/daemon/handlers/session-runtime-admission.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+      'retired session lifecycle path was restored: src/daemon/handlers/session-device-utils.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+      'retired session lifecycle path was restored: src/daemon/handlers/session-runtime-admission.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
     ],
   );
+});
+
+test('session lifecycle rejects any restored open handler path', () => {
+  const violations = checkRetiredSessionLifecyclePaths([
+    'src/daemon/handlers/session-open-regressed.ts',
+  ]);
+
+  assert.deepEqual(violations, [
+    {
+      rule: 'R10 daemon-modularity',
+      file: 'src/daemon/handlers/session-open-regressed.ts',
+      line: 1,
+      message:
+        'retired session lifecycle path was restored: src/daemon/handlers/session-open-regressed.ts. Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+    },
+  ]);
 });
 
 test('R9 records zone ceilings and keeps engine files outside the largest component', () => {

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -57,16 +57,19 @@ export function checkDaemonModularityRatchets(
 export function checkRetiredSessionLifecyclePaths(
   sourceFiles: readonly string[],
 ): LayeringViolation[] {
-  return SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS.filter((file) => sourceFiles.includes(file)).map(
-    (file) => ({
-      rule: 'R10 daemon-modularity',
-      file,
-      line: 1,
-      message:
-        `retired session lifecycle helper path was restored: ${file}. ` +
-        'Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
-    }),
+  const restoredPaths = sourceFiles.filter(
+    (file) =>
+      SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS.some((retiredPath) => retiredPath === file) ||
+      /^src\/daemon\/handlers\/session-open(?:-[^/]+)?\.ts$/.test(file),
   );
+  return restoredPaths.map((file) => ({
+    rule: 'R10 daemon-modularity',
+    file,
+    line: 1,
+    message:
+      `retired session lifecycle path was restored: ${file}. ` +
+      'Keep the neutral seam at its daemon owner instead of rebuilding a handler grab-bag.',
+  }));
 }
 
 function checkSessionStateBaseline(): LayeringViolation[] {

--- a/scripts/layering/model.test.ts
+++ b/scripts/layering/model.test.ts
@@ -317,7 +317,7 @@ test('session-state writes are found by field, and non-daemon or undeclared name
       // reads and comparisons are not writes
       ['src/daemon/handlers/find.ts', "if (session.refFrameState === 'active') return;"],
       // a write into a sub-object is not a write to the field itself
-      ['src/daemon/handlers/session-open.ts', 'session.refFrameState.inner = 1;'],
+      ['src/daemon/handlers/session-probe.ts', 'session.refFrameState.inner = 1;'],
       // a different binding that happens to have a matching property
       ['src/daemon/handlers/session-close.ts', "other.refFrameState = 'expired';"],
     ]),

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -80,8 +80,8 @@ export const SESSION_STATE_FIELD_OWNERS: Readonly<Record<string, readonly string
   // Open execution owns the paired lease/claim transition after the handler has admitted one
   // lifecycle binding. Keeping the records together prevents request-policy routing from gaining
   // a second durable owner as the execution seam stays package-bound.
-  lease: ['src/daemon/handlers/session-open-execution.ts'],
-  deviceClaim: ['src/daemon/handlers/session-open-execution.ts'],
+  lease: ['src/daemon/session-lifecycle/internal/session-open-execution.ts'],
+  deviceClaim: ['src/daemon/session-lifecycle/internal/session-open-execution.ts'],
 
   // #1398 (ADR 0017 session-scoped echo protection amendment): the ephemeral
   // literal->placeholder registry is populated and consulted only at the

--- a/src/__tests__/platform-runtime-runtime-hints.test.ts
+++ b/src/__tests__/platform-runtime-runtime-hints.test.ts
@@ -6,10 +6,7 @@ import {
   applyRuntimeHintValues,
   clearRuntimeHintValues,
 } from '../platform-runtime-runtime-hints.ts';
-import {
-  applyDeviceDefaultMetroHost,
-  runtimeHintValues,
-} from '../daemon/handlers/session-runtime.ts';
+import { applyDeviceDefaultMetroHost, runtimeHintValues } from '../daemon/session-runtime.ts';
 import { resolveRuntimeTransportHints } from '../utils/runtime-transport.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import {

--- a/src/daemon/__tests__/application-lifecycle-runtime-harness.ts
+++ b/src/daemon/__tests__/application-lifecycle-runtime-harness.ts
@@ -12,17 +12,14 @@ import {
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
-import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../../__tests__/test-utils/runtime-operation-facts.ts';
+import { unavailableDeploymentSnapshotAndShutdownOperationFacts } from '../../__tests__/test-utils/runtime-operation-facts.ts';
 import { deviceShape, type DeviceInfo } from '@agent-device/kernel/device';
 import { vi } from 'vitest';
-import type {
-  BindDeviceRuntime,
-  InspectDeviceRuntimeFacts,
-} from '../../request-runtime-binding.ts';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import {
   applicationLifecycleFixtureInteractor,
   applicationLifecycleRuntimeFixture,
-} from '../../__tests__/application-lifecycle-runtime-fixture.ts';
+} from './application-lifecycle-runtime-fixture.ts';
 
 vi.mock('node:timers/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:timers/promises')>();

--- a/src/daemon/app-event-runtime.ts
+++ b/src/daemon/app-event-runtime.ts
@@ -7,7 +7,7 @@ import { successText } from '@agent-device/kernel/success-text';
 import type { DaemonCommandContext } from './context.ts';
 import { admitRuntimeUse, type RuntimeAdmissionBindings } from './runtime-admission.ts';
 import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';
-import type { DaemonFailureResponse } from './handlers/response.ts';
+import type { DaemonFailureResponse } from './response.ts';
 
 /**
  * What the admit-then-bind step reports: either the refusal an unadmitted cell produced, or the

--- a/src/daemon/device-claim-conflict.ts
+++ b/src/daemon/device-claim-conflict.ts
@@ -12,7 +12,7 @@ import {
   type InspectedDeviceClaim,
 } from './device-claim-inspection.ts';
 import type { DaemonResponse } from './types.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 
 export type DeviceClaimConflictReason =
   | 'DEVICE_CLAIM_LIVE_OWNER'

--- a/src/daemon/generic-runtime-execution.ts
+++ b/src/daemon/generic-runtime-execution.ts
@@ -1,5 +1,5 @@
 import type { ResolvedGenericExecution } from './request-generic-dispatch.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import { resolveBoundFocusRuntime } from './focus-runtime.ts';
 import { resolveScreenshotGenericExecution } from './screenshot-runtime.ts';
 import { resolveBoundScrollRuntime } from './scroll-runtime.ts';

--- a/src/daemon/gesture-runtime.ts
+++ b/src/daemon/gesture-runtime.ts
@@ -17,7 +17,7 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import type { Rect } from '@agent-device/kernel/snapshot';
 import type { DaemonCommandContext } from './context.ts';
-import type { DaemonFailureResponse } from './handlers/response.ts';
+import type { DaemonFailureResponse } from './response.ts';
 import {
   admitRuntimeOperations,
   admitRuntimeUse,

--- a/src/daemon/handlers/__tests__/session-close-lifecycle-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-close-lifecycle-runtime.test.ts
@@ -20,7 +20,7 @@ import {
   mockBindDeviceRuntime,
   mockInspectDeviceRuntimeFacts,
 } from './session-command-harness.ts';
-import { lifecycleRuntimeFacts } from './application-lifecycle-runtime-harness.ts';
+import { lifecycleRuntimeFacts } from '../../__tests__/application-lifecycle-runtime-harness.ts';
 import { dispatchApplicationLifecycleEffect } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
 
 const mockDispatch = vi.mocked(dispatchApplicationLifecycleEffect);

--- a/src/daemon/handlers/__tests__/session-close-shutdown.fixtures.ts
+++ b/src/daemon/handlers/__tests__/session-close-shutdown.fixtures.ts
@@ -79,7 +79,7 @@ import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform
 import type { ScreenRecordingLiveHandle } from '@agent-device/contracts/screen-recording-runtime';
 import { createDurableResourceEnvelope } from '@agent-device/capture-kit';
 import { screenRecordingResourceStore } from '../../screen-recording-resource-store.ts';
-import { lifecycleRuntimeFacts } from './application-lifecycle-runtime-harness.ts';
+import { lifecycleRuntimeFacts } from '../../__tests__/application-lifecycle-runtime-harness.ts';
 import { dispatchApplicationLifecycleEffect } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
 
 export type { DeviceBinding, PlatformRuntimeOperations, SessionState };

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -51,7 +51,7 @@ import { inspectDeviceClaims } from '../../device-claim-inspection.ts';
 import { LeaseRegistry } from '../../lease-registry.ts';
 import { SessionStore } from '../../session-store.ts';
 import { handleCloseCommand as handleProductionCloseCommand } from '../session-close.ts';
-import { handleOpenCommand as handleProductionOpenCommand } from '../session-open.ts';
+import { handleSessionOpenCommands as handleProductionOpenCommand } from '../../session-lifecycle/index.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { makeAuthoringSession } from '../../../__tests__/test-utils/session-factories.ts';
 import { AppError } from '@agent-device/kernel/errors';
@@ -60,7 +60,7 @@ import {
   bindLifecycleRuntime,
   inspectProviderLifecycleRuntimeFacts,
   inspectLifecycleRuntimeFacts,
-} from './application-lifecycle-runtime-harness.ts';
+} from '../../__tests__/application-lifecycle-runtime-harness.ts';
 import { platformResourceCleanup } from '../../../platform-runtime-resource-cleanup.ts';
 
 const mockDispatch = vi.mocked(dispatchApplicationLifecycleEffect);

--- a/src/daemon/handlers/__tests__/session-runtime-command.test.ts
+++ b/src/daemon/handlers/__tests__/session-runtime-command.test.ts
@@ -13,7 +13,7 @@ import {
   mockBindDeviceRuntime,
   mockInspectDeviceRuntimeFacts,
 } from './session-command-harness.ts';
-import { lifecycleRuntimeFacts } from './application-lifecycle-runtime-harness.ts';
+import { lifecycleRuntimeFacts } from '../../__tests__/application-lifecycle-runtime-harness.ts';
 import {
   gestureBindDevice,
   gestureInspectFacts,

--- a/src/daemon/handlers/find-match-resolution.ts
+++ b/src/daemon/handlers/find-match-resolution.ts
@@ -11,7 +11,7 @@ import { preferOnscreenMatches } from './find-match-ranking.ts';
 import { formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
 import type { ElementMatchCandidateDetails } from '../../utils/error-candidates.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 export type FindMatchResult =
   | { ok: true; node: SnapshotState['nodes'][number] }

--- a/src/daemon/handlers/find-target-capture.ts
+++ b/src/daemon/handlers/find-target-capture.ts
@@ -4,7 +4,7 @@ import type { SnapshotQualityVerdict, SnapshotState } from '@agent-device/kernel
 import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 /** The tree a mutating find resolves its target against, plus what the capture disclosed. */
 export type FindTargetTree = {

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -13,7 +13,7 @@ import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
 import { readCommandMessage, successText } from '@agent-device/kernel/success-text';
-import { errorResponse, noActiveSessionError } from './response.ts';
+import { errorResponse, noActiveSessionError } from '../response.ts';
 import { withSystemSurfaceDisclosure } from './system-surface-disclosure.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';

--- a/src/daemon/handlers/interaction-flags.ts
+++ b/src/daemon/handlers/interaction-flags.ts
@@ -1,7 +1,7 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
 import type { SettleParams } from '@agent-device/contracts/interaction';
 import type { DaemonResponse } from '../types.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 const REF_UNSUPPORTED_FLAG_MAP: ReadonlyArray<[keyof CommandFlags, string]> = [
   ['snapshotDepth', '--depth'],

--- a/src/daemon/handlers/interaction-gesture.ts
+++ b/src/daemon/handlers/interaction-gesture.ts
@@ -32,7 +32,7 @@ import type { InteractionHandlerParams } from './interaction-common.ts';
 import { finalizeTouchInteraction } from './interaction-common.ts';
 import { createInteractionRuntime } from './interaction-runtime.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
-import { noActiveSessionError } from './response.ts';
+import { noActiveSessionError } from '../response.ts';
 import { assertRefMutationAdmitted } from './interaction-ref-policy.ts';
 import type { RecordedTargetCapture } from '../session-target-evidence.ts';
 import { gestureResponseData } from './interaction-gesture-response.ts';

--- a/src/daemon/handlers/interaction-ref-policy.ts
+++ b/src/daemon/handlers/interaction-ref-policy.ts
@@ -6,7 +6,7 @@ import {
 } from '../ref-frame.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import type { DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 /**
  * ADR 0014 mutation-admission enforcement. A ref-targeting mutation is admitted

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -13,7 +13,7 @@ import type { InteractionHandlerParams } from './interaction-common.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
 import { createDaemonRuntimePolicy } from '../runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from '../runtime-session.ts';
-import { NO_ACTIVE_SESSION_MESSAGE } from './response.ts';
+import { NO_ACTIVE_SESSION_MESSAGE } from '../response.ts';
 import type { Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
 import { getRequestSignal } from '@agent-device/host-kit/request';
 import { buildAppleRunnerRequestOptions } from '../apple-runner-options.ts';

--- a/src/daemon/handlers/interaction-touch-fill.ts
+++ b/src/daemon/handlers/interaction-touch-fill.ts
@@ -22,7 +22,7 @@ import {
 } from './interaction-touch-response.ts';
 import { dispatchRuntimeInteraction } from './interaction-touch-runtime.ts';
 import { parseFillTarget } from './interaction-touch-targets.ts';
-import { noActiveSessionError } from './response.ts';
+import { noActiveSessionError } from '../response.ts';
 import { prepareTouchDispatch } from './interaction-touch-prepare.ts';
 
 /**

--- a/src/daemon/handlers/interaction-touch-policy.ts
+++ b/src/daemon/handlers/interaction-touch-policy.ts
@@ -1,6 +1,6 @@
 import { isMacOs } from '@agent-device/kernel/device';
 import type { DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 export function unsupportedMacOsDesktopSurfaceInteraction(
   session: SessionState,

--- a/src/daemon/handlers/interaction-touch-prepare.ts
+++ b/src/daemon/handlers/interaction-touch-prepare.ts
@@ -6,7 +6,7 @@ import {
   type TouchRuntimeCommand,
 } from '../touch-runtime.ts';
 import type { InteractionHandlerParams } from './interaction-common.ts';
-import type { DaemonFailureResponse } from './response.ts';
+import type { DaemonFailureResponse } from '../response.ts';
 
 export type PreparedTouchDispatch =
   | Readonly<{ ok: false; response: DaemonFailureResponse }>

--- a/src/daemon/handlers/interaction-touch-press-admission.ts
+++ b/src/daemon/handlers/interaction-touch-press-admission.ts
@@ -20,7 +20,7 @@ import {
   type ParsedLongPressTarget,
   type ParsedTouchTarget,
 } from './interaction-touch-targets.ts';
-import { errorResponse, noActiveSessionError } from './response.ts';
+import { errorResponse, noActiveSessionError } from '../response.ts';
 
 /**
  * Whether a targeted `press`/`click`/`longpress`/`hover` may act, and on what: macOS

--- a/src/daemon/handlers/interaction-touch-runtime.ts
+++ b/src/daemon/handlers/interaction-touch-runtime.ts
@@ -27,7 +27,7 @@ import {
   pointPositionals,
   type InteractionResponsePayloads,
 } from './interaction-touch-response.ts';
-import { noActiveSessionError } from './response.ts';
+import { noActiveSessionError } from '../response.ts';
 import type { BoundTouchExecutor } from '../touch-runtime.ts';
 
 /**

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -12,7 +12,7 @@ import {
 import type { DaemonResponse } from '../types.ts';
 import { REF_GRAMMAR_HINT, splitRefGenerationSuffix } from '@agent-device/kernel/snapshot';
 import { parseCoordinateTarget } from './interaction-targeting.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 export type ParsedTouchTarget =
   | { ok: true; target: InteractionTarget; refGeneration?: number; durationMs?: never }

--- a/src/daemon/handlers/interaction.ts
+++ b/src/daemon/handlers/interaction.ts
@@ -6,7 +6,7 @@ import { refSnapshotFlagGuardResponse } from './interaction-flags.ts';
 import { dispatchGetViaRuntime, dispatchIsViaRuntime } from '../selector-runtime.ts';
 import { finalizeTouchInteraction } from './interaction-common.ts';
 import { expireRefFrame } from '../ref-frame.ts';
-import { errorResponse, noActiveSessionError } from './response.ts';
+import { errorResponse, noActiveSessionError } from '../response.ts';
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { normalizeError } from '@agent-device/kernel/errors';
 import {

--- a/src/daemon/handlers/react-native.ts
+++ b/src/daemon/handlers/react-native.ts
@@ -15,7 +15,7 @@ import { successText } from '@agent-device/kernel/success-text';
 import type { SnapshotQualityVerdict, SnapshotState } from '@agent-device/kernel/snapshot';
 import { isSparseSnapshotQualityVerdict } from '@agent-device/capture-kit/snapshot-quality-verdict';
 import type { DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse, noActiveSessionError } from './response.ts';
+import { errorResponse, noActiveSessionError } from '../response.ts';
 import { captureSnapshotForSession } from './interaction-snapshot.ts';
 import { finalizeTouchInteraction, type InteractionHandlerParams } from './interaction-common.ts';
 import { expireRefFrame } from '../ref-frame.ts';

--- a/src/daemon/handlers/session-app-deployment.ts
+++ b/src/daemon/handlers/session-app-deployment.ts
@@ -15,7 +15,7 @@ import { resolvePayloadInput } from '../../utils/payload-input.ts';
 import { resolveDeployResultTarget } from '../../utils/result-serialization.ts';
 import { withSuccessText } from '@agent-device/kernel/success-text';
 import { recordSessionAction } from './handler-utils.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,

--- a/src/daemon/handlers/session-audio.ts
+++ b/src/daemon/handlers/session-audio.ts
@@ -17,7 +17,7 @@ import {
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 
 type AudioParams = {
   req: DaemonRequest;

--- a/src/daemon/handlers/session-clipboard.ts
+++ b/src/daemon/handlers/session-clipboard.ts
@@ -17,7 +17,7 @@ import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-ru
 import { admitRuntimeUse, type RuntimeAdmissionBindings } from '../runtime-admission.ts';
 import { runtimeExecutionFromContext } from '../snapshot-runtime-capture-input.ts';
 import { successText } from '@agent-device/kernel/success-text';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import {
   requireSessionOrExplicitSelector,

--- a/src/daemon/handlers/session-close-lifecycle-teardown.ts
+++ b/src/daemon/handlers/session-close-lifecycle-teardown.ts
@@ -13,7 +13,7 @@ import {
   type SessionCleanupFailure,
 } from '../session-teardown.ts';
 import type { PlatformResourceCleanup } from '@agent-device/contracts/platform-resource-cleanup';
-import { hasRuntimeTransportHints, runtimeHintValues } from './session-runtime.ts';
+import { hasRuntimeTransportHints, runtimeHintValues } from '../session-runtime.ts';
 import type {
   CloseRuntime,
   CloseRuntimeWithRuntimeHintClear,

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -5,7 +5,7 @@ import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { successText, withSuccessText } from '@agent-device/kernel/success-text';
 import { resolveCommandDevice } from '../session-device-resolution.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import type { LeaseRegistry } from '../lease-registry.ts';
 import { releaseSessionLease } from '../lease-lifecycle.ts';
@@ -19,7 +19,7 @@ import type { SessionCleanupFailure } from '../session-teardown.ts';
 import { isWebSession } from '../web-session-names.ts';
 import { clearDeviceClaim } from '../device-claims.ts';
 import { applicationLifecycleExecutionFromRequest } from '../application-lifecycle-execution.ts';
-import { hasRuntimeTransportHints } from './session-runtime.ts';
+import { hasRuntimeTransportHints } from '../session-runtime.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import {
   buildRetriableRepairCloseFailureResponse,

--- a/src/daemon/handlers/session-network.ts
+++ b/src/daemon/handlers/session-network.ts
@@ -8,7 +8,7 @@ import { AppError, normalizeError } from '@agent-device/kernel/errors';
 import type { BindDeviceRuntime } from '../request-runtime-binding.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 
 const NETWORK_ACTIONS = ['dump', 'log'] as const;
 const NETWORK_ACTIONS_MESSAGE = `network requires ${NETWORK_ACTIONS.join(' or ')}`;

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -27,7 +27,7 @@ import { createNextAppLogFence } from '../app-log-start-preflight.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 import { handleAudioCommand } from './session-audio.ts';
 import { handlePerfRuntimeCommand } from './session-perf-runtime.ts';
 import { handleNetworkCommand } from './session-network.ts';

--- a/src/daemon/handlers/session-perf-runtime.ts
+++ b/src/daemon/handlers/session-perf-runtime.ts
@@ -28,7 +28,7 @@ import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-ru
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { recordSessionAction } from './handler-utils.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import {
   admitRuntimePlan,
   requireRuntimeBinding,

--- a/src/daemon/handlers/session-prepare.ts
+++ b/src/daemon/handlers/session-prepare.ts
@@ -12,7 +12,7 @@ import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,
 } from '../session-device-resolution.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 const PREPARE_IOS_RUNNER_TIMING_NOTE =
   'Top-level prepare timing fields are diagnostic and may overlap; use timing.additiveParts for additive wall-clock phases.';

--- a/src/daemon/handlers/session-runtime-command.ts
+++ b/src/daemon/handlers/session-runtime-command.ts
@@ -2,7 +2,7 @@ import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { publicPlatformString } from '@agent-device/kernel/device';
 import { clearRuntimeHintsRuntimeUse } from '@agent-device/contracts/application-lifecycle-runtime-plan';
 import { SessionStore } from '../session-store.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import { admitRuntimeUse } from '../runtime-admission.ts';
 import {
@@ -12,7 +12,7 @@ import {
   mergeRuntimeHints,
   runtimeHintValues,
   toRuntimePlatform,
-} from './session-runtime.ts';
+} from '../session-runtime.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { handlePortReverseCommand } from './session-runtime-port-reverse.ts';
 import { contextFromFlags } from '../context.ts';

--- a/src/daemon/handlers/session-runtime-port-reverse.ts
+++ b/src/daemon/handlers/session-runtime-port-reverse.ts
@@ -4,7 +4,7 @@ import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { admitRuntimeUse } from '../runtime-admission.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,

--- a/src/daemon/handlers/session-selector-dispatch.ts
+++ b/src/daemon/handlers/session-selector-dispatch.ts
@@ -7,7 +7,7 @@ import {
   requireSessionOrExplicitSelector,
   resolveCommandDevice,
 } from '../session-device-resolution.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { resolveBoundAppEventRuntime } from '../app-event-runtime.ts';
 import { resolveBoundKeyboardRuntime } from '../keyboard-runtime.ts';

--- a/src/daemon/handlers/session-state.ts
+++ b/src/daemon/handlers/session-state.ts
@@ -22,7 +22,7 @@ import {
   resolveCommandDevice,
   selectorTargetsSessionDevice,
 } from '../session-device-resolution.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import {
   admitRuntimeOperations,

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -1,14 +1,14 @@
 import type { DaemonResponse } from '../types.ts';
 import { handleReleaseMaterializedPathsCommand } from './session-app-source-deployment.ts';
 import { handleRuntimeCommand } from './session-runtime-command.ts';
-import { requireRuntimeBinding, requireRuntimeFacts } from '../session-runtime-admission.ts';
-import { handleOpenCommand } from './session-open.ts';
-import { composeOpenWithInitialSnapshot } from './session-open-foreground.ts';
 import { handleKeyboardCommand, handleAppEventCommand } from './session-selector-dispatch.ts';
 import { handleCloseCommand } from './session-close.ts';
 import { handleSessionAppDeploymentCommand } from './session-app-deployment-route.ts';
 import { runBatchCommands } from './session-batch.ts';
-import { handleSessionInventoryCommands } from '../session-lifecycle/index.ts';
+import {
+  handleSessionInventoryCommands,
+  handleSessionOpenCommands,
+} from '../session-lifecycle/index.ts';
 import { handleSessionStateCommands } from './session-state.ts';
 import { handleSessionObservabilityCommands } from './session-observability.ts';
 import { handleReplayCommand, handleReplayTestCommand } from './session-replay-command.ts';
@@ -21,13 +21,27 @@ import type {
   SessionCommandInput,
   SessionCommandParams,
 } from './session-command-input.ts';
-import type { SessionInventoryCommandInput } from '../session-lifecycle/index.ts';
+import type {
+  SessionInventoryCommandInput,
+  SessionOpenCommandInput,
+} from '../session-lifecycle/index.ts';
 import type { DescriptorSessionRouteCommandName } from '../../core/command-descriptor/registry.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 
 const handleSessionInventoryCommandGroup: SessionCommandHandler = (
   params: SessionCommandParams & SessionInventoryCommandInput,
 ) => handleSessionInventoryCommands(params);
+
+const handleSessionOpenCommandGroup: SessionCommandHandler = (params) =>
+  handleSessionOpenCommands({
+    req: params.req,
+    sessionName: params.sessionName,
+    logPath: params.logPath,
+    sessionStore: params.sessionStore,
+    inspectFacts: params.inspectFacts,
+    bindDevice: params.bindDevice,
+    reconcileOrphanedDeviceClaim: params.reconcileOrphanedDeviceClaim,
+  } satisfies SessionOpenCommandInput);
 
 const handleSessionStateCommandGroup: SessionCommandHandler = async ({
   req,
@@ -145,35 +159,7 @@ const SESSION_COMMAND_HANDLER_IMPLS = {
     await handleReleaseMaterializedPathsCommand({ req }),
   push: handleSessionAppDeploymentCommand,
   'trigger-app-event': handleAppEventCommand,
-  open: async ({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    inspectFacts,
-    bindDevice,
-    reconcileOrphanedDeviceClaim,
-  }) => {
-    const openResponse = await handleOpenCommand({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      inspectFacts,
-      bindDevice,
-      reconcileOrphanedDeviceClaim,
-    });
-    if (!openResponse.ok || req.flags?.foreground !== true) return openResponse;
-    return await composeOpenWithInitialSnapshot({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      inspectFacts: requireRuntimeFacts(inspectFacts),
-      bindDevice: requireRuntimeBinding(bindDevice),
-      openResponse,
-    });
-  },
+  open: handleSessionOpenCommandGroup,
   replay: handleReplayCommand,
   test: handleReplayTestCommand,
   batch: async ({ req, sessionName, invoke }) => await runBatchCommands(req, sessionName, invoke),

--- a/src/daemon/handlers/snapshot-alert.ts
+++ b/src/daemon/handlers/snapshot-alert.ts
@@ -18,7 +18,7 @@ import { recordIfSession } from './snapshot-session.ts';
 import { parseTimeout } from '../../utils/parse-timeout.ts';
 import { resolveRefFrameEffect } from '../daemon-command-registry.ts';
 import { expireRefFrame } from '../ref-frame.ts';
-import type { DaemonFailureResponse } from './response.ts';
+import type { DaemonFailureResponse } from '../response.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import { admitRuntimeUse, type RuntimeAdmissionBindings } from '../runtime-admission.ts';
 import { runtimeExecutionFromContext } from '../snapshot-runtime-capture-input.ts';

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -23,7 +23,7 @@ import { resolveDeferredInteractionOutcome } from '../deferred-interaction-outco
 import { createInteractionRetryTap } from '../interaction-retry-tap.ts';
 import type { SessionState } from '../types.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 
 type CaptureSnapshotParams = {
   device: SessionState['device'];

--- a/src/daemon/handlers/snapshot-settings.ts
+++ b/src/daemon/handlers/snapshot-settings.ts
@@ -12,7 +12,7 @@ import { contextFromFlags } from '../context.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { recordIfSession } from './snapshot-session.ts';
-import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
 import { readLocationCoordinate } from '@agent-device/kernel/location-coordinates';

--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -1,6 +1,6 @@
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 import { handleAlertCommand } from './snapshot-alert.ts';
 import { handleSettingsCommand, parseSettingsArgs } from './snapshot-settings.ts';
 import { dispatchSnapshotDiffViaRuntime } from '../snapshot-diff-runtime.ts';

--- a/src/daemon/handlers/trace-runtime.ts
+++ b/src/daemon/handlers/trace-runtime.ts
@@ -4,7 +4,7 @@ import type { TraceCommandResult } from '@agent-device/contracts/recording';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { recordSessionAction } from './handler-utils.ts';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../response.ts';
 
 export function handleTraceCommand(params: {
   req: DaemonRequest;

--- a/src/daemon/keyboard-runtime.ts
+++ b/src/daemon/keyboard-runtime.ts
@@ -26,7 +26,7 @@ import {
   type RuntimeAdmissionRequest,
 } from './runtime-admission.ts';
 import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';
-import type { DaemonFailureResponse } from './handlers/response.ts';
+import type { DaemonFailureResponse } from './response.ts';
 
 type KeyboardRuntimeAction = 'status' | 'dismiss' | 'enter';
 

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-record-exclusion.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-record-exclusion.test.ts
@@ -64,7 +64,7 @@ import { freshEvidence, makeRecordingReplayInvoke } from './session-replay-repai
 import {
   bindLifecycleRuntime,
   inspectLifecycleRuntimeFacts,
-} from '../../../handlers/__tests__/application-lifecycle-runtime-harness.ts';
+} from '../../../__tests__/application-lifecycle-runtime-harness.ts';
 import { platformResourceCleanup } from '../../../../platform-runtime-resource-cleanup.ts';
 import {
   captureSnapshotThroughLegacyDispatchFixture,

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-transaction.test.ts
@@ -84,7 +84,7 @@ import { freshEvidence, makeRecordingReplayInvoke } from './session-replay-repai
 import {
   bindLifecycleRuntime,
   inspectLifecycleRuntimeFacts,
-} from '../../../handlers/__tests__/application-lifecycle-runtime-harness.ts';
+} from '../../../__tests__/application-lifecycle-runtime-harness.ts';
 import { platformResourceCleanup } from '../../../../platform-runtime-resource-cleanup.ts';
 
 const mockDispatchCommand = legacyDispatchCapture;

--- a/src/daemon/replay/internal/native-command.ts
+++ b/src/daemon/replay/internal/native-command.ts
@@ -1,6 +1,6 @@
 import { asAppError } from '@agent-device/kernel/errors';
 import type { DaemonResponse, SessionState } from '../../types.ts';
-import { errorResponse } from '../../handlers/response.ts';
+import { errorResponse } from '../../response.ts';
 import { runAdReplay } from '@agent-device/ad-replay';
 import type { SnapshotTimingSample } from '@agent-device/contracts/capture';
 import { summarizeSnapshotTimingSamples } from '@agent-device/contracts/capture';

--- a/src/daemon/replay/internal/session-replay-maestro-runtime.ts
+++ b/src/daemon/replay/internal/session-replay-maestro-runtime.ts
@@ -20,14 +20,14 @@ import { createDaemonMaestroRuntimePort } from '../../adapters/maestro/daemon-ru
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../../types.ts';
 import { assertSessionSelectorMatches } from '../../session-selector.ts';
-import { errorResponse } from '../../handlers/response.ts';
+import { errorResponse } from '../../response.ts';
 import { buildReplayBuiltinVars } from './session-replay-vars.ts';
 import { createMaestroReplayObserver } from './session-replay-maestro-observer.ts';
 import {
   buildTypedMaestroReplayErrorResponse,
   buildTypedMaestroSuccessResponse,
 } from './session-replay-maestro-response.ts';
-import { resolveEffectiveOpenRuntimeHints } from '../../handlers/session-runtime.ts';
+import { resolveEffectiveOpenRuntimeHints } from '../../session-runtime.ts';
 import { buildMaestroReplayTargetDeviceResolutionOptions } from '../../replay-device-selection.ts';
 import {
   readReplayScriptSourceFile,

--- a/src/daemon/replay/internal/session-replay-runtime-engine-adapter.ts
+++ b/src/daemon/replay/internal/session-replay-runtime-engine-adapter.ts
@@ -1,6 +1,6 @@
 import type { SessionAction } from '@agent-device/contracts/session';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../../types.ts';
-import { errorResponse } from '../../handlers/response.ts';
+import { errorResponse } from '../../response.ts';
 import { readReplaySelectorDisplayValue } from '@agent-device/selectors';
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import type { SnapshotTimingSample } from '@agent-device/contracts/capture';

--- a/src/daemon/replay/internal/session-replay-runtime-plan.ts
+++ b/src/daemon/replay/internal/session-replay-runtime-plan.ts
@@ -3,7 +3,7 @@ import type { CommandFlags } from '@agent-device/contracts/command';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
 import type { ReplayCoordinator } from '../../session-replay-coordinator.ts';
 import type { ReplayCommand, ReplaySessionStore } from './command-types.ts';
-import { errorResponse } from '../../handlers/response.ts';
+import { errorResponse } from '../../response.ts';
 import { buildReplayScriptPlatformFlags } from '../../replay-device-selection.ts';
 import {
   inspectAdReplay,

--- a/src/daemon/replay/internal/session-replay-runtime-session.ts
+++ b/src/daemon/replay/internal/session-replay-runtime-session.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import type { DaemonRequest, DaemonResponse } from '../../types.ts';
 import type { ReplaySessionStore } from './command-types.ts';
 import { expandSessionPath } from '../../session-paths.ts';
-import { errorResponse, noActiveSessionError } from '../../handlers/response.ts';
+import { errorResponse, noActiveSessionError } from '../../response.ts';
 import {
   NO_SCRIPT_PUBLICATION,
   scriptTargetForce,

--- a/src/daemon/replay/internal/test-command.ts
+++ b/src/daemon/replay/internal/test-command.ts
@@ -15,7 +15,7 @@ import {
 } from '@agent-device/replay-test';
 import { runReplayCommand } from './native-command.ts';
 import { collectReplayActionArtifactPaths } from './session-replay-runtime-artifacts.ts';
-import { errorResponse } from '../../handlers/response.ts';
+import { errorResponse } from '../../response.ts';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import {
   emitRequestProgress,

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -45,7 +45,7 @@ import {
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { teardownSessionResources } from './session-teardown.ts';
 import { finalizeBoundSessionApplicationLifecycle } from './application-lifecycle-recovery.ts';
-import { runtimeHintValues } from './handlers/session-runtime.ts';
+import { runtimeHintValues } from './session-runtime.ts';
 import type { DeviceRuntimeGateway } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
 import type { PlatformRequestScope } from '@agent-device/contracts/platform-runtime-host';

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -20,7 +20,7 @@ import type {
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, DaemonResponseData } from './types.ts';
 import { RESPONSE_VIEWS } from './response-views.ts';
 import { SessionStore } from './session-store.ts';
-import { errorResponse, noActiveSessionError } from './handlers/response.ts';
+import { errorResponse, noActiveSessionError } from './response.ts';
 import { resolvePlatformProviderRequestContext } from './request-platform-provider-context.ts';
 import {
   countDiagnosticEventsByPhase,

--- a/src/daemon/response.ts
+++ b/src/daemon/response.ts
@@ -1,4 +1,4 @@
-import type { DaemonResponse } from '../types.ts';
+import type { DaemonResponse } from './types.ts';
 
 export type DaemonFailureResponse = Extract<DaemonResponse, { ok: false }>;
 

--- a/src/daemon/runtime-admission.ts
+++ b/src/daemon/runtime-admission.ts
@@ -12,7 +12,7 @@ import type {
   InspectDeviceRuntimeFacts,
   RuntimeAdmissionBindings,
 } from './request-runtime-binding.ts';
-import { errorResponse, type DaemonFailureResponse } from './handlers/response.ts';
+import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import type { DaemonCommandContext } from './context.ts';
 import type { ResolvedGenericExecution } from './request-generic-dispatch.ts';
 

--- a/src/daemon/screenshot-runtime-binding.ts
+++ b/src/daemon/screenshot-runtime-binding.ts
@@ -13,7 +13,7 @@ import type {
   SnapshotRuntimeOperations,
 } from '@agent-device/contracts/snapshot-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import {
   admitRuntimePlan,
   requireRuntimeBinding,

--- a/src/daemon/scroll-runtime.ts
+++ b/src/daemon/scroll-runtime.ts
@@ -24,7 +24,7 @@ import {
 } from '../snapshot/scroll-edge-state.ts';
 import { withSuccessText } from '@agent-device/kernel/success-text';
 import type { DaemonCommandContext } from './context.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import type { ResolvedGenericExecution } from './request-generic-dispatch.ts';
 import { resolveBoundGenericRuntime, type RuntimeAdmissionBindings } from './runtime-admission.ts';
 import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';

--- a/src/daemon/selector-runtime-backend.ts
+++ b/src/daemon/selector-runtime-backend.ts
@@ -6,7 +6,7 @@ import type {
 import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { publicPlatformString } from '@agent-device/kernel/device';
-import { noActiveSessionError } from './handlers/response.ts';
+import { noActiveSessionError } from './response.ts';
 import type { SnapshotState, SnapshotNode } from '@agent-device/kernel/snapshot';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -6,7 +6,7 @@ import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import { queryAppleRuntimeSelector } from '../platform-runtime-apple-resources.ts';
 import type { AppleRunnerRequestOptions } from './apple-runner-options.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import { markSessionPartialRefsIssued, resolveRefStalenessWarning } from './session-snapshot.ts';
 import { resolveSessionDevice, withSessionlessRunnerCleanup } from './handlers/snapshot-session.ts';
 import {

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -22,7 +22,7 @@ import { clearDaemonShutdownReport, writeDaemonShutdownReport } from '../daemon-
 import { createRequestHandler } from '../request-router.ts';
 import { stopSessionAppLog, teardownSessionResources } from '../session-teardown.ts';
 import { finalizeDaemonSessionApplicationLifecycle } from '../application-lifecycle-recovery.ts';
-import { runtimeHintValues } from '../handlers/session-runtime.ts';
+import { runtimeHintValues } from '../session-runtime.ts';
 import { closeDaemonServers } from './server-shutdown.ts';
 import type { DaemonInvokeFn, SessionState } from '../types.ts';
 import { createDaemonIdleReap } from './daemon-idle-reap.ts';

--- a/src/daemon/session-device-resolution.ts
+++ b/src/daemon/session-device-resolution.ts
@@ -7,7 +7,7 @@ import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { hasDeviceSelectionInput, hasExplicitDeviceSelector } from './device-selector-intent.ts';
 import { listSessionSelectorConflicts } from './session-selector.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 
 export function requireSessionOrExplicitSelector(
   command: string,

--- a/src/daemon/session-lifecycle/__tests__/application.test.ts
+++ b/src/daemon/session-lifecycle/__tests__/application.test.ts
@@ -13,16 +13,19 @@ vi.mock('../index.ts', async (importOriginal) => {
   return {
     ...actual,
     handleSessionInventoryCommands: vi.fn(actual.handleSessionInventoryCommands),
+    handleSessionOpenCommands: vi.fn(actual.handleSessionOpenCommands),
   };
 });
 
 import { handleSessionCommands } from '../../handlers/session.ts';
-import { handleSessionInventoryCommands } from '../index.ts';
+import { handleSessionInventoryCommands, handleSessionOpenCommands } from '../index.ts';
 
 const mockHandleSessionInventoryCommands = vi.mocked(handleSessionInventoryCommands);
+const mockHandleSessionOpenCommands = vi.mocked(handleSessionOpenCommands);
 
 beforeEach(() => {
   mockHandleSessionInventoryCommands.mockClear();
+  mockHandleSessionOpenCommands.mockClear();
 });
 
 function request(command: DaemonRequest['command']): DaemonRequest {
@@ -80,4 +83,29 @@ test('inventory commands retain their route responses and typed failures', async
       }),
     );
   }
+});
+
+test('open routes only its lifecycle input through the public facade', async () => {
+  const expected: DaemonResponse = { ok: true, data: { session: 'default' } };
+  mockHandleSessionOpenCommands.mockImplementationOnce(async () => expected);
+
+  await expect(run('open')).resolves.toEqual(expected);
+
+  const forwarded = mockHandleSessionOpenCommands.mock.calls.at(-1)?.[0];
+  expect(Object.keys(forwarded ?? {}).sort()).toEqual(
+    [
+      'bindDevice',
+      'inspectFacts',
+      'logPath',
+      'reconcileOrphanedDeviceClaim',
+      'req',
+      'sessionName',
+      'sessionStore',
+    ].sort(),
+  );
+  expect(forwarded).toMatchObject({
+    req: expect.objectContaining({ command: 'open' }),
+    sessionName: 'default',
+    logPath: '/tmp/agent-device-session-lifecycle-route.log',
+  });
 });

--- a/src/daemon/session-lifecycle/index.ts
+++ b/src/daemon/session-lifecycle/index.ts
@@ -1,2 +1,4 @@
 export { handleSessionInventoryCommands } from './internal/inventory.ts';
 export type { SessionInventoryCommandInput } from './internal/inventory.ts';
+export { handleSessionOpenCommands } from './internal/session-open.ts';
+export type { SessionOpenCommandInput } from './internal/session-open.ts';

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-device-in-use.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-device-in-use.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest';
-import { buildDeviceInUseBySessionError } from '../session-open-execution.ts';
-import type { SessionRef } from '../../types.ts';
-import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
+import { buildDeviceInUseBySessionError } from '../../../session-recovery-hints.ts';
+import type { SessionRef } from '../../../types.ts';
+import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/device-fixtures.ts';
 
 // DEVICE_IN_USE named `SessionState.name`, and for an implicitly cwd-scoped session that is
 // `default` while the session is stored — and addressable — as `cwd:<hash>:default`. Both the

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-execution-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-execution-runtime.test.ts
@@ -1,25 +1,25 @@
 import { test, expect, vi, beforeEach } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
-import type { DaemonRequest } from '../../types.ts';
+import type { DaemonRequest } from '../../../types.ts';
 import { AppError } from '@agent-device/kernel/errors';
 
 const mockResolveTargetDevice = vi.hoisted(() => vi.fn());
 
-vi.mock('../../../core/dispatch-resolve.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../core/dispatch-resolve.ts')>();
+vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   const { selectionFromResolveTargetDevice } =
-    await import('../../__tests__/device-selection-stub.ts');
+    await import('../../../__tests__/device-selection-stub.ts');
   return {
     ...actual,
     resolveTargetDevice: mockResolveTargetDevice,
     resolveTargetDeviceSelection: vi.fn(selectionFromResolveTargetDevice(mockResolveTargetDevice)),
   };
 });
-vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
-vi.mock('../../../platform-runtime-runtime-hints.ts', async (importOriginal) => {
+vi.mock('../../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('../../../../platform-runtime-runtime-hints.ts', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('../../../platform-runtime-runtime-hints.ts')>();
+    await importOriginal<typeof import('../../../../platform-runtime-runtime-hints.ts')>();
   return {
     ...actual,
     applyRuntimeHintValues: vi.fn(async () => {}),
@@ -40,8 +40,9 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
   return { ...actual, resolveIosApp: vi.fn(async () => 'com.example.demo') };
 });
-vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
+vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
   return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
 });
 vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
@@ -57,13 +58,13 @@ import {
   handleSessionCommands,
   mockBindDeviceRuntime,
   mockInspectDeviceRuntimeFacts,
-} from './session-command-harness.ts';
+} from '../../../handlers/__tests__/session-command-harness.ts';
 import {
   applyRuntimeHintValues,
   clearRuntimeHintValues,
-} from '../../../platform-runtime-runtime-hints.ts';
-import { resolveAndroidPackageForOpen } from '../../../platform-runtime-open-target.ts';
-import { dispatchApplicationLifecycleEffect } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
+} from '../../../../platform-runtime-runtime-hints.ts';
+import { resolveAndroidPackageForOpen } from '../../../../platform-runtime-open-target.ts';
+import { dispatchApplicationLifecycleEffect } from '../../../__tests__/application-lifecycle-runtime-fixture.ts';
 import {
   makeAndroidEmulator,
   makeSession,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-existing.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-existing.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { buildSnapshotSignatures } from '../../../snapshot/snapshot-freshness/index.ts';
+import { buildSnapshotSignatures } from '../../../../snapshot/snapshot-freshness/index.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   mockLifecycleDispatch as mockDispatch,
@@ -13,9 +13,9 @@ import {
   noopInvoke,
   assertInvalidArgsMessage,
   withMockedPlatform,
-} from './session-test-harness.ts';
-import type { SessionState } from '../../types.ts';
-import { handleSessionCommands } from './session-command-harness.ts';
+} from '../../../handlers/__tests__/session-test-harness.ts';
+import type { SessionState } from '../../../types.ts';
+import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
 
 test('open web URL on iOS device session without active app falls back to Safari', async () => {
   const sessionStore = makeSessionStore();

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-foreground.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-foreground.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 const dispatchSnapshotViaRuntime = vi.hoisted(() => vi.fn());
 
-vi.mock('../../snapshot-runtime.ts', () => ({ dispatchSnapshotViaRuntime }));
+vi.mock('../../../snapshot-runtime.ts', () => ({ dispatchSnapshotViaRuntime }));
 
 import { AppError } from '@agent-device/kernel/errors';
-import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import type { DaemonRequest, DaemonResponse } from '../../../types.ts';
 import {
   composeOpenWithInitialSnapshot,
   resolveForegroundOpenRequest,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.fixtures.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.fixtures.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { SessionStore } from '../../session-store.ts';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
-import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
+import { SessionStore } from '../../../session-store.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../../../types.ts';
+import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
 
 export const noopInvoke = async (_req: DaemonRequest): Promise<DaemonResponse> => ({
   ok: true,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.test.ts
@@ -4,20 +4,20 @@ import path from 'node:path';
 
 const mockResolveTargetDevice = vi.hoisted(() => vi.fn());
 
-vi.mock('../../../core/dispatch-resolve.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../core/dispatch-resolve.ts')>();
+vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   const { selectionFromResolveTargetDevice } =
-    await import('../../__tests__/device-selection-stub.ts');
+    await import('../../../__tests__/device-selection-stub.ts');
   return {
     ...actual,
     resolveTargetDevice: mockResolveTargetDevice,
     resolveTargetDeviceSelection: vi.fn(selectionFromResolveTargetDevice(mockResolveTargetDevice)),
   };
 });
-vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
-vi.mock('../../../platform-runtime-runtime-hints.ts', async (importOriginal) => {
+vi.mock('../../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('../../../../platform-runtime-runtime-hints.ts', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('../../../platform-runtime-runtime-hints.ts')>();
+    await importOriginal<typeof import('../../../../platform-runtime-runtime-hints.ts')>();
   return {
     ...actual,
     applyRuntimeHintValues: vi.fn(async () => {}),
@@ -38,8 +38,9 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
   return { ...actual, resolveIosApp: vi.fn(async () => 'com.example.demo') };
 });
-vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
+vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
   return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
 });
 vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
@@ -55,11 +56,11 @@ import {
   handleSessionCommands,
   mockBindDeviceRuntime,
   mockInspectDeviceRuntimeFacts,
-} from './session-command-harness.ts';
-import { applyRuntimeHintValues } from '../../../platform-runtime-runtime-hints.ts';
-import { resolveAndroidPackageForOpen } from '../../../platform-runtime-open-target.ts';
-import { dispatchApplicationLifecycleEffect } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
-import { lifecycleRuntimeFacts } from './application-lifecycle-runtime-harness.ts';
+} from '../../../handlers/__tests__/session-command-harness.ts';
+import { applyRuntimeHintValues } from '../../../../platform-runtime-runtime-hints.ts';
+import { resolveAndroidPackageForOpen } from '../../../../platform-runtime-open-target.ts';
+import { dispatchApplicationLifecycleEffect } from '../../../__tests__/application-lifecycle-runtime-fixture.ts';
+import { lifecycleRuntimeFacts } from '../../../__tests__/application-lifecycle-runtime-harness.ts';
 import {
   makeAndroidDevice,
   makeAndroidEmulator,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-surface.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-surface.test.ts
@@ -2,13 +2,13 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
 import { buildNextOpenSession, buildOpenResult } from '../session-open-surface.ts';
-import { resolveRequestedOpenSurface } from '../../../platform-runtime-open-target.ts';
+import { resolveRequestedOpenSurface } from '../../../../platform-runtime-open-target.ts';
 import {
   authoringPublication,
   makeIosSession,
-} from '../../../__tests__/test-utils/session-factories.ts';
-import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
-import { isSessionRecording } from '../../session-script-publication-capability.ts';
+} from '../../../../__tests__/test-utils/session-factories.ts';
+import { IOS_SIMULATOR } from '../../../../__tests__/test-utils/device-fixtures.ts';
+import { isSessionRecording } from '../../../session-script-publication-capability.ts';
 
 test('resolveRequestedOpenSurface rejects surface flag on iOS', () => {
   assert.throws(

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-target.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-target.test.ts
@@ -4,7 +4,7 @@ import { getAndroidAppState } from '@agent-device/platform-android/mechanics';
 import {
   inferAndroidPackageAfterOpen,
   resolveSessionAppBundleIdForTarget,
-} from '../../../platform-runtime-open-target.ts';
+} from '../../../../platform-runtime-open-target.ts';
 
 vi.mock('@agent-device/platform-android/mechanics', () => ({
   getAndroidAppState: vi.fn(),

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
@@ -14,13 +14,13 @@ import {
   makeSessionStore,
   makeSession,
   noopInvoke,
-} from './session-test-harness.ts';
-import type { SessionState } from '../../types.ts';
+} from '../../../handlers/__tests__/session-test-harness.ts';
+import type { SessionState } from '../../../types.ts';
 import {
   handleSessionCommands,
   mockBindDeviceRuntime,
   mockInspectDeviceRuntimeFacts,
-} from './session-command-harness.ts';
+} from '../../../handlers/__tests__/session-command-harness.ts';
 
 test('open URL on existing iOS session clears stale app bundle id', async () => {
   const sessionStore = makeSessionStore();

--- a/src/daemon/session-lifecycle/internal/session-open-execution.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-execution.ts
@@ -6,51 +6,45 @@ import {
 import {
   markSelectionBootOccurred,
   type DeviceSelectionResult,
-} from '../../core/device-selection-resolver.ts';
+} from '../../../core/device-selection-resolver.ts';
 import type { BoundDeviceRuntime } from '@agent-device/contracts/platform-runtime';
 import type { SessionSurface } from '@agent-device/contracts/session';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type {
-  DaemonRequest,
-  DaemonResponse,
-  SessionRef,
-  SessionScope,
-  SessionState,
-} from '../types.ts';
+import type { DaemonRequest, DaemonResponse, SessionScope, SessionState } from '../../types.ts';
 import {
   abortAuthoringOnSecondOpen,
   armAuthoringOnOpen,
   isAuthoringArmedSession,
-} from '../session-script-publication-capability.ts';
+} from '../../session-script-publication-capability.ts';
 import { isRequestCanceled } from '@agent-device/host-kit/request';
 import { createRequestCanceledError } from '@agent-device/kernel/errors';
 import {
   resolveSessionRequestLogPath,
   resolveSessionRunnerLogPath,
   SessionStore,
-} from '../session-store.ts';
+} from '../../session-store.ts';
 import {
   countConfiguredRuntimeHints,
   runtimeHintValues,
   setSessionRuntimeHintsForOpen,
-} from './session-runtime.ts';
+} from '../../session-runtime.ts';
 import { STARTUP_SAMPLE_METHOD, type StartupPerfSample } from './session-startup-metrics.ts';
 import { buildNextOpenSession, buildOpenResult } from './session-open-surface.ts';
-import { markDeferredInteractionOutcome } from '../deferred-interaction-outcome.ts';
+import { markDeferredInteractionOutcome } from '../../deferred-interaction-outcome.ts';
 import { emitDiagnostic, getDiagnosticsMeta } from '@agent-device/host-kit/diagnostics';
 import {
   prepareOpenCommandDetails,
   type ResolvedOpenRuntimeHintPlan,
 } from './session-open-prepare.ts';
-import { errorResponse } from './response.ts';
-import { buildSessionRecoveryHint } from '../session-recovery-hints.ts';
+import { errorResponse } from '../../response.ts';
+import { buildDeviceInUseBySessionError } from '../../session-recovery-hints.ts';
 import {
   isImplicitSessionScopeConflict,
   resolveSessionScope,
   resolvePublicSessionName,
-} from '../session-routing.ts';
-import { resolveSessionLeaseForRequest } from '../lease-lifecycle.ts';
-import { applicationLifecycleExecutionFromRequest } from '../application-lifecycle-execution.ts';
+} from '../../session-routing.ts';
+import { resolveSessionLeaseForRequest } from '../../lease-lifecycle.ts';
+import { applicationLifecycleExecutionFromRequest } from '../../application-lifecycle-execution.ts';
 import {
   abandonDeviceClaim,
   acquireDeviceClaim,
@@ -59,8 +53,8 @@ import {
   type DeviceClaimAcquireResult,
   type DeviceClaimSessionOwnership,
   type DeviceClaimReconciler,
-} from '../device-claims.ts';
-import { buildDeviceClaimConflictError } from '../device-claim-conflict.ts';
+} from '../../device-claims.ts';
+import { buildDeviceClaimConflictError } from '../../device-claim-conflict.ts';
 
 type OpenTiming = {
   totalDurationMs?: number;
@@ -244,9 +238,8 @@ export async function completeOpenCommand(params: {
     existingLease: existingSession?.lease,
   });
   if (deviceClaim) nextSession.deviceClaim = deviceClaim;
-  if (req.runtime !== undefined) {
+  if (req.runtime !== undefined)
     setSessionRuntimeHintsForOpen(sessionStore, sessionName, runtimeHints);
-  }
   const sessionStateDir = sessionStore.ensureSessionDir(sessionName);
   const requestLogPath = resolveSessionRequestLogPath(
     sessionStateDir,
@@ -311,9 +304,8 @@ async function prepareOpenDispatchSession(params: {
   const provisionalSession = createProvisionalOpenDispatchSession(params);
   sessionStore.set(sessionName, provisionalSession);
   const lifecycleResponse = await beforeDispatch(provisionalSession);
-  if (lifecycleResponse && !lifecycleResponse.ok) {
+  if (lifecycleResponse && !lifecycleResponse.ok)
     return { type: 'response', response: lifecycleResponse };
-  }
   return { type: 'session', session: sessionStore.get(sessionName) ?? provisionalSession };
 }
 
@@ -363,21 +355,6 @@ function findNewSessionDeviceConflict(params: {
     );
   }
   return buildDeviceInUseBySessionError(inUse, device);
-}
-
-// Exported as the single by-session DEVICE_IN_USE producer so the help-benchmark sample parity
-// test renders the exact error this handler returns; a message or hint change here fails that
-// gate instead of drifting past it.
-export function buildDeviceInUseBySessionError(
-  inUse: SessionRef,
-  device: DeviceInfo,
-): DaemonResponse {
-  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUse.address}".`, {
-    session: inUse.address,
-    deviceId: device.id,
-    deviceName: device.name,
-    hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
-  });
 }
 
 async function acquireLocalDeviceClaim(params: {
@@ -440,9 +417,8 @@ export async function openNewSessionWithDeviceClaim(params: {
     sessionStore,
     reconcileOrphanedDeviceClaim,
   });
-  if (localClaim.status === 'conflict') {
+  if (localClaim.status === 'conflict')
     return buildDeviceClaimConflictError(device, localClaim.conflict);
-  }
   const deviceClaim = localClaim.status === 'acquired' ? localClaim.ownership : undefined;
   const effects: NewSessionOpenEffects = { mayHaveStarted: false };
   const rollbackClaim = async () =>

--- a/src/daemon/session-lifecycle/internal/session-open-foreground.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-foreground.ts
@@ -1,9 +1,12 @@
 import { normalizeError, type NormalizedError } from '@agent-device/kernel/errors';
-import { dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
-import type { SessionStore } from '../session-store.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
-import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import { errorResponse } from './response.ts';
+import { dispatchSnapshotViaRuntime } from '../../snapshot-runtime.ts';
+import type { SessionStore } from '../../session-store.ts';
+import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import type {
+  BindDeviceRuntime,
+  InspectDeviceRuntimeFacts,
+} from '../../request-runtime-binding.ts';
+import { errorResponse } from '../../response.ts';
 
 export type ForegroundOpenResolution =
   | { type: 'not-requested' }
@@ -125,9 +128,8 @@ export async function composeOpenWithInitialSnapshot(params: {
       inspectFacts: params.inspectFacts,
       bindDevice: params.bindDevice,
     });
-    if (!snapshotResponse.ok) {
+    if (!snapshotResponse.ok)
       return openWithInitialSnapshotFailure(openResponse.data, snapshotResponse.error);
-    }
     return {
       ok: true,
       data: { ...openResponse.data, snapshot: snapshotResponse.data },

--- a/src/daemon/session-lifecycle/internal/session-open-prepare.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-prepare.ts
@@ -3,22 +3,27 @@ import type { RuntimeHintsApplicationInput } from '@agent-device/contracts/appli
 import { openApplicationRuntimeUse } from '@agent-device/contracts/application-lifecycle-runtime-plan';
 import type { BoundDeviceRuntime } from '@agent-device/contracts/platform-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { DaemonRequest, DaemonResponse, SessionRuntimeHints, SessionState } from '../types.ts';
-import { SessionStore } from '../session-store.ts';
+import type {
+  DaemonRequest,
+  DaemonResponse,
+  SessionRuntimeHints,
+  SessionState,
+} from '../../types.ts';
+import { SessionStore } from '../../session-store.ts';
 import {
   resolveRequestedOpenSurface,
   validateOpenRelaunchTarget,
-} from '../../platform-runtime-open-target.ts';
+} from '../../../platform-runtime-open-target.ts';
 import {
   hasRuntimeTransportHints,
   maybeClearRemovedRuntimeTransportHints,
   shouldClearRemovedRuntimeTransportHints,
   tryResolveOpenRuntimeHints,
-} from './session-runtime.ts';
+} from '../../session-runtime.ts';
 import { AppError } from '@agent-device/kernel/errors';
-import { errorResponse } from './response.ts';
+import { errorResponse } from '../../response.ts';
 import type { SessionSurface } from '@agent-device/contracts/session';
-import { resolveRunnerLogicalLeaseContext } from '../lease-context.ts';
+import { resolveRunnerLogicalLeaseContext } from '../../lease-context.ts';
 
 type OpenCommandDetails = {
   appBundleId?: string;

--- a/src/daemon/session-lifecycle/internal/session-open-surface.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-surface.ts
@@ -5,10 +5,10 @@ import {
   publicPlatformString,
   type DeviceInfo,
 } from '@agent-device/kernel/device';
-import type { SessionRuntimeHints, SessionScope, SessionState } from '../types.ts';
+import type { SessionRuntimeHints, SessionScope, SessionState } from '../../types.ts';
 import { successText } from '@agent-device/kernel/success-text';
 import type { StartupPerfSample } from './session-startup-metrics.ts';
-import type { DeviceSelectionResult } from '../../core/device-selection-resolver.ts';
+import type { DeviceSelectionResult } from '../../../core/device-selection-resolver.ts';
 
 export function buildOpenResult(params: {
   sessionName: string;
@@ -58,9 +58,7 @@ export function buildOpenResult(params: {
   if (appBundleId) result.appBundleId = appBundleId;
   if (startup) result.startup = startup;
   if (timing) result.timing = timing;
-  if (runtime && runtimeHintCount(runtime) > 0) {
-    result.runtime = runtime;
-  }
+  if (runtime && runtimeHintCount(runtime) > 0) result.runtime = runtime;
   if (device) {
     result.platform = publicPlatformString(device);
     result.target = device.target ?? 'mobile';

--- a/src/daemon/session-lifecycle/internal/session-open.ts
+++ b/src/daemon/session-lifecycle/internal/session-open.ts
@@ -1,4 +1,4 @@
-import { resolveTargetDeviceSelection } from '../../core/dispatch-resolve.ts';
+import { resolveTargetDeviceSelection } from '../../../core/dispatch-resolve.ts';
 import {
   openApplicationRuntimeUse,
   openApplicationWithRuntimeHintApplyAndClearUse,
@@ -7,11 +7,11 @@ import {
   resolveOpenApplicationRuntimePlan,
 } from '@agent-device/contracts/application-lifecycle-runtime-plan';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { SessionStore } from '../session-store.ts';
-import { refreshSessionDeviceIfNeeded } from '../session-device-resolution.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
+import { SessionStore } from '../../session-store.ts';
+import { refreshSessionDeviceIfNeeded } from '../../session-device-resolution.ts';
 import { withKeyedLock } from '@agent-device/kernel/keyed-lock';
-import { buildOpenTargetDeviceResolutionOptions } from '../open-device-selection.ts';
+import { buildOpenTargetDeviceResolutionOptions } from '../../open-device-selection.ts';
 import {
   invalidOpenArgs,
   prepareOpenCommandDetails,
@@ -21,13 +21,20 @@ import {
   validatePreResolvedOpenRequest,
   validateResolvedOpenRequest,
 } from './session-open-prepare.ts';
-import { resolveForegroundOpenRequest } from './session-open-foreground.ts';
-import { errorResponse } from './response.ts';
-import { expireRefFrame } from '../ref-frame.ts';
-import type { DeviceClaimReconciler } from '../device-claims.ts';
-import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import { admitRuntimeOperations } from '../runtime-admission.ts';
-import { resolveExistingSessionDeviceSelection } from '../../core/device-selection-resolver.ts';
+import {
+  composeOpenWithInitialSnapshot,
+  resolveForegroundOpenRequest,
+} from './session-open-foreground.ts';
+import { errorResponse } from '../../response.ts';
+import { expireRefFrame } from '../../ref-frame.ts';
+import type { DeviceClaimReconciler } from '../../device-claims.ts';
+import type {
+  BindDeviceRuntime,
+  InspectDeviceRuntimeFacts,
+} from '../../request-runtime-binding.ts';
+import { admitRuntimeOperations } from '../../runtime-admission.ts';
+import { resolveExistingSessionDeviceSelection } from '../../../core/device-selection-resolver.ts';
+import { requireRuntimeBinding, requireRuntimeFacts } from '../../session-runtime-admission.ts';
 import {
   completeOpenCommand,
   openNewSessionWithDeviceClaim,
@@ -36,7 +43,15 @@ import {
   type RuntimeHintClearOperation,
 } from './session-open-execution.ts';
 
-export { buildDeviceInUseBySessionError } from './session-open-execution.ts';
+export type SessionOpenCommandInput = Readonly<{
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  inspectFacts?: InspectDeviceRuntimeFacts;
+  bindDevice?: BindDeviceRuntime;
+  reconcileOrphanedDeviceClaim: DeviceClaimReconciler;
+}>;
 
 const firstSessionOpenLocks = new Map<string, Promise<unknown>>();
 
@@ -132,15 +147,7 @@ async function resolveOpenRuntimePlanAdmission(params: {
 }
 
 // fallow-ignore-next-line complexity
-export async function handleOpenCommand(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-  inspectFacts?: InspectDeviceRuntimeFacts;
-  bindDevice?: BindDeviceRuntime;
-  reconcileOrphanedDeviceClaim: DeviceClaimReconciler;
-}): Promise<DaemonResponse> {
+async function handleOpenCommand(params: SessionOpenCommandInput): Promise<DaemonResponse> {
   const { sessionName, logPath, sessionStore } = params;
 
   const session = sessionStore.get(sessionName);
@@ -167,9 +174,7 @@ export async function handleOpenCommand(params: {
       openTarget,
       session.surface,
     );
-    if (typeof surfaceResult !== 'string') {
-      return surfaceResult;
-    }
+    if (typeof surfaceResult !== 'string') return surfaceResult;
     if (!openTarget && surfaceResult === 'app') {
       return shouldRelaunch
         ? invalidOpenArgs('open --relaunch requires an app name or an active session app.')
@@ -182,9 +187,7 @@ export async function handleOpenCommand(params: {
       surface: surfaceResult,
       device: session.device,
     });
-    if (validation) {
-      return validation;
-    }
+    if (validation) return validation;
 
     const device = await refreshSessionDeviceIfNeeded(session.device);
     const selection = resolveExistingSessionDeviceSelection(device);
@@ -214,9 +217,7 @@ export async function handleOpenCommand(params: {
       clearRuntimeHints: admission.clearRuntimeHints,
       foreground: false,
     });
-    if (details.type === 'response') {
-      return details.response;
-    }
+    if (details.type === 'response') return details.response;
 
     return await completeOpenCommand({
       req,
@@ -243,18 +244,15 @@ export async function handleOpenCommand(params: {
 
   const shouldRelaunch = req.flags?.relaunch === true;
   const openTarget = req.positionals?.[0];
-  if (shouldRelaunch && !openTarget) {
+  if (shouldRelaunch && !openTarget)
     return invalidOpenArgs('open --relaunch requires an app argument.');
-  }
 
   const preResolvedValidation = await validatePreResolvedOpenRequest({
     shouldRelaunch,
     openTarget,
     platform: req.flags?.platform === 'android' ? 'android' : undefined,
   });
-  if (preResolvedValidation) {
-    return preResolvedValidation;
-  }
+  if (preResolvedValidation) return preResolvedValidation;
 
   const selection = await resolveTargetDeviceSelection(
     req.flags ?? {},
@@ -263,9 +261,7 @@ export async function handleOpenCommand(params: {
   const device = selection.device;
   await req.internal?.retainDeviceExecutionLock?.(device.id);
   const surfaceResult = resolveOpenSurfaceResponse(device, req.flags?.surface, openTarget);
-  if (typeof surfaceResult !== 'string') {
-    return surfaceResult;
-  }
+  if (typeof surfaceResult !== 'string') return surfaceResult;
 
   const validation = await validateResolvedOpenRequest({
     shouldRelaunch,
@@ -273,9 +269,7 @@ export async function handleOpenCommand(params: {
     surface: surfaceResult,
     device,
   });
-  if (validation) {
-    return validation;
-  }
+  if (validation) return validation;
 
   const runtimePlanAdmission = await resolveOpenRuntimePlanAdmission({
     req,
@@ -308,4 +302,17 @@ export async function handleOpenCommand(params: {
         selection,
       }),
   );
+}
+
+export async function handleSessionOpenCommands(
+  params: SessionOpenCommandInput,
+): Promise<DaemonResponse> {
+  const openResponse = await handleOpenCommand(params);
+  if (!openResponse.ok || params.req.flags?.foreground !== true) return openResponse;
+  return await composeOpenWithInitialSnapshot({
+    ...params,
+    inspectFacts: requireRuntimeFacts(params.inspectFacts),
+    bindDevice: requireRuntimeBinding(params.bindDevice),
+    openResponse,
+  });
 }

--- a/src/daemon/session-lifecycle/internal/session-startup-metrics.ts
+++ b/src/daemon/session-lifecycle/internal/session-startup-metrics.ts
@@ -1,5 +1,4 @@
 export const STARTUP_SAMPLE_METHOD = 'open-command-roundtrip';
-export const PERF_UNAVAILABLE_REASON = 'Not implemented for this platform in this release.';
 
 export type StartupPerfSample = {
   durationMs: number;

--- a/src/daemon/session-recovery-hints.ts
+++ b/src/daemon/session-recovery-hints.ts
@@ -1,5 +1,7 @@
-import type { SessionRef, SessionState } from './types.ts';
+import type { DeviceInfo } from '@agent-device/kernel/device';
 import { shellQuoteIfNeeded } from '@agent-device/host-kit/command';
+import type { DaemonResponse, SessionRef, SessionState } from './types.ts';
+import { errorResponse } from './response.ts';
 
 export type SessionRecoveryContext = 'device-in-use' | 'selector-conflict';
 
@@ -22,6 +24,18 @@ export function buildSessionRecoveryHint(ref: SessionRef, context: SessionRecove
     return buildRecordingSessionRecoveryHint(ref.address, context);
   }
   return buildOpenSessionRecoveryHint(ref.address, context);
+}
+
+export function buildDeviceInUseBySessionError(
+  inUse: SessionRef,
+  device: DeviceInfo,
+): DaemonResponse {
+  return errorResponse('DEVICE_IN_USE', `Device is already in use by session "${inUse.address}".`, {
+    session: inUse.address,
+    deviceId: device.id,
+    deviceName: device.name,
+    hint: buildSessionRecoveryHint(inUse, 'device-in-use'),
+  });
 }
 
 function buildRecordingSessionRecoveryHint(

--- a/src/daemon/session-runtime-admission.ts
+++ b/src/daemon/session-runtime-admission.ts
@@ -8,7 +8,7 @@ import { AppError } from '@agent-device/kernel/errors';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from './request-runtime-binding.ts';
 import type { SessionStore } from './session-store.ts';
 import type { DaemonRequest, DaemonResponse } from './types.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 
 export type RuntimeCommandHandlerParams = Readonly<{
   req: DaemonRequest;

--- a/src/daemon/session-runtime.ts
+++ b/src/daemon/session-runtime.ts
@@ -5,10 +5,10 @@ import {
 } from '@agent-device/contracts/application-lifecycle-runtime';
 import { AppError, asAppError } from '@agent-device/kernel/errors';
 import { publicPlatformString, type DeviceInfo } from '@agent-device/kernel/device';
-import type { DaemonRequest, SessionRuntimeHints, SessionState } from '../types.ts';
-import { SessionStore } from '../session-store.ts';
-import { trimRuntimeValue } from '../../utils/runtime-transport.ts';
-import { isAndroidEmulator, isIosSimulator } from '../device-targets.ts';
+import type { DaemonRequest, SessionRuntimeHints, SessionState } from './types.ts';
+import { SessionStore } from './session-store.ts';
+import { trimRuntimeValue } from '../utils/runtime-transport.ts';
+import { isAndroidEmulator, isIosSimulator } from './device-targets.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 
 type SessionRuntimeHintsStore = Readonly<{

--- a/src/daemon/snapshot-runtime-binding.ts
+++ b/src/daemon/snapshot-runtime-binding.ts
@@ -22,7 +22,7 @@ import {
   unwrapAdmittedRuntimePlan,
   type AdmittedRuntimePlan,
 } from './session-runtime-admission.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import { resolveSnapshotScope } from './handlers/snapshot-capture.ts';
 import { resolveSessionDevice } from './handlers/snapshot-session.ts';
 import {

--- a/src/daemon/touch-runtime.ts
+++ b/src/daemon/touch-runtime.ts
@@ -24,7 +24,7 @@ import { successText } from '@agent-device/kernel/success-text';
 import { requireIntInRange } from '../utils/validation.ts';
 import type { DaemonCommandContext } from './context.ts';
 import type { DirectIosSelectorTarget } from './direct-ios-selector.ts';
-import type { DaemonFailureResponse } from './handlers/response.ts';
+import type { DaemonFailureResponse } from './response.ts';
 import {
   admitRuntimeOperations,
   type RuntimeAdmissionBindings,

--- a/src/daemon/type-text-runtime.ts
+++ b/src/daemon/type-text-runtime.ts
@@ -9,7 +9,7 @@ import { successText } from '@agent-device/kernel/success-text';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import { requireIntInRange } from '../utils/validation.ts';
 import type { DaemonCommandContext } from './context.ts';
-import type { DaemonFailureResponse } from './handlers/response.ts';
+import type { DaemonFailureResponse } from './response.ts';
 import { admitRuntimeUse, type RuntimeAdmissionBindings } from './runtime-admission.ts';
 import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';
 

--- a/src/daemon/wait-current-surface.ts
+++ b/src/daemon/wait-current-surface.ts
@@ -2,7 +2,7 @@ import { WAIT_REASONS } from '@agent-device/contracts/wait';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { captureSnapshot } from './handlers/snapshot-capture.ts';
-import { errorResponse } from './handlers/response.ts';
+import { errorResponse } from './response.ts';
 import { normalizeType } from '@agent-device/contracts/snapshot';
 import { buildRuntimeCaptureInput } from './snapshot-runtime-capture-input.ts';
 import type { BoundSelectorCapture } from './selector-capture-binding.ts';


### PR DESCRIPTION
## Summary

Move the complete open-session application lifecycle behind the accepted session-lifecycle facade for #2174.

Project the exact open input from `handlers/session.ts`, preserve foreground composition and paired `lease`/`deviceClaim` ownership, and move the six lifecycle modules plus open tests and shared runtime seams out of the handler layer. No #2175/#2176 changes.

Closes #2174

## Validation

- `pnpm typecheck`
- `pnpm check:layering` — 178 structural tests and tracked guard passed
- `pnpm check:fallow --base origin/main` — no issues in 96 changed files
- Focused lifecycle/dependent suite — 12 files, 86 tests; the one hermetic process-signal regression passes in isolation
- Help-conformance parity/coverage — 23 tests passed
- `pnpm check:affected --run` — all runnable checks passed through build, package, integration, related tests, compatibility, and conformance; final gate stopped on three pre-existing mutation-model assertions for removed `src/utils/scroll-edge-state.ts`; native/device/provider/full-coverage lanes remain GitHub-authoritative
- Observed planted-red `pnpm check:layering` caught both forbidden lifecycle deep-import directions and the duplicate `deviceClaim` writer; all plant lines were removed
- Move-adjusted daemon production LOC: 56,357 to 56,346 (`+191/-202`, net `-11`)
- External read-only review: `claude -p --model sonnet --effort low --safe-mode --no-session-persistence --permission-mode plan ...` — `VERDICT: NO FINDINGS`