### PR TITLE
docs(layering): kill criteria on every rule module

### DIFF
--- a/scripts/layering/application-lifecycle-policy.ts
+++ b/scripts/layering/application-lifecycle-policy.ts
@@ -1,3 +1,14 @@
+// Catches: application-lifecycle state (the platform-runtime-gateway/application-resources/
+//   IME-activation trio) mutated from outside its declared owner file — an app-boot or IME
+//   readiness race that only shows up as an intermittent device-facing flake, because the type
+//   system sees a legal write to a legal field regardless of which module made it.
+// Evidence: d8a7d03faf (#1759) routed application lifecycle through runtime facts, the migration
+//   this ownership check protects; 7b48531d3b (#2081) retired the cutover scaffolding around it.
+// Cost: 201 LOC (119 rule + 82 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that the
+//   gateway/application-resources/IME-activation trio having one writer no longer matters.
+//   The trio are plain mutable fields, so an outside write type-checks.
+
 import { parseSync } from 'oxc-parser';
 import { memberName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';

--- a/scripts/layering/bin-alias-fast-path.ts
+++ b/scripts/layering/bin-alias-fast-path.ts
@@ -1,3 +1,16 @@
+// Catches: bin.ts's --help fast path re-declaring its own alias table instead of calling the
+//   real registry — the exact silent-drift bug #1618-adjacent produced, where tap/launch/
+//   relaunch fell out of a hand-written table and paid a full CLI bootstrap for static help
+//   text. bin.ts runs unconditionally on import, so no unit test can import and exercise it
+//   directly; only reading its source text structurally can catch a regression.
+// Evidence: d85072d935 (#1641) routed command aliases through the help fast path; 74a70f1764
+//   (#2046) removed next-major compatibility surfaces bin.ts once carried alongside it.
+// Cost: 650 LOC (339 rule + 311 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that bin.ts's --help
+//   fast path no longer needs to delegate to the real alias registry — moot once the fast path
+//   is deleted or its resolution is inlined into commands/cli-command-aliases.ts, leaving no
+//   second call site.
+//
 // R12 bin-alias-fast-path.
 //
 // `bin.ts`'s `--help` fast path resolves a command alias (`tap`, `launch`, …) to its canonical

--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -156,6 +156,20 @@ function checkLayeringRules(edges: readonly ResolvedImportEdge[]): LayeringViola
   return violations;
 }
 
