### PR TITLE
ci: avoid unrelated Apple runner cache invalidation

### DIFF
--- a/.github/actions/setup-apple-runner-build/action.yml
+++ b/.github/actions/setup-apple-runner-build/action.yml
@@ -44,7 +44,7 @@ runs:
       id: source-hash
       run: |
         set -euo pipefail
-        echo "value=${{ hashFiles('apple/runner/**', 'apple/snapshot-presentation/**', 'scripts/build-xcuitest-apple.sh', 'scripts/patch-xcuitest-runner-icon.ts', 'scripts/write-xcuitest-cache-metadata.mjs', 'packages/platform-apple/src/runner/apple-runner-platform.ts', 'packages/platform-apple/src/runner/runner-cache-metadata.ts', 'packages/platform-apple/src/runner/runner-icon.ts', 'packages/platform-apple/src/runner/runner-xctestrun.ts', 'packages/platform-apple/src/runner/runner-xctestrun-products.ts', '.github/actions/setup-apple-runner-build/action.yml', 'package.json', 'pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"
+        echo "value=${{ hashFiles('apple/runner/**', 'apple/snapshot-presentation/**', 'scripts/build-xcuitest-apple.sh', 'scripts/swift-toolchain-tmpdir.ts', 'scripts/patch-xcuitest-runner-icon.ts', 'scripts/write-xcuitest-cache-metadata.mjs', 'packages/platform-apple/src/runner/apple-runner-platform.ts', 'packages/platform-apple/src/runner/runner-cache-metadata.ts', 'packages/platform-apple/src/runner/runner-icon.ts', 'packages/platform-apple/src/runner/runner-xctestrun.ts', 'packages/platform-apple/src/runner/runner-xctestrun-products.ts', '.github/actions/setup-apple-runner-build/action.yml') }}" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Resolve Apple runner build variant
@@ -55,12 +55,19 @@ runs:
         INPUT_XCUITEST_DESTINATION: ${{ inputs.xcuitest-destination }}
       run: |
         set -euo pipefail
+        BUILD_COMMANDS="$(node -p 'JSON.stringify(Object.entries(require("./package.json").scripts).filter(([name]) => name.startsWith("build:xcuitest:")))')"
         VARIANT="$(
           printf '%s\n' \
             "$INPUT_GATE" \
+            "$BUILD_COMMANDS" \
+            "$(uname -m)" \
             "$INPUT_XCUITEST_PLATFORM" \
             "$INPUT_XCUITEST_DESTINATION" \
             "${AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS:-0}" \
+            "${AGENT_DEVICE_XCUITEST_ARCHS:-}" \
+            "${AGENT_DEVICE_IOS_BUNDLE_ID:-}" \
+            "${AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID:-}" \
+            "${AGENT_DEVICE_IOS_RUNNER_TEST_BUNDLE_ID:-}" \
             | shasum -a 256 \
             | cut -c1-16
         )"
@@ -89,4 +96,23 @@ runs:
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
       with:
         path: ${{ inputs.derived-path }}
-        key: ${{ inputs.cache-key-prefix }}-${{ steps.xcode.outputs.key }}${{ inputs.cache-key-suffix }}-${{ steps.build-variant.outputs.key }}-${{ steps.source-hash.outputs.value }}
+        key: ${{ steps.restore-runner-build.outputs.cache-primary-key }}
+
+    - name: Report Apple runner build cache
+      env:
+        CACHE_HIT: ${{ steps.restore-runner-build.outputs.cache-hit }}
+        CACHE_KEY: ${{ steps.restore-runner-build.outputs.cache-primary-key }}
+        BUILD_GATE: ${{ inputs.gate }}
+      run: |
+        set -euo pipefail
+        if [ "$CACHE_HIT" = 'true' ]; then
+          RESULT='restored exact prebuilt runner; compilation skipped'
+        else
+          RESULT='cache miss; built runner and attempted cache save'
+        fi
+        {
+          printf '### Apple runner cache (%s)\n\n' "$BUILD_GATE"
+          printf '%s\n\n' "$RESULT"
+          printf 'Key: `%s`\n' "$CACHE_KEY"
+        } >> "$GITHUB_STEP_SUMMARY"
+      shell: bash


### PR DESCRIPTION
## Summary

Keep prebuilt Apple runners reusable across unrelated dependency and package-version changes. Hash the runner build commands instead of the whole root manifest and lockfile, and include architecture, bundle IDs, and the Swift build wrapper in cache identity. Report cache hits/misses in the job summary and save using the restore action's primary key.

The existing main-branch producer already serves the iOS workflows: run 33981982967 restored a 65 MB runner in 3.4 seconds and preflight reported `buildMs: 0`. No additional prebuild workflow is needed. The revised key requires one initial rebuild per variant.

Scope: one shared CI action; no runtime, docs, or skill changes.

## Validation

Head: `31b07ed5bf96ab837995a039eafdf8fcc329cf34`.

All runnable `pnpm check:affected --run` checks passed. The first sandboxed attempt stopped because the cleanup guard could not run `ps`; the rerun with process-list access passed.

Focused shell checks demonstrated the old key's invalidation gaps and passed against the revised action. Actionlint passed for all seven consuming workflows. Native/device CI and the first new-key cache restore remain to be observed on GitHub.
