### PR TITLE
feat(runtime): register the managed local owner as an exact-only wrapper and add the neutral allocator port

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -305,6 +305,11 @@ Compatibility-engine evidence captured since the most recent mutation; mutation 
 **Provider**:
 An external adapter that owns a device runtime or contributes transport to a platform module.
 
+**Managed device allocator port**:
+The daemon-owned interface to a managed-device allocator: lease request, lookup, renewal, release,
+identity status, activation confirmation, and removal acknowledgement.
+_Avoid_: Simlock client, lease provider
+
 **Cloud WebDriver runtime**:
 A provider runtime that maps a cloud-owned Appium or WebDriver session into agent-device inventory,
 leases, runtime behavior, artifacts, and release.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -306,8 +306,8 @@ Compatibility-engine evidence captured since the most recent mutation; mutation 
 An external adapter that owns a device runtime or contributes transport to a platform module.
 
 **Managed device allocator port**:
-The daemon-owned interface to a managed-device allocator: lease request, lookup, renewal, release,
-identity status, activation confirmation, and removal acknowledgement.
+The daemon-owned interface to a managed-device allocator, covering everything the daemon needs to
+obtain, hold, and give back a managed device.
 _Avoid_: Simlock client, lease provider
 
 **Cloud WebDriver runtime**:

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -275,6 +275,10 @@
       "types": "./src/logs-runtime-plan.ts",
       "default": "./src/logs-runtime-plan.ts"
     },
+    "./managed-device-allocation": {
+      "types": "./src/managed-device-allocation.ts",
+      "default": "./src/managed-device-allocation.ts"
+    },
     "./managed-web-backend": {
       "types": "./src/managed-web-backend.ts",
       "default": "./src/managed-web-backend.ts"

--- a/packages/contracts/src/managed-device-allocation.ts
+++ b/packages/contracts/src/managed-device-allocation.ts
@@ -1,0 +1,160 @@
+import type { JsonObject } from './json.ts';
+
+/**
+ * agent-device's own interface to a managed-device allocator (ADR 0021 §3): lease request,
+ * lookup, supersession, cancellation, renewal, release, identity status, activation confirmation,
+ * and removal acknowledgement. The vocabulary matches the allocator's published contract so the
+ * two sides cannot drift, but the interface is owned here — no allocator package is a dependency,
+ * and the foundations implement it only as a scripted fake.
+ */
+
+/** The allocator's platform vocabulary; the daemon maps its own device families onto it. */
+export type ManagedLeasePlatform = 'ios' | 'android';
+
+/** A managed shape (ADR 0021 §5). The allocator owns canonical resolution against its catalog. */
+export type ManagedShapeRequest = Readonly<{
+  platform: ManagedLeasePlatform;
+  deviceType: string;
+  osVersion?: string;
+}>;
+
+/**
+ * The per-platform key a grant must carry for its device to be reachable. Each is a versioned
+ * driver contract on the allocator side, so the names are pinned as a type rather than restated
+ * as free strings wherever a lease is read.
+ */
+export type ManagedLeaseEnvironmentKey = 'SIMLOCK_IOS_DEVICE_SET' | 'ANDROID_ADB_SERVER_PORT';
+
+/** The typed reach projection of a lease's otherwise opaque environment record. */
+export type ManagedLeaseEnvironment =
+  | Readonly<{ platform: 'ios'; deviceSetPath: string }>
+  | Readonly<{ platform: 'android'; adbServerPort: number }>;
+
+/** A grant whose platform scoping key is absent or unparsable is unusable, not merely degraded. */
+export type LeaseEnvironmentError = Readonly<{
+  code: 'LEASE_ENVIRONMENT_INVALID';
+  platform: ManagedLeasePlatform;
+  key: ManagedLeaseEnvironmentKey;
+}>;
+
+export type ManagedLeaseEnvironmentOutcome =
+  | Readonly<{ ok: true; environment: ManagedLeaseEnvironment }>
+  | Readonly<{ ok: false; error: LeaseEnvironmentError }>;
+
+/** One granted managed-device lease. `environment` stays the allocator's raw record. */
+export type ManagedLease = Readonly<{
+  id: string;
+  ttlDeadline: number;
+  device: Readonly<{ address: string }>;
+  environment: Readonly<Record<string, string>>;
+}>;
+
+/**
+ * One created managed identity. The incarnation id is minted before the device exists and is
+ * preserved across reuse of the same Android identity, so it names the identity's creation rather
+ * than the request that happens to be holding it.
+ */
+export type ManagedIdentityRef = Readonly<{ deviceId: string; identityIncarnationId: string }>;
+
+export type ManagedIdentityState =
+  | 'reserved'
+  | 'active'
+  | 'idle'
+  | 'removing'
+  | 'removed'
+  | 'unknown';
+
+export type ManagedIdentityStatus = ManagedIdentityRef & Readonly<{ state: ManagedIdentityState }>;
+
+/**
+ * Fail-fast admission (ADR 0021 §4): the allocator refuses instead of queueing and agent-device
+ * adds no second queue. `activation: 'external-fence'` is the reusable-identity handshake, where
+ * the allocator validates its clean baseline under the requester's fence before publishing the
+ * grant; `'direct'` publishes as soon as the identity is ready.
+ */
+export type LeaseRequestInput = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  attemptKey: string;
+  shape: ManagedShapeRequest;
+  deadlineAtMs: number;
+  admission: 'fail-fast';
+  activation: 'direct' | 'external-fence';
+  attribution?: JsonObject;
+  /** Abandons only this caller's wait; the attempt keeps its own terminal outcome. */
+  signal?: AbortSignal;
+}>;
+
+export type LeaseRefusalReason =
+  | 'simulator-capacity'
+  | 'disk-low'
+  | 'invalid-shape'
+  | 'preparation-required'
+  | 'requester-busy';
+
+/** A refusal is terminal for its attempt key; only a capacity refusal names a retry delay. */
+export type LeaseRefusal = Readonly<{
+  reason: LeaseRefusalReason;
+  retryAfterMs?: number;
+  message?: string;
+}>;
+
+export type LeaseRequestState =
+  | 'pending'
+  | 'granted'
+  | 'refused'
+  | 'superseded'
+  | 'cancelled'
+  | 'unknown';
+
+/**
+ * All three identities are readable from one status because the managed binding fence is derived
+ * from them. `identityIncarnationId` is present from the moment an identity is reserved, so it is
+ * absent only while the request has not reached one.
+ */
+export type LeaseRequestStatus = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  identityIncarnationId?: string;
+  attemptKey: string;
+  state: LeaseRequestState;
+  lease?: ManagedLease;
+  refusal?: LeaseRefusal;
+}>;
+
+/** One attempt on one requester's allocation lane. */
+export type LeaseRequestRef = Readonly<{ requesterId: string; attemptKey: string }>;
+
+/** Supersession replaces exactly the expected prior generation, never a newer one. */
+export type SupersedeLeaseRequestInput = Readonly<{
+  requesterId: string;
+  expectedRequestGeneration: number;
+  replacement: LeaseRequestInput;
+}>;
+
+/** Activation binds one request to one identity, so it is scoped to all three ids. */
+export type LeaseActivationProof = Readonly<{
+  requesterId: string;
+  requestGeneration: number;
+  identityIncarnationId: string;
+}>;
+
+export type ManagedDeviceAllocatorPort = Readonly<{
+  instanceId: string;
+  requestLease(input: LeaseRequestInput): Promise<LeaseRequestStatus>;
+  getLeaseRequestStatus(request: LeaseRequestRef): Promise<LeaseRequestStatus>;
+  supersedeLeaseRequest(input: SupersedeLeaseRequestInput): Promise<LeaseRequestStatus>;
+  cancelLeaseRequest(request: LeaseRequestRef): Promise<LeaseRequestStatus>;
+  renewLease(input: Readonly<{ leaseId: string; ttlDeadline: number }>): Promise<ManagedLease>;
+  releaseLease(input: Readonly<{ leaseId: string }>): Promise<void>;
+  confirmLeaseActivation(proof: LeaseActivationProof): Promise<void>;
+  getManagedIdentityStatus(identity: ManagedIdentityRef): Promise<ManagedIdentityStatus>;
+  acknowledgeManagedIdentityRemoval(identity: ManagedIdentityRef): Promise<void>;
+  /**
+   * The one reader of a grant's environment record. It is not a call to the allocator: the record
+   * arrives with the lease, and the platform whose key must be present comes from the request.
+   */
+  readLeaseEnvironment(
+    input: Readonly<{ platform: ManagedLeasePlatform; lease: ManagedLease }>,
+  ): ManagedLeaseEnvironmentOutcome;
+}>;

--- a/packages/contracts/src/managed-device-allocation.ts
+++ b/packages/contracts/src/managed-device-allocation.ts
@@ -8,7 +8,7 @@ import type { JsonObject } from './json.ts';
  * and the foundations implement it only as a scripted fake.
  */
 
-/** The allocator's platform vocabulary; the daemon maps its own device families onto it. */
+/** The allocator's platform vocabulary. */
 export type ManagedLeasePlatform = 'ios' | 'android';
 
 /** A managed shape (ADR 0021 §5). The allocator owns canonical resolution against its catalog. */
