### PR TITLE
ci: enforce the image-size parser mitigation through a test-app gate

### DIFF
--- a/.github/actions/setup-test-app-dependencies/action.yml
+++ b/.github/actions/setup-test-app-dependencies/action.yml
@@ -10,7 +10,8 @@ runs:
   using: 'composite'
   steps:
     # Expo's dependency graph contains native binaries, so cache it by operating
-    # system, architecture, Node major, pnpm version, and the exact manifest.
+    # system, architecture, Node major, pnpm version, the exact manifest, and the
+    # pnpm patch files applied into it.
     - name: Resolve test app dependency cache key
       id: key
       shell: bash
@@ -24,7 +25,7 @@ runs:
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
       with:
         path: examples/test-app/node_modules
-        key: test-app-dependencies-v2-${{ runner.os }}-${{ runner.arch }}-node${{ steps.key.outputs.node_major }}-pnpm${{ steps.key.outputs.pnpm_version }}-${{ hashFiles('examples/test-app/package.json', 'examples/test-app/pnpm-lock.yaml', 'examples/test-app/pnpm-workspace.yaml', '.github/actions/setup-test-app-dependencies/action.yml') }}
+        key: test-app-dependencies-v2-${{ runner.os }}-${{ runner.arch }}-node${{ steps.key.outputs.node_major }}-pnpm${{ steps.key.outputs.pnpm_version }}-${{ hashFiles('examples/test-app/package.json', 'examples/test-app/pnpm-lock.yaml', 'examples/test-app/pnpm-workspace.yaml', 'examples/test-app/patches/**', '.github/actions/setup-test-app-dependencies/action.yml') }}
 
     - name: Install test app dependencies
       if: steps.restore.outputs.cache-hit != 'true'
@@ -36,4 +37,4 @@ runs:
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
       with:
         path: examples/test-app/node_modules
-        key: test-app-dependencies-v2-${{ runner.os }}-${{ runner.arch }}-node${{ steps.key.outputs.node_major }}-pnpm${{ steps.key.outputs.pnpm_version }}-${{ hashFiles('examples/test-app/package.json', 'examples/test-app/pnpm-lock.yaml', 'examples/test-app/pnpm-workspace.yaml', '.github/actions/setup-test-app-dependencies/action.yml') }}
+        key: test-app-dependencies-v2-${{ runner.os }}-${{ runner.arch }}-node${{ steps.key.outputs.node_major }}-pnpm${{ steps.key.outputs.pnpm_version }}-${{ hashFiles('examples/test-app/package.json', 'examples/test-app/pnpm-lock.yaml', 'examples/test-app/pnpm-workspace.yaml', 'examples/test-app/patches/**', '.github/actions/setup-test-app-dependencies/action.yml') }}

--- a/.github/workflows/test-app-build-cache.yml
+++ b/.github/workflows/test-app-build-cache.yml
@@ -50,6 +50,12 @@ jobs:
         uses: ./.github/actions/run-gate
         with: { gate: test-app-typecheck }
 
+      # image-size has no fixed release for its parser DoS advisories; this gate
+      # proves the in-tree pnpm patch still terminates the zero-length vectors.
+      - name: Run the image-size parser security test
+        uses: ./.github/actions/run-gate
+        with: { gate: test-app-security }
+
       - name: Resolve native fingerprint
         id: fingerprint
         env:

--- a/examples/test-app/security/image-size-security.test.mjs
+++ b/examples/test-app/security/image-size-security.test.mjs
@@ -5,14 +5,13 @@ import path from 'node:path';
 import test from 'node:test';
 
 const packageStore = path.join(process.cwd(), 'node_modules', '.pnpm');
+const patchHash = /^ {2}image-size@1\.2\.1: ([0-9a-f]{64})$/m.exec(
+  fs.readFileSync(path.join(process.cwd(), 'pnpm-lock.yaml'), 'utf8'),
+)?.[1];
+assert.ok(patchHash, 'the lockfile must record the image-size patch hash');
 const imageSizePath =
   process.env.IMAGE_SIZE_PACKAGE_DIR ??
