### PR TITLE
test(daemon): session-open-url-prewarm through the request seam

### DIFF
--- a/src/daemon/__tests__/test-device-runtime-gateway.ts
+++ b/src/daemon/__tests__/test-device-runtime-gateway.ts
@@ -5,6 +5,7 @@ import {
   availableApplicationLifecycleOperations,
 } from '@agent-device/contracts/application-lifecycle-runtime';
 import {
+  type DeviceBindingRequest,
   type DeviceRuntimeGateway,
   localRuntimeOwner,
   narrowDeviceBinding,
@@ -83,6 +84,28 @@ export const lifecycleDeviceRuntimeGateway: DeviceRuntimeGateway<PlatformRuntime
     bind: async ({ device }) => await lifecycleBindingForTest(device),
     shutdown: async () => {},
   });
+
+/**
+ * A fresh, unfrozen `lifecycleDeviceRuntimeGateway`-equivalent whose `inspectFacts`/`bind` are
+ * `vi.fn()` spies. The shared `lifecycleDeviceRuntimeGateway` above is `Object.freeze`d and reused
+ * across many router-seam suites, so it can't be spied on in place (and spying on it in place
+ * would leak call counts between tests in other files) — call this per test that needs to observe
+ * fact-inspection/binding call counts through the router seam.
+ */
+export function createLifecycleDeviceRuntimeGatewaySpies() {
+  const inspectFacts = vi.fn(
+    async (device: DeviceInfo) => (await lifecycleBindingForTest(device)).facts,
+  );
+  const bind = vi.fn(
+    async (request: DeviceBindingRequest) => await lifecycleBindingForTest(request.device),
+  );
+  const gateway: DeviceRuntimeGateway<PlatformRuntimeOperations> = {
+    inspectFacts,
+    bind,
+    shutdown: async () => {},
+  };
+  return { gateway, inspectFacts, bind };
+}
 
 export const unavailableDeviceRuntimeGateway: DeviceRuntimeGateway<PlatformRuntimeOperations> =
   Object.freeze({

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) =>
 });
 
 import {
+  createLifecycleDeviceRuntimeGatewaySpies,
   createRequestHandler,
   lifecycleDeviceRuntimeGateway,
 } from '../../../__tests__/test-device-runtime-gateway.ts';
@@ -98,13 +99,16 @@ beforeEach(() => {
   mockResolveIosSimulatorDeepLinkBundleId.mockResolvedValue(undefined);
 });
 
-function createHandler(sessionStore: ReturnType<typeof makeSessionStore>) {
+function createHandler(
+  sessionStore: ReturnType<typeof makeSessionStore>,
+  deviceRuntimeGateway = lifecycleDeviceRuntimeGateway,
+) {
   return createRequestHandler({
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     token: 'test-token',
     sessionStore,
     leaseRegistry: new LeaseRegistry(),
-    deviceRuntimeGateway: lifecycleDeviceRuntimeGateway,
+    deviceRuntimeGateway,
     deviceInventoryGateways: createTestDeviceInventoryGateways(),
     trackDownloadableArtifact: () => 'artifact-id',
   });
@@ -571,8 +575,12 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
     kind: 'simulator',
     booted: true,
   });
+  const { gateway, inspectFacts, bind } = createLifecycleDeviceRuntimeGatewaySpies();
 
