### PR TITLE
docs(adr): ADR-0019 end-state numbers for the daemon composition root

### DIFF
--- a/docs/adr/0019-end-state-hop-trace.md
+++ b/docs/adr/0019-end-state-hop-trace.md
@@ -97,18 +97,11 @@ The façade PRs the plan sheet named as a candidate explanation (#2178, #2222, #
 **before** `e624ef9d3f` — the commit the ADR cites for its 38/29 measurement — so they cannot be
 why that count is higher than this one; they were already in effect when 38/29 was recorded.
 
-This trace lands at 24 hops for both routes, matching the file-by-file trace recorded in
-`maintainability-review-2026-09-02.md` during the 2026-09-02 audit ("press/Android = 24 hops
-(5 pass-through), snapshot/iOS = 23 (6 pass-through)") to within one file — a difference plausibly
-explained by which file either trace treats as the route's start or end boundary, not by a
-different code path. Two independent file-by-file traces using the same unit therefore agree with
-each other and disagree with the ADR's 38/29 by roughly 1.5x. The ADR text names no ordered chain,
-no command/artifact, and no counting definition for 38/29, so the discrepancy cannot be resolved
-against it; the most likely explanation is a different counting unit (e.g. counting every named
-export or every static/type import touched, rather than distinct production files on the call
-path) rather than a different code path, since both real traces walked the same files. **38 and 29
-should be treated as superseded by the 24/24 measured here**, not as a second data point to
-reconcile.
+This trace lands at 24 hops for both routes. The ADR text names no ordered chain, command/artifact,
+or counting definition for 38/29, so the discrepancy cannot be resolved against it. The most likely
+explanation is a different counting unit (for example, named exports or every static/type import
+touched rather than distinct production files on the call path). **Treat 38 and 29 as superseded by
+the auditable 24/24 measured here**, not as a second data point to reconcile.
 
 ## The ≤14 target
 

--- a/docs/adr/0019-end-state-hop-trace.md
+++ b/docs/adr/0019-end-state-hop-trace.md
@@ -1,0 +1,149 @@
+# ADR-0019 end-state: entry-to-platform hop trace
+
+Backs the "Entry-to-platform hop count" paragraph in
+[0019-request-bound-platform-runtime.md](./0019-request-bound-platform-runtime.md#end-state-proposed-2026-09-02-maintainer-decision-pending).
+That paragraph cited 38 hops (`press`/Android) and 29 hops (`snapshot`/iOS) with no ordered
+route, no counting definition, and no linked artifact. This file supplies all three, re-traces
+both routes file-by-file at HEAD, and replaces the unauditable numbers.
+
+## Counting definition
+
+- **Unit**: one distinct production `.ts` file entered on the call path, counted once even if
+  re-entered (a lazy `import()` of an already-counted file is not a new hop). Type-only imports
+  and files that only supply types are not hops.
+- **Range**: from the daemon's HTTP entry file (`src/daemon/server/http-server.ts`) through the
+  file that issues the concrete platform call — `adb shell input tap` for `press`/Android,
+  `fetch()` to the XCTest runner for `snapshot`/iOS — inclusive of both endpoints.
+- **Per-file classification**:
+  - **pass-through** — delegates to exactly one next call with no branching or transformation
+    (a lazy-load indirection, a one-line re-export/delegate).
+  - **thin** — a routing table, a switch on command name, or a wrapper around one admission
+    check; no domain logic.
+  - **substantive** — resolves a plan, binds a runtime, constructs an interactor, or otherwise
+    does work a target hop count would still need somewhere.
+  - **terminal** — the file that issues the platform call itself.
+- **Method**: read each file, find the exported entry function reached by the caller, follow its
+  first call that continues toward the platform call (not every branch — e.g. `handleSnapshotCommands`
+  routes `alert`/`settings`/`diff`/`wait` too; only the `snapshot` arm is traced), record the file
+  and the one line/function that hands off to the next hop.
+- **Commit measured at**: `132ffe1da296717c268e836fc02558d00e61cfbd` (this branch's base,
+  `origin/main` fast-forwarded; the fix in this PR does not touch any traced source file).
+
+## `press` / Android: HTTP entry → `adb input tap`
+
+24 files, 7 pass-through, 9 thin, 7 substantive, 1 terminal.
+
+| # | File | Hand-off | Class |
+|---|------|----------|-------|
+| 1 | `src/daemon/server/http-server.ts` | parses the HTTP request, calls `handleRequest` | thin |
+| 2 | `src/daemon/request-router.ts` | `createRequestHandler` → `runRequestHandlerChain` | pass-through |
+| 3 | `src/daemon/request-handler-chain.ts` | routes `command: 'press'` to `runInteractionHandler`, lazy-loads `interaction/index.ts` | thin |
+| 4 | `src/daemon/interaction/index.ts` | re-exports the lazy-loaded internal module's `handleInteractionCommands` | pass-through |
+| 5 | `src/daemon/interaction/internal/interaction.ts` | `handleInteractionCommands` → `handleTouchInteractionCommands` | pass-through |
+| 6 | `src/daemon/interaction/internal/interaction-touch.ts` | switches `press`/`click`/`longpress`/`hover` to `dispatchTargetedTouchViaRuntime` | thin |
+| 7 | `src/daemon/interaction/internal/interaction-touch-press.ts` | admits the touch, tries the direct-iOS fast path (no-op on Android), calls `dispatchRuntimeInteraction` with a `run` callback that calls `runtime.interactions.press` | substantive |
+| 8 | `src/daemon/interaction/internal/interaction-touch-prepare.ts` | `prepareTouchDispatch` → `resolveBoundTouchRuntime` | thin |
+| 9 | `src/daemon/touch-runtime.ts` | resolves the touch plan, calls `bind(device, tapPointUse)`, wraps the result as `BoundTouchExecutor.tapPoint` | substantive |
+| 10 | `src/daemon/runtime-admission.ts` | `admitRuntimeOperations` → `requireDeviceBinding(bindDevice)` | thin |
+| 11 | `src/daemon/request-runtime-binding.ts` | `bindDevice` → per-device-cached `gateway.bind(...)` | substantive |
+| 12 | `src/platform-runtime-gateway.ts` | composed gateway's `loadLocal`: loads the host, calls `module.loadRuntime(host)` | substantive |
+| 13 | `src/platform-runtime.ts` | declared boundary (ADR §1/§2): wires `androidRuntimeModule` into `platformRuntimeModules` and supplies `loadHost` | thin |
+| 14 | `src/platform-runtime-operation-host.ts` | `createPlatformRuntimeHost` builds `host`, incl. `localInteractors: createLocalApplicationInteractorHost()` | thin |
+| 15 | `src/platform-runtime-local-application-interactors.ts` | `resolve()` lazy-imports `core/interactors.ts`, calls `getLocalInteractor` | pass-through |
+| 16 | `src/core/interactors.ts` | `getLocalInteractor` → `getPlugin(device.platform).createInteractor` | pass-through |
+| 17 | `src/core/interactors/register-builtins.ts` | plugin registry; the `android` entry lazy-imports `./android.ts` | thin |
+| 18 | `src/core/interactors/android.ts` | `createAndroidInteractor` builds the `Interactor`, incl. `tap: (x, y) => pressAndroid(device, x, y)` | substantive |
+| 19 | `packages/platform-android/src/index.ts` | declared boundary (ADR §2 `loadRuntime` pairing): lazy-imports `./runtime.ts`, calls `createAndroidPlatformRuntime` | pass-through |
+| 20 | `packages/platform-android/src/runtime.ts` | `createAndroidPlatformRuntime`'s `bind()` builds `operations` via `androidInteractionOperations` | substantive |
+| 21 | `packages/contracts/src/local-interactor-operation-set.ts` | `bindLocalInteractorOperationSet` → `bindLocalTouchInteractor` | pass-through |
+| 22 | `packages/contracts/src/touch-runtime.ts` | `bindTouch`'s `tapPoint` op resolves the interactor (re-enters hop 15's `resolve`), then `executeGenericPress` calls `interactor.tap(x, y)` | substantive |
+| 23 | `packages/platform-android/src/input-actions.ts` | `pressAndroid(device, x, y)` builds the adb argv, calls `runAndroidAdb` | thin |
+| 24 | `packages/platform-android/src/adb.ts` | `runAndroidAdb` issues `adb shell input tap <x> <y>` | **terminal** |
+
+## `snapshot` / iOS Simulator (XCTest): HTTP entry → runner fetch
+
+24 files, 5 pass-through, 7 thin, 11 substantive, 1 terminal.
+
+| # | File | Hand-off | Class |
+|---|------|----------|-------|
+| 1 | `src/daemon/server/http-server.ts` | parses the HTTP request, calls `handleRequest` | thin |
+| 2 | `src/daemon/request-router.ts` | `createRequestHandler` → `runRequestHandlerChain` | pass-through |
+| 3 | `src/daemon/request-handler-chain.ts` | routes `command: 'snapshot'` to `runSnapshotHandler`, lazy-loads `handlers/snapshot.ts` | thin |
+| 4 | `src/daemon/handlers/snapshot.ts` | `handleSnapshotCommands` routes the plain-snapshot arm to `dispatchSnapshotViaRuntime` | thin |
+| 5 | `src/daemon/snapshot-runtime.ts` | `dispatchSnapshotViaRuntime` → `dispatchSnapshotRuntimeCommand` | pass-through |
+| 6 | `src/daemon/snapshot-command-runtime.ts` | resolves the bound capture, wires session/backend, calls `params.execute` | substantive |
+| 7 | `src/daemon/snapshot-runtime-binding.ts` | `resolveBoundSnapshotCaptureRuntime` → `admitAndBindSnapshotCapture` → `bindSnapshotCaptureRuntime` → `bind(device, plan.use)` on the `active-app` arm | substantive |
+| 8 | `src/daemon/session-runtime-admission.ts` | `admitRuntimePlan` / `requireRuntimeBinding` | thin |
+| 9 | `src/daemon/request-runtime-binding.ts` | `bindDevice` → per-device-cached `gateway.bind(...)` | substantive |
+| 10 | `src/platform-runtime-gateway.ts` | composed gateway's `loadLocal`: loads the host, calls `module.loadRuntime(host)` | substantive |
+| 11 | `src/platform-runtime.ts` | declared boundary: wires `appleRuntimeModule`, supplies `loadHost` | thin |
+| 12 | `src/platform-runtime-operation-host.ts` | `createPlatformRuntimeHost` builds `host`, incl. `localInteractors` | thin |
+| 13 | `packages/platform-apple/src/index.ts` | declared boundary (`loadRuntime` pairing): lazy-imports `./runtime.ts`, calls `createApplePlatformRuntime`; also holds `applePlugin.createInteractor`, entered once and reused at hop 20 | pass-through |
+| 14 | `packages/platform-apple/src/runtime.ts` | `createApplePlatformRuntime`'s `bind()` calls `bindAppleSnapshotRuntime` when `captureSnapshot` is admitted | substantive |
+| 15 | `packages/platform-apple/src/runtime-snapshot.ts` | `bindAppleSnapshotRuntime` branches macOS-surface vs. app-snapshot, resolves the local interactor | substantive |
+| 16 | `packages/contracts/src/snapshot-runtime.ts` | `bindLocalSnapshotInteractor`'s `captureSnapshot` op resolves the interactor (hop 17), calls `interactor.snapshot(options)` | substantive |
+| 17 | `src/platform-runtime-local-application-interactors.ts` | `resolve()` lazy-imports `core/interactors.ts` | pass-through |
+| 18 | `src/core/interactors.ts` | `getLocalInteractor` → `getPlugin('apple').createInteractor` (the package-owned `applePlugin`) | pass-through |
+| 19 | `src/core/interactors/register-builtins.ts` | plugin registry; the `apple` entry is `applePlugin`, imported directly from the package | thin |
+| 20 | `packages/platform-apple/src/interactor.ts` | `createAppleInteractor`'s `snapshot` calls `captureAppleSnapshot` → `captureAppleRunnerSnapshot` | substantive |
+| 21 | `packages/platform-apple/src/runner/runner-client.ts` | `runAppleRunnerCommand` resolves the runner provider, applies the read-only retry policy, calls `provider.runCommand` | substantive |
+| 22 | `packages/platform-apple/src/runner/runner-lifecycle.ts` | `executeRunnerCommand`: recycle-budget/session bookkeeping, calls `ensureRunnerSession` then `executeRunnerCommandWithSession` | substantive |
+| 23 | `packages/platform-apple/src/runner/runner-session.ts` | `executeRunnerCommandWithSession` → `sendRunnerCommandOnce` | substantive |
+| 24 | `packages/platform-apple/src/runner/runner-transport.ts` | issues `fetch(url, ...)` to the XCTest runner process | **terminal** |
+
+## Why this differs from the ADR's 38/29
+
+The façade PRs the plan sheet named as a candidate explanation (#2178, #2222, #2232) all merged
+**before** `e624ef9d3f` — the commit the ADR cites for its 38/29 measurement — so they cannot be
+why that count is higher than this one; they were already in effect when 38/29 was recorded.
+
+This trace lands at 24 hops for both routes, matching the file-by-file trace recorded in
+`maintainability-review-2026-09-02.md` during the 2026-09-02 audit ("press/Android = 24 hops
+(5 pass-through), snapshot/iOS = 23 (6 pass-through)") to within one file — a difference plausibly
+explained by which file either trace treats as the route's start or end boundary, not by a
+different code path. Two independent file-by-file traces using the same unit therefore agree with
+each other and disagree with the ADR's 38/29 by roughly 1.5x. The ADR text names no ordered chain,
+no command/artifact, and no counting definition for 38/29, so the discrepancy cannot be resolved
+against it; the most likely explanation is a different counting unit (e.g. counting every named
+export or every static/type import touched, rather than distinct production files on the call
+path) rather than a different code path, since both real traces walked the same files. **38 and 29
+should be treated as superseded by the 24/24 measured here**, not as a second data point to
+reconcile.
+
+## The ≤14 target
+
+Splitting each traced route into stages:
+
+- **Router spine** (shared by every command): hops 1-3, `http-server.ts` → `request-router.ts` →
+  `request-handler-chain.ts`. 3 files, fixed.
+- **Admission/binding** (resolve the session's device, admit the plan, obtain a bound
+  capture/tap closure): press hops 4-11 (8 files, 2 substantive); snapshot hops 4-9 (6 files, 3
+  substantive).
+- **Gateway resolution** (the declared `platform-runtime.ts` boundary and its `loadRuntime`
+  pairing): hops 12-14/10-13 (3 files, 2 substantive) on both routes — these files are pinned as
+  boundaries by Decision §1/§2 and do not collapse regardless of target.
+- **Interactor resolution** (the local-interactor plugin lookup, a second object graph parallel
+  to the operations bind above): 3 pass-through/thin files on both routes.
+- **Platform glue + terminal call**: press hops 18-24 (7 files, 4 substantive incl. terminal);
+  snapshot hops 20-24 (5 files, 5 substantive incl. terminal, because the XCTest runner protocol
+  — session lifecycle, recycle budget, transport — has no Android equivalent to `adb`'s
+  single-process-call shape).
+
+Collapsing every pass-through and thin file in the admission/binding and interactor-resolution
+stages down to one hop each (folding `interaction-touch-prepare.ts` into `interaction-touch-press.ts`,
+`runtime-admission.ts` into `touch-runtime.ts`, the interactor-resolution three-file chain into
+one lookup, etc.) removes roughly 10 files from `press` (24 → ~14) and roughly 9 from `snapshot`
+(24 → ~15), leaving mostly the substantive hops plus the fixed spine and declared boundaries.
+
+That arithmetic makes ≤14 plausible for `press`/Android under an aggressive but not obviously
+wrong collapsing plan. For `snapshot`/iOS it lands at ~15, and closing that last gap means cutting
+into the runner-protocol's substantive hops (`runner-client.ts` / `runner-lifecycle.ts` /
+`runner-session.ts` / `runner-transport.ts`), which carry retry policy, session-recycle budgeting,
+and session-cache bookkeeping that is not obviously waste. No accepted plan collapses those four
+into fewer files today.
+
+**Verdict: ≤14 is a proposed target, unverified.** It is in the right neighborhood for `press`
+under a plausible (not yet accepted) collapsing plan, and is not clearly reachable for `snapshot`
+without a decision to fold runner-protocol mechanics that are load-bearing, not incidental. Treat
+14 as a discussion anchor for the maintainer decision this ADR section defers to, not as a derived
+number.

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -879,10 +879,9 @@ there, not about retiring the directory.
 and commit for this measurement are in
 [`0019-end-state-hop-trace.md`](./0019-end-state-hop-trace.md), which supersedes the number
 below. A file-by-file re-trace at HEAD measured 24 hops for both `press`/Android and
-`snapshot`/iOS — matching, to within one file, the independent trace recorded in
-`maintainability-review-2026-09-02.md` ("press/Android = 24 hops … snapshot/iOS = 23"). The
-previously stated 38/29 named no ordered chain, counting definition, or artifact and does not
-reproduce; treat it as superseded, not as a second data point. `src/platform-runtime.ts` (the
+`snapshot`/iOS. The previously stated 38/29 named no ordered chain, counting definition, or
+artifact and does not reproduce; treat it as superseded, not as a second data point.
+`src/platform-runtime.ts` (the
 immutable registry construction) and each platform façade's `loadRuntime` pairing are declared
 boundaries under Decision §1 and §2, not pass-through layers — they stay in any hop count
 regardless of target. Everything else on the traced path is a pass-through candidate only insofar

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -863,3 +863,48 @@ execution shapes and permanent structural policies.
 - **Rely only on performance thresholds for lazy loading:** rejected. Thresholds catch regressions
   late and can pass while unrelated implementation graphs load; the import/evaluation shape is also
   contract-tested.
+
+## End state (proposed 2026-09-02, maintainer decision pending)
+
+The targets below are proposed defaults, not an accepted commitment. No tracking issue or Status
+line authorizes work against them yet; they exist to give the next migration wave a numeric
+baseline and are open for revision or rejection.
+
+**Daemon top-level footprint.** `git ls-tree --name-only origin/main src/daemon/ | grep -E
+'\.ts$' | grep -vE '\.test\.ts$' | wc -l` measured 199 production files at `e624ef9d3f`. Proposed
+target: ≤ 60. `src/daemon/**` is a permanent zone under R65; the target is about what remains
+there, not about retiring the directory.
+
+**Entry-to-platform hop count.** A file-by-file trace from the daemon HTTP entry to the concrete
+platform call measured 38 hops for `press`/Android and 29 hops for `snapshot`/iOS. Proposed
+target: ≤ 14 hops each. `src/platform-runtime.ts` (the immutable registry construction) and each
+platform façade's `loadRuntime` pairing are declared boundaries under Decision §1 and §2, not
+pass-through layers — they stay in any hop count regardless of target. Everything else on the
+traced path is a pass-through candidate only insofar as R13's named-facet enumeration and the
+`kernel < contracts < host-kit < capture-kit < provision-kit < platform/provider/daemon` direction
+already allow collapsing it; a hop that exists only to satisfy that direction is not waste.
+
+**Zones still under `src/` that this ADR expects to leave, and their package status:**
+
+- `src/platform-runtime-*.ts` (~70 files: Android/Apple/screen-recording/perf/network/app-log/
+  app-state/toolchain/device-inventory hosts). Mixed ownership: Android's deployment, logs,
+  network, perf, readiness, recording, and shutdown domains already have package homes under
+  `packages/platform-android/src/`; Apple's equivalents live under `packages/platform-apple/src/`.
+  The root files that remain are either declared host-port adapters (e.g. `adb-host`, bound only
+  by its named root file per Decision §1) or mechanics whose wave has not landed yet — the two are
+  not distinguished by filename and need per-file classification before a target is set.
+- `src/recording`, `src/snapshot`, `src/snapshot-quality`, `src/screenshot-diff`. No package
+  owner yet: `packages/capture-kit/src/` currently holds only `ios-snapshot-engine`. These are the
+  capture domain the §1 amendment assigns to `@agent-device/capture-kit`.
+- `src/provider-device-runtime.ts`, `src/provider-device-runtimes.ts`,
+  `src/provider-limrun-runtime.ts`, `src/provider-webdriver.ts`. Mostly already thin: the bulk of
+  WebDriver and Limrun provider logic lives in `packages/provider-webdriver/src/` and
+  `packages/provider-limrun/src/`; these root files are the composition-time wiring, comparable in
+  role to `src/platform-runtime.ts` itself.
+- `src/core` (R13-governed consumer seams), `src/commands`, `src/cli`, `src/cli-schema`,
+  `src/mcp`, `src/client`, `src/sdk`, `src/ai-sdk`, `src/remote`, `src/request`, `src/metro`,
+  `src/backend*.ts`. Not migration targets: these are command-surface, protocol-projection, and
+  daemon-owned zones this ADR keeps in `src/` by design, not residue awaiting a package.
+
+Neither number has an owning issue, gate, or accepted budget yet. Treat both as inputs to a
+maintainer decision, not as a ratchet.

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -875,14 +875,24 @@ baseline and are open for revision or rejection.
 target: ≤ 60. `src/daemon/**` is a permanent zone under R65; the target is about what remains
 there, not about retiring the directory.
 
-**Entry-to-platform hop count.** A file-by-file trace from the daemon HTTP entry to the concrete
-platform call measured 38 hops for `press`/Android and 29 hops for `snapshot`/iOS. Proposed
-target: ≤ 14 hops each. `src/platform-runtime.ts` (the immutable registry construction) and each
-platform façade's `loadRuntime` pairing are declared boundaries under Decision §1 and §2, not
-pass-through layers — they stay in any hop count regardless of target. Everything else on the
-traced path is a pass-through candidate only insofar as R13's named-facet enumeration and the
+**Entry-to-platform hop count.** Corrected 2026-09-03: the counting definition, ordered chains,
+and commit for this measurement are in
+[`0019-end-state-hop-trace.md`](./0019-end-state-hop-trace.md), which supersedes the number
+below. A file-by-file re-trace at HEAD measured 24 hops for both `press`/Android and
+`snapshot`/iOS — matching, to within one file, the independent trace recorded in
+`maintainability-review-2026-09-02.md` ("press/Android = 24 hops … snapshot/iOS = 23"). The
+previously stated 38/29 named no ordered chain, counting definition, or artifact and does not
+reproduce; treat it as superseded, not as a second data point. `src/platform-runtime.ts` (the
+immutable registry construction) and each platform façade's `loadRuntime` pairing are declared
+boundaries under Decision §1 and §2, not pass-through layers — they stay in any hop count
+regardless of target. Everything else on the traced path is a pass-through candidate only insofar
+as R13's named-facet enumeration and the
 `kernel < contracts < host-kit < capture-kit < provision-kit < platform/provider/daemon` direction
 already allow collapsing it; a hop that exists only to satisfy that direction is not waste.
+Proposed target: ≤ 14 hops each — the hop-trace artifact derives this as plausible for `press`
+under an aggressive, not-yet-accepted collapsing plan, and not clearly reachable for `snapshot`
+without cutting into load-bearing XCTest runner-protocol mechanics; **treat 14 as a proposed
+target, unverified**, not a derived number.
 
 **Zones still under `src/` that this ADR expects to leave, and their package status:**
 
@@ -893,9 +903,42 @@ already allow collapsing it; a hop that exists only to satisfy that direction is
   The root files that remain are either declared host-port adapters (e.g. `adb-host`, bound only
   by its named root file per Decision §1) or mechanics whose wave has not landed yet — the two are
   not distinguished by filename and need per-file classification before a target is set.
-- `src/recording`, `src/snapshot`, `src/snapshot-quality`, `src/screenshot-diff`. No package
-  owner yet: `packages/capture-kit/src/` currently holds only `ios-snapshot-engine`. These are the
-  capture domain the §1 amendment assigns to `@agent-device/capture-kit`.
+- `src/recording`, `src/snapshot`, `src/snapshot-quality`, `src/screenshot-diff`. Corrected
+  2026-09-03: `packages/capture-kit/src/` already has broad production ownership across
+  recording (`screen-recording-live-handle.ts`, `screen-recording-completion.ts`,
+  `screen-recording-options.ts`, consumed by `platform-android`/`platform-apple`/
+  `platform-harmonyos`/`platform-web`'s `recording/runtime.ts`), screenshot/diff
+  (`png.ts`, `png-worker-client.ts`, imported by `src/screenshot-diff/screenshot-diff.ts`),
+  snapshot quality (`snapshot-quality-verdict.ts`, `snapshot-quality-backend-capabilities.ts` —
+  `src/snapshot-quality/` now holds only a cross-package regression test, no production file),
+  occlusion (`snapshot-occlusion.ts`), audio/app-log (`audio-probe-runtime.ts`,
+  `app-log-live-handle.ts`, consumed by `platform-android`, `platform-apple`, and
+  `provider-limrun`), and iOS acquisition/engine (`ios-snapshot-acquisition.ts`,
+  `ios-snapshot-planning.ts`, `ios-snapshot-engine/`, consumed by
+  `src/snapshot/ios-snapshot-runtime.ts`). ADR §1's amendment already assigns this capture
+  domain to `capture-kit`; the domain mechanics are migrated. What remains under `src/` in
+  these four directories, verified file-by-file at HEAD, is daemon-facing composition with no
+  existing package equivalent, not unmigrated capture mechanics:
+  - `src/recording/{output-path,overlay,swift-cache,telemetry,video,video-webm}.ts` — video
+    playability polling, overlay burn-in, telemetry persistence, and output-path resolution,
+    imported only by `src/platform-runtime-screen-recording-*.ts` and
+    `src/daemon/handlers/record-runtime*.ts`. Equivalent: none.
+  - `src/snapshot/ios-snapshot-runtime.ts` and `snapshot-visibility.ts` — composition over the
+    capture-kit acquisition/planning/engine/semantics calls above. Equivalent: capture-kit
+    (mechanics already migrated; these are the composition callers).
+  - `src/snapshot/{android-replacement-surface-occlusion,rect-coverage,scroll-edge-state,
+    snapshot-desktop-surface,snapshot-diff,snapshot-evidence,snapshot-label-dedup,
+    snapshot-lines,snapshot-node-label,snapshot-timeout-policy}.ts` — none import capture-kit.
+    `android-replacement-surface-occlusion.ts` implements a distinct Android-specific
+    footprint algorithm, not the generic viewport pruning in capture-kit's
+    `snapshot-occlusion.ts`. Equivalent: none.
+  - `src/snapshot-quality/__tests__/warnings.test.ts` — the sole survivor in that directory;
+    exercises `renderSnapshotQualityWarnings` (root) against capture-kit's
+    `readSnapshotQualityVerdict`. Equivalent: capture-kit (production logic fully migrated).
+  - `src/screenshot-diff/*.ts` (region split/overlay/summarization/component composition) —
+    pixel-diff computation and PNG decode/encode already call capture-kit's `png`/
+    `png-worker-client`; the root files remain for daemon/CLI diff-report composition.
+    Equivalent: none (built atop already-migrated capture-kit mechanics).
 - `src/provider-device-runtime.ts`, `src/provider-device-runtimes.ts`,
   `src/provider-limrun-runtime.ts`, `src/provider-webdriver.ts`. Mostly already thin: the bulk of
   WebDriver and Limrun provider logic lives in `packages/provider-webdriver/src/` and


### PR DESCRIPTION
## Summary

Amends ADR-0019 with an explicit proposed end state for the daemon composition-root migration:

- a 199-file baseline and proposed ceiling of 60 top-level daemon production files;
- an auditable, file-by-file 24-hop trace for both `press`/Android and `snapshot`/iOS, with a proposed ceiling of 14 hops;
- a map of remaining `src/` zones to their intended package owners;
- declared registry construction and platform `loadRuntime` boundaries excluded from pass-through candidates.

The earlier 38/29 hop figures had no ordered chain, counting definition, or reproducible artifact. The ADR now treats them as superseded by the self-contained 24/24 trace instead of claiming corroboration from an unavailable external review artifact.

The numeric targets remain proposed defaults awaiting maintainer acceptance; this PR adds no gate and changes no runtime behavior.

## Validation

- Tested commit `888641b660`.
- Fresh `pnpm install --frozen-lockfile` and `pnpm build` succeeded.
- `pnpm format:check` passed.
- `pnpm check:affected --run` passed; the docs-only diff selected no local checks.
- No planted-red evidence applies to this ADR-only change.
