### PR TITLE
test(daemon): session-relaunch-close through the request seam

### DIFF
--- a/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
+++ b/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
@@ -1,77 +1,199 @@
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { LeaseRegistry } from '../../lease-registry.ts';
 import { setActiveProviderDeviceRuntimes } from '../../../provider-device-runtime.ts';
+import { createTestDeviceInventoryGateways } from '../../../__tests__/test-utils/device-inventory-gateways.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import { makeSession } from '../../../__tests__/test-utils/session-factories.ts';
+import { getResolveTargetDeviceMock } from '../../__tests__/request-router-dispatch-mocks.ts';
+import type { DaemonRequest } from '../../types.ts';
+
+vi.mock('node:timers/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:timers/promises')>();
+  return { ...actual, setTimeout: vi.fn(async () => undefined) };
+});
+vi.mock('../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('@agent-device/platform-apple/runner/operations', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@agent-device/platform-apple/runner/operations')>();
+  return {
+    ...actual,
+    prepareIosRunner: vi.fn(async () => ({
+      runner: { currentUptimeMs: 42 },
+      connectMs: 3,
+      healthCheckMs: 3,
+    })),
+    prewarmAppleRunnerCache: vi.fn(),
+    prewarmIosRunnerSession: vi.fn(),
+    notifyIosRunnerAppRelaunched: vi.fn(async () => {}),
+    scheduleIosRunnerIdleStop: vi.fn(),
+    stopIosRunnerSession: vi.fn(async () => {}),
+  };
+});
+vi.mock('@agent-device/platform-apple/macos', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent-device/platform-apple/macos')>();
+  return { ...actual, runMacOsAlertAction: vi.fn(async () => {}) };
+});
+vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
+  return {
+    ...actual,
+    resolveIosApp: vi.fn(async (_device, app: string) => app),
+    resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
+  };
+});
+vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
+  return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
+});
+
 import {
-  mockLifecycleDispatch as mockDispatch,
-  mockResolveTargetDevice,
-  mockPrewarmIosRunnerSession,
-  mockNotifyIosRunnerAppRelaunched,
-  mockStopIosRunner,
-  mockScheduleIosRunnerIdleStop,
-  mockDismissMacOsAlert,
-  makeSessionStore,
-  makeSession,
-  noopInvoke,
-} from './session-test-harness.ts';
-import { handleSessionCommands } from './session-command-harness.ts';
+  createRequestHandler,
+  lifecycleDeviceRuntimeGateway,
+} from '../../__tests__/test-device-runtime-gateway.ts';
+import {
+  dispatchApplicationLifecycleEffect,
+  awaitFixtureReadiness,
+  discoverReadyAndroidEmulators,
+} from '../../__tests__/application-lifecycle-runtime-fixture.ts';
+import { ensureDeviceReady } from '../../device-ready.ts';
+import {
+  prewarmIosRunnerSession,
+  notifyIosRunnerAppRelaunched,
+  stopIosRunnerSession,
+  scheduleIosRunnerIdleStop,
+} from '@agent-device/platform-apple/runner/operations';
+import { runMacOsAlertAction } from '@agent-device/platform-apple/macos';
+
+const mockResolveTargetDevice = vi.mocked(getResolveTargetDeviceMock());
+const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
+const mockDispatch = vi.mocked(dispatchApplicationLifecycleEffect);
+const mockAwaitFixtureReadiness = vi.mocked(awaitFixtureReadiness);
+const mockDiscoverReadyAndroidEmulators = vi.mocked(discoverReadyAndroidEmulators);
+const mockPrewarmIosRunnerSession = vi.mocked(prewarmIosRunnerSession);
+const mockNotifyIosRunnerAppRelaunched = vi.mocked(notifyIosRunnerAppRelaunched);
+const mockStopIosRunner = vi.mocked(stopIosRunnerSession);
+const mockScheduleIosRunnerIdleStop = vi.mocked(scheduleIosRunnerIdleStop);
+const mockDismissMacOsAlert = vi.mocked(runMacOsAlertAction);
+
+beforeEach(() => {
+  vi.useRealTimers();
+  mockResolveTargetDevice.mockReset();
+  mockEnsureDeviceReady.mockReset();
+  mockEnsureDeviceReady.mockResolvedValue(undefined);
+  mockDispatch.mockReset();
+  mockDispatch.mockResolvedValue(undefined);
+  mockAwaitFixtureReadiness.mockReset();
+  mockAwaitFixtureReadiness.mockResolvedValue(undefined);
+  mockDiscoverReadyAndroidEmulators.mockReset();
+  mockDiscoverReadyAndroidEmulators.mockImplementation(async (device) => [
+    {
+      ...device,
+      id: device.id.startsWith('emulator-') ? device.id : `emulator-${device.id}`,
+      booted: true,
+    },
+  ]);
+  mockPrewarmIosRunnerSession.mockReset();
+  mockNotifyIosRunnerAppRelaunched.mockReset();
+  mockNotifyIosRunnerAppRelaunched.mockResolvedValue(undefined);
+  mockStopIosRunner.mockReset();
+  mockStopIosRunner.mockResolvedValue(undefined);
+  mockScheduleIosRunnerIdleStop.mockReset();
+  mockDismissMacOsAlert.mockReset();
+  mockDismissMacOsAlert.mockResolvedValue({} as any);
+});
+
+function createHandler(
+  sessionStore: ReturnType<typeof makeSessionStore>,
+  leaseRegistry: LeaseRegistry = new LeaseRegistry(),
+) {
+  return createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry,
+    deviceRuntimeGateway: lifecycleDeviceRuntimeGateway,
+    deviceInventoryGateways: createTestDeviceInventoryGateways(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+let requestSeq = 0;
+
+function sessionRequest(
+  session: string,
+  command: 'open' | 'close',
+  options: {
+    positionals?: string[];
+    flags?: Record<string, unknown>;
+    internal?: DaemonRequest['internal'];
+  } = {},
+): DaemonRequest {
+  requestSeq += 1;
+  return {
+    token: 'test-token',
+    session,
+    command,
+    positionals: options.positionals ?? [],
+    flags: options.flags ?? {},
+    internal: options.internal,
+    meta: { requestId: `req-${command}-${requestSeq}` },
+  };
+}
 
 test('open --relaunch closes and reopens active session app', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'android-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'android',
-      id: 'emulator-5554',
-      name: 'Pixel Emulator',
-      kind: 'emulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'android',
+        id: 'emulator-5554',
+        name: 'Pixel Emulator',
+        kind: 'emulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
     }),
-    appName: 'com.example.app',
-  });
+  );
 
   const calls: Array<{ command: string; positionals: string[] }> = [];
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push({ command, positionals });
+    calls.push({ command, positionals: positionals ?? [] });
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true } }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
-  expect(calls.length).toBe(2);
-  expect(calls[0]).toEqual({ command: 'close', positionals: ['com.example.app'] });
-  expect(calls[1]).toEqual({ command: 'open', positionals: ['com.example.app'] });
+  expect(response.ok).toBe(true);
+  expect(calls).toEqual([
+    { command: 'close', positionals: ['com.example.app'] },
+    { command: 'open', positionals: ['com.example.app'] },
+  ]);
 });
 
 test('open --relaunch leaves the old frame expired when the close dispatch fails after dispatch (ADR 0014)', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'android-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'android',
-      id: 'emulator-5554',
-      name: 'Pixel Emulator',
-      kind: 'emulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'android',
+        id: 'emulator-5554',
+        name: 'Pixel Emulator',
+        kind: 'emulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
+      snapshotGeneration: 400,
     }),