@@ -25,21 +25,23 @@ export type ManagedShapeRequest = Readonly<{
  */
 export type ManagedLeaseEnvironmentKey = 'SIMLOCK_IOS_DEVICE_SET' | 'ANDROID_ADB_SERVER_PORT';
 
-/** The typed reach projection of a lease's otherwise opaque environment record. */
+/**
+ * The typed reach projection of a lease's otherwise opaque environment record, and the failure a
+ * grant without its platform's key is. The reader that produces either lands with the unit that
+ * first turns a grant into a device; both names are part of the contract now so that reader
+ * cannot invent a second spelling for them.
+ */
+// fallow-ignore-next-line unused-type
 export type ManagedLeaseEnvironment =
   | Readonly<{ platform: 'ios'; deviceSetPath: string }>
   | Readonly<{ platform: 'android'; adbServerPort: number }>;
 
-/** A grant whose platform scoping key is absent or unparsable is unusable, not merely degraded. */
+// fallow-ignore-next-line unused-type
 export type LeaseEnvironmentError = Readonly<{
   code: 'LEASE_ENVIRONMENT_INVALID';
   platform: ManagedLeasePlatform;
   key: ManagedLeaseEnvironmentKey;
 }>;
-
-export type ManagedLeaseEnvironmentOutcome =
-  | Readonly<{ ok: true; environment: ManagedLeaseEnvironment }>
-  | Readonly<{ ok: false; error: LeaseEnvironmentError }>;
 
 /** One granted managed-device lease. `environment` stays the allocator's raw record. */
 export type ManagedLease = Readonly<{
@@ -150,11 +152,4 @@ export type ManagedDeviceAllocatorPort = Readonly<{
   confirmLeaseActivation(proof: LeaseActivationProof): Promise<void>;
   getManagedIdentityStatus(identity: ManagedIdentityRef): Promise<ManagedIdentityStatus>;
   acknowledgeManagedIdentityRemoval(identity: ManagedIdentityRef): Promise<void>;
-  /**
-   * The one reader of a grant's environment record. It is not a call to the allocator: the record
-   * arrives with the lease, and the platform whose key must be present comes from the request.
-   */
-  readLeaseEnvironment(
-    input: Readonly<{ platform: ManagedLeasePlatform; lease: ManagedLease }>,
-  ): ManagedLeaseEnvironmentOutcome;
 }>;

--- a/scripts/__tests__/eager-closure-budgets.ts
+++ b/scripts/__tests__/eager-closure-budgets.ts
@@ -236,6 +236,8 @@ export const FACADE_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   'packages/contracts/src/is-predicate.ts': 1,
   'packages/contracts/src/keyboard.ts': 1,
   'packages/contracts/src/logs-runtime-plan.ts': 5,
+  // The allocator port is types only, so its entry evaluates nothing but itself.
+  'packages/contracts/src/managed-device-allocation.ts': 1,
   'packages/contracts/src/managed-web-backend.ts': 1,
   'packages/contracts/src/navigation.ts': 1,
   'packages/contracts/src/network-runtime-plan.ts': 5,
@@ -416,7 +418,9 @@ export const HUB_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   // modules on the CLI path; the measured two-module growth is the contract being loaded, not
   // implementation or platform machinery being pulled in eagerly.
   'src/cli.ts': 382,
-  'src/platform-runtime.ts': 47,
+  // 47 -> 48: the composed gateway now composes the managed local owner wrapper, whose own value
+  // imports (the owner contract and kernel errors) were already in this closure.
+  'src/platform-runtime.ts': 48,
   'src/core/command-descriptor/registry.ts': 72,
   'src/core/command-descriptor/platform-execution-entry.ts': 3,
   'src/core/interactors/register-builtins.ts': 6,

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -113,6 +113,7 @@ const CONTRACT_EXPORTS = [
   '@agent-device/contracts/keyboard-runtime',
   '@agent-device/contracts/local-interactor-operation-set',
   '@agent-device/contracts/logs-runtime-plan',
+  '@agent-device/contracts/managed-device-allocation',
   '@agent-device/contracts/managed-web-backend',
   '@agent-device/contracts/navigation',
   '@agent-device/contracts/network-runtime',

--- a/src/__tests__/managed-device-allocator-fake.test.ts
+++ b/src/__tests__/managed-device-allocator-fake.test.ts
@@ -2,7 +2,6 @@ import type {
   LeaseRequestInput,
   LeaseRequestStatus,
   ManagedIdentityRef,
-  ManagedLease,
 } from '@agent-device/contracts/managed-device-allocation';
 import { describe, expect, test } from 'vitest';
 import { createScriptedManagedDeviceAllocator } from './test-utils/managed-device-allocator.fixtures.ts';
@@ -87,33 +86,5 @@ describe('scripted managed device allocator', () => {
       { method: 'releaseLease', input: { leaseId: 'lease-1' } },
     ]);
     expect(allocator.calls[0]?.input).toBe(request);
-  });
-
-  test('projects a grant environment and refuses one missing its platform key', () => {
-    const allocator = createScriptedManagedDeviceAllocator();
-    const iosLease = granted.lease as ManagedLease;
-    const androidLease: ManagedLease = {
-      ...iosLease,
-      environment: { ANDROID_ADB_SERVER_PORT: '5038' },
-    };
-
-    expect(allocator.readLeaseEnvironment({ platform: 'ios', lease: iosLease })).toEqual({
-      ok: true,
-      environment: { platform: 'ios', deviceSetPath: '/sets/managed' },
-    });
-    expect(allocator.readLeaseEnvironment({ platform: 'android', lease: androidLease })).toEqual({
-      ok: true,
-      environment: { platform: 'android', adbServerPort: 5038 },
-    });
-    expect(allocator.readLeaseEnvironment({ platform: 'android', lease: iosLease })).toEqual({
-      ok: false,
-      error: {
-        code: 'LEASE_ENVIRONMENT_INVALID',
-        platform: 'android',
-        key: 'ANDROID_ADB_SERVER_PORT',
-      },
-    });
-    // Reading a grant already in hand is not a call to the allocator.
-    expect(allocator.calls).toEqual([]);
   });
 });

--- a/src/__tests__/managed-device-allocator-fake.test.ts
+++ b/src/__tests__/managed-device-allocator-fake.test.ts
@@ -1,0 +1,119 @@
+import type {
+  LeaseRequestInput,
+  LeaseRequestStatus,
+  ManagedIdentityRef,
+  ManagedLease,
+} from '@agent-device/contracts/managed-device-allocation';
+import { describe, expect, test } from 'vitest';
+import { createScriptedManagedDeviceAllocator } from './test-utils/managed-device-allocator.fixtures.ts';
+
+const request: LeaseRequestInput = {
+  requesterId: 'requester-a',
+  requestGeneration: 1,
+  attemptKey: 'attempt-1',
+  shape: { platform: 'ios', deviceType: 'iPhone 16' },
+  deadlineAtMs: 1_000,
+  admission: 'fail-fast',
+  activation: 'direct',
+};
+
+const identity: ManagedIdentityRef = {
+  deviceId: 'device-a',
+  identityIncarnationId: 'incarnation-a',
+};
+
+const pending: LeaseRequestStatus = {
+  requesterId: request.requesterId,
+  requestGeneration: request.requestGeneration,
+  attemptKey: request.attemptKey,
+  state: 'pending',
+};
+
+const granted: LeaseRequestStatus = {
+  ...pending,
+  identityIncarnationId: identity.identityIncarnationId,
+  state: 'granted',
+  lease: {
+    id: 'lease-1',
+    ttlDeadline: 2_000,
+    device: { address: 'device-a' },
+    environment: { SIMLOCK_IOS_DEVICE_SET: '/sets/managed' },
+  },
+};
+
+describe('scripted managed device allocator', () => {
+  test('replays one step per method in order and refuses an unscripted call', async () => {
+    const allocator = createScriptedManagedDeviceAllocator({
+      instanceId: 'sim-a',
+      script: {
+        requestLease: [pending, granted],
+        getLeaseRequestStatus: [granted],
+        getManagedIdentityStatus: [new Error('allocator unreachable')],
+      },
+    });
+
+    expect(allocator.instanceId).toBe('sim-a');
+    await expect(allocator.requestLease(request)).resolves.toEqual(pending);
+    // Steps are consumed per method: the lookup between the two requests takes its own script.
+    await expect(
+      allocator.getLeaseRequestStatus({ requesterId: 'requester-a', attemptKey: 'attempt-1' }),
+    ).resolves.toEqual(granted);
+    await expect(allocator.requestLease(request)).resolves.toEqual(granted);
+    await expect(allocator.requestLease(request)).rejects.toThrow(
+      'Unscripted allocator call: requestLease',
+    );
+    await expect(allocator.getManagedIdentityStatus(identity)).rejects.toThrow(
+      'allocator unreachable',
+    );
+    await expect(
+      allocator.confirmLeaseActivation({
+        requesterId: 'requester-a',
+        requestGeneration: 1,
+        identityIncarnationId: 'incarnation-a',
+      }),
+    ).rejects.toThrow('Unscripted allocator call: confirmLeaseActivation');
+  });
+
+  test('records every call with the input it received', async () => {
+    const allocator = createScriptedManagedDeviceAllocator({
+      script: { requestLease: [granted], releaseLease: [undefined] },
+    });
+
+    await allocator.requestLease(request);
+    await allocator.releaseLease({ leaseId: 'lease-1' });
+
+    expect(allocator.calls).toEqual([
+      { method: 'requestLease', input: request },
+      { method: 'releaseLease', input: { leaseId: 'lease-1' } },
+    ]);
+    expect(allocator.calls[0]?.input).toBe(request);
+  });
+
+  test('projects a grant environment and refuses one missing its platform key', () => {
+    const allocator = createScriptedManagedDeviceAllocator();
+    const iosLease = granted.lease as ManagedLease;
+    const androidLease: ManagedLease = {
+      ...iosLease,
+      environment: { ANDROID_ADB_SERVER_PORT: '5038' },
+    };
+
+    expect(allocator.readLeaseEnvironment({ platform: 'ios', lease: iosLease })).toEqual({
+      ok: true,
+      environment: { platform: 'ios', deviceSetPath: '/sets/managed' },
+    });
+    expect(allocator.readLeaseEnvironment({ platform: 'android', lease: androidLease })).toEqual({
+      ok: true,
+      environment: { platform: 'android', adbServerPort: 5038 },
+    });
+    expect(allocator.readLeaseEnvironment({ platform: 'android', lease: iosLease })).toEqual({
+      ok: false,
+      error: {
+        code: 'LEASE_ENVIRONMENT_INVALID',
+        platform: 'android',
+        key: 'ANDROID_ADB_SERVER_PORT',
+      },
+    });
+    // Reading a grant already in hand is not a call to the allocator.
+    expect(allocator.calls).toEqual([]);
+  });
+});