-  path.join(
-    packageStore,
-    fs.readdirSync(packageStore).find((entry) => entry.startsWith('image-size@1.2.1_patch_hash=')),
-    'node_modules',
-    'image-size',
-  );
+  path.join(packageStore, `image-size@1.2.1_patch_hash=${patchHash}`, 'node_modules', 'image-size');
 assert.ok(fs.existsSync(imageSizePath), 'the image-size package must be installed');
 
 test('zero-length image records and boxes return within the parser budget', () => {
@@ -35,6 +34,17 @@ test('zero-length image records and boxes return within the parser budget', () =
         Buffer.from('jxl '),
         Buffer.alloc(4),
         zeroBox('junk'),
+      ]),
+      'No codestream found in JXL container',
+    ],
+    [
+      'JXL zero-size jxlp box',
+      Buffer.concat([
+        box(8, 'JXL '),
+        box(16, 'ftyp'),
+        Buffer.from('jxl '),
+        Buffer.alloc(4),
+        zeroBox('jxlp'),
       ]),
       'No codestream found in JXL container',
     ],

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "test-app:ios": "pnpm --dir examples/test-app ios",
     "test-app:android": "pnpm --dir examples/test-app android",
     "test-app:typecheck": "pnpm --dir examples/test-app typecheck",
+    "test-app:security": "pnpm --dir examples/test-app security:test",
     "test-app:replay:ios": "pnpm ad test examples/test-app/replays --platform ios --artifacts-dir .tmp/test-app-replay/ios",
     "test-app:replay:android": "pnpm ad test examples/test-app/replays --platform android --artifacts-dir .tmp/test-app-replay/android",
     "test-app:maestro": "node scripts/run-test-app-maestro-suite.mjs",

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -38,6 +38,12 @@ export const CHECK_CATALOG: readonly CheckSpec[] = [
   // The test app intentionally owns a separate Expo dependency graph. Do not
   // make every root-checkout validation install it implicitly.
   gate('test-app-typecheck', 'Expo test app typecheck', 'test-app:typecheck', false),
+  gate(
+    'test-app-security',
+    'Expo test app image-size parser security test',
+    'test-app:security',
+    false,
+  ),
   gate('layering', 'Import-direction layering guard', 'check:layering'),
   gate('di-seams', 'Test-only DI seam guard', 'check:di-seams'),
   gate('fallow', 'Fallow code-quality audit', 'check:fallow'),

--- a/scripts/check-affected/model.test.ts
+++ b/scripts/check-affected/model.test.ts
@@ -184,6 +184,21 @@ test('test app source selects root lint and format plus its isolated typecheck',
   ]);
 });
 