-    appName: 'com.example.app',
-    snapshotGeneration: 400,
-  });
+  );
   // A freshly issued frame is active before the relaunch.
   expect(sessionStore.get(sessionName)?.refFrameState).toBeUndefined();
 
@@ -82,19 +204,9 @@ test('open --relaunch leaves the old frame expired when the close dispatch fails
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  }).catch(() => null);
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true } }),
+  ).catch(() => null);
 
   // Whether the failure surfaced as an error response or a throw, the existing
   // session's frame was expired BEFORE the close dispatch and stays expired — a
@@ -104,7 +216,7 @@ test('open --relaunch leaves the old frame expired when the close dispatch fails
 });
 
 test('open --relaunch does not let an ambient provider claim suppress a local pre-close', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'provider-android-session';
   const device = {
     platform: 'android' as const,
@@ -127,27 +239,19 @@ test('open --relaunch does not let an ambient provider claim suppress a local pr
 
   const calls: Array<{ command: string; positionals: string[] }> = [];
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push({ command, positionals });
+    calls.push({ command, positionals: positionals ?? [] });
     return {};
   });
 
   try {
-    const response = await handleSessionCommands({
-      req: {
-        token: 't',
-        session: sessionName,
-        command: 'open',
+    const response = await createHandler(sessionStore)(
+      sessionRequest(sessionName, 'open', {
         positionals: ['com.example.app'],
         flags: { relaunch: true, platform: 'android' },
-      },
-      sessionName,
-      logPath: path.join(os.tmpdir(), 'daemon.log'),
-      sessionStore,
-      invoke: noopInvoke,
-    });
+      }),
+    );
 
-    expect(response).toBeTruthy();
-    expect(response?.ok).toBe(true);
+    expect(response.ok).toBe(true);
     expect(calls).toEqual([
       { command: 'close', positionals: ['com.example.app'] },
       { command: 'open', positionals: ['com.example.app'] },
@@ -158,29 +262,20 @@ test('open --relaunch does not let an ambient provider claim suppress a local pr
 });
 
 test('open --relaunch on physical iOS retains runner through close/open', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      appleOs: 'ios',
-      id: 'ios-device-1',
-      name: 'My iPhone',
-      kind: 'device',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const calls: string[] = [];
-  mockResolveTargetDevice.mockResolvedValue({
-    platform: 'apple',
-    appleOs: 'ios',
+  const device = {
+    platform: 'apple' as const,
+    appleOs: 'ios' as const,
     id: 'ios-device-1',
     name: 'My iPhone',
-    kind: 'device',
+    kind: 'device' as const,
     booted: true,
-  });
+  };
+  sessionStore.set(sessionName, makeSession(sessionName, { device, appName: 'com.example.app' }));
+
+  const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue(device);
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
   });
@@ -188,78 +283,48 @@ test('open --relaunch on physical iOS retains runner through close/open', async 
     calls.push('reset-runner-target');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true } }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['close:com.example.app', 'open:com.example.app', 'reset-runner-target']);
   expect(mockStopIosRunner).not.toHaveBeenCalled();
 });
 
 test('open --relaunch on iOS simulator collapses into one terminate-running open dispatch', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const calls: string[] = [];
-  mockResolveTargetDevice.mockResolvedValue({
-    platform: 'apple',
+  const device = {
+    platform: 'apple' as const,
     id: 'sim-1',
     name: 'iPhone 17 Pro',
-    kind: 'simulator',
+    kind: 'simulator' as const,
     booted: true,
-  });
+  };
+  sessionStore.set(sessionName, makeSession(sessionName, { device, appName: 'com.example.app' }));
+
+  const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue(device);
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
   });
   let openContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     if (command === 'open') openContext = context as Record<string, unknown>;
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true } }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['open:com.example.app']);
   expect(openContext?.terminateRunningApp).toBe(true);
   expect(mockNotifyIosRunnerAppRelaunched).toHaveBeenCalledWith(
@@ -269,120 +334,85 @@ test('open --relaunch on iOS simulator collapses into one terminate-running open
 });
 
 test('open <app> <url> --relaunch on iOS simulator delegates termination to the URL open', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-url-relaunch-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const calls: string[] = [];
-  mockResolveTargetDevice.mockResolvedValue({
-    platform: 'apple',
+  const device = {
+    platform: 'apple' as const,
     id: 'sim-1',
     name: 'iPhone 17 Pro',
-    kind: 'simulator',
+    kind: 'simulator' as const,
     booted: true,
-  });
+  };
+  sessionStore.set(sessionName, makeSession(sessionName, { device, appName: 'com.example.app' }));
+
+  const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue(device);
   let openContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     if (command === 'open') openContext = context as Record<string, unknown>;
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['com.example.app', 'https://example.com/deal'],
       flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['open:com.example.app https://example.com/deal']);
   expect(openContext?.terminateRunningApp).toBe(true);
 });
 
 test('open --relaunch --clear-app-state on iOS simulator keeps close-first ordering', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-clear-state-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const calls: string[] = [];
-  mockResolveTargetDevice.mockResolvedValue({
-    platform: 'apple',
+  const device = {
+    platform: 'apple' as const,
     id: 'sim-1',
     name: 'iPhone 17 Pro',
-    kind: 'simulator',
+    kind: 'simulator' as const,
     booted: true,
-  });
+  };
+  sessionStore.set(sessionName, makeSession(sessionName, { device, appName: 'com.example.app' }));
+
+  const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue(device);
   let openContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     if (command === 'open') openContext = context as Record<string, unknown>;
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true, clearAppState: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true, clearAppState: true } }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['close:com.example.app', 'open:com.example.app']);
   expect(openContext?.terminateRunningApp).toBeUndefined();
 });
 
 test('open --relaunch includes timing and waits for iOS runner prewarm after opening app', async () => {
   vi.useFakeTimers({ now: 1_000 });
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-timing-session';
   const events: string[] = [];
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      appleOs: 'ios',
-      id: 'ios-device-1',
-      name: 'My iPhone',
-      kind: 'device',
-      booted: true,
-    }),
-    appName: 'Example',
-    appBundleId: 'com.example.app',
-  });
+  const device = {
+    platform: 'apple' as const,
+    appleOs: 'ios' as const,
+    id: 'ios-device-1',
+    name: 'My iPhone',
+    kind: 'device' as const,
+    booted: true,
+  };
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, { device, appName: 'Example', appBundleId: 'com.example.app' }),
+  );
 
   mockPrewarmIosRunnerSession.mockImplementation(
     () =>
@@ -402,24 +432,14 @@ test('open --relaunch includes timing and waits for iOS runner prewarm after ope
     return {};
   });
 
