### PR TITLE
refactor(cli): derive the common flag readers from the common-field table

### DIFF
--- a/src/commands/cli-grammar/common.test.ts
+++ b/src/commands/cli-grammar/common.test.ts
@@ -23,9 +23,25 @@ const ALL_COMMON_FLAGS: Partial<CliFlags> = {
   androidDeviceAllowlist: 'emulator-5554,emulator-5556',
 };
 
+// Common-input-fields.ts rows that read a real `CliFlags` key but deliberately join neither
+// `flagIn` projection today (operator/env-sourced). Setting these too, on top of
+// `ALL_COMMON_FLAGS`, means a row that wrongly gained `flagIn: ['input']` would surface a
+// concrete value here rather than being silently dropped by `commonInputFromFlags`'s
+// `compactRecord` — over-inclusion `ALL_COMMON_FLAGS` alone cannot catch, since an unset flag
+// reads as `undefined` and gets compacted away either way.
+const NON_PROJECTED_COMMON_FLAGS: Partial<CliFlags> = {
+  daemonBaseUrl: 'https://daemon.example',
+  daemonAuthToken: 'token-value',
+  tenant: 'tenant-value',
+  runId: 'run-value',
+  leaseId: 'lease-value',
+};
+
 describe('commonInputFromFlags', () => {
   test('projects every common flag into the reader-input shape', () => {
-    expect(commonInputFromFlags(flags(ALL_COMMON_FLAGS))).toStrictEqual({
+    expect(
+      commonInputFromFlags(flags({ ...ALL_COMMON_FLAGS, ...NON_PROJECTED_COMMON_FLAGS })),
+    ).toStrictEqual({
       noRecord: true,
       session: 'my-session',
       platform: 'ios',
@@ -48,7 +64,9 @@ describe('commonInputFromFlags', () => {
 
 describe('selectionOptionsFromFlags', () => {
   test('projects the selection-options subset, keeping the raw target spelling', () => {
-    expect(selectionOptionsFromFlags(flags(ALL_COMMON_FLAGS))).toStrictEqual({
+    expect(
+      selectionOptionsFromFlags(flags({ ...ALL_COMMON_FLAGS, ...NON_PROJECTED_COMMON_FLAGS })),
+    ).toStrictEqual({
       noRecord: true,
       platform: 'ios',
       target: 'mobile',

--- a/src/commands/cli-grammar/common.test.ts
+++ b/src/commands/cli-grammar/common.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import type { CliFlags } from '@agent-device/contracts/command';
+import { commonInputFromFlags, selectionOptionsFromFlags } from './common.ts';
+
+function flags(overrides: Partial<CliFlags> = {}): CliFlags {
+  return overrides as CliFlags;
+}
+
+// Every flag either reader function is documented to read (see the `commonInputFromFlags` and
+// `selectionOptionsFromFlags` doc comments in ./common.ts).
+const ALL_COMMON_FLAGS: Partial<CliFlags> = {
+  noRecord: true,
+  session: 'my-session',
+  platform: 'ios',
+  target: 'mobile',
+  device: 'iPhone 15',
+  udid: 'ABCD-1234',
+  serial: 'emulator-5554',
+  iosSimulatorDeviceSet: '/tmp/device-set',
+  iosXctestrunFile: '/tmp/run.xctestrun',
+  iosXctestDerivedDataPath: '/tmp/derived-data',
+  iosXctestEnvDir: '/tmp/env-dir',
+  androidDeviceAllowlist: 'emulator-5554,emulator-5556',
+};
+
+describe('commonInputFromFlags', () => {
+  test('projects every common flag into the reader-input shape', () => {
+    expect(commonInputFromFlags(flags(ALL_COMMON_FLAGS))).toStrictEqual({
+      noRecord: true,
+      session: 'my-session',
+      platform: 'ios',
+      deviceTarget: 'mobile',
+      device: 'iPhone 15',
+      udid: 'ABCD-1234',
+      serial: 'emulator-5554',
+      iosSimulatorDeviceSet: '/tmp/device-set',
+      iosXctestrunFile: '/tmp/run.xctestrun',
+      iosXctestDerivedDataPath: '/tmp/derived-data',
+      iosXctestEnvDir: '/tmp/env-dir',
+      androidDeviceAllowlist: 'emulator-5554,emulator-5556',
+    });
+  });
+
+  test('drops every key when no common flag is set', () => {
+    expect(commonInputFromFlags(flags())).toStrictEqual({});
+  });
+});
+
+describe('selectionOptionsFromFlags', () => {
+  test('projects the selection-options subset, keeping the raw target spelling', () => {
+    expect(selectionOptionsFromFlags(flags(ALL_COMMON_FLAGS))).toStrictEqual({
+      noRecord: true,
+      platform: 'ios',
+      target: 'mobile',
+      device: 'iPhone 15',
+      udid: 'ABCD-1234',
+      serial: 'emulator-5554',
+      iosSimulatorDeviceSet: '/tmp/device-set',
+      androidDeviceAllowlist: 'emulator-5554,emulator-5556',
+    });
+  });
+
+  test('keeps every key present (undefined, not dropped) when no common flag is set', () => {
+    expect(selectionOptionsFromFlags(flags())).toStrictEqual({
+      noRecord: undefined,
+      platform: undefined,
+      target: undefined,
+      device: undefined,
+      udid: undefined,
+      serial: undefined,
+      iosSimulatorDeviceSet: undefined,
+      androidDeviceAllowlist: undefined,
+    });
+  });
+});

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -11,6 +11,7 @@ import {
   SELECTOR_EXPRESSION_REQUIRED_MESSAGE,
   splitSelectorFromArgs,
 } from '@agent-device/selectors';
+import { commonFlagProjection } from '../common-input-fields.ts';
 import type { SelectorSnapshotInput } from '../command-input.ts';
 import { compactRecord } from '../input-readers.ts';
 import type {
@@ -56,34 +57,24 @@ function readDeviceTarget(value: unknown): InternalRequestOptions['target'] | un
   return value === 'mobile' || value === 'tv' || value === 'desktop' ? value : undefined;
 }
 
+/**
+ * The reader-input shape: every common key whose `commands/common-input-fields.ts`
+ * row lists `input` in `flagIn`, keyed by its own row name (`deviceTarget`, not
+ * the CLI's `--target` spelling). `--no-record` is one such row
+ * (`COMMON_COMMAND_SUPPORTED_FLAG_KEYS`) — it is accepted on, and meaningful
+ * for, every recordable command, and joining the table's `flagIn` is what
+ * makes it ride this projection and `selectionOptionsFromFlags` below without
+ * either reader restating it (#1304/#1305 fixed only the reader layer, so the
+ * flag still never reached the daemon; the table now makes that drop
+ * impossible rather than merely documented against).
+ *
+ * `--record` deliberately does NOT join `flagIn`: it is scoped to the
+ * observation-only commands the repair-segment exclusion can drop (ADR 0012
+ * decision 6 amendment), so it stays on the narrow
+ * `observationRecordInputFromFlags` seam below.
+ */
 export function commonInputFromFlags(flags: CliFlags): Record<string, unknown> {
-  return compactRecord({
-    // `--no-record` is a COMMON flag (`COMMON_COMMAND_SUPPORTED_FLAG_KEYS`): it
-    // is accepted on, and meaningful for, every recordable command. It rides
-    // the common seam every reader already spreads, so a reader cannot forget
-    // it and a new reader inherits it for free. The three seams it must survive
-    // are this one, `readCommonInput`, and `commonToClientOptions`
-    // (`commands/common-input-fields.ts`) — a drop at any one of them silently
-    // disables the flag (#1304/#1305 fixed only the reader layer, so the flag
-    // still never reached the daemon).
-    //
-    // `--record` deliberately does NOT ride here: it is scoped to the
-    // observation-only commands the repair-segment exclusion can drop
-    // (ADR 0012 decision 6 amendment), so it stays on the narrow
-    // `observationRecordInputFromFlags` seam below.
-    noRecord: flags.noRecord,
-    session: flags.session,
-    platform: flags.platform,
-    deviceTarget: flags.target,
-    device: flags.device,
-    udid: flags.udid,
-    serial: flags.serial,
-    iosSimulatorDeviceSet: flags.iosSimulatorDeviceSet,
-    iosXctestrunFile: flags.iosXctestrunFile,
-    iosXctestDerivedDataPath: flags.iosXctestDerivedDataPath,
-    iosXctestEnvDir: flags.iosXctestEnvDir,
-    androidDeviceAllowlist: flags.androidDeviceAllowlist,
-  });
+  return compactRecord(commonFlagProjection(flags, 'input'));
 }
 
 /**
@@ -101,25 +92,16 @@ export function observationRecordInputFromFlags(flags: CliFlags): Record<string,
 }
 
 /**
- * The reader layer has TWO parallel common seams, not one: this builds the
- * client-options shape (`target`) for readers that construct a typed Options
- * object directly (`is`/`find`/`wait`/`settings`), while `commonInputFromFlags`
- * above builds the reader-input shape (`deviceTarget`). They are different
- * projections, not duplicates — so `--no-record` has to ride BOTH or the
- * readers using this one silently drop it (which is what #1304/#1305's
- * per-reader helper was papering over).
+ * The client-options shape for readers that construct a typed Options object
+ * directly (`is`/`find`/`wait`/`settings`): every common row that lists
+ * `selection` in `flagIn`, keyed by `clientKey ?? key` (so `deviceTarget`
+ * comes out as `target`, matching `commonToClientOptions`'s renaming). This is
+ * a different projection from `commonInputFromFlags` above, not a duplicate —
+ * unlike that one it is not compacted, so an unset common flag still appears
+ * with an `undefined` value.
  */
 export function selectionOptionsFromFlags(flags: CliFlags): SelectionOptions {
-  return {
-    noRecord: flags.noRecord,
-    platform: flags.platform,
-    target: flags.target,
-    device: flags.device,
-    udid: flags.udid,
-    serial: flags.serial,
-    iosSimulatorDeviceSet: flags.iosSimulatorDeviceSet,
-    androidDeviceAllowlist: flags.androidDeviceAllowlist,
-  };
+  return commonFlagProjection(flags, 'selection') as SelectionOptions;
 }
 
 export function selectorSnapshotInputFromFlags(flags: CliFlags): Record<string, unknown> {

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -65,8 +65,12 @@ function readDeviceTarget(value: unknown): InternalRequestOptions['target'] | un
  * for, every recordable command, and joining the table's `flagIn` is what
  * makes it ride this projection and `selectionOptionsFromFlags` below without
  * either reader restating it (#1304/#1305 fixed only the reader layer, so the
- * flag still never reached the daemon; the table now makes that drop
- * impossible rather than merely documented against).
+ * flag still never reached the daemon). One row now declares membership for
+ * both projections instead of two hand-written lists to keep in sync; the
+ * `flagKey` a row binds to is checked against `CliFlags` at compile time, but
+ * a *new* common row that omits `flagIn` still joins neither projection
+ * without a compile error — the #1304/#1305 failure mode is narrowed, not
+ * made impossible.
  *
  * `--record` deliberately does NOT join `flagIn`: it is scoped to the
  * observation-only commands the repair-segment exclusion can drop (ADR 0012

--- a/src/commands/cli-grammar/flag-groups.ts
+++ b/src/commands/cli-grammar/flag-groups.ts
@@ -53,8 +53,11 @@ export const REPLAY_FLAGS = flagKeys('replayUpdate', 'replayEnv');
 // structured command input, while the table's `cwd` and `debug` are not flags
 // and its `deviceTarget` row is spelled `target` here. Deriving this list from
 // that table would mean 25 rows carrying no schema, reader, or projection, so
-// the two stay separate; the table declares only `envFlagKeys`, where a flag key
-// names the environment variable an operator-owned input comes from.
+// the two stay separate; the table declares `envFlagKeys` (which environment
+// variable an operator-owned input comes from) and `flagKey`/`flagIn` (which
+// `CliFlags` property a row reads and which reader projections it joins) —
+// this list stays the parser-side axis, naming every flag the CLI grammar
+// accepts regardless of whether a common-input-fields row reads it at all.
 export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
   'remoteConfig',
   'stateDir',

--- a/src/commands/common-input-fields.ts
+++ b/src/commands/common-input-fields.ts
@@ -58,11 +58,21 @@ type CommonInputFieldSpec = {
   clientKey?: string;
   /** Who may write the key. Absent means the model — see `input-audience.ts`. */
   audience?: InputAudience;
-  /** The `CliFlags` property this key reads, when its spelling differs (e.g. `deviceTarget` reads `flags.target`). */
-  flagKey?: keyof CliFlags;
-  /** Which of `cli-grammar/common.ts`'s flag-derived projections include this row. Absent joins neither. */
-  flagIn?: readonly CommonFlagProjection[];
-};
+} & (
+  | {
+      /** Which of `cli-grammar/common.ts`'s flag-derived projections include this row. */
+      flagIn: readonly CommonFlagProjection[];
+      /**
+       * The `CliFlags` property this key reads, when its spelling differs (e.g. `deviceTarget`
+       * reads `flags.target`) or matches outright. Required together with `flagIn` and typed
+       * against `CliFlags`, so a row can only join a projection by naming a flag that actually
+       * exists — `cwd` and `debug`, which have no `CliFlags` counterpart, cannot declare
+       * `flagIn` at all rather than compiling to a binding that reads `undefined` forever.
+       */
+      flagKey: keyof CliFlags;
+    }
+  | { flagIn?: undefined; flagKey?: undefined }
+);
 
 /**
  * The common operator shape: the value comes from the key's own environment
@@ -78,6 +88,7 @@ const COMMON_INPUT_FIELDS = {
   session: {
     schema: { type: 'string', description: 'Agent-device session name.' },
     read: (record) => optionalString(record, 'session'),
+    flagKey: 'session',
     flagIn: ['input'],
   },
   platform: {
@@ -87,6 +98,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Platform selector used to resolve a device.',
     },
     read: (record) => optionalEnum(record, 'platform', PLATFORM_SELECTORS),
+    flagKey: 'platform',
     flagIn: ['input', 'selection'],
   },
   deviceTarget: {
@@ -115,6 +127,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Device name selector (a UDID belongs in udid, a serial in serial).',
     },
     read: (record) => optionalString(record, 'device'),
+    flagKey: 'device',
     flagIn: ['input', 'selection'],
   },
   udid: {
@@ -124,6 +137,7 @@ const COMMON_INPUT_FIELDS = {
         'Apple device or simulator UDID; the selector that pins one device when several share a name.',
     },
     read: (record) => optionalString(record, 'udid'),
+    flagKey: 'udid',
     flagIn: ['input', 'selection'],
   },
   serial: {
@@ -132,6 +146,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Android, HarmonyOS, or Vega VVD serial selector.',
     },
     read: (record) => optionalString(record, 'serial'),
+    flagKey: 'serial',
     flagIn: ['input', 'selection'],
   },
   iosSimulatorDeviceSet: {
@@ -141,6 +156,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosSimulatorDeviceSet'),
     audience: operatorAudience({ envFlagKeys: [], operatorConfig: true }),
+    flagKey: 'iosSimulatorDeviceSet',
     flagIn: ['input', 'selection'],
   },
   iosXctestrunFile: {
@@ -150,6 +166,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestrunFile'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagKey: 'iosXctestrunFile',
     flagIn: ['input'],
   },
   iosXctestDerivedDataPath: {
@@ -159,6 +176,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestDerivedDataPath'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagKey: 'iosXctestDerivedDataPath',
     flagIn: ['input'],
   },
   iosXctestEnvDir: {
@@ -168,6 +186,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestEnvDir'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagKey: 'iosXctestEnvDir',
     flagIn: ['input'],
   },
   androidDeviceAllowlist: {
@@ -176,16 +195,21 @@ const COMMON_INPUT_FIELDS = {
       description: 'Android serial allowlist used for device resolution.',
     },
     read: (record) => optionalString(record, 'androidDeviceAllowlist'),
+    flagKey: 'androidDeviceAllowlist',
     flagIn: ['input', 'selection'],
   },
   noRecord: {
     // `readFieldInput` keeps ONLY declared metadata fields plus this common
     // input, so a flag absent here is filtered out of every field-based
     // command's input before the client ever sees it. `flagIn` below is the
-    // only seam that used to be hand-maintained (#1304/#1305, #1311, #1313);
-    // it now rides both flag-derived projections structurally, the same as
-    // every other row.
+    // seam that used to be hand-maintained (#1304/#1305, #1311, #1313); it now
+    // rides both flag-derived projections from one row instead of two literals
+    // to keep in sync. That row still has to say so itself — a new common key
+    // that omits `flagIn` still joins neither projection silently, the same
+    // failure mode as before, just now a one-line omission instead of a
+    // missing entry in two hand-written lists.
     read: (record) => optionalBoolean(record, 'noRecord'),
+    flagKey: 'noRecord',
     flagIn: ['input', 'selection'],
   },
   daemonBaseUrl: {
@@ -276,12 +300,11 @@ export function commonFlagProjection(
   flags: CliFlags,
   projection: CommonFlagProjection,
 ): Record<string, unknown> {
-  const record = flags as unknown as Record<string, unknown>;
   const options: Record<string, unknown> = {};
   for (const [key, field] of COMMON_INPUT_ROWS) {
-    if (!field.flagIn?.includes(projection)) continue;
+    if (field.flagIn === undefined || !field.flagIn.includes(projection)) continue;
     const outputKey = projection === 'selection' ? (field.clientKey ?? key) : key;
-    options[outputKey] = record[field.flagKey ?? key];
+    options[outputKey] = flags[field.flagKey];
   }
   return options;
 }

--- a/src/commands/common-input-fields.ts
+++ b/src/commands/common-input-fields.ts
@@ -1,3 +1,4 @@
+import type { CliFlags } from '@agent-device/contracts/command';
 import type {
   AgentDeviceRequestOverrides,
   AgentDeviceSelectionOptions,
@@ -34,10 +35,19 @@ export type CommonCommandInput = Pick<
 export type CommonInputReadOptions = { readTargetAlias?: boolean };
 
 /**
+ * `cli-grammar/common.ts`'s two flag-derived projections a row can join:
+ * `input` is the reader-input shape (`commonInputFromFlags`, compacted), `selection` is the
+ * client-options shape kept by `is`/`find`/`wait`/`settings` (`selectionOptionsFromFlags`,
+ * not compacted). A row absent from both is never read off `CliFlags` at all.
+ */
+export type CommonFlagProjection = 'input' | 'selection';
+
+/**
  * One row per input key every command accepts. The JSON schema, the readers,
- * the client-options projection, and the model-facing audience boundary are all
- * derived from this table, so adding or reclassifying a common key is a one-row
- * edit rather than a matching edit in four parallel enumerations.
+ * the client-options projection, the model-facing audience boundary, and the two
+ * flag-derived projections below are all derived from this table, so adding or
+ * reclassifying a common key is a one-row edit rather than a matching edit across
+ * parallel enumerations.
  */
 type CommonInputFieldSpec = {
   /** Advertised property. Absent for a key each command schema carries itself (`noRecord`). */
@@ -48,6 +58,10 @@ type CommonInputFieldSpec = {
   clientKey?: string;
   /** Who may write the key. Absent means the model — see `input-audience.ts`. */
   audience?: InputAudience;
+  /** The `CliFlags` property this key reads, when its spelling differs (e.g. `deviceTarget` reads `flags.target`). */
+  flagKey?: keyof CliFlags;
+  /** Which of `cli-grammar/common.ts`'s flag-derived projections include this row. Absent joins neither. */
+  flagIn?: readonly CommonFlagProjection[];
 };
 
 /**
@@ -64,6 +78,7 @@ const COMMON_INPUT_FIELDS = {
   session: {
     schema: { type: 'string', description: 'Agent-device session name.' },
     read: (record) => optionalString(record, 'session'),
+    flagIn: ['input'],
   },
   platform: {
     schema: {
@@ -72,6 +87,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Platform selector used to resolve a device.',
     },
     read: (record) => optionalEnum(record, 'platform', PLATFORM_SELECTORS),
+    flagIn: ['input', 'selection'],
   },
   deviceTarget: {
     schema: {
@@ -81,6 +97,8 @@ const COMMON_INPUT_FIELDS = {
     },
     read: readDeviceTarget,
     clientKey: 'target',
+    flagKey: 'target',
+    flagIn: ['input', 'selection'],
   },
   target: {
     // Read through `deviceTarget` above, which reconciles the two spellings.
@@ -97,6 +115,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Device name selector (a UDID belongs in udid, a serial in serial).',
     },
     read: (record) => optionalString(record, 'device'),
+    flagIn: ['input', 'selection'],
   },
   udid: {
     schema: {
@@ -105,6 +124,7 @@ const COMMON_INPUT_FIELDS = {
         'Apple device or simulator UDID; the selector that pins one device when several share a name.',
     },
     read: (record) => optionalString(record, 'udid'),
+    flagIn: ['input', 'selection'],
   },
   serial: {
     schema: {
@@ -112,6 +132,7 @@ const COMMON_INPUT_FIELDS = {
       description: 'Android, HarmonyOS, or Vega VVD serial selector.',
     },
     read: (record) => optionalString(record, 'serial'),
+    flagIn: ['input', 'selection'],
   },
   iosSimulatorDeviceSet: {
     schema: {
@@ -120,6 +141,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosSimulatorDeviceSet'),
     audience: operatorAudience({ envFlagKeys: [], operatorConfig: true }),
+    flagIn: ['input', 'selection'],
   },
   iosXctestrunFile: {
     schema: {
@@ -128,6 +150,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestrunFile'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagIn: ['input'],
   },
   iosXctestDerivedDataPath: {
     schema: {
@@ -136,6 +159,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestDerivedDataPath'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagIn: ['input'],
   },
   iosXctestEnvDir: {
     schema: {
@@ -144,6 +168,7 @@ const COMMON_INPUT_FIELDS = {
     },
     read: (record) => optionalString(record, 'iosXctestEnvDir'),
     audience: ENV_OR_OPERATOR_CONFIG,
+    flagIn: ['input'],
   },
   androidDeviceAllowlist: {
     schema: {
@@ -151,13 +176,17 @@ const COMMON_INPUT_FIELDS = {
       description: 'Android serial allowlist used for device resolution.',
     },
     read: (record) => optionalString(record, 'androidDeviceAllowlist'),
+    flagIn: ['input', 'selection'],
   },
   noRecord: {
-    // Seam 2 of 3 for `--no-record` (see `commonInputFromFlags`). `readFieldInput`
-    // keeps ONLY declared metadata fields plus this common input, so a flag
-    // absent here is filtered out of every field-based command's input before
-    // the client ever sees it.
+    // `readFieldInput` keeps ONLY declared metadata fields plus this common
+    // input, so a flag absent here is filtered out of every field-based
+    // command's input before the client ever sees it. `flagIn` below is the
+    // only seam that used to be hand-maintained (#1304/#1305, #1311, #1313);
+    // it now rides both flag-derived projections structurally, the same as
+    // every other row.
     read: (record) => optionalBoolean(record, 'noRecord'),
+    flagIn: ['input', 'selection'],
   },
   daemonBaseUrl: {
     schema: { type: 'string', description: 'Remote daemon base URL.' },
@@ -227,14 +256,34 @@ export function commonToClientOptions(
   const options: Record<string, unknown> = {};
   for (const [key, field] of COMMON_INPUT_ROWS) {
     if (!field.read) continue;
-    // Seam 3 of 3 for `--no-record` (see `commonInputFromFlags`). Every
-    // `to*Options` projection (`toPressOptions`, `toGetOptions`, ...) rebuilds
-    // the client options object from this helper plus its own named fields, so
-    // a key absent here is dropped even when the reader forwarded it and
-    // `readCommonInput` kept it.
+    // Every `to*Options` projection (`toPressOptions`, `toGetOptions`, ...)
+    // rebuilds the client options object from this helper plus its own named
+    // fields, so a key absent from the table is dropped here even when the
+    // reader forwarded it and `readCommonInput` kept it (#1304/#1305).
     options[field.clientKey ?? key] = input[key as keyof CommonCommandInput];
   }
   return compactRecord(options) as AgentDeviceRequestOverrides & AgentDeviceSelectionOptions;
+}
+
+/**
+ * `cli-grammar/common.ts`'s two `CliFlags` readers (`commonInputFromFlags`,
+ * `selectionOptionsFromFlags`) project this same table instead of restating
+ * their key lists: a row joins a projection only when `flagIn` names it, and
+ * its output key is the row key for `input`, or `clientKey ?? key` for
+ * `selection` — the same renaming `commonToClientOptions` already applies.
+ */
+export function commonFlagProjection(
+  flags: CliFlags,
+  projection: CommonFlagProjection,
+): Record<string, unknown> {
+  const record = flags as unknown as Record<string, unknown>;
+  const options: Record<string, unknown> = {};
+  for (const [key, field] of COMMON_INPUT_ROWS) {
+    if (!field.flagIn?.includes(projection)) continue;
+    const outputKey = projection === 'selection' ? (field.clientKey ?? key) : key;
+    options[outputKey] = record[field.flagKey ?? key];
+  }
+  return options;
 }
 
 function readDeviceTarget(


### PR DESCRIPTION
## Summary

`commonInputFromFlags` and `selectionOptionsFromFlags` in
`src/commands/cli-grammar/common.ts` each hand-restated the common CLI
input keys as object literals, with no structural link to the
common-field table in `commands/common-input-fields.ts` that already
owns each key's schema, reader, client-options name, and audience.
Before, adding or reclassifying a common key meant remembering to also
touch both literals by hand — the exact failure mode `--no-record`
suffered in #1304/#1305. After, `CommonInputFieldSpec` carries a
`flagKey`/`flagIn` column, `flagKey` is required and typed against
`CliFlags` wherever `flagIn` is set (closing a gap where a row could
bind to a non-existent flag like `cwd` and silently read `undefined`
forever), and a new `commonFlagProjection(flags, projection)` helper
walks the table once for both readers.

## Validation

Tested commit: 8d4cb0892948e3ef633caf9da01551e083908f21 — `pnpm check:affected --run` green locally (format, lint, typecheck, layering, fallow, build, vitest-related: 1656 tests).

- The characterization test in `common.test.ts` ran green against the
  old literals and again unmodified against the table-derived version
  — deep-equal (key order changed, nothing consumes it). Extended the
  fixture so a row wrongly gaining `flagIn` shows an extra value
  instead of being compacted away; confirmed by temporarily adding
  `flagIn` to `daemonBaseUrl` (test failed) and `flagKey: 'cwd'` (`tsc`
  rejected it), then reverting both.
- `pnpm vitest run --project unit-core src/commands` — 575 tests green.
- `pnpm check:layering` — clean; the `cli-grammar/common.ts` →
  `commands/common-input-fields.ts` import is intra-`commands`-zone.

## Review notes

- Deferred: `selectionOptionsFromFlags` still casts to `SelectionOptions`.
  Removing it needs `common-input-fields.ts` to import from
  `cli-grammar/types.ts`, reversing the one-way dependency; not worth
  it for a cast the characterization test already pins.