--- a/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
+++ b/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
@@ -1,0 +1,92 @@
+import type {
+  ManagedDeviceAllocatorPort,
+  ManagedLease,
+  ManagedLeaseEnvironmentKey,
+  ManagedLeaseEnvironmentOutcome,
+  ManagedLeasePlatform,
+} from '@agent-device/contracts/managed-device-allocation';
+
+/** The port's calls to the allocator. `readLeaseEnvironment` reads a grant already in hand. */
+export type ScriptedAllocatorMethod = keyof Omit<
+  ManagedDeviceAllocatorPort,
+  'instanceId' | 'readLeaseEnvironment'
+>;
+
+export type ScriptedAllocatorCall = Readonly<{
+  method: ScriptedAllocatorMethod;
+  input: unknown;
+}>;
+
+export type ScriptedManagedDeviceAllocator = ManagedDeviceAllocatorPort &
+  Readonly<{ calls: ScriptedAllocatorCall[] }>;
+
+/**
+ * The only implementation of the allocator port in the foundations: it replays one scripted step
+ * per call, in the order the script lists them for that method, and refuses a call the script did
+ * not anticipate. No transport, no timers, and no lifecycle rules of its own — a test that wants
+ * an allocator behavior states it as a step.
+ */
+export function createScriptedManagedDeviceAllocator(
+  options: {
+    instanceId?: string;
+    script?: Partial<Record<ScriptedAllocatorMethod, readonly unknown[]>>;
+  } = {},
+): ScriptedManagedDeviceAllocator {
+  const calls: ScriptedAllocatorCall[] = [];
+  const remaining = new Map<ScriptedAllocatorMethod, unknown[]>(
+    Object.entries(options.script ?? {}).map(([method, steps]) => [
+      method as ScriptedAllocatorMethod,
+      [...(steps ?? [])],
+    ]),
+  );
+  const next = async <Result>(method: ScriptedAllocatorMethod, input: unknown): Promise<Result> => {
+    calls.push(Object.freeze({ method, input }));
+    const steps = remaining.get(method) ?? [];
+    if (steps.length === 0) throw new Error(`Unscripted allocator call: ${method}`);
+    const step = steps.shift();
+    if (step instanceof Error) throw step;
+    return step as Result;
+  };
+  return Object.freeze({
+    instanceId: options.instanceId ?? 'scripted-allocator',
+    calls,
+    requestLease: async (input) => await next('requestLease', input),
+    getLeaseRequestStatus: async (request) => await next('getLeaseRequestStatus', request),
+    supersedeLeaseRequest: async (input) => await next('supersedeLeaseRequest', input),
+    cancelLeaseRequest: async (request) => await next('cancelLeaseRequest', request),
+    renewLease: async (input) => await next('renewLease', input),
+    releaseLease: async (input) => await next('releaseLease', input),
+    confirmLeaseActivation: async (proof) => await next('confirmLeaseActivation', proof),
+    getManagedIdentityStatus: async (identity) => await next('getManagedIdentityStatus', identity),
+    acknowledgeManagedIdentityRemoval: async (identity) =>
+      await next('acknowledgeManagedIdentityRemoval', identity),
+    readLeaseEnvironment: ({ platform, lease }) => readLeaseEnvironment(platform, lease),
+  });
+}
+
+function readLeaseEnvironment(
+  platform: ManagedLeasePlatform,
+  lease: ManagedLease,
+): ManagedLeaseEnvironmentOutcome {
+  if (platform === 'ios') {
+    const deviceSetPath = lease.environment.SIMLOCK_IOS_DEVICE_SET;
+    return deviceSetPath === undefined || deviceSetPath.length === 0
+      ? environmentInvalid(platform, 'SIMLOCK_IOS_DEVICE_SET')
+      : Object.freeze({ ok: true, environment: Object.freeze({ platform, deviceSetPath }) });
+  }
+  const raw = lease.environment.ANDROID_ADB_SERVER_PORT;
+  const adbServerPort = raw === undefined ? Number.NaN : Number(raw);
+  return Number.isInteger(adbServerPort) && adbServerPort > 0
+    ? Object.freeze({ ok: true, environment: Object.freeze({ platform, adbServerPort }) })
+    : environmentInvalid(platform, 'ANDROID_ADB_SERVER_PORT');
+}
+
+function environmentInvalid(
+  platform: ManagedLeasePlatform,
+  key: ManagedLeaseEnvironmentKey,
+): ManagedLeaseEnvironmentOutcome {
+  return Object.freeze({
+    ok: false,
+    error: Object.freeze({ code: 'LEASE_ENVIRONMENT_INVALID', platform, key }),
+  });
+}

--- a/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
+++ b/src/__tests__/test-utils/managed-device-allocator.fixtures.ts
@@ -1,16 +1,6 @@
-import type {
-  ManagedDeviceAllocatorPort,
-  ManagedLease,
-  ManagedLeaseEnvironmentKey,
-  ManagedLeaseEnvironmentOutcome,
-  ManagedLeasePlatform,
-} from '@agent-device/contracts/managed-device-allocation';
+import type { ManagedDeviceAllocatorPort } from '@agent-device/contracts/managed-device-allocation';
 
-/** The port's calls to the allocator. `readLeaseEnvironment` reads a grant already in hand. */
-export type ScriptedAllocatorMethod = keyof Omit<
-  ManagedDeviceAllocatorPort,
-  'instanceId' | 'readLeaseEnvironment'
->;
+export type ScriptedAllocatorMethod = keyof Omit<ManagedDeviceAllocatorPort, 'instanceId'>;
 
 export type ScriptedAllocatorCall = Readonly<{
   method: ScriptedAllocatorMethod;
@@ -60,33 +50,5 @@ export function createScriptedManagedDeviceAllocator(
     getManagedIdentityStatus: async (identity) => await next('getManagedIdentityStatus', identity),
     acknowledgeManagedIdentityRemoval: async (identity) =>
       await next('acknowledgeManagedIdentityRemoval', identity),
-    readLeaseEnvironment: ({ platform, lease }) => readLeaseEnvironment(platform, lease),
-  });
-}
-
-function readLeaseEnvironment(
-  platform: ManagedLeasePlatform,
-  lease: ManagedLease,
-): ManagedLeaseEnvironmentOutcome {
-  if (platform === 'ios') {
-    const deviceSetPath = lease.environment.SIMLOCK_IOS_DEVICE_SET;
-    return deviceSetPath === undefined || deviceSetPath.length === 0
-      ? environmentInvalid(platform, 'SIMLOCK_IOS_DEVICE_SET')
-      : Object.freeze({ ok: true, environment: Object.freeze({ platform, deviceSetPath }) });
-  }
-  const raw = lease.environment.ANDROID_ADB_SERVER_PORT;
-  const adbServerPort = raw === undefined ? Number.NaN : Number(raw);
-  return Number.isInteger(adbServerPort) && adbServerPort > 0
-    ? Object.freeze({ ok: true, environment: Object.freeze({ platform, adbServerPort }) })
-    : environmentInvalid(platform, 'ANDROID_ADB_SERVER_PORT');
-}
-
-function environmentInvalid(
-  platform: ManagedLeasePlatform,
-  key: ManagedLeaseEnvironmentKey,
-): ManagedLeaseEnvironmentOutcome {
-  return Object.freeze({
-    ok: false,
-    error: Object.freeze({ code: 'LEASE_ENVIRONMENT_INVALID', platform, key }),
   });
 }

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -7,17 +7,23 @@ import {
 } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
   type DeviceBinding,
