### PR TITLE
refactor(ios): define snapshot acquisition and presentation contracts

### DIFF
--- a/contracts/fixtures/ios-snapshot-capture-hint.json
+++ b/contracts/fixtures/ios-snapshot-capture-hint.json
@@ -1,0 +1,211 @@
+[
+  {
+    "name": "regular-default-full",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": false,
+      "depth": null,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "regular-presented-depth",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": false,
+      "depth": 2,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": 2,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "regular-interactive-only",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": true,
+      "depth": null,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": true,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "regular-scoped-depth-stays-broad",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": true,
+      "depth": 3,
+      "scope": "Card",
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": true,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "regular-custom-actions",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": false,
+      "depth": null,
+      "scope": null,
+      "customActions": true,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": true,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "raw-default-full",
+    "request": {
+      "projection": "raw",
+      "interactiveOnly": false,
+      "depth": null,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "raw",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "raw-traversal-depth",
+    "request": {
+      "projection": "raw",
+      "interactiveOnly": false,
+      "depth": 4,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "raw",
+      "rawTraversalDepth": 4,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "raw-interactive-request-is-not-filtered",
+    "request": {
+      "projection": "raw",
+      "interactiveOnly": true,
+      "depth": null,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "raw",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "raw-scoped-depth-stays-broad",
+    "request": {
+      "projection": "raw",
+      "interactiveOnly": false,
+      "depth": 3,
+      "scope": "Panel",
+      "customActions": true,
+      "acquisitionIntent": "full"
+    },
+    "expected": {
+      "projection": "raw",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": true,
+      "acquisitionIntent": "full"
+    }
+  },
+  {
+    "name": "regular-surface-observation",
+    "request": {
+      "projection": "regular",
+      "interactiveOnly": false,
+      "depth": null,
+      "scope": null,
+      "customActions": false,
+      "acquisitionIntent": "surface-observation"
+    },
+    "expected": {
+      "projection": "regular",
+      "rawTraversalDepth": null,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": false,
+      "acquisitionIntent": "surface-observation"
+    }
+  },
+  {
+    "name": "raw-surface-observation-with-depth-and-actions",
+    "request": {
+      "projection": "raw",
+      "interactiveOnly": false,
+      "depth": 1,
+      "scope": null,
+      "customActions": true,
+      "acquisitionIntent": "surface-observation"
+    },
+    "expected": {
+      "projection": "raw",
+      "rawTraversalDepth": 1,
+      "regularPresentedDepth": null,
+      "interactiveOnly": false,
+      "customActions": true,
+      "acquisitionIntent": "surface-observation"
+    }
+  }
+]

--- a/packages/capture-kit/package.json
+++ b/packages/capture-kit/package.json
@@ -14,6 +14,10 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./ios-snapshot-planning": {
+      "types": "./src/ios-snapshot-planning.ts",
+      "default": "./src/ios-snapshot-planning.ts"
+    },
     "./mobile-snapshot-semantics": {
       "types": "./src/mobile-snapshot-semantics.ts",
       "default": "./src/mobile-snapshot-semantics.ts"

--- a/packages/capture-kit/src/index.ts
+++ b/packages/capture-kit/src/index.ts
@@ -30,12 +30,3 @@ export {
   assertAppLogSessionArtifacts,
 } from './app-log-session-artifacts.ts';
 export { mergeNetworkDumps, readRecentNetworkTrafficFromText } from './network-traffic.ts';
-export {
-  IOS_SNAPSHOT_PRODUCER_CAPABILITIES,
-  areIosSnapshotComparisonIdentitiesEqual,
-  buildIosSnapshotComparisonIdentity,
-  buildIosSnapshotPresentationKey,
-  createIosSnapshotRequest,
-  deriveIosCaptureHint,
-  planIosSnapshot,
-} from './ios-snapshot-planning.ts';

--- a/packages/capture-kit/src/index.ts
+++ b/packages/capture-kit/src/index.ts
@@ -30,3 +30,12 @@ export {
   assertAppLogSessionArtifacts,
 } from './app-log-session-artifacts.ts';
 export { mergeNetworkDumps, readRecentNetworkTrafficFromText } from './network-traffic.ts';
+export {
+  IOS_SNAPSHOT_PRODUCER_CAPABILITIES,
+  areIosSnapshotComparisonIdentitiesEqual,
+  buildIosSnapshotComparisonIdentity,
+  buildIosSnapshotPresentationKey,
+  createIosSnapshotRequest,
+  deriveIosCaptureHint,
+  planIosSnapshot,
+} from './ios-snapshot-planning.ts';

--- a/packages/capture-kit/src/ios-snapshot-planning.test.ts
+++ b/packages/capture-kit/src/ios-snapshot-planning.test.ts
@@ -17,7 +17,7 @@ import {
   createIosSnapshotRequest,
   deriveIosCaptureHint,
   planIosSnapshot,
-} from '@agent-device/capture-kit';
+} from '@agent-device/capture-kit/ios-snapshot-planning';
 
 type CaptureHintFixture = Readonly<{
   name: string;

--- a/packages/capture-kit/src/ios-snapshot-planning.test.ts
+++ b/packages/capture-kit/src/ios-snapshot-planning.test.ts
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+import type {
+  CaptureHint,
+  IosSnapshotAcquisitionProducerCapabilities,
+  IosSnapshotComparisonIdentity,
+  IosSnapshotInput,
+  IosSnapshotRequestInput,
+} from '@agent-device/contracts/ios-snapshot';
+import {
+  IOS_SNAPSHOT_PRODUCER_CAPABILITIES,
+  areIosSnapshotComparisonIdentitiesEqual,
+  buildIosSnapshotComparisonIdentity,
+  buildIosSnapshotPresentationKey,
+  createIosSnapshotRequest,
+  deriveIosCaptureHint,
+  planIosSnapshot,
+} from '@agent-device/capture-kit';
+
+type CaptureHintFixture = Readonly<{
+  name: string;
+  request: IosSnapshotRequestInput;
+  expected: CaptureHint;
+}>;
+
+const TABLE_PATH = path.resolve(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'contracts',
+  'fixtures',
+  'ios-snapshot-capture-hint.json',
+);
+
+test('the request-to-capture-hint table is exhaustive', () => {
+  const fixtures = JSON.parse(fs.readFileSync(TABLE_PATH, 'utf8')) as CaptureHintFixture[];
+  assert.ok(fixtures.length > 0, 'capture-hint table must not be empty');
+  assert.equal(new Set(fixtures.map((fixture) => fixture.name)).size, fixtures.length);
+  for (const fixture of fixtures) {
+    const request = createIosSnapshotRequest(fixture.request);
+    assert.deepEqual(deriveIosCaptureHint(request), fixture.expected, fixture.name);
+  }
+});
+
+test('normalization makes raw, scope, and absent values explicit', () => {
+  const request = createIosSnapshotRequest({
+    raw: true,
+    depth: 2,
+    scope: '  Card  ',
+    acquisitionIntent: 'surface-observation',
+  });
+  assert.deepEqual(request, {
+    projection: 'raw',
+    interactiveOnly: false,
+    depth: 2,
+    scope: 'Card',
+    customActions: false,
+    acquisitionIntent: 'surface-observation',
+  });
+  assert.deepEqual(buildIosSnapshotPresentationKey(request), {
+    projection: 'raw',
+    interactiveOnly: false,
+    depth: 2,
+    scope: 'Card',
+    customActions: false,
+  });
+});
+
+test('depth narrowing requires complete support for the requested projection', () => {
+  const rawRequest = createIosSnapshotRequest({ projection: 'raw', depth: 2 });
+  const regularRequest = createIosSnapshotRequest({ projection: 'regular', depth: 2 });
+  const rawComplete = acquiredProducer({
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'incomplete' },
+    },
+  });
+  const rawIncomplete = acquiredProducer({
+    acquisitionDepth: {
+      rawTraversal: { kind: 'incomplete' },
+      regularPresented: { kind: 'incomplete' },
+    },
+  });
+  assert.equal(planIosSnapshot(rawRequest, rawComplete).narrowing.depth, 2);
+  assert.equal(planIosSnapshot(rawRequest, rawIncomplete).narrowing.depth, null);
+
+  const regularComplete = acquiredProducer({
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'complete', maxDepth: 2 },
+    },
+  });
+  const regularTooShallow = acquiredProducer({
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'complete', maxDepth: 1 },
+    },
+  });
+  assert.equal(planIosSnapshot(regularRequest, regularComplete).narrowing.depth, 2);
+  assert.equal(planIosSnapshot(regularRequest, regularTooShallow).narrowing.depth, null);
+});
+
+test('scoped acquisition remains broad and reports scope completeness as evidence', () => {
+  const request = createIosSnapshotRequest({ projection: 'regular', depth: 2, scope: 'Card' });
+  const complete = acquiredProducer({ scopeCompleteness: 'complete' });
+  const incomplete = acquiredProducer({ scopeCompleteness: 'incomplete' });
+  assert.deepEqual(planIosSnapshot(request, complete).narrowing, {
+    depth: null,
+    scope: null,
+    interactiveOnly: false,
+  });
+  assert.equal(planIosSnapshot(request, complete).evidence.scope, 'complete');
+  assert.equal(planIosSnapshot(request, incomplete).evidence.scope, 'incomplete');
+});
+
+test('interactive narrowing requires complete queries and available hittability', () => {
+  const request = createIosSnapshotRequest({ interactiveOnly: true });
+  const complete = acquiredProducer({
+    interactiveQueryCompleteness: 'complete',
+    hittabilityEvidence: 'available',
+  });
+  const incompleteQuery = acquiredProducer({
+    interactiveQueryCompleteness: 'incomplete',
+    hittabilityEvidence: 'available',
+  });
+  const missingHittability = acquiredProducer({
+    interactiveQueryCompleteness: 'complete',
+    hittabilityEvidence: 'unavailable',
+  });
+  assert.equal(planIosSnapshot(request, complete).narrowing.interactiveOnly, true);
+  assert.equal(planIosSnapshot(request, incompleteQuery).narrowing.interactiveOnly, false);
+  assert.equal(planIosSnapshot(request, missingHittability).narrowing.interactiveOnly, false);
+});
+
+test('presented producers cannot claim acquisition narrowing', () => {
+  const request = createIosSnapshotRequest({ projection: 'regular', depth: 2 });
+  const plan = planIosSnapshot(request, IOS_SNAPSHOT_PRODUCER_CAPABILITIES['apple-runner']);
+  assert.deepEqual(plan.narrowing, { depth: null, scope: null, interactiveOnly: false });
+  assert.deepEqual(plan.evidence, {
+    scope: 'complete',
+    interactiveQuery: 'complete',
+    viewport: 'available',
+    hittability: 'available',
+  });
+});
+
+test('comparison identity rejects every identity axis and residue mismatch', () => {
+  const base = comparisonIdentity();
+  const mismatches: IosSnapshotComparisonIdentity[] = [
+    { ...base, producer: 'limrun-ios-tree' },
+    { ...base, intent: 'surface-observation' },
+    { ...base, lineage: { targetId: 'simulator-1', generation: 'generation-2' } },
+    { ...base, presentationKey: { ...base.presentationKey, depth: 1 } },
+    { ...base, residue: [{ kind: 'truncated', dimension: 'nodes' }] },
+  ];
+  assert.equal(areIosSnapshotComparisonIdentitiesEqual(base, { ...base }), true);
+  assert.equal(
+    areIosSnapshotComparisonIdentitiesEqual(base, {
+      ...base,
+      residue: [{ kind: 'provider-pruned', fields: ['scope', 'nodes'] }],
+    }),
+    false,
+  );
+  for (const mismatch of mismatches) {
+    assert.equal(areIosSnapshotComparisonIdentitiesEqual(base, mismatch), false);
+  }
+  assert.equal(
+    areIosSnapshotComparisonIdentitiesEqual(
+      { ...base, residue: [{ kind: 'provider-pruned', fields: ['scope', 'nodes'] }] },
+      { ...base, residue: [{ kind: 'provider-pruned', fields: ['nodes', 'scope'] }] },
+    ),
+    true,
+  );
+});
+
+test('comparison identity builder follows the closed input stage', () => {
+  const request = createIosSnapshotRequest({ acquisitionIntent: 'surface-observation' });
+  const acquired: IosSnapshotInput = {
+    stage: 'acquired',
+    acquisition: {
+      producer: 'simulator-ax-bridge',
+      intent: 'surface-observation',
+      hint: {
+        ...deriveIosCaptureHint(request),
+        acquisitionIntent: 'surface-observation',
+      },
+      nodes: [],
+      truncated: false,
+      viewport: { kind: 'reported', rect: { x: 0, y: 0, width: 10, height: 10 } },
+      lineage: { targetId: 'simulator-1', generation: 'generation-1' },
+      residue: [],
+    },
+  };
+  assert.deepEqual(buildIosSnapshotComparisonIdentity(acquired, request), {
+    producer: 'simulator-ax-bridge',
+    intent: 'surface-observation',
+    lineage: { targetId: 'simulator-1', generation: 'generation-1' },
+    presentationKey: {
+      projection: 'regular',
+      interactiveOnly: false,
+      depth: null,
+      scope: null,
+      customActions: false,
+    },
+    residue: [],
+  });
+});
+
+function acquiredProducer(
+  overrides: Partial<Omit<IosSnapshotAcquisitionProducerCapabilities, 'producer' | 'stage'>> = {},
+): IosSnapshotAcquisitionProducerCapabilities {
+  return {
+    producer: 'simulator-ax-bridge',
+    stage: 'acquired',
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'complete' },
+    },
+    scopeCompleteness: 'incomplete',
+    interactiveQueryCompleteness: 'incomplete',
+    viewportEvidence: 'available',
+    hittabilityEvidence: 'available',
+    ...overrides,
+  };
+}
+
+function comparisonIdentity(
+  overrides: Partial<IosSnapshotComparisonIdentity> = {},
+): IosSnapshotComparisonIdentity {
+  return {
+    producer: 'simulator-ax-bridge',
+    intent: 'full',
+    lineage: { targetId: 'simulator-1', generation: 'generation-1' },
+    presentationKey: {
+      projection: 'regular',
+      interactiveOnly: false,
+      depth: null,
+      scope: null,
+      customActions: false,
+    },
+    residue: [],
+    ...overrides,
+  };
+}