+test('the image-size parser mitigation is selected when its defining files change', () => {
+  for (const file of [
+    'examples/test-app/patches/image-size@1.2.1.patch',
+    'examples/test-app/security/image-size-security.test.mjs',
+    'examples/test-app/pnpm-workspace.yaml',
+  ]) {
+    const result = plan([file]);
+    assert.equal(result.failOpen, false, `${file} must not fail open`);
+    assert.ok(
+      result.checks.includes('test-app-security'),
+      `expected test-app-security for ${file}`,
+    );
+  }
+});
+
 test('unknown path fails open to the full check set', () => {
   const result = plan(['fixtures/unknown.data']);
   assert.equal(result.failOpen, true);

--- a/scripts/check-affected/model.ts
+++ b/scripts/check-affected/model.ts
@@ -33,6 +33,7 @@ export type CheckId =
   | 'lint'
   | 'typecheck'
   | 'test-app-typecheck'
+  | 'test-app-security'
   | 'layering'
   | 'di-seams'
   | 'fallow'
@@ -96,6 +97,7 @@ export const ALL_CHECKS: readonly CheckId[] = [
   'lint',
   'typecheck',
   'test-app-typecheck',
+  'test-app-security',
   'layering',
   'di-seams',
   'fallow',
@@ -495,6 +497,17 @@ const BUILD_OWNERSHIP: ReadonlyArray<{
     rule: 'own:mcp',
     detail: 'MCP registry metadata must stay in sync',
     owns: (file) => file === 'server.json' || file === 'smithery.yaml',
+  },
+  // image-size ships no fixed version for its parser DoS advisories; the in-tree
+  // pnpm patch is the mitigation, and only its defining files own the proof.
+  {
+    check: 'test-app-security',
+    rule: 'own:test-app-security',
+    detail: 'the image-size parser mitigation is proven by the test-app security suite',
+    owns: (file) =>
+      file.startsWith('examples/test-app/patches/') ||
+      file.startsWith('examples/test-app/security/') ||
+      file === 'examples/test-app/pnpm-workspace.yaml',
   },
   // TS/Swift golden tables (`contracts/fixtures/*.json`): the vitest parity test and the
   // runner XCTest twin both read them, so a table edit owns the unit lane and both runner


### PR DESCRIPTION
## Summary

`image-size` (a transitive of the test app's Metro) has two open Dependabot advisories — GHSA-w3rx-r6r6-pgpr (ICNS zero-length entry) and GHSA-5p2g-fcmc-qvqq (JXL/HEIF zero-size box), both DoS via infinite parser loops — and **no fixed version exists** (`latest` is still `2.0.2`, inside the vulnerable range). The mitigation already landed in #2182: an in-tree pnpm patch (`examples/test-app/patches/image-size@1.2.1.patch`) plus a budget test (`examples/test-app/security/image-size-security.test.mjs`, run by the `security:test` script).

The gaps this closes: that proof was a manual script — nothing in CI ran it, and the dependency-graph cache the test depends on could restore a **stale patched artifact** for a patch-only change, so even a wired-up gate would have tested the previous patch.

This registers the security suite as a first-class gate, `test-app-security`, and makes the enforcement sound end to end:

- Root script `test-app:security` → `pnpm --dir examples/test-app security:test`.
- Catalog entry in `CHECK_CATALOG` (CI-authoritative, `localRunnable: false`, mirroring `test-app-typecheck` — the test app owns an isolated Expo dependency graph and must not be installed by every root-checkout validation).
- Wired into the `Test App Build Cache` `fingerprint` job (runs on every PR and already restores the test app dependency graph, so the patched package is present).
- **Cache key completeness** (review finding): `setup-test-app-dependencies` now hashes `examples/test-app/patches/**` into its restore/save key alongside the manifests. Before, a patch-only edit left the key invariant, so a cache hit restored the previous patched `node_modules` and skipped `pnpm install` — the gate would run against the prior patch. Any patch change now forces a fresh install that applies the current patch.
- **Artifact resolution**: the test resolves the installed package by the `patchedDependencies` hash recorded in `pnpm-lock.yaml` instead of the first `image-size@1.2.1_patch_hash=*` directory it finds — the declared artifact is the one under test, and a missing declaration fails loudly.
- **Discriminating fixture**: added a JXL container whose zero-size box is named `jxlp` (the box `extractPartialStreams` searches for). Ground truth: on unpatched 1.2.1 the prior JXL fixture (zero-size box named `junk`) terminates via `findBox`'s `+8` advance, so it never exercised the advisory vector — only the new fixture and the ICNS fixture hang. A patch regression that drops the `boxSize < 8` guard is now caught by the JXL fixture; the ICNS break is still caught by the ICNS fixture.
- Selector ownership: the gate is selected — and stops failing open — when its defining files change (`examples/test-app/patches/`, `examples/test-app/security/`, and `examples/test-app/pnpm-workspace.yaml`, which carries the `patchedDependencies` declaration).

The patch itself is verified against both advisory vectors: the `boxSize < 8` guard in `readBox` stops the JXL `extractPartialStreams` stall on a size-0 `jxlp` (the guard, not `findBox`'s advance, is what hides a *matching* zero-size box), and the `imageHeader[1] < 8` break in the ICNS parser stops the zero-length-entry loop. The HEIF fixture is a termination budget pin: unpatched 1.2.1 has no unbounded loop in the HEIF path (a single `findBox` chain over the `+8`-advancing `findBox`), so it asserts the format named in the advisory stays within budget.

Closes Dependabot alerts #69 and #70 at the mitigation level (they cannot be cleared by a version bump; see residual note below).

## Validation

- **Plant proof of the cache hole (review request)**: with a patch-only change (dropped the `boxSize < 8` guard from the patch file), the pre-fix key hash was byte-identical (`000c575f…`) — a cache hit would restore the stale guarded artifact and the suite passed against it (installed `utils.js` carried the guard the tree patch no longer declared). With the fix, the same patch-only edit changes the key (`a7004046…` → `24f5bd59…`); the resulting install applied the weakened patch and the gate **failed** — `JXL zero-size jxlp box exceeded the parser budget` (`spawnSync … ETIMEDOUT`) — before the patch was restored.
- Restored state: `pnpm gate test-app-security` green (1 test, 4 fixtures: ICNS entry, HEIF box, JXL box, JXL zero-size jxlp box, each under a 1s budget), artifact resolved via the lockfile patch hash.
- `pnpm check:affected --run` green at this commit (format, lint, typecheck, layering, di-seams, fallow, mcp-metadata, build, package, integration, gate-manifest, affected-selector, `vitest related` over the changed surface).
- `pnpm gate gate-manifest` reports **52 checks wired across 27 lanes** (was 51) — the new gate is owned by a lane, so the "every gate owned and wired" invariant holds.
- New selector test asserts the gate is selected for each of its three defining paths and does not fail open; observed it red with the ownership entry removed, green restored.
- Rebased onto `309a5360f5`; main picked up no commits touching this PR's surface.

Residual: Dependabot reports by resolved version, so #69/#70 will remain "open" in the dashboard until upstream ships a fix or the maintainers mark them dismissed-as-mitigated; the patch + gate above are the durable control.