### PR TITLE
feat(runtime): add managed-local ownership and the exact-only managed runtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,8 +12,8 @@ An internal ownership group for related automation platforms: Apple, Android, Ha
 Linux, or web.
 
 **Platform leaf**:
-A concrete OS and device shape within a platform family whose support is classified independently,
-such as iOS simulator, physical iOS, tvOS, or macOS.
+A concrete OS and device shape within a platform family, classified independently: iOS simulator,
+physical iOS, tvOS, or macOS.
 
 **Platform module**:
 A private package that owns one platform family's device mechanics and exposes its metadata and
@@ -84,11 +84,10 @@ A device-scoped pause on agent mutations during human operation.
 
 **Command surface**:
 The catalog of public command identity, interface exposure, adapter policy, and shared metadata
-across CLI, Node.js, MCP, and batch entrypoints.
+across entrypoints.
 
 **Runtime use**:
-A command's platform-neutral declaration of operations required for admission and preferred fast
-paths whose absence does not reject the command.
+A command's platform-neutral declaration of required operations and optional preferred fast paths.
 
 **Inventory use**:
 An inventory command's platform-neutral declaration for composing device sources without binding a
@@ -98,8 +97,7 @@ selected device.
 The daemon-side source of truth for route ownership and request-policy traits.
 
 **Runner command traits**:
-Per-command classifications that control Apple runner lifecycle and recovery behavior independently
-of the public command surface.
+Per-command classifications controlling Apple runner lifecycle and recovery behavior.
 
 **Daemon RPC protocol version**:
 The integer used to detect breaking compatibility across the remote daemon boundary.
@@ -111,30 +109,29 @@ separately versioned helpers, persisted artifacts, and released API consumers.
 ### Interactions, selectors, and refs
 
 **Interactor**:
-The legacy monolithic interface between dispatch and platform behavior, retained only for commands
-not yet migrated to request-bound runtimes.
+The legacy monolithic interface between dispatch and platform behavior, kept only for unmigrated
+commands.
 _Avoid_: New or migrated command behavior
 
 **Interaction dispatch path**:
 One concrete route an interaction command takes from a resolved target to device execution.
 
 **Coordinate-first resolved element activation**:
-An Apple interaction that resolves a semantic element and then activates its resolved center point,
-avoiding a second element lookup after navigation.
+An Apple interaction that resolves a semantic element and activates its resolved center point
+without a second lookup.
 
 **Parent-owned touch point**:
-A point that preserves the selected parent's identity while avoiding independently interactive
+A point that keeps the selected parent's identity while avoiding independently interactive
 descendants at its center.
 
 **Guarantee cell**:
-One dispatch-path-by-guarantee classification stating where an interaction guarantee is enforced,
-delegated, inapplicable, or waived.
+One dispatch-path-by-guarantee classification: enforced, delegated, inapplicable, or waived.
 
 **Owned waiver**:
 A guarantee gap with a tracking issue and explicit owner.
 
 **Delegation-on-error**:
-A fast path returning semantic failures to the shared path. It establishes failure-side handling,
+A fast path that returns semantic failures to the shared path; it settles failure-side handling,
 not success-path parity.
 
 **Parity table**:
@@ -144,8 +141,8 @@ A golden cross-language rule table consumed by both TypeScript and native tests.
 A contract test's declaration of the guarantee cells it proves.
 
 **Ref frame**:
-The session's authorization namespace for mutating `@ref` targets, containing a frozen observation
-epoch and issuance scope separate from the latest operational snapshot.
+The session's authorization namespace for mutating `@ref` targets: a frozen observation epoch and
+issuance scope.
 
 **Frame expiry seam**:
 The point immediately before a mutating device operation where the active ref frame becomes invalid.
@@ -190,35 +187,31 @@ A backend-owned accessibility value before snapshot presentation.
 One backend attempt's raw accessibility nodes and attempt-level capture facts.
 
 **Snapshot producer**:
-The acquisition component that produced a snapshot's raw tree — the third identity axis beside
-the platform channel and the in-plan capture strategy. Producers on one channel carry different
-guarantees, so presentation, scope, and geometry logic keys on the producer, never the channel
-alone.
+The acquisition component that produced a snapshot's raw tree; presentation, scope, and geometry
+key on the producer, never on the platform channel alone.
 
 **Presentation options**:
 The policy input controlling how one snapshot acquisition becomes a public projection.
 
 **Snapshot policy facet**:
-The host-side owner of neutral snapshot policy: presentation, freshness, timeout and overlay.
-Platform acquisition supplies raw facts and a fold policy; runner-side Swift presentation remains
-separate across the process boundary.
+The host-side owner of neutral snapshot policy (presentation, freshness, timeout, overlay);
+platform acquisition supplies raw facts and a fold policy.
 
 **Capture hint**:
-The acquisition-facing view of a snapshot request, derived once from presentation options. It names
-the projection a backend must serve, keeps raw traversal depth separate from regular presented depth,
-and may narrow acquisition only where that backend can prove the narrowing complete.
+The acquisition-facing view of a snapshot request: the projection a backend must serve, raw
+traversal depth kept apart from presented depth, and narrowing only where the backend can prove it
+complete.
 
 **Regular presented-depth frontier**:
-The acquisition boundary for an unscoped regular snapshot, measured against regular presented depth
-after structural wrappers collapse. It is distinct from raw traversal depth.
+The acquisition boundary for an unscoped regular snapshot, measured against regular presented
+depth after structural wrappers collapse.
 
 **Snapshot eligibility**:
 Membership in a presented snapshot projection, independent of whether a node is currently hittable.
 
 **Clip fold**:
-The regular projection's single visibility interpreter, run inside presentation for every backend:
-viewport and scroll-container clipping, ancestor projection, scroll hints, and collapsed depth.
-Platform differences enter as a fold policy, never as a backend exception.
+The regular projection's single visibility interpreter (viewport and scroll-container clipping,
+ancestor projection, scroll hints, collapsed depth); platform differences enter as a fold policy.
 
 **Presented node**:
 A wire-facing snapshot value produced at the presentation boundary.
@@ -238,7 +231,7 @@ A fidelity limit in acquired evidence that presentation cannot repair and must d
 
 **AX-unavailable target invalidation**:
 The Apple behavior that discards a suspect cached application target after a root accessibility
-failure so the next command reacquires it.
+failure.
 
 ### Recording and replay
 
@@ -277,21 +270,15 @@ completed result, missing state, or typed refusal.
 ### Maestro compatibility
 
 **Maestro program**:
-A source-preserving typed representation of the Maestro Flow syntax and behavior supported by
-agent-device, interpreted through the compatibility runtime.
+A source-preserving typed representation of the supported Maestro Flow syntax and behavior.
 
 **Maestro observation generation**:
-Compatibility-engine evidence captured since the most recent mutation; mutation invalidates it
-before dispatch.
+Compatibility-engine evidence captured since the most recent mutation; mutation invalidates it.
 
 ### Providers and tests
 
 **Provider**:
 An external adapter that owns a device runtime or contributes transport to a platform module.
-
-**Provider-backed integration scenario**:
-A device-free test through the real daemon request path that replaces only external device or host
-tool execution.
 
 **Cloud WebDriver runtime**:
 A provider runtime that maps a cloud-owned Appium or WebDriver session into agent-device inventory,
@@ -302,15 +289,3 @@ Provider-hosted session output such as video, automation logs, device logs, or d
 
 **Daemon artifact type**:
 An optional semantic category supplied by the owner of a daemon-managed downloadable artifact.
-
-**Provider transcript**:
-An exact record of external provider calls used to verify command translation.
-
-**Scenario transcript**:
-A command-level integration flow describing user-visible behavior through daemon commands.
-
-**In-process provider scenario harness**:
-An integration runner that invokes the daemon request handler without opening an HTTP listener.
-
-**HTTP contract test**:
-A narrow test of JSON-RPC transport, authentication, and response finalization.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,7 +119,8 @@ selected device.
 The daemon-side source of truth for route ownership and request-policy traits.
 
 **Runner command traits**:
-Per-command classifications controlling Apple runner lifecycle and recovery behavior.
+Per-command classifications controlling Apple runner lifecycle and recovery behavior
+independently of the public command surface.
 
 **Daemon RPC protocol version**:
 The integer used to detect breaking compatibility across the remote daemon boundary.
@@ -153,8 +154,8 @@ One dispatch-path-by-guarantee classification: enforced, delegated, inapplicable
 A guarantee gap with a tracking issue and explicit owner.
 
 **Delegation-on-error**:
-A fast path that returns semantic failures to the shared path; it settles failure-side handling,
-not success-path parity.
+A fast path that returns semantic failures to the shared path; it establishes failure-side
+handling, not success-path parity.
 
 **Parity table**:
 A golden cross-language rule table consumed by both TypeScript and native tests.
@@ -217,12 +218,13 @@ The policy input controlling how one snapshot acquisition becomes a public proje
 
 **Snapshot policy facet**:
 The host-side owner of neutral snapshot policy (presentation, freshness, timeout, overlay);
-platform acquisition supplies raw facts and a fold policy.
+platform acquisition supplies raw facts and a fold policy, and runner-side Swift presentation stays
+separate across the process boundary.
 
 **Capture hint**:
 The acquisition-facing view of a snapshot request: the projection a backend must serve, raw
-traversal depth kept apart from presented depth, and narrowing only where the backend can prove it
-complete.
+traversal depth kept apart from regular presented depth, and narrowing only where the backend can
+prove it complete.
 
 **Regular presented-depth frontier**:
 The acquisition boundary for an unscoped regular snapshot, measured against regular presented
@@ -232,8 +234,9 @@ depth after structural wrappers collapse.
 Membership in a presented snapshot projection, independent of whether a node is currently hittable.
 
 **Clip fold**:
-The regular projection's single visibility interpreter (viewport and scroll-container clipping,
-ancestor projection, scroll hints, collapsed depth); platform differences enter as a fold policy.
+The regular projection's single visibility interpreter, run inside presentation for every
+backend: viewport and scroll-container clipping, ancestor projection, scroll hints, collapsed
+depth. Platform differences enter as a fold policy, never as a backend exception.
 
 **Presented node**:
 A wire-facing snapshot value produced at the presentation boundary.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -305,6 +305,11 @@ Compatibility-engine evidence captured since the most recent mutation; mutation 
 **Provider**:
 An external adapter that owns a device runtime or contributes transport to a platform module.
 
+**Managed device allocator port**:
+The daemon-owned interface to a managed-device allocator, covering everything the daemon needs to
+obtain, hold, and give back a managed device.
+_Avoid_: Simlock client, lease provider
+
 **Cloud WebDriver runtime**:
 A provider runtime that maps a cloud-owned Appium or WebDriver session into agent-device inventory,
 leases, runtime behavior, artifacts, and release.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,8 +27,13 @@ The platform-neutral boundary that reports runtime facts and binds an admitted d
 runtime owner.
 
 **Runtime owner**:
-The one local platform module or provider runtime selected to execute behavior for an
-ownership-qualified device.
+The one local platform module, managed local owner, or provider runtime selected to execute
+behavior for an ownership-qualified device.
+
+**Managed local owner**:
+The exact-only runtime owner for an allocator-managed local device; it delegates automation
+mechanics to the device's platform module while device lifecycle stays with the allocator.
+_Avoid_: Managed provider, provider runtime
 
 **Request binding**:
 A request-lived attachment of cancellation, diagnostics, progress, and admitted context to a
@@ -76,6 +81,23 @@ command.
 
 **Device-claim policy**:
 A command's observation, ownership, or exclusive-mutation rule.
+
+**Device-claim rule**:
+The per-owner-kind decision at the claim gate: ordinary, allocator-held, or none.
+_Avoid_: Claim policy, device-claim policy
+
+**Managed binding fence**:
+The ownership fence of one managed binding: requester and identity incarnation as its token,
+request generation as its generation.
+
+**Request generation**:
+The per-requester monotonic number of one allocation attempt on an allocation lane; never shared
+across requesters.
+
+**Identity incarnation**:
+The allocator-issued id of one creation of a managed identity, preserved across Android
+clean-baseline reuse; a fresh iOS identity is a new device with a new incarnation.
+_Avoid_: Request generation
 
 **Human-control hold**:
 A device-scoped pause on agent mutations during human operation.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -9,3 +9,21 @@ If a proposed change contradicts an ADR, say so explicitly and explain why the d
 reopened.
 
 `AGENTS.md` routes to the rest of this directory by task type.
+
+## Test-harness vocabulary
+
+**Provider-backed integration scenario**:
+A device-free test through the real daemon request path that replaces only external device or host
+tool execution.
+
+**Provider transcript**:
+An exact record of external provider calls used to verify command translation.
+
+**Scenario transcript**:
+A command-level integration flow describing user-visible behavior through daemon commands.
+
+**In-process provider scenario harness**:
+An integration runner that invokes the daemon request handler without opening an HTTP listener.
+
+**HTTP contract test**:
+A narrow test of JSON-RPC transport, authentication, and response finalization.

--- a/packages/capture-kit/src/durable-resource-envelope.test.ts
+++ b/packages/capture-kit/src/durable-resource-envelope.test.ts
@@ -127,3 +127,42 @@ test('neutral envelope canonicalizes persisted provider owner identity', () => {
     instance: 'tenant-a',
   });
 });
+
+test('neutral envelope canonicalizes persisted managed local owner identity on any family', () => {
+  const android = decodeDurableResourceEnvelope({
+    ...APP_LOG_ENVELOPE_FIXTURE,
+    owner: { kind: 'managed-local', instance: ' sim-a ' },
+  });
+  assert.equal(android.status, 'decoded');
+  if (android.status !== 'decoded') return;
+  assert.deepEqual(android.envelope.owner, { kind: 'managed-local', instance: 'sim-a' });
+  assert.ok(Object.isFrozen(android.envelope.owner));
+
+  // A managed owner carries no family, so the local-family coherence check does not apply.
+  const apple = decodeDurableResourceEnvelope({
+    ...APP_LOG_ENVELOPE_FIXTURE,
+    device: {
+      id: 'simulator-1',
+      family: 'apple',
+      appleOs: 'ios',
+      kind: 'simulator',
+      target: 'mobile',
+    },
+    owner: { kind: 'managed-local', instance: 'sim-a' },
+  });
+  assert.equal(apple.status, 'decoded');
+});
+
+test('neutral envelope rejects a managed local owner without an allocator instance', () => {
+  assert.deepEqual(
+    decodeDurableResourceEnvelope({
+      ...APP_LOG_ENVELOPE_FIXTURE,
+      owner: { kind: 'managed-local', instance: '   ' },
+    }),
+    {
+      status: 'unreattachable',
+      reason: 'descriptor-invalid',
+      message: 'Durable resource owner reference is invalid',
+    },
+  );
+});

