### PR TITLE
perf: bundle tar-stream to reduce install footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,6 @@
   "dependencies": {
     "@limrun/api": "^0.24.5",
     "ipaddr.js": "^2.5.0",
-    "tar-stream": "^3.2.0",
     "undici": "7.29.0",
     "yaml": "^2.9.0",
     "yauzl": "^3.4.0"
@@ -323,6 +322,7 @@
     "oxlint": "^1.79.0",
     "pngjs": "^7.0.0",
     "publint": "^0.3.24",
+    "tar-stream": "^3.2.0",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vite": "^8.2.1",

--- a/packages/host-kit/package.json
+++ b/packages/host-kit/package.json
@@ -7,12 +7,12 @@
   "dependencies": {
     "@agent-device/contracts": "workspace:*",
     "@agent-device/kernel": "workspace:*",
-    "tar-stream": "^3.2.0",
     "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@types/tar-stream": "^3.1.4",
-    "@types/yauzl": "^3.4.0"
+    "@types/yauzl": "^3.4.0",
+    "tar-stream": "^3.2.0"
   },
   "exports": {
     "./archive": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,9 +236,6 @@ importers:
       '@agent-device/kernel':
         specifier: workspace:*
         version: link:../kernel
-      tar-stream:
-        specifier: ^3.2.0
-        version: 3.2.0
       yauzl:
         specifier: ^3.4.0
         version: 3.4.0
@@ -249,6 +246,9 @@ importers:
       '@types/yauzl':
         specifier: ^3.4.0
         version: 3.4.0
+      tar-stream:
+        specifier: ^3.2.0
+        version: 3.2.0
 
   packages/kernel: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       ipaddr.js:
         specifier: ^2.5.0
         version: 2.5.0
-      tar-stream:
-        specifier: ^3.2.0
-        version: 3.2.0
       undici:
         specifier: ^7.29.0
         version: 7.29.0
@@ -159,6 +156,9 @@ importers:
       publint:
         specifier: ^0.3.24
         version: 0.3.24
+      tar-stream:
+        specifier: ^3.2.0
+        version: 3.2.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@arethetypeswrong/core@0.18.5)(publint@0.3.24)(typescript@7.0.2)

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
     'internal/update-check-entry': 'src/cli/update-check-entry.ts',
   },
   deps: {
-    alwaysBundle: [/^@agent-device\//, 'pngjs', 'tar-stream'],
+    alwaysBundle: [/^@agent-device\//],
     onlyBundle: [
       'pngjs',
       'tar-stream',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -76,8 +76,16 @@ export default defineConfig({
     'internal/update-check-entry': 'src/cli/update-check-entry.ts',
   },
   deps: {
-    alwaysBundle: [/^@agent-device\//, 'pngjs'],
-    onlyBundle: ['pngjs'],
+    alwaysBundle: [/^@agent-device\//, 'pngjs', 'tar-stream'],
+    onlyBundle: [
+      'pngjs',
+      'tar-stream',
+      'streamx',
+      'fast-fifo',
+      'b4a',
+      'text-decoder',
+      'events-universal',
+    ],
   },
   inputOptions: {
     // A build with missing workspace links resolves nothing under `alwaysBundle` and emits the


### PR DESCRIPTION
## Summary

Bundle tar-stream's Node.js dependency path so consumers no longer install tar-stream and its transitive packages. Archive extraction behavior stays unchanged.

A clean npm comparison removes 12 runtime packages and saves about 5.7 MB net with current registry resolutions, at a cost of 38,050 bytes of bundled JavaScript. Unused Bare runtime packages are excluded.

Declare tar-stream as a dev dependency in both root and host-kit, matching the existing bundled-pngjs pattern. Keep one explicit bundle allowlist; remove redundant pngjs/tar-stream `alwaysBundle` entries because dev dependencies bundle automatically. All 392 JavaScript/declaration outputs remain byte-identical after this simplification. Independent review found no further issues or smaller design preserving dependency enforcement.

Scope: four build/dependency metadata files. No dependency versions, runtime source, docs, or skills changed.

## Validation

Validated content at `02c811ea65`:

- Reproduced R11's host-kit dependency mismatch before the fix; all 198 layering tests and the layering scan pass afterward.
- Build, lint, typecheck, formatting, and 31 focused archive/package tests pass.
- Packed tarball passes publint, attw, dependency-closure validation, all 13 public imports, and CLI smoke checks in a clean install.
- Installed bundle extracts TAR/TGZ files and rejects path traversal with cleanup, without external tar-stream or Bare packages.

Full affected checks remain skipped at the user's request. Updated-head CI is pending.