-  const response = await createHandler(sessionStore)(
+  const response = await createHandler(
+    sessionStore,
+    gateway,
+  )(
     sessionRequest(sessionName, 'prepare', {
       positionals: ['ios-runner'],
       flags: { platform: 'ios', udid: 'sim-1', timeoutMs: 240000 },
@@ -581,6 +589,10 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
   );
 
   expect(response.ok).toBe(true);
+  expect(inspectFacts).toHaveBeenCalledTimes(1);
+  expect(bind).toHaveBeenCalledTimes(1);
+  // Readiness runs inside the admitted Apple binding, so `prepare` proves it by reaching the
+  // runner at all rather than by observing a retired root readiness call.
   expect(mockPrepareIosRunner).toHaveBeenCalledTimes(1);
   expect(mockPrepareIosRunner).toHaveBeenCalledWith(
     expect.objectContaining({ platform: 'apple', id: 'sim-1' }),
@@ -732,8 +744,12 @@ test('prepare ios-runner rejects non-Apple runner devices', async () => {
     kind: 'emulator',
     booted: true,
   });
+  const { gateway, inspectFacts, bind } = createLifecycleDeviceRuntimeGatewaySpies();
 
-  const response = await createHandler(sessionStore)(
+  const response = await createHandler(
+    sessionStore,
+    gateway,
+  )(
     sessionRequest('prepare-android', 'prepare', {
       positionals: ['ios-runner'],
       flags: { platform: 'android', serial: 'emulator-5554' },
@@ -745,6 +761,8 @@ test('prepare ios-runner rejects non-Apple runner devices', async () => {
     expect(response.error.code).toBe('UNSUPPORTED_OPERATION');
     expect(response.error.message).toBe('prepare is not supported on this device');
   }
+  expect(inspectFacts).toHaveBeenCalledTimes(1);
+  expect(bind).not.toHaveBeenCalled();
   expect(mockPrepareIosRunner).not.toHaveBeenCalled();
 });
 

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
@@ -1,41 +1,154 @@
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
+
+vi.mock('node:timers/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:timers/promises')>();
+  return { ...actual, setTimeout: vi.fn(async () => undefined) };
+});
+vi.mock('../../../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+vi.mock('@agent-device/platform-apple/runner/operations', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@agent-device/platform-apple/runner/operations')>();
+  return {
+    ...actual,
+    prepareIosRunner: vi.fn(async () => ({
+      runner: { currentUptimeMs: 42 },
+      connectMs: 3,
+      healthCheckMs: 3,
+    })),
+    prewarmAppleRunnerCache: vi.fn(),
+    prewarmIosRunnerSession: vi.fn(),
+    notifyIosRunnerAppRelaunched: vi.fn(async () => {}),
+    scheduleIosRunnerIdleStop: vi.fn(),
+    stopIosRunnerSession: vi.fn(async () => {}),
+  };
+});
+vi.mock('@agent-device/platform-apple/macos', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent-device/platform-apple/macos')>();
+  return { ...actual, runMacOsAlertAction: vi.fn(async () => {}) };
+});
+vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
+  return {
+    ...actual,
+    resolveIosApp: vi.fn(async (_device, app: string) => app),
+    resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
+  };
+});
+vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
+  return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
+});
+
 import {
-  mockLifecycleDispatch as mockDispatch,
-  mockResolveTargetDevice,
-  mockPrewarmIosRunnerSession,
-  mockNotifyIosRunnerAppRelaunched,
-  mockPrewarmAppleRunnerCache,
-  mockPrepareIosRunner,
-  mockResolveIosApp,
-  mockResolveIosSimulatorDeepLinkBundleId,
-  makeSessionStore,
-  makeSession,
-  noopInvoke,
-} from '../../../handlers/__tests__/session-test-harness.ts';
-import type { SessionState } from '../../../types.ts';
+  createRequestHandler,
+  lifecycleDeviceRuntimeGateway,
+} from '../../../__tests__/test-device-runtime-gateway.ts';
+import { dispatchApplicationLifecycleEffect } from '../../../__tests__/application-lifecycle-runtime-fixture.ts';
+import { getResolveTargetDeviceMock } from '../../../__tests__/request-router-dispatch-mocks.ts';
+import { createTestDeviceInventoryGateways } from '../../../../__tests__/test-utils/device-inventory-gateways.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
+import { makeSession } from '../../../../__tests__/test-utils/session-factories.ts';
+import { LeaseRegistry } from '../../../lease-registry.ts';
+import type { DaemonRequest } from '../../../types.ts';
 import {
-  handleSessionCommands,
-  mockBindDeviceRuntime,
-  mockInspectDeviceRuntimeFacts,
-} from '../../../handlers/__tests__/session-command-harness.ts';
+  prepareIosRunner,
+  prewarmAppleRunnerCache,
+  prewarmIosRunnerSession,
+  notifyIosRunnerAppRelaunched,
+} from '@agent-device/platform-apple/runner/operations';
+import {
+  resolveIosApp,
+  resolveIosSimulatorDeepLinkBundleId,
+} from '@agent-device/platform-apple/app-resolution';
+
+const mockResolveTargetDevice = vi.mocked(getResolveTargetDeviceMock());
+const mockDispatch = vi.mocked(dispatchApplicationLifecycleEffect);
+const mockPrepareIosRunner = vi.mocked(prepareIosRunner);
+const mockPrewarmAppleRunnerCache = vi.mocked(prewarmAppleRunnerCache);
+const mockPrewarmIosRunnerSession = vi.mocked(prewarmIosRunnerSession);
+const mockNotifyIosRunnerAppRelaunched = vi.mocked(notifyIosRunnerAppRelaunched);
+const mockResolveIosApp = vi.mocked(resolveIosApp);
+const mockResolveIosSimulatorDeepLinkBundleId = vi.mocked(resolveIosSimulatorDeepLinkBundleId);
+
+beforeEach(() => {
+  vi.useRealTimers();
+  mockResolveTargetDevice.mockReset();
+  mockDispatch.mockReset();
+  mockDispatch.mockResolvedValue(undefined);
+  mockPrepareIosRunner.mockReset();
+  mockPrepareIosRunner.mockResolvedValue({
+    runner: { currentUptimeMs: 42 },
+    connectMs: 3,
+    healthCheckMs: 3,
+  });
+  mockPrewarmAppleRunnerCache.mockReset();
+  mockPrewarmIosRunnerSession.mockReset();
+  mockNotifyIosRunnerAppRelaunched.mockReset();
+  mockNotifyIosRunnerAppRelaunched.mockResolvedValue(undefined);
+  mockResolveIosApp.mockReset();
+  mockResolveIosApp.mockImplementation(async (_device, app: string) =>
+    app.includes('.') ? app : `com.example.${app.toLowerCase()}`,
+  );
+  mockResolveIosSimulatorDeepLinkBundleId.mockReset();
+  mockResolveIosSimulatorDeepLinkBundleId.mockResolvedValue(undefined);
+});
+
+function createHandler(sessionStore: ReturnType<typeof makeSessionStore>) {
+  return createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    deviceRuntimeGateway: lifecycleDeviceRuntimeGateway,
+    deviceInventoryGateways: createTestDeviceInventoryGateways(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+}
+
+let requestSeq = 0;
+
+function sessionRequest(
+  session: string,
+  command: 'open' | 'prepare',
+  options: {
+    positionals?: string[];
+    flags?: Record<string, unknown>;
+    meta?: DaemonRequest['meta'];
+  } = {},
+): DaemonRequest {
+  requestSeq += 1;
+  return {
+    token: 'test-token',
+    session,
+    command,
+    positionals: options.positionals ?? [],
+    flags: options.flags ?? {},
+    meta: { requestId: `req-${command}-${requestSeq}`, ...options.meta },
+  };
+}
 
 test('open URL on existing iOS session clears stale app bundle id', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 15',
-      kind: 'simulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 15',
+        kind: 'simulator',
+        booted: true,
+      },
+      appBundleId: 'com.example.old',
+      appName: 'Old App',
     }),