-  const responsePromise = handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: [],
-      flags: { relaunch: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const responsePromise = createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { flags: { relaunch: true } }),
+  );
 
   await vi.advanceTimersByTimeAsync(250);
   const response = await responsePromise;
 
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(events).toEqual(['dispatch:close', 'dispatch:open', 'prewarm-start', 'prewarm-finish']);
   expect(mockStopIosRunner).not.toHaveBeenCalled();
   expect((response as any).data?.timing).toMatchObject({
@@ -432,7 +452,7 @@ test('open --relaunch includes timing and waits for iOS runner prewarm after ope
 });
 
 test('open --relaunch on iOS without existing session closes then opens target app', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-new-session';
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
@@ -451,46 +471,41 @@ test('open --relaunch on iOS without existing session closes then opens target a
     calls.push('reset-runner-target');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['com.example.app'],
       flags: { relaunch: true, platform: 'ios' },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['close:com.example.app', 'open:com.example.app', 'reset-runner-target']);
   expect(mockStopIosRunner).not.toHaveBeenCalled();
 });
 
 test('close on macOS session stops runner and dismisses automation alert before delete', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'macos-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      appleOs: 'macos',
-      id: 'host-macos-local',
-      name: 'Host Mac',
-      kind: 'device',
-      target: 'desktop',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        appleOs: 'macos',
+        id: 'host-macos-local',
+        name: 'Host Mac',
+        kind: 'device',
+        target: 'desktop',
+        booted: true,
+      },
+      appBundleId: 'com.apple.systempreferences',
+      appName: 'System Settings',
     }),
