### PR TITLE
chore(gates): drop the test-file size pin map, keep the merge-base ratchet

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -178,8 +178,9 @@ or remove flakes.
   along source topology is a performance win, not just a readability win.
 - The slow-test reporter enforces unit and integration budgets. Existing pins only shrink; a new
   pin needs measured justification.
-- Test files over 1,000 lines are pinned to their merge-base size and may only shrink. Split the
-  family before adding tests; never raise the pin.
+- Test files over 1,000 lines may be no longer than at the merge-base with `origin/main`, and no
+  new test file may cross that line. Split the family before adding tests; shrinking needs no
+  gate edit.
 - Keep isolation enabled and the pool on forks — both alternatives were measured and did not help.
   The useful optimization is importing the module under test, not a platform barrel.
 - Local Vitest runs use a four-worker cap. Override it when a run needs a different host share:

--- a/scripts/__tests__/eager-closure-budgets.ts
+++ b/scripts/__tests__/eager-closure-budgets.ts
@@ -37,9 +37,8 @@ export type EagerClosureBudget = {
    * A `<=` ceiling looks stricter than it is: the moment an entry legitimately shrinks, the
    * unchanged row silently becomes headroom, and the next regression up to the old number passes
    * unnoticed. Equality is what "only ever ratchets down" actually requires -- the same shape
-   * `test-file-size-ratchet.test.ts` uses for file length and R9/R10 use for cycle size and
-   * writer counts: growing fails, and shrinking ALSO fails until the row is lowered in the same
-   * PR, so the gain is kept rather than banked as slack.
+   * R9/R10 use for cycle size and writer counts: growing fails, and shrinking ALSO fails until
+   * the row is lowered in the same PR, so the gain is kept rather than banked as slack.
    *
    * Seeded from measurement, never rounded up. The regression this catches is a single static
    * import dragging a subtree in, measured by #1969 at 5-12% of the whole suite's import work

--- a/scripts/__tests__/test-file-size-ratchet.test.ts
+++ b/scripts/__tests__/test-file-size-ratchet.test.ts
@@ -5,59 +5,26 @@ import { walkFiles } from '../lib/walk-files.ts';
 import { runCmdSync } from '@agent-device/host-kit/command';
 
 /**
- * Test-file size ratchet (AGENTS.md "Scope & shape": past 1,000 lines is architecture debt,
- * and tests are not exempt; the topology rule says a test file mirrors its source module and
- * splits when the source does).
+ * Test-file size ratchet (AGENTS.md "Module and test topology": past 1,000 lines is architecture
+ * debt, and tests are not exempt; a test file mirrors its source module and splits when the
+ * source does).
  *
  * The slow-test ratchet keeps the unit suite's wall clock honest; this one keeps its files
- * readable in one bounded read. Every test file over the tripwire is pinned at its exact
- * length, R9-style (#1781 A6): growing a pinned file fails ("split it, don't add to it"), and
- * shrinking one fails until the pin is lowered, so the list only ever ratchets down. A file
- * that drops under the tripwire leaves the list; a new file may not cross it.
+ * readable in one bounded read. The rule is history-backed: every test file over the tripwire
+ * may be no longer than it was at the merge-base with origin/main, and a file that did not
+ * exist there may not cross the tripwire. Shrinking needs no gate edit; the merge-base is the
+ * only record of the previous length.
  *
- * The pin map alone could be edited alongside the file (raise a pin and grow into it; add a
- * pin with a new giant file), so the gate is history-backed as well: every test file over the
- * tripwire may be no longer than it was at the merge-base with origin/main (or no longer than
- * the tripwire if it did not exist there), and no pin may exceed its file's base length. Both
- * pin-edit bypasses go red against git, not against the map.
- *
- * Catches: a >1,000-line test file growing (with or without a matching pin edit), or a new one
- *   appearing (with or without a pin).
+ * Catches: a >1,000-line test file growing, or a new one appearing.
  * Evidence: 26 test files were over the line when this landed (2026-08-18); the largest,
  *   `snapshot-handler.test.ts`, gained 55 lines in the PR before, under a rule with no gate.
- * Cost: one directory walk and a line count per test file — well under a second.
- * Kill criterion: the pin list is empty. Delete this file with the last pin.
+ * Cost: one directory walk, a line count per test file, and one `git cat-file --batch` spawn
+ *   for the files over the tripwire — well under a second.
+ * Kill criterion: no test file under src/, packages/, test/, or scripts/ exceeds the tripwire at
+ *   the merge-base; delete this file when that holds.
  */
 
 const TRIPWIRE_LINES = 1_000;
-
-// Exact current lengths. Lower a pin when its file shrinks; never raise one — extract instead.
-const PINNED_TEST_FILE_LINES: Readonly<Record<string, number>> = Object.freeze({
-  'src/__tests__/remote-connection.test.ts': 2973,
-  'src/daemon/handlers/__tests__/snapshot-handler.test.ts': 2120,
-  'src/commands/interaction/runtime/settle.test.ts': 2359,
-  'src/daemon/replay/internal/__tests__/session-replay-runtime-maestro.test.ts': 1963,
-  'packages/platform-apple/src/runner/__tests__/runner-session.test.ts': 1957,
-  'src/daemon/client/__tests__/daemon-client.test.ts': 1873,
-  'packages/platform-android/src/__tests__/snapshot.test.ts': 1435,
-  'packages/platform-apple/src/runner/__tests__/runner-client.test.ts': 1441,
-  'src/__tests__/client.test.ts': 1554,
-  'test/integration/provider-scenarios/android-lifecycle.test.ts': 1556,
-  'src/daemon/client/__tests__/daemon-client-lifecycle.test.ts': 1409,
-  'packages/platform-apple/src/runner/__tests__/runner-command-retry.test.ts': 1280,
-  'src/__tests__/cli-client-commands.test.ts': 1304,
-  'src/__tests__/cli-config.test.ts': 1282,
-  'src/daemon/interaction/internal/__tests__/find.test.ts': 1199,
-  'packages/platform-apple/src/core/__tests__/perf.test.ts': 1222,
-  'src/mcp/__tests__/command-tools.test.ts': 1216,
-  'src/daemon/replay/internal/__tests__/session-replay-divergence.test.ts': 1100,
-  'packages/platform-apple/src/core/__tests__/apps.test.ts': 1146,
-  'src/daemon/replay/internal/__tests__/session-replay-repair-transaction.test.ts': 1202,
-  'src/daemon/replay/internal/__tests__/session-replay-target-verification-runtime.test.ts': 1182,
-  'src/__tests__/client-metro.test.ts': 1105,
-  'src/__tests__/cli-network.test.ts': 1092,
-  'packages/platform-android/src/__tests__/snapshot-helper.test.ts': 1002,
-});
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
 const TEST_ROOTS = ['src', 'packages', 'test', 'scripts'];
@@ -79,56 +46,12 @@ function countLines(file: string): number {
   return lines;
 }
 
-/** The ratchet decision, separated from the filesystem so the tests below can plant each red. */
-function ratchetFindings(
-  measured: ReadonlyMap<string, number>,
-  pinned: Readonly<Record<string, number>>,
-  tripwire: number,
-): string[] {
-  const findings: string[] = [];
-  for (const [file, lines] of [...measured].sort()) {
-    const pin = pinned[file];
-    if (pin === undefined) {
-      if (lines > tripwire) {
-        findings.push(
-          `${file} is ${lines} lines, over the ${tripwire}-line tripwire and not pinned: split it ` +
-            `along the source module it mirrors (docs/agents/testing.md) rather than pinning it.`,
-        );
-      }
-      continue;
-    }
-    if (lines <= tripwire) {
-      // Pins exist only for files over the tripwire: one on a smaller file grows the map for
-      // nothing (900 pinned at 900 would satisfy equality and history alike) and defeats the
-      // only-shrink kill criterion.
-      findings.push(
-        `${file} is ${lines} lines, at or under the ${tripwire}-line tripwire, but has a pin (${pin}): remove it — pins are only for files over the tripwire.`,
-      );
-      continue;
-    }
-    if (lines > pin) {
-      findings.push(
-        `${file} grew to ${lines} lines (pinned ${pin}): extract instead of adding to a file over the tripwire.`,
-      );
-    } else if (lines < pin) {
-      findings.push(
-        `${file} shrank to ${lines} lines (pinned ${pin}): lower its pin in this PR so the ratchet keeps the gain.`,
-      );
-    }
-  }
-  for (const file of Object.keys(pinned)) {
-    if (!measured.has(file)) {
-      findings.push(`${file} is pinned but does not exist: remove its pin.`);
-    }
-  }
-  return findings;
-}
-
 /**
  * Line counts of the given repo paths at the merge-base with origin/main, following renames, in
  * one `git cat-file --batch` spawn. `undefined` = the file did not exist there.
  */
 function baseLineCounts(paths: readonly string[]): ReadonlyMap<string, number | undefined> {
+  if (paths.length === 0) return new Map();
   const mergeBase = runCmdSync('git', ['merge-base', 'origin/main', 'HEAD'], {
     cwd: REPO_ROOT,
     allowFailure: true,
@@ -191,13 +114,9 @@ function parseCatFileBatch(
   return counts;
 }
 
-/**
- * The history-backed half: measured against the merge-base, not against the pin map, so
- * editing the map alongside the file cannot admit growth.
- */
-function historyFindings(
+/** The ratchet decision, separated from the filesystem so the test below can plant each red. */
+function ratchetFindings(
   measured: ReadonlyMap<string, number>,
-  pinned: Readonly<Record<string, number>>,
   baseLines: ReadonlyMap<string, number | undefined>,
   tripwire: number,
 ): string[] {
@@ -207,26 +126,18 @@ function historyFindings(
     const base = baseLines.get(file);
     if (base === undefined) {
       findings.push(
-        `${file} is ${lines} lines and did not exist at the merge-base: a new test file may not cross the ${tripwire}-line tripwire, pinned or not.`,
+        `${file} is ${lines} lines and did not exist at the merge-base: a new test file may not cross the ${tripwire}-line tripwire.`,
       );
     } else if (lines > Math.max(base, tripwire)) {
       findings.push(
-        `${file} is ${lines} lines, ${base} at the merge-base: a test file over the tripwire may not grow, whatever its pin says.`,
-      );
-    }
-  }
-  for (const [file, pin] of Object.entries(pinned).sort()) {
-    const base = baseLines.get(file);
-    if (base !== undefined && pin > base) {
-      findings.push(
-        `${file} is pinned at ${pin} but was ${base} lines at the merge-base: a pin may not be raised above its file's base length.`,
+        `${file} is ${lines} lines, ${base} at the merge-base: a test file over the tripwire may not grow; split it along the source module it mirrors (docs/agents/testing.md).`,
       );
     }
   }
   return findings;
 }
 
-test('no test file over the tripwire grows, and every pin matches its file exactly', () => {
+test('no test file over the tripwire is longer than at the merge-base, and no new file crosses it', () => {
   const measured = new Map<string, number>();
   for (const root of TEST_ROOTS) {
     for (const file of walkFiles(path.join(REPO_ROOT, root), isTestFile)) {
@@ -234,85 +145,43 @@ test('no test file over the tripwire grows, and every pin matches its file exact
     }
   }
   expect(measured.size).toBeGreaterThan(500);
-  expect(ratchetFindings(measured, PINNED_TEST_FILE_LINES, TRIPWIRE_LINES)).toEqual([]);
 
-  const ofInterest = [
-    ...new Set([
-      ...[...measured].filter(([, lines]) => lines > TRIPWIRE_LINES).map(([file]) => file),
-      ...Object.keys(PINNED_TEST_FILE_LINES),
-    ]),
-  ];
-  const baseLines = baseLineCounts(ofInterest);
-  expect(historyFindings(measured, PINNED_TEST_FILE_LINES, baseLines, TRIPWIRE_LINES)).toEqual([]);
+  const overTripwire = [...measured]
+    .filter(([, lines]) => lines > TRIPWIRE_LINES)
+    .map(([file]) => file);
+  const baseLines = baseLineCounts(overTripwire);
+  expect(ratchetFindings(measured, baseLines, TRIPWIRE_LINES)).toEqual([]);
 });
 
-test('planted reds: growth, shrink, unpinned crossing, and a stale pin each name their fix', () => {
-  const pinned = { 'a.test.ts': 1200, 'b.test.ts': 1500, 'e.test.ts': 900, 'gone.test.ts': 1100 };
-  const measured = new Map([
-    ['a.test.ts', 1201], // grew
-    ['b.test.ts', 900], // shrank under the tripwire: the pin must go
-    ['e.test.ts', 900], // unchanged sub-tripwire file that someone pinned at its own length
-    ['c.test.ts', 1001], // new offender
-    ['d.test.ts', 1000], // at the line, fine
-  ]);
-  expect(ratchetFindings(measured, pinned, 1000)).toEqual([
-    'a.test.ts grew to 1201 lines (pinned 1200): extract instead of adding to a file over the tripwire.',
-    'b.test.ts is 900 lines, at or under the 1000-line tripwire, but has a pin (1500): remove it — pins are only for files over the tripwire.',
-    'c.test.ts is 1001 lines, over the 1000-line tripwire and not pinned: split it along the source module it mirrors (docs/agents/testing.md) rather than pinning it.',
-    // The arbitrary-new-pin bypass: equality (900 == 900) and history (900 <= base) both pass,
-    // so this rule is the one that rejects it.
-    'e.test.ts is 900 lines, at or under the 1000-line tripwire, but has a pin (900): remove it — pins are only for files over the tripwire.',
-    'gone.test.ts is pinned but does not exist: remove its pin.',
-  ]);
-  expect(ratchetFindings(new Map([['a.test.ts', 1200]]), { 'a.test.ts': 1200 }, 1000)).toEqual([]);
-});
-
-test('planted reds against history: raising a pin, growing into it, and pinning a new giant file are all red', () => {
+test('planted reds: growth, a new giant file, and a file crossing the tripwire each name their fix', () => {
   const baseLines = new Map<string, number | undefined>([
-    ['a.test.ts', 1200], // existed, 1200 at base
+    ['a.test.ts', 1200],
     ['b.test.ts', 1500],
-    ['fresh.test.ts', undefined], // did not exist at base
-    ['small.test.ts', 900], // existed, under the tripwire at base
+    ['fresh.test.ts', undefined],
+    ['small.test.ts', 900],
   ]);
-  // Bypass 1: grow a pinned file and raise its pin so the equality pin stays green.
-  expect(
-    historyFindings(new Map([['a.test.ts', 1230]]), { 'a.test.ts': 1230 }, baseLines, 1000),
-  ).toEqual([
-    'a.test.ts is 1230 lines, 1200 at the merge-base: a test file over the tripwire may not grow, whatever its pin says.',
-    "a.test.ts is pinned at 1230 but was 1200 lines at the merge-base: a pin may not be raised above its file's base length.",
+  expect(ratchetFindings(new Map([['a.test.ts', 1230]]), baseLines, 1000)).toEqual([
+    'a.test.ts is 1230 lines, 1200 at the merge-base: a test file over the tripwire may not grow; split it along the source module it mirrors (docs/agents/testing.md).',
   ]);
-  // Raising the pin alone (before growing into it) is already red.
-  expect(
-    historyFindings(new Map([['a.test.ts', 1200]]), { 'a.test.ts': 1230 }, baseLines, 1000),
-  ).toEqual([
-    "a.test.ts is pinned at 1230 but was 1200 lines at the merge-base: a pin may not be raised above its file's base length.",
+  expect(ratchetFindings(new Map([['fresh.test.ts', 1400]]), baseLines, 1000)).toEqual([
+    'fresh.test.ts is 1400 lines and did not exist at the merge-base: a new test file may not cross the 1000-line tripwire.',
   ]);
-  // Bypass 2: add a new >1,000-line file together with a pin for it.
-  expect(
-    historyFindings(new Map([['fresh.test.ts', 1400]]), { 'fresh.test.ts': 1400 }, baseLines, 1000),
-  ).toEqual([
-    'fresh.test.ts is 1400 lines and did not exist at the merge-base: a new test file may not cross the 1000-line tripwire, pinned or not.',
+  expect(ratchetFindings(new Map([['small.test.ts', 1001]]), baseLines, 1000)).toEqual([
+    'small.test.ts is 1001 lines, 900 at the merge-base: a test file over the tripwire may not grow; split it along the source module it mirrors (docs/agents/testing.md).',
   ]);
-  // Same for a file that existed but was under the tripwire at base.
+  // Allowed: unchanged, shrunk (with no gate edit), under the tripwire, or new and small.
   expect(
-    historyFindings(new Map([['small.test.ts', 1001]]), { 'small.test.ts': 1001 }, baseLines, 1000),
-  ).toEqual([
-    'small.test.ts is 1001 lines, 900 at the merge-base: a test file over the tripwire may not grow, whatever its pin says.',
-    "small.test.ts is pinned at 1001 but was 900 lines at the merge-base: a pin may not be raised above its file's base length.",
-  ]);
-  // Allowed: shrink with a lowered pin, a pin that disappears, an unchanged file.
-  expect(
-    historyFindings(
+    ratchetFindings(
       new Map([
         ['a.test.ts', 1100],
         ['b.test.ts', 1500],
+        ['small.test.ts', 1000],
+        ['fresh.test.ts', 1000],
       ]),
-      { 'a.test.ts': 1100, 'b.test.ts': 1500 },
       baseLines,
       1000,
     ),
   ).toEqual([]);
-  expect(historyFindings(new Map([['a.test.ts', 950]]), {}, baseLines, 1000)).toEqual([]);
 });
 
 test('cat-file --batch output is parsed per request, in order, with misses as undefined', () => {


### PR DESCRIPTION
## Summary

The test-file size gate had two rules: an exact-length pin map for every test file over 1,000 lines, and a history-backed rule against the merge-base. The pin map duplicated what git already records and turned every shrink into a two-file edit. This drops the pin map and the three assertions that served only it (pin equals file, pin not above base, pin-list-empty kill criterion).

Gate behavior for test authors now:

- A test file over the 1,000-line tripwire may be no longer than at the merge-base with `origin/main`.
- A file absent at the merge-base may not cross the tripwire.
- Shrinking an over-tripwire file needs no gate edit.

Kill criterion: no test file under the walked roots exceeds the tripwire at the merge-base; delete the gate when that holds. `docs/agents/testing.md` no longer mentions pins; a stale citation in `eager-closure-budgets.ts` naming this gate as an equality-pin example is removed. Nothing else imported `PINNED_TEST_FILE_LINES`.

## Validation

Focused: `npx vitest run --project unit-core scripts/__tests__/test-file-size-ratchet.test.ts` (3 passed), `pnpm check:quick`, `pnpm check:gate-manifest`, `pnpm check:fallow`, all clean at 63ed6a2e64.

Planted red: a scratch commit appending 3 lines to `src/__tests__/cli-network.test.ts`, same vitest command:

```
× no test file over the tripwire is longer than at the merge-base, and no new file crosses it
+ "src/__tests__/cli-network.test.ts is 1095 lines, 1092 at the merge-base: a test file over the tripwire may not grow; split it along the source module it mirrors (docs/agents/testing.md)."
```

Planted green: a scratch commit deleting 3 lines from that file, no gate edit, passed 3/3. Both scratch commits were discarded before push.

Full affected gate: pending (serialized gate stage will append the result)
