### PR TITLE
test(remote-connection): extract shared fixtures from the connection suite

### DIFF
--- a/src/__tests__/remote-connection.fixtures.ts
+++ b/src/__tests__/remote-connection.fixtures.ts
@@ -1,0 +1,160 @@
+import path from 'node:path';
+import type { AgentDeviceClient } from '../agent-device-client.ts';
+import {
+  hashRemoteConfigFile,
+  writeRemoteConnectionState,
+  type RemoteConnectionState,
+} from '../remote/remote-connection-state.ts';
+import { mkdtempForTestSync } from './test-utils/tmp-dir.ts';
+
+export const unexpectedCommandCall = async (): Promise<never> => {
+  throw new Error('unexpected call');
+};
+
+function createThrowingMethodGroup<T extends object>(methods: Partial<T> = {}): T {
+  return new Proxy(methods, {
+    get: (target, property) => target[property as keyof T] ?? unexpectedCommandCall,
+  }) as T;
+}
+
+export type MetroPrepareResult = Awaited<ReturnType<AgentDeviceClient['metro']['prepare']>>;
+
+/** A reused React Native Metro whose Android bundle is served from the sandbox host. */
+export function metroPrepareResult(
+  overrides: Partial<MetroPrepareResult> = {},
+): MetroPrepareResult {
+  return {
+    projectRoot: '/tmp/project',
+    kind: 'react-native',
+    dependenciesInstalled: false,
+    packageManager: null,
+    started: false,
+    reused: true,
+    pid: 0,
+    logPath: '/tmp/project/.agent-device/metro.log',
+    statusUrl: 'http://127.0.0.1:8081/status',
+    runtimeFilePath: null,
+    iosRuntime: { platform: 'ios' },
+    androidRuntime: {
+      platform: 'android',
+      bundleUrl: 'https://sandbox.example.test/index.bundle?platform=android',
+    },
+    bridge: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A client whose device inventory is one booted Android emulator and whose lease, session-close,
+ * and Metro groups answer with plain success. Every other method throws `unexpected call`.
+ */
+export function createTestClient(
+  options: {
+    allocate?: AgentDeviceClient['leases']['allocate'];
+    heartbeat?: AgentDeviceClient['leases']['heartbeat'];
+    release?: AgentDeviceClient['leases']['release'];
+    prepare?: AgentDeviceClient['metro']['prepare'];
+    closeSession?: AgentDeviceClient['sessions']['close'];
+    listDevices?: AgentDeviceClient['devices']['list'];
+  } = {},
+): AgentDeviceClient {
+  return {
+    command: createThrowingMethodGroup<AgentDeviceClient['command']>(),
+    devices: createThrowingMethodGroup<AgentDeviceClient['devices']>({
+      list:
+        options.listDevices ??
+        (async () => [
+          {
+            platform: 'android',
+            target: 'mobile',
+            kind: 'emulator',
+            id: 'emulator-5554',
+            name: 'Android Emulator',
+            booted: true,
+            identifiers: { serial: 'emulator-5554' },
+            android: { serial: 'emulator-5554' },
+          },
+        ]),
+    }),
+    sessions: createThrowingMethodGroup<AgentDeviceClient['sessions']>({
+      close:
+        options.closeSession ??
+        (async () => ({
+          session: 'adc-android',
+          identifiers: { session: 'adc-android' },
+        })),
+    }),
+    apps: createThrowingMethodGroup<AgentDeviceClient['apps']>(),
+    materializations: createThrowingMethodGroup<AgentDeviceClient['materializations']>(),
+    leases: createThrowingMethodGroup<AgentDeviceClient['leases']>({
+      allocate:
+        options.allocate ??
+        (async (request) => ({
+          leaseId: 'lease-1',
+          tenantId: request.tenant,
+          runId: request.runId,
+          backend: request.leaseBackend ?? 'android-instance',
+        })),
+      heartbeat:
+        options.heartbeat ??
+        (async (request) => ({
+          leaseId: request.leaseId,
+          tenantId: request.tenant ?? 'acme',
+          runId: request.runId ?? 'run-123',
+          backend: request.leaseBackend ?? 'android-instance',
+        })),
+      release: options.release ?? (async () => ({ released: true })),
+    }),
+    metro: createThrowingMethodGroup<AgentDeviceClient['metro']>({
+      prepare: options.prepare ?? (async () => metroPrepareResult()),
+    }),
+    capture: createThrowingMethodGroup<AgentDeviceClient['capture']>(),
+    interactions: createThrowingMethodGroup<AgentDeviceClient['interactions']>(),
+    replay: createThrowingMethodGroup<AgentDeviceClient['replay']>(),
+    batch: createThrowingMethodGroup<AgentDeviceClient['batch']>(),
+    observability: createThrowingMethodGroup<AgentDeviceClient['observability']>(),
+    debug: createThrowingMethodGroup<AgentDeviceClient['debug']>(),
+    recording: createThrowingMethodGroup<AgentDeviceClient['recording']>(),
+    settings: createThrowingMethodGroup<AgentDeviceClient['settings']>(),
+  };
+}
+
+export type ConnectionWorkspace = {
+  tempRoot: string;
+  stateDir: string;
+  remoteConfigPath: string;
+};
+
+/** A scratch state directory and the path of its remote-config profile, which is not yet written. */
+export function connectionWorkspace(prefix: string): ConnectionWorkspace {
+  const tempRoot = mkdtempForTestSync(prefix);
+  return {
+    tempRoot,
+    stateDir: path.join(tempRoot, '.state'),
+    remoteConfigPath: path.join(tempRoot, 'remote.json'),
+  };
+}
+
+export type StoredConnectionSeed = Omit<
+  RemoteConnectionState,
+  'version' | 'remoteConfigHash' | 'connectedAt' | 'updatedAt'
+>;
+
+/**
+ * Persists a connection recorded against the profile file as it exists now: the stored hash is
+ * taken at seed time, so a later edit of `state.remoteConfigPath` reads as a changed profile.
+ */
+export function seedConnectionState(options: {
+  stateDir: string;
+  state: StoredConnectionSeed;
+}): RemoteConnectionState {
+  const state: RemoteConnectionState = {
+    version: 1,
+    remoteConfigHash: hashRemoteConfigFile(options.state.remoteConfigPath),
+    connectedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...options.state,
+  };
+  writeRemoteConnectionState({ stateDir: options.stateDir, state });
+  return state;
+}

--- a/src/__tests__/remote-connection.test.ts
+++ b/src/__tests__/remote-connection.test.ts
@@ -2,7 +2,13 @@ import { afterEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { mkdtempForTestSync } from './test-utils/tmp-dir.ts';
+import {
+  connectionWorkspace,
+  createTestClient,
+  metroPrepareResult,
+  seedConnectionState,
+  unexpectedCommandCall,
+} from './remote-connection.fixtures.ts';
 
 vi.mock('../metro/client-metro-companion.ts', () => ({
   stopMetroCompanion: vi.fn(),
@@ -40,10 +46,6 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-const unexpectedCommandCall = async (): Promise<never> => {
-  throw new Error('unexpected call');
-};
-
 test('deferred Metro config ignores perf-style kind values', () => {
   assert.equal(
     hasDeferredMetroConfig({
@@ -65,106 +67,8 @@ test('deferred Metro config ignores perf-style kind values', () => {
   );
 });
 
-function createThrowingMethodGroup<T extends object>(methods: Partial<T> = {}): T {
-  return new Proxy(methods, {
-    get: (target, property) => target[property as keyof T] ?? unexpectedCommandCall,
-  }) as T;
-}
-
-function createTestClient(
-  options: {
-    allocate?: AgentDeviceClient['leases']['allocate'];
-    heartbeat?: AgentDeviceClient['leases']['heartbeat'];
-    release?: AgentDeviceClient['leases']['release'];
-    prepare?: AgentDeviceClient['metro']['prepare'];
-    closeSession?: AgentDeviceClient['sessions']['close'];
-    listDevices?: AgentDeviceClient['devices']['list'];
-  } = {},
-): AgentDeviceClient {
-  return {
-    command: createThrowingMethodGroup<AgentDeviceClient['command']>(),
-    devices: createThrowingMethodGroup<AgentDeviceClient['devices']>({
-      list:
-        options.listDevices ??
-        (async () => [
-          {
-            platform: 'android',
-            target: 'mobile',
-            kind: 'emulator',
-            id: 'emulator-5554',
-            name: 'Android Emulator',
-            booted: true,
-            identifiers: { serial: 'emulator-5554' },
-            android: { serial: 'emulator-5554' },
-          },
-        ]),
-    }),
-    sessions: createThrowingMethodGroup<AgentDeviceClient['sessions']>({
-      close:
-        options.closeSession ??
-        (async () => ({
-          session: 'adc-android',
-          identifiers: { session: 'adc-android' },
-        })),
-    }),
-    apps: createThrowingMethodGroup<AgentDeviceClient['apps']>(),
-    materializations: createThrowingMethodGroup<AgentDeviceClient['materializations']>(),
-    leases: createThrowingMethodGroup<AgentDeviceClient['leases']>({
-      allocate:
-        options.allocate ??
-        (async (request) => ({
-          leaseId: 'lease-1',
-          tenantId: request.tenant,
-          runId: request.runId,
-          backend: request.leaseBackend ?? 'android-instance',
-        })),
-      heartbeat:
-        options.heartbeat ??
-        (async (request) => ({
-          leaseId: request.leaseId,
-          tenantId: request.tenant ?? 'acme',
-          runId: request.runId ?? 'run-123',
-          backend: request.leaseBackend ?? 'android-instance',
-        })),
-      release: options.release ?? (async () => ({ released: true })),
-    }),
-    metro: createThrowingMethodGroup<AgentDeviceClient['metro']>({
-      prepare:
-        options.prepare ??
-        (async () => ({
-          projectRoot: '/tmp/project',
-          kind: 'react-native',
-          dependenciesInstalled: false,
-          packageManager: null,
-          started: false,
-          reused: true,
-          pid: 0,
-          logPath: '/tmp/project/.agent-device/metro.log',
-          statusUrl: 'http://127.0.0.1:8081/status',
-          runtimeFilePath: null,
-          iosRuntime: { platform: 'ios' },
-          androidRuntime: {
-            platform: 'android',
-            bundleUrl: 'https://sandbox.example.test/index.bundle?platform=android',
-          },
-          bridge: null,
-        })),
-    }),
-    capture: createThrowingMethodGroup<AgentDeviceClient['capture']>(),
-    interactions: createThrowingMethodGroup<AgentDeviceClient['interactions']>(),
-    replay: createThrowingMethodGroup<AgentDeviceClient['replay']>(),
-    batch: createThrowingMethodGroup<AgentDeviceClient['batch']>(),
-    observability: createThrowingMethodGroup<AgentDeviceClient['observability']>(),
-    debug: createThrowingMethodGroup<AgentDeviceClient['debug']>(),
-    recording: createThrowingMethodGroup<AgentDeviceClient['recording']>(),
-    settings: createThrowingMethodGroup<AgentDeviceClient['settings']>(),
-  };
-}
-
 test('connect auto-generates a local session and writes minimal remote state', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace('agent-device-connect-');
   fs.writeFileSync(
     remoteConfigPath,
     JSON.stringify({ daemonBaseUrl: 'https://daemon.example.test' }),
@@ -203,8 +107,7 @@ test('connect auto-generates a local session and writes minimal remote state', a
 });
 
 test('connect proxy writes normal remote state with generated non-secret profile', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-proxy-');
 
   await captureStdout(async () => {
     await connectCommand({
@@ -252,8 +155,7 @@ test('connect proxy writes normal remote state with generated non-secret profile
 });
 
 test('connect daemon-base-url shortcut uses proxy profile for direct proxy URLs', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-shortcut-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-proxy-shortcut-');
 
   await captureStdout(async () => {
     await connectCommand({
@@ -284,8 +186,7 @@ test('connect daemon-base-url shortcut uses proxy profile for direct proxy URLs'
 });
 
 test('connect proxy scopes generated client identity by explicit session', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-sessions-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-proxy-sessions-');
 
   for (const session of ['agent-a', 'agent-b']) {
     await captureStdout(async () => {
@@ -315,8 +216,7 @@ test('connect proxy scopes generated client identity by explicit session', async
 });
 
 test('connect proxy notice distinguishes safe inventory from lease allocation', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-notice-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-proxy-notice-');
 
   const stdout = await captureStdout(async () => {
     await connectCommand({
@@ -342,9 +242,9 @@ test('connect proxy notice distinguishes safe inventory from lease allocation', 
 });
 
 test('generated remote config writer strips secret fields', () => {
-  const tempRoot = mkdtempForTestSync('agent-device-generated-profile-');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-generated-profile-');
   const configPath = writeGeneratedRemoteConfig({
-    stateDir: path.join(tempRoot, '.state'),
+    stateDir,
     provider: 'proxy',
     profile: {
       daemonBaseUrl: 'http://proxy.example.test/agent-device',
@@ -366,9 +266,9 @@ test('generated remote config writer strips secret fields', () => {
 });
 
 test('connect proxy rejects remote-config and unknown provider combinations', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-errors-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-proxy-errors-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
 
   await assert.rejects(
@@ -405,9 +305,9 @@ test('connect proxy rejects remote-config and unknown provider combinations', as
 });
 
 test('connect reports deferred Metro runtime preparation when remote config has Metro settings', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-metro-notice-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-metro-notice-',
+  );
   fs.writeFileSync(
     remoteConfigPath,
     JSON.stringify({
@@ -457,9 +357,9 @@ test('connect reports deferred Metro runtime preparation when remote config has 
 });
 
 test('connection status re-emits the deferred Metro command scoped to the named session', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connection-status-metro-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connection-status-metro-',
+  );
   fs.writeFileSync(
     remoteConfigPath,
     JSON.stringify({
@@ -508,9 +408,9 @@ test('connection status re-emits the deferred Metro command scoped to the named 
 });
 
 test('connect without a session creates a fresh connection without replacing the active one', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-idempotent-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-idempotent-',
+  );
   fs.writeFileSync(
     remoteConfigPath,
     JSON.stringify({ daemonBaseUrl: 'https://daemon.example.test' }),
@@ -560,9 +460,9 @@ test('connect without a session creates a fresh connection without replacing the
 });
 
 test('connect missing scope errors mention remote config or flags', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-scope-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-scope-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
 
   await assert.rejects(
@@ -606,23 +506,19 @@ test('connect missing scope errors mention remote config or flags', async () => 
 });
 
 test('deferred materialization allocates lease and prepares Metro for open', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-open-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-open-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let observedBridgeScope: { tenantId: string; runId: string; leaseId: string } | undefined;
@@ -652,21 +548,9 @@ test('deferred materialization allocates lease and prepares Metro for open', asy
       }),
       prepare: async (options) => {
         observedBridgeScope = options.bridgeScope;
-        return {
-          projectRoot: '/tmp/project',
-          kind: 'react-native',
-          dependenciesInstalled: false,
-          packageManager: null,
-          started: false,
-          reused: true,
-          pid: 0,
-          logPath: '/tmp/project/.agent-device/metro.log',
-          statusUrl: 'http://127.0.0.1:8081/status',
-          runtimeFilePath: null,
-          iosRuntime: { platform: 'ios' },
+        return metroPrepareResult({
           androidRuntime: { platform: 'android', bundleUrl: 'https://bundle.example.test' },
-          bridge: null,
-        };
+        });
       },
     }),
   });
@@ -691,24 +575,20 @@ test('deferred materialization allocates lease and prepares Metro for open', asy
 
 // fallow-ignore-next-line complexity
 test('proxy open resolves device key before allocating lease', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-open-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-proxy-open-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-proxy',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'proxy',
       runId: 'proxy-client-1',
       leaseProvider: 'proxy',
       clientId: 'client-1',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let allocateRequest: Parameters<AgentDeviceClient['leases']['allocate']>[0] | undefined;
@@ -771,24 +651,20 @@ test('proxy open resolves device key before allocating lease', async () => {
 });
 
 test('proxy install allocates a device lease before dispatch', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-install-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-proxy-install-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-proxy',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'proxy',
       runId: 'proxy-client-1',
       leaseProvider: 'proxy',
       clientId: 'client-1',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let allocateRequest: Parameters<AgentDeviceClient['leases']['allocate']>[0] | undefined;
@@ -838,25 +714,21 @@ test('proxy install allocates a device lease before dispatch', async () => {
 });
 
 test('artifacts command reuses the stored cloud lease without allocating', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-cloud-artifacts-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-cloud-artifacts-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({}));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-cloud',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'cloud-lease-1',
       leaseBackend: 'ios-instance',
       leaseProvider: 'aws-device-farm',
       platform: 'ios',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -884,23 +756,19 @@ test('artifacts command reuses the stored cloud lease without allocating', async
 });
 
 test('cloud webdriver connection allocates and heartbeats with extended lease TTL', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-cloud-ttl-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-cloud-ttl-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({}));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-cloud',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-123',
       leaseProvider: 'aws-device-farm',
       platform: 'ios',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   const baseFlags = {
@@ -961,24 +829,20 @@ test('cloud webdriver connection allocates and heartbeats with extended lease TT
 });
 
 test('proxy commands without active device lease fail before allocation', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-proxy-closed-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-proxy-closed-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-proxy',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'proxy',
       runId: 'proxy-client-1',
       leaseProvider: 'proxy',
       clientId: 'client-1',
       leaseBackend: 'ios-instance',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1009,9 +873,9 @@ test('proxy commands without active device lease fail before allocation', async 
 });
 
 test('direct remote-config materialization creates state and prepares Metro for open', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-direct-remote-open-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-direct-remote-open-',
+  );
   fs.writeFileSync(
     remoteConfigPath,
     JSON.stringify({
@@ -1049,21 +913,9 @@ test('direct remote-config materialization creates state and prepares Metro for 
       }),
       prepare: async (options) => {
         observedBridgeScope = options.bridgeScope;
-        return {
-          projectRoot: '/tmp/project',
-          kind: 'react-native',
-          dependenciesInstalled: false,
-          packageManager: null,
-          started: false,
-          reused: true,
-          pid: 0,
-          logPath: '/tmp/project/.agent-device/metro.log',
-          statusUrl: 'http://127.0.0.1:8081/status',
-          runtimeFilePath: null,
-          iosRuntime: { platform: 'ios' },
+        return metroPrepareResult({
           androidRuntime: { platform: 'android', bundleUrl: 'https://bundle.example.test' },
-          bridge: null,
-        };
+        });
       },
     }),
   });
@@ -1087,23 +939,19 @@ test('direct remote-config materialization creates state and prepares Metro for 
 });
 
 test('deferred materialization prepares Metro for batch when a step opens an app', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-batch-open-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-batch-open-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1141,17 +989,15 @@ test('deferred materialization prepares Metro for batch when a step opens an app
 });
 
 test('deferred materialization re-prepares runtime when explicit Metro overrides are provided', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-runtime-override-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-runtime-override-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
@@ -1167,8 +1013,6 @@ test('deferred materialization re-prepares runtime when explicit Metro overrides
         profileKey: remoteConfigPath,
         consumerKey: 'adc-android',
       },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let prepareRequest: Parameters<AgentDeviceClient['metro']['prepare']>[0] | undefined;
@@ -1195,24 +1039,16 @@ test('deferred materialization re-prepares runtime when explicit Metro overrides
     client: createTestClient({
       prepare: async (options) => {
         prepareRequest = options;
-        return {
+        return metroPrepareResult({
           projectRoot: '/tmp/project-new',
           kind: 'repack',
-          dependenciesInstalled: false,
-          packageManager: null,
-          started: false,
           reused: false,
-          pid: 0,
           logPath: '/tmp/project-new/.agent-device/metro.log',
-          statusUrl: 'http://127.0.0.1:8081/status',
-          runtimeFilePath: null,
-          iosRuntime: { platform: 'ios' },
           androidRuntime: {
             platform: 'android',
             bundleUrl: 'https://sandbox.example.test/index.bundle?platform=android&dev=true',
           },
-          bridge: null,
-        };
+        });
       },
     }),
     forceRuntimePrepare: true,
@@ -1241,9 +1077,9 @@ test('deferred materialization re-prepares runtime when explicit Metro overrides
 });
 
 test('cdp remote materialization prepares Metro runtime for bridge target discovery', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-agent-cdp-runtime-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-agent-cdp-runtime-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
   let prepareRequest: Parameters<AgentDeviceClient['metro']['prepare']>[0] | undefined;
 
@@ -1269,25 +1105,13 @@ test('cdp remote materialization prepares Metro runtime for bridge target discov
     client: createTestClient({
       prepare: async (options) => {
         prepareRequest = options;
-        return {
-          projectRoot: '/tmp/project',
-          kind: 'react-native',
-          dependenciesInstalled: false,
-          packageManager: null,
-          started: false,
-          reused: true,
-          pid: 0,
-          logPath: '/tmp/project/.agent-device/metro.log',
-          statusUrl: 'http://127.0.0.1:8081/status',
-          runtimeFilePath: null,
-          iosRuntime: { platform: 'ios' },
+        return metroPrepareResult({
           androidRuntime: {
             platform: 'android',
             bundleUrl:
               'https://proxy.example.test/api/metro/runtimes/runtime-1/index.bundle?platform=android',
           },
-          bridge: null,
-        };
+        });
       },
     }),
   });
@@ -1313,9 +1137,9 @@ test('cdp remote materialization prepares Metro runtime for bridge target discov
 });
 
 test('cdp remote materialization skips Metro runtime for non-target commands', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-agent-cdp-memory-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-agent-cdp-memory-',
+  );
   fs.writeFileSync(path.join(tempRoot, 'remote.json'), JSON.stringify({}));
   let prepared = false;
 
@@ -1355,9 +1179,9 @@ test('cdp remote materialization skips Metro runtime for non-target commands', a
 });
 
 test('cdp remote materialization skips Metro runtime without public CDP url', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-agent-cdp-no-public-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-agent-cdp-no-public-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({}));
   let prepared = false;
 
@@ -1396,25 +1220,21 @@ test('cdp remote materialization skips Metro runtime without public CDP url', as
 });
 
 test('deferred materialization heartbeats an existing lease before dispatch', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-heartbeat-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-heartbeat-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-existing',
       leaseBackend: 'android-instance',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let heartbeatCount = 0;
@@ -1468,23 +1288,19 @@ test('deferred materialization heartbeats an existing lease before dispatch', as
 });
 
 test('deferred materialization allocates pending lease for devices', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-devices-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-devices-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let allocateCount = 0;
@@ -1528,8 +1344,7 @@ test('deferred materialization allocates pending lease for devices', async () =>
 });
 
 test('deferred provider materialization forwards provider profile fields to lease allocation', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-provider-lease-flags-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-provider-lease-flags-');
   const remoteConfigPath = path.join(tempRoot, 'browserstack.json');
   fs.writeFileSync(
     remoteConfigPath,
@@ -1546,20 +1361,16 @@ test('deferred provider materialization forwards provider profile fields to leas
       providerBuild: 'live-smoke',
     }),
   );
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-browserstack',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'browserstack',
       runId: 'browserstack-run',
       leaseBackend: 'android-instance',
       leaseProvider: 'browserstack',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let allocateRequest: Parameters<AgentDeviceClient['leases']['allocate']>[0] | undefined;
@@ -1611,25 +1422,21 @@ test('deferred provider materialization forwards provider profile fields to leas
 });
 
 test('deferred materialization reallocates when the persisted lease is inactive', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-stale-lease-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-stale-lease-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-existing',
       leaseBackend: 'android-instance',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1672,23 +1479,19 @@ test('deferred materialization reallocates when the persisted lease is inactive'
 });
 
 test('deferred materialization preserves auth failures from lease allocation', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-auth-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-auth-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1723,22 +1526,18 @@ test('deferred materialization preserves auth failures from lease allocation', a
 });
 
 test('deferred materialization does not require a lease backend for close', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-close-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-close-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1772,18 +1571,16 @@ test('deferred materialization does not require a lease backend for close', asyn
 });
 
 test('deferred materialization stops the new Metro companion if state persistence fails', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-write-fail-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-write-fail-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://daemon.example' },
       tenant: 'acme',
       runId: 'run-123',
@@ -1793,8 +1590,6 @@ test('deferred materialization stops the new Metro companion if state persistenc
         profileKey: remoteConfigPath,
         consumerKey: 'adc-android',
       },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1850,24 +1645,20 @@ test('deferred materialization stops the new Metro companion if state persistenc
 });
 
 test('connect requires force when compatible scope changes platform', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-platform-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-platform-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1896,25 +1687,21 @@ test('connect requires force when compatible scope changes platform', async () =
 });
 
 test('connect requires force when the daemon endpoint changes', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-daemon-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-daemon-',
+  );
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://old.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       daemon: { baseUrl: 'https://old.example' },
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       platform: 'android',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -1942,8 +1729,7 @@ test('connect requires force when the daemon endpoint changes', async () => {
 });
 
 test('connect --force stops replaced Metro companion after state is updated', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-');
   const oldRemoteConfigPath = path.join(tempRoot, 'old-remote.json');
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   fs.writeFileSync(
@@ -1957,13 +1743,11 @@ test('connect --force stops replaced Metro companion after state is updated', as
     }),
   );
   fs.writeFileSync(newRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://new.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath: oldRemoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(oldRemoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
@@ -1977,8 +1761,6 @@ test('connect --force stops replaced Metro companion after state is updated', as
         profileKey: oldRemoteConfigPath,
         consumerKey: 'adc-android',
       },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2023,8 +1805,7 @@ test('connect --force stops replaced Metro companion after state is updated', as
 });
 
 test('connect --force without a session does not replace the active generated connection', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-active-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-active-');
   const oldRemoteConfigPath = path.join(tempRoot, 'old-remote.json');
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   fs.writeFileSync(
@@ -2035,13 +1816,11 @@ test('connect --force without a session does not replace the active generated co
     }),
   );
   fs.writeFileSync(newRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://new.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-7f3a2c',
       remoteConfigPath: oldRemoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(oldRemoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
@@ -2055,8 +1834,6 @@ test('connect --force without a session does not replace the active generated co
         profileKey: oldRemoteConfigPath,
         consumerKey: 'adc-7f3a2c',
       },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2106,8 +1883,7 @@ test('connect --force without a session does not replace the active generated co
 });
 
 test("connect --force releases the previous lease with the previous connection's own token, not the new one", async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-prev-token-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-prev-token-');
   const oldRemoteConfigPath = path.join(tempRoot, 'old-remote.json');
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   fs.writeFileSync(
@@ -2119,20 +1895,16 @@ test("connect --force releases the previous lease with the previous connection's
     }),
   );
   fs.writeFileSync(newRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://new.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath: oldRemoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(oldRemoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2172,28 +1944,23 @@ test("connect --force releases the previous lease with the previous connection's
 });
 
 test('connect --force skips releasing the previous lease when its token cannot be recovered and the endpoint differs', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-unreleasable-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-unreleasable-');
   const oldRemoteConfigPath = path.join(tempRoot, 'old-remote.json');
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   // No daemonAuthToken in the previous connection's own profile: its
   // credential cannot be recovered, and the new endpoint differs.
   fs.writeFileSync(oldRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://old.example' }));
   fs.writeFileSync(newRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://new.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath: oldRemoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(oldRemoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseCalled = false;
@@ -2234,8 +2001,7 @@ test('connect --force skips releasing the previous lease when its token cannot b
 });
 
 test('connect --force does not misclassify an env-sourced new token as the previous connection’s own credential', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-env-token-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-env-token-');
   const oldRemoteConfigPath = path.join(tempRoot, 'old-remote.json');
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   // Neither config file declares daemonAuthToken; the only source of a token
@@ -2246,20 +2012,16 @@ test('connect --force does not misclassify an env-sourced new token as the previ
   // Token B, supplied through the environment — not via --daemon-auth-token —
   // which is precisely the gap a merged-profile read would miss.
   vi.stubEnv('AGENT_DEVICE_DAEMON_AUTH_TOKEN', 'test-env-not-a-real-token');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath: oldRemoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(oldRemoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2300,8 +2062,7 @@ test('connect --force does not misclassify an env-sourced new token as the previ
 });
 
 test('connect --force does not treat a re-pointed config path’s token as the previous endpoint’s own', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-repointed-path-');
-  const stateDir = path.join(tempRoot, '.state');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connect-force-repointed-path-');
   // ONE path, reused. The previous connection was made against old.example
   // through this file; the file is then edited in place to describe a
   // different endpoint with a different credential. Distinct old/new paths
@@ -2316,22 +2077,18 @@ test('connect --force does not treat a re-pointed config path’s token as the p
       daemonAuthToken: 'test-old-not-a-real-token',
     }),
   );
-  writeRemoteConnectionState({
+  // Recorded while the file still described old.example — the fact that
+  // makes the later edit detectable.
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      // Recorded while the file still described old.example — the fact that
-      // makes the later edit detectable.
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   // The edit: same path, now endpoint B with token B.
@@ -2378,9 +2135,9 @@ test('connect --force does not treat a re-pointed config path’s token as the p
 });
 
 test('connect --force does not trust an unchanged profile token for a CLI-overridden previous endpoint', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-cli-override-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-force-cli-override-',
+  );
   // The profile has always described endpoint B. The previous connection used
   // explicit CLI credentials for endpoint A, so the unchanged file hash proves
   // only which file was loaded — not that its token authenticated endpoint A.
@@ -2391,13 +2148,11 @@ test('connect --force does not trust an unchanged profile token for a CLI-overri
       daemonAuthToken: 'test-new-not-a-real-token',
     }),
   );
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
@@ -2405,8 +2160,6 @@ test('connect --force does not trust an unchanged profile token for a CLI-overri
       // Effective previous endpoint A came from --daemon-base-url, overriding
       // the profile's endpoint B when this state was recorded.
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2445,9 +2198,9 @@ test('connect --force does not trust an unchanged profile token for a CLI-overri
 });
 
 test('connect --force still releases with a rotated credential when the config keeps the same endpoint', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-rotated-token-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-force-rotated-token-',
+  );
   const newRemoteConfigPath = path.join(tempRoot, 'new-remote.json');
   fs.writeFileSync(
     remoteConfigPath,
@@ -2457,20 +2210,16 @@ test('connect --force still releases with a rotated credential when the config k
     }),
   );
   fs.writeFileSync(newRemoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://new.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://old.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   // The file changed — so the hash no longer matches — but it still describes
@@ -2518,26 +2267,22 @@ test('connect --force still releases with a rotated credential when the config k
 });
 
 test('connect --force reuses the ambient token to release the previous lease when the endpoint is unchanged', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connect-force-same-endpoint-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connect-force-same-endpoint-',
+  );
   // No daemonAuthToken on the profile itself: the ambient flag is the only
   // source, matching an ordinary same-profile --force reconnect.
   fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-old',
       leaseId: 'lease-old',
       leaseBackend: 'android-instance',
       daemon: { baseUrl: 'https://daemon.example' },
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2575,9 +2320,7 @@ test('connect --force reuses the ambient token to release the previous lease whe
 });
 
 test('disconnect tolerates prior close and removes local connection state', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-disconnect-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace('agent-device-disconnect-');
   fs.mkdirSync(path.join(stateDir, 'remote-connections'), { recursive: true });
   fs.writeFileSync(remoteConfigPath, '{}');
   fs.writeFileSync(
@@ -2633,23 +2376,19 @@ test('disconnect tolerates prior close and removes local connection state', asyn
 });
 
 test('disconnect after connect-only cleanup stays local when no session resources exist', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-disconnect-pending-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-disconnect-pending-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-pending',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'limrun',
       runId: 'run-123',
       leaseBackend: 'android-instance',
       leaseProvider: 'limrun',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let closeCalls = 0;
@@ -2678,24 +2417,20 @@ test('disconnect after connect-only cleanup stays local when no session resource
 });
 
 test('disconnect without a session uses active connection state', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-disconnect-active-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-disconnect-active-',
+  );
   const closedSessions: Array<{ session: string | undefined; shutdown: boolean | undefined }> = [];
   fs.writeFileSync(remoteConfigPath, '{}');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-1',
       leaseBackend: 'android-instance',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -2727,24 +2462,20 @@ test('disconnect without a session uses active connection state', async () => {
 });
 
 test('disconnect human output surfaces provider release warnings and artifact links', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-disconnect-provider-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-disconnect-provider-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-browserstack',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'browserstack',
       runId: 'run-123',
       leaseId: 'lease-1',
       leaseBackend: 'android-instance',
       leaseProvider: 'browserstack',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -2803,17 +2534,15 @@ test('disconnect human output surfaces provider release warnings and artifact li
 });
 
 test('disconnect releases proxy lease with provider client and device metadata', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-disconnect-proxy-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-disconnect-proxy-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-proxy',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'proxy',
       runId: 'proxy-client-1',
       leaseId: 'abc123abc123abc1',
@@ -2824,8 +2553,6 @@ test('disconnect releases proxy lease with provider client and device metadata',
       leaseProvider: 'proxy',
       clientId: 'client-1',
       deviceKey: 'ios:mobile:SIM-001',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
   let releaseRequest: Parameters<AgentDeviceClient['leases']['release']>[0] | undefined;
@@ -2865,7 +2592,7 @@ test('disconnect releases proxy lease with provider client and device metadata',
 });
 
 test('connection status reports missing state without daemon calls', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connection-status-');
+  const { tempRoot, stateDir } = connectionWorkspace('agent-device-connection-status-');
   let handled = false;
   await captureStdout(async () => {
     handled = await connectionCommand({
@@ -2874,7 +2601,7 @@ test('connection status reports missing state without daemon calls', async () =>
         json: true,
         help: false,
         version: false,
-        stateDir: path.join(tempRoot, '.state'),
+        stateDir,
         session: 'adc-android',
       },
       client: createTestClient(),
@@ -2885,23 +2612,19 @@ test('connection status reports missing state without daemon calls', async () =>
 });
 
 test('connection status reports active connection state', async () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connection-active-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connection-active-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
-  writeRemoteConnectionState({
+  seedConnectionState({
     stateDir,
     state: {
-      version: 1,
       session: 'adc-android',
       remoteConfigPath,
-      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
       tenant: 'acme',
       runId: 'run-123',
       leaseId: 'lease-1',
       leaseBackend: 'android-instance',
-      connectedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
     },
   });
 
@@ -2923,9 +2646,9 @@ test('connection status reports active connection state', async () => {
 });
 
 test('connection state filenames distinguish unsafe session names', () => {
-  const tempRoot = mkdtempForTestSync('agent-device-connection-state-names-');
-  const stateDir = path.join(tempRoot, '.state');
-  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  const { tempRoot, stateDir, remoteConfigPath } = connectionWorkspace(
+    'agent-device-connection-state-names-',
+  );
   fs.writeFileSync(remoteConfigPath, '{}');
   const baseState = {
     version: 1 as const,


### PR DESCRIPTION
## Summary

Extracts the repeated remote-connection test setup into a sibling fixture module while preserving every scenario, input, override, and assertion.

The suite remains at 50 tests and 213 assertions. The extraction reduces the test file from 2,973 to 2,696 lines and removes the obsolete manual size-pin adjustment now superseded by main's history-backed ratchet.

## Validation

At `91fffd5f37b1017a7df94500d75f82df79739780`:

- `pnpm vitest run --project unit-core src/__tests__/remote-connection.test.ts` — 50/50 passed.
- `pnpm check:affected --run` — formatting, lint, typecheck, fallow, and related tests all passed.
- Fresh-worktree `pnpm install --frozen-lockfile` and `pnpm build` completed successfully.
- Rebased onto current main; the obsolete size-pin-only commit was dropped.

Touched scope: two test files; no production, runtime, package, documentation, or device-facing behavior.
