### PR TITLE
fix(daemon): skip sessionless local host teardown for provider devices

### DIFF
--- a/src/daemon/handlers/__tests__/snapshot-session-cleanup.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-session-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 vi.mock('@agent-device/platform-apple/runner/operations', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent-device/platform-apple/runner/operations')>()),
@@ -14,6 +14,8 @@ import { platformResourceCleanup } from '../../../platform-runtime-resource-clea
 import { closeIosApp } from '@agent-device/platform-apple/app-lifecycle';
 import { stopIosRunnerSession } from '@agent-device/platform-apple/runner/operations';
 import { IOS_SIMULATOR } from '../../../__tests__/test-utils/device-fixtures.ts';
+import { setActiveProviderDeviceRuntimes } from '../../../provider-device-runtime.ts';
+import type { ProviderDeviceRuntime } from '@agent-device/contracts/device';
 
 const mockStopIosRunnerSession = vi.mocked(stopIosRunnerSession);
 const mockCloseIosApp = vi.mocked(closeIosApp);
@@ -22,6 +24,10 @@ const returnOk = async () => 'ok';
 beforeEach(() => {
   mockStopIosRunnerSession.mockReset().mockResolvedValue();
   mockCloseIosApp.mockReset().mockResolvedValue();
+});
+
+afterEach(() => {
+  setActiveProviderDeviceRuntimes([]);
 });
 
 test('sessionless iOS runner cleanup stops the runner host app', async () => {
@@ -47,4 +53,28 @@ test('sessionless iOS runner host close is best effort', async () => {
   expect(result).toBe('ok');
   expect(mockStopIosRunnerSession).toHaveBeenCalledWith(IOS_SIMULATOR.id);
   expect(mockCloseIosApp).toHaveBeenCalledWith(IOS_SIMULATOR, 'com.callstack.agentdevice.runner');
+});
+
+test('sessionless cleanup leaves a provider-owned device to its provider', async () => {
+  const device = { ...IOS_SIMULATOR, id: 'limrun:ios:lease-a' };
+  const runtime: ProviderDeviceRuntime = {
+    provider: 'limrun',
+    leaseLifecycle: {},
+    deviceInventoryProvider: async () => [device],
+    ownsDevice: (candidate) => candidate.id === device.id,
+    getInteractor: () => undefined,
+    shutdown: async () => {},
+  };
+  setActiveProviderDeviceRuntimes([runtime]);
+
+  const result = await withSessionlessRunnerCleanup(
+    undefined,
+    device,
+    returnOk,
+    platformResourceCleanup,
+  );
+
+  expect(result).toBe('ok');
+  expect(mockStopIosRunnerSession).not.toHaveBeenCalled();
+  expect(mockCloseIosApp).not.toHaveBeenCalled();
 });

--- a/src/daemon/snapshot-session.ts
+++ b/src/daemon/snapshot-session.ts
@@ -2,6 +2,7 @@ import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import type { PlatformResourceCleanup } from '@agent-device/contracts/platform-resource-cleanup';
 import type { DaemonRequest, SessionScope, SessionState } from './types.ts';
 import { ensureDeviceReady } from './device-ready.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 import { SessionStore } from './session-store.ts';
 
 export async function resolveSessionDevice(
@@ -27,7 +28,12 @@ export async function withSessionlessRunnerCleanup<T>(
   try {
     return await task();
   } finally {
-    if (!session) await platformCleanup!.cleanupSessionlessExecutionHost(device);
+    // Symmetric with `ensureDeviceReady`: only a device this daemon prepared a local execution
+    // host for can have one to release. A provider-owned device runs on provider infrastructure,
+    // where local teardown drives host tooling at a device id this host does not own.
+    if (!session && !isActiveProviderDevice(device)) {
+      await platformCleanup!.cleanupSessionlessExecutionHost(device);
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

`withSessionlessRunnerCleanup` no longer releases the local iOS execution host when the device belongs to a provider runtime.

```ts
if (!session && !isActiveProviderDevice(device)) {
  await platformCleanup!.cleanupSessionlessExecutionHost(device);
}
```

## Why

A sessionless `snapshot`, `diff`, `alert`, `settings`, `wait` or `is` command releases the local XCTest execution host when it completes. That teardown ran for every iOS device, including a provider-owned one.

For a Limrun lease the device id is `limrun:ios:<leaseId>` with `kind: 'simulator'`, so the Apple path ran on the host for a device the host does not own:

```
dispatchSnapshotRuntimeCommand            src/daemon/snapshot-command-runtime.ts:66
 └ withSessionlessRunnerCleanup (finally) src/daemon/snapshot-session.ts:30
    └ cleanupSessionlessExecutionHost     src/platform-runtime-resource-cleanup.ts:70
       └ closeIosApp → terminateIosSimulatorApp
          └ ensureBootedSimulator → runXcrun   (3 × xcrun simctl + retry backoff ≈ 5.8 s)
```

`ensureDeviceReady` already declines local readiness work for a provider-owned device. The teardown side was not symmetric. One guard covers all four call sites of the helper.

## How it surfaced

`test/integration/provider-scenarios/limrun-ios-snapshot-owner.test.ts` (added in #2233) exceeded the 5000 ms default timeout on macOS. The request always settled — it took about 6.2 s, and the local `xcrun` work was almost all of it. That made `pnpm check:affected --run` red for unrelated changes.

The path itself predates #2233; that test is the first end-to-end provider scenario that reaches it.

## Notes for a reviewer

- CI stayed green because the provider-integration lane runs on `ubuntu-latest`, where `xcrun` does not exist and the calls fail immediately. The defect is only visible on macOS.
- The new test in `snapshot-session-cleanup.test.ts` fails when the guard is removed, so it is not vacuous.
- `stopIosRunnerSession` and `cleanupOwnedIosRunnerLease` were also being called for the provider device. Both operate on local runner-session state, so they were no-ops for it.

## Verification

- `limrun-ios-snapshot-owner.test.ts`: 6.2 s timeout → 294 ms, passing.
- Full `provider-integration` lane: 55 files, 164 tests, all pass.
- The 8 unit files that cover this seam: 88 tests, all pass.
- `pnpm typecheck`, `oxlint`, `oxfmt --check`, and the layering guard all pass.