--- a/packages/capture-kit/src/durable-resource-envelope.ts
+++ b/packages/capture-kit/src/durable-resource-envelope.ts
@@ -20,6 +20,7 @@ import {
   type ResourceOwnershipFence,
   type RuntimeOwnerRef,
   localRuntimeOwner,
+  managedLocalRuntimeOwner,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import { freezeJsonObject, isBoundedJsonObject } from './durable-json.ts';
@@ -120,6 +121,9 @@ function decodeRuntimeOwnerRef(value: unknown): RuntimeOwnerRef | null {
   if (!isObject(value)) return null;
   if (value.kind === 'local-family' && isPlatform(value.family)) {
     return localRuntimeOwner(value.family);
+  }
+  if (value.kind === 'managed-local' && isNonEmptyString(value.instance)) {
+    return managedLocalRuntimeOwner(value.instance);
   }
   if (
     value.kind === 'provider-runtime' &&

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -275,6 +275,10 @@
       "types": "./src/logs-runtime-plan.ts",
       "default": "./src/logs-runtime-plan.ts"
     },
+    "./managed-device-allocation": {
+      "types": "./src/managed-device-allocation.ts",
+      "default": "./src/managed-device-allocation.ts"
+    },
     "./managed-web-backend": {
       "types": "./src/managed-web-backend.ts",
       "default": "./src/managed-web-backend.ts"

--- a/packages/contracts/src/managed-device-allocation.ts
+++ b/packages/contracts/src/managed-device-allocation.ts
@@ -1,0 +1,155 @@
+import type { JsonObject } from './json.ts';
+
+/**
+ * agent-device's own interface to a managed-device allocator (ADR 0021 §3): lease request,
+ * lookup, supersession, cancellation, renewal, release, identity status, activation confirmation,
+ * and removal acknowledgement. The vocabulary matches the allocator's published contract so the
+ * two sides cannot drift, but the interface is owned here — no allocator package is a dependency,
+ * and the foundations implement it only as a scripted fake.
+ */
+
+/** The allocator's platform vocabulary. */
+export type ManagedLeasePlatform = 'ios' | 'android';
+
+/** A managed shape (ADR 0021 §5). The allocator owns canonical resolution against its catalog. */
+export type ManagedShapeRequest = Readonly<{
+  platform: ManagedLeasePlatform;
+  deviceType: string;
+  osVersion?: string;
+}>;
+
+/**
+ * The per-platform key a grant must carry for its device to be reachable. Each is a versioned
+ * driver contract on the allocator side, so the names are pinned as a type rather than restated
+ * as free strings wherever a lease is read.
+ */
+export type ManagedLeaseEnvironmentKey = 'SIMLOCK_IOS_DEVICE_SET' | 'ANDROID_ADB_SERVER_PORT';
+
+/**
+ * The typed reach projection of a lease's otherwise opaque environment record, and the failure a
+ * grant without its platform's key is. The reader that produces either lands with the unit that
+ * first turns a grant into a device; both names are part of the contract now so that reader
+ * cannot invent a second spelling for them.
+ */
+// fallow-ignore-next-line unused-type
+export type ManagedLeaseEnvironment =
+  | Readonly<{ platform: 'ios'; deviceSetPath: string }>
+  | Readonly<{ platform: 'android'; adbServerPort: number }>;
+
+// fallow-ignore-next-line unused-type
+export type LeaseEnvironmentError = Readonly<{
+  code: 'LEASE_ENVIRONMENT_INVALID';
+  platform: ManagedLeasePlatform;
+  key: ManagedLeaseEnvironmentKey;
+}>;
+
+/** One granted managed-device lease. `environment` stays the allocator's raw record. */
+export type ManagedLease = Readonly<{
+  id: string;
+  ttlDeadline: number;
+  device: Readonly<{ address: string }>;
+  environment: Readonly<Record<string, string>>;
+}>;
+
+/**
+ * One created managed identity. The incarnation id is minted before the device exists and is
+ * preserved across reuse of the same Android identity, so it names the identity's creation rather
+ * than the request that happens to be holding it.
+ */
+export type ManagedIdentityRef = Readonly<{ deviceId: string; identityIncarnationId: string }>;
+
+export type ManagedIdentityState =
+  | 'reserved'
+  | 'active'
+  | 'idle'
+  | 'removing'
+  | 'removed'
+  | 'unknown';
+
+export type ManagedIdentityStatus = ManagedIdentityRef & Readonly<{ state: ManagedIdentityState }>;
+
+/**
+ * Fail-fast admission (ADR 0021 §4): the allocator refuses instead of queueing and agent-device
+ * adds no second queue. `activation: 'external-fence'` is the reusable-identity handshake, where
+ * the allocator validates its clean baseline under the requester's fence before publishing the
+ * grant; `'direct'` publishes as soon as the identity is ready.
+ */
+export type LeaseRequestInput = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  attemptKey: string;
+  shape: ManagedShapeRequest;
+  deadlineAtMs: number;
+  admission: 'fail-fast';
+  activation: 'direct' | 'external-fence';
+  attribution?: JsonObject;
+  /** Abandons only this caller's wait; the attempt keeps its own terminal outcome. */
+  signal?: AbortSignal;
+}>;
+
+export type LeaseRefusalReason =
+  | 'simulator-capacity'
+  | 'disk-low'
+  | 'invalid-shape'
+  | 'preparation-required'
+  | 'requester-busy';
+
+/** A refusal is terminal for its attempt key; only a capacity refusal names a retry delay. */
+export type LeaseRefusal = Readonly<{
+  reason: LeaseRefusalReason;
+  retryAfterMs?: number;
+  message?: string;
+}>;
+
+export type LeaseRequestState =
+  | 'pending'
+  | 'granted'
+  | 'refused'
+  | 'superseded'
+  | 'cancelled'
+  | 'unknown';
+
+/**
+ * All three identities are readable from one status because the managed binding fence is derived
+ * from them. `identityIncarnationId` is present from the moment an identity is reserved, so it is
+ * absent only while the request has not reached one.
+ */
+export type LeaseRequestStatus = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  identityIncarnationId?: string;
+  attemptKey: string;
+  state: LeaseRequestState;
+  lease?: ManagedLease;
+  refusal?: LeaseRefusal;
+}>;
+
+/** One attempt on one requester's allocation lane. */
+export type LeaseRequestRef = Readonly<{ requesterId: string; attemptKey: string }>;
+
+/** Supersession replaces exactly the expected prior generation, never a newer one. */
+export type SupersedeLeaseRequestInput = Readonly<{
+  requesterId: string;
+  expectedRequestGeneration: number;
+  replacement: LeaseRequestInput;
+}>;
+
+/** Activation binds one request to one identity, so it is scoped to all three ids. */
+export type LeaseActivationProof = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  identityIncarnationId: string;
+}>;
+
+export type ManagedDeviceAllocatorPort = Readonly<{
+  instanceId: string;
+  requestLease(input: LeaseRequestInput): Promise<LeaseRequestStatus>;
+  getLeaseRequestStatus(request: LeaseRequestRef): Promise<LeaseRequestStatus>;
+  supersedeLeaseRequest(input: SupersedeLeaseRequestInput): Promise<LeaseRequestStatus>;
+  cancelLeaseRequest(request: LeaseRequestRef): Promise<LeaseRequestStatus>;
+  renewLease(input: Readonly<{ leaseId: string; ttlDeadline: number }>): Promise<ManagedLease>;
+  releaseLease(input: Readonly<{ leaseId: string }>): Promise<void>;
+  confirmLeaseActivation(proof: LeaseActivationProof): Promise<void>;
+  getManagedIdentityStatus(identity: ManagedIdentityRef): Promise<ManagedIdentityStatus>;
+  acknowledgeManagedIdentityRemoval(identity: ManagedIdentityRef): Promise<void>;
+}>;

--- a/packages/contracts/src/platform-runtime-unavailable.test.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import { providerRuntimeOwner } from './platform-runtime.ts';
+import {
+  localRuntimeOwner,
+  managedLocalRuntimeOwner,
+  providerRuntimeOwner,
+} from './platform-runtime.ts';
 import { applicationLifecycleOperationFacts } from './application-lifecycle-runtime.ts';
-import { createUnavailablePlatformRuntimeBinding } from './platform-runtime-unavailable.ts';
+import {
+  createUnavailablePlatformRuntimeBinding,
+  createUnavailablePlatformRuntimeFacts,
+  type UnavailablePlatformRuntimeFacts,
+} from './platform-runtime-unavailable.ts';
 
 const device = {
   id: 'linux-host',
@@ -24,39 +32,41 @@ const lifecycle = applicationLifecycleOperationFacts({
   configureProviderPortReverse: { available: false, reason: 'unsupported-platform-leaf' },
 });
 
+const UNAVAILABLE_FACTS: UnavailablePlatformRuntimeFacts = {
+  appLog: { available: false, reason: 'unsupported-provider-mode' },
+  network: { available: false, reason: 'owner-capability-missing' },
+  screenshot: { available: false, reason: 'unsupported-device-kind' },
+  viewport: { available: false, reason: 'unsupported-platform-leaf' },
+  focus: { available: false, reason: 'unsupported-provider-mode' },
+  gesture: { available: false, reason: 'unsupported-provider-mode' },
+  scroll: { available: false, reason: 'unsupported-provider-mode' },
+  typeText: { available: false, reason: 'unsupported-provider-mode' },
+  touch: { available: false, reason: 'unsupported-provider-mode' },
+  elementText: { available: false, reason: 'unsupported-provider-mode' },
+  back: { available: false, reason: 'unsupported-provider-mode' },
+  home: { available: false, reason: 'unsupported-provider-mode' },
+  orientation: { available: false, reason: 'unsupported-provider-mode' },
+  tvRemote: { available: false, reason: 'unsupported-provider-mode' },
+  keyboardStatus: { available: false, reason: 'unsupported-provider-mode' },
+  keyboardDismiss: { available: false, reason: 'unsupported-provider-mode' },
+  keyboardEnter: { available: false, reason: 'unsupported-provider-mode' },
+  readClipboard: { available: false, reason: 'unsupported-provider-mode' },
+  writeClipboard: { available: false, reason: 'unsupported-provider-mode' },
+  appSwitcher: { available: false, reason: 'unsupported-provider-mode' },
+  triggerAppEvent: { available: false, reason: 'unsupported-provider-mode' },
+  setSetting: { available: false, reason: 'unsupported-provider-mode' },
+  readAlert: { available: false, reason: 'unsupported-provider-mode' },
+  awaitAlert: { available: false, reason: 'unsupported-provider-mode' },
+  acceptAlert: { available: false, reason: 'unsupported-provider-mode' },
+  dismissAlert: { available: false, reason: 'unsupported-provider-mode' },
+  audioProbeCapture: { available: false, reason: 'unsupported-provider-mode' },
+  audioProbeQuery: { available: false, reason: 'unsupported-provider-mode' },
+  lifecycle,
+};
+
 test('generic unavailable binding preserves exact provider ownership and mode', async () => {
   const owner = providerRuntimeOwner('webdriver', 'tenant-a');
-  const binding = createUnavailablePlatformRuntimeBinding(device, owner, {
-    appLog: { available: false, reason: 'unsupported-provider-mode' },
-    network: { available: false, reason: 'owner-capability-missing' },
-    screenshot: { available: false, reason: 'unsupported-device-kind' },
-    viewport: { available: false, reason: 'unsupported-platform-leaf' },
-    focus: { available: false, reason: 'unsupported-provider-mode' },
-    gesture: { available: false, reason: 'unsupported-provider-mode' },
-    scroll: { available: false, reason: 'unsupported-provider-mode' },
-    typeText: { available: false, reason: 'unsupported-provider-mode' },
-    touch: { available: false, reason: 'unsupported-provider-mode' },
-    elementText: { available: false, reason: 'unsupported-provider-mode' },
-    back: { available: false, reason: 'unsupported-provider-mode' },
-    home: { available: false, reason: 'unsupported-provider-mode' },
-    orientation: { available: false, reason: 'unsupported-provider-mode' },
-    tvRemote: { available: false, reason: 'unsupported-provider-mode' },
-    keyboardStatus: { available: false, reason: 'unsupported-provider-mode' },
-    keyboardDismiss: { available: false, reason: 'unsupported-provider-mode' },
-    keyboardEnter: { available: false, reason: 'unsupported-provider-mode' },
-    readClipboard: { available: false, reason: 'unsupported-provider-mode' },
-    writeClipboard: { available: false, reason: 'unsupported-provider-mode' },
-    appSwitcher: { available: false, reason: 'unsupported-provider-mode' },
-    triggerAppEvent: { available: false, reason: 'unsupported-provider-mode' },
-    setSetting: { available: false, reason: 'unsupported-provider-mode' },
-    readAlert: { available: false, reason: 'unsupported-provider-mode' },
-    awaitAlert: { available: false, reason: 'unsupported-provider-mode' },
-    acceptAlert: { available: false, reason: 'unsupported-provider-mode' },
-    dismissAlert: { available: false, reason: 'unsupported-provider-mode' },
-    audioProbeCapture: { available: false, reason: 'unsupported-provider-mode' },
-    audioProbeQuery: { available: false, reason: 'unsupported-provider-mode' },
-    lifecycle,
-  });
+  const binding = createUnavailablePlatformRuntimeBinding(device, owner, UNAVAILABLE_FACTS);
 
   assert.equal(binding.owner, owner);
   assert.equal(binding.facts.device.providerMode, 'provider-runtime');
@@ -84,4 +94,21 @@ test('generic unavailable binding preserves exact provider ownership and mode', 
   });
   assert.deepEqual(binding.operations, {});
   await binding[Symbol.asyncDispose]();
+});
+
+test('generic unavailable facts report provider mode local for a managed local owner', () => {
+  const owner = managedLocalRuntimeOwner('sim-a');
+  assert.equal(
+    createUnavailablePlatformRuntimeFacts(device, owner, UNAVAILABLE_FACTS).device.providerMode,
+    'local',
+  );
+  assert.equal(
+    createUnavailablePlatformRuntimeFacts(device, localRuntimeOwner('linux'), UNAVAILABLE_FACTS)
+      .device.providerMode,
+    'local',
+  );
+  assert.equal(
+    createUnavailablePlatformRuntimeBinding(device, owner, UNAVAILABLE_FACTS).owner,
+    owner,
+  );
 });

--- a/packages/contracts/src/platform-runtime-unavailable.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeFacts,
   RuntimeOperationUnavailability,
   RuntimeOwnerRef,
+  RuntimeProviderMode,
 } from './platform-runtime.ts';
 import { screenshotRuntimeOperationFacts } from './screenshot-runtime.ts';
 import { snapshotRuntimeOperationFacts } from './snapshot-runtime.ts';
