### PR TITLE
fix(ci): fingerprint the test app from its own directory

### DIFF
--- a/.github/actions/setup-fixture-app/resolve-artifact-name.sh
+++ b/.github/actions/setup-fixture-app/resolve-artifact-name.sh
@@ -21,7 +21,9 @@ if [ ! -x "$FINGERPRINT_BIN" ]; then
   exit 1
 fi
 
-FINGERPRINT_JSON="$("$FINGERPRINT_BIN" fingerprint:generate --platform "$PLATFORM")"
+# @expo/fingerprint treats process.cwd() as the project root.
+FINGERPRINT_ABS="$(cd "$(dirname "$FINGERPRINT_BIN")" && pwd)/$(basename "$FINGERPRINT_BIN")"
+FINGERPRINT_JSON="$(cd examples/test-app && "$FINGERPRINT_ABS" fingerprint:generate --platform "$PLATFORM")"
 if ! HASH="$(
   printf '%s\n' "$FINGERPRINT_JSON" |
     jq -ser '

--- a/test/ci/trusted-fixture-artifact.test.mjs
+++ b/test/ci/trusted-fixture-artifact.test.mjs
@@ -64,6 +64,75 @@ test('producer, consumers, upload, and concurrency use the canonical platform-sc
   );
 });
 
+test('resolve-artifact-name.sh fingerprints examples/test-app, not the workspace root', (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-fingerprint-cwd-'));
+  t.after(() => fs.rmSync(tempRoot, { force: true, recursive: true }));
+
+  // A repo-root native helper dir that must be excluded once the fingerprint
+  // is scoped correctly, and the fixture app's own native module that must be
+  // included.
+  fs.mkdirSync(path.join(tempRoot, 'android'), { recursive: true });
+  fs.mkdirSync(path.join(tempRoot, 'examples/test-app/modules/push-broadcast-lab/android'), {
+    recursive: true,
+  });
+  const fingerprintBinDir = path.join(tempRoot, 'examples/test-app/node_modules/.bin');
+  fs.mkdirSync(fingerprintBinDir, { recursive: true });
+  const sourcesLog = path.join(tempRoot, 'fingerprint-sources.json');
+
+  // Stand-in for @expo/fingerprint: reports every `android` directory
+  // reachable under its own process.cwd(), the same cwd-scoped native-dir
+  // discovery the real tool performs.
+  fs.writeFileSync(
+    path.join(fingerprintBinDir, 'fingerprint'),
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs');",
+      "const path = require('node:path');",
+      'function findAndroidDirs(dir, found) {',
+      '  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {',
+      "    if (!entry.isDirectory() || entry.name === 'node_modules' || entry.name === '.git') continue;",
+      '    const full = path.join(dir, entry.name);',
+      "    if (entry.name === 'android') found.push(full);",
+      '    findAndroidDirs(full, found);',
+      '  }',
+      '  return found;',
+      '}',
+      'const cwd = process.cwd();',
+      'const dirs = findAndroidDirs(cwd, []).map((p) => path.relative(cwd, p));',
+      "const report = { hash: 'stub-' + dirs.length, sources: dirs.map((filePath) => ({ type: 'dir', filePath })) };",
+      'if (process.env.TEST_FINGERPRINT_SOURCES_LOG) {',
+      '  fs.writeFileSync(process.env.TEST_FINGERPRINT_SOURCES_LOG, JSON.stringify(report));',
+      '}',
+      'process.stdout.write(JSON.stringify(report));',
+      '',
+    ].join('\n'),
+  );
+  fs.chmodSync(path.join(fingerprintBinDir, 'fingerprint'), 0o755);
+
+  const scriptDir = path.join(tempRoot, '.github/actions/setup-fixture-app');
+  fs.mkdirSync(scriptDir, { recursive: true });
+  fs.copyFileSync(
+    '.github/actions/setup-fixture-app/resolve-artifact-name.sh',
+    path.join(scriptDir, 'resolve-artifact-name.sh'),
+  );
+
+  const result = spawnSync('sh', [path.join(scriptDir, 'resolve-artifact-name.sh'), 'android'], {
+    cwd: tempRoot,
+    encoding: 'utf8',
+    env: { ...process.env, TEST_FINGERPRINT_SOURCES_LOG: sourcesLog },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout.trim(), /^fingerprint\.stub-1\.android$/);
+
+  const sources = JSON.parse(fs.readFileSync(sourcesLog, 'utf8')).sources;
+  const sourcePaths = sources.map((source) => source.filePath);
+  assert.deepEqual(sourcePaths, ['modules/push-broadcast-lab/android']);
+  assert.ok(
+    !sourcePaths.includes('android'),
+    `expected the workspace-root android/ helpers to be excluded, got ${JSON.stringify(sourcePaths)}`,
+  );
+});
+
 test('Android smoke consumes the restored APK through catalog fixture E2E', (t) => {
   const workflow = parse(fs.readFileSync('.github/workflows/android.yml', 'utf8'));
   const replayEvidence = JSON.parse(


### PR DESCRIPTION
## Summary

`resolve-artifact-name.sh` (rewritten in #2182) ran `fingerprint fingerprint:generate` from the
workspace root. `@expo/fingerprint` hashes `process.cwd()` as its project root, so the fixture
build-cache key was the whole repository's fingerprint, not `examples/test-app`'s native sources:
four cold keys landed in ~25 h with zero test-app changes, and a real native change in the fixture
app no longer rotated the key. The script now runs the fingerprint with cwd `examples/test-app`,
so the key tracks the fixture app's own native sources again. Its stdout contract
(`fingerprint.<hash>.<platform>`) and every caller (`fetch-artifact.sh`,
`test-app-build-cache.yml`) are unchanged.

## Validation

- `pnpm test:fixture-cache` — 12/12, including a new case that pins the cwd scoping.
- `pnpm check:quick` clean; `pnpm format` no diff.
- Real `@expo/fingerprint` from both roots: workspace root → `ae1fe489a6…`, the last observed cold
  key from runs 33426167727 and 33550746596, whose sources list the root `android/`;
  `examples/test-app` → `6421ef37c1…`, whose sources list `modules/push-broadcast-lab/android`.
  The fixed script reproduces the latter.
- Planted red, pre-fix script: `AssertionError [ERR_ASSERTION]: The input did not match the
  regular expression /^fingerprint\.stub-1\.android$/. Input: 'fingerprint.stub-2.android'` — the
  buggy cwd counts both `android/` directories. Green after the fix.

Full affected gate: green at `ad78a9870f` (`pnpm check:affected --run`; 34/34 runnable checks
passed, 0 failures).
