### PR TITLE
test(daemon): session-devices-batch-runtime through the request seam

### DIFF
--- a/src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts
@@ -2,22 +2,51 @@ import { test, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { retainMaterializedPaths } from '../../../materialized-path-registry.ts';
+
+vi.mock('../../../materialized-path-registry.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../materialized-path-registry.ts')>();
+  return { ...actual, cleanupRetainedMaterializedPathsForSession: vi.fn(async () => {}) };
+});
+
 import {
-  mockCleanupRetainedMaterializedPaths,
-  makeSessionStore,
-  makeSession,
-  noopInvoke,
-} from '../../../handlers/__tests__/session-test-harness.ts';
-import type { DaemonRequest } from '../../../types.ts';
+  cleanupRetainedMaterializedPathsForSession,
+  retainMaterializedPaths,
+} from '../../../materialized-path-registry.ts';
+import { handleSessionInventoryCommands } from '../inventory.ts';
+import { runBatchCommands } from '../../../handlers/session-batch.ts';
+import { handleReleaseMaterializedPathsCommand } from '../../../handlers/session-app-source-deployment.ts';
 import { handleSessionCommands } from '../../../handlers/__tests__/session-command-harness.ts';
+import { makeSessionStore } from '../../../../__tests__/test-utils/store-factory.ts';
+import { makeSession } from '../../../../__tests__/test-utils/session-factories.ts';
+import type { DaemonRequest, DaemonResponse } from '../../../types.ts';
 import { mkdtempForTestSync } from '../../../../__tests__/test-utils/tmp-dir.ts';
 import { withTestDeviceInventory } from '../../../../__tests__/test-utils/device-inventory-gateways.ts';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { readCurrentOwnerIdentity } from '@agent-device/host-kit/process';
 