+/**
+ * Catches: a production import cycle — A imports B imports A at the value level — that a
+ *   file-by-file review cannot see because each edge looks locally fine; only walking the
+ *   whole graph exposes the loop. No other gate looks at cycles at all.
+ * Evidence: 3d70943550 (#984) introduced the import-direction DAG gate this cycle check
+ *   anchors; f19864e486 (#1410) added the dependency-graph report built on the same model.
+ * Cost: not attributed (folded into check.ts's whole-graph pass; no standalone module or
+ *   test file to size separately).
+ * Kill criterion: none enforced today; retire only by maintainer decision that an acyclic
+ *   value-import graph no longer matters. tsc rejects a cyclic `references` edge between
+ *   projects, but no tsconfig declares references today and the A4 spike found they are a
+ *   build-cache mechanism, not a boundary: value imports inside one project are never
+ *   cycle-checked, and a cross-package edge resolves through root node_modules with no error.
+ */
 function checkCycles(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   return findValueImportCycles(edges).map((cycle) => ({
     rule: 'R4 value-import-cycle',
@@ -190,6 +204,19 @@ function checkRecordRuntimeOwnership(sources: ReadonlyMap<string, string>): Laye
   });
 }
 
+/**
+ * Catches: a value import that runs against the ranked target spine's declared order (a lower
+ *   zone importing a higher one) — the runtime-consequential half of what R6 also checks for
+ *   type-only edges; neither zone-policy.ts's table nor the cycle check names direction.
+ * Evidence: 3d70943550 (#984) introduced the ranked spine and its back-edge check; docs/
+ *   dependency-graph-findings.md tracks the count this rule ratchets.
+ * Cost: not attributed (folded into check.ts's whole-graph pass; no standalone module or
+ *   test file to size separately).
+ * Kill criterion: none enforced today; retire only by maintainer decision that the ranked spine's
+ *   import direction no longer matters. Splitting zones into packages would not replace it: the
+ *   A4 spike found an undeclared workspace package still resolves through root node_modules and
+ *   a relative tunnel into another package's src still compiles.
+ */
 function checkBackEdges(edges: readonly ResolvedImportEdge[]): LayeringViolation[] {
   const seen = new Set<string>();
   return edges.flatMap((edge) => {
@@ -208,6 +235,18 @@ function checkBackEdges(edges: readonly ResolvedImportEdge[]): LayeringViolation
   });
 }
 
+// Catches: a type-only import against the ranked spine's declared order — a design-level
+//   dependency (zone A is stated in terms of zone B) that R5 is blind to because it costs
+//   nothing at runtime, so nothing else flags "the type shape leaks the wrong direction."
+// Evidence: the R5-adjacent commits in check.ts's history introduced this ratchet; the 61-to-5
+//   reduction and the two remaining deliberate inversions are recorded below and in
+//   docs/dependency-graph-findings.md.
+// Cost: not attributed (folded into check.ts's whole-graph pass; no standalone module or test
+//   file to size separately).
+// Kill criterion: none enforced today; retire only by maintainer decision that type-only spine
+//   inversions no longer matter. Reaching zero remaining inversions does not retire it: at zero
+//   the ratchet is what keeps the count from regrowing, and tsc never rejects a type-only edge.
+//
 // R6 ratchet: type-only spine inversions, per zone pair. R5 cannot see these (a type-only import
 // is free at runtime), but "zone A is declared in terms of zone B" is still a boundary claim, and
 // ranking type edges surfaced 61 of them. Down to 5, and every one of the 5 is now a deliberate

--- a/scripts/layering/contracts-implementation-policy.ts
+++ b/scripts/layering/contracts-implementation-policy.ts
@@ -1,3 +1,17 @@
+// Catches: packages/contracts production source calling host, process, or timer mechanics
+//   directly — contracts owns vocabulary only, and a mechanic call there means an adapter's
+//   concern leaked into the shared-vocabulary package every zone imports, invisible to
+//   consumers because the call itself is fully typed and legal Node code.
+// Evidence: 8f98d23f14 (#1750) gave R18 its own number after an id collision; 057ab1c82d (#1746)
+//   fixed double-reporting in this same authority check.
+// Cost: 337 LOC (206 rule + 131 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that contracts owning
+//   vocabulary only no longer matters. package.json cannot replace it: node: built-ins are not
+//   dependencies and timer globals need no import. The A4 spike found `types: []` would break
+//   contracts' AbortSignal/URL/Buffer/process uses while every lib that supplies them also
+//   supplies setTimeout, and the file-level bans (interaction-outcome, snapshot-quality-warnings,
+//   network-traffic and ios-snapshot type-only statements, kernel-only imports) have no tsc form.
+
 import { parseSync } from 'oxc-parser';
 import type { LayeringViolation } from './model.ts';
 

--- a/scripts/layering/daemon-modularity.ts
+++ b/scripts/layering/daemon-modularity.ts
@@ -45,6 +45,20 @@ const ENGINE_FILE_PREFIXES = [
   'packages/replay-test/src/',
 ] as const;
 
+/**
+ * Catches: the daemon modularity migration regressing quietly — a SessionState field losing
+ *   its owner, a logical module gaining a forbidden or internal import, or an external
+ *   daemon/types.ts importer count creeping up — any of which erodes the wave-by-wave
+ *   extraction #1478/#1478-P5 already paid for, and nothing enforces the wave order itself.
+ * Evidence: 2316fd32c5 (#1487) pinned the migration contracts this ratchet grew from;
+ *   6984a1e095 (#1852) fixed the R10 zone-listing message when the type-cycle ceiling trips.
+ * Cost: 937 LOC total for the file (323 rule + 614 test; shared with R9's checkTypeCycleBaseline
+ *   below, not attributed separately).
+ * Kill criterion: none enforced today; retire only by maintainer decision that the daemon
+ *   modularity baselines (SessionState field-owner counts, logical-module import policies and
+ *   facades, the external daemon/types.ts importer list, per-zone cycle ceilings) no longer
+ *   matter. Every one is a count or an import edge the compiler accepts either way.
+ */
 export function checkDaemonModularityRatchets(
   edges: readonly ResolvedImportEdge[],
   largestTypeCycleMembers: readonly string[],
@@ -143,6 +157,20 @@ function checkSessionStateBaseline(): LayeringViolation[] {
   return violations;
 }
 
+/**
+ * Catches: the largest type-only import cycle growing past its pinned size, or the baseline
+ *   shrinking without the ceiling being lowered to match — R4 keeps the value graph acyclic, so
+ *   these cycles cost nothing at runtime, but an ungoverned type cycle can grow without bound
+ *   while every individual edge still looks locally reasonable.
+ * Evidence: 6984a1e095 (#1852) fixed R10's zone listing when this ceiling trips, evidence the
+ *   check fires in practice; ef6ec2995b (#1825, #1781 A6) made the R9 shrink direction
+ *   mandatory rather than advisory.
+ * Cost: 937 LOC total for the file (323 rule + 614 test; shared with R10's ratchets above, not
+ *   attributed separately).
+ * Kill criterion: none enforced today; retire only by maintainer decision that a bounded
+ *   type-only cycle size no longer matters. tsc never rejects a type-only cycle, and emptying
+ *   LARGEST_TYPE_CYCLE_ZONE_CEILINGS pins the size at zero rather than retiring the check.
+ */
 function checkTypeCycleBaseline(members: readonly string[]): LayeringViolation[] {
   const violations: LayeringViolation[] = [];
   const baseline = DAEMON_MODULARITY_BASELINE.largestTypeCycle;

--- a/scripts/layering/daemon-platform-boundary.ts
+++ b/scripts/layering/daemon-platform-boundary.ts
@@ -4,6 +4,20 @@ import { isProductionSourceFile } from './tracked-sources.ts';
 import type { LayeringViolation } from './model.ts';
 
 /**
+ * Catches: src/daemon importing a concrete platform package or the retired src/platforms path,
+ *   in any form — static, dynamic, or type-only — the terminal boundary the R11/R13 package
+ *   split exists to make possible; a daemon module that reaches around a platform's package
+ *   facade defeats the composition-root discipline R13 enforces on the other side.
+ * Evidence: c794c11d7e (#2072) closed the daemon platform boundary this rule pins; 1522126f1f
+ *   (#2212) kept close lifecycle behind the session facade rather than reopening the boundary.
+ * Cost: 694 LOC (402 rule + 292 test).
+ * Kill criterion: none enforced today; retire only by maintainer decision that src/daemon staying
+ *   free of concrete-platform imports no longer matters. A package boundary would not replace
+ *   it: @agent-device/platform-* resolves from src/daemon through root node_modules whether
+ *   declared or not (A4 spike), and the retired src/platforms path is a plain relative import.
+ */
+
+/**
  * R65 rejects every concrete-platform dependency from tracked production daemon sources.
  *
  * The module record supplies static imports and re-exports; the AST supplies dynamic imports and

--- a/scripts/layering/ios-snapshot-engine-policy.ts
+++ b/scripts/layering/ios-snapshot-engine-policy.ts
@@ -1,3 +1,16 @@
+// Catches: an iOS snapshot caller reaching the XCTest/Limrun/Appium runners directly instead of
+//   through the one converged engine.ts — the fragmentation #2222's "converge Limrun snapshots
+//   through engine" and #758's "bulk-snapshot DEPTH limit" both trace back to, where each
+//   backend's snapshot path could silently diverge from the others' presentation contract.
+// Evidence: a8ee397168 (#2213) added the snapshot engine conformance gates this policy
+//   enforces; 6c8c0508d9 (#2222) converged Limrun snapshots through the engine it protects.
+// Cost: 267 LOC (229 rule + 38 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that the engine.ts →
+//   runner-presentation.ts call topology (presentIosSnapshot and publishIosSnapshot each make
+//   their one delegating call; the runner file never folds, validates, or builds the
+//   presentation itself) no longer matters. An exports map cannot replace it: both files sit
+//   in one package and call each other by relative import, which no manifest restricts.
+
 import { parseSync } from 'oxc-parser';
 import type { LayeringViolation } from './model.ts';
 import { memberPath, visitAst } from './layering-ast.ts';

--- a/scripts/layering/package-boundaries.ts
+++ b/scripts/layering/package-boundaries.ts
@@ -1,3 +1,17 @@
+// Catches: a package reaching back into root src/, a root file tunnelling into packages/*/src
+//   with a relative path, an undeclared workspace import, or a subpath the exports map does not
+//   name — bypasses Node's own resolution error cannot see, because a relative route resolves
+//   fine even though it duplicates the module under its specifier form.
+// Evidence: 76453add71 (#1494, #1490 W0) established the workspace split this rule protects;
+//   83322a3f2f (#1574) pinned exact facade symbols for every workspace package.
+// Cost: 1239 LOC (363 rule + 876 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that the workspace
+//   boundary no longer matters. `pnpm typecheck` already covers two branches for src/ and
+//   packages/ importers (NodeNext rejects a non-exported subpath with TS2307; composite rootDir
+//   rejects a package→root relative escape with TS6059), but the A4 spike found no compiler
+//   mechanism for an undeclared workspace:* dependency, a root→packages/*/src relative tunnel,
+//   or any scripts/ import: project references are a build-cache mechanism, not a boundary.
+//
 // R11 package-boundaries: the workspace rules of #1490, as data the gate walks.
 //
 // Package resolution already makes a deep `@agent-device/*` specifier a runtime

--- a/scripts/layering/platform-composition-policy.ts
+++ b/scripts/layering/platform-composition-policy.ts
@@ -1,3 +1,17 @@
+// Catches: src/platform-runtime.ts, the one canonical composition root, wiring a platform
+//   package's implementation eagerly instead of through the lazy provider-composition seam —
+//   a startup-cost regression (every platform's code loading on every process start) that only
+//   shows up as a perf number, not a type error.
+// Evidence: 03f0f408c2 (#2070) moved platform provider composition out of the daemon into this
+//   root; c7f42ccedc (#2117) moved the Android family behind package exports the composition
+//   file now targets.
+// Cost: 103 LOC (no dedicated test file; exercised through platform-package-policy.test.ts);
+//   shares rule id R13 with platform-package-policy.ts (1030 LOC) and
+//   platform-package-source-policy.ts (230 LOC).
+// Kill criterion: none enforced today; retire only by maintainer decision that lazy platform
+//   composition in src/platform-runtime.ts no longer matters. The build cannot tell an eager
+//   import from the lazy seam; both resolve and type-check identically.
+
 import { parseSync } from 'oxc-parser';
 import { parseImports, type LayeringViolation } from './model.ts';
 

--- a/scripts/layering/platform-package-policy.ts
+++ b/scripts/layering/platform-package-policy.ts
@@ -1,3 +1,19 @@
+// Catches: a platform package's private implementation loaded before the one canonical
+//   composition root assembles it, or a cross-boundary edge into another platform family's
+//   private surface — the six platform packages moved behind package facades (#2116-#2125)
+//   specifically to make eager loading and cross-family reach-ins visible, and only a source
+//   walk over every package's imports can confirm the boundary actually held.
+// Evidence: 838ed223b5 (#2116) moved the six W6 platform families behind package facades;
+//   ed26b31c94 (#2125) contracted the Apple platform surface to match.
+// Cost: 1030 LOC (377 rule + 653 test); shared with platform-composition-policy.ts (103 LOC)
+//   and platform-package-source-policy.ts (230 LOC), which this module orchestrates.
+// Kill criterion: none enforced today; retire only by maintainer decision that platform-family
+//   isolation (private manifests with exact exports, static imports only from the composition
+//   root, no sibling-family reach-ins, no top-level loadInventory/loadRuntime) no longer
+//   matters. Publishing the families separately would not replace it: the A4 spike found an
+//   undeclared workspace package still resolves through root node_modules and a relative tunnel
+//   into a sibling's src still compiles; project references are a build cache, not a boundary.
+
 import path from 'node:path';
 import { PLATFORMS } from '@agent-device/kernel/device';
 import { parseImports, type LayeringViolation } from './model.ts';

--- a/scripts/layering/platform-package-source-policy.ts
+++ b/scripts/layering/platform-package-source-policy.ts
@@ -1,3 +1,17 @@
+// Catches: a platform package touching ambient host state (fs, os, process) directly instead
+//   of through capture-kit's declared ports — a substrate leak that lets a platform module read
+//   or mutate host state the request-scoped runtime cannot account for, invisible to a type
+//   check because the ambient APIs are fully typed and legal to call.
+// Evidence: c06bed9f77 (#1699) extracted platform device inventory runtime, the first substrate
+//   split this rule started policing; d76e0f94e9 (#1779) migrated snapshot the same way.
+// Cost: 230 LOC (157 rule + 73 test); shares rule id R13 with platform-package-policy.ts (1030
+//   LOC) and platform-composition-policy.ts (103 LOC).
+// Kill criterion: none enforced today; retire only by maintainer decision that platform packages
+//   keeping host access (ambient fs/os/process imports, host state at module evaluation, xcrun
+//   outside appleTools) behind capture-kit ports no longer matters. Typed ports do not make the
+//   ambient imports unresolvable: @types/node stays in scope for every platform tsconfig, and
+//   the A4 spike found it must (platform-apple's runner subtree legitimately uses fs/net/os).
+
 import { parseSync } from 'oxc-parser';
 import { memberPath } from './layering-ast.ts';
 import { parseImports, type LayeringViolation } from './model.ts';

--- a/scripts/layering/provider-snapshot-presentation-policy.ts
+++ b/scripts/layering/provider-snapshot-presentation-policy.ts
@@ -1,3 +1,16 @@
+// Catches: a provider-* package acquiring an iOS snapshot outside the capture-kit acquisition
+//   entrypoint, or presenting it outside src/snapshot/ios-snapshot-runtime.ts — the exact split
+//   R72's engine convergence closed for the runner layer, mirrored here one layer up for the
+//   provider packages that call into it.
+// Evidence: 7ee1a5ded7 (#2233) carried provider acquisitions through this one presentation
+//   owner, the change this policy was written to hold in place.
+// Cost: 195 LOC (111 rule + 84 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that provider-* packages
+//   reaching presentation only through @agent-device/capture-kit/ios-snapshot-acquisition, and
+//   never constructing, discarding, or reassigning acquisition residue, no longer matter. An
+//   exports map cannot replace it: it restricts external specifiers, not the transitive walk
+//   into src/snapshot/ or a provider-local `residue` property or assignment.
+
 import { parseSync } from 'oxc-parser';
 import type { LayeringViolation, ResolvedImportEdge } from './model.ts';
 import { memberPath, propertyName, visitAst } from './layering-ast.ts';

--- a/scripts/layering/record-runtime-mechanics-policy.ts
+++ b/scripts/layering/record-runtime-mechanics-policy.ts
@@ -1,3 +1,16 @@
+// Catches: the daemon record owner reaching past its declared coordinators to spawn or poll a
+//   native process/timer directly — the same "delegate to your single owner" shape as R7 and
+//   R12, applied to record's runtime mechanics; a type check cannot see this because runCmd and
+//   setInterval are both fully typed, legal calls from anywhere.
+// Evidence: 1b2e786128 (#1724) moved screen recording onto the platform runtime, the migration
+//   this ownership boundary protects against regressing.
+// Cost: 165 LOC (112 rule + 53 test); shares rule id R16 with record-runtime-registry-policy.ts
+//   (137 LOC).
+// Kill criterion: none enforced today; retire only by maintainer decision that the daemon record
+//   owner staying free of native mechanics (runCmd*/spawn*/timer calls, child kill, platform
+//   comparisons and switches) no longer matters. A typed capture-kit port would not replace it:
+//   setTimeout is a global and spawn stays importable from the owner whatever port it holds.
+
 import { parseSync } from 'oxc-parser';
 import { memberName, type ProductionSource, visitAst } from './layering-ast.ts';
 

--- a/scripts/layering/record-runtime-registry-policy.ts
+++ b/scripts/layering/record-runtime-registry-policy.ts
@@ -1,3 +1,15 @@
+// Catches: src/core/command-descriptor/registry.ts's record command descriptor missing the
+//   runtime-descriptor join assertion — a wiring gap where record's registry entry silently
+//   stops being checked against the request-bound runtime it must join, invisible to a type
+//   check because the assertion's absence is not a type error, just a missing call.
+// Evidence: 03c3984066 (#1969) granularized contracts entry surfaces the registry imports from,
+//   which this join assertion depends on staying wired correctly.
+// Cost: 137 LOC (106 rule + 31 test); shares rule id R16 with record-runtime-mechanics-policy.ts
+//   (165 LOC).
+// Kill criterion: none enforced today; retire only by maintainer decision that the record
+//   descriptor's runtime-descriptor join assertion no longer matters. Nothing in the registry's
+//   types requires the join call, so its absence is not a compile error.
+
 import { parseSync } from 'oxc-parser';
 import { memberName, type ProductionSource, visitAst } from './layering-ast.ts';
 

--- a/scripts/layering/retired-paths-policy.ts
+++ b/scripts/layering/retired-paths-policy.ts
@@ -1,3 +1,14 @@
+// Catches: a tracked file reappearing under a retired root — src/utils (R14), the grab-bag zone
+//   #2149 retired, or src/replay/ (R71), the caller-side replay code #2151 dissolved into command
+//   and CLI owners — a zone with no owner left to hold its invariants, so a module landing there
+//   is a silent regression rather than a placement any reviewer would flag by name.
+// Evidence: db08548026 (#2149, #2229) enforced the src/utils retirement; caa3dc23f9 (#2151)
+//   dissolved caller-side src/replay; 5eebba5fcd (#2240) folded both into this one table.
+// Cost: 208 LOC (38 rule + 13 shared retired-zone-policy.ts + 157 test).
+// Kill criterion: none enforced today (git tracks any path; only this table rejects one); retire
+//   a row only by maintainer decision that its retired root no longer needs a guard — in practice
+//   once a full release cycle passes with zero violations under it.
+
 import type { LayeringViolation } from './model.ts';
 import { retiredPathViolations } from './retired-zone-policy.ts';
 

--- a/scripts/layering/rule-ids.ts
+++ b/scripts/layering/rule-ids.ts
@@ -15,6 +15,19 @@ import path from 'node:path';
  * naming registry, not a behavioural claim.
  */
 
+// Catches: two rule modules declaring the same numeric id — #1656 and #1750 both reached for
+//   R17 independently, and because the files differ, git sees no conflict; every review
+//   comment, CI annotation, and code reference to that number then addresses two different
+//   rules with no way to tell which one is meant. (This module has no single rule id of its
+//   own; R98/R99 in its test file are placeholder ids the collision-detection tests exercise,
+//   not declared production rules.)
+// Evidence: 8f98d23f14 (#1750) gave the colliding rule its own number after the collision this
+//   module now prevents from recurring.
+// Cost: 191 LOC (106 rule + 85 test); not attributed for wall-time share.
+// Kill criterion: none enforced today; retire only by maintainer decision that unique rule ids no
+//   longer matter — moot only if ids stop being chosen by hand, and no generated id sequence
+//   exists today.
+
 export type RuleDeclaration = {
   id: string;
   name: string;

--- a/scripts/layering/runtime-execution-policy.ts
+++ b/scripts/layering/runtime-execution-policy.ts
@@ -1,3 +1,15 @@
+// Catches: daemon code constructing or narrowing an AdmittedRuntimePlan/BoundDeviceRuntime
+//   outside runtime-admission.ts — manufacturing a runtime proof instead of receiving one from
+//   the single admission authority, which "Guarantees erode at path boundaries" (AGENTS.md)
+//   names directly; a type check alone cannot see this because the forged value still type-
+//   checks as the real proof type.
+// Evidence: 7b48531d3b (#2081) retired ADR-0019 cutover scaffolding this policy outlived;
+//   4454aef139 (#2092) removed the retired migration scaffolding alongside it.
+// Cost: 362 LOC (216 rule + 146 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that runtime-admission.ts
+//   being the sole producer of AdmittedRuntimePlan/BoundDeviceRuntime no longer matters. The
+//   token is a type, so an `as` cast or narrowing to it type-checks from any module.
+
 import { parseSync } from 'oxc-parser';
 import { memberName, propertyName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';

--- a/scripts/layering/selector-pipeline-ownership.ts
+++ b/scripts/layering/selector-pipeline-ownership.ts
@@ -1,6 +1,20 @@
 import type { LayeringViolation, ResolvedImportEdge } from './model.ts';
 
 /**
+ * Catches: a route to the matching engine that bypasses selector-pipeline-policy.ts's declared
+ *   structural stages (occlusion, off-screen, hittable-ancestor promotion, poll budget) — the
+ *   route still gets an ambiguity contract, so it looks correct in review while silently
+ *   skipping every stage the declared owner exists to guarantee.
+ * Evidence: 74eab2a554 (#1744) routed selector-resolution structural stages into this typed
+ *   policy, the migration this ownership check protects against regressing.
+ * Cost: 154 LOC (66 rule + 88 test).
+ * Kill criterion: none enforced today; retire only by maintainer decision that a single admitted
+ *   importer of @agent-device/selectors/engine no longer matters. The exports map makes the
+ *   engine resolvable, not private: any module can import the subpath, so only this edge scan
+ *   sees a second importer.
+ */
+
+/**
  * R19 selector-pipeline-ownership (#1656).
  *
  * The structural stages of selector resolution — occlusion, off-screen,

--- a/scripts/layering/session-resource-ownership.ts
+++ b/scripts/layering/session-resource-ownership.ts
@@ -1,3 +1,14 @@
+// Catches: a session resource field (appLog, appLogFailure, audioProbe, perfCapture) written
+//   from outside its declared owner module — R7's session-state-ownership shape applied to the
+//   narrower set of per-resource fields these session-scoped runtimes carry, where the same
+//   aliasing hazard (get()/set() hand back and re-put the live reference) applies.
+// Evidence: 7b48531d3b (#2081) retired ADR-0019 cutover scaffolding this policy protected during
+//   the runtime-command migration; 4454aef139 (#2092) removed what it retired.
+// Cost: 115 LOC (57 rule + 58 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that per-owner write
+//   authority over appLog/appLogFailure/audioProbe/perfCapture no longer matters. The fields
+//   are plain mutable properties on the shared session record, so an outside write type-checks.
+
 import { parseSync } from 'oxc-parser';
 import { propertyName, visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';

--- a/scripts/layering/session-state.ts
+++ b/scripts/layering/session-state.ts
@@ -1,3 +1,17 @@
+// Catches: a daemon module writing a SessionState field it does not own — aliasing through
+//   SessionStore.get()/set() lets any module mutate store-owned state, and only a full-graph
+//   AST walk over every assignment site (not a review of one module) can tell whose write
+//   it was.
+// Evidence: PR #1392 (e8b779cb32) fixed a close-time script-save failure leaking the session/
+//   device claim — a symptom of unowned SessionState writes; the field-owner table this file
+//   enforces is the durable fix.
+// Cost: 262 LOC (no dedicated test file; exercised through daemon-modularity.test.ts and
+//   model.test.ts).
+// Kill criterion: none enforced today; retire only by maintainer decision that per-field
+//   SessionState write ownership no longer matters. SessionStore hands out the live record
+//   through get()/set(), so a `session.<field> =` from any module type-checks; no owner exists
+//   at the type level.
+//
 // R7 session-state ownership.
 //
 // `SessionStore.get()` hands back the live `SessionState` out of a private Map, and `set()`

--- a/scripts/layering/source-execution-policy.ts
+++ b/scripts/layering/source-execution-policy.ts
@@ -1,3 +1,15 @@
+// Catches: a `using`/`await using` declaration landing in source-checkout TypeScript that Node's
+//   type stripper runs directly — syntax tsc accepts and type-checks fine, but that the
+//   source-execution path (no build step) cannot run, so the failure would otherwise surface
+//   only at runtime, on whichever command path first hits the file.
+// Evidence: 7b48531d3b (#2081) retired ADR-0019 cutover scaffolding alongside this policy;
+//   4454aef139 (#2092) removed the retired migration scaffolding it depended on.
+// Cost: 57 LOC (31 rule + 26 test).
+// Kill criterion: none enforced today (tsc accepts `using`; only running the file exposes it);
+//   retire only by maintainer decision that source execution without a build step no longer
+//   matters — moot once the Node floor in package.json engines runs `using`/`await using`
+//   natively.
+
 import { parseSync } from 'oxc-parser';
 import { visitAst } from './layering-ast.ts';
 import type { LayeringViolation } from './model.ts';

--- a/scripts/layering/substrate-domain-shape.ts
+++ b/scripts/layering/substrate-domain-shape.ts
@@ -1,3 +1,15 @@
+// Catches: a substrate package (capture-kit and peers) dispatching through request-scoped
+//   async_hooks, or a retired src/contracts/ production file reappearing — either one re-mixes
+//   request-bound state into durable capture code, which type-checks fine because async_hooks
+//   and the retired path are both ordinary, legal imports from where the violation happens.
+// Evidence: e832325e87 (#2088) split host mechanics into the host-kit capability ports this
+//   rule keeps request-scoped dispatch out of.
+// Cost: 170 LOC (110 rule + 60 test).
+// Kill criterion: none enforced today; retire only by maintainer decision that capture-kit staying
+//   free of request-scoped dispatch, and src/contracts/ staying retired, no longer matter.
+//   package.json cannot replace it: node:async_hooks is a built-in, not a dependency, and no
+//   manifest governs a tracked path under src/contracts/.
+
 import { parseSync } from 'oxc-parser';
 import type { LayeringViolation } from './model.ts';
 

--- a/scripts/layering/zone-policy.ts
+++ b/scripts/layering/zone-policy.ts
@@ -1,6 +1,18 @@
 import type { ImportEdge } from './model.ts';
 
 /**
+ * Catches: a core or daemon module reaching up into commands/ — the one direction the ranked
+ *   spine (R5/R6) cannot see on its own, because "commands is above core" is a zone-table fact,
+ *   not a rank the cycle/back-edge checkers infer.
+ * Evidence: ba1a5efbc6 (#1449) introduced the policy table after R1-R3 lived as hand-written
+ *   predicates; 2e0879a260 (#987) records the SDK-barrel exemption R3 needed before retirement.
+ * Cost: 152 LOC (72 rule + 80 test).
+ * Kill criterion: none enforced today; retire only by maintainer decision that "core and daemon
+ *   never import commands/" no longer matters — moot only if commands/ absorbs core and daemon
+ *   as internal implementation detail and the zone table collapses to one row or fewer.
+ */
+
+/**
  * R2 as data: which zone may import which.
  *
  * The original folder policies were hand-written predicate functions. Stating the remaining rule


### PR DESCRIPTION
## Summary

Every layering rule/policy module under `scripts/layering/` now carries a four-line header —
`Catches:`, `Evidence:`, `Cost:`, `Kill criterion:` — stating what defect class the rule catches
and why no other gate sees it, a real PR/commit that motivated or exercised the rule, its LOC
cost (rule + test), and the concrete condition under which the rule gets deleted. This covers R2,
R4-R7, R9-R14, R16, R18, R19, R65-R73, and the rule-id uniqueness gate (rule-ids.ts). Modules that
share one file (daemon-modularity.ts for R9/R10; check.ts for R4/R5/R6) get one header per rule.
No behavior change, no code lines touched — comment-only.

R3 platforms-seam has no active declaration to annotate (zone-policy.test.ts asserts its
absence); R17 devices and R98/R99 are not declared anywhere under `scripts/layering/` (R17 lives
outside this directory, R98/R99 are collision-test fixtures only) — see Tradeoffs.

## Validation

- `pnpm check:layering` — green, 198/198 node:test assertions pass.
- `pnpm check:quick` (oxlint + tsc -b) — clean.
- `npx vitest run --project unit-core scripts/layering` — reports "No test files found": the
  layering suite runs under `node --test` via `check:layering`, not vitest's `unit-core` project,
  which doesn't include `scripts/layering/**` in its `include` globs (confirmed pre-existing).
- Planted-red: added a quoted `'R2 imposter-rule'` string inside zone-policy.ts's new header
  comment (the exact mistake the task's CAUTION warns against), then ran `pnpm check:layering`.
  Observed failure:
  `✖ the layering rules currently in tree carry no unallowed collision` —
  `AssertionError: Expected values to be strictly deep-equal: + ['two rules answer to one id: R2
  names commands-floor and imposter-rule. Allocate the next free number.'] - []`. Reverted; gate
  is green again.
- Full affected gate: green at 8fdb1c81bed391cbdf3231160565d7da0d849457 (pnpm check:affected --run;
  gates run: format, lint, typecheck, layering, di-seams, fallow, mcp-metadata, build, package,
  integration-node, macos-coverage, vitest-related, integration-progress, replay-compat,
  daemon-wire-compat, affected-selector, gate-manifest, gate-manifest-model, depgraph,
  tmpdir-leaks, tmpdir-leaks-model, coverage-model, wire-compat-model, production-exports,
  bundle-owner-files, fixture-cache, fixture-fallback, command-docs, agent-guidance,
  xctest-selection, maestro-conformance, mutation-model; rest GitHub-authoritative/parked).

## Tradeoffs / follow-ups

- R3 and R17 have no module under `scripts/layering/` to annotate today (R3 is retired with only
  a negative test; R17 "devices" lives outside this directory per rule-ids.ts's own history
  comment). R98/R99 only appear as example ids inside rule-ids.test.ts's collision fixtures, not
  as declared production rules — rule-ids.ts itself got a header instead, describing the
  uniqueness gate it implements.

