### PR TITLE
test(android-e2e): make an alert-dismiss failure self-explaining

### DIFF
--- a/packages/platform-android/src/__tests__/alert-detection.test.ts
+++ b/packages/platform-android/src/__tests__/alert-detection.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { chooseAndroidAlertButton, findAndroidAlertCandidate } from '../alert-detection.ts';
-import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import { button, node, text } from './alert-fixtures.ts';
 
 test('chooseAndroidAlertButton prefers platform ids over ambiguous labels', () => {
   const candidate = findAndroidAlertCandidate([
@@ -58,41 +58,3 @@ test('chooseAndroidAlertButton accepts a single neutral button', () => {
 
   assert.equal(chooseAndroidAlertButton(candidate?.buttons ?? [], 'accept')?.label, 'Later');
 });
-
-function node(
-  index: number,
-  type: string,
-  overrides: Partial<RawSnapshotNode> = {},
-): RawSnapshotNode {
-  return {
-    index,
-    parentIndex: index === 0 ? undefined : 0,
-    type,
-    bundleId: 'com.example.app',
-    ...overrides,
-  };
-}
-
-function text(index: number, label: string, identifier: string, parentIndex = 0): RawSnapshotNode {
-  return node(index, 'android.widget.TextView', { label, identifier, parentIndex });
-}
-
-function button(
-  index: number,
-  label: string,
-  identifier: string,
-  origin: { x: number; y: number },
-  permission = false,
-  parentIndex = 0,
-): RawSnapshotNode {
-  const packageName = permission ? 'com.google.android.permissioncontroller' : 'com.example.app';
-  const id = permission ? `com.android.permissioncontroller:id/${identifier}` : identifier;
-  return node(index, 'android.widget.Button', {
-    label,
-    identifier: id,
-    bundleId: packageName,
-    parentIndex,
-    rect: { ...origin, width: 128, height: 52 },
-    hittable: true,
-  });
-}

--- a/packages/platform-android/src/__tests__/alert-fixtures.ts
+++ b/packages/platform-android/src/__tests__/alert-fixtures.ts
@@ -1,0 +1,44 @@
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+
+export function node(
+  index: number,
+  type: string,
+  overrides: Partial<RawSnapshotNode> = {},
+): RawSnapshotNode {
+  return {
+    index,
+    parentIndex: index === 0 ? undefined : 0,
+    type,
+    bundleId: 'com.example.app',
+    ...overrides,
+  };
+}
+
+export function text(
+  index: number,
+  label: string,
+  identifier: string,
+  parentIndex = 0,
+): RawSnapshotNode {
+  return node(index, 'android.widget.TextView', { label, identifier, parentIndex });
+}
+
+export function button(
+  index: number,
+  label: string,
+  identifier: string,
+  origin: { x: number; y: number },
+  permission = false,
+  parentIndex = 0,
+): RawSnapshotNode {
+  const packageName = permission ? 'com.google.android.permissioncontroller' : 'com.example.app';
+  const id = permission ? `com.android.permissioncontroller:id/${identifier}` : identifier;
+  return node(index, 'android.widget.Button', {
+    label,
+    identifier: id,
+    bundleId: packageName,
+    parentIndex,
+    rect: { ...origin, width: 128, height: 52 },
+    hittable: true,
+  });
+}

--- a/packages/platform-android/src/__tests__/alert.test.ts
+++ b/packages/platform-android/src/__tests__/alert.test.ts
@@ -1,0 +1,114 @@
+import { test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+
+const runAndroidAdb = vi.fn(async (_device: DeviceInfo, _args: string[]) => ({
+  exitCode: 0,
+  stdout: '',
+  stderr: '',
+}));
+vi.mock('../adb.ts', () => ({ runAndroidAdb }));
+
+const { handleAndroidAlert } = await import('../alert.ts');
+
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel',
+  kind: 'emulator',
+  booted: true,
+};
+
+test('dismissing a button alert records the tapped button and its coordinates', async () => {
+  runAndroidAdb.mockClear();
+  const result = await handleAndroidAlert(device, 'dismiss', {
+    captureNodes: async () => [
+      node(0, 'android.app.AlertDialog'),
+      text(1, 'Automation confirmation', 'android:id/alertTitle'),
+      button(2, 'Cancel', 'android:id/button2', { x: 210, y: 612 }),
+    ],
+  });
+
+  assert.deepEqual(result, {
+    kind: 'alertHandled',
+    platform: 'android',
+    action: 'dismiss',
+    handled: true,
+    alert: {
+      title: 'Automation confirmation',
+      buttons: ['Cancel'],
+      platform: 'android',
+      source: 'native-dialog',
+      packageName: 'com.example.app',
+    },
+    button: 'Cancel',
+    coordinates: { x: 274, y: 638 },
+    message: 'Alert dismissed',
+  });
+  assert.deepEqual(runAndroidAdb.mock.calls[0]?.[1], ['shell', 'input', 'tap', '274', '638']);
+});
+
+test('accepting a button alert records the tapped button and its coordinates', async () => {
+  runAndroidAdb.mockClear();
+  const result = await handleAndroidAlert(device, 'accept', {
+    captureNodes: async () => [
+      node(0, 'android.app.AlertDialog'),
+      text(1, 'Automation confirmation', 'android:id/alertTitle'),
+      button(2, 'OK', 'android:id/button1', { x: 52, y: 612 }),
+    ],
+  });
+
+  assert.equal(result.kind, 'alertHandled');
+  assert.deepEqual('coordinates' in result ? result.coordinates : undefined, { x: 116, y: 638 });
+});
+
+test('a fallback Back dismissal (no matching button) carries no coordinates', async () => {
+  runAndroidAdb.mockClear();
+  const result = await handleAndroidAlert(device, 'dismiss', {
+    captureNodes: async () => [
+      node(0, 'android.app.AlertDialog'),
+      text(1, 'Automation confirmation', 'android:id/alertTitle'),
+    ],
+  });
+
+  assert.equal(result.kind, 'alertHandled');
+  assert.ok(result.kind === 'alertHandled' && !('coordinates' in result));
+  assert.equal(result.kind === 'alertHandled' ? result.button : undefined, 'Back');
+  assert.deepEqual(runAndroidAdb.mock.calls[0]?.[1], ['shell', 'input', 'keyevent', '4']);
+});
+
+function node(
+  index: number,
+  type: string,
+  overrides: Partial<RawSnapshotNode> = {},
+): RawSnapshotNode {
+  return {
+    index,
+    parentIndex: index === 0 ? undefined : 0,
+    type,
+    bundleId: 'com.example.app',
+    ...overrides,
+  };
+}
+
+function text(index: number, label: string, identifier: string, parentIndex = 0): RawSnapshotNode {
+  return node(index, 'android.widget.TextView', { label, identifier, parentIndex });
+}
+
+function button(
+  index: number,
+  label: string,
+  identifier: string,
+  origin: { x: number; y: number },
+  parentIndex = 0,
+): RawSnapshotNode {
+  return node(index, 'android.widget.Button', {
+    label,
+    identifier,
+    bundleId: 'com.example.app',
+    parentIndex,
+    rect: { ...origin, width: 128, height: 52 },
+    hittable: true,
+  });
+}

--- a/packages/platform-android/src/__tests__/alert.test.ts
+++ b/packages/platform-android/src/__tests__/alert.test.ts
@@ -1,7 +1,7 @@
 import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import type { RawSnapshotNode } from '@agent-device/kernel/snapshot';
+import { button, node, text } from './alert-fixtures.ts';
 
 const runAndroidAdb = vi.fn(async (_device: DeviceInfo, _args: string[]) => ({
   exitCode: 0,
@@ -77,38 +77,3 @@ test('a fallback Back dismissal (no matching button) carries no coordinates', as
   assert.equal(result.kind === 'alertHandled' ? result.button : undefined, 'Back');
   assert.deepEqual(runAndroidAdb.mock.calls[0]?.[1], ['shell', 'input', 'keyevent', '4']);
 });
-
-function node(
-  index: number,
-  type: string,
-  overrides: Partial<RawSnapshotNode> = {},
-): RawSnapshotNode {
-  return {
-    index,
-    parentIndex: index === 0 ? undefined : 0,
-    type,
-    bundleId: 'com.example.app',
-    ...overrides,
-  };
-}
-
-function text(index: number, label: string, identifier: string, parentIndex = 0): RawSnapshotNode {
-  return node(index, 'android.widget.TextView', { label, identifier, parentIndex });
-}
-
-function button(
-  index: number,
-  label: string,
-  identifier: string,
-  origin: { x: number; y: number },
-  parentIndex = 0,
-): RawSnapshotNode {
-  return node(index, 'android.widget.Button', {
-    label,
-    identifier,
-    bundleId: 'com.example.app',
-    parentIndex,
-    rect: { ...origin, width: 128, height: 52 },
-    hittable: true,
-  });
-}

--- a/packages/platform-android/src/alert.ts
+++ b/packages/platform-android/src/alert.ts
@@ -47,6 +47,7 @@ export type AndroidAlertResult =
       handled: true;
       alert: AndroidAlertInfo;
       button: string;
+      coordinates?: { x: number; y: number };
       message?: string;
     };
 
@@ -102,7 +103,10 @@ async function handleAndroidAlertAction(
   const button = chooseAndroidAlertButton(candidate.buttons, action);
   if (button) {
     await pressAndroid(device, button.x, button.y);
-    return buildAndroidAlertHandledResponse(action, candidate.alert, button.label);
+    return buildAndroidAlertHandledResponse(action, candidate.alert, button.label, {
+      x: button.x,
+      y: button.y,
+    });
   }
 
   if (action === 'dismiss') {
@@ -153,6 +157,7 @@ function buildAndroidAlertHandledResponse(
   action: 'accept' | 'dismiss',
   alert: AndroidAlertInfo,
   button: string,
+  coordinates?: { x: number; y: number },
 ): AndroidAlertResult {
   return {
     kind: 'alertHandled',
@@ -161,6 +166,7 @@ function buildAndroidAlertHandledResponse(
     handled: true,
     alert,
     button,
+    ...(coordinates ? { coordinates } : {}),
     ...successText(`Alert ${action}ed`),
   };
 }

--- a/test/integration/android-emulator-e2e/live-automation-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-automation-scenario.ts
@@ -164,10 +164,10 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
   const alert = await runStep(context, 'inspect Android native alert', ['alert', 'get']);
   assertJsonContains(alert, 'Automation confirmation', 'alert get should expose fixture dialog');
   await runStep(context, 'dismiss Android native alert', ['alert', 'dismiss']);
-  await assertWaitText(context, 'Alert result: cancelled');
+  await assertElementText(context, 'id="automation-alert-result"', 'Alert result: cancelled');
   await runStep(context, 'reopen Android native alert', ['click', 'id="automation-open-alert"']);
   await runStep(context, 'accept Android native alert', ['alert', 'accept']);
-  await assertWaitText(context, 'Alert result: accepted');
+  await assertElementText(context, 'id="automation-alert-result"', 'Alert result: accepted');
   verifyCommand(context, C.alert, 'alert wait/get/dismiss/accept produce fixture-visible results');
 
   await assertHomeAndRecentsRestoration(context);

--- a/test/integration/live-device-e2e/runtime.ts
+++ b/test/integration/live-device-e2e/runtime.ts
@@ -140,7 +140,7 @@ export function createLiveDeviceHarness<
       status: result.status,
       step,
     });
-    assertStepOutcome(context, step, fullArgs, result, failedAsExpected, stepOptions);
+    await assertStepOutcome(context, step, fullArgs, result, failedAsExpected, stepOptions);
     updateSessionState(context, args[0], result.status);
     return result;
   }
@@ -158,27 +158,51 @@ export function createLiveDeviceHarness<
     writeStepHistory(context);
   }
 
-  function assertStepOutcome(
+  async function assertStepOutcome(
     context: Context,
     step: string,
     fullArgs: string[],
     result: CliJsonResult,
     failedAsExpected: boolean,
     stepOptions: RunStepOptions,
-  ): void {
+  ): Promise<void> {
     const unexpectedFailure =
       result.status !== 0 && !failedAsExpected && stepOptions.allowFailure !== true;
     if (unexpectedFailure) {
+      const screenshotPath =
+        fullArgs[0] === 'wait' ? await captureWaitTimeoutScreenshot(context) : undefined;
       const message = [
         formatResultDebug(step, fullArgs, result),
         `scenario: ${context.currentScenario}`,
         `artifacts: ${context.artifactDir}`,
+        `screenshot: ${screenshotPath ?? '(capture failed or not applicable)'}`,
       ].join('\n');
       fs.writeFileSync(path.join(context.artifactDir, 'failed-step.txt'), message);
       assert.fail(message);
     }
     if (stepOptions.expectFailure === true && result.status === 0) {
       assert.fail(`${step} unexpectedly succeeded\ncommand: agent-device ${fullArgs.join(' ')}`);
+    }
+  }
+
+  /**
+   * Best-effort evidence for a `wait` timeout: the daemon's own surface dump caps at a handful of
+   * labels, so a screenshot is the only artifact that shows the whole screen the wait gave up on.
+   * A failed capture must not mask the original wait failure, so this never throws.
+   */
+  async function captureWaitTimeoutScreenshot(context: Context): Promise<string | undefined> {
+    const screenshotPath = path.join(
+      context.artifactDir,
+      `wait-timeout-${context.stepHistory.length}.png`,
+    );
+    try {
+      const capture = await (options.runCli ?? runBuiltCliJson)(
+        options.commonFlags(context, ['screenshot', screenshotPath]),
+        context.env,
+      );
+      return capture.status === 0 ? screenshotPath : undefined;
+    } catch {
+      return undefined;
     }
   }
 

--- a/test/integration/live-device-e2e/runtime.ts
+++ b/test/integration/live-device-e2e/runtime.ts
@@ -185,11 +185,7 @@ export function createLiveDeviceHarness<
     }
   }
 
-  /**
-   * Best-effort evidence for a `wait` timeout: the daemon's own surface dump caps at a handful of
-   * labels, so a screenshot is the only artifact that shows the whole screen the wait gave up on.
-   * A failed capture must not mask the original wait failure, so this never throws.
-   */
+  /** Best-effort: never throws, returns undefined on a failed capture. */
   async function captureWaitTimeoutScreenshot(context: Context): Promise<string | undefined> {
     const screenshotPath = path.join(
       context.artifactDir,


### PR DESCRIPTION
## Summary

Android's post-alert canary now reads `automation-alert-result` directly (`get text
id="automation-alert-result"`) instead of a screen-wide `wait text`, whose surface dump (capped
at 6 labels) often missed the element under contention, masking real failures behind a truncated
label list. `alert accept`/`dismiss` also record the tapped button's coordinates alongside its
label in the result. The live-device e2e harness now captures a best-effort
`wait-timeout-<n>.png` screenshot whenever a `wait` step times out, referenced from
`failed-step.txt`; a failed capture never masks the original failure.

Not changed: the daemon's wait-surface label cap — out of scope; this routes around it.

## Validation (at 927f068f9b)

- `npx vitest run --project unit-core packages/platform-android/src/__tests__/alert.test.ts
  alert-detection.test.ts` — 7/7 passing; both suites now share fixtures from the new
  `alert-fixtures.ts`.
- `pnpm check:quick`, `pnpm check:layering` (198/198), `pnpm check:fallow --base origin/main` —
  all clean.
- Planted red: reverted `coordinates` in `alert.ts` — dismiss/accept cases failed as expected,
  3/3 green after re-applying. Also corrupted the shared `button()` fixture's rect width — 2/7
  alert tests failed, confirming both suites are wired to the extracted fixtures; reverted, 7/7
  green.
- `live-automation-scenario.ts` / `runtime.ts` are e2e-only, exercised by this PR's Android lane.
- Full affected gate: pending.

## Tradeoffs / follow-ups

`assertElementText` is a single non-retrying `get text`, unlike the polling `wait text` it
replaces; `alert accept`/`dismiss` don't wait for JS-side state to settle, so a contention-slow
run could race the read. The live Android lane here is the evidence gate; if it flakes, switch to
a selector-scoped wait instead of reverting to the broad one.
