### PR TITLE
fix(security): bump fast-uri override to 3.1.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   undici@7: ^7.29.0
   brace-expansion@5: ^5.0.9
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   postcss: 8.5.23
   qs: 6.15.2
   react-router: 7.18.2
@@ -2575,8 +2575,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5471,7 +5471,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5903,7 +5903,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ minimumReleaseAgeExclude:
 overrides:
   undici@7: '^7.29.0'
   brace-expansion@5: '^5.0.9'
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   postcss: 8.5.23
   qs: 6.15.2
   react-router: 7.18.2


### PR DESCRIPTION
## Summary

`fast-uri` is a transitive of `ajv@8.20.0` and is pinned through the root workspace override. The pin sat at `3.1.5`, which is inside all four open Dependabot advisories for the package:

- GHSA-jqff-g426-hqxp — host confusion via percent-encoded scheme normalization (`>= 3.0.0, < 3.1.6`)
- GHSA-fph4-wmhf-6fwf — SSRF via repeated hostname percent-decoding (`>= 3.1.2, < 3.1.6`)
- GHSA-f65p-4m7j-42xc — SSRF via malformed IPv6 normalization (`>= 3.0.0, < 3.1.6`)
- GHSA-5jgf-p345-68v8 — host confusion via skipped IDN canonicalization (`>= 3.1.3, < 3.1.6`)

Bump the override to `3.1.6` (the first fixed version). The lockfile diff is exactly the four `fast-uri` entries; `ajv@8.20.0` declares `fast-uri: ^3.0.0`, so `3.1.6` satisfies the parent range without an override-shape change.

Closes Dependabot alerts #80, #81, #82, #83.

## Validation

- `pnpm install` resolves cleanly; `node_modules/.pnpm/ajv@8.20.0/node_modules/fast-uri` now resolves to `fast-uri@3.1.6`, and the lockfile has zero references to `fast-uri@3.1.5`.
- `pnpm gate typecheck`, `pnpm gate unit` (1158 test files / 8705 tests), `pnpm gate gate-manifest`, `pnpm gate affected-selector` all green at this commit.
- `pnpm gate lint` and `format:check` report findings only inside the untracked local `agent-conf/` directory of the validating worktree (pre-existing local state, absent on a clean checkout); `pnpm exec oxfmt --check pnpm-workspace.yaml pnpm-lock.yaml` is clean for the two changed files.
- The root tooling paths fail open to the full check set; the remaining lanes (native, device, provider, coverage) are GitHub-authoritative per AGENTS.md and will run on this head.