### PR TITLE
test(vitest): retire the subprocess-stub kill-criterion experiment

### DIFF
--- a/scripts/gate/model.test.ts
+++ b/scripts/gate/model.test.ts
@@ -22,7 +22,7 @@ const model = loadModel(repoRoot, tracked);
 
 const scriptModel = (scripts: Record<string, string>) => ({
   scripts,
-  vitestProjects: ['unit-core', 'subprocess-stub'],
+  vitestProjects: ['unit-core', 'extra-project'],
   opaque: {},
 });
 
@@ -61,31 +61,30 @@ test('a filtered Vitest run does not credit the whole project', () => {
 test('a bare Vitest run spans every configured project', () => {
   assert.deepEqual(scriptUnits('all', scriptModel({ all: 'vitest run --coverage' })), [
     'vitest:unit-core',
-    'vitest:subprocess-stub',
+    'vitest:extra-project',
   ]);
 });
 
 test('a negated --project subtracts from the configured set, so the skipped one is not credited', () => {
   assert.deepEqual(
-    scriptUnits('cov', scriptModel({ cov: 'vitest run --coverage --project=!subprocess-stub' })),
+    scriptUnits('cov', scriptModel({ cov: 'vitest run --coverage --project=!extra-project' })),
     ['vitest:unit-core'],
   );
 });
 
-// The real `test:coverage:ci` shape: a negated `--project` leg, then a second leg that is a
-// nested script. Both indirections have to survive, or the lane stops owning the project it
-// hands to that leg.
-test('the two halves of test:coverage:ci together still own every project', () => {
+// A negated `--project` leg followed by a nested script must preserve both
+// indirections, or the lane stops owning the project handed to that leg.
+test('split coverage commands together still own every project', () => {
   assert.deepEqual(
     scriptUnits(
       'test:coverage:ci',
       scriptModel({
         'test:coverage:ci':
-          'vitest run --coverage --project=!subprocess-stub && pnpm test:subprocess-stub',
-        'test:subprocess-stub': 'vitest run --project subprocess-stub',
+          'vitest run --coverage --project=!extra-project && pnpm test:extra-project',
+        'test:extra-project': 'vitest run --project extra-project',
       }),
     ),
-    ['vitest:unit-core', 'vitest:subprocess-stub'],
+    ['vitest:unit-core', 'vitest:extra-project'],
   );
 });
 

--- a/scripts/gate/model.test.ts
+++ b/scripts/gate/model.test.ts
@@ -22,7 +22,7 @@ const model = loadModel(repoRoot, tracked);
 
 const scriptModel = (scripts: Record<string, string>) => ({
   scripts,
-  vitestProjects: ['unit-core', 'extra-project'],
+  vitestProjects: ['unit-core', 'fuzz-worker'],
   opaque: {},
 });
 
@@ -61,13 +61,13 @@ test('a filtered Vitest run does not credit the whole project', () => {
 test('a bare Vitest run spans every configured project', () => {
   assert.deepEqual(scriptUnits('all', scriptModel({ all: 'vitest run --coverage' })), [
     'vitest:unit-core',
-    'vitest:extra-project',
+    'vitest:fuzz-worker',
   ]);
 });
 
 test('a negated --project subtracts from the configured set, so the skipped one is not credited', () => {
   assert.deepEqual(
-    scriptUnits('cov', scriptModel({ cov: 'vitest run --coverage --project=!extra-project' })),
+    scriptUnits('cov', scriptModel({ cov: 'vitest run --coverage --project=!fuzz-worker' })),
     ['vitest:unit-core'],
   );
 });
@@ -79,12 +79,11 @@ test('split coverage commands together still own every project', () => {
     scriptUnits(
       'test:coverage:ci',
       scriptModel({
-        'test:coverage:ci':
-          'vitest run --coverage --project=!extra-project && pnpm test:extra-project',
-        'test:extra-project': 'vitest run --project extra-project',
+        'test:coverage:ci': 'vitest run --coverage --project=!fuzz-worker && pnpm test:fuzz-worker',
+        'test:fuzz-worker': 'vitest run --project fuzz-worker',
       }),
     ),
-    ['vitest:unit-core', 'vitest:extra-project'],
+    ['vitest:unit-core', 'vitest:fuzz-worker'],
   );
 });
 

--- a/scripts/mutation/test-scope.ts
+++ b/scripts/mutation/test-scope.ts
@@ -9,7 +9,7 @@
 // own static module graph.
 //
 // Two files are removed from whatever Vitest returns:
-//   - the real-subprocess-spawn tests (SUBPROCESS_STUB_TESTS in vitest.config.ts —
+//   - the real-subprocess-spawn tests (MUTATION_EXCLUDED_TESTS in vitest.config.ts —
 //     spawns stubbed binaries and waits real subprocess/retry/poll time, out of scope
 //     by the issue's constraint, and thousands of mutant runs would turn it into
 //     timeout noise regardless of whether Vitest itself still serializes it, #1823);

--- a/src/__tests__/test-utils/fake-adb.ts
+++ b/src/__tests__/test-utils/fake-adb.ts
@@ -37,8 +37,8 @@ export type FakeAdbProviderExtras = AndroidAdbProvider extends infer P
  * production {@link withAndroidAdbProvider} scope — the same seam the daemon
  * installs per request and the provider-scenario lane exercises. Prefer this
  * over PATH-stub subprocess helpers (`withMockedAdb`): no PATH
- * mutation, no spawns, no real subprocess waits, so converted files can leave
- * SUBPROCESS_STUB_TESTS in vitest.config.ts (#1823).
+ * mutation, no spawns, no real subprocess waits, so converted files do not need a
+ * mutation exclusion in vitest.config.ts.
  *
  * The fake `exec` receives device-scoped args without a leading
  * `-s <serial>`: scoped providers are per-device, and raw `runCmd('adb', …)`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,13 +4,12 @@ import slowTestGateReporter from './scripts/vitest-slow-test-reporter.ts';
 
 // Files that spawn a real subprocess per case. They used to run one at a time in
 // their own serialized `subprocess-stub` project so broad file parallelism couldn't
-// starve a spawn past its internal budget and turn it into a generic timeout.
-// #1823 is now running that project's own kill criterion: un-serialized here in
-// `unit-core`'s default forks pool, watched for 20 consecutive CI runs with no
-// timeout-shaped failure. Revert (restore the project, restore this list to
-// unit-core's exclude) the moment one appears. Still excluded from the mutation
-// lane via SERIALIZED_TESTS below regardless of this experiment's outcome —
-// thousands of mutant reruns times a real spawn per case is timeout noise either way.
+// starve a spawn past its internal budget and turn it into a generic timeout. #1823's
+// kill criterion — 20 consecutive CI runs un-serialized in `unit-core`'s default forks
+// pool with no timeout-shaped failure — was met, so the project is gone and these
+// files run un-serialized here. The list still feeds SERIALIZED_TESTS below: a real
+// per-case spawn is timeout noise under thousands of mutant reruns regardless of
+// Vitest's own scheduling, so the mutation lane keeps excluding them.
 const SUBPROCESS_STUB_TESTS: readonly string[] = [
   // Stubs npx plus the package managers and spawns a real Metro dev server per case.
   'src/__tests__/client-metro.test.ts',
@@ -106,8 +105,8 @@ export default defineConfig({
             'src/**/*.test.ts',
             'packages/*/src/**/*.test.ts',
             // The subprocess watchdog self-check (#1823): spawns a real node subprocess per
-            // case, one hangs on purpose (#1414). Formerly a `subprocess-stub` member; see
-            // SUBPROCESS_STUB_TESTS above for the kill-criterion experiment this rides.
+            // case, one hangs on purpose (#1414). Formerly a `subprocess-stub` member,
+            // deleted once its kill criterion was met; see SUBPROCESS_STUB_TESTS above.
             'scripts/fuzz/harness.test.ts',
             // The validation fuzz generators' expectation gates (#1781 B2): in-process, no
             // subprocess or worker, so they ride the fast lane unlike their serialized siblings.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,15 +2,9 @@ import { defineConfig } from 'vitest/config';
 import { resolveVitestMaxWorkers } from './scripts/lib/vitest-concurrency.ts';
 import slowTestGateReporter from './scripts/vitest-slow-test-reporter.ts';
 
-// Files that spawn a real subprocess per case. They used to run one at a time in
-// their own serialized `subprocess-stub` project so broad file parallelism couldn't
-// starve a spawn past its internal budget and turn it into a generic timeout. #1823's
-// kill criterion — 20 consecutive CI runs un-serialized in `unit-core`'s default forks
-// pool with no timeout-shaped failure — was met, so the project is gone and these
-// files run un-serialized here. The list still feeds SERIALIZED_TESTS below: a real
-// per-case spawn is timeout noise under thousands of mutant reruns regardless of
-// Vitest's own scheduling, so the mutation lane keeps excluding them.
-const SUBPROCESS_STUB_TESTS: readonly string[] = [
+// A real per-case spawn is timeout noise under thousands of mutant reruns, so the
+// mutation lane excludes these tests even though the unit lane runs them normally.
+const MUTATION_EXCLUDED_SUBPROCESS_TESTS: readonly string[] = [
   // Stubs npx plus the package managers and spawns a real Metro dev server per case.
   'src/__tests__/client-metro.test.ts',
   // The SUT is the subprocess watchdog: a node subprocess per case, one hangs on purpose (#1414).
@@ -55,13 +49,14 @@ const FUZZ_WORKER_TESTS: readonly string[] = [
   'scripts/fuzz/corpus-replay.test.ts',
 ];
 /**
- * Every test the mutation lane must not collect: a real per-case subprocess spawn is
- * timeout noise under thousands of mutant reruns, independent of whether Vitest also
- * serializes it — `fuzz-worker` still does; `subprocess-stub`'s former members no
- * longer do (#1823). The two lists above stay module-local: this union is the whole
- * cross-file surface, and the mutation lane wants exactly it.
+ * Every test the mutation lane must not collect. The two lists above stay
+ * module-local: this union is the whole cross-file surface, and the mutation lane
+ * wants exactly it.
  */
-export const SERIALIZED_TESTS: readonly string[] = [...SUBPROCESS_STUB_TESTS, ...FUZZ_WORKER_TESTS];
+export const MUTATION_EXCLUDED_TESTS: readonly string[] = [
+  ...MUTATION_EXCLUDED_SUBPROCESS_TESTS,
+  ...FUZZ_WORKER_TESTS,
+];
 
 // Imported by vitest.mutation.config.ts so the two lanes cannot drift: a guard
 // added here must reach the Stryker sandbox too.
@@ -104,9 +99,8 @@ export default defineConfig({
           include: [
             'src/**/*.test.ts',
             'packages/*/src/**/*.test.ts',
-            // The subprocess watchdog self-check (#1823): spawns a real node subprocess per
-            // case, one hangs on purpose (#1414). Formerly a `subprocess-stub` member,
-            // deleted once its kill criterion was met; see SUBPROCESS_STUB_TESTS above.
+            // The subprocess watchdog self-check: spawns a real node subprocess per case,
+            // and one hangs on purpose (#1414).
             'scripts/fuzz/harness.test.ts',
             // The validation fuzz generators' expectation gates (#1781 B2): in-process, no
             // subprocess or worker, so they ride the fast lane unlike their serialized siblings.
@@ -197,8 +191,7 @@ export default defineConfig({
       },
       {
         test: {
-          // Serialized for the same contention reason `subprocess-stub` used to be (#1823):
-          // the per-case watchdog budget is real wall clock. The project exists so the
+          // Serialized because the per-case watchdog budget is real wall clock. The project exists so the
           // coverage run can leave it out (see the comment above), not to run it differently.
           name: 'fuzz-worker',
           include: [...FUZZ_WORKER_TESTS],

--- a/vitest.mutation.config.ts
+++ b/vitest.mutation.config.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { readTestScope, threadHostileTestFiles } from './scripts/mutation/test-scope.ts';
 import { workspaceSourceAliases } from './scripts/mutation/workspace-aliases.ts';
-import { SERIALIZED_TESTS, SETUP_FILES } from './vitest.config.ts';
+import { MUTATION_EXCLUDED_TESTS, SETUP_FILES } from './vitest.config.ts';
 
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 
@@ -21,7 +21,11 @@ export default defineConfig({
   },
   test: {
     include: scope ?? ['src/**/*.test.ts', 'packages/*/src/**/*.test.ts'],
-    exclude: [...SERIALIZED_TESTS, ...threadHostileTestFiles(repoRoot), '**/node_modules/**'],
+    exclude: [
+      ...MUTATION_EXCLUDED_TESTS,
+      ...threadHostileTestFiles(repoRoot),
+      '**/node_modules/**',
+    ],
     setupFiles: [...SETUP_FILES],
   },
 });


### PR DESCRIPTION
## Summary

Retires #1823's subprocess-stub kill-criterion experiment after its observation window completed without timeout-shaped failures.

The former project is now absent from both configuration and source commentary. Mutation exclusions are named for their current purpose (`MUTATION_EXCLUDED_TESTS`), and the gate-model fixture mirrors the active `fuzz-worker` project rather than preserving the retired topology.

The affected real-subprocess tests continue to run normally in `unit-core` and remain excluded from mutation execution. No runtime behavior changes.

## Validation

- Tested exact commit `dc8102909a`.
- `pnpm check:affected --run` passed every runnable local check for the cleanup; the final fixture correction passed the focused 7-test gate-model suite.
- GitHub-authoritative device, coverage, and native lanes are running on the exact head.
- Repository search finds no remaining `subprocess-stub` or `SUBPROCESS_STUB_TESTS` references.
- No planted-red proof applies: this is a behavior-preserving ownership rename and removal of retired commentary.
