### PR TITLE
ci(ios): give the pan-duration replay a budget that absorbs a runner rebuild

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -246,11 +246,14 @@ jobs:
       # ignoring a `gesture pan` duration). Split out of gesture-lab.ad, which stays full-tier
       # (dispatch-only via replays-manual.yml) because its multi-touch commands are a separate,
       # heavier concern. This is the only automatic lane this assertion runs in today.
+      # --timeout raises the per-attempt budget past the script's own 60s: it absorbs an
+      # in-replay runner rebuild (measured 48-61s build + ~40s launch) on a runner cache miss;
+      # the normal path finishes in 21-34s.
       - name: Run gesture pan-duration smoke replay
         run: |
           xcrun simctl install "${{ steps.ios-simulator.outputs.simulator-udid }}" "${{ steps.fixture-app.outputs.app-path }}"
           pnpm clean:daemon
-          node --experimental-strip-types src/bin.ts test examples/test-app/replays/gesture-pan-duration.ad --udid "${{ steps.ios-simulator.outputs.simulator-udid }}" --retries 2 --artifacts-dir test/artifacts/replays-ios-gesture-pan-duration --report-junit test/artifacts/replays-ios-gesture-pan-duration.junit.xml
+          node --experimental-strip-types src/bin.ts test examples/test-app/replays/gesture-pan-duration.ad --udid "${{ steps.ios-simulator.outputs.simulator-udid }}" --timeout 180000 --retries 2 --artifacts-dir test/artifacts/replays-ios-gesture-pan-duration --report-junit test/artifacts/replays-ios-gesture-pan-duration.junit.xml
           pnpm clean:daemon
 
       - name: Assert simulator automation preserved host focus


### PR DESCRIPTION
## Summary

`ios.yml`'s "Run gesture pan-duration smoke replay" step now passes `--timeout 180000` to the
`test` command, raising the per-attempt wall-clock budget from the script's own
`context timeout=60000` (`examples/test-app/replays/gesture-pan-duration.ad`) to 180 s. The CLI
`--timeout` flag (`timeoutMs`, `src/commands/cli-grammar/flag-definitions-workflow.ts:68-73`)
resolves ahead of the script's `attemptDefaults.timeoutMs` in `resolveReplayTestTimeout`
(`packages/replay-test/src/internal/session-test-discovery.ts:122-126`), so the flag fully
overrides the `.ad` file's context timeout for this workflow invocation without touching the
shared script (also used by `replays-manual.yml`).

All 5 recent failures of this step (runs 33424104858, 33426167796, 33532770285, 33550746429,
33607775894) were the replay's `open --relaunch` running a full `xcodebuild build-for-testing`
after a spurious runner `cache_metadata_mismatch` (48-61 s build + ~40 s launch), consuming the
60 s budget before `--retries 2` could fire — the abandoned build made the timeout an
infrastructure failure with only 1 attempt in every junit. Green runs finish in 21-34 s; a
flaky-green control (run 33645155931) finished its rebuild at 48.5 s and passed only on retry. The
180 s budget absorbs a worst-case rebuild-plus-launch with headroom.

## Validation

Workflow-only YAML change; no code path to plant a violation against. Confirmed from source
(cited above) that `--timeout` exists and overrides the script's `context timeout=` per attempt.
Ran `pnpm check:gate-manifest` (workflow YAML audit): "gate manifest: ok — 51 checks wired across
27 lanes, manual-only: replay-android, replay-ios, replay-ios-device." Ran `pnpm check:quick`
(oxlint + typecheck) clean. Diagnosis evidence: CI runs 33424104858, 33426167796, 33532770285,
33550746429, 33607775894 (failures) and 33645155931 (flaky-green control).

Full affected gate: green at 259cc62a0bb795268338c1dc7b1e9160041c5792 (pnpm check:affected --run; 34 local checks incl. unit, mutation-model).