+const noopInvoke = async (_req: DaemonRequest): Promise<DaemonResponse> => ({
+  ok: true,
+  data: {},
+});
+
+const mockCleanupRetainedMaterializedPaths = vi.mocked(cleanupRetainedMaterializedPathsForSession);
+
+async function runDevices(
+  flags: DaemonRequest['flags'],
+  inventory: readonly DeviceInfo[],
+): Promise<DaemonResponse | null> {
+  return await withTestDeviceInventory(
+    { local: async () => inventory },
+    async () =>
+      await handleSessionInventoryCommands({
+        req: { token: 't', session: 'default', command: 'devices', positionals: [], flags },
+        sessionName: 'default',
+        sessionStore: makeSessionStore('agent-device-devices-batch-runtime-'),
+      }),
+  );
+}
+
 test('devices filters Apple-family platform selectors', async () => {
-  const sessionStore = makeSessionStore();
   const inventory: DeviceInfo[] = [
     {
       platform: 'android' as const,
@@ -45,40 +74,25 @@ test('devices filters Apple-family platform selectors', async () => {
       booted: true,
     },
   ];
-  const runDevices = async (flags: DaemonRequest['flags']) =>
-    await withTestDeviceInventory(
-      { local: async () => inventory },
-      async () =>
-        await handleSessionCommands({
-          req: {
-            token: 't',
-            session: 'default',
-            command: 'devices',
-            positionals: [],
-            flags,
-          },
-          sessionName: 'default',
-          logPath: path.join(os.tmpdir(), 'daemon.log'),
-          sessionStore,
-          invoke: noopInvoke,
-        }),
-    );
 
-  const macosResponse = await runDevices({ platform: 'macos' });
+  const macosResponse = await runDevices({ platform: 'macos' }, inventory);
   expect(macosResponse?.ok).toBeTruthy();
   if (macosResponse?.ok) {
     const devices = macosResponse.data?.devices as Array<{ platform: string }> | undefined;
     expect(devices?.map((device) => device.platform)).toEqual(['macos']);
   }
 
-  const iosResponse = await runDevices({ platform: 'ios' });
+  const iosResponse = await runDevices({ platform: 'ios' }, inventory);
   expect(iosResponse?.ok).toBeTruthy();
   if (iosResponse?.ok) {
     const devices = iosResponse.data?.devices as Array<{ platform: string }> | undefined;
     expect(devices?.map((device) => device.platform)).toEqual(['ios']);
   }
 
-  const appleDesktopResponse = await runDevices({ platform: 'apple', target: 'desktop' });
+  const appleDesktopResponse = await runDevices(
+    { platform: 'apple', target: 'desktop' },
+    inventory,
+  );
   expect(appleDesktopResponse?.ok).toBeTruthy();
   if (appleDesktopResponse?.ok) {
     const devices = appleDesktopResponse.data?.devices as Array<{ platform: string }> | undefined;
@@ -87,8 +101,7 @@ test('devices filters Apple-family platform selectors', async () => {
 });
 
 test('devices surfaces appleOs additively while keeping platform the public leaf', async () => {
-  const sessionStore = makeSessionStore();
-  const inventory = [
+  const inventory: DeviceInfo[] = [
     {
       platform: 'apple' as const,
       id: 'sim-1',
@@ -101,23 +114,7 @@ test('devices surfaces appleOs additively while keeping platform the public leaf
     },
   ];
 
-  const response = await withTestDeviceInventory(
-    { local: async () => inventory },
-    async () =>
-      await handleSessionCommands({
-        req: {
-          token: 't',
-          session: 'default',
-          command: 'devices',
-          positionals: [],
-          flags: { platform: 'ios' },
-        },
-        sessionName: 'default',
-        logPath: path.join(os.tmpdir(), 'daemon.log'),
-        sessionStore,
-        invoke: noopInvoke,
-      }),
-  );
+  const response = await runDevices({ platform: 'ios' }, inventory);
 
   expect(response?.ok).toBeTruthy();
   if (response?.ok) {
@@ -134,9 +131,8 @@ test('devices surfaces appleOs additively while keeping platform the public leaf
 });
 
 test('batch stops on first failing step with partial results', async () => {
-  const sessionStore = makeSessionStore();
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
@@ -148,10 +144,8 @@ test('batch stops on first failing step with partial results', async () => {
         ],
       },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
+    'default',
+    async (stepReq) => {
       if (stepReq.command === 'click') {
         return {
           ok: false,
@@ -166,10 +160,10 @@ test('batch stops on first failing step with partial results', async () => {
       }
       return { ok: true, data: {} };
     },
-  });
+  );
   expect(response).toBeTruthy();
-  expect(response?.ok).toBe(false);
-  if (response && !response.ok) {
+  expect(response.ok).toBe(false);
+  if (!response.ok) {
     expect(response.error.code).toBe('COMMAND_FAILED');
     expect(response.error.message).toMatch(/Batch failed at step 2/);
     expect(response.error.details?.step).toBe(2);
@@ -184,54 +178,44 @@ test('batch stops on first failing step with partial results', async () => {
 });
 
 test('batch rejects nested replay and batch commands', async () => {
-  const sessionStore = makeSessionStore();
-  const nestedReplay = await handleSessionCommands({
-    req: {
+  const nestedReplay = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
       positionals: [],
-      flags: {
-        batchSteps: [{ command: 'replay', positionals: ['./flow.ad'] }],
-      },
+      flags: { batchSteps: [{ command: 'replay', positionals: ['./flow.ad'] }] },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    'default',
+    noopInvoke,
+  );
   expect(nestedReplay).toBeTruthy();
-  expect(nestedReplay?.ok).toBe(false);
-  if (nestedReplay && !nestedReplay.ok) {
+  expect(nestedReplay.ok).toBe(false);
+  if (!nestedReplay.ok) {
     expect(nestedReplay.error.code).toBe('INVALID_ARGS');
   }
 
-  const nestedBatch = await handleSessionCommands({
-    req: {
+  const nestedBatch = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
       positionals: [],
-      flags: {
-        batchSteps: [{ command: 'batch', positionals: [] }],
-      },
+      flags: { batchSteps: [{ command: 'batch', positionals: [] }] },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
-  });
+    'default',
+    noopInvoke,
+  );
   expect(nestedBatch).toBeTruthy();
-  expect(nestedBatch?.ok).toBe(false);
-  if (nestedBatch && !nestedBatch.ok) {
+  expect(nestedBatch.ok).toBe(false);
+  if (!nestedBatch.ok) {
     expect(nestedBatch.error.code).toBe('INVALID_ARGS');
   }
 });
 
 test('batch step flags override parent selector flags', async () => {
-  const sessionStore = makeSessionStore();
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
@@ -247,25 +231,22 @@ test('batch step flags override parent selector flags', async () => {
         ],
       },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
+    'default',
+    async (stepReq) => {
       expect(stepReq.flags?.platform).toBe('android');
       return { ok: true, data: {} };
     },
-  });
+  );
   expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
 });
 
 // #1900: `batch` (`session-batch.ts` -> `runBatch`) just re-invokes each step through the normal
 // `DaemonInvokeFn` with no platform branching of its own, so a web platform selector threads
 // through the same way any other platform selector does.
 test('batch step forwards the parent web platform selector to each invoked step', async () => {
-  const sessionStore = makeSessionStore();
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
@@ -278,23 +259,20 @@ test('batch step forwards the parent web platform selector to each invoked step'
         ],
       },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
+    'default',
+    async (stepReq) => {
       expect(stepReq.flags?.platform).toBe('web');
       return { ok: true, data: {} };
     },
-  });
+  );
   expect(response).toBeTruthy();
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
 });
 
 test('batch step forwards typed runtime payload', async () => {
-  const sessionStore = makeSessionStore();
   const seenRuntimes: Array<DaemonRequest['runtime']> = [];
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
@@ -305,131 +283,93 @@ test('batch step forwards typed runtime payload', async () => {
             command: 'open',
             positionals: ['Demo'],
             flags: { platform: 'android' },
-            runtime: {
-              metroHost: '10.0.0.10',
-              metroPort: 8081,
-            },
+            runtime: { metroHost: '10.0.0.10', metroPort: 8081 },
           },
         ],
       },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
+    'default',
+    async (stepReq) => {
       seenRuntimes.push(stepReq.runtime);
       return { ok: true, data: {} };
     },
-  });
+  );
 
-  expect(response?.ok).toBe(true);
-  expect(seenRuntimes).toEqual([
-    {
-      metroHost: '10.0.0.10',
-      metroPort: 8081,
-    },
-  ]);
+  expect(response.ok).toBe(true);
+  expect(seenRuntimes).toEqual([{ metroHost: '10.0.0.10', metroPort: 8081 }]);
 });
 
 test('batch step inherits parent runtime unless the step overrides it', async () => {
-  const sessionStore = makeSessionStore();
   const seenRuntimes: Array<DaemonRequest['runtime']> = [];
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
       positionals: [],
-      runtime: {
-        platform: 'android',
-        bundleUrl: 'https://bundle.example.test',
-      },
+      runtime: { platform: 'android', bundleUrl: 'https://bundle.example.test' },
       flags: {
         batchSteps: [
+          { command: 'open', positionals: ['Demo'] },
           {
             command: 'open',
             positionals: ['Demo'],
-          },
-          {
-            command: 'open',
-            positionals: ['Demo'],
-            runtime: {
-              metroHost: '10.0.0.10',
-              metroPort: 8081,
-            },
+            runtime: { metroHost: '10.0.0.10', metroPort: 8081 },
           },
         ],
       },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
+    'default',
+    async (stepReq) => {
       seenRuntimes.push(stepReq.runtime);
       return { ok: true, data: {} };
     },
-  });
+  );
 
-  expect(response?.ok).toBe(true);
+  expect(response.ok).toBe(true);
   expect(seenRuntimes).toEqual([
-    {
-      platform: 'android',
-      bundleUrl: 'https://bundle.example.test',
-    },
-    {
-      metroHost: '10.0.0.10',
-      metroPort: 8081,
-    },
+    { platform: 'android', bundleUrl: 'https://bundle.example.test' },
+    { metroHost: '10.0.0.10', metroPort: 8081 },
   ]);
 });
 
 test('batch step pins nested requests to the resolved session', async () => {
-  const sessionStore = makeSessionStore();
   const seenSessions: Array<{ session: string; flagSession: string | undefined }> = [];
 
-  const response = await handleSessionCommands({
-    req: {
+  const response = await runBatchCommands(
+    {
       token: 't',
       session: 'default',
       command: 'batch',
       positionals: [],
-      flags: {
-        batchSteps: [{ command: 'wait', positionals: ['100'] }],
-      },
+      flags: { batchSteps: [{ command: 'wait', positionals: ['100'] }] },
     },
-    sessionName: 'resolved-session',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: async (stepReq) => {
-      seenSessions.push({
-        session: stepReq.session,
-        flagSession: stepReq.flags?.session,
-      });
+    'resolved-session',
+    async (stepReq) => {
+      seenSessions.push({ session: stepReq.session, flagSession: stepReq.flags?.session });
       return { ok: true, data: {} };
     },
-  });
+  );
 
-  expect(response?.ok).toBe(true);
-  expect(seenSessions).toEqual([
-    {
-      session: 'resolved-session',
-      flagSession: 'resolved-session',
-    },
-  ]);
+  expect(response.ok).toBe(true);
+  expect(seenSessions).toEqual([{ session: 'resolved-session', flagSession: 'resolved-session' }]);
 });
 
 test('close clears retained materialized install paths bound to the session', async () => {
-  const sessionStore = makeSessionStore();
+  const sessionStore = makeSessionStore('agent-device-devices-batch-runtime-');
   const sessionName = 'materialized-close-active';
-  sessionStore.set(sessionName, {
-    ...makeSession(sessionName, {
-      platform: 'apple',
-      id: 'sim-1',
-      name: 'iPhone 17 Pro',
-      kind: 'simulator',
-      booted: true,
+  sessionStore.set(
+    sessionName,
+    makeSession(sessionName, {
+      device: {
+        platform: 'apple',
+        id: 'sim-1',
+        name: 'iPhone 17 Pro',
+        kind: 'simulator',
+        booted: true,
+      },
     }),
-  });
+  );
   const tempRoot = mkdtempForTestSync('agent-device-session-materialized-');
   const appPath = path.join(tempRoot, 'Sample.app');
   fs.mkdirSync(appPath, { recursive: true });
@@ -440,20 +380,14 @@ test('close clears retained materialized install paths bound to the session', as
     ttlMs: 60_000,
   });
 
-  // Use real cleanup implementation so retained paths are actually removed
+  // Use the real cleanup implementation so the retained path is actually removed.
   const { cleanupRetainedMaterializedPathsForSession: realCleanup } = await vi.importActual<
     typeof import('../../../materialized-path-registry.ts')
   >('../../../materialized-path-registry.ts');
   mockCleanupRetainedMaterializedPaths.mockImplementation(realCleanup);
 
   const response = await handleSessionCommands({
-    req: {
-      token: 't',
-      session: sessionName,
-      command: 'close',
-      positionals: [],
-      flags: {},
-    },
+    req: { token: 't', session: sessionName, command: 'close', positionals: [], flags: {} },
     sessionName,
     logPath: path.join(os.tmpdir(), 'daemon.log'),
     sessionStore,
@@ -467,31 +401,21 @@ test('close clears retained materialized install paths bound to the session', as
 });
 
 test('release_materialized_paths removes retained install artifacts', async () => {
-  const sessionStore = makeSessionStore();
   const tempRoot = mkdtempForTestSync('agent-device-release-materialized-');
   const appPath = path.join(tempRoot, 'Sample.app');
   fs.mkdirSync(appPath, { recursive: true });
   fs.writeFileSync(path.join(appPath, 'Info.plist'), 'plist');
-  const retained = await retainMaterializedPaths({
-    installablePath: appPath,
-    ttlMs: 60_000,
-  });
+  const retained = await retainMaterializedPaths({ installablePath: appPath, ttlMs: 60_000 });
 
-  const response = await handleSessionCommands({
+  const response = await handleReleaseMaterializedPathsCommand({
     req: {
       token: 't',
       session: 'default',
       command: 'release_materialized_paths',
       positionals: [],
       flags: {},
-      meta: {
-        materializationId: retained.materializationId,
-      },
+      meta: { materializationId: retained.materializationId },
     },
-    sessionName: 'default',
-    logPath: path.join(os.tmpdir(), 'daemon.log'),
-    sessionStore,
-    invoke: noopInvoke,
   });
 
   expect(response?.ok).toBe(true);
@@ -524,29 +448,12 @@ test('devices projects the blocking claim owner and hides provably dead owners',
   };
   writeClaim('emulator-5554', owner.pid, owner.startTime);
   writeClaim('emulator-5556', 999_999_999, 'long-gone');
-  const sessionStore = makeSessionStore();
   const inventory: DeviceInfo[] = [
     makeAndroidInventoryDevice('emulator-5554'),
     makeAndroidInventoryDevice('emulator-5556'),
   ];
   try {
-    const response = await withTestDeviceInventory(
-      { local: async () => inventory },
-      async () =>
-        await handleSessionCommands({
-          req: {
-            token: 't',
-            session: 'default',
-            command: 'devices',
-            positionals: [],
-            flags: { platform: 'android' },
-          },
-          sessionName: 'default',
-          logPath: path.join(os.tmpdir(), 'daemon.log'),
-          sessionStore,
-          invoke: noopInvoke,
-        }),
-    );
+    const response = await runDevices({ platform: 'android' }, inventory);
     expect(response?.ok).toBeTruthy();
     if (response?.ok) {
       const devices = response.data?.devices as Array<Record<string, unknown>> | undefined;
@@ -585,26 +492,9 @@ test('an allocator-held claim does not project claimedBy', async () => {
       updatedAtMs: 1,
     }),
   );
-  const sessionStore = makeSessionStore();
   const inventory: DeviceInfo[] = [makeAndroidInventoryDevice('emulator-5554')];
   try {
-    const response = await withTestDeviceInventory(
-      { local: async () => inventory },
-      async () =>
-        await handleSessionCommands({
-          req: {
-            token: 't',
-            session: 'default',
-            command: 'devices',
-            positionals: [],
-            flags: { platform: 'android' },
-          },
-          sessionName: 'default',
-          logPath: path.join(os.tmpdir(), 'daemon.log'),
-          sessionStore,
-          invoke: noopInvoke,
-        }),
-    );
+    const response = await runDevices({ platform: 'android' }, inventory);
     expect(response?.ok).toBeTruthy();
     if (response?.ok) {
       const devices = response.data?.devices as Array<Record<string, unknown>> | undefined;
@@ -650,7 +540,6 @@ test('a claim never projects onto a same-id device from another platform family'
       updatedAtMs: 1,
     }),
   );
-  const sessionStore = makeSessionStore();
   const inventory: DeviceInfo[] = [
     {
       platform: 'apple',
@@ -664,23 +553,7 @@ test('a claim never projects onto a same-id device from another platform family'
     makeAndroidInventoryDevice('shared-id'),
   ];
   try {
-    const response = await withTestDeviceInventory(
-      { local: async () => inventory },
-      async () =>
-        await handleSessionCommands({
-          req: {
-            token: 't',
-            session: 'default',
-            command: 'devices',
-            positionals: [],
-            flags: {},
-          },
-          sessionName: 'default',
-          logPath: path.join(os.tmpdir(), 'daemon.log'),
-          sessionStore,
-          invoke: noopInvoke,
-        }),
-    );
+    const response = await runDevices({}, inventory);
     expect(response?.ok).toBeTruthy();
     if (response?.ok) {
       const devices = response.data?.devices as Array<Record<string, unknown>> | undefined;


### PR DESCRIPTION
## Summary

Rewrites `src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts`
(14 scenarios) to drive each one through the production handler its own subject owns, instead of
the bypassed `handlers/__tests__/session-test-harness.ts`: `handleSessionInventoryCommands` for the
5 `devices` scenarios, `runBatchCommands` for the 7 `batch` scenarios, `handleSessionCommands` (the
facts/facets harness, unchanged) for the materialized-close scenario, and
`handleReleaseMaterializedPathsCommand` directly for `release_materialized_paths`. Every scenario
title and observable assertion (response payload, error code/details, `claimedBy` projection) is
unchanged; only the entry point and mock surface moved.

The file no longer imports `session-test-harness.ts`, dropping the 10 module-level `vi.mock` calls
it pulled in as a side effect (`core/dispatch-resolve.ts`, the Apple runner/app-resolution/macos
mocks, Android mechanics, `host-kit/command`, `platform-runtime-*`) — none of these
devices/batch/close scenarios ever reach those paths. It keeps one narrow, locally-scoped
`vi.mock` of `materialized-path-registry.ts`'s `cleanupRetainedMaterializedPathsForSession`, the one
production dependency the close teardown path imports directly rather than through
`inspectFacts`/`bindDevice`.

## Validation

- `npx vitest run --project unit-core src/daemon/session-lifecycle/internal/__tests__/session-devices-batch-runtime.test.ts` — 14/14 pass.
- `npx vitest run --project unit-core src/core/__tests__/batch.test.ts src/daemon/session-lifecycle/internal/__tests__/session-inventory-appleos.test.ts` — sibling suites sharing the touched seams, 14/14 pass.
- `pnpm check:quick`, `pnpm check:layering`, `pnpm check:fallow --base origin/main` — all clean.
- Planted red #1: removed the `cleanupRetainedMaterializedPathsForSession` call from
  `session-close-lifecycle-teardown.ts`'s close path, ran "close clears retained materialized
  install paths bound to the session" alone — `AssertionError: expected true to be false`
  (retained path still on disk) — restored, verified green.
- Planted red #2: changed `executed: index` to `executed: index + 1` in `core/batch.ts`'s
  failure-detail builder, ran "batch stops on first failing step with partial results" alone —
  `AssertionError: expected 2 to be 1` — restored, verified green.
- Full affected gate: green at 22bb42c73ba9ee717b82ccf53658f9aa3ba06f22 (pnpm check:affected --run; gates run: format, lint, typecheck, fallow, vitest-related).

## Tradeoffs / follow-ups

None.