-    appBundleId: 'com.example.old',
-    appName: 'Old App',
-  });
+  );
 
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
@@ -47,25 +160,14 @@ test('open URL on existing iOS session clears stale app bundle id', async () => 
   let dispatchedContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, _command, _positionals, _out, context) => {
     dispatchedContext = context as Record<string, unknown> | undefined;
-    return {};
+    return undefined;
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['https://example.com/path'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['https://example.com/path'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   const updated = sessionStore.get(sessionName);
   expect(updated?.appBundleId).toBe(undefined);
   expect(updated?.appName).toBe('https://example.com/path');
@@ -73,44 +175,36 @@ test('open URL on existing iOS session clears stale app bundle id', async () => 
 });
 
 test('open URL on existing macOS session clears stale app bundle id', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'macos-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      appleOs: 'macos',
-      id: 'host-mac',
-      name: 'Mac',
-      kind: 'device',
-      target: 'desktop',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        appleOs: 'macos',
+        id: 'host-mac',
+        name: 'Mac',
+        kind: 'device',
+        target: 'desktop',
+        booted: true,
+      },
+      appBundleId: 'com.example.old',
+      appName: 'Old App',
     }),
-    appBundleId: 'com.example.old',
-    appName: 'Old App',
-  });
+  );
 
   let dispatchedContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, _command, _positionals, _out, context) => {
     dispatchedContext = context as Record<string, unknown> | undefined;
-    return {};
+    return undefined;
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['https://example.com/path'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['https://example.com/path'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   const updated = sessionStore.get(sessionName);
   expect(updated?.appBundleId).toBe(undefined);
   expect(updated?.appName).toBe('https://example.com/path');
@@ -118,42 +212,34 @@ test('open URL on existing macOS session clears stale app bundle id', async () =
 });
 
 test('open URL on existing iOS device session preserves app bundle id context', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-device-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'iPhone Device',
-      kind: 'device',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'iPhone Device',
+        kind: 'device',
+        booted: true,
+      },
+      appBundleId: 'com.example.app',
+      appName: 'Example App',
     }),
