### PR TITLE
refactor(contracts): build unavailable runtime facts once

### DIFF
--- a/packages/contracts/src/platform-runtime-unavailable.test.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.test.ts
@@ -92,6 +92,11 @@ test('generic unavailable binding preserves exact provider ownership and mode', 
     available: false,
     reason: 'unsupported-provider-mode',
   });
+  // `apps` is left unclassified above (an optional cell): it inherits the network gap's reason.
+  assert.deepEqual(binding.facts.operations.listApps, {
+    available: false,
+    reason: 'owner-capability-missing',
+  });
   assert.deepEqual(binding.operations, {});
   await binding[Symbol.asyncDispose]();
 });

--- a/packages/contracts/src/platform-runtime-unavailable.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.ts
@@ -90,52 +90,61 @@ type FrozenUnavailablePlatformRuntimeFacts = Readonly<
 type UnavailableCellKey = keyof Omit<UnavailablePlatformRuntimeFacts, 'lifecycle'>;
 
 /**
- * Whether a cell left unclassified by its owner falls back to the caller's network gap, or must be
- * stated by the owner itself. Only `apps`, `appDeployment`, `appState`, `screenRecording`,
- * `snapshot`, `readiness`, `shutdown`, and `perf` inherit: an owner that did not classify one of
- * these families has, by construction, the same reason its transport does. Every other cell is
- * owner-stated (#1873) — capture, interaction, navigation, keyboard, clipboard, the app switcher,
- * app-event delivery, settings, and alerts each differ by family or leaf in a way a transport gap
- * cannot speak for, so none of them may inherit a sibling's or the network's reason.
+ * Every cell name, for iteration. Whether a cell left unclassified by its owner falls back to the
+ * caller's network gap, or must be stated by the owner itself, is decided by
+ * `UnavailablePlatformRuntimeFacts` alone: an optional property inherits `network`, a required one
+ * is owner-stated (#1873) and always present. No second table restates that split — a misclassified
+ * cell there would fail to type-check rather than silently produce a malformed fact.
  */
