### PR TITLE
refactor(daemon): move shared snapshot execution out of handlers

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -268,11 +268,6 @@
         "count": 1
       }
     },
-    "src/daemon/handlers/snapshot-capture.ts": {
-      "crap_moderate": {
-        "count": 3
-      }
-    },
     "src/daemon/handlers/snapshot-settings.ts": {
       "complexity_moderate": {
         "count": 1

--- a/scripts/layering/architecture-ownership.ts
+++ b/scripts/layering/architecture-ownership.ts
@@ -96,6 +96,12 @@ export const SESSION_OBSERVABILITY_RETIRED_HANDLER_PATHS = [
   'src/daemon/handlers/session-audio.ts',
 ] as const;
 
+export const SNAPSHOT_EXECUTION_RETIRED_HANDLER_PATHS = [
+  'src/daemon/handlers/snapshot-capture.ts',
+  'src/daemon/handlers/snapshot-interactor-capture.ts',
+  'src/daemon/handlers/snapshot-session.ts',
+] as const;
+
 export const LOGICAL_MODULE_POLICIES = [
   {
     name: 'ad-replay',

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -79,6 +79,7 @@ import {
   checkRetiredInteractionPaths,
   checkRetiredSessionLifecyclePaths,
   checkRetiredSessionObservabilityPaths,
+  checkRetiredSnapshotExecutionPaths,
   daemonModularitySummary,
 } from './daemon-modularity.ts';
 import {
@@ -594,6 +595,7 @@ export const LAYERING_RULES: Readonly<Record<LayeringRuleId, LayeringRule>> = {
     ...checkDaemonModularityRatchets(context.edges, context.typeCycleMembers),
     ...checkRetiredSessionLifecyclePaths(context.sourceFiles),
     ...checkRetiredSessionObservabilityPaths(context.sourceFiles),
+    ...checkRetiredSnapshotExecutionPaths(context.sourceFiles),
     ...checkRetiredInteractionPaths(context.sourceFiles),
   ],
   'daemon-platform-boundary': (context) =>

--- a/scripts/layering/daemon-modularity.test.ts
+++ b/scripts/layering/daemon-modularity.test.ts
@@ -5,6 +5,7 @@ import {
   checkRetiredInteractionPaths,
   checkRetiredSessionLifecyclePaths,
   checkRetiredSessionObservabilityPaths,
+  checkRetiredSnapshotExecutionPaths,
   DAEMON_MODULARITY_BASELINE,
   TYPE_CYCLE_BASELINE,
 } from './daemon-modularity.ts';
@@ -414,6 +415,25 @@ test('session observability rejects handler deep imports in both directions', ()
       },
     ],
   );
+});
+
+test('snapshot execution cannot return to handler-owned support paths', () => {
+  const restored = [
+    'src/daemon/handlers/snapshot-capture.ts',
+    'src/daemon/handlers/snapshot-interactor-capture.ts',
+    'src/daemon/handlers/snapshot-session.ts',
+  ];
+
+  assert.deepEqual(
+    checkRetiredSnapshotExecutionPaths(restored).map(({ file, message }) => ({ file, message })),
+    restored.map((file) => ({
+      file,
+      message:
+        `retired snapshot execution handler path was restored: ${file}. ` +
+        'Reuse the daemon-owned snapshot execution module instead of restoring shared mechanics beneath a route adapter.',
+    })),
+  );
+  assert.deepEqual(checkRetiredSnapshotExecutionPaths(['src/daemon/handlers/snapshot.ts']), []);
 });
 
 test('session lifecycle rejects restored neutral helper paths', () => {

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -5,6 +5,7 @@ import {
   matchesDeclaredRoot,
   SESSION_LIFECYCLE_RETIRED_HANDLER_PATHS,
   SESSION_OBSERVABILITY_RETIRED_HANDLER_PATHS,
+  SNAPSHOT_EXECUTION_RETIRED_HANDLER_PATHS,
   type LogicalModulePolicy,
 } from './architecture-ownership.ts';
 import { targetDagZone, type LayeringViolation, type ResolvedImportEdge } from './model.ts';
@@ -75,6 +76,18 @@ export function checkRetiredSessionObservabilityPaths(
     SESSION_OBSERVABILITY_RETIRED_HANDLER_PATHS,
     /^src\/daemon\/handlers\/session-(?:observability|perf|logs|events|network|audio)(?:-[^/]+)?\.ts$/,
     'session observability',
+  );
+}
+
+export function checkRetiredSnapshotExecutionPaths(
+  sourceFiles: readonly string[],
+): LayeringViolation[] {
+  return checkRetiredHandlerPaths(
+    sourceFiles,
+    SNAPSHOT_EXECUTION_RETIRED_HANDLER_PATHS,
+    /$^/,
+    'snapshot execution handler',
+    'Reuse the daemon-owned snapshot execution module instead of restoring shared mechanics beneath a route adapter.',
   );
 }
 

--- a/scripts/layering/daemon-platform-boundary.test.ts
+++ b/scripts/layering/daemon-platform-boundary.test.ts
@@ -246,7 +246,7 @@ test('R65 rejects platform selection inside cleanup orchestrators', () => {
 
   const predicate = violations(
     'export const cleanup = (device: any) => isIosFamily(device);',
-    'src/daemon/handlers/snapshot-session.ts',
+    'src/daemon/snapshot-session.ts',
   );
   assert.match(predicate[0]?.message ?? '', /typed root-composed cleanup capability/);
 
@@ -259,7 +259,7 @@ test('R65 rejects platform selection inside cleanup orchestrators', () => {
   assert.deepEqual(
     violations(
       'export const cleanup = (owner: any, device: any) => owner.cleanupSessionlessExecutionHost(device);',
-      'src/daemon/handlers/snapshot-session.ts',
+      'src/daemon/snapshot-session.ts',
     ),
     [],
   );

--- a/scripts/layering/daemon-platform-boundary.ts
+++ b/scripts/layering/daemon-platform-boundary.ts
@@ -361,7 +361,7 @@ export function daemonPlatformBoundaryViolations(
 const CLEANUP_ORCHESTRATORS = new Set([
   'src/daemon/session-teardown.ts',
   'src/daemon/session-lifecycle/internal/session-close-lifecycle-teardown.ts',
-  'src/daemon/handlers/snapshot-session.ts',
+  'src/daemon/snapshot-session.ts',
 ]);
 
 function cleanupDispatchViolations(sources: readonly ProductionSource[]): LayeringViolation[] {

--- a/src/cli/replay-test/__tests__/session-test-reporter-values.test.ts
+++ b/src/cli/replay-test/__tests__/session-test-reporter-values.test.ts
@@ -13,7 +13,7 @@
 import { expect, test, vi } from 'vitest';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
 
-vi.mock('../../../daemon/handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../daemon/snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(async () => {
     throw new Error('no device runner available in this test');
   }),

--- a/src/daemon/__tests__/interaction-get-runtime-fixture.ts
+++ b/src/daemon/__tests__/interaction-get-runtime-fixture.ts
@@ -27,7 +27,7 @@ import {
 } from '@agent-device/contracts/touch-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import { captureSnapshotWithInteractor } from '../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../snapshot-interactor-capture.ts';
 import { androidObservationFixture } from './android-observation-fixture.ts';
 import { createUnavailableRuntimeFactsForTest } from '../../__tests__/test-utils/runtime-operation-facts.ts';
 

--- a/src/daemon/__tests__/legacy-snapshot-capture-fixture.ts
+++ b/src/daemon/__tests__/legacy-snapshot-capture-fixture.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { SnapshotResult } from '@agent-device/contracts/interactor-types';
-import type { captureSnapshotWithInteractor } from '../handlers/snapshot-interactor-capture.ts';
+import type { captureSnapshotWithInteractor } from '../snapshot-interactor-capture.ts';
 
 type CaptureParams = Parameters<typeof captureSnapshotWithInteractor>[0];
 

--- a/src/daemon/__tests__/snapshot-capture.test.ts
+++ b/src/daemon/__tests__/snapshot-capture.test.ts
@@ -1,11 +1,11 @@
 import { expect, test, vi } from 'vitest';
 import { captureSnapshotData } from '../snapshot-capture.ts';
-import { buildSnapshotVisibility } from '../../../snapshot/snapshot-visibility.ts';
+import { buildSnapshotVisibility } from '../../snapshot/snapshot-visibility.ts';
 import {
   ANDROID_EMULATOR,
   IOS_SIMULATOR,
   MACOS_DEVICE,
-} from '../../../__tests__/test-utils/device-fixtures.ts';
+} from '../../__tests__/test-utils/device-fixtures.ts';
 
 const captureSnapshotWithInteractor = vi.hoisted(() => vi.fn());
 vi.mock('../snapshot-interactor-capture.ts', () => ({ captureSnapshotWithInteractor }));

--- a/src/daemon/__tests__/snapshot-quality-latch.test.ts
+++ b/src/daemon/__tests__/snapshot-quality-latch.test.ts
@@ -18,7 +18,7 @@ import type { SessionState } from '../types.ts';
 import { legacyDispatchCapture } from './legacy-snapshot-capture-fixture.ts';
 import { snapshotRuntimeFixture } from './snapshot-runtime-fixture.ts';
 
-vi.mock('../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('./legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/__tests__/system-surface-disclosure.test.ts
+++ b/src/daemon/__tests__/system-surface-disclosure.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../core/dispatch-resolve.ts', async (importOriginal) => {
   };
 });
 
-vi.mock('../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('./legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/handlers/__tests__/react-native.test.ts
+++ b/src/daemon/handlers/__tests__/react-native.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 import path from 'node:path';
 import { handleReactNativeCommands } from '../react-native.ts';
-import { captureSnapshot } from '../snapshot-capture.ts';
+import { captureSnapshot } from '../../snapshot-capture.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { SessionState } from '../../types.ts';
 import { mkdtempForTestSync } from '../../../__tests__/test-utils/tmp-dir.ts';
@@ -11,7 +11,7 @@ import {
   resetGetRuntimeFixture,
 } from '../../__tests__/interaction-get-runtime-fixture.ts';
 
-vi.mock('../snapshot-capture.ts', () => ({
+vi.mock('../../snapshot-capture.ts', () => ({
   captureSnapshot: vi.fn(),
 }));
 

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../__tests__/interaction-get-runtime-fixture.ts';
 import fs from 'node:fs';
 import { handleSnapshotCommands as handleProductionSnapshotCommands } from '../snapshot.ts';
-import { captureSnapshot } from '../snapshot-capture.ts';
+import { captureSnapshot } from '../../snapshot-capture.ts';
 import { SessionStore } from '../../session-store.ts';
 import { setActiveProviderDeviceRuntimes } from '../../../provider-device-runtime.ts';
 import type { DaemonResponse, SessionState } from '../../types.ts';
@@ -31,7 +31,7 @@ import {
   makeSessionStore,
 } from './snapshot-handler-fixture.ts';
 
-vi.mock('../snapshot-interactor-capture.ts', async () => {
+vi.mock('../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/handlers/__tests__/snapshot-session-cleanup.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-session-cleanup.test.ts
@@ -9,7 +9,7 @@ vi.mock('@agent-device/platform-apple/app-lifecycle', async (importOriginal) => 
   closeIosApp: vi.fn(async () => {}),
 }));
 
-import { withSessionlessRunnerCleanup } from '../snapshot-session.ts';
+import { withSessionlessRunnerCleanup } from '../../snapshot-session.ts';
 import { platformResourceCleanup } from '../../../platform-runtime-resource-cleanup.ts';
 import { closeIosApp } from '@agent-device/platform-apple/app-lifecycle';
 import { stopIosRunnerSession } from '@agent-device/platform-apple/runner/operations';

--- a/src/daemon/handlers/__tests__/snapshot-truncation.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-truncation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { captureSnapshotWithInteractor } from '../snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../snapshot-interactor-capture.ts';
 import { handleSnapshotCommands as handleProductionSnapshotCommands } from '../snapshot.ts';
 import { setActiveProviderDeviceRuntimes } from '../../../provider-device-runtime.ts';
 import { platformResourceCleanup } from '../../../platform-runtime-resource-cleanup.ts';

--- a/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
+++ b/src/daemon/handlers/__tests__/wait-landmark-recording.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../../core/dispatch-resolve.ts', async (importOriginal) => {
   };
 });
 
-vi.mock('../snapshot-interactor-capture.ts', async () => {
+vi.mock('../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/handlers/snapshot-alert.ts
+++ b/src/daemon/handlers/snapshot-alert.ts
@@ -14,7 +14,7 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { contextFromFlags } from '../context.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
-import { recordIfSession } from './snapshot-session.ts';
+import { recordIfSession } from '../snapshot-session.ts';
 import { parseTimeout } from '../../core/parse-timeout.ts';
 import { resolveRefFrameEffect } from '../daemon-command-registry.ts';
 import { expireRefFrame } from '../ref-frame.ts';

--- a/src/daemon/handlers/snapshot-settings.ts
+++ b/src/daemon/handlers/snapshot-settings.ts
@@ -11,7 +11,7 @@ import type { BoundDeviceRuntime } from '@agent-device/contracts/platform-runtim
 import { contextFromFlags } from '../context.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
-import { recordIfSession } from './snapshot-session.ts';
+import { recordIfSession } from '../snapshot-session.ts';
 import { errorResponse, type DaemonFailureResponse } from '../response.ts';
 import { expireRefFrame } from '../ref-frame.ts';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';

--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -6,7 +6,7 @@ import { handleSettingsCommand, parseSettingsArgs } from './snapshot-settings.ts
 import { dispatchSnapshotDiffViaRuntime } from '../snapshot-diff-runtime.ts';
 import { dispatchSnapshotViaRuntime } from '../snapshot-runtime.ts';
 import { dispatchWaitViaRuntime } from '../selector-runtime.ts';
-import { resolveSessionDevice, withSessionlessRunnerCleanup } from './snapshot-session.ts';
+import { resolveSessionDevice, withSessionlessRunnerCleanup } from '../snapshot-session.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import type { PlatformResourceCleanup } from '@agent-device/contracts/platform-resource-cleanup';
 

--- a/src/daemon/interaction/index.ts
+++ b/src/daemon/interaction/index.ts
@@ -1,7 +1,7 @@
 import type { Rect } from '@agent-device/kernel/snapshot';
 import { buildRuntimeCaptureInput } from '../snapshot-runtime-capture-input.ts';
 import { setSessionSnapshot } from '../session-snapshot.ts';
-import { captureSnapshot as captureSnapshotThroughHandler } from '../handlers/snapshot-capture.ts';
+import { captureSnapshot } from '../snapshot-capture.ts';
 import { captureInteractionSnapshot } from './internal/interaction-snapshot.ts';
 import { createInteractionRuntimeForRoute } from './internal/interaction-runtime.ts';
 import { readSettleRequest, settleFlagGuardResponse } from './internal/interaction-flags.ts';
@@ -31,7 +31,7 @@ export const captureSnapshotForSession: CaptureSnapshotForSession = async (
     contextFromFlags,
     options,
     capture: async ({ flags: effectiveFlags, options: captureOptions, context }) => {
-      const { snapshot } = await captureSnapshotThroughHandler({
+      const { snapshot } = await captureSnapshot({
         device: session.device,
         session,
         flags: effectiveFlags,

--- a/src/daemon/interaction/internal/__tests__/find-single-bind.test.ts
+++ b/src/daemon/interaction/internal/__tests__/find-single-bind.test.ts
@@ -11,7 +11,7 @@ import {
 import { invokeFindHandler } from './find-handler-fixture.ts';
 import { legacyDispatchCapture } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/interaction/internal/__tests__/find.test.ts
+++ b/src/daemon/interaction/internal/__tests__/find.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/interaction/internal/__tests__/interaction-get.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-get.test.ts
@@ -26,7 +26,7 @@ const { mockRunAppleRunnerCommand } = vi.hoisted(() => ({
   mockRunAppleRunnerCommand: vi.fn(),
 }));
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/interaction/internal/__tests__/interaction-ios-tap-outcome.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-ios-tap-outcome.test.ts
@@ -29,9 +29,9 @@ import {
   mockTapPoint,
   resetGetRuntimeFixture,
 } from '../../../__tests__/interaction-get-runtime-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../../__tests__/legacy-snapshot-capture-fixture.ts');
   return {
     captureSnapshotWithInteractor: vi.fn(fixture.captureSnapshotThroughLegacyDispatchFixture),

--- a/src/daemon/interaction/internal/__tests__/interaction-snapshot-scope.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-snapshot-scope.test.ts
@@ -15,7 +15,7 @@ import { captureSnapshotForSession } from '../../index.ts';
 
 const captured = vi.hoisted(() => ({ options: [] as SnapshotOptions[] }));
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(async ({ options }: { options: SnapshotOptions }) => {
     captured.options.push(options);
     const nodes = [

--- a/src/daemon/interaction/internal/__tests__/interaction-target-evidence.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-target-evidence.test.ts
@@ -26,7 +26,7 @@ const { mockRunAppleRunnerCommand } = vi.hoisted(() => ({
   mockRunAppleRunnerCommand: vi.fn(),
 }));
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', async () => {
+vi.mock('../../../snapshot-interactor-capture.ts', async () => {
   const fixture = await import('../../../__tests__/legacy-snapshot-capture-fixture.ts');
   return { captureSnapshotWithInteractor: fixture.captureSnapshotThroughLegacyDispatchFixture };
 });

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-android-freshness.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-android-freshness.test.ts
@@ -27,7 +27,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -42,7 +42,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-android-readiness.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-android-readiness.test.ts
@@ -38,7 +38,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -61,7 +61,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-direct-ios-eligibility.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-direct-ios-eligibility.test.ts
@@ -29,7 +29,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -44,7 +44,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-direct-ios.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-direct-ios.test.ts
@@ -24,7 +24,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-fill.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-fill.test.ts
@@ -38,7 +38,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -53,7 +53,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-payload.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-payload.test.ts
@@ -32,7 +32,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -47,7 +47,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-press-admission.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-press-admission.test.ts
@@ -39,7 +39,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -54,7 +54,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-press.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-press.test.ts
@@ -36,7 +36,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -51,7 +51,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-response.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-response.test.ts
@@ -33,7 +33,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -48,7 +48,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch-runtime.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch-runtime.test.ts
@@ -32,7 +32,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -47,7 +47,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/interaction/internal/__tests__/interaction-touch.test.ts
+++ b/src/daemon/interaction/internal/__tests__/interaction-touch.test.ts
@@ -36,7 +36,7 @@ vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -51,7 +51,7 @@ import {
   getAndroidBlockingDialogObservation,
   getAndroidScreenSize,
 } from '@agent-device/platform-android/mechanics';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
 const mockGetAndroidBlockingDialogObservation = vi.mocked(getAndroidBlockingDialogObservation);
 const mockGetAndroidScreenSize = vi.mocked(getAndroidScreenSize);

--- a/src/daemon/replay/__tests__/application.test.ts
+++ b/src/daemon/replay/__tests__/application.test.ts
@@ -16,14 +16,14 @@ import { SessionStore } from '../../session-store.ts';
 import { createReplaySession } from '../../handlers/session-replay-command.ts';
 import { runReplayCommand, runReplayTestCommand } from '../index.ts';
 import type { ReplayCommand, ReplayTestCommand } from '../internal/command-types.ts';
-import { captureSnapshotWithInteractor } from '../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../snapshot-interactor-capture.ts';
 import {
   legacyDispatchCapture,
   resetLegacySnapshotCapture,
 } from '../../__tests__/legacy-snapshot-capture-fixture.ts';
 import { baseReplayRequest, writeReplayFile } from './session-replay-runtime.fixtures.ts';
 
-vi.mock('../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 

--- a/src/daemon/replay/internal/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -34,7 +34,7 @@ import path from 'node:path';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
 import { AppError } from '@agent-device/kernel/errors';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { makeIosSession } from '../../../../__tests__/test-utils/session-factories.ts';
 import {
   baseReplayRequest as baseReq,

--- a/src/daemon/replay/internal/__tests__/session-replay-divergence-android-occlusion.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-divergence-android-occlusion.test.ts
@@ -14,13 +14,13 @@ import {
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
 import { buildReplayFailureDivergence } from '../session-replay-divergence.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 
 vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 

--- a/src/daemon/replay/internal/__tests__/session-replay-divergence-publication.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-divergence-publication.test.ts
@@ -3,11 +3,11 @@ import path from 'node:path';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { makeIosSession } from '../../../../__tests__/test-utils/session-factories.ts';
 import type { SnapshotState } from '@agent-device/kernel/snapshot';
 import type { ReplayDivergence } from '@agent-device/contracts/divergence';

--- a/src/daemon/replay/internal/__tests__/session-replay-divergence.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-divergence.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -23,7 +23,7 @@ vi.mock('@agent-device/host-kit/retry', async (importOriginal) => {
   return { ...actual, sleep: vi.fn(async () => {}) };
 });
 
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   makeAndroidSession,

--- a/src/daemon/replay/internal/__tests__/session-replay-maestro-failure.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-maestro-failure.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 import fs from 'node:fs';
@@ -25,7 +25,7 @@ import {
 } from '../session-replay-maestro-failure.ts';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { makeIosSession } from '../../../../__tests__/test-utils/session-factories.ts';
 import { baseReplayRequest as baseReq } from '../../__tests__/session-replay-runtime.fixtures.ts';
 import { replaySessionForTest } from './replay-session-fixture.ts';

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-acceptance.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-acceptance.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -21,7 +21,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { makeIosSession } from '../../../../__tests__/test-utils/session-factories.ts';
 import type { DaemonRequest } from '../../../types.ts';
 import { parseReplayScriptDetailed } from '@agent-device/ad-script';

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-empty-tail.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-empty-tail.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -37,7 +37,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-loop.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-loop.test.ts
@@ -17,14 +17,14 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
 import path from 'node:path';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   makeIosSession,
   repairPublication,

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-record-exclusion.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-record-exclusion.test.ts
@@ -41,7 +41,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 import fs from 'node:fs';
@@ -50,7 +50,7 @@ import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { handleSessionCloseCommands as handleProductionCloseCommand } from '../../../session-lifecycle/index.ts';
 import { SessionStore } from '../../../session-store.ts';
 import { LeaseRegistry } from '../../../lease-registry.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   makeIosSession,
   authoringPublication,

--- a/src/daemon/replay/internal/__tests__/session-replay-repair-transaction.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-repair-transaction.test.ts
@@ -42,7 +42,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 import fs from 'node:fs';
@@ -51,7 +51,7 @@ import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
 import { handleSessionCloseCommands as handleProductionCloseCommand } from '../../../session-lifecycle/index.ts';
 import { SessionStore } from '../../../session-store.ts';
 import { LeaseRegistry } from '../../../lease-registry.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   legacyDispatchCapture,
   resetLegacySnapshotCapture,

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime-binding.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime-binding.test.ts
@@ -6,7 +6,7 @@ import { resolveTargetDevice } from '../../../../core/dispatch-resolve.ts';
 import { captureSnapshotThroughLegacyDispatchFixture } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
 import { SessionStore } from '../../../session-store.ts';
 import { runReplayForTest } from '../../__tests__/replay-command-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { baseReplayRequest as baseReq } from '../../__tests__/session-replay-runtime.fixtures.ts';
 import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
 
@@ -15,7 +15,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime-failure-response.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime-failure-response.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 import path from 'node:path';
@@ -17,7 +17,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   baseReplayRequest as baseReq,
   writeReplayFile,

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime-failure.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime-failure.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 import fs from 'node:fs';
@@ -20,7 +20,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   baseReplayRequest as baseReq,
   writeReplayFile,

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime-maestro.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime-maestro.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -62,7 +62,7 @@ import {
 } from '../../../../__tests__/test-utils/replay-script-source.ts';
 import { makeIosSession } from '../../../../__tests__/test-utils/session-factories.ts';
 import { captureSnapshotThroughLegacyDispatchFixture } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import { seedReplayFixtureSession } from '../../__tests__/session-replay-runtime.fixtures.ts';
 
 vi.mocked(captureSnapshotWithInteractor).mockImplementation(

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime-plan.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime-plan.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -19,7 +19,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   makeAndroidSession,
   makeIosSession,

--- a/src/daemon/replay/internal/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-runtime.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -19,7 +19,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   makeIosSession,
   makeRepairArmedSession,

--- a/src/daemon/replay/internal/__tests__/session-replay-script-source.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-script-source.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../core/dispatch-resolve.ts')>();
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -30,7 +30,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 
 const mockCaptureSnapshotWithInteractor = vi.mocked(captureSnapshotWithInteractor);
 

--- a/src/daemon/replay/internal/__tests__/session-replay-selector-routes.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-selector-routes.test.ts
@@ -9,7 +9,7 @@ import {
   captureSnapshotThroughLegacyDispatchFixture,
   legacyDispatchCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 import {
   baseReplayRequest,
   writeReplayFile,
@@ -20,7 +20,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 

--- a/src/daemon/replay/internal/__tests__/session-replay-target-verification-runtime.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-target-verification-runtime.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../../../core/dispatch-resolve.ts', async (importOriginal) => {
   return { ...actual, resolveTargetDevice: vi.fn() };
 });
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(),
 }));
 
@@ -42,7 +42,7 @@ import {
   legacyDispatchCapture,
   resetLegacySnapshotCapture,
 } from '../../../__tests__/legacy-snapshot-capture-fixture.ts';
-import { captureSnapshotWithInteractor } from '../../../handlers/snapshot-interactor-capture.ts';
+import { captureSnapshotWithInteractor } from '../../../snapshot-interactor-capture.ts';
 
 const mockDispatchCommand = legacyDispatchCapture;
 const mockCaptureSnapshotWithInteractor = vi.mocked(captureSnapshotWithInteractor);

--- a/src/daemon/replay/internal/__tests__/session-test-suite-infrastructure.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-test-suite-infrastructure.test.ts
@@ -7,7 +7,7 @@ import type { DaemonResponse } from '../../../types.ts';
 import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
 import { expectOkData, makeSessionStore } from './session-test-suite.fixtures.ts';
 
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(async () => {
     throw new Error('no device runner available in this test');
   }),

--- a/src/daemon/replay/internal/__tests__/session-test-suite.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-test-suite.test.ts
@@ -8,7 +8,7 @@ import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts'
 // device runner, so without a mock those calls fall through to the real
 // (slow/hanging) runner dispatch path. Reject fast so failure-path tests keep
 // exercising `divergence.screen: unavailable` deterministically.
-vi.mock('../../../handlers/snapshot-interactor-capture.ts', () => ({
+vi.mock('../../../snapshot-interactor-capture.ts', () => ({
   captureSnapshotWithInteractor: vi.fn(async () => {
     throw new Error('no device runner available in this test');
   }),

--- a/src/daemon/replay/internal/session-replay-divergence.ts
+++ b/src/daemon/replay/internal/session-replay-divergence.ts
@@ -7,7 +7,7 @@ import { displayLabel, formatRole } from '../../../snapshot/snapshot-lines.ts';
 import type { ResponseLevel } from '@agent-device/kernel/contracts';
 import type { DaemonError } from '@agent-device/kernel/errors';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
-import { captureSnapshot } from '../../handlers/snapshot-capture.ts';
+import { captureSnapshot } from '../../snapshot-capture.ts';
 import { collectReplaySelectorCandidates } from './session-replay-heal.ts';
 import { buildSelectorCandidates, resolveReplaySuggestionCandidate } from '@agent-device/selectors';
 import { collectSettleChromeRefs } from '../../../core/snapshot-chrome.ts';

--- a/src/daemon/screenshot-runtime.ts
+++ b/src/daemon/screenshot-runtime.ts
@@ -20,7 +20,7 @@ import {
 } from '@agent-device/capture-kit/screenshot-density';
 import { runtimeExecutionFromContext } from './snapshot-runtime-capture-input.ts';
 import type { DaemonCommandContext } from './context.ts';
-import { captureSnapshotData } from './handlers/snapshot-capture.ts';
+import { captureSnapshotData } from './snapshot-capture.ts';
 import { buildSnapshotState } from '../core/snapshot-state.ts';
 import type {
   RecordedGenericRequest,

--- a/src/daemon/selector-capture-runtime.ts
+++ b/src/daemon/selector-capture-runtime.ts
@@ -9,7 +9,7 @@ import {
 import { isSparseSnapshotQualityVerdict } from '@agent-device/capture-kit/snapshot-quality-verdict';
 import type { DaemonRequest, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
-import { captureSnapshot } from './handlers/snapshot-capture.ts';
+import { captureSnapshot } from './snapshot-capture.ts';
 import { setSessionSnapshot } from './session-snapshot.ts';
 import { getActiveAndroidSnapshotFreshness } from './session-snapshot-freshness.ts';
 import { isPostGestureStabilizationPending } from './deferred-interaction-outcome.ts';

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -6,7 +6,7 @@ import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { errorResponse } from './response.ts';
 import { markSessionPartialRefsIssued, resolveRefStalenessWarning } from './session-snapshot.ts';
-import { resolveSessionDevice, withSessionlessRunnerCleanup } from './handlers/snapshot-session.ts';
+import { resolveSessionDevice, withSessionlessRunnerCleanup } from './snapshot-session.ts';
 import {
   checkElementTargetArgs,
   checkGetFormat,

--- a/src/daemon/snapshot-capture.ts
+++ b/src/daemon/snapshot-capture.ts
@@ -13,17 +13,17 @@ import {
   type SnapshotStateProvenance,
   type SnapshotState,
 } from '@agent-device/kernel/snapshot';
-import { resolveRefLabel } from '../../core/snapshot-node-lookup.ts';
+import { resolveRefLabel } from '../core/snapshot-node-lookup.ts';
 import { captureSnapshotWithInteractor } from './snapshot-interactor-capture.ts';
-import { buildSnapshotState } from '../../core/snapshot-state.ts';
-import { clearAndroidSnapshotFreshness } from '../session-snapshot-freshness.ts';
-import type { SnapshotFreshnessMode } from '../../snapshot/snapshot-freshness/index.ts';
-import { contextFromFlags } from '../context.ts';
-import { resolveDeferredInteractionOutcome } from '../deferred-interaction-outcome.ts';
-import { createInteractionRetryTap } from '../interaction-retry-tap.ts';
-import type { SessionState } from '../types.ts';
-import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
-import { errorResponse, type DaemonFailureResponse } from '../response.ts';
+import { buildSnapshotState } from '../core/snapshot-state.ts';
+import { clearAndroidSnapshotFreshness } from './session-snapshot-freshness.ts';
+import type { SnapshotFreshnessMode } from '../snapshot/snapshot-freshness/index.ts';
+import { contextFromFlags } from './context.ts';
+import { resolveDeferredInteractionOutcome } from './deferred-interaction-outcome.ts';
+import { createInteractionRetryTap } from './interaction-retry-tap.ts';
+import type { SessionState } from './types.ts';
+import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from './request-runtime-binding.ts';
+import { errorResponse, type DaemonFailureResponse } from './response.ts';
 
 type CaptureSnapshotParams = {
   device: SessionState['device'];

--- a/src/daemon/snapshot-command-runtime.ts
+++ b/src/daemon/snapshot-command-runtime.ts
@@ -12,8 +12,8 @@ import { type CommandSessionRecord, createAgentDevice } from '../runtime.ts';
 import { getRequestSignal } from '@agent-device/host-kit/request';
 import type { RuntimeAdmissionBindings } from './request-runtime-binding.ts';
 import { maybeBuildAndroidSnapshotTimeoutFailure } from './android-snapshot-timeout-evidence.ts';
-import { captureSnapshot } from './handlers/snapshot-capture.ts';
-import { buildSnapshotSession, withSessionlessRunnerCleanup } from './handlers/snapshot-session.ts';
+import { captureSnapshot } from './snapshot-capture.ts';
+import { buildSnapshotSession, withSessionlessRunnerCleanup } from './snapshot-session.ts';
 import { resolveSessionScope } from './session-routing.ts';
 import { activateCompleteRefFrame } from './ref-frame.ts';
 import {

--- a/src/daemon/snapshot-interactor-capture.ts
+++ b/src/daemon/snapshot-interactor-capture.ts
@@ -19,7 +19,7 @@ export async function captureSnapshotWithInteractor(params: {
   runnerContext: RunnerContext;
   options: SnapshotOptions;
 }): Promise<SnapshotResult> {
-  const { getInteractor } = await import('../../core/interactors.ts');
+  const { getInteractor } = await import('../core/interactors.ts');
   const interactor = await getInteractor(params.device, params.runnerContext);
   return await interactor.snapshot(params.options);
 }

--- a/src/daemon/snapshot-runtime-binding.ts
+++ b/src/daemon/snapshot-runtime-binding.ts
@@ -23,8 +23,8 @@ import {
   type AdmittedRuntimePlan,
 } from './session-runtime-admission.ts';
 import { errorResponse } from './response.ts';
-import { resolveSnapshotScope } from './handlers/snapshot-capture.ts';
-import { resolveSessionDevice } from './handlers/snapshot-session.ts';
+import { resolveSnapshotScope } from './snapshot-capture.ts';
+import { resolveSessionDevice } from './snapshot-session.ts';
 import {
   selectElementTextOperation,
   selectFindMutatingOperations,

--- a/src/daemon/snapshot-session.ts
+++ b/src/daemon/snapshot-session.ts
@@ -1,8 +1,8 @@
-import { resolveTargetDevice } from '../../core/dispatch-resolve.ts';
+import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import type { PlatformResourceCleanup } from '@agent-device/contracts/platform-resource-cleanup';
-import type { DaemonRequest, SessionScope, SessionState } from '../types.ts';
-import { ensureDeviceReady } from '../device-ready.ts';
-import { SessionStore } from '../session-store.ts';
+import type { DaemonRequest, SessionScope, SessionState } from './types.ts';
+import { ensureDeviceReady } from './device-ready.ts';
+import { SessionStore } from './session-store.ts';
 
 export async function resolveSessionDevice(
   sessionStore: SessionStore,

--- a/src/daemon/wait-current-surface.ts
+++ b/src/daemon/wait-current-surface.ts
@@ -1,7 +1,7 @@
 import { WAIT_REASONS } from '@agent-device/contracts/wait';
 import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
-import { captureSnapshot } from './handlers/snapshot-capture.ts';
+import { captureSnapshot } from './snapshot-capture.ts';
 import { errorResponse } from './response.ts';
 import { normalizeType } from '@agent-device/contracts/snapshot';
 import { buildRuntimeCaptureInput } from './snapshot-runtime-capture-input.ts';


### PR DESCRIPTION
## Summary

Move shared snapshot capture, interactor dispatch, and session cleanup execution out of the route-adapter directory so snapshot, interaction, replay, selector, screenshot, and wait callers reuse one daemon-owned seam. Keep `handlers/snapshot.ts` as the request adapter and add an R10 guard that prevents the retired support paths from returning.

Production code is move-adjusted exact: 116 additions and 116 deletions. The net 41 lines are architecture enforcement and its planted-red test.

Closes #2230.

## Validation

- observed planted-red R10 failure for a restored `src/daemon/handlers/snapshot-capture.ts`
- `pnpm check:affected --run`
- `pnpm check:layering`
- `pnpm check:fallow --base origin/main`
- focused snapshot, interaction, replay, cleanup, and CLI characterization tests