-    appBundleId: 'com.apple.systempreferences',
-    appName: 'System Settings',
-  });
+  );
 
   const calls: string[] = [];
   mockStopIosRunner.mockImplementation(async (deviceId) => {
@@ -503,22 +518,9 @@ test('close on macOS session stops runner and dismisses automation alert before 
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(sessionRequest(sessionName, 'close'));
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual([
     'stop-runner:host-macos-local',
     'dismiss-alert:dismiss:com.apple.systempreferences',
@@ -527,77 +529,57 @@ test('close on macOS session stops runner and dismisses automation alert before 
 });
 
 test('close on iOS simulator session retains runner and deletes the session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: {},
-    },
+  sessionStore.set(
     sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  const response = await createHandler(sessionStore)(sessionRequest(sessionName, 'close'));
+
+  expect(response.ok).toBe(true);
   expect(mockStopIosRunner).not.toHaveBeenCalled();
   expect(mockScheduleIosRunnerIdleStop).toHaveBeenCalledWith('sim-1');
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('close on iOS simulator with scoped simulator set stops runner before deleting session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-scoped-simulator-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-      simulatorSetPath: '/tmp/tenant-a/simulator-set',
-    }),
-    appName: 'com.example.app',
-  });
-
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: {},
-    },
+  sessionStore.set(
     sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+        simulatorSetPath: '/tmp/tenant-a/simulator-set',
+      },
+      appName: 'com.example.app',
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  const response = await createHandler(sessionStore)(sessionRequest(sessionName, 'close'));
+
+  expect(response.ok).toBe(true);
   expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('close on leased iOS simulator session stops runner before deleting session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-leased-simulator-session';
   const leaseRegistry = new LeaseRegistry();
   const lease = leaseRegistry.allocateLease({
@@ -607,197 +589,161 @@ test('close on leased iOS simulator session stops runner before deleting session
     deviceKey: 'ios:sim-1',
     clientId: 'client-a',
   });
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-    lease: {
-      leaseId: lease.leaseId,
-      tenantId: lease.tenantId,
-      runId: lease.runId,
-      leaseBackend: lease.backend,
-      deviceKey: lease.deviceKey,
-      clientId: lease.clientId,
-      expiresAt: lease.expiresAt,
-    },
-  });
-
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: {},
-    },
+  sessionStore.set(
     sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
+      lease: {
+        leaseId: lease.leaseId,
+        tenantId: lease.tenantId,
+        runId: lease.runId,
+        leaseBackend: lease.backend,
+        deviceKey: lease.deviceKey,
+        clientId: lease.clientId,
+        expiresAt: lease.expiresAt,
+      },
+    }),
+  );
+
+  const response = await createHandler(
     sessionStore,
     leaseRegistry,
-    invoke: noopInvoke,
-  });
+  )(sessionRequest(sessionName, 'close'));
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('close --shutdown on iOS simulator stops runner before deleting session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-shutdown-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
-    }),
-    appName: 'com.example.app',
-  });
-
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: { shutdown: true },
-    },
+  sessionStore.set(
     sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'close', { flags: { shutdown: true } }),