@@ -147,7 +148,7 @@ export function createUnavailablePlatformRuntimeFacts(
   return Object.freeze({
     device: {
       ...deviceShape(device),
-      providerMode: owner.kind === 'local-family' ? 'local' : 'provider-runtime',
+      providerMode: providerModeForOwner(owner),
     },
     operations: {
       appLogInspect: appLog,
@@ -237,6 +238,17 @@ export function createUnavailablePlatformRuntimeFacts(
       ...lifecycle,
     },
   });
+}
+
+/** A managed local owner executes through its local family, so it reports the local mode. */
+function providerModeForOwner(owner: RuntimeOwnerRef): RuntimeProviderMode {
+  switch (owner.kind) {
+    case 'local-family':
+    case 'managed-local':
+      return 'local';
+    case 'provider-runtime':
+      return 'provider-runtime';
+  }
 }
 
 function freezeUnavailableFacts(

--- a/packages/contracts/src/platform-runtime.test.ts
+++ b/packages/contracts/src/platform-runtime.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import { test } from 'vitest';
 import { AppError } from '@agent-device/kernel/errors';
 import {
+  decodeManagedBindingFence,
   localRuntimeOwner,
+  managedBindingFence,
+  managedLocalRuntimeOwner,
   narrowDeviceBinding,
   providerRuntimeOwner,
   runtimeOwnerKey,
@@ -98,8 +102,22 @@ test('runtime use freezes declarations and rejects dynamic overlap or duplicates
   );
 });
 
-test('runtime owner keys distinguish local families and configured provider instances', () => {
+test('runtime owner keys distinguish local families, managed local owners, and configured provider instances', () => {
   assert.equal(runtimeOwnerKey(localRuntimeOwner('apple')), 'local:apple');
+  assert.equal(runtimeOwnerKey(managedLocalRuntimeOwner('sim-a')), 'managed:["sim-a"]');
+  // One string names three different owners as a family, an allocator instance, and a provider.
+  assert.notEqual(
+    runtimeOwnerKey(managedLocalRuntimeOwner('apple')),
+    runtimeOwnerKey(localRuntimeOwner('apple')),
+  );
+  assert.notEqual(
+    runtimeOwnerKey(managedLocalRuntimeOwner('limrun')),
+    runtimeOwnerKey(providerRuntimeOwner('limrun', 'limrun')),
+  );
+  assert.notEqual(
+    runtimeOwnerKey(managedLocalRuntimeOwner('a"]')),
+    runtimeOwnerKey(managedLocalRuntimeOwner('a')),
+  );
   assert.notEqual(
     runtimeOwnerKey(providerRuntimeOwner('webdriver', 'tenant-a')),
     runtimeOwnerKey(providerRuntimeOwner('webdriver', 'tenant-b')),
@@ -115,6 +133,87 @@ test('runtime owner keys distinguish local families and configured provider inst
       providerRuntimeOwner('webdriver', 'tenant-a'),
     ),
     true,
+  );
+});
+
+test('managed local owner is keyed by one trimmed allocator instance', () => {
+  const owner = managedLocalRuntimeOwner(' sim-a ');
+  assert.deepEqual(owner, { kind: 'managed-local', instance: 'sim-a' });
+  assert.ok(Object.isFrozen(owner));
+  assert.throws(() => managedLocalRuntimeOwner('  '), /non-empty/);
+  assert.equal(sameRuntimeOwner(owner, managedLocalRuntimeOwner('sim-a')), true);
+  assert.equal(sameRuntimeOwner(owner, managedLocalRuntimeOwner('sim-b')), false);
+});
+
+test('managed binding fence separates requesters that share one identity incarnation', () => {
+  const requesterA = managedBindingFence({
+    requesterId: 'requester-a',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-1',
+  });
+  const requesterB = managedBindingFence({
+    requesterId: 'requester-b',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-1',
+  });
+  assert.notDeepEqual(requesterA, requesterB);
+  assert.equal(requesterA.generation, 1);
+  assert.ok(Object.isFrozen(requesterA));
+  // The allocator owns the form of its ids: a padded id is a different id, fenced verbatim.
+  const padded = managedBindingFence({
+    requesterId: ' requester-a ',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-1',
+  });
+  assert.notDeepEqual(requesterA, padded);
+  assert.deepEqual(decodeManagedBindingFence(padded), {
+    requesterId: ' requester-a ',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-1',
+  });
+  // Canonical JSON, not a separator: requester and incarnation can never re-split.
+  assert.notEqual(
+    managedBindingFence({ requesterId: 'a:b', requestGeneration: 1, identityIncarnationId: 'c' })
+      .token,
+    managedBindingFence({ requesterId: 'a', requestGeneration: 1, identityIncarnationId: 'b:c' })
+      .token,
+  );
+  assert.throws(
+    () =>
+      managedBindingFence({ requesterId: '  ', requestGeneration: 1, identityIncarnationId: 'x' }),
+    TypeError,
+  );
+  assert.throws(
+    () =>
+      managedBindingFence({ requesterId: 'a', requestGeneration: 1.5, identityIncarnationId: 'x' }),
+    TypeError,
+  );
+});
+
+test('managed binding fence decodes only what managedBindingFence encoded', () => {
+  const identity = {
+    requesterId: 'requester-a',
+    requestGeneration: 3,
+    identityIncarnationId: 'incarnation-1',
+  };
+  const decoded = decodeManagedBindingFence(managedBindingFence(identity));
+  assert.deepEqual(decoded, identity);
+  assert.ok(decoded && Object.isFrozen(decoded));
+  // A durable-capture fence token is an opaque UUID, never a managed binding.
+  assert.equal(decodeManagedBindingFence({ token: crypto.randomUUID(), generation: 1 }), null);
+  for (const token of [
+    JSON.stringify(['a', 'b', 'c']),
+    JSON.stringify(['a', 7]),
+    JSON.stringify(['', 'b']),
+    JSON.stringify([' ', 'b']),
+    // Non-canonical encoding of a well-formed pair: it re-encodes to a different token.
+    '["a", "b"]',
+  ]) {
+    assert.equal(decodeManagedBindingFence({ token, generation: 1 }), null, token);
+  }
+  assert.equal(
+    decodeManagedBindingFence({ token: JSON.stringify(['a', 'b']), generation: -1 }),
+    null,
   );
 });
 

--- a/packages/contracts/src/platform-runtime.ts
+++ b/packages/contracts/src/platform-runtime.ts
@@ -49,6 +49,7 @@ export type RuntimeUse<
 
 export type RuntimeOwnerRef =
   | Readonly<{ kind: 'local-family'; family: Platform }>
+  | Readonly<{ kind: 'managed-local'; instance: string }>
   | Readonly<{ kind: 'provider-runtime'; provider: string; instance: string }>;
 
 export function localRuntimeOwner(family: Platform): RuntimeOwnerRef {
@@ -76,10 +77,32 @@ export function providerRuntimeOwner(
   });
 }
 
+/**
+ * One managed local owner per allocator instance: it executes on a local device the allocator
+ * holds by delegating automation mechanics to the device's platform family, and takes no device
+ * lifecycle. Family-agnostic by design: the device carries its family.
+ */
+export function managedLocalRuntimeOwner(
+  instance: string,
+): Extract<RuntimeOwnerRef, { kind: 'managed-local' }> {
+  const normalizedInstance = instance.trim();
+  if (normalizedInstance.length === 0) {
+    throw new TypeError(
+      'Managed local runtime owner requires a non-empty allocator instance identity',
+    );
+  }
+  return Object.freeze({ kind: 'managed-local', instance: normalizedInstance });
+}
+
 export function runtimeOwnerKey(owner: RuntimeOwnerRef): string {
-  return owner.kind === 'local-family'
-    ? `local:${owner.family}`
-    : `provider:${JSON.stringify([owner.provider, owner.instance])}`;
+  switch (owner.kind) {
+    case 'local-family':
+      return `local:${owner.family}`;
+    case 'managed-local':
+      return `managed:${JSON.stringify([owner.instance])}`;
+    case 'provider-runtime':
+      return `provider:${JSON.stringify([owner.provider, owner.instance])}`;
+  }
 }
 
 export function sameRuntimeOwner(left: RuntimeOwnerRef, right: RuntimeOwnerRef): boolean {
@@ -141,6 +164,75 @@ export type ResourceOwnershipFence = Readonly<{
   token: string;
   generation: number;
 }>;
+
+/** The three identities one managed binding fence carries (ADR 0021). */
+export type ManagedBindingIdentity = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  identityIncarnationId: string;
+}>;
+
+/**
+ * The managed binding fence: token = the canonical JSON tuple of requester and identity
+ * incarnation, generation = the request generation. The tuple encoding keeps two requesters on
+ * one identity incarnation apart at every generation, the same way {@link runtimeOwnerKey}
+ * keeps provider instances apart. Both ids are fenced exactly as given: the allocator owns their
+ * form, so a blank id is a `TypeError` rather than an id this function quietly rewrote into one
+ * that fences a different request.
+ */
+export function managedBindingFence(identity: ManagedBindingIdentity): ResourceOwnershipFence {
+  if (
+    !isNonBlankString(identity.requesterId) ||
+    !isNonBlankString(identity.identityIncarnationId) ||
+    !isRequestGeneration(identity.requestGeneration)
+  ) {
+    throw new TypeError(
+      'Managed binding fence requires non-empty requester and identity incarnation ids and a non-negative integer request generation',
+    );
+  }
+  return Object.freeze({
+    token: JSON.stringify([identity.requesterId, identity.identityIncarnationId]),
+    generation: identity.requestGeneration,
+  });
+}
+
+/**
+ * Reads back only what {@link managedBindingFence} encoded: the decoded identity must re-encode
+ * to the very same token, so a capture-style opaque token, a non-canonical JSON encoding, or any
+ * other tuple shape yields null.
+ */
+export function decodeManagedBindingFence(
+  fence: ResourceOwnershipFence,
+): ManagedBindingIdentity | null {
+  const tuple = parseJsonTuple(fence.token);
+  if (!tuple || tuple.length !== 2) return null;
+  const [requesterId, identityIncarnationId] = tuple;
+  if (!isNonBlankString(requesterId) || !isNonBlankString(identityIncarnationId)) return null;
+  if (!isRequestGeneration(fence.generation)) return null;
+  const identity = Object.freeze({
+    requesterId,
+    requestGeneration: fence.generation,
+    identityIncarnationId,
+  });
+  return managedBindingFence(identity).token === fence.token ? identity : null;
+}
+
+function isRequestGeneration(value: number): boolean {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseJsonTuple(token: string): unknown[] | null {
+  try {
+    const parsed: unknown = JSON.parse(token);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 export type DeviceBindingIntent =
   | Readonly<{ kind: 'ordinary' }>

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -113,6 +113,7 @@ const CONTRACT_EXPORTS = [
   '@agent-device/contracts/keyboard-runtime',
   '@agent-device/contracts/local-interactor-operation-set',
   '@agent-device/contracts/logs-runtime-plan',
+  '@agent-device/contracts/managed-device-allocation',
   '@agent-device/contracts/managed-web-backend',
   '@agent-device/contracts/navigation',
   '@agent-device/contracts/network-runtime',

--- a/src/__tests__/managed-device-allocator-fake.test.ts
+++ b/src/__tests__/managed-device-allocator-fake.test.ts
@@ -1,0 +1,90 @@
+import type {
+  LeaseRequestInput,
+  LeaseRequestStatus,
+  ManagedIdentityRef,
+} from '@agent-device/contracts/managed-device-allocation';
+import { describe, expect, test } from 'vitest';
+import { createScriptedManagedDeviceAllocator } from './test-utils/managed-device-allocator.fixtures.ts';
+
+const request: LeaseRequestInput = {
+  requesterId: 'requester-a',
+  requestGeneration: 1,
+  attemptKey: 'attempt-1',
+  shape: { platform: 'ios', deviceType: 'iPhone 16' },
+  deadlineAtMs: 1_000,
+  admission: 'fail-fast',
+  activation: 'direct',
+};
+
+const identity: ManagedIdentityRef = {
+  deviceId: 'device-a',
+  identityIncarnationId: 'incarnation-a',
+};
+
+const pending: LeaseRequestStatus = {
+  requesterId: request.requesterId,
+  requestGeneration: request.requestGeneration,
+  attemptKey: request.attemptKey,
+  state: 'pending',
+};
+
+const granted: LeaseRequestStatus = {
+  ...pending,
+  identityIncarnationId: identity.identityIncarnationId,
+  state: 'granted',
+  lease: {
+    id: 'lease-1',
+    ttlDeadline: 2_000,
+    device: { address: 'device-a' },
+    environment: { SIMLOCK_IOS_DEVICE_SET: '/sets/managed' },
+  },
+};
+
+describe('scripted managed device allocator', () => {
+  test('replays one step per method in order and refuses an unscripted call', async () => {
+    const allocator = createScriptedManagedDeviceAllocator({
+      instanceId: 'sim-a',
+      script: {
+        requestLease: [pending, granted],
+        getLeaseRequestStatus: [granted],
+        getManagedIdentityStatus: [new Error('allocator unreachable')],
+      },
+    });
+
+    expect(allocator.instanceId).toBe('sim-a');
+    await expect(allocator.requestLease(request)).resolves.toEqual(pending);
+    // Steps are consumed per method: the lookup between the two requests takes its own script.
+    await expect(
+      allocator.getLeaseRequestStatus({ requesterId: 'requester-a', attemptKey: 'attempt-1' }),
+    ).resolves.toEqual(granted);
+    await expect(allocator.requestLease(request)).resolves.toEqual(granted);
+    await expect(allocator.requestLease(request)).rejects.toThrow(
+      'Unscripted allocator call: requestLease',
+    );
+    await expect(allocator.getManagedIdentityStatus(identity)).rejects.toThrow(
+      'allocator unreachable',
+    );
+    await expect(
+      allocator.confirmLeaseActivation({
+        requesterId: 'requester-a',
+        requestGeneration: 1,
+        identityIncarnationId: 'incarnation-a',
+      }),
+    ).rejects.toThrow('Unscripted allocator call: confirmLeaseActivation');
+  });
+
+  test('records every call with the input it received', async () => {
+    const allocator = createScriptedManagedDeviceAllocator({
+      script: { requestLease: [granted], releaseLease: [undefined] },
+    });
+
+    await allocator.requestLease(request);
+    await allocator.releaseLease({ leaseId: 'lease-1' });
+
+    expect(allocator.calls).toEqual([
+      { method: 'requestLease', input: request },
+      { method: 'releaseLease', input: { leaseId: 'lease-1' } },
+    ]);
+    expect(allocator.calls[0]?.input).toBe(request);
+  });
+});

--- a/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
+++ b/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
@@ -1,0 +1,54 @@
+import type { ManagedDeviceAllocatorPort } from '@agent-device/contracts/managed-device-allocation';
+
+export type ScriptedAllocatorMethod = keyof Omit<ManagedDeviceAllocatorPort, 'instanceId'>;
+
+export type ScriptedAllocatorCall = Readonly<{
+  method: ScriptedAllocatorMethod;
+  input: unknown;
+}>;
+
+export type ScriptedManagedDeviceAllocator = ManagedDeviceAllocatorPort &
+  Readonly<{ calls: ScriptedAllocatorCall[] }>;
+
+/**
+ * The only implementation of the allocator port in the foundations: it replays one scripted step
+ * per call, in the order the script lists them for that method, and refuses a call the script did
+ * not anticipate. No transport, no timers, and no lifecycle rules of its own — a test that wants
+ * an allocator behavior states it as a step.
+ */
+export function createScriptedManagedDeviceAllocator(
+  options: {
+    instanceId?: string;
+    script?: Partial<Record<ScriptedAllocatorMethod, readonly unknown[]>>;
+  } = {},
+): ScriptedManagedDeviceAllocator {
+  const calls: ScriptedAllocatorCall[] = [];
+  const remaining = new Map<ScriptedAllocatorMethod, unknown[]>(
+    Object.entries(options.script ?? {}).map(([method, steps]) => [
+      method as ScriptedAllocatorMethod,
+      [...(steps ?? [])],
+    ]),
+  );
+  const next = async <Result>(method: ScriptedAllocatorMethod, input: unknown): Promise<Result> => {
+    calls.push(Object.freeze({ method, input }));
+    const steps = remaining.get(method) ?? [];
+    if (steps.length === 0) throw new Error(`Unscripted allocator call: ${method}`);
+    const step = steps.shift();
+    if (step instanceof Error) throw step;
+    return step as Result;
+  };
+  return Object.freeze({
+    instanceId: options.instanceId ?? 'scripted-allocator',
+    calls,
+    requestLease: async (input) => await next('requestLease', input),
+    getLeaseRequestStatus: async (request) => await next('getLeaseRequestStatus', request),
+    supersedeLeaseRequest: async (input) => await next('supersedeLeaseRequest', input),
+    cancelLeaseRequest: async (request) => await next('cancelLeaseRequest', request),
+    renewLease: async (input) => await next('renewLease', input),
+    releaseLease: async (input) => await next('releaseLease', input),
+    confirmLeaseActivation: async (proof) => await next('confirmLeaseActivation', proof),
+    getManagedIdentityStatus: async (identity) => await next('getManagedIdentityStatus', identity),
+    acknowledgeManagedIdentityRemoval: async (identity) =>
+      await next('acknowledgeManagedIdentityRemoval', identity),
+  });
+}

--- a/src/daemon/__tests__/application-lifecycle-runtime-harness.ts
+++ b/src/daemon/__tests__/application-lifecycle-runtime-harness.ts
@@ -8,6 +8,7 @@ import {
   type DeviceBinding,
   type RuntimeFacts,
   localRuntimeOwner,
+  managedLocalRuntimeOwner,
   narrowDeviceBinding,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
@@ -114,6 +115,13 @@ export const inspectLifecycleRuntimeFacts: InspectDeviceRuntimeFacts = async (de
 
 export const bindLifecycleRuntime: BindDeviceRuntime = async (device, use) =>
   narrowDeviceBinding(await lifecycleBinding(device), use);
+
+/** The same local lifecycle mechanics under a managed local owner that holds no allocator-held claim. */
+export const bindManagedLocalLifecycleRuntime: BindDeviceRuntime = async (device, use) =>
+  narrowDeviceBinding(
+    { ...(await lifecycleBinding(device)), owner: managedLocalRuntimeOwner('fixture-allocator') },
+    use,
+  );
 
 function providerLifecycleBinding(device: DeviceInfo): DeviceBinding<PlatformRuntimeOperations> {
   const facts = providerLifecycleRuntimeFacts(device);

--- a/src/daemon/__tests__/device-claim-admission.test.ts
+++ b/src/daemon/__tests__/device-claim-admission.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { localRuntimeOwner, providerRuntimeOwner } from '@agent-device/contracts/platform-runtime';
+import {
+  localRuntimeOwner,
+  managedBindingFence,
+  managedLocalRuntimeOwner,
+  providerRuntimeOwner,
+  type DeviceBindingIntent,
+} from '@agent-device/contracts/platform-runtime';
 import { asAppError } from '@agent-device/kernel/errors';
 import { ANDROID_EMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
 import {
@@ -19,6 +25,17 @@ import type { DeviceClaimPolicy } from '../../core/command-descriptor/types.ts';
 
 const setup = isolatedDeviceClaimStores('agent-device-claim-admission-');
 const localAndroid = localRuntimeOwner('android');
+const managedOwner = managedLocalRuntimeOwner('sim-a');
+const ORDINARY: DeviceBindingIntent = { kind: 'ordinary' };
+const MANAGED_BINDING: DeviceBindingIntent = {
+  kind: 'exact-owner',
+  owner: managedOwner,
+  fence: managedBindingFence({
+    requesterId: 'requester-1',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-1',
+  }),
+};
 
 function makeAdmission(policy: DeviceClaimPolicy, stateDir: string, command = 'made-up-command') {
   return createDeviceClaimAdmission({
@@ -52,7 +69,7 @@ test.for(POLICY_CLAIMS)(
     const { stateDir, claimsDir } = setup();
     const admission = makeAdmission(policy, stateDir);
 
-    await admission.admit(ANDROID_EMULATOR, localAndroid);
+    await admission.admit(ANDROID_EMULATOR, localAndroid, ORDINARY);
     expect(claimedSessions()).toEqual(held);
 
     await admission[Symbol.asyncDispose]();
@@ -76,7 +93,9 @@ test('a foreign live claim refuses the command before it can reach device operat
 
   const admission = makeAdmission('transient-exclusive', stateDir, 'shutdown');
   const error = asAppError(
-    await admission.admit(ANDROID_EMULATOR, localAndroid).catch((error: unknown) => error),
+    await admission
+      .admit(ANDROID_EMULATOR, localAndroid, ORDINARY)
+      .catch((error: unknown) => error),
   );
 
   expect(error.code).toBe('DEVICE_IN_USE');
@@ -102,7 +121,7 @@ test('a claim already held by this daemon covers the command instead of collidin
   });
 
   const admission = makeAdmission('transient-exclusive', stateDir, 'install');
-  await admission.admit(ANDROID_EMULATOR, localAndroid);
+  await admission.admit(ANDROID_EMULATOR, localAndroid, ORDINARY);
   await admission[Symbol.asyncDispose]();
 
   // The session claim is untouched: the command neither replaced nor released it.
@@ -123,7 +142,7 @@ test("an abandoned claim becomes this command's own transient claim and is relea
   expect(await abandonDeviceClaim(aborted.ownership)).toBe('abandoned');
 
   const admission = makeAdmission('transient-exclusive', stateDir, 'install');
-  await admission.admit(ANDROID_EMULATOR, localAndroid);
+  await admission.admit(ANDROID_EMULATOR, localAndroid, ORDINARY);
 
   // Coverage would have left the abandoned record owning the device with nothing to release it.
   expect(claimedSessions()).toEqual(['transient:install']);
@@ -135,11 +154,71 @@ test('a provider-owned device takes no host-local claim', async () => {
   const { stateDir, claimsDir } = setup();
   const admission = makeAdmission('transient-exclusive', stateDir);
 
-  await admission.admit(ANDROID_EMULATOR, providerRuntimeOwner('limrun', 'instance-1'));
+  await admission.admit(ANDROID_EMULATOR, providerRuntimeOwner('limrun', 'instance-1'), ORDINARY);
   await admission[Symbol.asyncDispose]();
 
   expect(fs.existsSync(claimsDir)).toBe(false);
 });
+
+test('a managed local owner is refused allocator-claim-missing under a managed binding fence and never takes a transient claim', async () => {
+  const { stateDir, claimsDir } = setup();
+  const admission = makeAdmission('transient-exclusive', stateDir, 'shutdown');
+
+  const error = asAppError(
+    await admission
+      .admit(ANDROID_EMULATOR, managedOwner, MANAGED_BINDING)
+      .catch((error: unknown) => error),
+  );
+
+  expect(error.code).toBe('COMMAND_FAILED');
+  expect(error.details?.reason).toBe('allocator-claim-missing');
+  expect(error.details?.retriable).toBe(false);
+  expect(error.details?.owner).toBe('managed:["sim-a"]');
+  expect(error.details?.hint).toMatch(/allocator-held claim/);
+  // The verifier never reaches for the store: nothing to acquire, nothing to give back.
+  expect(fs.existsSync(claimsDir)).toBe(false);
+  await admission[Symbol.asyncDispose]();
+  expect(fs.existsSync(claimsDir)).toBe(false);
+});
+
+test('a managed local owner bound without a managed binding fence is refused as a contract violation', async () => {
+  const { stateDir, claimsDir } = setup();
+  const admission = makeAdmission('transient-exclusive', stateDir, 'shutdown');
+
+  const error = asAppError(
+    await admission
+      .admit(ANDROID_EMULATOR, managedOwner, ORDINARY)
+      .catch((error: unknown) => error),
+  );
+
+  expect(error.code).toBe('COMMAND_FAILED');
+  expect(error.details?.reason).toBe('runtime-contract-invalid');
+  expect(fs.existsSync(claimsDir)).toBe(false);
+  await admission[Symbol.asyncDispose]();
+});
+
+// The rule is evaluated under every policy: the ordinary arm alone reads the policy (the
+// POLICY_CLAIMS table above), while a managed local owner is verified even where an ordinary
+// owner would never touch the store, and a provider owner never is.
+test.for(POLICY_CLAIMS.map(([policy]) => policy))(
+  'the device-claim rule is evaluated under the %s policy: managed local owners are verified, provider owners never claim',
+  async (policy, { expect }) => {
+    const { stateDir, claimsDir } = setup();
+    const admission = makeAdmission(policy, stateDir);
+
+    const error = asAppError(
+      await admission
+        .admit(ANDROID_EMULATOR, managedOwner, MANAGED_BINDING)
+        .catch((error: unknown) => error),
+    );
+    expect(error.code).toBe('COMMAND_FAILED');
+    expect(error.details?.reason).toBe('allocator-claim-missing');
+
+    await admission.admit(ANDROID_EMULATOR, providerRuntimeOwner('limrun', 'instance-1'), ORDINARY);
+    await admission[Symbol.asyncDispose]();
+    expect(fs.existsSync(claimsDir)).toBe(false);
+  },
+);
 
 /** Claims visible while one command holds a device binding from the real request scope. */
 async function claimsWhileBound(command: string, stateDir: string) {

--- a/src/daemon/__tests__/device-claim-allocator.test.ts
+++ b/src/daemon/__tests__/device-claim-allocator.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest';
+import fs from 'node:fs';
+import {
+  localRuntimeOwner,
+  managedBindingFence,
+  managedLocalRuntimeOwner,
+  type DeviceBindingIntent,
+} from '@agent-device/contracts/platform-runtime';
+import { ANDROID_EMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
+import {
+  isolatedDeviceClaimStores,
+  retainOrphanedDeviceClaims,
+} from '../../__tests__/test-utils/device-claim-store.ts';
+import { requireAllocatorHeldDeviceClaim } from '../device-claim-allocator.ts';
+import { canonicalLocalDeviceKey, resolveDeviceClaimPath } from '../device-claim-paths.ts';
+import { acquireDeviceClaim, deviceClaimIdentity } from '../device-claims.ts';
+
+const setup = isolatedDeviceClaimStores('agent-device-claim-allocator-');
+const owner = managedLocalRuntimeOwner('sim-a');
+const fence = managedBindingFence({
+  requesterId: 'requester-1',
+  requestGeneration: 1,
+  identityIncarnationId: 'incarnation-1',
+});
+const managedBinding: DeviceBindingIntent = { kind: 'exact-owner', owner, fence };
+
+function verify(intent: DeviceBindingIntent) {
+  return requireAllocatorHeldDeviceClaim({ device: ANDROID_EMULATOR, owner, intent });
+}
+
+test('requireAllocatorHeldDeviceClaim refuses a binding without a managed binding fence before reading the store', () => {
+  const { claimsDir } = setup();
+
+  // An ordinary binding, an exact binding of another owner, and an exact binding of this owner
+  // under an opaque capture-style fence all fail the managed binding shape.
+  expect(verify({ kind: 'ordinary' })).toEqual({ status: 'binding-invalid' });
+  expect(verify({ kind: 'exact-owner', owner: localRuntimeOwner('android'), fence })).toEqual({
+    status: 'binding-invalid',
+  });
+  expect(verify({ kind: 'exact-owner', owner, fence: { token: 'fence', generation: 1 } })).toEqual({
+    status: 'binding-invalid',
+  });
+  expect(fs.existsSync(claimsDir)).toBe(false);
+});
+
+test('requireAllocatorHeldDeviceClaim reports a missing claim without creating the store', () => {
+  const { claimsDir } = setup();
+
+  expect(verify(managedBinding)).toEqual({ status: 'missing' });
+  expect(fs.existsSync(claimsDir)).toBe(false);
+});
+
+test('requireAllocatorHeldDeviceClaim reports a foreign live claim as a conflict and never touches it', async () => {
+  const { stateDir, claimsDir } = setup();
+  await acquireDeviceClaim({
+    device: ANDROID_EMULATOR,
+    session: 'owner-session',
+    workspace: '/worktrees/foreign',
+    stateDir,
+    reconcileOrphanedDeviceClaim: retainOrphanedDeviceClaims,
+  });
+  const claimPath = resolveDeviceClaimPath(
+    canonicalLocalDeviceKey(deviceClaimIdentity(ANDROID_EMULATOR)),
+  );
+  const before = fs.readFileSync(claimPath, 'utf8');
+
+  const outcome = verify(managedBinding);
+
+  expect(outcome.status).toBe('conflict');
+  if (outcome.status !== 'conflict') return;
+  expect(outcome.conflict.classification).toBe('live');
+  expect(outcome.conflict.claim?.session).toBe('owner-session');
+  // Read-only: the record is byte-identical, no lock directory was taken, and nothing else
+  // appeared in the store.
+  expect(fs.readFileSync(claimPath, 'utf8')).toBe(before);
+  expect(fs.existsSync(`${claimPath}.lock`)).toBe(false);
+  expect(fs.readdirSync(claimsDir)).toHaveLength(1);
+});

--- a/src/daemon/__tests__/device-claim-conflict.test.ts
+++ b/src/daemon/__tests__/device-claim-conflict.test.ts
@@ -2,13 +2,16 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { managedLocalRuntimeOwner } from '@agent-device/contracts/platform-runtime';
+import { AppError } from '@agent-device/kernel/errors';
 import {
   ALLOCATOR_CLAIM_MISSING,
   buildAllocatorHeldRefusal,
   buildDeviceClaimConflictError,
   buildDeviceClaimInspectionCommand,
+  decideAllocatorHeldAdmission,
   isDeviceClaimConflictReason,
 } from '../device-claim-conflict.ts';
+import type { AllocatorHeldClaimAdmission } from '../device-claim-allocator.ts';
 import type { InspectedDeviceClaim } from '../device-claim-inspection.ts';
 
 const device: DeviceInfo = {
@@ -85,6 +88,38 @@ test('a missing allocator-held claim is a permanent COMMAND_FAILED refusal outsi
   assert.match(String(response.error.hint), /allocator-held claim/);
   // Replay retries every conflict reason as infrastructure; a never-activated identity is not one.
   assert.equal(isDeviceClaimConflictReason(ALLOCATOR_CLAIM_MISSING), false);
+});
+
+// Every verifier outcome names its admission here, so an outcome this table does not answer
+// fails to compile. `decideAllocatorHeldAdmission` returns a decision rather than an optional
+// error for the same reason: a gate reads `admitted`, never the absence of an answer.
+const ADMITTED_BY_OUTCOME_STATUS: Readonly<Record<AllocatorHeldClaimAdmission['status'], boolean>> =
+  {
+    'binding-invalid': false,
+    missing: false,
+    conflict: false,
+  };
+
+test('every allocator-held verifier outcome is decided, and none of them is decided by silence', () => {
+  const owner = managedLocalRuntimeOwner('sim-a');
+  const outcomes: readonly AllocatorHeldClaimAdmission[] = [
+    { status: 'binding-invalid' },
+    { status: 'missing' },
+    { status: 'conflict', conflict: conflict('live') },
+  ];
+
+  // The cases below cover the whole union, not whichever members happened to be listed.
+  assert.deepEqual(
+    outcomes.map((outcome) => outcome.status).sort(),
+    Object.keys(ADMITTED_BY_OUTCOME_STATUS).sort(),
+  );
+  for (const outcome of outcomes) {
+    const decision = decideAllocatorHeldAdmission(device, owner, outcome);
+    assert.equal(decision.admitted, ADMITTED_BY_OUTCOME_STATUS[outcome.status], outcome.status);
+    // A refusal always carries the error the gates throw; an unanswered arm would land here
+    // as `undefined` and admit the device instead.
+    if (!decision.admitted) assert.ok(decision.error instanceof AppError, outcome.status);
+  }
 });
 
 test('each allocator-held verifier outcome maps to its own refusal', () => {

--- a/src/daemon/__tests__/device-claim-conflict.test.ts
+++ b/src/daemon/__tests__/device-claim-conflict.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import { managedLocalRuntimeOwner } from '@agent-device/contracts/platform-runtime';
 import {
+  ALLOCATOR_CLAIM_MISSING,
+  buildAllocatorHeldRefusal,
   buildDeviceClaimConflictError,
   buildDeviceClaimInspectionCommand,
+  isDeviceClaimConflictReason,
 } from '../device-claim-conflict.ts';
 import type { InspectedDeviceClaim } from '../device-claim-inspection.ts';
 
@@ -67,4 +71,35 @@ test('routes a provably dead owner to the exact stale release command', () => {
     command: 'agent-device device release --platform android --serial emulator-5554 --stale',
   });
   assert.match(String(response.error.hint), /settle its resources and release the claim with:/);
+});
+
+test('a missing allocator-held claim is a permanent COMMAND_FAILED refusal outside the conflict reasons', () => {
+  const owner = managedLocalRuntimeOwner('sim-a');
+  const response = buildAllocatorHeldRefusal(device, owner, { status: 'missing' });
+  assert.ok(response && !response.ok);
+  assert.equal(response.error.code, 'COMMAND_FAILED');
+  assert.equal(response.error.retriable, false);
+  assert.equal(response.error.details?.reason, ALLOCATOR_CLAIM_MISSING);
+  assert.equal(response.error.details?.owner, 'managed:["sim-a"]');
+  assert.equal(response.error.details?.deviceKey, 'local:android:none:emulator-5554');
+  assert.match(String(response.error.hint), /allocator-held claim/);
+  // Replay retries every conflict reason as infrastructure; a never-activated identity is not one.
+  assert.equal(isDeviceClaimConflictReason(ALLOCATOR_CLAIM_MISSING), false);
+});
+
+test('each allocator-held verifier outcome maps to its own refusal', () => {
+  const owner = managedLocalRuntimeOwner('sim-a');
+  const invalid = buildAllocatorHeldRefusal(device, owner, { status: 'binding-invalid' });
+  assert.ok(invalid && !invalid.ok);
+  assert.equal(invalid.error.code, 'COMMAND_FAILED');
+  assert.equal(invalid.error.details?.reason, 'runtime-contract-invalid');
+  assert.equal(invalid.error.retriable, false);
+
+  const foreign = buildAllocatorHeldRefusal(device, owner, {
+    status: 'conflict',
+    conflict: conflict('live'),
+  });
+  assert.ok(foreign && !foreign.ok);
+  assert.equal(foreign.error.code, 'DEVICE_IN_USE');
+  assert.equal(foreign.error.details?.reason, 'DEVICE_CLAIM_LIVE_OWNER');
 });

--- a/src/daemon/__tests__/device-claim-rule.test.ts
+++ b/src/daemon/__tests__/device-claim-rule.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  localRuntimeOwner,
+  managedLocalRuntimeOwner,
+  providerRuntimeOwner,
+  type RuntimeOwnerRef,
+} from '@agent-device/contracts/platform-runtime';
+import { deviceClaimRuleForOwner, type DeviceClaimRule } from '../device-claim-rule.ts';
+
+// Every owner kind names its rule here, so a fourth kind fails to compile until it does.
+const RULE_BY_OWNER_KIND: Readonly<Record<RuntimeOwnerRef['kind'], DeviceClaimRule>> = {
+  'local-family': 'ordinary',
+  'managed-local': 'allocator-held',
+  'provider-runtime': 'none',
+};
+
+test('the device-claim rule selects ordinary for a local family, allocator-held for a managed local owner, and none for a provider runtime', () => {
+  assert.equal(deviceClaimRuleForOwner(localRuntimeOwner('android')), 'ordinary');
+  assert.equal(deviceClaimRuleForOwner(managedLocalRuntimeOwner('sim-a')), 'allocator-held');
+  assert.equal(deviceClaimRuleForOwner(providerRuntimeOwner('limrun', 'instance-1')), 'none');
+});
+
+test.each([
+  localRuntimeOwner('apple'),
+  managedLocalRuntimeOwner('sim-b'),
+  providerRuntimeOwner('webdriver', 'tenant-a'),
+])('the device-claim rule is exhaustive over owner kinds: $kind', (owner) => {
+  assert.equal(deviceClaimRuleForOwner(owner), RULE_BY_OWNER_KIND[owner.kind]);
+});

--- a/src/daemon/__tests__/request-runtime-binding.test.ts
+++ b/src/daemon/__tests__/request-runtime-binding.test.ts
@@ -7,7 +7,9 @@ import {
 import { networkDumpUse } from '@agent-device/contracts/network-runtime-plan';
 import {
   type DeviceBinding,
+  type DeviceBindingIntent,
   type DeviceRuntimeGateway,
+  type RuntimeOwnerRef,
   localRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import type { PlatformRuntimeOperations } from '@agent-device/contracts/platform-runtime-operations';
@@ -36,10 +38,13 @@ const admitDeviceClaim = async () => {};
 
 test('request runtime binding caches one broad owner and projects each declared use', async () => {
   const runtime = makeGateway();
+  const admit = vi.fn(
+    async (_device: DeviceInfo, _owner: RuntimeOwnerRef, _intent: DeviceBindingIntent) => {},
+  );
   const bindings = createRequestRuntimeBindings({
     gateway: runtime.gateway,
     scope,
-    admitDeviceClaim,
+    admitDeviceClaim: admit,
   });
 
   const admission = await bindings.bindDevice(device('one'), appLogAdmissionUse);
@@ -48,6 +53,10 @@ test('request runtime binding caches one broad owner and projects each declared 
   const network = await bindings.bindDevice(device('one'), networkDumpUse);
 
   expect(runtime.bind).toHaveBeenCalledOnce();
+  // Claim admission receives the ordinary intent the gateway bound, once per device.
+  expect(admit).toHaveBeenCalledOnce();
+  expect(admit.mock.calls[0]?.[2]).toEqual({ kind: 'ordinary' });
+  expect(admit.mock.calls[0]?.[2]).toBe(runtime.bind.mock.calls[0]?.[0].intent);
   expect(admission.operations.appLogInspect).toBe(runtime.operations.appLogInspect);
   expect(Object.keys(inspect.operations)).toEqual(['appLogInspect']);
   expect(Object.keys(doctor.operations)).toEqual(['appLogInspect', 'appLogDoctor']);
@@ -126,10 +135,13 @@ test('preferred absence is visible without failing while required absence fails 
 
 test('exact-owner recovery binds the persisted owner and fence without ordinary arbitration', async () => {
   const runtime = makeGateway();
+  const admit = vi.fn(
+    async (_device: DeviceInfo, _owner: RuntimeOwnerRef, _intent: DeviceBindingIntent) => {},
+  );
   const bindings = createRequestRuntimeBindings({
     gateway: runtime.gateway,
     scope,
-    admitDeviceClaim,
+    admitDeviceClaim: admit,
   });
   const selected = device('one');
   const owner = localRuntimeOwner('android');
@@ -156,6 +168,10 @@ test('exact-owner recovery binds the persisted owner and fence without ordinary 
     intent: { kind: 'exact-owner', owner, fence },
     scope: recoveryScope,
   });
+  // Claim admission receives the exact-owner intent with its fence, the same object the
+  // gateway bound.
+  expect(admit).toHaveBeenCalledWith(selected, owner, { kind: 'exact-owner', owner, fence });
+  expect(admit.mock.calls[0]?.[2]).toBe(runtime.bind.mock.calls[0]?.[0].intent);
   await bindings[Symbol.asyncDispose]();
   expect(runtime.disposals).toEqual(['one']);
 });

--- a/src/daemon/device-claim-admission.ts
+++ b/src/daemon/device-claim-admission.ts
@@ -6,7 +6,7 @@ import type {
 import type { DeviceClaimPolicy } from '../core/command-descriptor/types.ts';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
 import { requireAllocatorHeldDeviceClaim } from './device-claim-allocator.ts';
-import { allocatorHeldAdmissionError, deviceClaimConflictError } from './device-claim-conflict.ts';
+import { decideAllocatorHeldAdmission, deviceClaimConflictError } from './device-claim-conflict.ts';
 import { deviceClaimRuleForOwner } from './device-claim-rule.ts';
 import {
   acquireTransientDeviceClaim,
@@ -54,12 +54,12 @@ export function createDeviceClaimAdmission(params: {
         case 'none':
           return;
         case 'allocator-held': {
-          const error = allocatorHeldAdmissionError(
+          const decision = decideAllocatorHeldAdmission(
             device,
             owner,
             requireAllocatorHeldDeviceClaim({ device, owner, intent }),
           );
-          if (error) throw error;
+          if (!decision.admitted) throw decision.error;
           return;
         }
         case 'ordinary': {

--- a/src/daemon/device-claim-admission.ts
+++ b/src/daemon/device-claim-admission.ts
@@ -21,12 +21,16 @@ import {
  * happens here, under every policy: an ordinary owner takes a transient claim
  * only when the executing command's declared {@link DeviceClaimPolicy} is
  * `transient-exclusive`; a managed local owner is verified against its
- * allocator-held claim; a provider owner takes nothing. There is no other way
- * to obtain device operations, so none of it can be forgotten by a handler.
+ * allocator-held claim; a provider owner takes nothing.
  *
  * `admit` is called once per device binding by the request runtime bindings,
  * which is where per-device deduplication already lives, with the binding
- * intent the gateway bound.
+ * intent the gateway bound. A command handler has no other way to obtain
+ * device operations, so a handler cannot forget any of this. Two daemon-owned
+ * recovery paths do bind outside the seam and are the known gap:
+ * application-lifecycle-recovery.ts (ordinary intent, daemon shutdown) and
+ * durable-capture-runtime-recovery.ts (exact-owner intent read back from a
+ * durable envelope).
  */
 export type DeviceClaimAdmission = AsyncDisposable &
   Readonly<{

--- a/src/daemon/device-claim-admission.ts
+++ b/src/daemon/device-claim-admission.ts
@@ -1,35 +1,41 @@
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { RuntimeOwnerRef } from '@agent-device/contracts/platform-runtime';
+import type {
+  DeviceBindingIntent,
+  RuntimeOwnerRef,
+} from '@agent-device/contracts/platform-runtime';
 import type { DeviceClaimPolicy } from '../core/command-descriptor/types.ts';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
-import { deviceClaimConflictError } from './device-claim-conflict.ts';
+import { requireAllocatorHeldDeviceClaim } from './device-claim-allocator.ts';
+import { allocatorHeldAdmissionError, deviceClaimConflictError } from './device-claim-conflict.ts';
+import { deviceClaimRuleForOwner } from './device-claim-rule.ts';
 import {
   acquireTransientDeviceClaim,
   clearDeviceClaim,
-  isLocalDeviceClaimTarget,
   type DeviceClaimReconciler,
   type DeviceClaimSessionOwnership,
 } from './device-claims.ts';
 
 /**
  * The #1320 claim gate a request passes on its way from a device binding to
- * device operations. It is built from the executing command's declared
- * {@link DeviceClaimPolicy}, so `transient-exclusive` enforcement cannot be
- * forgotten by a handler: there is no other way to obtain device operations.
+ * device operations. The device-claim rule of the admitted owner decides what
+ * happens here, under every policy: an ordinary owner takes a transient claim
+ * only when the executing command's declared {@link DeviceClaimPolicy} is
+ * `transient-exclusive`; a managed local owner is verified against its
+ * allocator-held claim; a provider owner takes nothing. There is no other way
+ * to obtain device operations, so none of it can be forgotten by a handler.
  *
  * `admit` is called once per device binding by the request runtime bindings,
- * which is where per-device deduplication already lives.
+ * which is where per-device deduplication already lives, with the binding
+ * intent the gateway bound.
  */
 export type DeviceClaimAdmission = AsyncDisposable &
   Readonly<{
-    /** Throws `DEVICE_IN_USE` when a foreign live claim owns the device. */
-    admit(device: DeviceInfo, owner: RuntimeOwnerRef): Promise<void>;
+    /**
+     * Throws `DEVICE_IN_USE` when a foreign live claim owns the device and
+     * `COMMAND_FAILED` when a managed local owner has no allocator-held claim.
+     */
+    admit(device: DeviceInfo, owner: RuntimeOwnerRef, intent: DeviceBindingIntent): Promise<void>;
   }>;
-
-const NO_CLAIM_INTERACTION: DeviceClaimAdmission = Object.freeze({
-  admit: async () => {},
-  [Symbol.asyncDispose]: async () => {},
-});
 
 export function createDeviceClaimAdmission(params: {
   policy: DeviceClaimPolicy;
@@ -38,29 +44,43 @@ export function createDeviceClaimAdmission(params: {
   stateDir: string;
   reconcileOrphanedDeviceClaim: DeviceClaimReconciler;
 }): DeviceClaimAdmission {
-  // `none`/`observe`/`require-owner` never read or write the claim store, and
-  // `acquire-session`/`release-session` own the session claim through the open
-  // and close lifecycles instead.
-  if (params.policy !== 'transient-exclusive') return NO_CLAIM_INTERACTION;
-
   // The caller admits once per device binding, so this only has to remember what
   // it took in order to give it back.
   const acquired: DeviceClaimSessionOwnership[] = [];
 
   return {
-    admit: async (device, owner) => {
-      // Remote/provider devices are owned by their provider lease, exactly as
-      // `open` decides through the admitted runtime owner rather than flags.
-      if (!isLocalDeviceClaimTarget(owner)) return;
-      const result = await acquireTransientDeviceClaim({
-        device,
-        command: params.command,
-        workspace: params.workspace,
-        stateDir: params.stateDir,
-        reconcileOrphanedDeviceClaim: params.reconcileOrphanedDeviceClaim,
-      });
-      if (result.status === 'conflict') throw deviceClaimConflictError(device, result.conflict);
-      if (result.status === 'acquired') acquired.push(result.ownership);
+    admit: async (device, owner, intent) => {
+      switch (deviceClaimRuleForOwner(owner)) {
+        case 'none':
+          return;
+        case 'allocator-held': {
+          const error = allocatorHeldAdmissionError(
+            device,
+            owner,
+            requireAllocatorHeldDeviceClaim({ device, owner, intent }),
+          );
+          if (error) throw error;
+          return;
+        }
+        case 'ordinary': {
+          // `none`/`observe`/`require-owner` never read or write the claim store,
+          // and `acquire-session`/`release-session` own the session claim through
+          // the open and close lifecycles instead.
+          if (params.policy !== 'transient-exclusive') return;
+          const result = await acquireTransientDeviceClaim({
+            device,
+            command: params.command,
+            workspace: params.workspace,
+            stateDir: params.stateDir,
+            reconcileOrphanedDeviceClaim: params.reconcileOrphanedDeviceClaim,
+          });
+          if (result.status === 'conflict') {
+            throw deviceClaimConflictError(device, result.conflict);
+          }
+          if (result.status === 'acquired') acquired.push(result.ownership);
+          return;
+        }
+      }
     },
     [Symbol.asyncDispose]: async () => {
       for (const ownership of acquired.splice(0)) {

--- a/src/daemon/device-claim-allocator.ts
+++ b/src/daemon/device-claim-allocator.ts
@@ -1,0 +1,45 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import {
+  decodeManagedBindingFence,
+  sameRuntimeOwner,
+  type DeviceBindingIntent,
+  type RuntimeOwnerRef,
+} from '@agent-device/contracts/platform-runtime';
+import { inspectDeviceClaimFile, type InspectedDeviceClaim } from './device-claim-inspection.ts';
+import { canonicalLocalDeviceKey, resolveDeviceClaimPath } from './device-claim-paths.ts';
+import { deviceClaimIdentity } from './device-claims.ts';
+
+/**
+ * What the allocator-held arm of the device-claim rule found. `binding-invalid`: the binding
+ * is not an exact-owner binding of this managed owner under a managed binding fence. `missing`:
+ * the store holds no claim for the device. `conflict`: the store holds a claim that is not this
+ * installation's allocator-held claim; it is reported and never touched.
+ */
+export type AllocatorHeldClaimAdmission =
+  | Readonly<{ status: 'binding-invalid' }>
+  | Readonly<{ status: 'missing' }>
+  | Readonly<{ status: 'conflict'; conflict: InspectedDeviceClaim }>;
+
+/**
+ * The read-only verifier both claim gates consult for a managed local owner. It never acquires,
+ * never locks, and never clears: a managed identity executes only under the allocator-held claim
+ * its allocator established, and every record the store can hold today is process-owned.
+ */
+export function requireAllocatorHeldDeviceClaim(params: {
+  device: DeviceInfo;
+  owner: RuntimeOwnerRef;
+  intent: DeviceBindingIntent;
+}): AllocatorHeldClaimAdmission {
+  const { device, owner, intent } = params;
+  if (
+    intent.kind !== 'exact-owner' ||
+    !sameRuntimeOwner(intent.owner, owner) ||
+    decodeManagedBindingFence(intent.fence) === null
+  ) {
+    return { status: 'binding-invalid' };
+  }
+  const deviceKey = canonicalLocalDeviceKey(deviceClaimIdentity(device));
+  const existing = inspectDeviceClaimFile(resolveDeviceClaimPath(deviceKey));
+  if (!existing) return { status: 'missing' };
+  return { status: 'conflict', conflict: existing };
+}

--- a/src/daemon/device-claim-conflict.ts
+++ b/src/daemon/device-claim-conflict.ts
@@ -144,23 +144,30 @@ function managedBindingRequiredError(device: DeviceInfo, owner: RuntimeOwnerRef)
   );
 }
 
+/** What a claim gate does about one verifier outcome. An admission carries no error to throw. */
+export type AllocatorHeldAdmissionDecision =
+  | Readonly<{ admitted: true }>
+  | Readonly<{ admitted: false; error: AppError }>;
+
 /**
- * One refusal per verifier outcome. The switch has no default, so an outcome the
- * verifier learns to produce is a compile error here until it is answered; an
- * admitted outcome answers `undefined`.
+ * The single answer both claim gates read. The switch has no default and the return type
+ * excludes `undefined`, so an outcome the verifier learns to produce is a compile error here
+ * until this function answers it. That is why the decision is a value rather than an optional
+ * error: a gate asks whether the outcome was admitted, and an unanswered outcome cannot reach
+ * it as silence that reads like an admission.
  */
-export function allocatorHeldAdmissionError(
+export function decideAllocatorHeldAdmission(
   device: DeviceInfo,
   owner: RuntimeOwnerRef,
   outcome: AllocatorHeldClaimAdmission,
-): AppError | undefined {
+): AllocatorHeldAdmissionDecision {
   switch (outcome.status) {
     case 'binding-invalid':
-      return managedBindingRequiredError(device, owner);
+      return { admitted: false, error: managedBindingRequiredError(device, owner) };
     case 'missing':
-      return allocatorClaimMissingError(device, owner);
+      return { admitted: false, error: allocatorClaimMissingError(device, owner) };
     case 'conflict':
-      return deviceClaimConflictError(device, outcome.conflict);
+      return { admitted: false, error: deviceClaimConflictError(device, outcome.conflict) };
   }
 }
 
@@ -170,8 +177,8 @@ export function buildAllocatorHeldRefusal(
   owner: RuntimeOwnerRef,
   outcome: AllocatorHeldClaimAdmission,
 ): DaemonResponse | undefined {
-  const error = allocatorHeldAdmissionError(device, owner, outcome);
-  return error ? claimRefusalResponse(error) : undefined;
+  const decision = decideAllocatorHeldAdmission(device, owner, outcome);
+  return decision.admitted ? undefined : claimRefusalResponse(decision.error);
 }
 
 function claimRefusalResponse(error: AppError): DaemonResponse {

--- a/src/daemon/device-claim-conflict.ts
+++ b/src/daemon/device-claim-conflict.ts
@@ -4,7 +4,11 @@ import {
   type DeviceInfo,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import { runtimeOwnerKey, type RuntimeOwnerRef } from '@agent-device/contracts/platform-runtime';
 import { shellQuoteIfNeeded } from '@agent-device/host-kit/command';
+import type { AllocatorHeldClaimAdmission } from './device-claim-allocator.ts';
+import { canonicalLocalDeviceKey } from './device-claim-paths.ts';
+import { deviceClaimIdentity } from './device-claims.ts';
 import {
   deviceClaimOwnerCannotRelease,
   deviceClaimRequiresStaleInspection,
@@ -28,6 +32,14 @@ const DEVICE_CLAIM_CONFLICT_REASONS = new Set<DeviceClaimConflictReason>([
 export function isDeviceClaimConflictReason(value: unknown): value is DeviceClaimConflictReason {
   return DEVICE_CLAIM_CONFLICT_REASONS.has(value as DeviceClaimConflictReason);
 }
+
+/**
+ * The reason of the allocator-held arm's refusal when no allocator-held claim
+ * exists. Deliberately not a {@link DeviceClaimConflictReason}: replay retries
+ * every conflict reason as infrastructure, and a managed identity that no
+ * allocator activated is a permanent condition, not a collision.
+ */
+export const ALLOCATOR_CLAIM_MISSING = 'allocator-claim-missing';
 
 export function buildDeviceClaimInspectionCommand(
   device: DeviceInfo,
@@ -102,7 +114,67 @@ export function buildDeviceClaimConflictError(
   device: DeviceInfo,
   conflict: InspectedDeviceClaim,
 ): DaemonResponse {
-  const error = deviceClaimConflictError(device, conflict);
+  return claimRefusalResponse(deviceClaimConflictError(device, conflict));
+}
+
+function allocatorClaimMissingError(device: DeviceInfo, owner: RuntimeOwnerRef): AppError {
+  return new AppError(
+    'COMMAND_FAILED',
+    `${publicPlatformString(device)} device ${device.id} is a managed identity with no allocator-held execution claim for this installation.`,
+    {
+      reason: ALLOCATOR_CLAIM_MISSING,
+      owner: runtimeOwnerKey(owner),
+      deviceKey: canonicalLocalDeviceKey(deviceClaimIdentity(device)),
+      retriable: false,
+      hint: 'A managed identity becomes executable only after its allocator activates it and this installation holds its allocator-held claim.',
+    },
+  );
+}
+
+function managedBindingRequiredError(device: DeviceInfo, owner: RuntimeOwnerRef): AppError {
+  return new AppError(
+    'COMMAND_FAILED',
+    'A managed local owner executes only under an exact-owner binding that carries a managed binding fence.',
+    {
+      reason: 'runtime-contract-invalid',
+      owner: runtimeOwnerKey(owner),
+      deviceKey: canonicalLocalDeviceKey(deviceClaimIdentity(device)),
+      retriable: false,
+    },
+  );
+}
+
+/**
+ * One refusal per verifier outcome. The switch has no default, so an outcome the
+ * verifier learns to produce is a compile error here until it is answered; an
+ * admitted outcome answers `undefined`.
+ */
+export function allocatorHeldAdmissionError(
+  device: DeviceInfo,
+  owner: RuntimeOwnerRef,
+  outcome: AllocatorHeldClaimAdmission,
+): AppError | undefined {
+  switch (outcome.status) {
+    case 'binding-invalid':
+      return managedBindingRequiredError(device, owner);
+    case 'missing':
+      return allocatorClaimMissingError(device, owner);
+    case 'conflict':
+      return deviceClaimConflictError(device, outcome.conflict);
+  }
+}
+
+/** `open` returns the allocator-held refusal as a response, exactly as it does the conflict. */
+export function buildAllocatorHeldRefusal(
+  device: DeviceInfo,
+  owner: RuntimeOwnerRef,
+  outcome: AllocatorHeldClaimAdmission,
+): DaemonResponse | undefined {
+  const error = allocatorHeldAdmissionError(device, owner, outcome);
+  return error ? claimRefusalResponse(error) : undefined;
+}
+
+function claimRefusalResponse(error: AppError): DaemonResponse {
   const { hint, retriable, ...details } = error.details ?? {};
   return errorResponse(error.code, error.message, details, { hint, retriable });
 }

--- a/src/daemon/device-claim-rule.ts
+++ b/src/daemon/device-claim-rule.ts
@@ -1,0 +1,22 @@
+import type { RuntimeOwnerRef } from '@agent-device/contracts/platform-runtime';
+
+/**
+ * The device-claim rule: what a runtime owner's kind selects at a claim gate.
+ * `ordinary` acquires a host-local device claim, `allocator-held` executes only
+ * under an existing allocator-held claim and never acquires or clears one, and
+ * `none` leaves the claim store alone because the provider lease already
+ * excludes peers. The rule follows the admitted runtime owner, never request
+ * metadata.
+ */
+export type DeviceClaimRule = 'ordinary' | 'allocator-held' | 'none';
+
+export function deviceClaimRuleForOwner(owner: RuntimeOwnerRef): DeviceClaimRule {
+  switch (owner.kind) {
+    case 'local-family':
+      return 'ordinary';
+    case 'managed-local':
+      return 'allocator-held';
+    case 'provider-runtime':
+      return 'none';
+  }
+}

--- a/src/daemon/device-claims.ts
+++ b/src/daemon/device-claims.ts
@@ -10,7 +10,6 @@ import {
 } from '@agent-device/kernel/device';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
 import { ownerIdentityMatches, readCurrentOwnerIdentity } from '@agent-device/host-kit/process';
-import type { RuntimeOwnerRef } from '@agent-device/contracts/platform-runtime';
 import { publishFileSync, acquireProcessLock } from '@agent-device/host-kit/file';
 
 import {
@@ -73,11 +72,6 @@ export type DeviceClaimAcquireResult =
 export type TransientDeviceClaimResult =
   | DeviceClaimAcquireResult
   | { status: 'covered-by-owned-claim' };
-
-/** Claim policy follows the admitted runtime owner, never request metadata. */
-export function isLocalDeviceClaimTarget(owner: RuntimeOwnerRef): boolean {
-  return owner.kind === 'local-family';
-}
 
 /**
  * The claim `session` recorded for a command-scoped claim. Claim records carry

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -58,6 +58,7 @@ import type { DeviceInfo } from '@agent-device/kernel/device';
 import { makeAuthoringSession } from '../../../__tests__/test-utils/session-factories.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import {
+  bindManagedLocalLifecycleRuntime,
   bindProviderLifecycleRuntime,
   bindLifecycleRuntime,
   inspectProviderLifecycleRuntimeFacts,
@@ -350,6 +351,43 @@ test('provider-owned open creates no host-local device claim from its selected o
   assert.equal(response.ok, true);
   assert.deepEqual(inspectDeviceClaims({ serial: android.id }), []);
   assert.equal(store.get('remote-open')?.deviceClaim, undefined);
+});
+
+test('a managed local owner open is refused through the real route and creates no host-local device claim', async () => {
+  const { store, stateDir } = setup();
+  mockResolveTargetDevice.mockResolvedValue(android);
+  mockDispatch.mockResolvedValue(undefined);
+
+  const response = await handleOpenCommand({
+    req: {
+      command: 'open',
+      token: 'test',
+      session: 'managed-open',
+      positionals: ['Demo'],
+      flags: { platform: 'android' },
+    },
+    sessionName: 'managed-open',
+    logPath: path.join(stateDir, 'daemon.log'),
+    sessionStore: store,
+    bindDevice: bindManagedLocalLifecycleRuntime,
+  });
+
+  assert.equal(response.ok, false);
+  if (response.ok) return;
+  // Session open binds ordinarily, and a managed local owner executes only under a managed
+  // binding fence, so the route refuses before it can ask for an allocator-held claim.
+  assert.equal(response.error.code, 'COMMAND_FAILED');
+  assert.equal(response.error.retriable, false);
+  assert.equal(response.error.details?.reason, 'runtime-contract-invalid');
+  assert.equal(response.error.details?.owner, 'managed:["fixture-allocator"]');
+  // No host-local claim, no session, and no device effect precede the refusal.
+  assert.deepEqual(inspectDeviceClaims({}), []);
+  assert.equal(store.get('managed-open'), undefined);
+  assert.equal(mockEnsureDeviceReady.mock.calls.length, 0);
+  assert.equal(mockResolveAndroidPackage.mock.calls.length, 0);
+  assert.equal(mockApplyRuntimeHints.mock.calls.length, 0);
+  assert.equal(vi.mocked(activateAndroidTestIme).mock.calls.length, 0);
+  assert.equal(mockDispatch.mock.calls.length, 0);
 });
 
 test('a foreign live claim rejects open before platform preparation or mutation', async () => {

--- a/src/daemon/replay/internal/__tests__/session-test-infrastructure.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-test-infrastructure.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { isReplayInfrastructureFailure } from '../session-test-infrastructure.ts';
+import { ALLOCATOR_CLAIM_MISSING } from '../../../device-claim-conflict.ts';
 import type { DaemonResponse } from '../../../types.ts';
 import type { ReplaySuiteTestResult } from '@agent-device/contracts/replay';
 
@@ -118,6 +119,20 @@ test('isReplayInfrastructureFailure rejects normal replay failures', () => {
       code: 'ELEMENT_NOT_FOUND',
       message: 'Maestro selector did not match: text="Settings"',
       details: { reason: 'selector_not_found' },
+    },
+  };
+
+  assert.equal(isReplayInfrastructureFailure(response), false);
+});
+
+test('isReplayInfrastructureFailure does not retry a missing allocator-held claim as infrastructure', () => {
+  const response: DaemonResponse = {
+    ok: false,
+    error: {
+      code: 'COMMAND_FAILED',
+      message:
+        'android device emulator-5554 is a managed identity with no allocator-held execution claim for this installation.',
+      details: { reason: ALLOCATOR_CLAIM_MISSING, retriable: false },
     },
   };
 

--- a/src/daemon/request-runtime-binding.ts
+++ b/src/daemon/request-runtime-binding.ts
@@ -3,6 +3,7 @@ import { AsyncCleanupStack } from '@agent-device/contracts/async-lifecycle';
 import {
   type BoundDeviceRuntime,
   type DeviceBinding,
+  type DeviceBindingIntent,
   type DeviceRuntimeGateway,
   type ResourceOwnershipFence,
   type RuntimeFacts,
@@ -84,19 +85,26 @@ export type RequestRuntimeBindings = AsyncDisposable &
  * device operation exists, and admitting here covers every handler by
  * construction. A refusal rejects the cached promise, so a second `bindDevice`
  * for the same device re-attempts rather than inheriting a rejected binding.
+ * The gate receives the very intent the gateway bound, so an exact-owner fence
+ * reaches claim admission unchanged.
  */
 export function createRequestRuntimeBindings(params: {
   gateway: DeviceRuntimeGateway<PlatformRuntimeOperations>;
   scope: PlatformRequestScope;
-  admitDeviceClaim: (device: DeviceInfo, owner: RuntimeOwnerRef) => Promise<void>;
+  admitDeviceClaim: (
+    device: DeviceInfo,
+    owner: RuntimeOwnerRef,
+    intent: DeviceBindingIntent,
+  ) => Promise<void>;
 }): RequestRuntimeBindings {
   const cleanups = new AsyncCleanupStack();
   const bindings = new Map<string, Promise<DeviceBinding<PlatformRuntimeOperations>>>();
 
   const admitBinding = async (
     binding: DeviceBinding<PlatformRuntimeOperations>,
+    intent: DeviceBindingIntent,
   ): Promise<DeviceBinding<PlatformRuntimeOperations>> => {
-    await params.admitDeviceClaim(binding.device, binding.owner);
+    await params.admitDeviceClaim(binding.device, binding.owner, intent);
     return binding;
   };
 
@@ -104,14 +112,11 @@ export function createRequestRuntimeBindings(params: {
     const key = deviceIdentityKey(deviceIdentity(device));
     let bindingPromise = bindings.get(key);
     if (!bindingPromise) {
+      const intent: DeviceBindingIntent = { kind: 'ordinary' };
       bindingPromise = params.gateway
-        .bind({
-          device,
-          intent: { kind: 'ordinary' },
-          scope: params.scope,
-        })
+        .bind({ device, intent, scope: params.scope })
         .then((binding) => cleanups.use(binding))
-        .then(admitBinding);
+        .then((binding) => admitBinding(binding, intent));
       bindings.set(key, bindingPromise);
       void bindingPromise.catch(() => {
         if (bindings.get(key) === bindingPromise) bindings.delete(key);
@@ -122,12 +127,9 @@ export function createRequestRuntimeBindings(params: {
 
   // Exact-owner bindings deliberately bypass the cache, so they admit their own.
   const bindExactDevice: BindExactDeviceRuntime = async (device, owner, fence, use, scope) => {
-    const published = await params.gateway.bind({
-      device,
-      intent: { kind: 'exact-owner', owner, fence },
-      scope,
-    });
-    const binding = await admitBinding(await adoptExactBinding(cleanups, published, scope));
+    const intent: DeviceBindingIntent = { kind: 'exact-owner', owner, fence };
+    const published = await params.gateway.bind({ device, intent, scope });
+    const binding = await admitBinding(await adoptExactBinding(cleanups, published, scope), intent);
     return narrowDeviceBinding(binding, use);
   };
 

--- a/src/daemon/session-lifecycle/internal/session-open-execution.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-execution.ts
@@ -378,8 +378,9 @@ async function acquireDeviceClaimForOwner(params: {
     case 'none':
       return { status: 'not-required' };
     case 'allocator-held': {
-      // Session open binds ordinarily and carries no fence; a session admitted under the
-      // allocator-held claim executes under it and records no claim of its own.
+      // Session open binds ordinarily, so this literal is the truth of the route and not a
+      // placeholder: the Host open route replaces it with the request's exact intent when it
+      // lands. Until then a managed owner reaches here without a fence and is always refused.
       const response = buildAllocatorHeldRefusal(
         device,
         owner,

--- a/src/daemon/session-lifecycle/internal/session-open-execution.ts
+++ b/src/daemon/session-lifecycle/internal/session-open-execution.ts
@@ -49,12 +49,16 @@ import {
   abandonDeviceClaim,
   acquireDeviceClaim,
   clearDeviceClaim,
-  isLocalDeviceClaimTarget,
   type DeviceClaimAcquireResult,
   type DeviceClaimSessionOwnership,
   type DeviceClaimReconciler,
 } from '../../device-claims.ts';
-import { buildDeviceClaimConflictError } from '../../device-claim-conflict.ts';
+import {
+  buildAllocatorHeldRefusal,
+  buildDeviceClaimConflictError,
+} from '../../device-claim-conflict.ts';
+import { requireAllocatorHeldDeviceClaim } from '../../device-claim-allocator.ts';
+import { deviceClaimRuleForOwner } from '../../device-claim-rule.ts';
 
 type OpenTiming = {
   totalDurationMs?: number;
@@ -357,23 +361,41 @@ function findNewSessionDeviceConflict(params: {
   return buildDeviceInUseBySessionError(inUse, device);
 }
 
-async function acquireLocalDeviceClaim(params: {
+async function acquireDeviceClaimForOwner(params: {
   req: DaemonRequest;
   device: DeviceInfo;
   owner: OpenApplicationRuntime['owner'];
   sessionName: string;
   sessionStore: SessionStore;
   reconcileOrphanedDeviceClaim: DeviceClaimReconciler;
-}): Promise<DeviceClaimAcquireResult | { status: 'not-required' }> {
+}): Promise<
+  | DeviceClaimAcquireResult
+  | { status: 'not-required' }
+  | { status: 'refused'; response: DaemonResponse }
+> {
   const { req, device, owner, sessionName, sessionStore, reconcileOrphanedDeviceClaim } = params;
-  if (!isLocalDeviceClaimTarget(owner)) return { status: 'not-required' };
-  return await acquireDeviceClaim({
-    device,
-    session: sessionName,
-    workspace: req.meta?.cwd ?? process.cwd(),
-    stateDir: sessionStore.resolveDaemonStateDir(),
-    reconcileOrphanedDeviceClaim,
-  });
+  switch (deviceClaimRuleForOwner(owner)) {
+    case 'none':
+      return { status: 'not-required' };
+    case 'allocator-held': {
+      // Session open binds ordinarily and carries no fence; a session admitted under the
+      // allocator-held claim executes under it and records no claim of its own.
+      const response = buildAllocatorHeldRefusal(
+        device,
+        owner,
+        requireAllocatorHeldDeviceClaim({ device, owner, intent: { kind: 'ordinary' } }),
+      );
+      return response ? { status: 'refused', response } : { status: 'not-required' };
+    }
+    case 'ordinary':
+      return await acquireDeviceClaim({
+        device,
+        session: sessionName,
+        workspace: req.meta?.cwd ?? process.cwd(),
+        stateDir: sessionStore.resolveDaemonStateDir(),
+        reconcileOrphanedDeviceClaim,
+      });
+  }
 }
 
 export async function openNewSessionWithDeviceClaim(params: {
@@ -409,7 +431,7 @@ export async function openNewSessionWithDeviceClaim(params: {
   const conflict = findNewSessionDeviceConflict({ req, device, sessionStore });
   if (conflict) return conflict;
 
-  const localClaim = await acquireLocalDeviceClaim({
+  const ownerClaim = await acquireDeviceClaimForOwner({
     req,
     device,
     owner: lifecycle.owner,
@@ -417,9 +439,10 @@ export async function openNewSessionWithDeviceClaim(params: {
     sessionStore,
     reconcileOrphanedDeviceClaim,
   });
-  if (localClaim.status === 'conflict')
-    return buildDeviceClaimConflictError(device, localClaim.conflict);
-  const deviceClaim = localClaim.status === 'acquired' ? localClaim.ownership : undefined;
+  if (ownerClaim.status === 'conflict')
+    return buildDeviceClaimConflictError(device, ownerClaim.conflict);
+  if (ownerClaim.status === 'refused') return ownerClaim.response;
+  const deviceClaim = ownerClaim.status === 'acquired' ? ownerClaim.ownership : undefined;
   const effects: NewSessionOpenEffects = { mayHaveStarted: false };
   const rollbackClaim = async () =>
     await rollbackNewSessionClaim({

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -7,17 +7,23 @@ import {
 } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
   type DeviceBinding,
+  type DeviceBindingRequest,
   type RuntimeFacts,
+  type RuntimeOperationKey,
   type RuntimeOwnerRef,
+  type RuntimeProviderMode,
+  localRuntimeOwner,
   providerRuntimeOwner,
+  sameRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import type {
   PlatformRuntimeHost,
+  PlatformRuntimeModule,
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime-operations';
 import type { PlatformRequestScope } from '@agent-device/contracts/platform-runtime-host';
-import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { DeviceInfo, Platform } from '@agent-device/kernel/device';
 import type { LimrunRuntimeDependencies } from '@agent-device/provider-limrun';
 import {
   createUnavailableRuntimeFactsForTest,
@@ -59,6 +65,108 @@ export function gatewayFixture(registrations: readonly PlatformRuntimeProviderRe
     loadHost: async () => ({}) as PlatformRuntimeHost,
     providerRuntimes: registrations.map(({ runtime }) => runtime),
     providerModules: registrations,
+  });
+}
+
+/**
+ * Every cell a managed local owner must withhold, listed once so the local family fixture can
+ * offer all of them and the managed tests can assert that none survives the wrapper.
+ */
+export const MANAGED_WITHHELD_OPERATIONS = [
+  'ensureReady',
+  'bootTarget',
+  'bootTargetHeadless',
+  'shutdownTarget',
+  'deployApp',
+  'deployMaterializedApp',
+  'prepareApplicationOpen',
+  'prepareAppleRunner',
+  'closeApplication',
+  'finalizeApplicationClose',
+  'appLogStart',
+  'appLogReattach',
+  'appLogCleanup',
+  'screenRecordingStart',
+  'screenRecordingReattach',
+  'screenRecordingCleanup',
+  'audioProbeStart',
+  'audioProbeReattach',
+  'audioProbeCleanup',
+  'perfNativeCaptureStart',
+  'perfNativeCaptureReattach',
+  'perfNativeCaptureCleanup',
+  'captureScreenshot',
+  'setSetting',
+  'readClipboard',
+  'writeClipboard',
+  'openApplication',
+] as const satisfies readonly RuntimeOperationKey<PlatformRuntimeOperations>[];
+
+/** The one cell the family owner offers that a managed binding keeps. */
+export const MANAGED_RETAINED_OPERATION = 'tapPoint';
+
+export type LocalFamilyRuntimeFixture = Readonly<{
+  module: PlatformRuntimeModule;
+  /** Every bind request the family owner received, in order. */
+  requests: DeviceBindingRequest[];
+  calls: { loads: number; disposals: number };
+}>;
+
+/**
+ * A local family owner that offers every withheld cell plus one retained cell, and that refuses a
+ * foreign exact-owner intent the way the real family runtimes do.
+ */
+export function localFamilyRuntimeFixture(options: {
+  family: Platform;
+  device: DeviceInfo;
+  providerMode?: RuntimeProviderMode;
+}): LocalFamilyRuntimeFixture {
+  const owner = localRuntimeOwner(options.family);
+  const requests: DeviceBindingRequest[] = [];
+  const calls = { loads: 0, disposals: 0 };
+  const base = createUnavailableRuntimeFactsForTest(options.device, owner);
+  const available = Object.freeze({ available: true } as const);
+  const offered: Record<string, unknown> = {};
+  const operations: Record<string, unknown> = {};
+  for (const key of [...MANAGED_WITHHELD_OPERATIONS, MANAGED_RETAINED_OPERATION]) {
+    offered[key] = available;
+    operations[key] = async () => undefined;
+  }
+  const facts = Object.freeze({
+    device: { ...base.device, providerMode: options.providerMode ?? base.device.providerMode },
+    operations: Object.freeze({ ...base.operations, ...offered }),
+  }) as RuntimeFacts<PlatformRuntimeOperations>;
+  const runtimeOwner: PlatformRuntimeOwner = {
+    owner,
+    ownsDevice: () => true,
+    inspectFacts: async () => facts,
+    bind: async (request) => {
+      requests.push(request);
+      if (request.intent.kind === 'exact-owner' && !sameRuntimeOwner(request.intent.owner, owner)) {
+        throw new TypeError('A local family runtime cannot bind a foreign exact owner');
+      }
+      return {
+        device: request.device,
+        owner,
+        facts,
+        operations: operations as DeviceBinding<PlatformRuntimeOperations>['operations'],
+        [Symbol.asyncDispose]: async () => {
+          calls.disposals += 1;
+        },
+      };
+    },
+    shutdown: async () => {},
+  };
+  return Object.freeze({
+    module: {
+      family: options.family,
+      loadRuntime: async () => {
+        calls.loads += 1;
+        return runtimeOwner;
+      },
+    },
+    requests,
+    calls,
   });
 }
 

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -1,6 +1,7 @@
 import {
   type DeviceBinding,
   localRuntimeOwner,
+  managedLocalRuntimeOwner,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import type {
@@ -397,6 +398,38 @@ describe('composed platform runtime gateway', () => {
     });
     expect(binding.owner).toEqual(ref);
     expect(ownsDevice).not.toHaveBeenCalled();
+  });
+
+  test('an exact managed local owner is unavailable until a managed owner registration exists', async () => {
+    const hostLoad = vi.fn(async () => ({}) as PlatformRuntimeHost);
+    const localLoad = vi.fn(async () =>
+      runtimeOwner({ ref: localRuntimeOwner('apple'), providerMode: 'local' }),
+    );
+    const registration = providerRuntime({ ref: providerRuntimeOwner('limrun', 'stable') });
+    const runtimeGateway = createComposedPlatformRuntimeGateway({
+      modules: new Map([['apple', { family: 'apple', loadRuntime: localLoad }]]),
+      loadHost: hostLoad,
+      providerRuntimes: [registration.runtime],
+      providerModules: [registration],
+    });
+
+    await expect(
+      runtimeGateway.bind({
+        device,
+        intent: {
+          kind: 'exact-owner',
+          owner: managedLocalRuntimeOwner('sim-a'),
+          fence: { token: 'fence', generation: 1 },
+        },
+        scope,
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNSUPPORTED_OPERATION',
+      details: { reason: 'owner-unavailable', owner: 'managed:["sim-a"]' },
+    });
+    // Neither the device's local family nor any provider stands in for a managed owner.
+    expect(localLoad).not.toHaveBeenCalled();
+    expect(hostLoad).not.toHaveBeenCalled();
   });
 
   test('rejects ambiguous ordinary provider ownership', async () => {

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -1,6 +1,9 @@
 import {
   type DeviceBinding,
+  type DeviceBindingIntent,
+  type RuntimeProviderMode,
   localRuntimeOwner,
+  managedBindingFence,
   managedLocalRuntimeOwner,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
@@ -8,6 +11,7 @@ import type {
   PlatformRuntimeHost,
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
+  PlatformRuntimeProviderModule,
 } from '@agent-device/contracts/platform-runtime-operations';
 import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import { createUnavailablePlatformRuntimeFacts } from '@agent-device/contracts/platform-runtime-unavailable';
@@ -27,6 +31,8 @@ import {
   gatewayFixtureScope as scope,
   LIFECYCLE_FACETS,
   limrunTestDependencies,
+  localFamilyRuntimeFixture,
+  MANAGED_RETAINED_OPERATION,
   providerLifecycleOwnerFixture as providerLifecycleOwner,
   providerRuntimeFixture as providerRuntime,
   runtimeOwnerFixture as runtimeOwner,
@@ -612,4 +618,108 @@ describe('composed platform runtime gateway', () => {
       expect(disposed).toHaveBeenCalledOnce();
     },
   );
+});
+
+describe('managed local owner registration', () => {
+  const managed = managedLocalRuntimeOwner('sim-a');
+  const fence = managedBindingFence({
+    requesterId: 'requester-a',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-a',
+  });
+  const exactly = (owner = managed): DeviceBindingIntent => ({
+    kind: 'exact-owner',
+    owner,
+    fence,
+  });
+
+  function managedGateway(providerMode?: RuntimeProviderMode) {
+    const family = localFamilyRuntimeFixture({ family: 'apple', device, providerMode });
+    const runtimeGateway = createComposedPlatformRuntimeGateway({
+      modules: new Map([['apple', family.module]]),
+      loadHost: async () => ({}) as PlatformRuntimeHost,
+      managedOwners: [managed],
+    });
+    return { family, runtimeGateway };
+  }
+
+  test('binds an exact managed owner through the local family owner under an ordinary intent', async () => {
+    const { family, runtimeGateway } = managedGateway();
+
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(family.requests[0]?.intent).toEqual({ kind: 'ordinary' });
+    expect(binding.facts.operations.bootTarget).toMatchObject({
+      available: false,
+      reason: 'owner-capability-missing',
+    });
+    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+  });
+
+  test('leaves ordinary selection on the local family owner while a managed owner is registered', async () => {
+    const { runtimeGateway } = managedGateway();
+
+    const facts = await runtimeGateway.inspectFacts(device);
+    const binding = await runtimeGateway.bind({ device, intent: { kind: 'ordinary' }, scope });
+
+    expect(binding.owner).toEqual(localRuntimeOwner('apple'));
+    expect(facts.operations.bootTarget).toEqual({ available: true });
+    expect(binding.facts.operations.bootTarget).toEqual({ available: true });
+  });
+
+  test('a managed local owner is not registrable as an ordinary provider module', () => {
+    const managedModule = {
+      // @ts-expect-error `providerModules` pairs one ProviderDeviceRuntime with one
+      // provider-runtime owner, so ordinary selection cannot be handed a managed local owner.
+      owner: managedLocalRuntimeOwner('sim-a'),
+      loadRuntime: async () => runtimeOwner({ ref: managed }),
+    } satisfies PlatformRuntimeProviderModule;
+
+    expect(managedModule.owner).toEqual(managed);
+  });
+
+  // A managed owner delegates to the device's local family owner and inherits its provider mode
+  // verbatim (see the "unlaundered" wrapper test), so it must be admitted the same way an ordinary
+  // local-family binding is: local or transport-composed. Rejecting transport-composed here would
+  // refuse every managed binding over a remote-transport local device (e.g. ADB-over-transport, a
+  // web-provider proxy) as a spurious owner/facts mismatch.
+  test('accepts a managed binding whose local facts report a transport-composed device', async () => {
+    const { runtimeGateway } = managedGateway('transport-composed');
+
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(binding.facts.device.providerMode).toBe('transport-composed');
+  });
+
+  // A second bind resolves only because the managed owner is composed once: a fresh wrapper per
+  // bind would register a second owner under the same key and be refused as a duplicate.
+  test('reuses one managed owner per registered instance and refuses unregistered ones', async () => {
+    const { family, runtimeGateway } = managedGateway();
+
+    const first = await runtimeGateway.bind({ device, intent: exactly(), scope });
+    const second = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(second.owner).toEqual(first.owner);
+    expect(family.calls.loads).toBe(1);
+    await first[Symbol.asyncDispose]();
+    expect(family.calls.disposals).toBe(1);
+    await expect(
+      runtimeGateway.bind({ device, intent: exactly(managedLocalRuntimeOwner('sim-b')), scope }),
+    ).rejects.toMatchObject({
+      code: 'UNSUPPORTED_OPERATION',
+      details: { reason: 'owner-unavailable', owner: 'managed:["sim-b"]' },
+    });
+  });
+
+  test('rejects duplicate managed owner registrations', () => {
+    expect(() =>
+      createComposedPlatformRuntimeGateway({
+        modules: new Map(),
+        loadHost: async () => ({}) as PlatformRuntimeHost,
+        managedOwners: [managed, managedLocalRuntimeOwner('sim-a')],
+      }),
+    ).toThrow('Duplicate platform runtime owner');
+  });
 });

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -296,7 +296,7 @@ async function selectExactOwner(
       throw ownerUnavailable(ref);
     }
     case 'managed-local':
-      // No managed owner is registered yet; the exact-only managed registry lands with ADR 0021.
+      // No managed owner is registered yet; U3 fills this arm with the exact-only registry.
       throw ownerUnavailable(ref);
     case 'provider-runtime': {
       const registration = providersByOwner.get(runtimeOwnerKey(ref));

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -30,6 +30,10 @@ import {
   type Platform,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import {
+  createManagedLocalRuntimeOwner,
+  type ManagedLocalRuntimeOwnerRef,
+} from './platform-runtime-managed-owner.ts';
 
 export type PlatformRuntimeProviderRegistration = Readonly<{
   runtime: ProviderDeviceRuntime;
@@ -41,6 +45,12 @@ export function createComposedPlatformRuntimeGateway(options: {
   loadHost: () => Promise<PlatformRuntimeHost>;
   providerRuntimes?: readonly ProviderDeviceRuntime[];
   providerModules?: readonly PlatformRuntimeProviderRegistration[];
+  /**
+   * Managed local owners are registered here and nowhere else. The list has no ordinary reader:
+   * `selectOrdinaryProvider`, `inspectFacts` and the ordinary `bind` arm never see it, so exact
+   * selection is the only way to reach one.
+   */
+  managedOwners?: readonly ManagedLocalRuntimeOwnerRef[];
 }): DeviceRuntimeGateway<PlatformRuntimeOperations> {
   const providersByOwner = new Map<string, PlatformRuntimeProviderRegistration>();
   const modulesByRuntime = new Map<ProviderDeviceRuntime, PlatformRuntimeProviderModule>();
@@ -59,8 +69,17 @@ export function createComposedPlatformRuntimeGateway(options: {
     providersByOwner.set(key, registration);
     modulesByRuntime.set(runtime, module);
   }
+  const managedByOwner = new Map<string, ManagedLocalRuntimeOwnerRef>();
+  for (const ref of options.managedOwners ?? []) {
+    const key = runtimeOwnerKey(ref);
+    if (managedByOwner.has(key)) {
+      throw runtimeContractError(`Duplicate platform runtime owner: ${key}`);
+    }
+    managedByOwner.set(key, ref);
+  }
   const localLoads = new Map<Platform, Promise<PlatformRuntimeOwner>>();
   const providerLoads = new Map<PlatformRuntimeProviderModule, Promise<PlatformRuntimeOwner>>();
+  const managedLoads = new Map<string, PlatformRuntimeOwner>();
   const loadedOwners = new Map<string, PlatformRuntimeOwner>();
   let hostLoad: Promise<PlatformRuntimeHost> | undefined;
   const loadHost = async () => {
@@ -151,6 +170,18 @@ export function createComposedPlatformRuntimeGateway(options: {
       throw error;
     }
   };
+  // A managed owner is composed from a registered ref and this gateway's own local loader, so
+  // there is nothing to load lazily except the family owner it delegates to.
+  const loadManaged = async (ref: ManagedLocalRuntimeOwnerRef) => {
+    const key = runtimeOwnerKey(ref);
+    const registered = managedByOwner.get(key);
+    if (!registered) throw ownerUnavailable(ref);
+    const existing = managedLoads.get(key);
+    if (existing) return existing;
+    const owner = registerOwner(createManagedLocalRuntimeOwner({ owner: registered, loadLocal }));
+    managedLoads.set(key, owner);
+    return owner;
+  };
 
   return Object.freeze({
     applicationLifecycle,
@@ -171,6 +202,7 @@ export function createComposedPlatformRuntimeGateway(options: {
           providersByOwner,
           loadProvider,
           loadLocal,
+          loadManaged,
         );
         return await bindAndValidate(selected, request);
       }
@@ -191,6 +223,7 @@ export function createComposedPlatformRuntimeGateway(options: {
       loadedOwners.clear();
       localLoads.clear();
       providerLoads.clear();
+      managedLoads.clear();
     },
   });
 }
@@ -292,6 +325,7 @@ async function selectExactOwner(
   providersByOwner: ReadonlyMap<string, PlatformRuntimeProviderRegistration>,
   loadProvider: (module: PlatformRuntimeProviderModule) => Promise<PlatformRuntimeOwner>,
   loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>,
+  loadManaged: (ref: ManagedLocalRuntimeOwnerRef) => Promise<PlatformRuntimeOwner>,
 ): Promise<PlatformRuntimeOwner> {
   switch (ref.kind) {
     case 'local-family': {
@@ -300,8 +334,7 @@ async function selectExactOwner(
       throw ownerUnavailable(ref);
     }
     case 'managed-local':
-      // No managed owner is registered yet; U3 fills this arm with the exact-only registry.
-      throw ownerUnavailable(ref);
+      return await loadManaged(ref);
     case 'provider-runtime': {
       const registration = providersByOwner.get(runtimeOwnerKey(ref));
       if (registration) return await loadProvider(registration.module);

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -273,9 +273,14 @@ function providerModeMatchesOwner(
   mode: DeviceBinding<PlatformRuntimeOperations>['facts']['device']['providerMode'],
   owner: RuntimeOwnerRef,
 ): boolean {
-  return owner.kind === 'local-family'
-    ? mode === 'local' || mode === 'transport-composed'
-    : mode === 'provider-runtime';
+  switch (owner.kind) {
+    case 'local-family':
+      return mode === 'local' || mode === 'transport-composed';
+    case 'managed-local':
+      return mode === 'local';
+    case 'provider-runtime':
+      return mode === 'provider-runtime';
+  }
 }
 
 async function selectExactOwner(
@@ -284,14 +289,21 @@ async function selectExactOwner(
   loadProvider: (module: PlatformRuntimeProviderModule) => Promise<PlatformRuntimeOwner>,
   loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>,
 ): Promise<PlatformRuntimeOwner> {
-  if (ref.kind === 'local-family') {
-    const owner = await loadLocal(ref.family);
-    if (sameRuntimeOwner(owner.owner, ref)) return owner;
-    throw ownerUnavailable(ref);
+  switch (ref.kind) {
+    case 'local-family': {
+      const owner = await loadLocal(ref.family);
+      if (sameRuntimeOwner(owner.owner, ref)) return owner;
+      throw ownerUnavailable(ref);
+    }
+    case 'managed-local':
+      // No managed owner is registered yet; the exact-only managed registry lands with ADR 0021.
+      throw ownerUnavailable(ref);
+    case 'provider-runtime': {
+      const registration = providersByOwner.get(runtimeOwnerKey(ref));
+      if (registration) return await loadProvider(registration.module);
+      throw ownerUnavailable(ref);
+    }
   }
-  const registration = providersByOwner.get(runtimeOwnerKey(ref));
-  if (registration) return await loadProvider(registration.module);
-  throw ownerUnavailable(ref);
 }
 
 function unavailableProviderBinding(

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -277,7 +277,11 @@ function providerModeMatchesOwner(
     case 'local-family':
       return mode === 'local' || mode === 'transport-composed';
     case 'managed-local':
-      return mode === 'local';
+      // A managed owner delegates to the device's local family owner (`selectExactOwner`'s
+      // `managed-local` arm loads it through the same `loadLocal`), so it inherits that owner's
+      // provider modes verbatim, transport-composed included. This arm is unreachable until a
+      // managed owner is registered; U3 pins it with a binding regression test.
+      return mode === 'local' || mode === 'transport-composed';
     case 'provider-runtime':
       return mode === 'provider-runtime';
   }

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -30,10 +30,7 @@ import {
   type Platform,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
-import {
-  createManagedLocalRuntimeOwner,
-  type ManagedLocalRuntimeOwnerRef,
-} from './platform-runtime-managed-owner.ts';
+import type { ManagedLocalRuntimeOwnerRef } from './platform-runtime-managed-owner.ts';
 
 export type PlatformRuntimeProviderRegistration = Readonly<{
   runtime: ProviderDeviceRuntime;
@@ -170,14 +167,16 @@ export function createComposedPlatformRuntimeGateway(options: {
       throw error;
     }
   };
-  // A managed owner is composed from a registered ref and this gateway's own local loader, so
-  // there is nothing to load lazily except the family owner it delegates to.
+  // The wrapper module is loaded dynamically so an ordinary bind, which never reaches this arm,
+  // does not pay for it: `src/platform-runtime.ts`'s eager closure is a no-growth hub, and a
+  // static import here would be a permanent edge every command pays at startup.
   const loadManaged = async (ref: ManagedLocalRuntimeOwnerRef) => {
     const key = runtimeOwnerKey(ref);
     const registered = managedByOwner.get(key);
     if (!registered) throw ownerUnavailable(ref);
     const existing = managedLoads.get(key);
     if (existing) return existing;
+    const { createManagedLocalRuntimeOwner } = await import('./platform-runtime-managed-owner.ts');
     const owner = registerOwner(createManagedLocalRuntimeOwner({ owner: registered, loadLocal }));
     managedLoads.set(key, owner);
     return owner;

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -1,0 +1,162 @@
+import {
+  type DeviceBindingIntent,
+  type ResourceOwnershipFence,
+  type RuntimeOwnerRef,
+  type RuntimeProviderMode,
+  localRuntimeOwner,
+  managedBindingFence,
+  managedLocalRuntimeOwner,
+  narrowDeviceBinding,
+} from '@agent-device/contracts/platform-runtime';
+import {
+  appStateUse,
+  appsRuntimeUse,
+  bootTargetUse,
+  shutdownTargetUse,
+  type PlatformRuntimeHost,
+} from '@agent-device/contracts/platform-runtime-operations';
+import { deployAppUse } from '@agent-device/contracts/app-deployment-runtime-plan';
+import { describe, expect, test } from 'vitest';
+import { createManagedLocalRuntimeOwner } from './platform-runtime-managed-owner.ts';
+import {
+  gatewayFixtureDevice as device,
+  gatewayFixtureScope as scope,
+  localFamilyRuntimeFixture,
+  MANAGED_RETAINED_OPERATION,
+  MANAGED_WITHHELD_OPERATIONS,
+} from './platform-runtime-gateway.fixtures.ts';
+
+const managed = managedLocalRuntimeOwner('sim-a');
+const fence = managedBindingFence({
+  requesterId: 'requester-a',
+  requestGeneration: 1,
+  identityIncarnationId: 'incarnation-a',
+});
+
+function exactly(
+  owner: RuntimeOwnerRef = managed,
+  withFence: ResourceOwnershipFence = fence,
+): DeviceBindingIntent {
+  return { kind: 'exact-owner', owner, fence: withFence };
+}
+
+function managedOwnerFixture(providerMode?: RuntimeProviderMode) {
+  const family = localFamilyRuntimeFixture({ family: 'apple', device, providerMode });
+  const owner = createManagedLocalRuntimeOwner({
+    owner: managed,
+    loadLocal: async () => await family.module.loadRuntime({} as PlatformRuntimeHost),
+  });
+  return { family, owner };
+}
+
+function thrownBy(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected the runtime use to be refused');
+}
+
+describe('managed local runtime owner', () => {
+  test('withholds every lifecycle-bearing and durable capture cell and keeps the rest', async () => {
+    const { owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    // A cell dropped from this list would silently stop being covered by the assertions below.
+    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(27);
+    for (const key of MANAGED_WITHHELD_OPERATIONS) {
+      expect(binding.facts.operations[key]).toMatchObject({
+        available: false,
+        reason: 'owner-capability-missing',
+      });
+      expect(binding.operations[key]).toBeUndefined();
+    }
+    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+    expect(binding.operations[MANAGED_RETAINED_OPERATION]).toBeTypeOf('function');
+  });
+
+  // The exclusion covers binding cells only. Pre-binding readiness still boots a device through
+  // direct platform tooling before any binding exists; moving it under the binding is its own unit.
+  test('refuses every runtime use that needs a withheld cell', async () => {
+    const { owner } = managedOwnerFixture();
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+    const refused = {
+      code: 'UNSUPPORTED_OPERATION',
+      details: { reason: 'owner-capability-missing' },
+    };
+
+    expect(thrownBy(() => narrowDeviceBinding(binding, appsRuntimeUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, appStateUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, bootTargetUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, shutdownTargetUse))).toMatchObject(refused);
+    // `deployAppUse` requires `deployApp` alone, so only the cell itself can refuse `install`.
+    expect(thrownBy(() => narrowDeviceBinding(binding, deployAppUse))).toMatchObject(refused);
+  });
+
+  test('rewrites the owner, delegates under an ordinary intent, and forwards disposal', async () => {
+    const { family, owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(binding.device).toEqual(device);
+    expect(family.requests).toHaveLength(1);
+    expect(family.requests[0]?.intent).toEqual({ kind: 'ordinary' });
+    expect(family.requests[0]?.scope).toBe(scope);
+    await binding[Symbol.asyncDispose]();
+    expect(family.calls.disposals).toBe(1);
+  });
+
+  test('binds only under an exact-owner intent that names this owner', async () => {
+    const { family, owner } = managedOwnerFixture();
+    const refusal = {
+      code: 'COMMAND_FAILED',
+      details: { reason: 'runtime-contract-invalid' },
+    };
+
+    await expect(owner.bind({ device, intent: { kind: 'ordinary' }, scope })).rejects.toMatchObject(
+      refusal,
+    );
+    await expect(
+      owner.bind({ device, intent: exactly(localRuntimeOwner('apple')), scope }),
+    ).rejects.toMatchObject(refusal);
+    await expect(
+      owner.bind({ device, intent: exactly(managedLocalRuntimeOwner('sim-b')), scope }),
+    ).rejects.toMatchObject(refusal);
+    expect(family.requests).toEqual([]);
+  });
+
+  test('does not read the fence: what a managed fence proves belongs to the claim gate', async () => {
+    const { owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({
+      device,
+      intent: exactly(managed, { token: 'an-opaque-capture-token', generation: 7 }),
+      scope,
+    });
+
+    expect(binding.owner).toEqual(managed);
+  });
+
+  test('never claims a device and projects the same withholding onto inspected facts', async () => {
+    const { owner } = managedOwnerFixture();
+
+    expect(owner.ownsDevice(device)).toBe(false);
+    const facts = await owner.inspectFacts(device);
+    expect(facts.operations.bootTarget).toMatchObject({
+      available: false,
+      reason: 'owner-capability-missing',
+    });
+    expect(facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+  });
+
+  test('reports the family owner provider mode it was given, unlaundered', async () => {
+    const { owner } = managedOwnerFixture('transport-composed');
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    expect(binding.facts.device.providerMode).toBe('transport-composed');
+  });
+});

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -1,0 +1,178 @@
+import {
+  type DeviceBinding,
+  type RuntimeFacts,
+  type RuntimeOperationFact,
+  type RuntimeOperationKey,
+  type RuntimeOperationUnavailability,
+  type RuntimeOwnerRef,
+  sameRuntimeOwner,
+} from '@agent-device/contracts/platform-runtime';
+import type {
+  PlatformRuntimeOperations,
+  PlatformRuntimeOwner,
+} from '@agent-device/contracts/platform-runtime-operations';
+import type { Platform } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+
+export type ManagedLocalRuntimeOwnerRef = Extract<RuntimeOwnerRef, { kind: 'managed-local' }>;
+
+type ManagedOperationKey = RuntimeOperationKey<PlatformRuntimeOperations>;
+
+/**
+ * What a managed local owner withholds, grouped by the mechanics that make it impossible rather
+ * than by catalog family: an operation is here because executing it would boot, shut down, or
+ * durably own the allocator's device.
+ */
+const WITHHELD_MANAGED_OPERATIONS = [
+  {
+    // The two deployment cells belong here for the same reason as the explicit boot cells: both
+    // family deployment runtimes ensure device readiness first, and `deployAppUse` requires
+    // `deployApp` alone, so nothing else would have caught `install` on a managed binding.
+    hint: 'Managed-device lifecycle belongs to the allocator.',
+    keys: [
+      'ensureReady',
+      'bootTarget',
+      'bootTargetHeadless',
+      'shutdownTarget',
+      'deployApp',
+      'deployMaterializedApp',
+    ],
+  },
+  {
+    // These four are lifecycle-bearing even though they read as application operations: open
+    // preparation and Apple runner preparation boot the target unconditionally, and the close
+    // pair carries the shutdown half of the same sequence.
+    hint: 'Application open and close take device readiness and shutdown steps the allocator owns.',
+    keys: [
+      'prepareApplicationOpen',
+      'prepareAppleRunner',
+      'closeApplication',
+      'finalizeApplicationClose',
+    ],
+  },
+  {
+    // A durable capture is adopted by comparing the envelope's owner with the binding's owner, and
+    // the family runtime stamps envelopes with its own local owner — so a capture started under a
+    // managed binding could never be reattached or cleaned up under it.
+    hint: 'Durable captures are not adoptable under a managed local owner yet.',
+    keys: [
+      'appLogStart',
+      'appLogReattach',
+      'appLogCleanup',
+      'screenRecordingStart',
+      'screenRecordingReattach',
+      'screenRecordingCleanup',
+      'audioProbeStart',
+      'audioProbeReattach',
+      'audioProbeCleanup',
+      'perfNativeCaptureStart',
+      'perfNativeCaptureReattach',
+      'perfNativeCaptureCleanup',
+    ],
+  },
+  {
+    // Below cell-selection granularity, the Apple family runtime can boot the simulator lazily:
+    // screenshot capture retries through a boot on a shutdown failure, and settings, clipboard and
+    // application launch each resolve a local interactor the same way. Closing that path is a
+    // family-runtime change (the same class as the pre-binding readiness bypass named in "Named
+    // out of scope" below); until then, a managed binding withholds these cells outright rather
+    // than leave an allocator-owned device open to an implicit boot.
+    hint: 'Managed-device lifecycle belongs to the allocator; this cell can lazily boot the device.',
+    keys: ['captureScreenshot', 'setSetting', 'readClipboard', 'writeClipboard', 'openApplication'],
+  },
+] as const satisfies readonly Readonly<{ hint: string; keys: readonly ManagedOperationKey[] }>[];
+
+/**
+ * The exact-only runtime owner for one allocator instance. It owns no mechanics of its own: it
+ * binds the device's local family owner, republishes that binding under the managed owner, and
+ * withholds the cells whose declared work is device lifecycle.
+ *
+ * Withholding cells is not a complete lifecycle exclusion and does not claim to be. Screenshot
+ * capture, settings, clipboard and application launch are withheld here even though their declared
+ * work is not device lifecycle, because their Apple family-runtime implementations can boot the
+ * simulator lazily below cell-selection granularity. Pre-binding readiness is the same class of
+ * gap, one level up: `session-device-resolution` boots a device through direct simctl/adb before
+ * any binding exists, gated only by provider ownership. Closing both is a family-runtime and
+ * daemon change tracked as a follow-up, not attempted here.
+ *
+ * It delegates with an ordinary intent because a family owner refuses an exact-owner intent that
+ * names anyone but itself. The managed intent's fence is not read here: the device-claim gate owns
+ * what a managed binding fence proves.
+ */
+export function createManagedLocalRuntimeOwner(params: {
+  owner: ManagedLocalRuntimeOwnerRef;
+  loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>;
+}): PlatformRuntimeOwner {
+  return Object.freeze({
+    owner: params.owner,
+    // Selection is exact-only by construction: ordinary selection never consults this owner, and
+    // claiming a device here would be the one way it could.
+    ownsDevice: () => false,
+    inspectFacts: async (device) => {
+      const local = await params.loadLocal(device.platform);
+      return projectManagedFacts(await local.inspectFacts(device));
+    },
+    bind: async (request) => {
+      if (
+        request.intent.kind !== 'exact-owner' ||
+        !sameRuntimeOwner(request.intent.owner, params.owner)
+      ) {
+        throw new AppError(
+          'COMMAND_FAILED',
+          'A managed local owner binds only under an exact-owner intent naming it',
+          { reason: 'runtime-contract-invalid' },
+        );
+      }
+      const local = await params.loadLocal(request.device.platform);
+      const binding = await local.bind({
+        device: request.device,
+        intent: { kind: 'ordinary' },
+        scope: request.scope,
+      });
+      const facts = projectManagedFacts(binding.facts);
+      return Object.freeze({
+        device: binding.device,
+        owner: params.owner,
+        facts,
+        operations: admittedOperations(binding.operations, facts),
+        [Symbol.asyncDispose]: async () => await binding[Symbol.asyncDispose](),
+      });
+    },
+    // The delegated family owner is registered with the gateway in its own right, which is what
+    // shuts it down; this wrapper holds nothing else.
+    shutdown: async () => undefined,
+  });
+}
+
+function projectManagedFacts(
+  facts: RuntimeFacts<PlatformRuntimeOperations>,
+): RuntimeFacts<PlatformRuntimeOperations> {
+  const withheld: Partial<Record<ManagedOperationKey, RuntimeOperationFact>> = {};
+  for (const group of WITHHELD_MANAGED_OPERATIONS) {
+    const fact: RuntimeOperationUnavailability = Object.freeze({
+      available: false,
+      reason: 'owner-capability-missing',
+      hint: group.hint,
+    });
+    for (const key of group.keys) withheld[key] = fact;
+  }
+  // The device shape is the family owner's answer, provider mode included: a managed owner
+  // executes on a local device and may not launder a transport-composed one into a local claim.
+  return Object.freeze({
+    device: facts.device,
+    operations: Object.freeze({ ...facts.operations, ...withheld }),
+  });
+}
+
+/** Facts are the only admission authority, so an operation cannot outlive its own fact. */
+function admittedOperations(
+  operations: DeviceBinding<PlatformRuntimeOperations>['operations'],
+  facts: RuntimeFacts<PlatformRuntimeOperations>,
+): DeviceBinding<PlatformRuntimeOperations>['operations'] {
+  const admitted: Record<string, unknown> = {};
+  for (const [key, operation] of Object.entries(operations)) {
+    const fact: RuntimeOperationFact | undefined = facts.operations[key as ManagedOperationKey];
+    if (fact?.available === true) admitted[key] = operation;
+  }
+  return Object.freeze(admitted) as DeviceBinding<PlatformRuntimeOperations>['operations'];
+}


### PR DESCRIPTION
## Summary

ADR 0021 foundations for managed local runtimes. This branch now intentionally contains the two units that GitHub has already combined: #2258's owner/claim-admission foundation and merged #2259's exact-only managed-owner wrapper plus neutral allocator port. #2263 remains the focused allocator-held claim-store layer on top.

- `RuntimeOwnerRef` gains the exhaustive `managed-local` kind. The existing claim gate maps owners to one total `ordinary | allocator-held | none` rule, and managed admission returns an explicit admitted/refused result; there is no parallel command path.
- `managedBindingFence` is the canonical requester/incarnation fence. Its decoder accepts only the canonical encoding and preserves allocator-issued identifiers verbatim.
- The existing composed runtime gateway owns one exact-only `managedOwners` registry. Ordinary selection cannot reach it. The wrapper delegates device mechanics to the existing local-family owner, republishes the binding under the managed owner, and removes lifecycle, implicit-boot, and non-adoptable durable-capture cells through the existing capability/narrowing machinery.
- `@agent-device/contracts/managed-device-allocation` is a types-only allocator port with a scripted test fake. It adds no allocator dependency, socket code, or production call site.
- The wrapper is loaded lazily from the gateway, preserving the eager import closure.

Nothing in production registers a managed owner or calls the allocator yet, so this foundation does not make managed sessions reachable and changes no device-facing behavior. Pre-binding readiness and durable-capture adoption remain explicitly deferred to the allocation-flow/lifecycle units, where they can be exercised end to end.

Combining these units is deliberate now that #2259 was merged into this branch: splitting them again would discard an already-merged unit and create a second implementation path. They share the owner/gateway contract and remain one coherent runtime foundation. Claim persistence and clearing stay separate in #2263 because the claim store is an independent owner with different failure and recovery rules.

Scope: 33 files, +1,943/-180 against `main`. The npm unpacked increase is 5.6 kB: approximately 2.1 kB is the managed-owner wrapper, 1.1 kB is the batch-runner projection, and the apparent 56.3 kB `device-claim-rule.js` addition is predominantly the renamed 54.9 kB `device-claim-conflict.js` chunk. The remaining growth is contracts/projections; startup stayed flat within measurement noise.

## Validation

Exact head: `83d5522d3fd4f16afb5de4cb208ef3f8c190476f`.

- GitHub: every required lane is green, including iOS, Android, macOS, Linux, Coverage, Integration, Repo Guards, CodeQL, Agent Guidance, and Size.
- `pnpm check:affected --run`: green across format, lint, typecheck, layering, fallow, build, unit, integration, package, and repository guards.
- Layering: 198/198. Eager-closure budgets: 407/407, with the lazy managed-owner import preventing closure growth.
- Planted-red coverage exercised the owner-kind switches, total admission decision, canonical fence, exact-only registry, wrapper delegation/capability filtering, composed local transport acceptance, and scripted allocator fake.
- No simulator/emulator evidence is claimed or required for this foundation: no production path can register or select a managed owner.