-    appBundleId: 'com.example.app',
-    appName: 'Example App',
-  });
+  );
 
   let dispatchedContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, _command, _positionals, _out, context) => {
     dispatchedContext = context as Record<string, unknown> | undefined;
-    return {};
+    return undefined;
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['myapp://item/42'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['myapp://item/42'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   const updated = sessionStore.get(sessionName);
   expect(updated?.appBundleId).toBe('com.example.app');
   expect(updated?.appName).toBe('myapp://item/42');
@@ -161,19 +247,22 @@ test('open URL on existing iOS device session preserves app bundle id context', 
 });
 
 test('open custom URL on existing iOS simulator session preserves app bundle id context', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-simulator-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
+      appBundleId: 'com.example.app',
+      appName: 'Example App',
     }),
-    appBundleId: 'com.example.app',
-    appName: 'Example App',
-  });
+  );
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
     id: 'sim-1',
@@ -185,25 +274,14 @@ test('open custom URL on existing iOS simulator session preserves app bundle id 
   let dispatchedContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, _command, _positionals, _out, context) => {
     dispatchedContext = context as Record<string, unknown> | undefined;
-    return {};
+    return undefined;
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['myapp://item/42'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['myapp://item/42'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   const updated = sessionStore.get(sessionName);
   expect(updated?.appBundleId).toBe('com.example.app');
   expect(updated?.appName).toBe('myapp://item/42');
@@ -211,7 +289,7 @@ test('open custom URL on existing iOS simulator session preserves app bundle id 
 });
 
 test('open custom URL on fresh iOS simulator session infers app bundle id from URL scheme', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-simulator-url-session';
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
@@ -225,25 +303,17 @@ test('open custom URL on fresh iOS simulator session infers app bundle id from U
   let dispatchedContext: Record<string, unknown> | undefined;
   mockDispatch.mockImplementation(async (_device, _command, _positionals, _out, context) => {
     dispatchedContext = context as Record<string, unknown> | undefined;
-    return {};
+    return undefined;
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['rne://navigator-layout'],
       flags: { platform: 'ios', udid: 'sim-1' },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(mockResolveIosSimulatorDeepLinkBundleId).toHaveBeenCalledWith(
     expect.objectContaining({ id: 'sim-1', kind: 'simulator' }),
     'rne://navigator-layout',
@@ -256,42 +326,32 @@ test('open custom URL on fresh iOS simulator session infers app bundle id from U
 });
 
 test('open iOS simulator app prewarms runner cache during cold boot', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-simulator-cold-boot-cache-prewarm';
-  const device: SessionState['device'] = {
-    platform: 'apple',
+  const device = {
+    platform: 'apple' as const,
     id: 'sim-1',
     name: 'iPhone 17 Pro',
-    kind: 'simulator',
+    kind: 'simulator' as const,
     booted: false,
   };
   mockResolveTargetDevice.mockResolvedValue(device);
   mockResolveIosApp.mockResolvedValueOnce('com.example.app');
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['Demo'],
       flags: { platform: 'ios', udid: 'sim-1' },
       meta: { requestId: 'open-request' },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
-  // Readiness is package-owned now: a cold boot runs the binding's onColdBootStart hook, which
-  // is what starts the runner-cache warm in parallel with the boot.
+  expect(response.ok).toBe(true);
   await vi.waitFor(() => {
     expect(mockPrewarmAppleRunnerCache).toHaveBeenCalledWith(
       device,
       expect.objectContaining({
-        logPath: expect.stringMatching(/daemon\.log$/),
+        logPath: expect.stringMatching(/runner\.log$/),
         requestId: 'open-request',
       }),
     );
@@ -300,61 +360,56 @@ test('open iOS simulator app prewarms runner cache during cold boot', async () =
 });
 
 test('open iOS app session prewarms runner session when app bundle id is known', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-device-session';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'iPhone Device',
-      kind: 'device',
-      booted: true,
-    }),
-    appBundleId: 'com.example.previous',
-    appName: 'Previous App',
-  });
-
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['Settings', 'myapp://screen/to'],
-      flags: {},
-    },
+  sessionStore.set(
     sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'iPhone Device',
+        kind: 'device',
+        booted: true,
+      },
+      appBundleId: 'com.example.previous',
+      appName: 'Previous App',
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['Settings', 'myapp://screen/to'] }),
+  );
+
+  expect(response.ok).toBe(true);
   await vi.waitFor(() => {
     expect(mockPrewarmIosRunnerSession).toHaveBeenCalledTimes(1);
     expect(mockPrewarmIosRunnerSession).toHaveBeenCalledWith(
       expect.objectContaining({ platform: 'apple', id: 'ios-device-1' }),
-      expect.objectContaining({ logPath: expect.stringMatching(/daemon\.log$/) }),
+      expect.objectContaining({ logPath: expect.stringMatching(/runner\.log$/) }),
     );
   });
 });
 
 test('open iOS Maestro app link waits for runner prewarm before launching app', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-maestro-open-link';
   const events: string[] = [];
   let finishPrewarm: (() => void) | undefined;
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'iPhone Device',
-      kind: 'device',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'iPhone Device',
+        kind: 'device',
+        booted: true,
+      },
+      appBundleId: 'com.example.previous',
+      appName: 'Previous App',
     }),
