### PR TITLE
refactor(url): split client and Metro URL ownership

### DIFF
--- a/src/__tests__/eager-closure-budgets.ts
+++ b/src/__tests__/eager-closure-budgets.ts
@@ -398,7 +398,8 @@ export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   // module records for the same code, with no new subtree behind any of them.
   // #2148 moves output-only CLI dependencies behind call-time imports and reduces the entry
   // closure by two modules.
-  'src/cli.ts': 378,
+  // #2146 splits one eagerly reached URL utility into its client and Metro owners.
+  'src/cli.ts': 379,
   'src/platform-runtime.ts': 47,
   'src/core/command-descriptor/registry.ts': 71,
   'src/core/command-descriptor/platform-execution-entry.ts': 3,

--- a/src/client/base-url.test.ts
+++ b/src/client/base-url.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { normalizeBaseUrl } from '../url.ts';
+import { normalizeBaseUrl } from './base-url.ts';
 
 test('normalizeBaseUrl trims trailing slashes without changing other characters', () => {
   assert.equal(normalizeBaseUrl('https://example.test'), 'https://example.test');

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,0 +1,7 @@
+export function normalizeBaseUrl(input: string): string {
+  let end = input.length;
+  while (end > 0 && input.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return end === input.length ? input : input.slice(0, end);
+}

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,7 +1,5 @@
 export function normalizeBaseUrl(input: string): string {
   let end = input.length;
-  while (end > 0 && input.charCodeAt(end - 1) === 47) {
-    end -= 1;
-  }
+  while (end > 0 && input.charCodeAt(end - 1) === 47) end -= 1;
   return end === input.length ? input : input.slice(0, end);
 }

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,5 +1,7 @@
 export function normalizeBaseUrl(input: string): string {
   let end = input.length;
-  while (end > 0 && input.charCodeAt(end - 1) === 47) end -= 1;
+  while (end > 0 && input.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
   return end === input.length ? input : input.slice(0, end);
 }

--- a/src/client/client-companion-tunnel-worker.ts
+++ b/src/client/client-companion-tunnel-worker.ts
@@ -25,7 +25,7 @@ import type {
   MetroTunnelRequestMessage as MetroCompanionRequest,
   MetroTunnelResponseMessage,
 } from '../metro/metro.ts';
-import { normalizeBaseUrl } from '../utils/url.ts';
+import { normalizeBaseUrl } from './base-url.ts';
 
 const COMPANION_REGISTER_TIMEOUT_MS = 5_000;
 const COMPANION_REGISTER_MAX_RETRY_DELAY_MS = 60_000;

--- a/src/client/client-companion-tunnel.ts
+++ b/src/client/client-companion-tunnel.ts
@@ -17,7 +17,7 @@ import {
   ENV_COMPANION_TUNNEL_STATE_PATH,
   ENV_COMPANION_TUNNEL_UNREGISTER_PATH,
 } from './client-companion-tunnel-contract.ts';
-import { normalizeBaseUrl } from '../utils/url.ts';
+import { normalizeBaseUrl } from './base-url.ts';
 import { runCmdDetached } from '@agent-device/host-kit/command';
 import {
   isProcessAlive,

--- a/src/metro/bundle-url.test.ts
+++ b/src/metro/bundle-url.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildBundleUrl } from './bundle-url.ts';
+
+test('buildBundleUrl normalizes the base URL and adds Metro query parameters', () => {
+  assert.equal(
+    buildBundleUrl('https://example.test///', 'ios'),
+    'https://example.test/index.bundle?platform=ios&dev=true&minify=false',
+  );
+});
+
+test('buildBundleUrl preserves the URL path and serializes a custom entry path', () => {
+  assert.equal(
+    buildBundleUrl(
+      'https://example.test:8081/api/metro/runtimes/runtime-1/',
+      'android',
+      '.expo/.virtual-metro-entry.bundle',
+    ),
+    'https://example.test:8081/api/metro/runtimes/runtime-1/.expo/.virtual-metro-entry.bundle?platform=android&dev=true&minify=false',
+  );
+});

--- a/src/metro/bundle-url.ts
+++ b/src/metro/bundle-url.ts
@@ -1,10 +1,4 @@
-export function normalizeBaseUrl(input: string): string {
-  let end = input.length;
-  while (end > 0 && input.charCodeAt(end - 1) === 47) {
-    end -= 1;
-  }
-  return end === input.length ? input : input.slice(0, end);
-}
+import { normalizeBaseUrl } from '../client/base-url.ts';
 
 export function buildBundleUrl(
   baseUrl: string,

--- a/src/metro/bundle-url.ts
+++ b/src/metro/bundle-url.ts
@@ -1,11 +1,13 @@
 import { normalizeBaseUrl } from '../client/base-url.ts';
+
 export function buildBundleUrl(
   baseUrl: string,
   platform: 'ios' | 'android',
   entryPath = 'index.bundle',
 ): string {
   const url = new URL(`${normalizeBaseUrl(baseUrl)}/${entryPath}`);
-  const query = { platform, dev: 'true', minify: 'false' };
-  Object.entries(query).forEach(([key, value]) => url.searchParams.set(key, value));
+  url.searchParams.set('platform', platform);
+  url.searchParams.set('dev', 'true');
+  url.searchParams.set('minify', 'false');
   return url.toString();
 }

--- a/src/metro/bundle-url.ts
+++ b/src/metro/bundle-url.ts
@@ -1,13 +1,11 @@
 import { normalizeBaseUrl } from '../client/base-url.ts';
-
 export function buildBundleUrl(
   baseUrl: string,
   platform: 'ios' | 'android',
   entryPath = 'index.bundle',
 ): string {
   const url = new URL(`${normalizeBaseUrl(baseUrl)}/${entryPath}`);
-  url.searchParams.set('platform', platform);
-  url.searchParams.set('dev', 'true');
-  url.searchParams.set('minify', 'false');
+  const query = { platform, dev: 'true', minify: 'false' };
+  Object.entries(query).forEach(([key, value]) => url.searchParams.set(key, value));
   return url.toString();
 }

--- a/src/metro/client-metro.ts
+++ b/src/metro/client-metro.ts
@@ -29,7 +29,8 @@ import {
   readProjectPackageJson,
   type PackageJsonShape,
 } from '../utils/project-runtime.ts';
-import { buildBundleUrl, normalizeBaseUrl } from '../utils/url.ts';
+import { normalizeBaseUrl } from '../client/base-url.ts';
+import { buildBundleUrl } from './bundle-url.ts';
 import {
   EXPO_VIRTUAL_ENTRY_BUNDLE_PATH,
   parsePort,

--- a/src/sdk/metro.ts
+++ b/src/sdk/metro.ts
@@ -1,4 +1,5 @@
-export { buildBundleUrl, normalizeBaseUrl } from '../utils/url.ts';
+export { normalizeBaseUrl } from '../client/base-url.ts';
+export { buildBundleUrl } from '../metro/bundle-url.ts';
 export type {
   MetroBridgeDescriptor,
   MetroTunnelRequestMessage,


### PR DESCRIPTION
## Summary

Split the URL helpers into their owning client and Metro modules. Companion tunnel consumers now use the client-owned base URL normalizer; Metro builds bundle URLs through its Metro owner; `agent-device/metro` re-exports both names directly from their owners. The old shared utility and test are removed. Closes #2146.

The moved production implementations remain verbatim. After discounting the physical move, the only production additions are the three required owner edges: the Metro owner imports the client normalizer, and the two existing multi-symbol import/export statements split across the two named owners. No common/shared module, compatibility shim, internal barrel, or duplicate implementation was added. The exact CLI eager-closure budget records the measured 379-module ownership split.

## Validation

- Observed planted-red proof: retaining the trailing slash made `src/client/base-url.test.ts` fail; changing the bundle query to `minify=true` made both `src/metro/bundle-url.test.ts` cases fail; both violations were restored.
- Focused client/Metro/companion/public/eager-closure validation passed: 10 files, 439 tests.
- `pnpm check:affected --run` passed: format, lint, typecheck, layering, Fallow, build, and 1,158 related tests.
- Clean-consumer package verification, `pnpm check:production-exports`, and the package/layering/Fallow checks passed.