+  type DeviceBindingRequest,
   type RuntimeFacts,
+  type RuntimeOperationKey,
   type RuntimeOwnerRef,
+  type RuntimeProviderMode,
+  localRuntimeOwner,
   providerRuntimeOwner,
+  sameRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
 import type {
   PlatformRuntimeHost,
+  PlatformRuntimeModule,
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime-operations';
 import type { PlatformRequestScope } from '@agent-device/contracts/platform-runtime-host';
-import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { DeviceInfo, Platform } from '@agent-device/kernel/device';
 import type { LimrunRuntimeDependencies } from '@agent-device/provider-limrun';
 import {
   createUnavailableRuntimeFactsForTest,
@@ -59,6 +65,101 @@ export function gatewayFixture(registrations: readonly PlatformRuntimeProviderRe
     loadHost: async () => ({}) as PlatformRuntimeHost,
     providerRuntimes: registrations.map(({ runtime }) => runtime),
     providerModules: registrations,
+  });
+}
+
+/**
+ * Every cell a managed local owner must withhold, listed once so the local family fixture can
+ * offer all of them and the managed tests can assert that none survives the wrapper.
+ */
+export const MANAGED_WITHHELD_OPERATIONS = [
+  'ensureReady',
+  'bootTarget',
+  'bootTargetHeadless',
+  'shutdownTarget',
+  'prepareApplicationOpen',
+  'prepareAppleRunner',
+  'closeApplication',
+  'finalizeApplicationClose',
+  'appLogStart',
+  'appLogReattach',
+  'appLogCleanup',
+  'screenRecordingStart',
+  'screenRecordingReattach',
+  'screenRecordingCleanup',
+  'audioProbeStart',
+  'audioProbeReattach',
+  'audioProbeCleanup',
+  'perfNativeCaptureStart',
+  'perfNativeCaptureReattach',
+  'perfNativeCaptureCleanup',
+] as const satisfies readonly RuntimeOperationKey<PlatformRuntimeOperations>[];
+
+/** The one cell the family owner offers that a managed binding keeps. */
+export const MANAGED_RETAINED_OPERATION = 'captureScreenshot';
+
+export type LocalFamilyRuntimeFixture = Readonly<{
+  module: PlatformRuntimeModule;
+  /** Every bind request the family owner received, in order. */
+  requests: DeviceBindingRequest[];
+  calls: { loads: number; disposals: number };
+}>;
+
+/**
+ * A local family owner that offers every withheld cell plus one retained cell, and that refuses a
+ * foreign exact-owner intent the way the real family runtimes do.
+ */
+export function localFamilyRuntimeFixture(options: {
+  family: Platform;
+  device: DeviceInfo;
+  providerMode?: RuntimeProviderMode;
+}): LocalFamilyRuntimeFixture {
+  const owner = localRuntimeOwner(options.family);
+  const requests: DeviceBindingRequest[] = [];
+  const calls = { loads: 0, disposals: 0 };
+  const base = createUnavailableRuntimeFactsForTest(options.device, owner);
+  const available = Object.freeze({ available: true } as const);
+  const offered: Record<string, unknown> = {};
+  const operations: Record<string, unknown> = {};
+  for (const key of [...MANAGED_WITHHELD_OPERATIONS, MANAGED_RETAINED_OPERATION]) {
+    offered[key] = available;
+    operations[key] = async () => undefined;
+  }
+  const facts = Object.freeze({
+    device: { ...base.device, providerMode: options.providerMode ?? base.device.providerMode },
+    operations: Object.freeze({ ...base.operations, ...offered }),
+  }) as RuntimeFacts<PlatformRuntimeOperations>;
+  const runtimeOwner: PlatformRuntimeOwner = {
+    owner,
+    ownsDevice: () => true,
+    inspectFacts: async () => facts,
+    bind: async (request) => {
+      requests.push(request);
+      if (request.intent.kind === 'exact-owner' && !sameRuntimeOwner(request.intent.owner, owner)) {
+        throw new TypeError('A local family runtime cannot bind a foreign exact owner');
+      }
+      return {
+        device: request.device,
+        owner,
+        facts,
+        operations: operations as DeviceBinding<PlatformRuntimeOperations>['operations'],
+        [Symbol.asyncDispose]: async () => {
+          calls.disposals += 1;
+        },
+      };
+    },
+    shutdown: async () => {},
+  };
+  return Object.freeze({
+    module: {
+      family: options.family,
+      loadRuntime: async () => {
+        calls.loads += 1;
+        return runtimeOwner;
+      },
+    },
+    requests,
+    calls,
   });
 }
 

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -77,6 +77,8 @@ export const MANAGED_WITHHELD_OPERATIONS = [
   'bootTarget',
   'bootTargetHeadless',
   'shutdownTarget',
+  'deployApp',
+  'deployMaterializedApp',
   'prepareApplicationOpen',
   'prepareAppleRunner',
   'closeApplication',

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -95,10 +95,15 @@ export const MANAGED_WITHHELD_OPERATIONS = [
   'perfNativeCaptureStart',
   'perfNativeCaptureReattach',
   'perfNativeCaptureCleanup',
+  'captureScreenshot',
+  'setSetting',
+  'readClipboard',
+  'writeClipboard',
+  'openApplication',
 ] as const satisfies readonly RuntimeOperationKey<PlatformRuntimeOperations>[];
 
 /** The one cell the family owner offers that a managed binding keeps. */
-export const MANAGED_RETAINED_OPERATION = 'captureScreenshot';
+export const MANAGED_RETAINED_OPERATION = 'tapPoint';
 
 export type LocalFamilyRuntimeFixture = Readonly<{
   module: PlatformRuntimeModule;

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -32,6 +32,7 @@ import {
   LIFECYCLE_FACETS,
   limrunTestDependencies,
   localFamilyRuntimeFixture,
+  MANAGED_RETAINED_OPERATION,
   providerLifecycleOwnerFixture as providerLifecycleOwner,
   providerRuntimeFixture as providerRuntime,
   runtimeOwnerFixture as runtimeOwner,
@@ -653,7 +654,7 @@ describe('managed local owner registration', () => {
       available: false,
       reason: 'owner-capability-missing',
     });
-    expect(binding.facts.operations.captureScreenshot).toEqual({ available: true });
+    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
   });
 
   test('leaves ordinary selection on the local family owner while a managed owner is registered', async () => {
@@ -678,12 +679,18 @@ describe('managed local owner registration', () => {
     expect(managedModule.owner).toEqual(managed);
   });
 
-  test('rejects a managed binding whose local facts report a transport-composed device', async () => {
+  // A managed owner delegates to the device's local family owner and inherits its provider mode
+  // verbatim (see the "unlaundered" wrapper test), so it must be admitted the same way an ordinary
+  // local-family binding is: local or transport-composed. Rejecting transport-composed here would
+  // refuse every managed binding over a remote-transport local device (e.g. ADB-over-transport, a
+  // web-provider proxy) as a spurious owner/facts mismatch.
+  test('accepts a managed binding whose local facts report a transport-composed device', async () => {
     const { runtimeGateway } = managedGateway('transport-composed');
 
-    await expect(runtimeGateway.bind({ device, intent: exactly(), scope })).rejects.toMatchObject({
-      details: { reason: 'runtime-contract-invalid' },
-    });
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(binding.facts.device.providerMode).toBe('transport-composed');
   });
 
   // A second bind resolves only because the managed owner is composed once: a fresh wrapper per

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -1,6 +1,9 @@
 import {
   type DeviceBinding,
+  type DeviceBindingIntent,
+  type RuntimeProviderMode,
   localRuntimeOwner,
+  managedBindingFence,
   managedLocalRuntimeOwner,
   providerRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime';
@@ -8,6 +11,7 @@ import type {
   PlatformRuntimeHost,
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
+  PlatformRuntimeProviderModule,
 } from '@agent-device/contracts/platform-runtime-operations';
 import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import { createUnavailablePlatformRuntimeFacts } from '@agent-device/contracts/platform-runtime-unavailable';
@@ -27,6 +31,7 @@ import {
   gatewayFixtureScope as scope,
   LIFECYCLE_FACETS,
   limrunTestDependencies,
+  localFamilyRuntimeFixture,
   providerLifecycleOwnerFixture as providerLifecycleOwner,
   providerRuntimeFixture as providerRuntime,
   runtimeOwnerFixture as runtimeOwner,
@@ -612,4 +617,102 @@ describe('composed platform runtime gateway', () => {
       expect(disposed).toHaveBeenCalledOnce();
     },
   );
+});
+
+describe('managed local owner registration', () => {
+  const managed = managedLocalRuntimeOwner('sim-a');
+  const fence = managedBindingFence({
+    requesterId: 'requester-a',
+    requestGeneration: 1,
+    identityIncarnationId: 'incarnation-a',
+  });
+  const exactly = (owner = managed): DeviceBindingIntent => ({
+    kind: 'exact-owner',
+    owner,
+    fence,
+  });
+
+  function managedGateway(providerMode?: RuntimeProviderMode) {
+    const family = localFamilyRuntimeFixture({ family: 'apple', device, providerMode });
+    const runtimeGateway = createComposedPlatformRuntimeGateway({
+      modules: new Map([['apple', family.module]]),
+      loadHost: async () => ({}) as PlatformRuntimeHost,
+      managedOwners: [managed],
+    });
+    return { family, runtimeGateway };
+  }
+
+  test('binds an exact managed owner through the local family owner under an ordinary intent', async () => {
+    const { family, runtimeGateway } = managedGateway();
+
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(family.requests[0]?.intent).toEqual({ kind: 'ordinary' });
+    expect(binding.facts.operations.bootTarget).toMatchObject({
+      available: false,
+      reason: 'owner-capability-missing',
+    });
+    expect(binding.facts.operations.captureScreenshot).toEqual({ available: true });
+  });
+
+  test('leaves ordinary selection on the local family owner while a managed owner is registered', async () => {
+    const { runtimeGateway } = managedGateway();
+
+    const facts = await runtimeGateway.inspectFacts(device);
+    const binding = await runtimeGateway.bind({ device, intent: { kind: 'ordinary' }, scope });
+
+    expect(binding.owner).toEqual(localRuntimeOwner('apple'));
+    expect(facts.operations.bootTarget).toEqual({ available: true });
+    expect(binding.facts.operations.bootTarget).toEqual({ available: true });
+  });
+
+  test('a managed local owner is not registrable as an ordinary provider module', () => {
+    const managedModule = {
+      // @ts-expect-error `providerModules` pairs one ProviderDeviceRuntime with one
+      // provider-runtime owner, so ordinary selection cannot be handed a managed local owner.
+      owner: managedLocalRuntimeOwner('sim-a'),
+      loadRuntime: async () => runtimeOwner({ ref: managed }),
+    } satisfies PlatformRuntimeProviderModule;
+
+    expect(managedModule.owner).toEqual(managed);
+  });
+
+  test('rejects a managed binding whose local facts report a transport-composed device', async () => {
+    const { runtimeGateway } = managedGateway('transport-composed');
+
+    await expect(runtimeGateway.bind({ device, intent: exactly(), scope })).rejects.toMatchObject({
+      details: { reason: 'runtime-contract-invalid' },
+    });
+  });
+
+  // A second bind resolves only because the managed owner is composed once: a fresh wrapper per
+  // bind would register a second owner under the same key and be refused as a duplicate.
+  test('reuses one managed owner per registered instance and refuses unregistered ones', async () => {
+    const { family, runtimeGateway } = managedGateway();
+
+    const first = await runtimeGateway.bind({ device, intent: exactly(), scope });
+    const second = await runtimeGateway.bind({ device, intent: exactly(), scope });
+
+    expect(second.owner).toEqual(first.owner);
+    expect(family.calls.loads).toBe(1);
+    await first[Symbol.asyncDispose]();
+    expect(family.calls.disposals).toBe(1);
+    await expect(
+      runtimeGateway.bind({ device, intent: exactly(managedLocalRuntimeOwner('sim-b')), scope }),
+    ).rejects.toMatchObject({
+      code: 'UNSUPPORTED_OPERATION',
+      details: { reason: 'owner-unavailable', owner: 'managed:["sim-b"]' },
+    });
+  });
+
+  test('rejects duplicate managed owner registrations', () => {
+    expect(() =>
+      createComposedPlatformRuntimeGateway({
+        modules: new Map(),
+        loadHost: async () => ({}) as PlatformRuntimeHost,
+        managedOwners: [managed, managedLocalRuntimeOwner('sim-a')],
+      }),
+    ).toThrow('Duplicate platform runtime owner');
+  });
 });

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -30,6 +30,10 @@ import {
   type Platform,
 } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import {
+  createManagedLocalRuntimeOwner,
+  type ManagedLocalRuntimeOwnerRef,
+} from './platform-runtime-managed-owner.ts';
 
 export type PlatformRuntimeProviderRegistration = Readonly<{
   runtime: ProviderDeviceRuntime;
@@ -41,6 +45,12 @@ export function createComposedPlatformRuntimeGateway(options: {
   loadHost: () => Promise<PlatformRuntimeHost>;
   providerRuntimes?: readonly ProviderDeviceRuntime[];
   providerModules?: readonly PlatformRuntimeProviderRegistration[];
+  /**
+   * Managed local owners are registered here and nowhere else. The list has no ordinary reader:
+   * `selectOrdinaryProvider`, `inspectFacts` and the ordinary `bind` arm never see it, so exact
+   * selection is the only way to reach one.
+   */
+  managedOwners?: readonly ManagedLocalRuntimeOwnerRef[];
 }): DeviceRuntimeGateway<PlatformRuntimeOperations> {
   const providersByOwner = new Map<string, PlatformRuntimeProviderRegistration>();
   const modulesByRuntime = new Map<ProviderDeviceRuntime, PlatformRuntimeProviderModule>();
@@ -59,8 +69,17 @@ export function createComposedPlatformRuntimeGateway(options: {
     providersByOwner.set(key, registration);
     modulesByRuntime.set(runtime, module);
   }
+  const managedByOwner = new Map<string, ManagedLocalRuntimeOwnerRef>();
+  for (const ref of options.managedOwners ?? []) {
+    const key = runtimeOwnerKey(ref);
+    if (managedByOwner.has(key)) {
+      throw runtimeContractError(`Duplicate platform runtime owner: ${key}`);
+    }
+    managedByOwner.set(key, ref);
+  }
   const localLoads = new Map<Platform, Promise<PlatformRuntimeOwner>>();
   const providerLoads = new Map<PlatformRuntimeProviderModule, Promise<PlatformRuntimeOwner>>();
+  const managedLoads = new Map<string, PlatformRuntimeOwner>();
   const loadedOwners = new Map<string, PlatformRuntimeOwner>();
   let hostLoad: Promise<PlatformRuntimeHost> | undefined;
   const loadHost = async () => {
@@ -151,6 +170,18 @@ export function createComposedPlatformRuntimeGateway(options: {
       throw error;
     }
   };
+  // A managed owner is composed from a registered ref and this gateway's own local loader, so
+  // there is nothing to load lazily except the family owner it delegates to.
+  const loadManaged = async (ref: ManagedLocalRuntimeOwnerRef) => {
+    const key = runtimeOwnerKey(ref);
+    const registered = managedByOwner.get(key);
+    if (!registered) throw ownerUnavailable(ref);
+    const existing = managedLoads.get(key);
+    if (existing) return existing;
+    const owner = registerOwner(createManagedLocalRuntimeOwner({ owner: registered, loadLocal }));
+    managedLoads.set(key, owner);
+    return owner;
+  };
 
   return Object.freeze({
     applicationLifecycle,
@@ -171,6 +202,7 @@ export function createComposedPlatformRuntimeGateway(options: {
           providersByOwner,
           loadProvider,
           loadLocal,
+          loadManaged,
         );
         return await bindAndValidate(selected, request);
       }
@@ -191,6 +223,7 @@ export function createComposedPlatformRuntimeGateway(options: {
       loadedOwners.clear();
       localLoads.clear();
       providerLoads.clear();
+      managedLoads.clear();
     },
   });
 }
@@ -292,6 +325,7 @@ async function selectExactOwner(
   providersByOwner: ReadonlyMap<string, PlatformRuntimeProviderRegistration>,
   loadProvider: (module: PlatformRuntimeProviderModule) => Promise<PlatformRuntimeOwner>,
   loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>,
+  loadManaged: (ref: ManagedLocalRuntimeOwnerRef) => Promise<PlatformRuntimeOwner>,
 ): Promise<PlatformRuntimeOwner> {
   switch (ref.kind) {
     case 'local-family': {
@@ -300,8 +334,7 @@ async function selectExactOwner(
       throw ownerUnavailable(ref);
     }
     case 'managed-local':
-      // No managed owner is registered yet; U3 fills this arm with the exact-only registry.
-      throw ownerUnavailable(ref);
+      return await loadManaged(ref);
     case 'provider-runtime': {
       const registration = providersByOwner.get(runtimeOwnerKey(ref));
       if (registration) return await loadProvider(registration.module);

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -65,7 +65,7 @@ describe('managed local runtime owner', () => {
     const binding = await owner.bind({ device, intent: exactly(), scope });
 
     // A cell dropped from this list would silently stop being covered by the assertions below.
-    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(22);
+    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(27);
     for (const key of MANAGED_WITHHELD_OPERATIONS) {
       expect(binding.facts.operations[key]).toMatchObject({
         available: false,

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -15,6 +15,7 @@ import {
   shutdownTargetUse,
   type PlatformRuntimeHost,
 } from '@agent-device/contracts/platform-runtime-operations';
+import { deployAppUse } from '@agent-device/contracts/app-deployment-runtime-plan';
 import { describe, expect, test } from 'vitest';
 import { createManagedLocalRuntimeOwner } from './platform-runtime-managed-owner.ts';
 import {
@@ -64,7 +65,7 @@ describe('managed local runtime owner', () => {
     const binding = await owner.bind({ device, intent: exactly(), scope });
 
     // A cell dropped from this list would silently stop being covered by the assertions below.
-    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(20);
+    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(22);
     for (const key of MANAGED_WITHHELD_OPERATIONS) {
       expect(binding.facts.operations[key]).toMatchObject({
         available: false,
@@ -90,6 +91,8 @@ describe('managed local runtime owner', () => {
     expect(thrownBy(() => narrowDeviceBinding(binding, appStateUse))).toMatchObject(refused);
     expect(thrownBy(() => narrowDeviceBinding(binding, bootTargetUse))).toMatchObject(refused);
     expect(thrownBy(() => narrowDeviceBinding(binding, shutdownTargetUse))).toMatchObject(refused);
+    // `deployAppUse` requires `deployApp` alone, so only the cell itself can refuse `install`.
+    expect(thrownBy(() => narrowDeviceBinding(binding, deployAppUse))).toMatchObject(refused);
   });
 
   test('rewrites the owner, delegates under an ordinary intent, and forwards disposal', async () => {

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -1,0 +1,159 @@
+import {
+  type DeviceBindingIntent,
+  type ResourceOwnershipFence,
+  type RuntimeOwnerRef,
+  type RuntimeProviderMode,
+  localRuntimeOwner,
+  managedBindingFence,
+  managedLocalRuntimeOwner,
+  narrowDeviceBinding,
+} from '@agent-device/contracts/platform-runtime';
+import {
+  appStateUse,
+  appsRuntimeUse,
+  bootTargetUse,
+  shutdownTargetUse,
+  type PlatformRuntimeHost,
+} from '@agent-device/contracts/platform-runtime-operations';
+import { describe, expect, test } from 'vitest';
+import { createManagedLocalRuntimeOwner } from './platform-runtime-managed-owner.ts';
+import {
+  gatewayFixtureDevice as device,
+  gatewayFixtureScope as scope,
+  localFamilyRuntimeFixture,
+  MANAGED_RETAINED_OPERATION,
+  MANAGED_WITHHELD_OPERATIONS,
+} from './platform-runtime-gateway.fixtures.ts';
+
+const managed = managedLocalRuntimeOwner('sim-a');
+const fence = managedBindingFence({
+  requesterId: 'requester-a',
+  requestGeneration: 1,
+  identityIncarnationId: 'incarnation-a',
+});
+
+function exactly(
+  owner: RuntimeOwnerRef = managed,
+  withFence: ResourceOwnershipFence = fence,
+): DeviceBindingIntent {
+  return { kind: 'exact-owner', owner, fence: withFence };
+}
+
+function managedOwnerFixture(providerMode?: RuntimeProviderMode) {
+  const family = localFamilyRuntimeFixture({ family: 'apple', device, providerMode });
+  const owner = createManagedLocalRuntimeOwner({
+    owner: managed,
+    loadLocal: async () => await family.module.loadRuntime({} as PlatformRuntimeHost),
+  });
+  return { family, owner };
+}
+
+function thrownBy(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected the runtime use to be refused');
+}
+
+describe('managed local runtime owner', () => {
+  test('withholds every lifecycle-bearing and durable capture cell and keeps the rest', async () => {
+    const { owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    // A cell dropped from this list would silently stop being covered by the assertions below.
+    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(20);
+    for (const key of MANAGED_WITHHELD_OPERATIONS) {
+      expect(binding.facts.operations[key]).toMatchObject({
+        available: false,
+        reason: 'owner-capability-missing',
+      });
+      expect(binding.operations[key]).toBeUndefined();
+    }
+    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+    expect(binding.operations[MANAGED_RETAINED_OPERATION]).toBeTypeOf('function');
+  });
+
+  // The exclusion covers binding cells only. Pre-binding readiness still boots a device through
+  // direct platform tooling before any binding exists; moving it under the binding is its own unit.
+  test('refuses every runtime use that needs a withheld cell', async () => {
+    const { owner } = managedOwnerFixture();
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+    const refused = {
+      code: 'UNSUPPORTED_OPERATION',
+      details: { reason: 'owner-capability-missing' },
+    };
+
+    expect(thrownBy(() => narrowDeviceBinding(binding, appsRuntimeUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, appStateUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, bootTargetUse))).toMatchObject(refused);
+    expect(thrownBy(() => narrowDeviceBinding(binding, shutdownTargetUse))).toMatchObject(refused);
+  });
+
+  test('rewrites the owner, delegates under an ordinary intent, and forwards disposal', async () => {
+    const { family, owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    expect(binding.owner).toEqual(managed);
+    expect(binding.device).toEqual(device);
+    expect(family.requests).toHaveLength(1);
+    expect(family.requests[0]?.intent).toEqual({ kind: 'ordinary' });
+    expect(family.requests[0]?.scope).toBe(scope);
+    await binding[Symbol.asyncDispose]();
+    expect(family.calls.disposals).toBe(1);
+  });
+
+  test('binds only under an exact-owner intent that names this owner', async () => {
+    const { family, owner } = managedOwnerFixture();
+    const refusal = {
+      code: 'COMMAND_FAILED',
+      details: { reason: 'runtime-contract-invalid' },
+    };
+
+    await expect(owner.bind({ device, intent: { kind: 'ordinary' }, scope })).rejects.toMatchObject(
+      refusal,
+    );
+    await expect(
+      owner.bind({ device, intent: exactly(localRuntimeOwner('apple')), scope }),
+    ).rejects.toMatchObject(refusal);
+    await expect(
+      owner.bind({ device, intent: exactly(managedLocalRuntimeOwner('sim-b')), scope }),
+    ).rejects.toMatchObject(refusal);
+    expect(family.requests).toEqual([]);
+  });
+
+  test('does not read the fence: what a managed fence proves belongs to the claim gate', async () => {
+    const { owner } = managedOwnerFixture();
+
+    const binding = await owner.bind({
+      device,
+      intent: exactly(managed, { token: 'an-opaque-capture-token', generation: 7 }),
+      scope,
+    });
+
+    expect(binding.owner).toEqual(managed);
+  });
+
+  test('never claims a device and projects the same withholding onto inspected facts', async () => {
+    const { owner } = managedOwnerFixture();
+
+    expect(owner.ownsDevice(device)).toBe(false);
+    const facts = await owner.inspectFacts(device);
+    expect(facts.operations.bootTarget).toMatchObject({
+      available: false,
+      reason: 'owner-capability-missing',
+    });
+    expect(facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+  });
+
+  test('reports the family owner provider mode it was given, unlaundered', async () => {
+    const { owner } = managedOwnerFixture('transport-composed');
+
+    const binding = await owner.bind({ device, intent: exactly(), scope });
+
+    expect(binding.facts.device.providerMode).toBe('transport-composed');
+  });
+});

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -25,8 +25,18 @@ type ManagedOperationKey = RuntimeOperationKey<PlatformRuntimeOperations>;
  */
 const WITHHELD_MANAGED_OPERATIONS = [
   {
+    // The two deployment cells belong here for the same reason as the explicit boot cells: both
+    // family deployment runtimes ensure device readiness first, and `deployAppUse` requires
+    // `deployApp` alone, so nothing else would have caught `install` on a managed binding.
     hint: 'Managed-device lifecycle belongs to the allocator.',
-    keys: ['ensureReady', 'bootTarget', 'bootTargetHeadless', 'shutdownTarget'],
+    keys: [
+      'ensureReady',
+      'bootTarget',
+      'bootTargetHeadless',
+      'shutdownTarget',
+      'deployApp',
+      'deployMaterializedApp',
+    ],
   },
   {
     // These four are lifecycle-bearing even though they read as application operations: open
@@ -65,7 +75,12 @@ const WITHHELD_MANAGED_OPERATIONS = [
 /**
  * The exact-only runtime owner for one allocator instance. It owns no mechanics of its own: it
  * binds the device's local family owner, republishes that binding under the managed owner, and
- * withholds every cell whose execution would take device lifecycle away from the allocator.
+ * withholds the cells whose declared work is device lifecycle.
+ *
+ * Withholding cells is not a complete lifecycle exclusion and does not claim to be. Several
+ * retained Apple cells — screenshot capture, settings, clipboard, application launch — boot the
+ * simulator lazily inside the family runtime, where cell selection cannot reach; that is the same
+ * class as the pre-binding readiness path, and closing it is a family-runtime change.
  *
  * It delegates with an ordinary intent because a family owner refuses an exact-owner intent that
  * names anyone but itself. The managed intent's fence is not read here: the device-claim gate owns

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -70,6 +70,16 @@ const WITHHELD_MANAGED_OPERATIONS = [
       'perfNativeCaptureCleanup',
     ],
   },
+  {
+    // Below cell-selection granularity, the Apple family runtime can boot the simulator lazily:
+    // screenshot capture retries through a boot on a shutdown failure, and settings, clipboard and
+    // application launch each resolve a local interactor the same way. Closing that path is a
+    // family-runtime change (the same class as the pre-binding readiness bypass named in "Named
+    // out of scope" below); until then, a managed binding withholds these cells outright rather
+    // than leave an allocator-owned device open to an implicit boot.
+    hint: 'Managed-device lifecycle belongs to the allocator; this cell can lazily boot the device.',
+    keys: ['captureScreenshot', 'setSetting', 'readClipboard', 'writeClipboard', 'openApplication'],
+  },
 ] as const satisfies readonly Readonly<{ hint: string; keys: readonly ManagedOperationKey[] }>[];
 
 /**
@@ -77,10 +87,13 @@ const WITHHELD_MANAGED_OPERATIONS = [
  * binds the device's local family owner, republishes that binding under the managed owner, and
  * withholds the cells whose declared work is device lifecycle.
  *
- * Withholding cells is not a complete lifecycle exclusion and does not claim to be. Several
- * retained Apple cells — screenshot capture, settings, clipboard, application launch — boot the
- * simulator lazily inside the family runtime, where cell selection cannot reach; that is the same
- * class as the pre-binding readiness path, and closing it is a family-runtime change.
+ * Withholding cells is not a complete lifecycle exclusion and does not claim to be. Screenshot
+ * capture, settings, clipboard and application launch are withheld here even though their declared
+ * work is not device lifecycle, because their Apple family-runtime implementations can boot the
+ * simulator lazily below cell-selection granularity. Pre-binding readiness is the same class of
+ * gap, one level up: `session-device-resolution` boots a device through direct simctl/adb before
+ * any binding exists, gated only by provider ownership. Closing both is a family-runtime and
+ * daemon change tracked as a follow-up, not attempted here.
  *
  * It delegates with an ordinary intent because a family owner refuses an exact-owner intent that
  * names anyone but itself. The managed intent's fence is not read here: the device-claim gate owns

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -1,0 +1,150 @@
+import {
+  type DeviceBinding,
+  type RuntimeFacts,
+  type RuntimeOperationFact,
+  type RuntimeOperationKey,
+  type RuntimeOperationUnavailability,
+  type RuntimeOwnerRef,
+  sameRuntimeOwner,
+} from '@agent-device/contracts/platform-runtime';
+import type {
+  PlatformRuntimeOperations,
+  PlatformRuntimeOwner,
+} from '@agent-device/contracts/platform-runtime-operations';
+import type { Platform } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+
+export type ManagedLocalRuntimeOwnerRef = Extract<RuntimeOwnerRef, { kind: 'managed-local' }>;
+
+type ManagedOperationKey = RuntimeOperationKey<PlatformRuntimeOperations>;
+
+/**
+ * What a managed local owner withholds, grouped by the mechanics that make it impossible rather
+ * than by catalog family: an operation is here because executing it would boot, shut down, or
+ * durably own the allocator's device.
+ */
+const WITHHELD_MANAGED_OPERATIONS = [
+  {
+    hint: 'Managed-device lifecycle belongs to the allocator.',
+    keys: ['ensureReady', 'bootTarget', 'bootTargetHeadless', 'shutdownTarget'],
+  },
+  {
+    // These four are lifecycle-bearing even though they read as application operations: open
+    // preparation and Apple runner preparation boot the target unconditionally, and the close
+    // pair carries the shutdown half of the same sequence.
+    hint: 'Application open and close take device readiness and shutdown steps the allocator owns.',
+    keys: [
+      'prepareApplicationOpen',
+      'prepareAppleRunner',
+      'closeApplication',
+      'finalizeApplicationClose',
+    ],
+  },
+  {
+    // A durable capture is adopted by comparing the envelope's owner with the binding's owner, and
+    // the family runtime stamps envelopes with its own local owner — so a capture started under a
+    // managed binding could never be reattached or cleaned up under it.
+    hint: 'Durable captures are not adoptable under a managed local owner yet.',
+    keys: [
+      'appLogStart',
+      'appLogReattach',
+      'appLogCleanup',
+      'screenRecordingStart',
+      'screenRecordingReattach',
+      'screenRecordingCleanup',
+      'audioProbeStart',
+      'audioProbeReattach',
+      'audioProbeCleanup',
+      'perfNativeCaptureStart',
+      'perfNativeCaptureReattach',
+      'perfNativeCaptureCleanup',
+    ],
+  },
+] as const satisfies readonly Readonly<{ hint: string; keys: readonly ManagedOperationKey[] }>[];
+
+/**
+ * The exact-only runtime owner for one allocator instance. It owns no mechanics of its own: it
+ * binds the device's local family owner, republishes that binding under the managed owner, and
+ * withholds every cell whose execution would take device lifecycle away from the allocator.
+ *
+ * It delegates with an ordinary intent because a family owner refuses an exact-owner intent that
+ * names anyone but itself. The managed intent's fence is not read here: the device-claim gate owns
+ * what a managed binding fence proves.
+ */
+export function createManagedLocalRuntimeOwner(params: {
+  owner: ManagedLocalRuntimeOwnerRef;
+  loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>;
+}): PlatformRuntimeOwner {
+  return Object.freeze({
+    owner: params.owner,
+    // Selection is exact-only by construction: ordinary selection never consults this owner, and
+    // claiming a device here would be the one way it could.
+    ownsDevice: () => false,
+    inspectFacts: async (device) => {
+      const local = await params.loadLocal(device.platform);
+      return projectManagedFacts(await local.inspectFacts(device));
+    },
+    bind: async (request) => {
+      if (
+        request.intent.kind !== 'exact-owner' ||
+        !sameRuntimeOwner(request.intent.owner, params.owner)
+      ) {
+        throw new AppError(
+          'COMMAND_FAILED',
+          'A managed local owner binds only under an exact-owner intent naming it',
+          { reason: 'runtime-contract-invalid' },
+        );
+      }
+      const local = await params.loadLocal(request.device.platform);
+      const binding = await local.bind({
+        device: request.device,
+        intent: { kind: 'ordinary' },
+        scope: request.scope,
+      });
+      const facts = projectManagedFacts(binding.facts);
+      return Object.freeze({
+        device: binding.device,
+        owner: params.owner,
+        facts,
+        operations: admittedOperations(binding.operations, facts),
+        [Symbol.asyncDispose]: async () => await binding[Symbol.asyncDispose](),
+      });
+    },
+    // The delegated family owner is registered with the gateway in its own right, which is what
+    // shuts it down; this wrapper holds nothing else.
+    shutdown: async () => undefined,
+  });
+}
+
+function projectManagedFacts(
+  facts: RuntimeFacts<PlatformRuntimeOperations>,
+): RuntimeFacts<PlatformRuntimeOperations> {
+  const withheld: Partial<Record<ManagedOperationKey, RuntimeOperationFact>> = {};
+  for (const group of WITHHELD_MANAGED_OPERATIONS) {
+    const fact: RuntimeOperationUnavailability = Object.freeze({
+      available: false,
+      reason: 'owner-capability-missing',
+      hint: group.hint,
+    });
+    for (const key of group.keys) withheld[key] = fact;
+  }
+  // The device shape is the family owner's answer, provider mode included: a managed owner
+  // executes on a local device and may not launder a transport-composed one into a local claim.
+  return Object.freeze({
+    device: facts.device,
+    operations: Object.freeze({ ...facts.operations, ...withheld }),
+  });
+}
+
+/** Facts are the only admission authority, so an operation cannot outlive its own fact. */
+function admittedOperations(
+  operations: DeviceBinding<PlatformRuntimeOperations>['operations'],
+  facts: RuntimeFacts<PlatformRuntimeOperations>,
+): DeviceBinding<PlatformRuntimeOperations>['operations'] {
+  const admitted: Record<string, unknown> = {};
+  for (const [key, operation] of Object.entries(operations)) {
+    const fact: RuntimeOperationFact | undefined = facts.operations[key as ManagedOperationKey];
+    if (fact?.available === true) admitted[key] = operation;
+  }
+  return Object.freeze(admitted) as DeviceBinding<PlatformRuntimeOperations>['operations'];
+}


### PR DESCRIPTION
## Summary

ADR 0021 foundations, unit 3. Stacked on #2258 (`adr0021/u1-owner-kind`); U4 stacks on this.

Unit 1 added the `managed-local` owner kind and left the gateway's exact-owner arm for it failing
closed. This unit gives that arm a registry, the owner it selects, and agent-device's own allocator
port. **Nothing in production registers a managed owner or calls an allocator**, so every arm here
is reached from tests only; the point of the unit is that the arms exist and fail closed.

What changes for command authors and platform behavior:

- A new gateway option, `managedOwners`, is the only place a managed local owner can be registered,
  and only the `managed-local` arm of `selectExactOwner` reads it. Ordinary selection cannot reach
  a managed owner by construction rather than by a check.
- A managed binding is a local family binding republished under the managed owner, with
  twenty-seven cells withheld as `owner-capability-missing` and the operations filtered by those
  facts (R66). A command author sees the same `narrowDeviceBinding` refusal any unsupported cell
  produces.
- The allocator port is a types-only contracts subpath with a scripted fake. No socket code, no
  allocator package dependency, no production call site.

12 files touched, no scope growth beyond the runtime-gateway/contracts surface the unit names;
`src/platform-runtime.ts` is deliberately not edited (no production producer of managed owners
exists yet, so `createPlatformRuntimeGateway` gains no pass-through).

## The exact-only registry

`createComposedPlatformRuntimeGateway` gains a `managedOwners` list that only the `managed-local`
arm of `selectExactOwner` reads. `selectOrdinaryProvider`, `inspectFacts` and the ordinary `bind`
arm never see it, and `providerModules` pairs one `ProviderDeviceRuntime` with one
`provider-runtime` owner — so ordinary selection cannot be handed a managed owner. A
`@ts-expect-error` pins that: a managed ref is not assignable to a provider module's owner. A
duplicate instance is refused at composition, an unregistered instance still answers
`owner-unavailable`, and a registered one is composed once.

## The wrapper

`src/platform-runtime-managed-owner.ts` (root zone, no platform imports) binds only under an
exact-owner intent naming itself, loads the device's own family owner through the gateway's loader,
delegates with `{ kind: 'ordinary' }` — a family owner refuses a foreign exact owner — and
republishes the binding under the managed owner. It does not decode the fence: what a managed
binding fence proves is the device-claim gate's business, and a second reader would be a second
answer. `ownsDevice` returns false.

Twenty-seven cells are withheld, enumerated by mechanics rather than by catalog group:

- device lifecycle: `ensureReady`, `bootTarget`, `bootTargetHeadless`, `shutdownTarget`, plus
  `deployApp` and `deployMaterializedApp` — both family deployment runtimes ensure readiness before
  installing, and `deployAppUse` requires `deployApp` alone, so nothing else would have refused it;
- application cells that boot or shut the device down: `prepareApplicationOpen`,
  `prepareAppleRunner`, `closeApplication`, `finalizeApplicationClose`;
- the twelve durable-capture cells (app log, screen recording, audio probe, native perf capture),
  which a managed binding could never reattach because the family runtime stamps envelopes with its
  own local owner;
- `captureScreenshot`, `setSetting`, `readClipboard`, `writeClipboard`, `openApplication` — none is
  declared device lifecycle, but each Apple family-runtime implementation can boot the simulator
  lazily below cell-selection granularity (screenshot retries through a boot on a shutdown failure;
  the other three resolve a local interactor the same lazy way), which is exactly the implicit-boot
  fallback ADR-0021 §3 rules out for a managed device.

**A managed session cannot be opened in the foundations.** A managed binding loses every command
whose runtime use requires a withheld cell: `install` (and push-notification delivery), `apps` and
`app-state`, `device boot` and `device shutdown`, `open` and `close`, and the durable capture starts
(`logs start`, `record start`, audio probe capture, native perf capture). That is the intended shape
of the foundations — the allocator owns the device's lifecycle — not a gap to work around in daemon
code.

## Named out of scope

- **Withholding cells is not a complete lifecycle exclusion, and the code says so.** The four
  lazily-booting Apple cells named above are now withheld rather than left as a caveat — an earlier
  revision of this PR retained them and disclosed the gap instead of closing it; review caught that
  the disclosure preserved the exact bypass ADR-0021 §3 rules out, so the fix withholds them.
- **Pre-binding readiness is the same class, at the daemon level, and stays open.**
  `session-device-resolution` → `device-ready` → `platform-runtime-device-ready` boots a device
  through direct simctl/adb before any binding exists, gated only by provider ownership — below
  where a managed binding's cell withholding can reach at all. The exclusion above covers binding
  cells only, and the exclusion test says so.
- Closing the daemon-level gap is its own follow-up: pre-binding readiness moves under the binding
  once a managed owner is actually reachable from production (no unit before the allocation-flow
  unit can exercise it end to end).
- **Durable captures stay unavailable** until family runtimes stamp the outward owner on their
  envelopes (adoption compares the envelope's owner key with the binding's). Same family-runtime
  change; not attempted here.
- **Delegating with an ordinary intent** means local exact-owner recovery semantics never apply
  under a managed binding — consistent with durable captures being unavailable. The delegation test
  pins the choice, so forwarding a local-family exact intent later is a deliberate change.

## The allocator port

`@agent-device/contracts/managed-device-allocation` is agent-device's own interface to a
managed-device allocator: lease request, lookup, supersession, cancellation, renewal, release,
activation confirmation, identity status, and removal acknowledgement. Types only, with no
dependency on any allocator package and no socket code. The member and field names match the
allocator's published contract (`requestGeneration`, `identityIncarnationId`,
`expectedRequestGeneration`, `confirmLeaseActivation`, `getManagedIdentityStatus`,
`acknowledgeManagedIdentityRemoval`, `admission: 'fail-fast'`,
`activation: 'direct' | 'external-fence'`, `LEASE_ENVIRONMENT_INVALID { platform, key }`, and the
`{ platform: 'ios', deviceSetPath } | { platform: 'android', adbServerPort }` projection) so the two
sides cannot drift.

Shaping notes:

- Failures that would otherwise be invented error codes — a busy requester lane, an unknown attempt
  — are modelled where the contract already puts them: a refusal reason and a request state on
  `LeaseRequestStatus`. Protocol-version skew belongs to the unit that opens the socket.
- `ManagedLeaseEnvironment` and `LeaseEnvironmentError` are declared but have no reader yet. The
  reader, and the mapping from agent-device's own device families onto the port's
  `'ios' | 'android'` vocabulary, land with the allocation-flow unit that first turns a grant into
  a `DeviceInfo`. Both carry the repo's one-line `fallow-ignore-next-line unused-type` idiom rather
  than a baseline entry.
- The port's only implementation is a scripted fake under `src/__tests__/test-utils/*.fixtures.ts`.

## Pins moved

- Three-place pin for the new contracts subpath: `packages/contracts/package.json#exports`,
  `CONTRACT_EXPORTS`, and a `FACADE_BUDGETS` row of 1 (types only, so the entry evaluates itself).
- `HUB_BUDGETS['src/platform-runtime.ts']` 47 → 48, measured: the composed gateway now composes the
  wrapper, whose own value imports (the owner contract, kernel errors) were already in that closure.
- CONTEXT.md: **Managed device allocator port**.

## Validation

Evidence gathered at `e2978a6637` (rebased onto #2258's blocking fixes; includes the withhold-cells
review fix below). **Published and reported** — CI on the head is the authority.

`pnpm check:affected --run` fail-opens to the full 57-check set (the diff touches tooling files), and
the whole set passed at this commit: format, lint, typecheck, layering, di-seams,
`check:fallow --base origin/main` (clean over 34 changed files), build, package, integration-node,
macOS command coverage, vitest-related, unit + smoke, provider-integration, integration-progress,
replay-compat, daemon-wire-compat, production-exports, bundle-owner-files, command-docs,
agent-guidance, xctest-selection, maestro-conformance, and the gate/mutation/coverage model suites.
The GitHub-authoritative lanes (device replay, Swift/Android helper builds, coverage, mutation, fuzz)
are skipped locally by design.

Two earlier full runs on this branch each aborted at `vitest-related` on a *different* test timing
out at the 5 s vitest limit under parallel load —
`test/integration/provider-scenarios/ios-lifecycle.test.ts` (4.9 s in isolation) and
`src/daemon/__tests__/gesture-admission-parity.test.ts` (3.3 s in isolation, already flagged by the
slow-test gate at a 2.5 s budget). Both pass in isolation, both are timeouts rather than assertion
failures, and neither is on a path this change touches. `check:affected` aborts at the first failed
lane, so those two runs did not reach the lanes after `vitest-related`; the clean third run did, and
CI on the head is what settles it.

Regression tests, each with the revert that makes it fail (all executed as mutations against the
real code; every one went red):

- the withheld set — dropping `deployApp`/`deployMaterializedApp`, `prepareAppleRunner`, the
  durable-capture cells, or the five lazily-booting cells (`captureScreenshot`, `setSetting`,
  `readClipboard`, `writeClipboard`, `openApplication`) from the wrapper's list; returning
  `binding.operations` unfiltered;
- `narrowDeviceBinding` refusals for `appsRuntimeUse`, `appStateUse`, `bootTargetUse`,
  `shutdownTargetUse` and `deployAppUse`;
- the wrapper — forwarding the managed exact intent to the family owner (the family fixture throws
  on a foreign exact owner), dropping the owner rewrite (`bindAndValidate` then rejects), accepting
  an ordinary or foreign intent, or not forwarding disposal;
- the gateway — restoring the fail-closed `managed-local` arm, dropping the composition-time
  duplicate check, or composing a fresh wrapper per bind (the second registration is then refused);
- `providerModeMatchesOwner`'s `managed-local` arm accepting `transport-composed` (fixed on #2258
  and rebased in here): `accepts a managed binding whose local facts report a transport-composed
  device` binds through the gateway with a `transport-composed` local family device and asserts
  success — replacing an earlier version of this test that asserted the opposite (rejection), which
  is what review caught: the arm rejected the mode the PR's own known-gap note said it should accept;
- the scripted fake — consuming steps from one shared queue, or recording no calls.

No device-facing behavior changes, so no simulator/emulator evidence is owed: nothing in production
can select a managed owner yet.