-    appBundleId: 'com.example.previous',
-    appName: 'Previous App',
-  });
+  );
 
   mockPrewarmIosRunnerSession.mockImplementation(
     () =>
@@ -368,34 +423,24 @@ test('open iOS Maestro app link waits for runner prewarm before launching app', 
   );
   mockDispatch.mockImplementation(async (_device, command) => {
     events.push(`dispatch:${command}`);
-    return {};
+    return undefined;
   });
 
-  const responsePromise = handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const responsePromise = createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['com.example.app', 'rne://screen-layout'],
-      flags: {
-        maestro: { prewarmRunnerBeforeOpen: true },
-      },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+      flags: { maestro: { prewarmRunnerBeforeOpen: true } },
+    }),
+  );
 
   await vi.waitFor(() => expect(events).toEqual(['prewarm-start']));
 
   finishPrewarm?.();
   const response = await responsePromise;
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(events).toEqual(['prewarm-start', 'prewarm-finish', 'dispatch:open']);
-  expect((response as any).data?.timing).toMatchObject({
+  expect((response as { data?: Record<string, unknown> }).data?.timing).toMatchObject({
     runnerPrewarmKind: 'session',
     runnerPrewarmScheduled: true,
     runnerPrewarmWaited: true,
@@ -403,7 +448,7 @@ test('open iOS Maestro app link waits for runner prewarm before launching app', 
 });
 
 test('open iOS Maestro app link resets a simulator runner prewarmed before URL dispatch', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-simulator-maestro-open-link';
   const events: string[] = [];
   const device = {
@@ -413,11 +458,14 @@ test('open iOS Maestro app link resets a simulator runner prewarmed before URL d
     kind: 'simulator' as const,
     booted: true,
   };
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, device),
-    appBundleId: 'com.example.app',
-    appName: 'Example App',
-  });
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device,
+      appBundleId: 'com.example.app',
+      appName: 'Example App',
+    }),
+  );
   mockResolveTargetDevice.mockResolvedValue(device);
 
   mockPrewarmIosRunnerSession.mockImplementation(async () => {
@@ -425,27 +473,20 @@ test('open iOS Maestro app link resets a simulator runner prewarmed before URL d
   });
   mockDispatch.mockImplementation(async (_device, command) => {
     events.push(`dispatch:${command}`);
-    return {};
+    return undefined;
   });
   mockNotifyIosRunnerAppRelaunched.mockImplementation(async () => {
     events.push('target-reset');
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
       positionals: ['com.example.app', 'rne://screen-layout'],
       flags: { maestro: { prewarmRunnerBeforeOpen: true } },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(events).toEqual(['prewarm', 'dispatch:open', 'target-reset']);
   expect(mockNotifyIosRunnerAppRelaunched).toHaveBeenCalledWith(
     expect.objectContaining({ id: 'ios-simulator-1' }),
@@ -454,48 +495,41 @@ test('open iOS Maestro app link resets a simulator runner prewarmed before URL d
 });
 
 test('open iOS Maestro app link reports blocking runner prewarm failures before launching app', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-maestro-open-link-prewarm-failed';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'iPhone Device',
-      kind: 'device',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'iPhone Device',
+        kind: 'device',
+        booted: true,
+      },
+      appBundleId: 'com.example.previous',
+      appName: 'Previous App',
     }),
-    appBundleId: 'com.example.previous',
-    appName: 'Previous App',
-  });
+  );
   mockPrewarmIosRunnerSession.mockRejectedValueOnce(
     new AppError('COMMAND_FAILED', 'Developer mode is disabled for Apple development tools', {
       hint: 'Run `sudo DevToolsSecurity -enable`.',
     }),
   );
 
