### PR TITLE
fix: preserve physical iOS session health check

### DIFF
--- a/packages/platform-apple/src/lifecycle.test.ts
+++ b/packages/platform-apple/src/lifecycle.test.ts
@@ -96,6 +96,38 @@ test('starts an unawaited physical iOS first-open runner without a redundant hea
   });
 });
 
+test('preserves runner health proof for an unawaited physical iOS open in an existing session', async () => {
+  const signal = new AbortController().signal;
+  const events: string[] = [];
+  const interactor = {
+    open: vi.fn(async () => {
+      events.push('open');
+    }),
+  } as unknown as Interactor;
+  const baseHost = platformRuntimeHostFixture();
+  const prewarmRunnerSession = vi.fn(async () => {
+    events.push('prewarm');
+  });
+  const host = {
+    ...baseHost,
+    localInteractors: { resolve: async () => interactor },
+    appleApplications: {
+      ...baseHost.appleApplications,
+      prewarmRunnerSession,
+    },
+  } as unknown as PlatformRuntimeHost;
+  const lifecycle = bindAppleApplicationLifecycle({ host, device, signal });
+
+  await lifecycle.openApplication({
+    ...openInput(),
+    hasExistingSession: true,
+    relaunch: false,
+  });
+
+  expect(events).toEqual(['open', 'prewarm']);
+  expect(prewarmRunnerSession).toHaveBeenCalledWith(device, {}, signal, false);
+});
+
 test('preserves the health check when physical iOS runner prewarm is awaited', async () => {
   const signal = new AbortController().signal;
   const events: string[] = [];

--- a/packages/platform-apple/src/lifecycle.ts
+++ b/packages/platform-apple/src/lifecycle.ts
@@ -409,6 +409,7 @@ function isUnawaitedPhysicalIosOpen(device: DeviceInfo, input: OpenApplicationIn
   return (
     device.kind === 'device' &&
     device.appleOs === 'ios' &&
+    !input.hasExistingSession &&
     !input.relaunch &&
     !input.prewarmRunnerBeforeOpen
   );


### PR DESCRIPTION
## Summary

Restore physical iOS runner health proof for an ordinary open in an existing session.

PR #2215 intentionally removed the redundant uptime probe from an unawaited first open, but its predicate also matched later opens in an active session. This keeps the first-open optimization and limits `healthCheck: false` to sessions that do not already exist.

Adds an adversarial lifecycle regression covering the existing-session boundary. Two files changed; scope stayed within Apple application lifecycle.

## Validation

- Planted red: the new lifecycle test received `{ healthCheck: false }` on the pre-fix source.
- Focused green: lifecycle 9/9; runner prewarm contract 3/3.
- Physical iPhone: an ordinary same-session Settings open was followed by a warm, healthy XCTest tree snapshot in 1.09s (116.96ms acquisition); session close and retained-runner cleanup succeeded.
- `pnpm check:affected --run`: format, lint, typecheck, layering, fallow, and build passed. The related-test lane encountered timeout-shaped host contention while other worktrees were running gates; its initial six failures passed serially 38/38, and the later changing failures had passed in the prior run. GitHub CI remains authoritative for the exact head.

No CLI, help, docs, or skill surface changed.