-const UNAVAILABLE_CELL_POLICY = {
-  appLog: 'owner-stated',
-  apps: 'inherits-network',
-  appDeployment: 'inherits-network',
-  appState: 'inherits-network',
-  network: 'owner-stated',
-  screenRecording: 'inherits-network',
-  screenshot: 'owner-stated',
-  snapshot: 'inherits-network',
-  viewport: 'owner-stated',
-  focus: 'owner-stated',
-  gesture: 'owner-stated',
-  scroll: 'owner-stated',
-  typeText: 'owner-stated',
-  touch: 'owner-stated',
-  elementText: 'owner-stated',
-  back: 'owner-stated',
-  home: 'owner-stated',
-  orientation: 'owner-stated',
-  tvRemote: 'owner-stated',
-  keyboardStatus: 'owner-stated',
-  keyboardDismiss: 'owner-stated',
-  keyboardEnter: 'owner-stated',
-  readClipboard: 'owner-stated',
-  writeClipboard: 'owner-stated',
-  appSwitcher: 'owner-stated',
-  triggerAppEvent: 'owner-stated',
-  setSetting: 'owner-stated',
-  readAlert: 'owner-stated',
-  awaitAlert: 'owner-stated',
-  acceptAlert: 'owner-stated',
-  dismissAlert: 'owner-stated',
-  audioProbeCapture: 'owner-stated',
-  audioProbeQuery: 'owner-stated',
-  perf: 'inherits-network',
-  readiness: 'inherits-network',
-  shutdown: 'inherits-network',
-} satisfies Record<UnavailableCellKey, 'owner-stated' | 'inherits-network'>;
+const UNAVAILABLE_CELLS = {
+  appLog: true,
+  apps: true,
+  appDeployment: true,
+  appState: true,
+  network: true,
+  screenRecording: true,
+  screenshot: true,
+  snapshot: true,
+  viewport: true,
+  focus: true,
+  gesture: true,
+  scroll: true,
+  typeText: true,
+  touch: true,
+  elementText: true,
+  back: true,
+  home: true,
+  orientation: true,
+  tvRemote: true,
+  keyboardStatus: true,
+  keyboardDismiss: true,
+  keyboardEnter: true,
+  readClipboard: true,
+  writeClipboard: true,
+  appSwitcher: true,
+  triggerAppEvent: true,
+  setSetting: true,
+  readAlert: true,
+  awaitAlert: true,
+  acceptAlert: true,
+  dismissAlert: true,
+  audioProbeCapture: true,
+  audioProbeQuery: true,
+  perf: true,
+  readiness: true,
+  shutdown: true,
+} satisfies Record<UnavailableCellKey, true>;
+
+/** Fills every cell name through `fn`, in the one place a cell record is assembled by key. */
+function mapUnavailableCells<Value>(
+  fn: (cell: UnavailableCellKey) => Value,
+): Record<UnavailableCellKey, Value> {
+  const result = {} as Record<UnavailableCellKey, Value>;
+  for (const cell of Object.keys(UNAVAILABLE_CELLS) as UnavailableCellKey[]) {
+    result[cell] = fn(cell);
+  }
+  return result;
+}
 
 /**
  * A complete facts value for one unavailability reason, for owners with no runtime module at all:
@@ -146,9 +155,7 @@ export function createFullyUnavailablePlatformRuntimeFacts(
   unavailable: RuntimeOperationUnavailability,
 ): UnavailablePlatformRuntimeFacts {
   return Object.freeze({
-    ...(Object.fromEntries(
-      Object.keys(UNAVAILABLE_CELL_POLICY).map((cell) => [cell, unavailable]),
-    ) as Record<UnavailableCellKey, RuntimeOperationUnavailability>),
+    ...mapUnavailableCells(() => unavailable),
     lifecycle: applicationLifecycleOperationFacts({
       resolveOpenTarget: unavailable,
       prepareApplicationOpen: unavailable,
@@ -295,19 +302,10 @@ function providerModeForOwner(owner: RuntimeOwnerRef): RuntimeProviderMode {
 function freezeUnavailableFacts(
   unavailable: UnavailablePlatformRuntimeFacts,
 ): FrozenUnavailablePlatformRuntimeFacts {
-  const cells = {} as Record<UnavailableCellKey, RuntimeOperationUnavailability>;
-  for (const cell of Object.keys(UNAVAILABLE_CELL_POLICY) as UnavailableCellKey[]) {
-    const stated = unavailable[cell] as RuntimeOperationUnavailability | undefined;
-    // Every optional cell falls back to the caller's network gap; every owner-stated cell is
-    // required by the input type, so `stated` is always defined for it.
-    const resolved: RuntimeOperationUnavailability =
-      UNAVAILABLE_CELL_POLICY[cell] === 'inherits-network'
-        ? (stated ?? unavailable.network)
-        : (stated as RuntimeOperationUnavailability);
-    cells[cell] = Object.freeze({ ...resolved });
-  }
   return Object.freeze({
-    ...cells,
+    ...mapUnavailableCells((cell) =>
+      Object.freeze({ ...(unavailable[cell] ?? unavailable.network) }),
+    ),
     lifecycle: applicationLifecycleOperationFacts(unavailable.lifecycle),
   });
 }

--- a/packages/contracts/src/platform-runtime-unavailable.ts
+++ b/packages/contracts/src/platform-runtime-unavailable.ts
@@ -87,6 +87,82 @@ type FrozenUnavailablePlatformRuntimeFacts = Readonly<
     Readonly<{ lifecycle: ApplicationLifecycleOperationFacts }>
 >;
 
+type UnavailableCellKey = keyof Omit<UnavailablePlatformRuntimeFacts, 'lifecycle'>;
+
+/**
+ * Whether a cell left unclassified by its owner falls back to the caller's network gap, or must be
+ * stated by the owner itself. Only `apps`, `appDeployment`, `appState`, `screenRecording`,
+ * `snapshot`, `readiness`, `shutdown`, and `perf` inherit: an owner that did not classify one of
+ * these families has, by construction, the same reason its transport does. Every other cell is
+ * owner-stated (#1873) — capture, interaction, navigation, keyboard, clipboard, the app switcher,
+ * app-event delivery, settings, and alerts each differ by family or leaf in a way a transport gap
+ * cannot speak for, so none of them may inherit a sibling's or the network's reason.
+ */
+const UNAVAILABLE_CELL_POLICY = {
+  appLog: 'owner-stated',
+  apps: 'inherits-network',
+  appDeployment: 'inherits-network',
+  appState: 'inherits-network',
+  network: 'owner-stated',
+  screenRecording: 'inherits-network',
+  screenshot: 'owner-stated',
+  snapshot: 'inherits-network',
+  viewport: 'owner-stated',
+  focus: 'owner-stated',
+  gesture: 'owner-stated',
+  scroll: 'owner-stated',
+  typeText: 'owner-stated',
+  touch: 'owner-stated',
+  elementText: 'owner-stated',
+  back: 'owner-stated',
+  home: 'owner-stated',
+  orientation: 'owner-stated',
+  tvRemote: 'owner-stated',
+  keyboardStatus: 'owner-stated',
+  keyboardDismiss: 'owner-stated',
+  keyboardEnter: 'owner-stated',
+  readClipboard: 'owner-stated',
+  writeClipboard: 'owner-stated',
+  appSwitcher: 'owner-stated',
+  triggerAppEvent: 'owner-stated',
+  setSetting: 'owner-stated',
+  readAlert: 'owner-stated',
+  awaitAlert: 'owner-stated',
+  acceptAlert: 'owner-stated',
+  dismissAlert: 'owner-stated',
+  audioProbeCapture: 'owner-stated',
+  audioProbeQuery: 'owner-stated',
+  perf: 'inherits-network',
+  readiness: 'inherits-network',
+  shutdown: 'inherits-network',
+} satisfies Record<UnavailableCellKey, 'owner-stated' | 'inherits-network'>;
+
+/**
+ * A complete facts value for one unavailability reason, for owners with no runtime module at all:
+ * every cell, lifecycle included, reports the same reason, so a missing owner cannot leave a cell
+ * unclassified by omission.
+ */
+export function createFullyUnavailablePlatformRuntimeFacts(
+  unavailable: RuntimeOperationUnavailability,
+): UnavailablePlatformRuntimeFacts {
+  return Object.freeze({
+    ...(Object.fromEntries(
+      Object.keys(UNAVAILABLE_CELL_POLICY).map((cell) => [cell, unavailable]),
+    ) as Record<UnavailableCellKey, RuntimeOperationUnavailability>),
+    lifecycle: applicationLifecycleOperationFacts({
+      resolveOpenTarget: unavailable,
+      prepareApplicationOpen: unavailable,
+      openApplication: unavailable,
+      applyRuntimeHints: unavailable,
+      clearRuntimeHints: unavailable,
+      closeApplication: unavailable,
+      finalizeApplicationClose: unavailable,
+      prepareAppleRunner: unavailable,
+      configureProviderPortReverse: unavailable,
+    }),
+  });
+}
+
 export function createUnavailablePlatformRuntimeBinding(
   device: DeviceInfo,
   owner: RuntimeOwnerRef,
@@ -106,136 +182,101 @@ export function createUnavailablePlatformRuntimeFacts(
   owner: RuntimeOwnerRef,
   unavailable: UnavailablePlatformRuntimeFacts,
 ): RuntimeFacts<PlatformRuntimeOperations> {
-  const {
-    appLog,
-    apps,
-    appDeployment,
-    appState,
-    network,
-    screenRecording,
-    screenshot,
-    snapshot,
-    viewport,
-    focus,
-    gesture,
-    scroll,
-    typeText,
-    touch,
-    elementText,
-    back,
-    home,
-    orientation,
-    tvRemote,
-    keyboardStatus,
-    keyboardDismiss,
-    keyboardEnter,
-    readClipboard,
-    writeClipboard,
-    appSwitcher,
-    triggerAppEvent,
-    setSetting,
-    readAlert,
-    awaitAlert,
-    acceptAlert,
-    dismissAlert,
-    audioProbeCapture,
-    audioProbeQuery,
-    perf,
-    readiness,
-    shutdown,
-    lifecycle,
-  } = freezeUnavailableFacts(unavailable);
+  const frozen = freezeUnavailableFacts(unavailable);
   return Object.freeze({
     device: {
       ...deviceShape(device),
       providerMode: providerModeForOwner(owner),
     },
     operations: {
-      appLogInspect: appLog,
-      appLogDoctor: appLog,
-      appLogStart: appLog,
-      appLogReattach: appLog,
-      appLogCleanup: appLog,
-      listApps: apps,
-      deployApp: appDeployment,
-      materializeAppSource: appDeployment,
-      deployMaterializedApp: appDeployment,
-      sendPushNotification: appDeployment,
-      appState,
-      networkDump: network,
-      screenRecordingStart: screenRecording,
-      screenRecordingReattach: screenRecording,
-      screenRecordingCleanup: screenRecording,
-      ...screenshotRuntimeOperationFacts({ capture: screenshot }),
+      appLogInspect: frozen.appLog,
+      appLogDoctor: frozen.appLog,
+      appLogStart: frozen.appLog,
+      appLogReattach: frozen.appLog,
+      appLogCleanup: frozen.appLog,
+      listApps: frozen.apps,
+      deployApp: frozen.appDeployment,
+      materializeAppSource: frozen.appDeployment,
+      deployMaterializedApp: frozen.appDeployment,
+      sendPushNotification: frozen.appDeployment,
+      appState: frozen.appState,
+      networkDump: frozen.network,
+      screenRecordingStart: frozen.screenRecording,
+      screenRecordingReattach: frozen.screenRecording,
+      screenRecordingCleanup: frozen.screenRecording,
+      ...screenshotRuntimeOperationFacts({ capture: frozen.screenshot }),
       ...snapshotRuntimeOperationFacts({
-        capture: snapshot,
-        customActions: snapshot,
-        withoutActiveApp: snapshot,
+        capture: frozen.snapshot,
+        customActions: frozen.snapshot,
+        withoutActiveApp: frozen.snapshot,
       }),
       // The preferred text reading starts unavailable for every family, on the same sentinel as
       // capture: an owner that has a native reading declares it explicitly, and one that does not
       // sends every text wait to the canonical tree.
       ...selectorObservationRuntimeOperationFacts({
-        findText: snapshot,
-        findSelector: snapshot,
+        findText: frozen.snapshot,
+        findSelector: frozen.snapshot,
       }),
-      ...viewportRuntimeOperationFacts({ setViewport: viewport }),
-      ...focusRuntimeOperationFacts({ focus }),
+      ...viewportRuntimeOperationFacts({ setViewport: frozen.viewport }),
+      ...focusRuntimeOperationFacts({ focus: frozen.focus }),
       ...gestureRuntimeOperationFacts({
-        plan: gesture,
-        directionalFling: gesture,
-        multiTouch: gesture,
-        targetAuthoredDrag: gesture,
-        viewport: gesture,
+        plan: frozen.gesture,
+        directionalFling: frozen.gesture,
+        multiTouch: frozen.gesture,
+        targetAuthoredDrag: frozen.gesture,
+        viewport: frozen.gesture,
       }),
-      ...scrollRuntimeOperationFacts({ scroll }),
-      ...typeTextRuntimeOperationFacts({ type: typeText }),
+      ...scrollRuntimeOperationFacts({ scroll: frozen.scroll }),
+      ...typeTextRuntimeOperationFacts({ type: frozen.typeText }),
       ...touchRuntimeOperationFacts({
-        tap: touch,
-        tapRef: touch,
-        longPress: touch,
-        hover: touch,
-        hoverRef: touch,
-        fill: touch,
-        fillRef: touch,
-        tapElementSelector: touch,
+        tap: frozen.touch,
+        tapRef: frozen.touch,
+        longPress: frozen.touch,
+        hover: frozen.touch,
+        hoverRef: frozen.touch,
+        fill: frozen.touch,
+        fillRef: frozen.touch,
+        tapElementSelector: frozen.touch,
       }),
-      ...elementTextRuntimeOperationFacts({ readTextAtPoint: elementText }),
-      ...backRuntimeOperationFacts({ back }),
-      ...homeRuntimeOperationFacts({ home }),
-      ...orientationRuntimeOperationFacts({ orientation }),
-      ...tvRemoteRuntimeOperationFacts({ tvRemote }),
+      ...elementTextRuntimeOperationFacts({ readTextAtPoint: frozen.elementText }),
+      ...backRuntimeOperationFacts({ back: frozen.back }),
+      ...homeRuntimeOperationFacts({ home: frozen.home }),
+      ...orientationRuntimeOperationFacts({ orientation: frozen.orientation }),
+      ...tvRemoteRuntimeOperationFacts({ tvRemote: frozen.tvRemote }),
       ...keyboardRuntimeOperationFacts({
-        status: keyboardStatus,
-        dismiss: keyboardDismiss,
-        enter: keyboardEnter,
+        status: frozen.keyboardStatus,
+        dismiss: frozen.keyboardDismiss,
+        enter: frozen.keyboardEnter,
       }),
-      ...clipboardRuntimeOperationFacts({ read: readClipboard, write: writeClipboard }),
-      ...appSwitcherRuntimeOperationFacts({ appSwitcher }),
-      ...appEventRuntimeOperationFacts({ triggerAppEvent }),
-      ...settingsRuntimeOperationFacts({ setSetting }),
+      ...clipboardRuntimeOperationFacts({
+        read: frozen.readClipboard,
+        write: frozen.writeClipboard,
+      }),
+      ...appSwitcherRuntimeOperationFacts({ appSwitcher: frozen.appSwitcher }),
+      ...appEventRuntimeOperationFacts({ triggerAppEvent: frozen.triggerAppEvent }),
+      ...settingsRuntimeOperationFacts({ setSetting: frozen.setSetting }),
       ...alertRuntimeOperationFacts({
-        read: readAlert,
-        wait: awaitAlert,
-        accept: acceptAlert,
-        dismiss: dismissAlert,
+        read: frozen.readAlert,
+        wait: frozen.awaitAlert,
+        accept: frozen.acceptAlert,
+        dismiss: frozen.dismissAlert,
       }),
       ...audioProbeRuntimeOperationFacts({
-        capture: audioProbeCapture,
-        query: audioProbeQuery,
+        capture: frozen.audioProbeCapture,
+        query: frozen.audioProbeQuery,
       }),
       ...perfRuntimeOperationFacts({
-        frames: perf,
-        memorySample: perf,
-        memorySnapshot: perf,
-        nativeCapture: perf,
-        profileReport: perf,
+        frames: frozen.perf,
+        memorySample: frozen.perf,
+        memorySnapshot: frozen.perf,
+        nativeCapture: frozen.perf,
+        profileReport: frozen.perf,
       }),
-      ensureReady: readiness,
-      bootTarget: readiness,
-      bootTargetHeadless: readiness,
-      shutdownTarget: shutdown,
-      ...lifecycle,
+      ensureReady: frozen.readiness,
+      bootTarget: frozen.readiness,
+      bootTargetHeadless: frozen.readiness,
+      shutdownTarget: frozen.shutdown,
+      ...frozen.lifecycle,
     },
   });
 }
@@ -254,66 +295,19 @@ function providerModeForOwner(owner: RuntimeOwnerRef): RuntimeProviderMode {
 function freezeUnavailableFacts(
   unavailable: UnavailablePlatformRuntimeFacts,
 ): FrozenUnavailablePlatformRuntimeFacts {
-  // Every optional cell falls back to the caller's network gap: an owner that did not classify a
-  // family has, by construction, the same reason its transport does.
-  const orNetwork = (fact: RuntimeOperationUnavailability | undefined) =>
-    Object.freeze({ ...(fact ?? unavailable.network) });
+  const cells = {} as Record<UnavailableCellKey, RuntimeOperationUnavailability>;
+  for (const cell of Object.keys(UNAVAILABLE_CELL_POLICY) as UnavailableCellKey[]) {
+    const stated = unavailable[cell] as RuntimeOperationUnavailability | undefined;
+    // Every optional cell falls back to the caller's network gap; every owner-stated cell is
+    // required by the input type, so `stated` is always defined for it.
+    const resolved: RuntimeOperationUnavailability =
+      UNAVAILABLE_CELL_POLICY[cell] === 'inherits-network'
+        ? (stated ?? unavailable.network)
+        : (stated as RuntimeOperationUnavailability);
+    cells[cell] = Object.freeze({ ...resolved });
+  }
   return Object.freeze({
-    appLog: Object.freeze({ ...unavailable.appLog }),
-    apps: orNetwork(unavailable.apps),
-    appDeployment: orNetwork(unavailable.appDeployment),
-    appState: orNetwork(unavailable.appState),
-    network: Object.freeze({ ...unavailable.network }),
-    screenRecording: orNetwork(unavailable.screenRecording),
-    // Capture cells are stated by their owner, never inherited from the transport gap (#1873).
-    screenshot: Object.freeze({ ...unavailable.screenshot }),
-    snapshot: orNetwork(unavailable.snapshot),
-    viewport: Object.freeze({ ...unavailable.viewport }),
-    // Interaction cells are stated by their owner: a family that can drive touch says so for its
-    // exact kinds, and one that cannot must say why rather than inherit a transport gap.
-    focus: Object.freeze({ ...unavailable.focus }),
-    gesture: Object.freeze({ ...unavailable.gesture }),
-    scroll: Object.freeze({ ...unavailable.scroll }),
-    typeText: Object.freeze({ ...unavailable.typeText }),
-    touch: Object.freeze({ ...unavailable.touch }),
-    readiness: orNetwork(unavailable.readiness),
-    shutdown: orNetwork(unavailable.shutdown),
-    elementText: Object.freeze({ ...unavailable.elementText }),
-    // Navigation and keyboard cells are stated by their owner too: each differs by family
-    // (harmonyos drives back/home but not orientation/tvRemote; android alone answers a keyboard
-    // status read), so none of them may inherit a sibling's gap.
-    back: Object.freeze({ ...unavailable.back }),
-    home: Object.freeze({ ...unavailable.home }),
-    orientation: Object.freeze({ ...unavailable.orientation }),
-    tvRemote: Object.freeze({ ...unavailable.tvRemote }),
-    keyboardStatus: Object.freeze({ ...unavailable.keyboardStatus }),
-    keyboardDismiss: Object.freeze({ ...unavailable.keyboardDismiss }),
-    keyboardEnter: Object.freeze({ ...unavailable.keyboardEnter }),
-    // Clipboard cells are stated by their owner for the same reason: the surface differs by leaf
-    // and kind (an Apple simulator has one, a physical non-macOS Apple device does not), and read
-    // and write can diverge on a provider whose extension exposes only one half.
-    readClipboard: Object.freeze({ ...unavailable.readClipboard }),
-    writeClipboard: Object.freeze({ ...unavailable.writeClipboard }),
-    // The app switcher is the springboard surface `home` drives, and differs by owner the same
-    // way: an owner states it for its exact leaf rather than inheriting a sibling's gap.
-    appSwitcher: Object.freeze({ ...unavailable.appSwitcher }),
-    // App-event delivery opens a URL on the device, which is not something a transport gap can
-    // speak for: each owner states whether it can open one at all.
-    triggerAppEvent: Object.freeze({ ...unavailable.triggerAppEvent }),
-    // Device settings differ by leaf and kind the way the pasteboard does, and a provider can
-    // own a device without exposing any settings API at all, so each owner states its own cell.
-    setSetting: Object.freeze({ ...unavailable.setSetting }),
-    readAlert: Object.freeze({ ...unavailable.readAlert }),
-    awaitAlert: Object.freeze({ ...unavailable.awaitAlert }),
-    acceptAlert: Object.freeze({ ...unavailable.acceptAlert }),
-    dismissAlert: Object.freeze({ ...unavailable.dismissAlert }),
-    // Audio cells are stated by their owner (#1873): host capture and the page probe live on
-    // different families entirely, so neither may inherit a transport gap.
-    audioProbeCapture: Object.freeze({ ...unavailable.audioProbeCapture }),
-    audioProbeQuery: Object.freeze({ ...unavailable.audioProbeQuery }),
-    // Perf starts native tools and may create a durable capture. Every exact owner states the
-    // gap rather than inheriting a transport failure that could imply local-tool fallthrough.
-    perf: orNetwork(unavailable.perf),
+    ...cells,
     lifecycle: applicationLifecycleOperationFacts(unavailable.lifecycle),
   });
 }

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -514,37 +514,10 @@ describe('composed platform runtime gateway', () => {
     });
     expect(hostLoad).not.toHaveBeenCalled();
     expect(localLoad).not.toHaveBeenCalled();
-  });
-
-  test('reports identical facts for a provider without a module on both the bind and inspect paths', async () => {
-    const runtimeGateway = createComposedPlatformRuntimeGateway({
-      modules: new Map([
-        [
-          'apple',
-          {
-            family: 'apple',
-            loadRuntime: async () =>
-              runtimeOwner({ ref: { kind: 'local-family', family: 'apple' } }),
-          },
-        ],
-      ]),
-      loadHost: async () => ({}) as PlatformRuntimeHost,
-      providerRuntimes: [
-        {
-          provider: 'webdriver',
-          leaseLifecycle: {},
-          deviceInventoryProvider: async () => null,
-          ownsDevice: () => true,
-          getInteractor: () => undefined,
-          shutdown: async () => {},
-        },
-      ],
-    });
-    const binding = await runtimeGateway.bind({ device, intent: { kind: 'ordinary' }, scope });
     const inspected = await runtimeGateway.inspectFacts(device);
     // The bind and inspect arms build this fact set independently; both must derive from the same
     // construction path rather than two hand-maintained maps that can drift from each other.
-    expect(binding.facts).toEqual(inspected);
+    expect(binding.facts).toStrictEqual(inspected);
   });
 
   test.each(LIFECYCLE_FACETS)(

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -516,6 +516,37 @@ describe('composed platform runtime gateway', () => {
     expect(localLoad).not.toHaveBeenCalled();
   });
 
+  test('reports identical facts for a provider without a module on both the bind and inspect paths', async () => {
+    const runtimeGateway = createComposedPlatformRuntimeGateway({
+      modules: new Map([
+        [
+          'apple',
+          {
+            family: 'apple',
+            loadRuntime: async () =>
+              runtimeOwner({ ref: { kind: 'local-family', family: 'apple' } }),
+          },
+        ],
+      ]),
+      loadHost: async () => ({}) as PlatformRuntimeHost,
+      providerRuntimes: [
+        {
+          provider: 'webdriver',
+          leaseLifecycle: {},
+          deviceInventoryProvider: async () => null,
+          ownsDevice: () => true,
+          getInteractor: () => undefined,
+          shutdown: async () => {},
+        },
+      ],
+    });
+    const binding = await runtimeGateway.bind({ device, intent: { kind: 'ordinary' }, scope });
+    const inspected = await runtimeGateway.inspectFacts(device);
+    // The bind and inspect arms build this fact set independently; both must derive from the same
+    // construction path rather than two hand-maintained maps that can drift from each other.
+    expect(binding.facts).toEqual(inspected);
+  });
+
   test.each(LIFECYCLE_FACETS)(
     'keeps provider-owned unsupported $0 operations closed without loading a local runtime',
     async (facet, operations) => {

--- a/src/platform-runtime-gateway.ts
+++ b/src/platform-runtime-gateway.ts
@@ -1,5 +1,4 @@
 import type { ProviderDeviceRuntime } from '@agent-device/contracts/device';
-import { applicationLifecycleOperationFacts } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
   type DeviceBinding,
   type DeviceBindingRequest,
@@ -17,6 +16,7 @@ import type {
   PlatformRuntimeProviderModule,
 } from '@agent-device/contracts/platform-runtime-operations';
 import {
+  createFullyUnavailablePlatformRuntimeFacts,
   createUnavailablePlatformRuntimeBinding,
   createUnavailablePlatformRuntimeFacts,
 } from '@agent-device/contracts/platform-runtime-unavailable';
@@ -342,111 +342,30 @@ async function selectExactOwner(
   }
 }
 
+/** Missing provider modules must fail closed per operation, never via a shared lifecycle bucket. */
+const UNSUPPORTED_PROVIDER_MODE = Object.freeze({
+  available: false,
+  reason: 'unsupported-provider-mode',
+} as const);
+
 function unavailableProviderBinding(
   runtime: ProviderDeviceRuntime,
   device: DeviceInfo,
 ): DeviceBinding<PlatformRuntimeOperations> {
   const owner = providerRuntimeOwner(runtime.provider, 'default');
-  const unavailable = Object.freeze({
-    available: false,
-    reason: 'unsupported-provider-mode',
-  });
-  return createUnavailablePlatformRuntimeBinding(device, owner, {
-    appLog: unavailable,
-    appState: unavailable,
-    network: unavailable,
-    screenshot: unavailable,
-    viewport: unavailable,
-    focus: unavailable,
-    gesture: unavailable,
-    scroll: unavailable,
-    typeText: unavailable,
-    touch: unavailable,
-    elementText: unavailable,
-    back: unavailable,
-    home: unavailable,
-    orientation: unavailable,
-    tvRemote: unavailable,
-    keyboardStatus: unavailable,
-    keyboardDismiss: unavailable,
-    keyboardEnter: unavailable,
-    readClipboard: unavailable,
-    writeClipboard: unavailable,
-    appSwitcher: unavailable,
-    triggerAppEvent: unavailable,
-    setSetting: unavailable,
-    readAlert: unavailable,
-    awaitAlert: unavailable,
-    acceptAlert: unavailable,
-    dismissAlert: unavailable,
-    audioProbeCapture: unavailable,
-    audioProbeQuery: unavailable,
-    lifecycle: unavailableProviderLifecycleFacts(unavailable),
-  });
-}
-
-function unavailableProviderFacts(runtime: ProviderDeviceRuntime, device: DeviceInfo) {
-  const unavailable = Object.freeze({
-    available: false,
-    reason: 'unsupported-provider-mode',
-  } as const);
-  return createUnavailablePlatformRuntimeFacts(
+  return createUnavailablePlatformRuntimeBinding(
     device,
-    providerRuntimeOwner(runtime.provider, 'default'),
-    {
-      appLog: unavailable,
-      appState: unavailable,
-      network: unavailable,
-      screenshot: unavailable,
-      viewport: unavailable,
-      focus: unavailable,
-      gesture: unavailable,
-      scroll: unavailable,
-      typeText: unavailable,
-      touch: unavailable,
-      elementText: unavailable,
-      back: unavailable,
-      home: unavailable,
-      orientation: unavailable,
-      tvRemote: unavailable,
-      keyboardStatus: unavailable,
-      keyboardDismiss: unavailable,
-      keyboardEnter: unavailable,
-      readClipboard: unavailable,
-      writeClipboard: unavailable,
-      appSwitcher: unavailable,
-      triggerAppEvent: unavailable,
-      setSetting: unavailable,
-      readAlert: unavailable,
-      awaitAlert: unavailable,
-      acceptAlert: unavailable,
-      dismissAlert: unavailable,
-      audioProbeCapture: unavailable,
-      audioProbeQuery: unavailable,
-      readiness: unavailable,
-      lifecycle: unavailableProviderLifecycleFacts(unavailable),
-    },
+    owner,
+    createFullyUnavailablePlatformRuntimeFacts(UNSUPPORTED_PROVIDER_MODE),
   );
 }
 
-/** Missing provider modules must fail closed per operation, never via a shared lifecycle bucket. */
-function unavailableProviderLifecycleFacts(
-  unavailable: Extract<
-    DeviceBinding<PlatformRuntimeOperations>['facts']['operations'][keyof PlatformRuntimeOperations],
-    { available: false }
-  >,
-) {
-  return applicationLifecycleOperationFacts({
-    resolveOpenTarget: unavailable,
-    prepareApplicationOpen: unavailable,
-    openApplication: unavailable,
-    applyRuntimeHints: unavailable,
-    clearRuntimeHints: unavailable,
-    closeApplication: unavailable,
-    finalizeApplicationClose: unavailable,
-    prepareAppleRunner: unavailable,
-    configureProviderPortReverse: unavailable,
-  });
+function unavailableProviderFacts(runtime: ProviderDeviceRuntime, device: DeviceInfo) {
+  return createUnavailablePlatformRuntimeFacts(
+    device,
+    providerRuntimeOwner(runtime.provider, 'default'),
+    createFullyUnavailablePlatformRuntimeFacts(UNSUPPORTED_PROVIDER_MODE),
+  );
 }
 
 function ownerUnavailable(owner: RuntimeOwnerRef): AppError {


### PR DESCRIPTION
## Summary

`platform-runtime-unavailable.ts` classified all 34 `UnavailablePlatformRuntimeFacts` cells with
one `Object.freeze` call and comment each. Replaced with a key-only `UNAVAILABLE_CELLS` list and
one `mapUnavailableCells` helper shared by both call sites; `freezeUnavailableFacts` now resolves
each cell as `unavailable[cell] ?? unavailable.network`, accepted without a cast because the
optional/required split already says which cells can fall through. The gateway's two hand-written
"every cell is unavailable" maps — already drifted (binding map omitted `readiness`, facts map
didn't) — become one-liners over a new exported `createFullyUnavailablePlatformRuntimeFacts()`.

Before: a `'owner-stated' | 'inherits-network'` policy table restated the type's optionality by
hand, unchecked against it, so a misclassified entry compiled and its cast turned it into
`Object.freeze({ ...undefined })` = `{}` at runtime. After: the fallback reads the type directly,
so that misclassification can't be written.

## Validation

Tested commit: edf38153059586a92fd12c2aee10384815bf25db — `pnpm check:affected --run` green locally (format, lint, typecheck, layering, fallow, build, vitest-related: 306 files / 2067 tests).

- `pnpm vitest run --project unit-core packages/contracts/src/platform-runtime-unavailable.test.ts
  src/platform-runtime-gateway.test.ts`: both green (29 tests).
- `pnpm check:quick` (oxlint + typecheck): clean.
- Seen red once: reverted the `?? unavailable.network` fallback; the new `listApps` assertion
  failed with exactly the `{}` shape above. Restored before committing.
- Folded the duplicated bind/inspect parity test into the fixture test above it; switched
  `toEqual` to `toStrictEqual` (an omitted cell is how the maps could drift and `toEqual` ignores
  `undefined`-valued keys).

## Review notes

- File-size item (contracts file under 300 lines): not met. 319 → 311 lines; recorded as a miss
  rather than forced further.