-  await expect(
-    handleSessionCommands({
-      req: {
-        token: 't',
-        session: sessionName,
-        command: 'open',
-        positionals: ['com.example.app', 'rne://screen-layout'],
-        flags: {
-          maestro: { prewarmRunnerBeforeOpen: true },
-        },
-      },
-      sessionName,
-      logPath: path.join(os.tmpdir(), 'daemon.log'),
-      sessionStore,
-      invoke: noopInvoke,
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', {
+      positionals: ['com.example.app', 'rne://screen-layout'],
+      flags: { maestro: { prewarmRunnerBeforeOpen: true } },
     }),
-  ).rejects.toMatchObject({
-    code: 'COMMAND_FAILED',
-    message: 'Developer mode is disabled for Apple development tools',
-    details: {
-      hint: expect.stringContaining('DevToolsSecurity -enable'),
-    },
-  });
+  );
+
+  expect(response.ok).toBe(false);
+  if (!response.ok) {
+    expect(response.error.code).toBe('COMMAND_FAILED');
+    expect(response.error.message).toBe('Developer mode is disabled for Apple development tools');
+    expect(response.error.hint).toEqual(expect.stringContaining('DevToolsSecurity -enable'));
+  }
   expect(mockDispatch).not.toHaveBeenCalled();
   expect(mockPrewarmIosRunnerSession).toHaveBeenCalledWith(
     expect.objectContaining({ platform: 'apple', id: 'ios-device-1' }),
@@ -504,40 +538,31 @@ test('open iOS Maestro app link reports blocking runner prewarm failures before 
 });
 
 test('open iOS URL without app bundle id skips runner prewarm', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'ios-device-session';
   sessionStore.set(
     sessionName,
     makeSession(sessionName, {
-      platform: 'apple',
-      id: 'ios-device-1',
-      name: 'iPhone Device',
-      kind: 'device',
-      booted: true,
+      device: {
+        platform: 'apple',
+        id: 'ios-device-1',
+        name: 'iPhone Device',
+        kind: 'device',
+        booted: true,
+      },
     }),
   );
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'open',
-      positionals: ['myapp://screen/to'],
-      flags: {},
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'open', { positionals: ['myapp://screen/to'] }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(mockPrewarmIosRunnerSession).not.toHaveBeenCalled();
 });
 
 test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'prepare-ios-runner';
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
@@ -547,27 +572,15 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
     booted: true,
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'prepare',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'prepare', {
       positionals: ['ios-runner'],
       flags: { platform: 'ios', udid: 'sim-1', timeoutMs: 240000 },
       meta: { requestId: 'prepare-request' },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
-  expect(mockInspectDeviceRuntimeFacts).toHaveBeenCalledTimes(1);
-  expect(mockBindDeviceRuntime).toHaveBeenCalledTimes(1);
-  // Readiness runs inside the admitted Apple binding now, so `prepare` proves it by reaching the
-  // runner at all rather than by observing the retired root readiness call.
+  expect(response.ok).toBe(true);
   expect(mockPrepareIosRunner).toHaveBeenCalledTimes(1);
   expect(mockPrepareIosRunner).toHaveBeenCalledWith(
     expect.objectContaining({ platform: 'apple', id: 'sim-1' }),
@@ -575,7 +588,7 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
       cleanStaleBundles: true,
       buildTimeoutMs: 240000,
       healthTimeoutMs: 240000,
-      logPath: expect.stringMatching(/daemon\.log$/),
+      logPath: expect.stringMatching(/runner\.log$/),
       prepareDeadline: expect.objectContaining({
         elapsedMs: expect.any(Function),
         isExpired: expect.any(Function),
@@ -585,22 +598,24 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
       startupTimeoutMs: 240000,
     }),
   );
-  expect((response as any).data).toMatchObject({
-    action: 'ios-runner',
-    platform: 'ios',
-    deviceId: 'sim-1',
-    deviceName: 'iPhone 17 Pro',
-    kind: 'simulator',
-    connectMs: 3,
-    healthCheckMs: 3,
-    runner: { currentUptimeMs: 42 },
-    message: 'Prepared Apple runner: iPhone 17 Pro',
-  });
+  if (response.ok) {
+    expect(response.data).toMatchObject({
+      action: 'ios-runner',
+      platform: 'ios',
+      deviceId: 'sim-1',
+      deviceName: 'iPhone 17 Pro',
+      kind: 'simulator',
+      connectMs: 3,
+      healthCheckMs: 3,
+      runner: { currentUptimeMs: 42 },
+      message: 'Prepared Apple runner: iPhone 17 Pro',
+    });
+  }
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('prepare ios-runner explains overlapping timing fields with additive parts', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'prepare-ios-runner-timing';
   vi.useFakeTimers();
   vi.setSystemTime(new Date(1_000));
@@ -622,22 +637,16 @@ test('prepare ios-runner explains overlapping timing fields with additive parts'
       };
     });
 