+  );
+
+  expect(response.ok).toBe(true);
   expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('close <app> on iOS stops runner before app close dispatch and performs final idempotent stop', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-close-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'My iPhone',
-      kind: 'device',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'My iPhone',
+        kind: 'device',
+        booted: true,
+      },
+      appName: 'com.example.app',
     }),
-    appName: 'com.example.app',
-  });
+  );
 
   const calls: string[] = [];
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: ['com.example.app'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'close', { positionals: ['com.example.app'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['stop-runner', 'close:com.example.app', 'stop-runner']);
 });
 
 test('close <app> on iOS simulator retains runner while terminating app', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-close-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appName: 'com.example.app',
     }),
-    appName: 'com.example.app',
-  });
+  );
 
   const calls: string[] = [];
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: ['com.example.app'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'close', { positionals: ['com.example.app'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual(['close:com.example.app']);
 });
 
 test('app-only close terminates an iOS simulator app without ending its session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'ios-simulator-app-only-close';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appBundleId: 'com.example.app',
+      appName: 'Example App',
     }),
-    appBundleId: 'com.example.app',
-    appName: 'Example App',
-  });
+  );
 
   mockDispatch.mockImplementation(async () => ({}));
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'close', {
       positionals: ['com.example.app'],
       internal: { closeAppOnly: true },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(mockDispatch).toHaveBeenCalledWith(
     expect.objectContaining({ id: 'sim-1' }),
     'close',
@@ -810,21 +756,24 @@ test('app-only close terminates an iOS simulator app without ending its session'
 });
 
 test('close <app> on macOS stops runner before app close dispatch and dismisses automation alert', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-relaunch-close-');
   const sessionName = 'macos-close-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      appleOs: 'macos',
-      id: 'host-macos-local',
-      name: 'Host Mac',
-      kind: 'device',
-      target: 'desktop',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        appleOs: 'macos',
+        id: 'host-macos-local',
+        name: 'Host Mac',
+        kind: 'device',
+        target: 'desktop',
+        booted: true,
+      },
+      appBundleId: 'com.apple.systempreferences',
+      appName: 'System Settings',
     }),