--- a/packages/capture-kit/src/ios-snapshot-planning.ts
+++ b/packages/capture-kit/src/ios-snapshot-planning.ts
@@ -1,0 +1,243 @@
+import type {
+  CaptureHint,
+  IosAcquisitionResidue,
+  IosSnapshotAcquisitionDepthCapability,
+  IosSnapshotComparisonIdentity,
+  IosSnapshotInput,
+  IosSnapshotPlan,
+  IosSnapshotPresentationKey,
+  IosSnapshotProducer,
+  IosSnapshotProducerCapabilities,
+  IosSnapshotRequest,
+  IosSnapshotRequestInput,
+} from '@agent-device/contracts/ios-snapshot';
+
+const IOS_SNAPSHOT_PRODUCER_CAPABILITY_VALUES = {
+  'apple-runner': {
+    producer: 'apple-runner',
+    stage: 'presented',
+    acquisitionDepth: {
+      rawTraversal: { kind: 'not-applicable' },
+      regularPresented: { kind: 'not-applicable' },
+    },
+    scopeCompleteness: 'complete',
+    interactiveQueryCompleteness: 'complete',
+    viewportEvidence: 'available',
+    hittabilityEvidence: 'available',
+  },
+  'simulator-ax-bridge': {
+    producer: 'simulator-ax-bridge',
+    stage: 'acquired',
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'incomplete' },
+    },
+    scopeCompleteness: 'incomplete',
+    interactiveQueryCompleteness: 'incomplete',
+    viewportEvidence: 'available',
+    hittabilityEvidence: 'available',
+  },
+  'appium-source': {
+    producer: 'appium-source',
+    stage: 'acquired',
+    acquisitionDepth: {
+      rawTraversal: { kind: 'incomplete' },
+      regularPresented: { kind: 'incomplete' },
+    },
+    scopeCompleteness: 'incomplete',
+    interactiveQueryCompleteness: 'incomplete',
+    viewportEvidence: 'unavailable',
+    hittabilityEvidence: 'unavailable',
+  },
+  'limrun-ios-tree': {
+    producer: 'limrun-ios-tree',
+    stage: 'acquired',
+    acquisitionDepth: {
+      rawTraversal: { kind: 'complete' },
+      regularPresented: { kind: 'incomplete' },
+    },
+    scopeCompleteness: 'incomplete',
+    interactiveQueryCompleteness: 'incomplete',
+    viewportEvidence: 'available',
+    hittabilityEvidence: 'unavailable',
+  },
+} as const satisfies Record<IosSnapshotProducer, IosSnapshotProducerCapabilities>;
+
+export const IOS_SNAPSHOT_PRODUCER_CAPABILITIES: Readonly<
+  Record<IosSnapshotProducer, IosSnapshotProducerCapabilities>
+> = Object.freeze(IOS_SNAPSHOT_PRODUCER_CAPABILITY_VALUES);
+
+export function createIosSnapshotRequest(input: IosSnapshotRequestInput = {}): IosSnapshotRequest {
+  return Object.freeze({
+    projection: input.projection ?? (input.raw === true ? 'raw' : 'regular'),
+    interactiveOnly: input.interactiveOnly === true,
+    depth: typeof input.depth === 'number' ? input.depth : null,
+    scope: input.scope?.trim() || null,
+    customActions: input.customActions === true,
+    acquisitionIntent: input.acquisitionIntent ?? 'full',
+  });
+}
+
+export function buildIosSnapshotPresentationKey(
+  request: IosSnapshotRequest,
+): IosSnapshotPresentationKey {
+  return Object.freeze({
+    projection: request.projection,
+    interactiveOnly: request.interactiveOnly,
+    depth: request.depth,
+    scope: request.scope,
+    customActions: request.customActions,
+  });
+}
+
+export function deriveIosCaptureHint(request: IosSnapshotRequest): CaptureHint {
+  const isScoped = request.scope !== null;
+  const isRaw = request.projection === 'raw';
+  return Object.freeze({
+    projection: request.projection,
+    rawTraversalDepth: isRaw && !isScoped ? request.depth : null,
+    regularPresentedDepth: !isRaw && !isScoped ? request.depth : null,
+    interactiveOnly: !isRaw && request.interactiveOnly,
+    customActions: request.customActions,
+    acquisitionIntent: request.acquisitionIntent,
+  });
+}
+
+export function planIosSnapshot(
+  request: IosSnapshotRequest,
+  producer: IosSnapshotProducerCapabilities,
+): IosSnapshotPlan {
+  const hint = deriveIosCaptureHint(request);
+  const requestedDepth = hint.rawTraversalDepth ?? hint.regularPresentedDepth;
+  const depthSupport = depthSupportFor(request, producer);
+  const depth =
+    requestedDepth !== null && isCompleteFor(depthSupport, requestedDepth) ? requestedDepth : null;
+  const interactiveOnly =
+    producer.stage === 'acquired' &&
+    hint.interactiveOnly &&
+    producer.interactiveQueryCompleteness === 'complete' &&
+    producer.hittabilityEvidence === 'available';
+
+  return Object.freeze({
+    request,
+    producer: producer.producer,
+    hint,
+    narrowing: Object.freeze({ depth, scope: null, interactiveOnly }),
+    evidence: Object.freeze({
+      scope: producer.scopeCompleteness,
+      interactiveQuery: producer.interactiveQueryCompleteness,
+      viewport: producer.viewportEvidence,
+      hittability: producer.hittabilityEvidence,
+    }),
+  });
+}
+
+export function areIosSnapshotComparisonIdentitiesEqual(
+  left: IosSnapshotComparisonIdentity,
+  right: IosSnapshotComparisonIdentity,
+): boolean {
+  return (
+    left.producer === right.producer &&
+    left.intent === right.intent &&
+    lineagesEqual(left.lineage, right.lineage) &&
+    presentationKeysEqual(left.presentationKey, right.presentationKey) &&
+    residuesEqual(left.residue, right.residue)
+  );
+}
+
+export function buildIosSnapshotComparisonIdentity(
+  input: IosSnapshotInput,
+  request: IosSnapshotRequest,
+): IosSnapshotComparisonIdentity {
+  if (input.stage === 'acquired') {
+    return Object.freeze({
+      producer: input.acquisition.producer,
+      intent: input.acquisition.intent,
+      lineage: input.acquisition.lineage,
+      presentationKey: buildIosSnapshotPresentationKey(request),
+      residue: Object.freeze([...input.acquisition.residue]),
+    });
+  }
+  return Object.freeze({
+    producer: input.presentation.producer,
+    intent: input.presentation.intent,
+    lineage: input.validation.lineage,
+    presentationKey: input.validation.presentationKey,
+    residue: Object.freeze([...input.validation.residue]),
+  });
+}
+
+function depthSupportFor(
+  request: IosSnapshotRequest,
+  producer: IosSnapshotProducerCapabilities,
+): IosSnapshotAcquisitionDepthCapability['rawTraversal'] {
+  if (producer.stage !== 'acquired') return { kind: 'not-applicable' };
+  return request.projection === 'raw'
+    ? producer.acquisitionDepth.rawTraversal
+    : producer.acquisitionDepth.regularPresented;
+}
+
+function isCompleteFor(
+  support: IosSnapshotAcquisitionDepthCapability['rawTraversal'],
+  requestedDepth: number,
+): boolean {
+  return (
+    support.kind === 'complete' &&
+    (support.maxDepth === undefined || requestedDepth <= support.maxDepth)
+  );
+}
+
+function lineagesEqual(
+  left: IosSnapshotComparisonIdentity['lineage'],
+  right: IosSnapshotComparisonIdentity['lineage'],
+): boolean {
+  return left.targetId === right.targetId && left.generation === right.generation;
+}
+
+function presentationKeysEqual(
+  left: IosSnapshotPresentationKey,
+  right: IosSnapshotPresentationKey,
+): boolean {
+  return (
+    left.projection === right.projection &&
+    left.interactiveOnly === right.interactiveOnly &&
+    left.depth === right.depth &&
+    left.scope === right.scope &&
+    left.customActions === right.customActions
+  );
+}
+
+function residuesEqual(
+  left: readonly IosAcquisitionResidue[],
+  right: readonly IosAcquisitionResidue[],
+): boolean {
+  return (
+    left.map(residueIdentity).sort().join('\u0000') ===
+    right.map(residueIdentity).sort().join('\u0000')
+  );
+}
+
+function residueIdentity(residue: IosAcquisitionResidue): string {
+  switch (residue.kind) {
+    case 'provider-pruned':
+      return JSON.stringify({ kind: residue.kind, fields: [...residue.fields].sort() });
+    case 'missing-viewport':
+      return JSON.stringify({ kind: residue.kind, reason: residue.reason });
+    case 'truncated':
+      return JSON.stringify({
+        kind: residue.kind,
+        dimension: residue.dimension,
+        limit: residue.limit,
+      });
+    case 'stale-generation':
+      return JSON.stringify({
+        kind: residue.kind,
+        expected: residue.expected,
+        observed: residue.observed,
+      });
+    case 'unavailable-fact':
+      return JSON.stringify({ kind: residue.kind, fact: residue.fact });
+    case 'fallback-source':
+      return JSON.stringify({ kind: residue.kind, producer: residue.producer });
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -243,6 +243,10 @@
       "types": "./src/interaction-guarantees.ts",
       "default": "./src/interaction-guarantees.ts"
     },
+    "./ios-snapshot": {
+      "types": "./src/ios-snapshot.ts",
+      "default": "./src/ios-snapshot.ts"
+    },
     "./interactor-operation-catalog": {
       "types": "./src/interactor-operation-catalog.ts",
       "default": "./src/interactor-operation-catalog.ts"

--- a/packages/contracts/src/ios-snapshot.test.ts
+++ b/packages/contracts/src/ios-snapshot.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type {
+  IosHittabilityEvidence,
+  IosRunnerQualityPayloadFacts,
+  IosSnapshotEngine,
+  IosSnapshotInput,
+  IosSnapshotPublication,
+  IosSnapshotValidationFacts,
+} from './ios-snapshot.ts';
+
+const validation: IosSnapshotValidationFacts = {
+  presentationKey: {
+    projection: 'regular',
+    interactiveOnly: false,
+    depth: null,
+    scope: null,
+    customActions: false,
+  },
+  viewport: { kind: 'missing', reason: 'not-provided' },
+  hittability: { kind: 'unavailable', reason: 'not-provided' },
+  lineage: { targetId: 'simulator-1', generation: 'generation-1' },
+  residue: [],
+};
+
+const acquired: IosSnapshotInput = {
+  stage: 'acquired',
+  acquisition: {
+    producer: 'simulator-ax-bridge',
+    intent: 'full',
+    hint: {
+      projection: 'raw',
+      rawTraversalDepth: null,
+      regularPresentedDepth: null,
+      interactiveOnly: false,
+      customActions: false,
+      acquisitionIntent: 'full',
+    },
+    nodes: [],
+    truncated: false,
+    viewport: { kind: 'missing', reason: 'not-supported' },
+    lineage: { targetId: 'simulator-1', generation: 'generation-1' },
+    residue: [],
+  },
+};
+
+const presented: IosSnapshotInput = {
+  stage: 'presented',
+  presentation: {
+    producer: 'apple-runner',
+    intent: 'full',
+    payload: { nodes: [], truncated: false },
+    qualityPayload: { nodes: [], truncated: false, scope: null },
+  },
+  validation,
+};
+
+const publication: IosSnapshotPublication = {
+  payload: { nodes: [], truncated: false },
+  presentationKey: validation.presentationKey,
+  comparisonIdentity: {
+    producer: 'apple-runner',
+    intent: 'full',
+    lineage: validation.lineage,
+    presentationKey: validation.presentationKey,
+    residue: [],
+  },
+  residue: [],
+};
+
+const nonRunnerPresentation: IosSnapshotInput = {
+  stage: 'presented',
+  presentation: {
+    // @ts-expect-error a presented input cannot use a non-runner producer
+    producer: 'appium-source',
+    intent: 'full',
+    payload: { nodes: [], truncated: false },
+  },
+  validation,
+};
+
+const doubleStage: IosSnapshotInput = {
+  stage: 'acquired',
+  acquisition: acquired.acquisition,
+  // @ts-expect-error a stage carries exactly one acquisition or presentation payload
+  presentation: presented.presentation,
+};
+
+// @ts-expect-error a presented stage cannot skip its runner presentation payload
+const skippedPresentation: IosSnapshotInput = { stage: 'presented', validation };
+
+const qualityPayloadWithScope: IosRunnerQualityPayloadFacts = {
+  nodes: [],
+  truncated: false,
+  // @ts-expect-error quality validation payloads are explicitly unscoped
+  scope: 'Card',
+};
+
+const manufacturedHittability = {
+  // @ts-expect-error geometry and enabled state do not manufacture hittability evidence
+  rect: { x: 0, y: 0, width: 10, height: 10 },
+  enabled: true,
+} satisfies IosHittabilityEvidence;
+
+const publicationWithQualityPayload: IosSnapshotPublication = {
+  ...publication,
+  // @ts-expect-error publication deliberately has no quality-payload field
+  qualityPayload: { nodes: [], truncated: false, scope: null },
+};
+
+const engineWithSecondPresentation: IosSnapshotEngine = {
+  plan: null as unknown as IosSnapshotEngine['plan'],
+  publish: null as unknown as IosSnapshotEngine['publish'],
+  // @ts-expect-error the engine surface has no second presentation operation
+  present: null as never,
+};
+
+test('iOS snapshot stage and engine surfaces stay closed', () => {
+  assert.equal(acquired.stage, 'acquired');
+  assert.equal(presented.stage, 'presented');
+  assert.deepEqual(['plan', 'publish'] satisfies (keyof IosSnapshotEngine)[], ['plan', 'publish']);
+  void doubleStage;
+  void skippedPresentation;
+  void nonRunnerPresentation;
+  void qualityPayloadWithScope;
+  void manufacturedHittability;
+  void publicationWithQualityPayload;
+  void engineWithSecondPresentation;
+});

--- a/packages/contracts/src/ios-snapshot.ts
+++ b/packages/contracts/src/ios-snapshot.ts
@@ -1,0 +1,240 @@
+import type { RawSnapshotNode, Rect, SnapshotNode } from '@agent-device/kernel/snapshot';
+
+export type IosSnapshotProducer =
+  | 'apple-runner'
+  | 'simulator-ax-bridge'
+  | 'appium-source'
+  | 'limrun-ios-tree';
+
+export type IosAcquisitionProducer = Exclude<IosSnapshotProducer, 'apple-runner'>;
+export type IosAcquisitionIntent = 'full' | 'surface-observation';
+export type IosSnapshotProjection = 'regular' | 'raw';
+export type IosSnapshotCompleteness = 'complete' | 'incomplete';
+export type IosSnapshotEvidenceAvailability = 'available' | 'unavailable';
+
+export type IosSnapshotGeneration = string;
+
+export type IosSnapshotLineage = Readonly<{
+  targetId?: string;
+  generation?: IosSnapshotGeneration;
+}>;
+
+export type IosSnapshotPresentationKey = Readonly<{
+  projection: IosSnapshotProjection;
+  interactiveOnly: boolean;
+  depth: number | null;
+  scope: string | null;
+  customActions: boolean;
+}>;
+
+export type IosSnapshotRequest = Readonly<{
+  projection: IosSnapshotProjection;
+  interactiveOnly: boolean;
+  depth: number | null;
+  scope: string | null;
+  customActions: boolean;
+  acquisitionIntent: IosAcquisitionIntent;
+}>;
+
+export type IosSnapshotRequestInput = Readonly<{
+  projection?: IosSnapshotProjection;
+  raw?: boolean;
+  interactiveOnly?: boolean;
+  depth?: number | null;
+  scope?: string | null;
+  customActions?: boolean;
+  acquisitionIntent?: IosAcquisitionIntent;
+}>;
+
+export type CaptureHint = Readonly<{
+  projection: IosSnapshotProjection;
+  rawTraversalDepth: number | null;
+  regularPresentedDepth: number | null;
+  interactiveOnly: boolean;
+  customActions: boolean;
+  acquisitionIntent: IosAcquisitionIntent;
+}>;
+
+export type IosSnapshotDepthSupport =
+  | Readonly<{ kind: 'complete'; maxDepth?: number }>
+  | Readonly<{ kind: 'incomplete' }>
+  | Readonly<{ kind: 'not-applicable' }>;
+
+export type IosSnapshotAcquisitionDepthCapability = Readonly<{
+  rawTraversal: IosSnapshotDepthSupport;
+  regularPresented: IosSnapshotDepthSupport;
+}>;
+
+export type IosSnapshotFact =
+  | 'acquisition-depth'
+  | 'scope'
+  | 'interactive-query'
+  | 'viewport'
+  | 'hittability'
+  | 'generation';
+
+type IosSnapshotProducerCapabilityFacts = Readonly<{
+  acquisitionDepth: IosSnapshotAcquisitionDepthCapability;
+  scopeCompleteness: IosSnapshotCompleteness;
+  interactiveQueryCompleteness: IosSnapshotCompleteness;
+  viewportEvidence: IosSnapshotEvidenceAvailability;
+  hittabilityEvidence: IosSnapshotEvidenceAvailability;
+}>;
+
+export type IosSnapshotAcquisitionProducerCapabilities = IosSnapshotProducerCapabilityFacts &
+  Readonly<{
+    producer: IosAcquisitionProducer;
+    stage: 'acquired';
+  }>;
+
+export type IosSnapshotPresentedProducerCapabilities = IosSnapshotProducerCapabilityFacts &
+  Readonly<{
+    producer: 'apple-runner';
+    stage: 'presented';
+  }>;
+
+export type IosSnapshotProducerCapabilities =
+  | IosSnapshotAcquisitionProducerCapabilities
+  | IosSnapshotPresentedProducerCapabilities;
+
+export type IosViewportEvidence =
+  | Readonly<{ kind: 'reported'; rect: Rect }>
+  | Readonly<{ kind: 'derived'; rect: Rect }>
+  | Readonly<{
+      kind: 'missing';
+      reason: 'not-provided' | 'not-supported' | 'invalid';
+    }>;
+
+export type IosHittabilityEvidence =
+  | Readonly<{ kind: 'available' }>
+  | Readonly<{
+      kind: 'unavailable';
+      reason: 'not-provided' | 'not-supported' | 'partial';
+    }>;
+
+export type IosProviderPrunedField = 'nodes' | 'depth' | 'scope' | 'interactive-only';
+export type IosTruncationDimension = 'nodes' | 'depth' | 'payload';
+
+export type IosAcquisitionResidue =
+  | Readonly<{
+      kind: 'provider-pruned';
+      fields: readonly IosProviderPrunedField[];
+    }>
+  | Readonly<{
+      kind: 'missing-viewport';
+      reason: 'not-provided' | 'not-supported' | 'invalid';
+    }>
+  | Readonly<{
+      kind: 'truncated';
+      dimension: IosTruncationDimension;
+      limit?: number;
+    }>
+  | Readonly<{
+      kind: 'stale-generation';
+      expected?: IosSnapshotGeneration;
+      observed?: IosSnapshotGeneration;
+    }>
+  | Readonly<{
+      kind: 'unavailable-fact';
+      fact: IosSnapshotFact;
+    }>
+  | Readonly<{
+      kind: 'fallback-source';
+      producer: IosSnapshotProducer;
+    }>;
+
+type IosSnapshotAcquisitionForIntent<Intent extends IosAcquisitionIntent> = Readonly<{
+  producer: IosAcquisitionProducer;
+  intent: Intent;
+  hint: CaptureHint & Readonly<{ acquisitionIntent: Intent }>;
+  nodes: readonly RawSnapshotNode[];
+  truncated: boolean;
+  viewport: IosViewportEvidence;
+  lineage: IosSnapshotLineage;
+  residue: readonly IosAcquisitionResidue[];
+}>;
+
+export type IosSnapshotAcquisition =
+  | IosSnapshotAcquisitionForIntent<'full'>
+  | IosSnapshotAcquisitionForIntent<'surface-observation'>;
+
+export type IosRunnerPayloadFacts = Readonly<{
+  nodes: readonly RawSnapshotNode[];
+  truncated: boolean;
+  effectiveDepth?: number;
+}>;
+
+export type IosRunnerQualityPayloadFacts = IosRunnerPayloadFacts &
+  Readonly<{
+    scope: null;
+  }>;
+
+export type IosRunnerPresentation = Readonly<{
+  producer: 'apple-runner';
+  intent: IosAcquisitionIntent;
+  payload: IosRunnerPayloadFacts;
+  qualityPayload?: IosRunnerQualityPayloadFacts;
+}>;
+
+export type IosSnapshotValidationFacts = Readonly<{
+  presentationKey: IosSnapshotPresentationKey;
+  viewport: IosViewportEvidence;
+  hittability: IosHittabilityEvidence;
+  lineage: IosSnapshotLineage;
+  residue: readonly IosAcquisitionResidue[];
+}>;
+
+export type IosSnapshotInput =
+  | Readonly<{
+      stage: 'acquired';
+      acquisition: IosSnapshotAcquisition;
+    }>
+  | Readonly<{
+      stage: 'presented';
+      presentation: IosRunnerPresentation;
+      validation: IosSnapshotValidationFacts;
+    }>;
+
+export type IosSnapshotAcquisitionNarrowing = Readonly<{
+  depth: number | null;
+  scope: null;
+  interactiveOnly: boolean;
+}>;
+
+export type IosSnapshotPlan = Readonly<{
+  request: IosSnapshotRequest;
+  producer: IosSnapshotProducer;
+  hint: CaptureHint;
+  narrowing: IosSnapshotAcquisitionNarrowing;
+  evidence: Readonly<{
+    scope: IosSnapshotCompleteness;
+    interactiveQuery: IosSnapshotCompleteness;
+    viewport: IosSnapshotEvidenceAvailability;
+    hittability: IosSnapshotEvidenceAvailability;
+  }>;
+}>;
+
+export type IosSnapshotPublishedPayload = Readonly<{
+  nodes: readonly SnapshotNode[];
+  truncated: boolean;
+}>;
+
+export type IosSnapshotComparisonIdentity = Readonly<{
+  producer: IosSnapshotProducer;
+  intent: IosAcquisitionIntent;
+  lineage: IosSnapshotLineage;
+  presentationKey: IosSnapshotPresentationKey;
+  residue: readonly IosAcquisitionResidue[];
+}>;
+
+export type IosSnapshotPublication = Readonly<{
+  payload: IosSnapshotPublishedPayload;
+  presentationKey: IosSnapshotPresentationKey;
+  comparisonIdentity: IosSnapshotComparisonIdentity;
+  residue: readonly IosAcquisitionResidue[];
+}>;
+
+export type IosSnapshotEngine = Readonly<{
+  plan(request: IosSnapshotRequest, producer: IosSnapshotProducerCapabilities): IosSnapshotPlan;
+  publish(input: IosSnapshotInput, request: IosSnapshotRequest): IosSnapshotPublication;
+}>;

--- a/scripts/layering/contracts-implementation-policy.test.ts
+++ b/scripts/layering/contracts-implementation-policy.test.ts
@@ -101,7 +101,7 @@ test('iOS snapshot contracts reject planning implementation and provider imports
   assert.match(
     messages(
       [
-        "import type { planIosSnapshot } from '@agent-device/capture-kit';",
+        "import type { planIosSnapshot } from '@agent-device/capture-kit/ios-snapshot-planning';",
         'export type IosPlan = { readonly value: string };',
       ].join('\n'),
       contract,

--- a/scripts/layering/contracts-implementation-policy.test.ts
+++ b/scripts/layering/contracts-implementation-policy.test.ts
@@ -91,3 +91,41 @@ test('contracts rejects snapshot quality warning rendering', () => {
     /src\/snapshot\/snapshot-presentation/,
   );
 });
+
+test('iOS snapshot contracts reject planning implementation and provider imports', () => {
+  const contract = 'packages/contracts/src/ios-snapshot.ts';
+  assert.match(
+    messages('export const presentSnapshot = (nodes: unknown[]) => nodes;', contract)[0]!,
+    /typed vocabulary only/,
+  );
+  assert.match(
+    messages(
+      [
+        "import type { planIosSnapshot } from '@agent-device/capture-kit';",
+        'export type IosPlan = { readonly value: string };',
+      ].join('\n'),
+      contract,
+    )[0]!,
+    /planning algorithms or provider\/lifecycle implementation/,
+  );
+  assert.match(
+    messages(
+      [
+        "import type { ProviderSnapshot } from '@agent-device/provider-ios';",
+        'export type IosProvider = { readonly value: string };',
+      ].join('\n'),
+      contract,
+    )[0]!,
+    /provider\/lifecycle implementation/,
+  );
+  assert.deepEqual(
+    messages(
+      [
+        "import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';",
+        'export type IosNode = RawSnapshotNode;',
+      ].join('\n'),
+      contract,
+    ),
+    [],
+  );
+});

--- a/scripts/layering/contracts-implementation-policy.ts
+++ b/scripts/layering/contracts-implementation-policy.ts
@@ -13,6 +13,7 @@ const FORBIDDEN_TIMER_CALLS = new Set([
   'setInterval',
   'setTimeout',
 ]);
+const IOS_SNAPSHOT_CONTRACT = 'packages/contracts/src/ios-snapshot.ts';
 
 /** Contracts owns vocabulary. Host/process/timer mechanics belong in capture-kit or an adapter. */
 export function contractsImplementationAuthorityViolations(
@@ -46,6 +47,8 @@ export function contractsImplementationAuthorityViolations(
       );
     }
     if (networkTrafficViolation) violations.push(networkTrafficViolation);
+    const iosSnapshotViolation = iosSnapshotContractViolation(file.path, file.source, parsed);
+    if (iosSnapshotViolation) violations.push(iosSnapshotViolation);
     for (const site of moduleSpecifiers(parsed.module, file.source)) {
       if (!FORBIDDEN_HOST_MODULES.test(site.spec)) continue;
       violations.push(
@@ -70,6 +73,31 @@ export function contractsImplementationAuthorityViolations(
     });
   }
   return violations;
+}
+
+function iosSnapshotContractViolation(
+  file: string,
+  source: string,
+  parsed: ReturnType<typeof parseSync>,
+): LayeringViolation | undefined {
+  if (file !== IOS_SNAPSHOT_CONTRACT) return undefined;
+  const implementation = parsed.program.body.find((statement) => !isTypeOnlyStatement(statement));
+  if (implementation && typeof implementation === 'object') {
+    return violation(
+      file,
+      lineAt(source, Number((implementation as Record<string, unknown>).start ?? 0)),
+      'iOS snapshot contracts own typed vocabulary only; planning algorithms and provider/lifecycle implementations cannot enter contracts',
+    );
+  }
+  const disallowedImport = moduleSpecifiers(parsed.module, source).find(
+    ({ spec }) => !spec.startsWith('@agent-device/kernel/'),
+  );
+  if (!disallowedImport) return undefined;
+  return violation(
+    file,
+    disallowedImport.line,
+    `iOS snapshot contracts may import only kernel vocabulary; '${disallowedImport.spec}' would bring planning algorithms or provider/lifecycle implementation into contracts`,
+  );
 }
 
 function networkTrafficImplementationViolation(

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -458,6 +458,7 @@ test('the real tree parses, declares, and passes R11', () => {
   );
   assert.deepEqual([...captureKitPackage.exportTargets.keys()].sort(), [
     '@agent-device/capture-kit',
+    '@agent-device/capture-kit/ios-snapshot-planning',
     '@agent-device/capture-kit/mobile-snapshot-semantics',
     '@agent-device/capture-kit/png',
     '@agent-device/capture-kit/png-resize',

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -107,6 +107,7 @@ const CONTRACT_EXPORTS = [
   '@agent-device/contracts/interaction-guarantees',
   '@agent-device/contracts/interactor-operation-catalog',
   '@agent-device/contracts/interactor-types',
+  '@agent-device/contracts/ios-snapshot',
   '@agent-device/contracts/keyboard',
   '@agent-device/contracts/keyboard-runtime',
   '@agent-device/contracts/local-interactor-operation-set',

--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -120,6 +120,8 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   // --- @agent-device/capture-kit ---
   // R60 review: audio-probe split into descriptor/status/recovery/live-process modules (+3 files).
   'packages/capture-kit/src/index.ts': 32,
+  // #2190 keeps iOS snapshot planning behind its dedicated subpath instead of the broad root.
+  'packages/capture-kit/src/ios-snapshot-planning.ts': 1,
   'packages/capture-kit/src/png-resize.ts': 18,
   'packages/capture-kit/src/png-rgb-difference.ts': 1,
   'packages/capture-kit/src/png-size.ts': 3,
@@ -222,6 +224,8 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   'packages/contracts/src/interaction-error.ts': 1,
   'packages/contracts/src/interaction-guarantees.ts': 1,
   'packages/contracts/src/interactor-types.ts': 1,
+  // #2190's iOS snapshot vocabulary has type-only imports and remains a one-module entry.
+  'packages/contracts/src/ios-snapshot.ts': 1,
   'packages/contracts/src/keyboard.ts': 1,
   'packages/contracts/src/logs-runtime-plan.ts': 5,
   'packages/contracts/src/managed-web-backend.ts': 1,


### PR DESCRIPTION
Closes #2190

## Publication status

Published and reported at commit `bce60b56f`. This PR is open for review; it is not claimed merge-ready while the required external audit remains outstanding.

## Summary

- Add the closed, typed iOS snapshot acquisition/presentation vocabulary in `@agent-device/contracts`.
- Add pure request-to-capture-hint derivation, producer capability policy, narrowing evidence, and comparison identity helpers in `@agent-device/capture-kit/ios-snapshot-planning`.
- Keep the planner behind a dedicated capture-kit subpath so the broad `@agent-device/capture-kit` facade remains implementation-lazy.
- Add the implementation-independent golden derivation table, exhaustive type tests, capability/comparison tests, and the structural contracts-only guard.
- Preserve the issue boundary: no live routing, producer selection, presentation implementation, fallback behavior, public command behavior, daemon RPC fields, provider migration, or ADR ownership change.

## Validation

- `pnpm format`, focused contract/planning tests, layering, and Fallow checks passed.
- The focused contract/planning/eager run passed 3 test files and 406 tests; the eager-closure gate passed all 397 tests, including exact one-module pins for both new entry surfaces.
- The planted-red eager check temporarily lowered the iOS contracts pin from 1 to 0 and failed with the named stale-pin diagnostic; restoring the measured pin returned the gate to green.
- `pnpm check:layering` passed all 179 tests; R11 now reports 198 exported subpaths with zero boundary violations. `pnpm check:fallow --base origin/main` reports no issues in 12 changed files.
- The canonical `pnpm check:affected --run` selected 56 checks because of package/tooling changes. Format, lint, typecheck, layering, DI seams, Fallow, metadata, build, package, integration-node, and macOS coverage passed. Its Vitest-related portion reached 367 files and 2,849 tests; 366 files and 2,848 tests passed, with the sole failure being the known hermetic `session-open-runtime` process-ownership case. That case passes 1/1 when isolated.
- The first iOS CI smoke attempt hit `TEXT_INPUT_COMMIT_NOT_OBSERVED` while seeding the fixture email field, with empty xcodebuild stderr. The failed job rerun passed the full iOS simulator lane, so this was classified as a native-lane flake rather than a PR-attributable failure.
- All GitHub CI checks for the current head pass, including Coverage, Repo Guards, Typecheck & Package, Integration Tests, and the iOS, Android, macOS, and Linux smoke lanes. The physical-device iOS replay is skipped by lane configuration.
- The standalone mutation-model self-test has three pre-existing failures on this head and clean `origin/main`: the stale `scroll-edge-state` registry path and its two ownership assertions. This PR does not touch that registry or ownership surface.
- The wire compatibility gate reports no intentional daemon RPC wire change. The remote head matches the exact commit above.

## Review note

The required external adversarial read-only `claude -p` review remains outstanding because the Claude CLI is unauthenticated in this environment. It was not replaced with another reviewer, and this limitation is intentionally reported here for follow-up.

No documentation or skill changes were needed because this is an internal unreleased contract/planning change with no public behavior change.