-    const response = await handleSessionCommands({
-      req: {
-        token: 't',
-        session: sessionName,
-        command: 'prepare',
+    const response = await createHandler(sessionStore)(
+      sessionRequest(sessionName, 'prepare', {
         positionals: ['ios-runner'],
         flags: { platform: 'ios', udid: 'sim-1' },
-      },
-      sessionName,
-      logPath: path.join(os.tmpdir(), 'daemon.log'),
-      sessionStore,
-      invoke: noopInvoke,
-    });
+      }),
+    );
 
-    expect(response?.ok).toBe(true);
-    const data = (response as any).data;
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const data = response.data as Record<string, any>;
     expect(data).toMatchObject({
       buildMs: 10_642,
       connectMs: 12_635,
@@ -668,7 +677,7 @@ test('prepare ios-runner explains overlapping timing fields with additive parts'
 });
 
 test('prepare ios-runner starts the XCTest runner on an explicit macOS selector', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   const sessionName = 'prepare-macos-runner';
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'apple',
@@ -680,23 +689,15 @@ test('prepare ios-runner starts the XCTest runner on an explicit macOS selector'
     booted: true,
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'prepare',
+  const response = await createHandler(sessionStore)(
+    sessionRequest(sessionName, 'prepare', {
       positionals: ['ios-runner'],
       flags: { platform: 'macos', timeoutMs: 240000 },
       meta: { requestId: 'prepare-macos-request' },
-    },
-    sessionName,
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(mockPrepareIosRunner).toHaveBeenCalledWith(
     expect.objectContaining({ platform: 'apple', id: 'host-macos-local' }),
     expect.objectContaining({
@@ -710,18 +711,20 @@ test('prepare ios-runner starts the XCTest runner on an explicit macOS selector'
       requestId: 'prepare-macos-request',
     }),
   );
-  expect((response as any).data).toMatchObject({
-    action: 'ios-runner',
-    platform: 'macos',
-    deviceId: 'host-macos-local',
-    deviceName: 'Host Mac',
-    kind: 'device',
-    message: 'Prepared Apple runner: Host Mac',
-  });
+  if (response.ok) {
+    expect(response.data).toMatchObject({
+      action: 'ios-runner',
+      platform: 'macos',
+      deviceId: 'host-macos-local',
+      deviceName: 'Host Mac',
+      kind: 'device',
+      message: 'Prepared Apple runner: Host Mac',
+    });
+  }
 });
 
 test('prepare ios-runner rejects non-Apple runner devices', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
   mockResolveTargetDevice.mockResolvedValue({
     platform: 'android',
     id: 'emulator-5554',
@@ -730,51 +733,30 @@ test('prepare ios-runner rejects non-Apple runner devices', async () => {
     booted: true,
   });
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: 'prepare-android',
-      command: 'prepare',
+  const response = await createHandler(sessionStore)(
+    sessionRequest('prepare-android', 'prepare', {
       positionals: ['ios-runner'],
       flags: { platform: 'android', serial: 'emulator-5554' },
-    },
-    sessionName: 'prepare-android',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(false);
-  if (response && !response.ok) {
+  expect(response.ok).toBe(false);
+  if (!response.ok) {
     expect(response.error.code).toBe('UNSUPPORTED_OPERATION');
     expect(response.error.message).toBe('prepare is not supported on this device');
   }
-  expect(mockInspectDeviceRuntimeFacts).toHaveBeenCalledTimes(1);
-  expect(mockBindDeviceRuntime).not.toHaveBeenCalled();
   expect(mockPrepareIosRunner).not.toHaveBeenCalled();
 });
 
 test('prepare requires the ios-runner subcommand', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-session-open-url-prewarm-');
 
-  const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: 'prepare-invalid',
-      command: 'prepare',
-      positionals: [],
-      flags: { platform: 'ios' },
-    },
-    sessionName: 'prepare-invalid',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+  const response = await createHandler(sessionStore)(
+    sessionRequest('prepare-invalid', 'prepare', { flags: { platform: 'ios' } }),
+  );
 
-  expect(response).toBeTruthy();
-  expect(response?.ok).toBe(false);
-  if (response && !response.ok) {
+  expect(response.ok).toBe(false);
+  if (!response.ok) {
     expect(response.error.code).toBe('INVALID_ARGS');
     expect(response.error.message).toBe('prepare requires a subcommand: ios-runner');
   }


### PR DESCRIPTION
## Summary

Rewrites `src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts`
(16 scenarios covering URL/app-bundle-id inference and iOS runner prewarm
timing on `open`/`prepare`) to drive through the production request router
(`createRequestHandler` + `lifecycleDeviceRuntimeGateway`, the seam
`request-router-open.test.ts` and `session-relaunch-close` already use)
instead of the bypassed `session-test-harness.ts`/`session-command-harness.ts`.

The rewrite initially dropped two assertions from the two `prepare ios-runner`
tests (`inspectFacts`/`bind` call counts, verifying fact-inspection runs once
and binding is correctly skipped before the android-device rejection). Fixed:
`test-device-runtime-gateway.ts` gained `createLifecycleDeviceRuntimeGatewaySpies()`,
a fresh unfrozen gateway with `vi.fn()`-wrapped `inspectFacts`/`bind` (the
shared frozen fixture can't be spied on in place without leaking call counts
into other suites); the two tests now use it and reassert the original counts.

Two assertions also changed to match what the real seam produces: `logPath`
now matches the router's session-scoped `runner.log` path, and the
blocked-prewarm error reads the top-level `error.hint` field this seam uses.

## Validation
- Full affected gate: green at c44cadf74974ee70bcdaf6fac96ad1a13f5d9915 (pnpm check:affected --run; gates run: format, lint, typecheck, fallow, vitest-related)
- `npx vitest run --project unit-core src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts` — 16/16 pass.
- Sibling suites sharing touched fixtures (`request-router-open.test.ts`, `request-router-lock-policy.test.ts`, `request-router-replay-scope.test.ts`, `request-router-response-level.test.ts`, `request-router-session-address.test.ts`, `request-router-typed-error.test.ts`, `session-relaunch-close.test.ts`) — all pass.
- `tsc -p tsconfig.json --noEmit` — clean.
- Planted red, restored assertions: flipped `inspectFacts`/`bind` expected counts in both `prepare ios-runner` tests — each failed with the expected `AssertionError` — reverted, verified green.