-    appBundleId: 'com.apple.systempreferences',
-    appName: 'System Settings',
-  });
+  );
 
   const calls: string[] = [];
   mockStopIosRunner.mockImplementation(async (deviceId) => {
@@ -837,26 +786,15 @@ test('close <app> on macOS stops runner before app close dispatch and dismisses 
     return {};
   });
   mockDispatch.mockImplementation(async (_device, command, positionals) => {
-    calls.push(`${command}:${positionals.join(' ')}`);
+    calls.push(`${command}:${(positionals ?? []).join(' ')}`);
     return {};
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: ['System Settings'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'close', { positionals: ['System Settings'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(calls).toEqual([
     'stop-runner:host-macos-local',
     'close:System Settings',


### PR DESCRIPTION
## Summary

Rewrites `src/daemon/handlers/__tests__/session-relaunch-close.test.ts` (the
largest `session-test-harness.ts` consumer, 866 lines) to drive its 18
open/close relaunch scenarios through the production request router
(`createRequestHandler` + `lifecycleDeviceRuntimeGateway`, the same seam
`request-router-open.test.ts` already uses) instead of calling the daemon's
session handler directly through a bypassed harness. Every scenario title and
every observable assertion (response ok/error, session-store state, dispatch
call order at the runtime-facet boundary, timing payload) is unchanged; only
the entry point and the mock surface moved.

The file no longer imports `session-test-harness.ts` (that harness still
backs its other 10 consumers, untouched) and drops its raw `vi.mock` of
`core/dispatch-resolve.ts` in favor of the shared
`request-router-dispatch-mocks.ts` helper. Three of the old harness's module
mocks (`platform-runtime-runtime-hints.ts`, `platform-android/mechanics`,
`materialized-path-registry.ts`) are gone: none of these 18 scenarios reach
those code paths once routed through `lifecycleDeviceRuntimeGateway`'s bound
operations, confirmed by running the suite without them.

## Validation

- `npx vitest run --project unit-core src/daemon/handlers/__tests__/session-relaunch-close.test.ts` — 18/18 pass.
- `npx vitest run --project unit-core src/daemon/handlers/__tests__/session-relaunch-guards.test.ts src/daemon/handlers/__tests__/session-boot-shutdown.test.ts src/daemon/__tests__/request-router-open.test.ts` — sibling suites sharing the touched fixtures, 37/37 pass.
- `pnpm check:quick`, `pnpm check:layering`, `pnpm check:fallow --base origin/main`, `pnpm check:gate-manifest` — all clean.
- Planted red #1 (ADR 0014 pin): removed `expireRefFrame(session)` from `src/daemon/session-lifecycle/internal/session-open.ts`'s relaunch path, ran the ADR-0014 test alone — `AssertionError: expected undefined to be 'expired'` — restored, verified green.
- Planted red #2 (simulator relaunch collapse): forced the `terminateRunningApp` branch off in `packages/platform-apple/src/lifecycle.ts`'s `dispatchAppleOpen`, ran the "collapses into one terminate-running open dispatch" test alone — `AssertionError: expected undefined to be true` — restored, verified green.
- Full affected gate: pending (serialized gate stage will append the result).

## Tradeoffs / follow-ups

Dispatch-order assertions (what was dispatched to the lifecycle-effect fixture
and to the still-module-mocked iOS runner operations, in what sequence) are
kept rather than deleted: they observe the same facet/seam boundary
`request-router-open.test.ts` already asserts on for this codebase's current
migration state, not generic dispatch. Stripping them would have discarded
the file's core regression coverage (relaunch/close ordering) without an
equivalent observable substitute.
