### PR TITLE
feat: delegate reviewed managed automation

### DIFF
--- a/packages/platform-android/src/deployment/native.ts
+++ b/packages/platform-android/src/deployment/native.ts
@@ -3,6 +3,7 @@ import type { PushNotificationInput } from '@agent-device/contracts/app-deployme
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import path from 'node:path';
+import { currentManagedDeviceScope } from '@agent-device/provision-kit/managed-device-scope';
 
 export async function installAndroidArtifact(
   host: PlatformRuntimeHost,
@@ -11,6 +12,7 @@ export async function installAndroidArtifact(
   packageNameHint: string | undefined,
   signal: AbortSignal,
 ): Promise<string | undefined> {
+  assertManagedAndroidInstallablePath(installablePath);
   const before = packageNameHint ? undefined : await listInstalledPackages(host, device, signal);
   if (path.extname(installablePath).toLowerCase() === '.aab') {
     await installAndroidBundle(host, device, installablePath, signal);
@@ -27,6 +29,19 @@ export async function installAndroidArtifact(
   const after = await listInstalledPackages(host, device, signal);
   const installed = [...after].filter((name) => !before?.has(name));
   return installed.length === 1 ? installed[0] : undefined;
+}
+
+export function assertManagedAndroidInstallablePath(installablePath: string): void {
+  if (currentManagedDeviceScope() && path.extname(installablePath).toLowerCase() === '.aab') {
+    throw new AppError(
+      'UNSUPPORTED_OPERATION',
+      'Managed Android deployment does not support app bundles.',
+      {
+        reason: 'managed-bundle-install-unavailable',
+        hint: 'Install an APK on this managed device.',
+      },
+    );
+  }
 }
 
 export async function uninstallAndroidPackage(

--- a/packages/platform-android/src/deployment/runtime.ts
+++ b/packages/platform-android/src/deployment/runtime.ts
@@ -4,18 +4,21 @@ import type {
   AppDeploymentRuntimeOperations,
   DeployMaterializedAppInput,
   MaterializeAppSourceInput,
+  MaterializedAppSource,
   PushNotificationInput,
 } from '@agent-device/contracts/app-deployment-runtime';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import type { RuntimeOperationFact } from '@agent-device/contracts/platform-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import { currentManagedDeviceScope } from '@agent-device/provision-kit/managed-device-scope';
 import { ensureAndroidReady } from '../readiness/runtime.ts';
 import {
   inferAndroidAppName,
   installAndroidArtifact,
   pushAndroidNotification,
   uninstallAndroidPackage,
+  assertManagedAndroidInstallablePath,
 } from './native.ts';
 
 const available = Object.freeze({ available: true } as const);
@@ -66,20 +69,28 @@ async function deployAndroidApp(
     // cache boundary here in the Android deployment owner: clear before boot/resolve/uninstall
     // and after materialization/install, including partial failures.
     return await host.androidDeployment.withInvalidatedAppResolutionCache(device, async () => {
-      if (device.booted !== true) {
-        await ensureAndroidReady(host, device, { headless: false }, signal);
-      }
-      const packageName = await host.androidDeployment.resolveAppPackage(device, input.app);
-      await uninstallAndroidPackage(host, device, packageName, signal);
-      const artifact = await host.androidDeployment.prepareArtifact(
-        { source: { kind: 'path', path: input.appPath } },
-        { resolveIdentity: false, signal },
-      );
+      let artifact: MaterializedAppSource | undefined;
       try {
+        if (currentManagedDeviceScope()) {
+          artifact = await host.androidDeployment.prepareArtifact(
+            { source: { kind: 'path', path: input.appPath } },
+            { resolveIdentity: false, signal },
+          );
+          assertManagedAndroidInstallablePath(artifact.installablePath);
+        }
+        if (device.booted !== true) {
+          await ensureAndroidReady(host, device, { headless: false }, signal);
+        }
+        const packageName = await host.androidDeployment.resolveAppPackage(device, input.app);
+        await uninstallAndroidPackage(host, device, packageName, signal);
+        artifact ??= await host.androidDeployment.prepareArtifact(
+          { source: { kind: 'path', path: input.appPath } },
+          { resolveIdentity: false, signal },
+        );
         await installAndroidArtifact(host, device, artifact.installablePath, undefined, signal);
         return { packageName, launchTarget: packageName };
       } finally {
-        await artifact.cleanup();
+        await artifact?.cleanup();
       }
     });
   }
@@ -87,15 +98,22 @@ async function deployAndroidApp(
   // Existing install semantics wait for a selected Android target before taking the
   // before-install package inventory. Keep that platform rule here, rather than
   // reviving a daemon readiness adapter.
-  if (device.booted !== true) {
-    await ensureAndroidReady(host, device, { headless: false }, signal);
-  }
-
-  const artifact = await host.androidDeployment.prepareArtifact(
-    { source: { kind: 'path', path: input.appPath } },
-    { resolveIdentity: true, signal },
-  );
+  let artifact: MaterializedAppSource | undefined;
   try {
+    if (currentManagedDeviceScope()) {
+      artifact = await host.androidDeployment.prepareArtifact(
+        { source: { kind: 'path', path: input.appPath } },
+        { resolveIdentity: true, signal },
+      );
+      assertManagedAndroidInstallablePath(artifact.installablePath);
+    }
+    if (device.booted !== true) {
+      await ensureAndroidReady(host, device, { headless: false }, signal);
+    }
+    artifact ??= await host.androidDeployment.prepareArtifact(
+      { source: { kind: 'path', path: input.appPath } },
+      { resolveIdentity: true, signal },
+    );
     const packageName = await installAndroidArtifact(
       host,
       device,
@@ -113,7 +131,7 @@ async function deployAndroidApp(
       launchTarget: packageName,
     };
   } finally {
-    await artifact.cleanup();
+    await artifact?.cleanup();
   }
 }
 

--- a/packages/platform-android/src/readiness/runtime.ts
+++ b/packages/platform-android/src/readiness/runtime.ts
@@ -8,6 +8,7 @@ export type AndroidReadinessHost = Pick<
 >;
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import { delegateManagedDeviceReadiness } from '@agent-device/provision-kit/managed-device-scope';
 
 const BOOT_TIMEOUT_MS = 120_000;
 const POLL_MS = 1_000;
@@ -19,6 +20,7 @@ export async function ensureAndroidReady(
   signal: AbortSignal,
 ): Promise<DeviceInfo> {
   signal.throwIfAborted();
+  if (await delegateManagedDeviceReadiness(device)) return { ...device, booted: true };
   if (device.kind === 'emulator' && (device.booted !== true || !isRunningEmulator(device))) {
     return await ensureEmulatorReady(host, device, input, signal);
   }

--- a/packages/platform-apple/src/core/simulator.ts
+++ b/packages/platform-apple/src/core/simulator.ts
@@ -5,6 +5,7 @@ import { Deadline, retryWithPolicy } from '@agent-device/host-kit/retry';
 
 import { createTtlMemo } from '@agent-device/kernel/ttl-memo';
 import { bootFailureHint, classifyBootFailure } from '@agent-device/provision-kit/boot-diagnostics';
+import { delegateManagedDeviceReadiness } from '@agent-device/provision-kit/managed-device-scope';
 
 import {
   IOS_BOOT_TIMEOUT_MS,
@@ -85,6 +86,7 @@ export async function ensureBootedSimulator(
 ): Promise<void> {
   if (device.kind !== 'simulator') return;
   options.signal?.throwIfAborted();
+  if (await delegateManagedDeviceReadiness(device)) return;
 
   const state = wasSimulatorRecentlyObservedBooted(device)
     ? 'Booted'

--- a/packages/platform-apple/src/core/simulator.ts
+++ b/packages/platform-apple/src/core/simulator.ts
@@ -5,7 +5,7 @@ import { Deadline, retryWithPolicy } from '@agent-device/host-kit/retry';
 
 import { createTtlMemo } from '@agent-device/kernel/ttl-memo';
 import { bootFailureHint, classifyBootFailure } from '@agent-device/provision-kit/boot-diagnostics';
-import { delegateManagedDeviceReadiness } from '@agent-device/provision-kit/managed-device-scope';
+import { createScopedProvider } from '@agent-device/kernel/scoped-provider';
 
 import {
   IOS_BOOT_TIMEOUT_MS,
@@ -17,6 +17,17 @@ import { runAppleToolCommand, runXcrun } from './tool-provider.ts';
 
 const IOS_SIMULATOR_HOST_APPS = ['Simulator'] as const;
 const IOS_DEVICE_HUB_HOST_APPS = ['Device Hub', 'Simulator'] as const;
+
+const simulatorReadiness = createScopedProvider<
+  ((device: DeviceInfo) => Promise<void>) | undefined
+>(undefined);
+
+export async function withSimulatorReadiness<T>(
+  ensureReady: (device: DeviceInfo) => Promise<void>,
+  task: () => Promise<T>,
+): Promise<T> {
+  return await simulatorReadiness.run(ensureReady, task);
+}
 
 type OpenIosSimulatorAppOptions = {
   background?: boolean;
@@ -86,7 +97,12 @@ export async function ensureBootedSimulator(
 ): Promise<void> {
   if (device.kind !== 'simulator') return;
   options.signal?.throwIfAborted();
-  if (await delegateManagedDeviceReadiness(device)) return;
+  const ensureReady = simulatorReadiness.resolve();
+  if (ensureReady) {
+    await ensureReady(device);
+    options.signal?.throwIfAborted();
+    return;
+  }
 
   const state = wasSimulatorRecentlyObservedBooted(device)
     ? 'Booted'

--- a/packages/platform-apple/src/readiness/runtime.ts
+++ b/packages/platform-apple/src/readiness/runtime.ts
@@ -1,6 +1,7 @@
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import { isMacOs, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
+import { delegateManagedDeviceReadiness } from '@agent-device/provision-kit/managed-device-scope';
 import { getSimulatorState, simctlArgs } from '../simulator-state.ts';
 
 /** Readiness reads exactly these host ports; the lifecycle binding composes the same subset. */
@@ -27,6 +28,7 @@ export async function ensureAppleReady(
   options: AppleReadinessOptions = {},
 ): Promise<DeviceInfo> {
   signal.throwIfAborted();
+  if (await delegateManagedDeviceReadiness(device)) return { ...device, booted: true };
   if (isMacOs(device)) return { ...device, booted: true };
   if (device.kind === 'device') {
     await host.deviceReadiness.applePhysical.ensureConnected(device, signal);

--- a/packages/platform-apple/src/runtime-simulator-readiness.test.ts
+++ b/packages/platform-apple/src/runtime-simulator-readiness.test.ts
@@ -20,32 +20,31 @@ test('bound simulator readiness captures authority and refuses mismatches or fai
     }),
     async () => {
       const device = { ...IOS_SIMULATOR, simulatorSetPath: '/managed/set' };
-      const ensureReady = vi.fn(async () => {});
+      const admit = vi.fn(async (): Promise<never> => {
+        throw new Error('Deep readiness must not recursively admit');
+      });
       const operations = await withManagedDeviceScope(
         {
           device,
           owner: managedLocalRuntimeOwner('allocator'),
           fence: { token: 'fence', generation: 1 },
-          ensureReady,
+          admit,
           run: async <T>(task: () => Promise<T>) => await task(),
         },
         async () => bindSimulatorReadiness(Object.freeze({ ensureBootedSimulator })),
       );
       await operations.ensureBootedSimulator(device);
-      expect(ensureReady).toHaveBeenCalledOnce();
+      expect(admit).not.toHaveBeenCalled();
       await expect(
         operations.ensureBootedSimulator({ ...device, simulatorSetPath: undefined }),
       ).rejects.toMatchObject({ details: { reason: 'managed-device-transport-mismatch' } });
-      expect(ensureReady).toHaveBeenCalledOnce();
+      expect(admit).not.toHaveBeenCalled();
       const abort = new AbortController();
       abort.abort(new Error('cancelled'));
       await expect(
         operations.ensureBootedSimulator(device, { signal: abort.signal }),
       ).rejects.toThrow('cancelled');
-      expect(ensureReady).toHaveBeenCalledOnce();
-      ensureReady.mockRejectedValueOnce(new Error('lease fenced'));
-      await expect(operations.ensureBootedSimulator(device)).rejects.toThrow('lease fenced');
-      expect(ensureReady).toHaveBeenCalledTimes(2);
+      expect(admit).not.toHaveBeenCalled();
     },
   );
 });

--- a/packages/platform-apple/src/runtime-simulator-readiness.test.ts
+++ b/packages/platform-apple/src/runtime-simulator-readiness.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, vi } from 'vitest';
+import { managedLocalRuntimeOwner } from '@agent-device/contracts/platform-runtime';
+import { withManagedDeviceScope } from '@agent-device/provision-kit/managed-device-scope';
+import { IOS_SIMULATOR } from './__tests__/device-fixtures.ts';
+import { ensureBootedSimulator } from './core/simulator.ts';
+import { createLocalAppleToolProvider, withAppleToolProvider } from './core/tool-provider.ts';
+import { bindSimulatorReadiness } from './runtime-simulator-readiness.ts';
+
+test('ordinary simulator operations preserve their binding without a readiness override', () => {
+  const operations = { ensureBootedSimulator };
+  expect(bindSimulatorReadiness(operations)).toBe(operations);
+});
+
+test('bound simulator readiness captures authority and refuses mismatches or failures before local boot', async () => {
+  await withAppleToolProvider(
+    createLocalAppleToolProvider({
+      runCommand: async () => {
+        throw new Error('Unexpected local readiness');
+      },
+    }),
+    async () => {
+      const device = { ...IOS_SIMULATOR, simulatorSetPath: '/managed/set' };
+      const ensureReady = vi.fn(async () => {});
+      const operations = await withManagedDeviceScope(
+        {
+          device,
+          owner: managedLocalRuntimeOwner('allocator'),
+          fence: { token: 'fence', generation: 1 },
+          ensureReady,
+          run: async <T>(task: () => Promise<T>) => await task(),
+        },
+        async () => bindSimulatorReadiness(Object.freeze({ ensureBootedSimulator })),
+      );
+      await operations.ensureBootedSimulator(device);
+      expect(ensureReady).toHaveBeenCalledOnce();
+      await expect(
+        operations.ensureBootedSimulator({ ...device, simulatorSetPath: undefined }),
+      ).rejects.toMatchObject({ details: { reason: 'managed-device-transport-mismatch' } });
+      expect(ensureReady).toHaveBeenCalledOnce();
+      const abort = new AbortController();
+      abort.abort(new Error('cancelled'));
+      await expect(
+        operations.ensureBootedSimulator(device, { signal: abort.signal }),
+      ).rejects.toThrow('cancelled');
+      expect(ensureReady).toHaveBeenCalledOnce();
+      ensureReady.mockRejectedValueOnce(new Error('lease fenced'));
+      await expect(operations.ensureBootedSimulator(device)).rejects.toThrow('lease fenced');
+      expect(ensureReady).toHaveBeenCalledTimes(2);
+    },
+  );
+});

--- a/packages/platform-apple/src/runtime-simulator-readiness.ts
+++ b/packages/platform-apple/src/runtime-simulator-readiness.ts
@@ -1,0 +1,11 @@
+import { withMethodScope } from '@agent-device/kernel/scoped-provider';
+import { resolveManagedDeviceReadiness } from '@agent-device/provision-kit/managed-device-scope';
+import { withSimulatorReadiness } from './core/simulator.ts';
+
+export function bindSimulatorReadiness<T extends object>(operations: T): Readonly<T> {
+  const ensureReady = resolveManagedDeviceReadiness();
+  if (!ensureReady) return Object.freeze(operations);
+  return Object.freeze({
+    ...withMethodScope({ ...operations }, (task) => withSimulatorReadiness(ensureReady, task)),
+  });
+}

--- a/packages/platform-apple/src/runtime.ts
+++ b/packages/platform-apple/src/runtime.ts
@@ -4,6 +4,7 @@ import {
   localRuntimeOwner,
   whenAdmitted,
 } from '@agent-device/contracts/platform-runtime';
+import { bindSimulatorReadiness } from './runtime-simulator-readiness.ts';
 import type { NetworkDumpInput } from '@agent-device/contracts/network-runtime';
 import type {
   PlatformRuntimeHost,
@@ -494,7 +495,7 @@ export function createApplePlatformRuntime(host: PlatformRuntimeHost): PlatformR
         device: logs.device,
         owner,
         facts,
-        operations: Object.freeze(operations),
+        operations: bindSimulatorReadiness(operations),
         [Symbol.asyncDispose]: async () => await logs[Symbol.asyncDispose](),
       }) satisfies DeviceBinding<PlatformRuntimeOperations>;
     },

--- a/packages/provision-kit/package.json
+++ b/packages/provision-kit/package.json
@@ -10,6 +10,10 @@
     "@agent-device/kernel": "workspace:*"
   },
   "exports": {
+    "./managed-device-scope": {
+      "types": "./src/managed-device-scope.ts",
+      "default": "./src/managed-device-scope.ts"
+    },
     "./app-resolution-cache": {
       "types": "./src/app-resolution-cache.ts",
       "default": "./src/app-resolution-cache.ts"

--- a/packages/provision-kit/src/managed-device-scope.test.ts
+++ b/packages/provision-kit/src/managed-device-scope.test.ts
@@ -18,8 +18,8 @@ test('managed readiness scopes isolate concurrent devices and leave ordinary rea
     device,
     owner: managedLocalRuntimeOwner('allocator'),
     fence: { token: 'fence', generation: 1 },
-    ensureReady: async () => {
-      ready.push(device.id);
+    admit: async <T>(_task: () => Promise<T>): Promise<T> => {
+      throw new Error('Readiness must not recursively admit');
     },
     run: async <T>(task: () => Promise<T>) => await task(),
   };
@@ -30,13 +30,11 @@ test('managed readiness scopes isolate concurrent devices and leave ordinary rea
         {
           ...managed,
           device: selected,
-          ensureReady: async () => {
-            ready.push(id);
-          },
         },
         async () => {
           await Promise.resolve();
           expect(await delegateManagedDeviceReadiness(selected)).toBe(true);
+          ready.push(id);
           await expect(
             delegateManagedDeviceReadiness({ ...selected, id: 'foreign' }),
           ).rejects.toMatchObject({ details: { reason: 'managed-device-transport-mismatch' } });

--- a/packages/provision-kit/src/managed-device-scope.test.ts
+++ b/packages/provision-kit/src/managed-device-scope.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+import { managedLocalRuntimeOwner } from '@agent-device/contracts/platform-runtime';
+import {
+  currentManagedDeviceScope,
+  delegateManagedDeviceReadiness,
+  withManagedDeviceScope,
+} from './managed-device-scope.ts';
+
+test('managed readiness scopes isolate concurrent devices and leave ordinary readiness untouched', async () => {
+  const ready: string[] = [];
+  const device = {
+    platform: 'android' as const,
+    kind: 'emulator' as const,
+    id: 'one',
+    name: 'one',
+  };
+  const managed = {
+    device,
+    owner: managedLocalRuntimeOwner('allocator'),
+    fence: { token: 'fence', generation: 1 },
+    ensureReady: async () => {
+      ready.push(device.id);
+    },
+    run: async <T>(task: () => Promise<T>) => await task(),
+  };
+  await Promise.all(
+    ['one', 'two'].map(async (id) => {
+      const selected = { ...device, id };
+      await withManagedDeviceScope(
+        {
+          ...managed,
+          device: selected,
+          ensureReady: async () => {
+            ready.push(id);
+          },
+        },
+        async () => {
+          await Promise.resolve();
+          expect(await delegateManagedDeviceReadiness(selected)).toBe(true);
+          await expect(
+            delegateManagedDeviceReadiness({ ...selected, id: 'foreign' }),
+          ).rejects.toMatchObject({ details: { reason: 'managed-device-transport-mismatch' } });
+        },
+      );
+    }),
+  );
+  expect(ready.sort()).toEqual(['one', 'two']);
+  expect(currentManagedDeviceScope()).toBeUndefined();
+  expect(await delegateManagedDeviceReadiness(device)).toBe(false);
+});

--- a/packages/provision-kit/src/managed-device-scope.ts
+++ b/packages/provision-kit/src/managed-device-scope.ts
@@ -1,0 +1,37 @@
+import type { PlatformRequestScope } from '@agent-device/contracts/platform-runtime-host';
+import { deviceIdentity, sameDeviceIdentity, type DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+import { createScopedProvider } from '@agent-device/kernel/scoped-provider';
+
+type ManagedDeviceScope = NonNullable<PlatformRequestScope['managedDevice']>;
+const scope = createScopedProvider<ManagedDeviceScope | undefined>(undefined);
+
+export function currentManagedDeviceScope(): ManagedDeviceScope | undefined {
+  return scope.resolve();
+}
+
+export async function withManagedDeviceScope<T>(
+  managed: ManagedDeviceScope,
+  task: () => Promise<T>,
+): Promise<T> {
+  return await scope.run(managed, task);
+}
+
+export function assertManagedDeviceIdentity(managed: ManagedDeviceScope, device: DeviceInfo): void {
+  if (
+    !sameDeviceIdentity(deviceIdentity(managed.device), deviceIdentity(device)) ||
+    managed.device.simulatorSetPath !== device.simulatorSetPath
+  ) {
+    throw new AppError('COMMAND_FAILED', 'Managed automation cannot select another device.', {
+      reason: 'managed-device-transport-mismatch',
+    });
+  }
+}
+
+export async function delegateManagedDeviceReadiness(device: DeviceInfo): Promise<boolean> {
+  const managed = currentManagedDeviceScope();
+  if (!managed) return false;
+  assertManagedDeviceIdentity(managed, device);
+  await managed.ensureReady();
+  return true;
+}

--- a/packages/provision-kit/src/managed-device-scope.ts
+++ b/packages/provision-kit/src/managed-device-scope.ts
@@ -28,10 +28,20 @@ export function assertManagedDeviceIdentity(managed: ManagedDeviceScope, device:
   }
 }
 
-export async function delegateManagedDeviceReadiness(device: DeviceInfo): Promise<boolean> {
+export function resolveManagedDeviceReadiness():
+  | ((device: DeviceInfo) => Promise<void>)
+  | undefined {
   const managed = currentManagedDeviceScope();
-  if (!managed) return false;
-  assertManagedDeviceIdentity(managed, device);
-  await managed.ensureReady();
+  if (!managed) return undefined;
+  return async (device) => {
+    assertManagedDeviceIdentity(managed, device);
+    await managed.ensureReady();
+  };
+}
+
+export async function delegateManagedDeviceReadiness(device: DeviceInfo): Promise<boolean> {
+  const ensureReady = resolveManagedDeviceReadiness();
+  if (!ensureReady) return false;
+  await ensureReady(device);
   return true;
 }

--- a/packages/provision-kit/src/managed-device-scope.ts
+++ b/packages/provision-kit/src/managed-device-scope.ts
@@ -35,7 +35,6 @@ export function resolveManagedDeviceReadiness():
   if (!managed) return undefined;
   return async (device) => {
     assertManagedDeviceIdentity(managed, device);
-    await managed.ensureReady();
   };
 }
 

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -427,6 +427,7 @@ test('the real tree parses, declares, and passes R11', () => {
     '@agent-device/provision-kit/install-source-config',
     '@agent-device/provision-kit/install-source-network',
     '@agent-device/provision-kit/install-source-network-transport',
+    '@agent-device/provision-kit/managed-device-scope',
     '@agent-device/provision-kit/toolchain-probe',
   ]);
   assert.deepEqual([...provisionKitPackage.workspaceDependencies].sort(), [

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -85,7 +85,7 @@ export function gatewayFixture(registrations: readonly PlatformRuntimeProviderRe
   });
 }
 
-export const MANAGED_RETAINED_OPERATION = 'setSetting';
+export const REVIEWED_MANAGED_OPERATION = 'setSetting';
 
 export type LocalFamilyRuntimeFixture = Readonly<{
   module: PlatformRuntimeModule;

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -61,7 +61,7 @@ export function managedGatewayScope(
       device,
       owner,
       fence,
-      ensureReady: async () => {},
+      admit: async (task) => await task(),
       run: async (task) => await task(),
     },
   };

--- a/src/platform-runtime-gateway.fixtures.ts
+++ b/src/platform-runtime-gateway.fixtures.ts
@@ -8,8 +8,8 @@ import {
 import {
   type DeviceBinding,
   type DeviceBindingRequest,
+  type ResourceOwnershipFence,
   type RuntimeFacts,
-  type RuntimeOperationKey,
   type RuntimeOwnerRef,
   type RuntimeProviderMode,
   localRuntimeOwner,
@@ -50,6 +50,23 @@ export const gatewayFixtureScope: PlatformRequestScope = {
   progress: { report: () => {} },
 };
 
+export function managedGatewayScope(
+  device: DeviceInfo,
+  owner: Extract<RuntimeOwnerRef, { kind: 'managed-local' }>,
+  fence: ResourceOwnershipFence,
+): PlatformRequestScope {
+  return {
+    ...gatewayFixtureScope,
+    managedDevice: {
+      device,
+      owner,
+      fence,
+      ensureReady: async () => {},
+      run: async (task) => await task(),
+    },
+  };
+}
+
 export const LIFECYCLE_FACETS = [
   ['openTarget', ['resolveOpenTarget', 'prepareApplicationOpen', 'openApplication']],
   ['prepareAppleRunner', ['prepareAppleRunner']],
@@ -68,42 +85,7 @@ export function gatewayFixture(registrations: readonly PlatformRuntimeProviderRe
   });
 }
 
-/**
- * Every cell a managed local owner must withhold, listed once so the local family fixture can
- * offer all of them and the managed tests can assert that none survives the wrapper.
- */
-export const MANAGED_WITHHELD_OPERATIONS = [
-  'ensureReady',
-  'bootTarget',
-  'bootTargetHeadless',
-  'shutdownTarget',
-  'deployApp',
-  'deployMaterializedApp',
-  'prepareApplicationOpen',
-  'prepareAppleRunner',
-  'closeApplication',
-  'finalizeApplicationClose',
-  'appLogStart',
-  'appLogReattach',
-  'appLogCleanup',
-  'screenRecordingStart',
-  'screenRecordingReattach',
-  'screenRecordingCleanup',
-  'audioProbeStart',
-  'audioProbeReattach',
-  'audioProbeCleanup',
-  'perfNativeCaptureStart',
-  'perfNativeCaptureReattach',
-  'perfNativeCaptureCleanup',
-  'captureScreenshot',
-  'setSetting',
-  'readClipboard',
-  'writeClipboard',
-  'openApplication',
-] as const satisfies readonly RuntimeOperationKey<PlatformRuntimeOperations>[];
-
-/** The one cell the family owner offers that a managed binding keeps. */
-export const MANAGED_RETAINED_OPERATION = 'tapPoint';
+export const MANAGED_RETAINED_OPERATION = 'setSetting';
 
 export type LocalFamilyRuntimeFixture = Readonly<{
   module: PlatformRuntimeModule;
@@ -112,10 +94,6 @@ export type LocalFamilyRuntimeFixture = Readonly<{
   calls: { loads: number; disposals: number };
 }>;
 
-/**
- * A local family owner that offers every withheld cell plus one retained cell, and that refuses a
- * foreign exact-owner intent the way the real family runtimes do.
- */
 export function localFamilyRuntimeFixture(options: {
   family: Platform;
   device: DeviceInfo;
@@ -128,7 +106,7 @@ export function localFamilyRuntimeFixture(options: {
   const available = Object.freeze({ available: true } as const);
   const offered: Record<string, unknown> = {};
   const operations: Record<string, unknown> = {};
-  for (const key of [...MANAGED_WITHHELD_OPERATIONS, MANAGED_RETAINED_OPERATION]) {
+  for (const key of Object.keys(base.operations)) {
     offered[key] = available;
     operations[key] = async () => undefined;
   }

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -33,6 +33,7 @@ import {
   limrunTestDependencies,
   localFamilyRuntimeFixture,
   MANAGED_RETAINED_OPERATION,
+  managedGatewayScope,
   providerLifecycleOwnerFixture as providerLifecycleOwner,
   providerRuntimeFixture as providerRuntime,
   runtimeOwnerFixture as runtimeOwner,
@@ -631,6 +632,7 @@ describe('managed local owner registration', () => {
     requestGeneration: 1,
     identityIncarnationId: 'incarnation-a',
   });
+  const managedScope = managedGatewayScope(device, managed, fence);
   const exactly = (owner = managed): DeviceBindingIntent => ({
     kind: 'exact-owner',
     owner,
@@ -650,7 +652,7 @@ describe('managed local owner registration', () => {
   test('binds an exact managed owner through the local family owner under an ordinary intent', async () => {
     const { family, runtimeGateway } = managedGateway();
 
-    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope: managedScope });
 
     expect(binding.owner).toEqual(managed);
     expect(family.requests[0]?.intent).toEqual({ kind: 'ordinary' });
@@ -691,7 +693,7 @@ describe('managed local owner registration', () => {
   test('accepts a managed binding whose local facts report a transport-composed device', async () => {
     const { runtimeGateway } = managedGateway('transport-composed');
 
-    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope });
+    const binding = await runtimeGateway.bind({ device, intent: exactly(), scope: managedScope });
 
     expect(binding.owner).toEqual(managed);
     expect(binding.facts.device.providerMode).toBe('transport-composed');
@@ -702,8 +704,8 @@ describe('managed local owner registration', () => {
   test('reuses one managed owner per registered instance and refuses unregistered ones', async () => {
     const { family, runtimeGateway } = managedGateway();
 
-    const first = await runtimeGateway.bind({ device, intent: exactly(), scope });
-    const second = await runtimeGateway.bind({ device, intent: exactly(), scope });
+    const first = await runtimeGateway.bind({ device, intent: exactly(), scope: managedScope });
+    const second = await runtimeGateway.bind({ device, intent: exactly(), scope: managedScope });
 
     expect(second.owner).toEqual(first.owner);
     expect(family.calls.loads).toBe(1);

--- a/src/platform-runtime-gateway.test.ts
+++ b/src/platform-runtime-gateway.test.ts
@@ -32,7 +32,7 @@ import {
   LIFECYCLE_FACETS,
   limrunTestDependencies,
   localFamilyRuntimeFixture,
-  MANAGED_RETAINED_OPERATION,
+  REVIEWED_MANAGED_OPERATION,
   managedGatewayScope,
   providerLifecycleOwnerFixture as providerLifecycleOwner,
   providerRuntimeFixture as providerRuntime,
@@ -660,7 +660,7 @@ describe('managed local owner registration', () => {
       available: false,
       reason: 'owner-capability-missing',
     });
-    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+    expect(binding.facts.operations[REVIEWED_MANAGED_OPERATION]).toEqual({ available: true });
   });
 
   test('leaves ordinary selection on the local family owner while a managed owner is registered', async () => {

--- a/src/platform-runtime-managed-owner.fixtures.ts
+++ b/src/platform-runtime-managed-owner.fixtures.ts
@@ -59,10 +59,11 @@ async function managedAutomationScope(platform: ManagedLeasePlatform) {
     managedDevice: {
       ...scope.managedDevice!,
       run: reachability.run,
-      ensureReady: async () => {
-        const result = await admission.run(horizon, scope.signal, async () => {});
+      admit: async <T>(task: () => Promise<T>) => {
+        const result = await admission.run(horizon, scope.signal, task);
         if (result.status !== 'admitted')
           throw new AppError('COMMAND_FAILED', 'Managed lease refused.', { reason: result.status });
+        return result.value;
       },
     },
   };

--- a/src/platform-runtime-managed-owner.fixtures.ts
+++ b/src/platform-runtime-managed-owner.fixtures.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { runCmd } from '@agent-device/host-kit/command';
+import { Deadline } from '@agent-device/host-kit/retry';
+import { AppError } from '@agent-device/kernel/errors';
+import type {
+  ManagedLease,
+  ManagedLeasePlatform,
+} from '@agent-device/contracts/managed-device-allocation';
+import { createManagedLeaseReachability } from './managed-device-reachability.ts';
+import { createManagedLeaseAdmission } from './daemon/managed-device-allocation/lease-admission.ts';
+import { createScriptedManagedDeviceAllocator } from './__tests__/test-utils/managed-device-allocator.fixtures.ts';
+import {
+  ALLOCATION_GRANTED_STATUS,
+  ALLOCATION_LEASE,
+  ALLOCATION_REQUEST,
+} from './daemon/managed-device-allocation/__tests__/fixtures.ts';
+import { managedGatewayScope } from './platform-runtime-gateway.fixtures.ts';
+import { createComposedPlatformRuntimeGateway } from './platform-runtime-gateway.ts';
+import { platformRuntimeModules } from './platform-runtime.ts';
+import { createPlatformRuntimeHost } from './platform-runtime-operation-host.ts';
+import { mkdtempForTestSync } from './__tests__/test-utils/tmp-dir.ts';
+import './platform-runtime-android-adb-host.ts';
+
+export const AUTOMATION_APP_ID = 'com.example.demo';
+export const AUTOMATION_PNG = Buffer.from('89504e470d0a1a0a0000000049454e44ae426082', 'hex');
+
+async function managedAutomationScope(platform: ManagedLeasePlatform) {
+  const lease: ManagedLease = {
+    ...ALLOCATION_LEASE,
+    ttlDeadline: Date.now() + 60_000,
+    device: { address: platform === 'ios' ? 'managed-ios' : 'emulator-15037' },
+    environment:
+      platform === 'ios'
+        ? { SIMLOCK_IOS_DEVICE_SET: '/managed/set' }
+        : { ANDROID_ADB_SERVER_PORT: '15037' },
+  };
+  const grant = { ...ALLOCATION_GRANTED_STATUS, lease };
+  const allocator = createScriptedManagedDeviceAllocator({
+    script: {
+      requestLease: [grant],
+      renewLease: [{ ...lease, ttlDeadline: Date.now() + 180_000 }],
+    },
+  });
+  const reachability = createManagedLeaseReachability({ platform, lease });
+  const admission = createManagedLeaseAdmission({
+    allocator,
+    reachability,
+    grant: await allocator.requestLease({
+      ...ALLOCATION_REQUEST,
+      shape: { ...ALLOCATION_REQUEST.shape, platform },
+    }),
+    renewalSafetyWindowMs: 1_000,
+  });
+  const scope = managedGatewayScope(reachability.device, admission.owner, admission.fence);
+  const horizon = { deadline: Deadline.fromTimeoutMs(90_000), teardownTimeoutMs: 1_000 };
+  const managedScope = {
+    ...scope,
+    managedDevice: {
+      ...scope.managedDevice!,
+      run: reachability.run,
+      ensureReady: async () => {
+        const result = await admission.run(horizon, scope.signal, async () => {});
+        if (result.status !== 'admitted')
+          throw new AppError('COMMAND_FAILED', 'Managed lease refused.', { reason: result.status });
+      },
+    },
+  };
+  return { scope: managedScope, admission, allocator, device: reachability.device };
+}
+
+export async function managedAutomationBinding(platform: ManagedLeasePlatform) {
+  const fixture = await managedAutomationScope(platform);
+  const host = managedAutomationHost();
+  const gateway = createComposedPlatformRuntimeGateway({
+    modules: platformRuntimeModules,
+    loadHost: async () => host,
+    managedOwners: [fixture.admission.owner],
+  });
+  const binding = await gateway.bind({
+    device: fixture.device,
+    scope: fixture.scope,
+    intent: { kind: 'exact-owner', owner: fixture.admission.owner, fence: fixture.admission.fence },
+  });
+  return { ...fixture, binding, host };
+}
+
+export async function managedAutomationApk(root: string): Promise<string> {
+  fs.writeFileSync(
+    path.join(root, 'AndroidManifest.xml'),
+    `<manifest package="${AUTOMATION_APP_ID}" />`,
+  );
+  const apkPath = path.join(root, 'Demo.apk');
+  await runCmd('zip', ['-q', apkPath, 'AndroidManifest.xml'], { cwd: root });
+  return apkPath;
+}
+
+function managedAutomationHost() {
+  const sessionsDir = mkdtempForTestSync('managed-automation-');
+  const unused = async (): Promise<never> => {
+    throw new Error('Unexpected native lifecycle or durable resource operation');
+  };
+  const host = createPlatformRuntimeHost({
+    sessionsDir,
+    resolveSessionArtifacts: (sessionId) => ({
+      outputPath: path.join(sessionsDir, sessionId, 'app.log'),
+      pidPath: path.join(sessionsDir, sessionId, 'app-log.pid'),
+    }),
+    shutdownLoaders: { apple: unused, android: unused },
+    snapshot: { captureSurface: unused, presentIosAcquisition: unused },
+  });
+  return {
+    ...host,
+    toolchains: { prepare: async () => {} },
+    commands: { ...host.commands, run: unused },
+    deviceReadiness: {
+      ...host.deviceReadiness,
+      appleAutomation: {
+        keepHot: () => {
+          throw new Error('Unexpected local boot');
+        },
+        markBooted: () => {},
+        wasRecentlyObservedBooted: async () => false,
+      },
+      androidEmulator: {
+        discover: unused,
+        launch: () => {
+          throw new Error('Unexpected emulator launch');
+        },
+        terminate: unused,
+      },
+    },
+  };
+}
+
+export async function withManagedAdbFixture<T>(
+  task: (fixture: { root: string; calls(): string[][] }) => Promise<T>,
+): Promise<T> {
+  const root = mkdtempForTestSync('managed-automation-adb-');
+  const callPath = path.join(root, 'calls.jsonl');
+  const adbPath = path.join(root, 'adb');
+  fs.writeFileSync(
+    adbPath,
+    [
+      '#!/usr/bin/env node',
+      'const fs = require("node:fs");',
+      'const args = process.argv.slice(2);',
+      `fs.appendFileSync(${JSON.stringify(callPath)}, JSON.stringify(args) + '\\n');`,
+      'if (args.includes("fingerprint")) { process.stderr.write("unknown command"); process.exit(1); }',
+      'if (args.includes("screencap")) {',
+      `  if (fs.existsSync(${JSON.stringify(path.join(root, 'corrupt-screenshot'))})) { process.stdout.write('invalid'); process.exit(0); }`,
+      `  process.stdout.write(Buffer.from('${AUTOMATION_PNG.toString('hex')}', 'hex'));`,
+      '} else if (args.includes("list") && args.includes("packages")) {',
+      `  process.stdout.write('package:${AUTOMATION_APP_ID}\\n');`,
+      '} else if (args.includes("clipboard") && args.includes("get")) {',
+      '  process.stdout.write("managed clipboard");',
+      '} else { process.stdout.write("Success"); }',
+    ].join('\n'),
+  );
+  fs.chmodSync(adbPath, 0o755);
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${root}${path.delimiter}${previousPath ?? ''}`;
+  try {
+    return await task({
+      root,
+      calls: () =>
+        fs.existsSync(callPath)
+          ? fs
+              .readFileSync(callPath, 'utf8')
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line))
+          : [],
+    });
+  } finally {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+}

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -16,15 +16,34 @@ import {
   type PlatformRuntimeHost,
 } from '@agent-device/contracts/platform-runtime-operations';
 import { deployAppUse } from '@agent-device/contracts/app-deployment-runtime-plan';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runCmd } from '@agent-device/host-kit/command';
+import { sleep } from '@agent-device/host-kit/retry';
+import { withAppleToolProvider } from '@agent-device/platform-apple/tool-provider';
+import { createRecordingAppleToolProvider } from '../test/integration/provider-scenarios/providers.ts';
+import { createDemoIosApp } from '../test/integration/provider-scenarios/fixtures.ts';
+import {
+  AUTOMATION_APP_ID,
+  AUTOMATION_PNG,
+  managedAutomationBinding,
+  managedAutomationApk,
+  withManagedAdbFixture,
+} from './platform-runtime-managed-owner.fixtures.ts';
 import { createManagedLocalRuntimeOwner } from './platform-runtime-managed-owner.ts';
 import {
   gatewayFixtureDevice as device,
-  gatewayFixtureScope as scope,
+  gatewayFixtureScope as ordinaryScope,
+  managedGatewayScope,
   localFamilyRuntimeFixture,
   MANAGED_RETAINED_OPERATION,
-  MANAGED_WITHHELD_OPERATIONS,
 } from './platform-runtime-gateway.fixtures.ts';
+
+vi.mock('@agent-device/host-kit/retry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent-device/host-kit/retry')>()),
+  sleep: vi.fn(async () => {}),
+}));
 
 const managed = managedLocalRuntimeOwner('sim-a');
 const fence = managedBindingFence({
@@ -32,6 +51,146 @@ const fence = managedBindingFence({
   requestGeneration: 1,
   identityIncarnationId: 'incarnation-a',
 });
+
+test('managed iOS delegates deployment and system operations without local readiness or runner startup', async () => {
+  const app = createDemoIosApp('managed-ios-automation-');
+  let biometricAttempts = 0;
+  const native = createRecordingAppleToolProvider({
+    plist: {
+      readJson: async () => ({ CFBundleIdentifier: AUTOMATION_APP_ID, CFBundleName: 'Demo' }),
+    },
+    simctl: async (args) => {
+      expect(args.slice(0, 2)).toEqual(['--set', '/managed/set']);
+      const command = args[2];
+      if (command === 'list')
+        return {
+          stdout: JSON.stringify({
+            devices: { ios: [{ udid: 'managed-ios', state: 'Shutdown' }] },
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      expect(['install', 'uninstall', 'pbpaste', 'pbcopy', 'ui', 'biometric', 'push']).toContain(
+        command,
+      );
+      if (command === 'biometric' && ++biometricAttempts === 1)
+        return { stdout: '', stderr: 'unknown command', exitCode: 1 };
+      return {
+        stdout: command === 'pbpaste' ? 'managed clipboard\n' : '',
+        stderr: '',
+        exitCode: 0,
+      };
+    },
+  });
+  try {
+    await withAppleToolProvider(native.provider, async () => {
+      const { binding, allocator, admission } = await managedAutomationBinding('ios');
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
+      const ops = binding.operations;
+      await ops.ensureReady!({});
+      await ops.deployApp!({
+        app: AUTOMATION_APP_ID,
+        appPath: app.appPath,
+        replaceExisting: false,
+      });
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: app.appPath, replaceExisting: true });
+      const artifact = await ops.materializeAppSource!({
+        source: { kind: 'path', path: app.appPath },
+      });
+      try {
+        await ops.deployMaterializedApp!({ artifact });
+      } finally {
+        await artifact.cleanup();
+      }
+      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
+      expect(await ops.readClipboard!({})).toBe('managed clipboard');
+      await ops.writeClipboard!({ text: 'managed' });
+      await ops.setSetting!({ setting: 'appearance', state: 'dark' });
+      await ops.setSetting!({ setting: 'faceid', state: 'match' });
+      expect(biometricAttempts).toBe(2);
+      expect(native.calls.filter((call) => call[3] === 'install')).toHaveLength(3);
+      expect(
+        native.calls.some((call) => ['list', 'boot', 'bootstatus', 'shutdown'].includes(call[3]!)),
+      ).toBe(false);
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease', 'renewLease']);
+      const before = native.calls.length;
+      admission.fenceBinding('replaced');
+      await expect(ops.readClipboard!({})).rejects.toMatchObject({
+        details: { reason: 'teardown-required' },
+      });
+      await binding[Symbol.asyncDispose]();
+      expect(native.calls).toHaveLength(before);
+    });
+  } finally {
+    fs.rmSync(app.tempRoot, { recursive: true, force: true });
+  }
+});
+
+test.skipIf(process.platform === 'win32')(
+  'managed Android contains bind probes, APK deployment, settings, clipboard and screenshot',
+  async () => {
+    await withManagedAdbFixture(async (native) => {
+      const { binding, host, allocator, admission } = await managedAutomationBinding('android');
+      expect(native.calls()).toHaveLength(1);
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
+      const ops = binding.operations;
+      const apkPath = await managedAutomationApk(native.root);
+      await ops.ensureReady!({});
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: false });
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: true });
+      const artifact = await ops.materializeAppSource!({ source: { kind: 'path', path: apkPath } });
+      try {
+        await ops.deployMaterializedApp!({ artifact });
+      } finally {
+        await artifact.cleanup();
+      }
+      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
+      expect(await ops.readClipboard!({})).toBe('managed clipboard');
+      await ops.writeClipboard!({ text: 'managed' });
+      await ops.setSetting!({ setting: 'fingerprint', state: 'match' });
+      await ops.setSetting!({
+        setting: 'clear-app-state',
+        state: 'clear',
+        appBundleId: AUTOMATION_APP_ID,
+      });
+      const outPath = path.join(native.root, 'capture.png');
+      await ops.captureScreenshot!({ outPath, options: { stabilize: false } });
+      expect(fs.readFileSync(outPath)).toEqual(AUTOMATION_PNG);
+      const calls = native.calls();
+      expect(calls.filter((args) => args[4] === 'install')).toHaveLength(3);
+      expect(calls.some((args) => args.slice(4).join(' ') === 'emu finger touch 1')).toBe(true);
+      for (const args of calls)
+        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
+      const bundle = path.join(native.root, 'App.aab');
+      fs.writeFileSync(bundle, 'bundle');
+      const archive = path.join(native.root, 'bundle.zip');
+      await runCmd('zip', ['-q', archive, 'App.aab'], { cwd: native.root });
+      const commands = vi.spyOn(host.commands, 'run');
+      for (const replaceExisting of [false, true]) {
+        await expect(
+          ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: bundle, replaceExisting }),
+        ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      }
+      await expect(
+        ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: archive, replaceExisting: true }),
+      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      await expect(
+        ops.deployMaterializedApp!({
+          artifact: { installablePath: bundle, cleanup: async () => {} },
+        }),
+      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      expect(commands).not.toHaveBeenCalled();
+      expect(native.calls()).toEqual(calls);
+      admission.fenceBinding('released');
+      await expect(ops.readClipboard!({})).rejects.toMatchObject({
+        details: { reason: 'teardown-required' },
+      });
+      await binding[Symbol.asyncDispose]();
+      expect(native.calls()).toEqual(calls);
+    });
+  },
+);
+const scope = managedGatewayScope(device, managed, fence);
 
 function exactly(
   owner: RuntimeOwnerRef = managed,
@@ -58,15 +217,49 @@ function thrownBy(run: () => unknown): unknown {
   throw new Error('expected the runtime use to be refused');
 }
 
+test.skipIf(process.platform === 'win32')(
+  'managed screenshot failure keeps demo-mode cleanup on its private transport',
+  async () => {
+    await withManagedAdbFixture(async (native) => {
+      const { binding } = await managedAutomationBinding('android');
+      vi.mocked(sleep).mockClear();
+      fs.writeFileSync(path.join(native.root, 'corrupt-screenshot'), '');
+      await expect(
+        binding.operations.captureScreenshot!({ outPath: path.join(native.root, 'bad.png') }),
+      ).rejects.toThrow('valid PNG header');
+      expect(sleep).toHaveBeenCalledOnce();
+      const calls = native.calls();
+      expect(calls.at(-1)?.at(-1)).toBe(
+        'am broadcast -a com.android.systemui.demo -e command exit',
+      );
+      for (const args of calls)
+        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
+      await binding[Symbol.asyncDispose]();
+    });
+  },
+);
+
 describe('managed local runtime owner', () => {
-  test('withholds every lifecycle-bearing and durable capture cell and keeps the rest', async () => {
+  test('exposes only reviewed operations even when the local family offers every cell', async () => {
     const { owner } = managedOwnerFixture();
 
     const binding = await owner.bind({ device, intent: exactly(), scope });
 
-    // A cell dropped from this list would silently stop being covered by the assertions below.
-    expect(MANAGED_WITHHELD_OPERATIONS).toHaveLength(27);
-    for (const key of MANAGED_WITHHELD_OPERATIONS) {
+    const enabled = [
+      'ensureReady',
+      'deployApp',
+      'materializeAppSource',
+      'deployMaterializedApp',
+      'sendPushNotification',
+      'setSetting',
+      'readClipboard',
+      'writeClipboard',
+    ];
+    expect(Object.keys(binding.operations).sort()).toEqual(enabled.sort());
+    for (const key of Object.keys(binding.facts.operations) as Array<
+      keyof typeof binding.facts.operations
+    >) {
+      if (enabled.includes(key)) continue;
       expect(binding.facts.operations[key]).toMatchObject({
         available: false,
         reason: 'owner-capability-missing',
@@ -91,8 +284,7 @@ describe('managed local runtime owner', () => {
     expect(thrownBy(() => narrowDeviceBinding(binding, appStateUse))).toMatchObject(refused);
     expect(thrownBy(() => narrowDeviceBinding(binding, bootTargetUse))).toMatchObject(refused);
     expect(thrownBy(() => narrowDeviceBinding(binding, shutdownTargetUse))).toMatchObject(refused);
-    // `deployAppUse` requires `deployApp` alone, so only the cell itself can refuse `install`.
-    expect(thrownBy(() => narrowDeviceBinding(binding, deployAppUse))).toMatchObject(refused);
+    expect(narrowDeviceBinding(binding, deployAppUse).owner).toEqual(managed);
   });
 
   test('rewrites the owner, delegates under an ordinary intent, and forwards disposal', async () => {
@@ -128,13 +320,16 @@ describe('managed local runtime owner', () => {
     expect(family.requests).toEqual([]);
   });
 
-  test('does not read the fence: what a managed fence proves belongs to the claim gate', async () => {
+  test('compares the opaque fence exactly while its meaning stays with the claim gate', async () => {
     const { owner } = managedOwnerFixture();
 
     const binding = await owner.bind({
       device,
       intent: exactly(managed, { token: 'an-opaque-capture-token', generation: 7 }),
-      scope,
+      scope: managedGatewayScope(device, managed, {
+        token: 'an-opaque-capture-token',
+        generation: 7,
+      }),
     });
 
     expect(binding.owner).toEqual(managed);
@@ -149,7 +344,7 @@ describe('managed local runtime owner', () => {
       available: false,
       reason: 'owner-capability-missing',
     });
-    expect(facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
+    expect(facts.operations[MANAGED_RETAINED_OPERATION].available).toBe(false);
   });
 
   test('reports the family owner provider mode it was given, unlaundered', async () => {
@@ -158,5 +353,20 @@ describe('managed local runtime owner', () => {
     const binding = await owner.bind({ device, intent: exactly(), scope });
 
     expect(binding.facts.device.providerMode).toBe('transport-composed');
+  });
+
+  test('refuses absent or mismatched managed authority before loading local mechanics', async () => {
+    const { family, owner } = managedOwnerFixture();
+    for (const candidate of [
+      ordinaryScope,
+      managedGatewayScope({ ...device, simulatorSetPath: '/foreign' }, managed, fence),
+      managedGatewayScope(device, managedLocalRuntimeOwner('foreign'), fence),
+      managedGatewayScope(device, managed, { ...fence, generation: 2 }),
+    ]) {
+      await expect(
+        owner.bind({ device, intent: exactly(), scope: candidate }),
+      ).rejects.toBeDefined();
+    }
+    expect(family.calls.loads).toBe(0);
   });
 });

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -240,6 +240,62 @@ test.skipIf(process.platform === 'win32')(
 );
 
 describe('managed local runtime owner', () => {
+  test('dispatches the real operation inside admission before authority can be fenced', async () => {
+    const events: string[] = [];
+    const cancellation = new AbortController();
+    let cancelOnAdmission = false;
+    const family = localFamilyRuntimeFixture({ family: 'apple', device });
+    const local = await family.module.loadRuntime({} as PlatformRuntimeHost);
+    const owner = createManagedLocalRuntimeOwner({
+      owner: managed,
+      loadLocal: async () => ({
+        ...local,
+        bind: async (request) => {
+          const binding = await local.bind(request);
+          return {
+            ...binding,
+            operations: {
+              ...binding.operations,
+              readClipboard: async () => {
+                events.push('native');
+                expect(events.at(-2)).toBe('admitted');
+                return 'clipboard';
+              },
+            },
+          };
+        },
+      }),
+    });
+    const binding = await owner.bind({
+      device,
+      intent: exactly(),
+      scope: {
+        ...scope,
+        signal: cancellation.signal,
+        managedDevice: {
+          ...scope.managedDevice!,
+          admit: async (task) => {
+            events.push('admitted');
+            if (cancelOnAdmission) cancellation.abort(new Error('cancelled during admission'));
+            try {
+              return await task();
+            } finally {
+              events.push('fenced');
+            }
+          },
+        },
+      },
+    });
+    expect(await binding.operations.readClipboard!({})).toBe('clipboard');
+    cancelOnAdmission = true;
+    await expect(binding.operations.readClipboard!({})).rejects.toThrow(
+      'cancelled during admission',
+    );
+    await binding[Symbol.asyncDispose]();
+    expect(events).toEqual(['admitted', 'native', 'fenced', 'admitted', 'fenced']);
+    expect(family.calls.disposals).toBe(1);
+  });
+
   test('exposes only reviewed operations even when the local family offers every cell', async () => {
     const { owner } = managedOwnerFixture();
 

--- a/src/platform-runtime-managed-owner.test.ts
+++ b/src/platform-runtime-managed-owner.test.ts
@@ -16,34 +16,15 @@ import {
   type PlatformRuntimeHost,
 } from '@agent-device/contracts/platform-runtime-operations';
 import { deployAppUse } from '@agent-device/contracts/app-deployment-runtime-plan';
-import { describe, expect, test, vi } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
-import { runCmd } from '@agent-device/host-kit/command';
-import { sleep } from '@agent-device/host-kit/retry';
-import { withAppleToolProvider } from '@agent-device/platform-apple/tool-provider';
-import { createRecordingAppleToolProvider } from '../test/integration/provider-scenarios/providers.ts';
-import { createDemoIosApp } from '../test/integration/provider-scenarios/fixtures.ts';
-import {
-  AUTOMATION_APP_ID,
-  AUTOMATION_PNG,
-  managedAutomationBinding,
-  managedAutomationApk,
-  withManagedAdbFixture,
-} from './platform-runtime-managed-owner.fixtures.ts';
+import { describe, expect, test } from 'vitest';
 import { createManagedLocalRuntimeOwner } from './platform-runtime-managed-owner.ts';
 import {
   gatewayFixtureDevice as device,
   gatewayFixtureScope as ordinaryScope,
   managedGatewayScope,
   localFamilyRuntimeFixture,
-  MANAGED_RETAINED_OPERATION,
+  REVIEWED_MANAGED_OPERATION,
 } from './platform-runtime-gateway.fixtures.ts';
-
-vi.mock('@agent-device/host-kit/retry', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@agent-device/host-kit/retry')>()),
-  sleep: vi.fn(async () => {}),
-}));
 
 const managed = managedLocalRuntimeOwner('sim-a');
 const fence = managedBindingFence({
@@ -52,144 +33,6 @@ const fence = managedBindingFence({
   identityIncarnationId: 'incarnation-a',
 });
 
-test('managed iOS delegates deployment and system operations without local readiness or runner startup', async () => {
-  const app = createDemoIosApp('managed-ios-automation-');
-  let biometricAttempts = 0;
-  const native = createRecordingAppleToolProvider({
-    plist: {
-      readJson: async () => ({ CFBundleIdentifier: AUTOMATION_APP_ID, CFBundleName: 'Demo' }),
-    },
-    simctl: async (args) => {
-      expect(args.slice(0, 2)).toEqual(['--set', '/managed/set']);
-      const command = args[2];
-      if (command === 'list')
-        return {
-          stdout: JSON.stringify({
-            devices: { ios: [{ udid: 'managed-ios', state: 'Shutdown' }] },
-          }),
-          stderr: '',
-          exitCode: 0,
-        };
-      expect(['install', 'uninstall', 'pbpaste', 'pbcopy', 'ui', 'biometric', 'push']).toContain(
-        command,
-      );
-      if (command === 'biometric' && ++biometricAttempts === 1)
-        return { stdout: '', stderr: 'unknown command', exitCode: 1 };
-      return {
-        stdout: command === 'pbpaste' ? 'managed clipboard\n' : '',
-        stderr: '',
-        exitCode: 0,
-      };
-    },
-  });
-  try {
-    await withAppleToolProvider(native.provider, async () => {
-      const { binding, allocator, admission } = await managedAutomationBinding('ios');
-      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
-      const ops = binding.operations;
-      await ops.ensureReady!({});
-      await ops.deployApp!({
-        app: AUTOMATION_APP_ID,
-        appPath: app.appPath,
-        replaceExisting: false,
-      });
-      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: app.appPath, replaceExisting: true });
-      const artifact = await ops.materializeAppSource!({
-        source: { kind: 'path', path: app.appPath },
-      });
-      try {
-        await ops.deployMaterializedApp!({ artifact });
-      } finally {
-        await artifact.cleanup();
-      }
-      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
-      expect(await ops.readClipboard!({})).toBe('managed clipboard');
-      await ops.writeClipboard!({ text: 'managed' });
-      await ops.setSetting!({ setting: 'appearance', state: 'dark' });
-      await ops.setSetting!({ setting: 'faceid', state: 'match' });
-      expect(biometricAttempts).toBe(2);
-      expect(native.calls.filter((call) => call[3] === 'install')).toHaveLength(3);
-      expect(
-        native.calls.some((call) => ['list', 'boot', 'bootstatus', 'shutdown'].includes(call[3]!)),
-      ).toBe(false);
-      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease', 'renewLease']);
-      const before = native.calls.length;
-      admission.fenceBinding('replaced');
-      await expect(ops.readClipboard!({})).rejects.toMatchObject({
-        details: { reason: 'teardown-required' },
-      });
-      await binding[Symbol.asyncDispose]();
-      expect(native.calls).toHaveLength(before);
-    });
-  } finally {
-    fs.rmSync(app.tempRoot, { recursive: true, force: true });
-  }
-});
-
-test.skipIf(process.platform === 'win32')(
-  'managed Android contains bind probes, APK deployment, settings, clipboard and screenshot',
-  async () => {
-    await withManagedAdbFixture(async (native) => {
-      const { binding, host, allocator, admission } = await managedAutomationBinding('android');
-      expect(native.calls()).toHaveLength(1);
-      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
-      const ops = binding.operations;
-      const apkPath = await managedAutomationApk(native.root);
-      await ops.ensureReady!({});
-      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: false });
-      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: true });
-      const artifact = await ops.materializeAppSource!({ source: { kind: 'path', path: apkPath } });
-      try {
-        await ops.deployMaterializedApp!({ artifact });
-      } finally {
-        await artifact.cleanup();
-      }
-      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
-      expect(await ops.readClipboard!({})).toBe('managed clipboard');
-      await ops.writeClipboard!({ text: 'managed' });
-      await ops.setSetting!({ setting: 'fingerprint', state: 'match' });
-      await ops.setSetting!({
-        setting: 'clear-app-state',
-        state: 'clear',
-        appBundleId: AUTOMATION_APP_ID,
-      });
-      const outPath = path.join(native.root, 'capture.png');
-      await ops.captureScreenshot!({ outPath, options: { stabilize: false } });
-      expect(fs.readFileSync(outPath)).toEqual(AUTOMATION_PNG);
-      const calls = native.calls();
-      expect(calls.filter((args) => args[4] === 'install')).toHaveLength(3);
-      expect(calls.some((args) => args.slice(4).join(' ') === 'emu finger touch 1')).toBe(true);
-      for (const args of calls)
-        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
-      const bundle = path.join(native.root, 'App.aab');
-      fs.writeFileSync(bundle, 'bundle');
-      const archive = path.join(native.root, 'bundle.zip');
-      await runCmd('zip', ['-q', archive, 'App.aab'], { cwd: native.root });
-      const commands = vi.spyOn(host.commands, 'run');
-      for (const replaceExisting of [false, true]) {
-        await expect(
-          ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: bundle, replaceExisting }),
-        ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
-      }
-      await expect(
-        ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: archive, replaceExisting: true }),
-      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
-      await expect(
-        ops.deployMaterializedApp!({
-          artifact: { installablePath: bundle, cleanup: async () => {} },
-        }),
-      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
-      expect(commands).not.toHaveBeenCalled();
-      expect(native.calls()).toEqual(calls);
-      admission.fenceBinding('released');
-      await expect(ops.readClipboard!({})).rejects.toMatchObject({
-        details: { reason: 'teardown-required' },
-      });
-      await binding[Symbol.asyncDispose]();
-      expect(native.calls()).toEqual(calls);
-    });
-  },
-);
 const scope = managedGatewayScope(device, managed, fence);
 
 function exactly(
@@ -216,28 +59,6 @@ function thrownBy(run: () => unknown): unknown {
   }
   throw new Error('expected the runtime use to be refused');
 }
-
-test.skipIf(process.platform === 'win32')(
-  'managed screenshot failure keeps demo-mode cleanup on its private transport',
-  async () => {
-    await withManagedAdbFixture(async (native) => {
-      const { binding } = await managedAutomationBinding('android');
-      vi.mocked(sleep).mockClear();
-      fs.writeFileSync(path.join(native.root, 'corrupt-screenshot'), '');
-      await expect(
-        binding.operations.captureScreenshot!({ outPath: path.join(native.root, 'bad.png') }),
-      ).rejects.toThrow('valid PNG header');
-      expect(sleep).toHaveBeenCalledOnce();
-      const calls = native.calls();
-      expect(calls.at(-1)?.at(-1)).toBe(
-        'am broadcast -a com.android.systemui.demo -e command exit',
-      );
-      for (const args of calls)
-        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
-      await binding[Symbol.asyncDispose]();
-    });
-  },
-);
 
 describe('managed local runtime owner', () => {
   test('dispatches the real operation inside admission before authority can be fenced', async () => {
@@ -322,8 +143,8 @@ describe('managed local runtime owner', () => {
       });
       expect(binding.operations[key]).toBeUndefined();
     }
-    expect(binding.facts.operations[MANAGED_RETAINED_OPERATION]).toEqual({ available: true });
-    expect(binding.operations[MANAGED_RETAINED_OPERATION]).toBeTypeOf('function');
+    expect(binding.facts.operations[REVIEWED_MANAGED_OPERATION]).toEqual({ available: true });
+    expect(binding.operations[REVIEWED_MANAGED_OPERATION]).toBeTypeOf('function');
   });
 
   // The exclusion covers binding cells; request-runtime binding owns the separate pre-binding
@@ -391,7 +212,7 @@ describe('managed local runtime owner', () => {
     expect(binding.owner).toEqual(managed);
   });
 
-  test('never claims a device and projects the same withholding onto inspected facts', async () => {
+  test('never claims a device and leaves unbound inspection entirely unavailable', async () => {
     const { owner } = managedOwnerFixture();
 
     expect(owner.ownsDevice(device)).toBe(false);
@@ -400,7 +221,7 @@ describe('managed local runtime owner', () => {
       available: false,
       reason: 'owner-capability-missing',
     });
-    expect(facts.operations[MANAGED_RETAINED_OPERATION].available).toBe(false);
+    expect(facts.operations[REVIEWED_MANAGED_OPERATION].available).toBe(false);
   });
 
   test('reports the family owner provider mode it was given, unlaundered', async () => {

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -11,6 +11,15 @@ import type {
   PlatformRuntimeOperations,
   PlatformRuntimeOwner,
 } from '@agent-device/contracts/platform-runtime-operations';
+import {
+  createFullyUnavailablePlatformRuntimeFacts,
+  createUnavailablePlatformRuntimeFacts,
+} from '@agent-device/contracts/platform-runtime-unavailable';
+import { withMethodScope } from '@agent-device/kernel/scoped-provider';
+import {
+  assertManagedDeviceIdentity,
+  withManagedDeviceScope,
+} from '@agent-device/provision-kit/managed-device-scope';
 import type { Platform } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 
@@ -18,85 +27,24 @@ export type ManagedLocalRuntimeOwnerRef = Extract<RuntimeOwnerRef, { kind: 'mana
 
 type ManagedOperationKey = RuntimeOperationKey<PlatformRuntimeOperations>;
 
-/**
- * What a managed local owner withholds, grouped by the mechanics that make it impossible rather
- * than by catalog family: an operation is here because executing it would boot, shut down, or
- * durably own the allocator's device.
- */
-const WITHHELD_MANAGED_OPERATIONS = [
-  {
-    // The two deployment cells belong here for the same reason as the explicit boot cells: both
-    // family deployment runtimes ensure device readiness first, and `deployAppUse` requires
-    // `deployApp` alone, so nothing else would have caught `install` on a managed binding.
-    hint: 'Managed-device lifecycle belongs to the allocator.',
-    keys: [
-      'ensureReady',
-      'bootTarget',
-      'bootTargetHeadless',
-      'shutdownTarget',
-      'deployApp',
-      'deployMaterializedApp',
-    ],
-  },
-  {
-    // These four are lifecycle-bearing even though they read as application operations: open
-    // preparation and Apple runner preparation boot the target unconditionally, and the close
-    // pair carries the shutdown half of the same sequence.
-    hint: 'Application open and close take device readiness and shutdown steps the allocator owns.',
-    keys: [
-      'prepareApplicationOpen',
-      'prepareAppleRunner',
-      'closeApplication',
-      'finalizeApplicationClose',
-    ],
-  },
-  {
-    // A durable capture is adopted by comparing the envelope's owner with the binding's owner, and
-    // the family runtime stamps envelopes with its own local owner — so a capture started under a
-    // managed binding could never be reattached or cleaned up under it.
-    hint: 'Durable captures are not adoptable under a managed local owner yet.',
-    keys: [
-      'appLogStart',
-      'appLogReattach',
-      'appLogCleanup',
-      'screenRecordingStart',
-      'screenRecordingReattach',
-      'screenRecordingCleanup',
-      'audioProbeStart',
-      'audioProbeReattach',
-      'audioProbeCleanup',
-      'perfNativeCaptureStart',
-      'perfNativeCaptureReattach',
-      'perfNativeCaptureCleanup',
-    ],
-  },
-  {
-    // Below cell-selection granularity, the Apple family runtime can boot the simulator lazily:
-    // screenshot capture retries through a boot on a shutdown failure, and settings, clipboard and
-    // application launch each resolve a local interactor the same way. The daemon fences its
-    // pre-binding readiness path separately; until these cells are allocator-backed, a managed
-    // binding withholds them rather than leave an allocator-owned device open to an implicit boot.
-    hint: 'Managed-device lifecycle belongs to the allocator; this cell can lazily boot the device.',
-    keys: ['captureScreenshot', 'setSetting', 'readClipboard', 'writeClipboard', 'openApplication'],
-  },
-] as const satisfies readonly Readonly<{ hint: string; keys: readonly ManagedOperationKey[] }>[];
+const REVIEWED_MANAGED_OPERATIONS: Partial<Record<ManagedOperationKey, 'both' | 'android'>> = {
+  ensureReady: 'both',
+  deployApp: 'both',
+  materializeAppSource: 'both',
+  deployMaterializedApp: 'both',
+  sendPushNotification: 'both',
+  setSetting: 'both',
+  readClipboard: 'both',
+  writeClipboard: 'both',
+  captureScreenshot: 'android',
+};
 
-/**
- * The exact-only runtime owner for one allocator instance. It owns no mechanics of its own: it
- * binds the device's local family owner, republishes that binding under the managed owner, and
- * withholds the cells whose declared work is device lifecycle.
- *
- * Withholding cells is not a complete lifecycle exclusion and does not claim to be. Screenshot
- * capture, settings, clipboard and application launch are withheld here even though their declared
- * work is not device lifecycle, because their Apple family-runtime implementations can boot the
- * simulator lazily below cell-selection granularity. The daemon's pre-binding readiness path is
- * fenced at request-runtime binding, while these lazy cells remain allocator-backed follow-up
- * work.
- *
- * It delegates with an ordinary intent because a family owner refuses an exact-owner intent that
- * names anyone but itself. The managed intent's fence is not read here: the device-claim gate owns
- * what a managed binding fence proves.
- */
+const unavailable: RuntimeOperationUnavailability = Object.freeze({
+  available: false,
+  reason: 'owner-capability-missing',
+  hint: 'This operation has no verified managed-device automation path.',
+});
+
 export function createManagedLocalRuntimeOwner(params: {
   owner: ManagedLocalRuntimeOwnerRef;
   loadLocal: (family: Platform) => Promise<PlatformRuntimeOwner>;
@@ -107,8 +55,11 @@ export function createManagedLocalRuntimeOwner(params: {
     // claiming a device here would be the one way it could.
     ownsDevice: () => false,
     inspectFacts: async (device) => {
-      const local = await params.loadLocal(device.platform);
-      return projectManagedFacts(await local.inspectFacts(device));
+      return createUnavailablePlatformRuntimeFacts(
+        device,
+        params.owner,
+        createFullyUnavailablePlatformRuntimeFacts(unavailable),
+      );
     },
     bind: async (request) => {
       if (
@@ -121,19 +72,48 @@ export function createManagedLocalRuntimeOwner(params: {
           { reason: 'runtime-contract-invalid' },
         );
       }
+      const managed = request.scope.managedDevice;
+      if (
+        !managed ||
+        !sameRuntimeOwner(managed.owner, params.owner) ||
+        managed.fence.token !== request.intent.fence.token ||
+        managed.fence.generation !== request.intent.fence.generation
+      ) {
+        throw new AppError(
+          'COMMAND_FAILED',
+          'Managed automation requires its exact request authority.',
+          { reason: 'runtime-contract-invalid' },
+        );
+      }
+      assertManagedDeviceIdentity(managed, request.device);
+      const run = <T>(task: () => Promise<T>) =>
+        managed.run(() => withManagedDeviceScope(managed, task));
       const local = await params.loadLocal(request.device.platform);
-      const binding = await local.bind({
-        device: request.device,
-        intent: { kind: 'ordinary' },
-        scope: request.scope,
-      });
+      const binding = await run(() =>
+        local.bind({
+          device: request.device,
+          intent: { kind: 'ordinary' },
+          scope: request.scope,
+        }),
+      );
       const facts = projectManagedFacts(binding.facts);
       return Object.freeze({
         device: binding.device,
         owner: params.owner,
         facts,
-        operations: admittedOperations(binding.operations, facts),
-        [Symbol.asyncDispose]: async () => await binding[Symbol.asyncDispose](),
+        operations: admittedOperations(
+          withMethodScope({ ...binding.operations }, (task) =>
+            run(async () => {
+              request.scope.signal.throwIfAborted();
+              await managed.ensureReady();
+              request.scope.signal.throwIfAborted();
+              return await task();
+            }),
+          ),
+          facts,
+        ),
+        [Symbol.asyncDispose]: async () =>
+          await run(async () => await binding[Symbol.asyncDispose]()),
       });
     },
     // The delegated family owner is registered with the gateway in its own right, which is what
@@ -145,21 +125,22 @@ export function createManagedLocalRuntimeOwner(params: {
 function projectManagedFacts(
   facts: RuntimeFacts<PlatformRuntimeOperations>,
 ): RuntimeFacts<PlatformRuntimeOperations> {
-  const withheld: Partial<Record<ManagedOperationKey, RuntimeOperationFact>> = {};
-  for (const group of WITHHELD_MANAGED_OPERATIONS) {
-    const fact: RuntimeOperationUnavailability = Object.freeze({
-      available: false,
-      reason: 'owner-capability-missing',
-      hint: group.hint,
-    });
-    for (const key of group.keys) withheld[key] = fact;
-  }
-  // The device shape is the family owner's answer, provider mode included: a managed owner
-  // executes on a local device and may not launder a transport-composed one into a local claim.
+  const operations = Object.fromEntries(
+    Object.entries(facts.operations).map(([key, fact]) => {
+      const reviewed = REVIEWED_MANAGED_OPERATIONS[key as ManagedOperationKey];
+      const supported =
+        facts.device.family === 'android' ||
+        (facts.device.family === 'apple' && facts.device.appleOs === 'ios');
+      return [
+        key,
+        supported && (reviewed === 'both' || reviewed === facts.device.family) ? fact : unavailable,
+      ];
+    }),
+  );
   return Object.freeze({
     device: facts.device,
-    operations: Object.freeze({ ...facts.operations, ...withheld }),
-  });
+    operations: Object.freeze(operations),
+  }) as RuntimeFacts<PlatformRuntimeOperations>;
 }
 
 /** Facts are the only admission authority, so an operation cannot outlive its own fact. */

--- a/src/platform-runtime-managed-owner.ts
+++ b/src/platform-runtime-managed-owner.ts
@@ -105,9 +105,10 @@ export function createManagedLocalRuntimeOwner(params: {
           withMethodScope({ ...binding.operations }, (task) =>
             run(async () => {
               request.scope.signal.throwIfAborted();
-              await managed.ensureReady();
-              request.scope.signal.throwIfAborted();
-              return await task();
+              return await managed.admit(async () => {
+                request.scope.signal.throwIfAborted();
+                return await task();
+              });
             }),
           ),
           facts,

--- a/test/integration/provider-scenarios/managed-runtime-automation.fixtures.ts
+++ b/test/integration/provider-scenarios/managed-runtime-automation.fixtures.ts
@@ -7,20 +7,20 @@ import type {
   ManagedLease,
   ManagedLeasePlatform,
 } from '@agent-device/contracts/managed-device-allocation';
-import { createManagedLeaseReachability } from './managed-device-reachability.ts';
-import { createManagedLeaseAdmission } from './daemon/managed-device-allocation/lease-admission.ts';
-import { createScriptedManagedDeviceAllocator } from './__tests__/test-utils/managed-device-allocator.fixtures.ts';
+import { createManagedLeaseReachability } from '../../../src/managed-device-reachability.ts';
+import { createManagedLeaseAdmission } from '../../../src/daemon/managed-device-allocation/lease-admission.ts';
+import { createScriptedManagedDeviceAllocator } from '../../../src/__tests__/test-utils/managed-device-allocator.fixtures.ts';
 import {
   ALLOCATION_GRANTED_STATUS,
   ALLOCATION_LEASE,
   ALLOCATION_REQUEST,
-} from './daemon/managed-device-allocation/__tests__/fixtures.ts';
-import { managedGatewayScope } from './platform-runtime-gateway.fixtures.ts';
-import { createComposedPlatformRuntimeGateway } from './platform-runtime-gateway.ts';
-import { platformRuntimeModules } from './platform-runtime.ts';
-import { createPlatformRuntimeHost } from './platform-runtime-operation-host.ts';
-import { mkdtempForTestSync } from './__tests__/test-utils/tmp-dir.ts';
-import './platform-runtime-android-adb-host.ts';
+} from '../../../src/daemon/managed-device-allocation/__tests__/fixtures.ts';
+import { managedGatewayScope } from '../../../src/platform-runtime-gateway.fixtures.ts';
+import { createComposedPlatformRuntimeGateway } from '../../../src/platform-runtime-gateway.ts';
+import { platformRuntimeModules } from '../../../src/platform-runtime.ts';
+import { createPlatformRuntimeHost } from '../../../src/platform-runtime-operation-host.ts';
+import { mkdtempForTestSync } from '../../../src/__tests__/test-utils/tmp-dir.ts';
+import '../../../src/platform-runtime-android-adb-host.ts';
 
 export const AUTOMATION_APP_ID = 'com.example.demo';
 export const AUTOMATION_PNG = Buffer.from('89504e470d0a1a0a0000000049454e44ae426082', 'hex');

--- a/test/integration/provider-scenarios/managed-runtime-automation.test.ts
+++ b/test/integration/provider-scenarios/managed-runtime-automation.test.ts
@@ -1,0 +1,181 @@
+import { expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runCmd } from '@agent-device/host-kit/command';
+import { sleep } from '@agent-device/host-kit/retry';
+import { withAppleToolProvider } from '@agent-device/platform-apple/tool-provider';
+import { createRecordingAppleToolProvider } from './providers.ts';
+import { createDemoIosApp } from './fixtures.ts';
+import {
+  AUTOMATION_APP_ID,
+  AUTOMATION_PNG,
+  managedAutomationBinding,
+  managedAutomationApk,
+  withManagedAdbFixture,
+} from './managed-runtime-automation.fixtures.ts';
+
+vi.mock('@agent-device/host-kit/retry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent-device/host-kit/retry')>()),
+  sleep: vi.fn(async () => {}),
+}));
+
+test('managed iOS delegates deployment and system operations without local readiness or runner startup', async () => {
+  const app = createDemoIosApp('managed-ios-automation-');
+  let biometricAttempts = 0;
+  const native = createRecordingAppleToolProvider({
+    plist: {
+      readJson: async () => ({ CFBundleIdentifier: AUTOMATION_APP_ID, CFBundleName: 'Demo' }),
+    },
+    simctl: async (args) => {
+      expect(args.slice(0, 2)).toEqual(['--set', '/managed/set']);
+      const command = args[2];
+      if (command === 'list')
+        return {
+          stdout: JSON.stringify({
+            devices: { ios: [{ udid: 'managed-ios', state: 'Shutdown' }] },
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      expect(['install', 'uninstall', 'pbpaste', 'pbcopy', 'ui', 'biometric', 'push']).toContain(
+        command,
+      );
+      if (command === 'biometric' && ++biometricAttempts === 1)
+        return { stdout: '', stderr: 'unknown command', exitCode: 1 };
+      return {
+        stdout: command === 'pbpaste' ? 'managed clipboard\n' : '',
+        stderr: '',
+        exitCode: 0,
+      };
+    },
+  });
+  try {
+    await withAppleToolProvider(native.provider, async () => {
+      const { binding, allocator, admission } = await managedAutomationBinding('ios');
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
+      const ops = binding.operations;
+      await ops.ensureReady!({});
+      await ops.deployApp!({
+        app: AUTOMATION_APP_ID,
+        appPath: app.appPath,
+        replaceExisting: false,
+      });
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: app.appPath, replaceExisting: true });
+      const artifact = await ops.materializeAppSource!({
+        source: { kind: 'path', path: app.appPath },
+      });
+      try {
+        await ops.deployMaterializedApp!({ artifact });
+      } finally {
+        await artifact.cleanup();
+      }
+      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
+      expect(await ops.readClipboard!({})).toBe('managed clipboard');
+      await ops.writeClipboard!({ text: 'managed' });
+      await ops.setSetting!({ setting: 'appearance', state: 'dark' });
+      await ops.setSetting!({ setting: 'faceid', state: 'match' });
+      expect(biometricAttempts).toBe(2);
+      expect(native.calls.filter((call) => call[3] === 'install')).toHaveLength(3);
+      expect(
+        native.calls.some((call) => ['list', 'boot', 'bootstatus', 'shutdown'].includes(call[3]!)),
+      ).toBe(false);
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease', 'renewLease']);
+      const before = native.calls.length;
+      admission.fenceBinding('replaced');
+      await expect(ops.readClipboard!({})).rejects.toMatchObject({
+        details: { reason: 'teardown-required' },
+      });
+      await binding[Symbol.asyncDispose]();
+      expect(native.calls).toHaveLength(before);
+    });
+  } finally {
+    fs.rmSync(app.tempRoot, { recursive: true, force: true });
+  }
+});
+
+test.skipIf(process.platform === 'win32')(
+  'managed Android contains bind probes, APK deployment, settings, clipboard and screenshot',
+  async () => {
+    await withManagedAdbFixture(async (native) => {
+      const { binding, host, allocator, admission } = await managedAutomationBinding('android');
+      expect(native.calls()).toHaveLength(1);
+      expect(allocator.calls.map(({ method }) => method)).toEqual(['requestLease']);
+      const ops = binding.operations;
+      const apkPath = await managedAutomationApk(native.root);
+      await ops.ensureReady!({});
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: false });
+      await ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: apkPath, replaceExisting: true });
+      const artifact = await ops.materializeAppSource!({ source: { kind: 'path', path: apkPath } });
+      try {
+        await ops.deployMaterializedApp!({ artifact });
+      } finally {
+        await artifact.cleanup();
+      }
+      await ops.sendPushNotification!({ appId: AUTOMATION_APP_ID, payload: {} });
+      expect(await ops.readClipboard!({})).toBe('managed clipboard');
+      await ops.writeClipboard!({ text: 'managed' });
+      await ops.setSetting!({ setting: 'fingerprint', state: 'match' });
+      await ops.setSetting!({
+        setting: 'clear-app-state',
+        state: 'clear',
+        appBundleId: AUTOMATION_APP_ID,
+      });
+      const outPath = path.join(native.root, 'capture.png');
+      await ops.captureScreenshot!({ outPath, options: { stabilize: false } });
+      expect(fs.readFileSync(outPath)).toEqual(AUTOMATION_PNG);
+      const calls = native.calls();
+      expect(calls.filter((args) => args[4] === 'install')).toHaveLength(3);
+      expect(calls.some((args) => args.slice(4).join(' ') === 'emu finger touch 1')).toBe(true);
+      for (const args of calls)
+        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
+      const bundle = path.join(native.root, 'App.aab');
+      fs.writeFileSync(bundle, 'bundle');
+      const archive = path.join(native.root, 'bundle.zip');
+      await runCmd('zip', ['-q', archive, 'App.aab'], { cwd: native.root });
+      const commands = vi.spyOn(host.commands, 'run');
+      for (const replaceExisting of [false, true]) {
+        await expect(
+          ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: bundle, replaceExisting }),
+        ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      }
+      await expect(
+        ops.deployApp!({ app: AUTOMATION_APP_ID, appPath: archive, replaceExisting: true }),
+      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      await expect(
+        ops.deployMaterializedApp!({
+          artifact: { installablePath: bundle, cleanup: async () => {} },
+        }),
+      ).rejects.toMatchObject({ details: { reason: 'managed-bundle-install-unavailable' } });
+      expect(commands).not.toHaveBeenCalled();
+      expect(native.calls()).toEqual(calls);
+      admission.fenceBinding('released');
+      await expect(ops.readClipboard!({})).rejects.toMatchObject({
+        details: { reason: 'teardown-required' },
+      });
+      await binding[Symbol.asyncDispose]();
+      expect(native.calls()).toEqual(calls);
+    });
+  },
+);
+
+test.skipIf(process.platform === 'win32')(
+  'managed screenshot failure keeps demo-mode cleanup on its private transport',
+  async () => {
+    await withManagedAdbFixture(async (native) => {
+      const { binding } = await managedAutomationBinding('android');
+      vi.mocked(sleep).mockClear();
+      fs.writeFileSync(path.join(native.root, 'corrupt-screenshot'), '');
+      await expect(
+        binding.operations.captureScreenshot!({ outPath: path.join(native.root, 'bad.png') }),
+      ).rejects.toThrow('valid PNG header');
+      expect(sleep).toHaveBeenCalledOnce();
+      const calls = native.calls();
+      expect(calls.at(-1)?.at(-1)).toBe(
+        'am broadcast -a com.android.systemui.demo -e command exit',
+      );
+      for (const args of calls)
+        expect(args.slice(0, 4)).toEqual(['-P', '15037', '-s', 'emulator-15037']);
+      await binding[Symbol.asyncDispose]();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Delegate reviewed managed operations through exact lease authority and transport scope: iOS/Android deployment, push, clipboard and settings, plus Android screenshots. Each operation passes its actual task into admission; deep readiness validates canonical identity without recursively admitting or booting locally. Cleanup retains transport scope after fencing.

Simulator readiness captures its callback at lazy runtime binding, preserving eager-import budgets. Unsupported Android bundles fail before uninstall or bundletool dispatch. Unreviewed operations remain unavailable; Simlock owns allocation and lifecycle. Request admission wiring follows this layer.

Based on published #2311 `65bcfb1696037872ff2159a19097f18153ea2731`, following #2308 and #2307 on main `80997b6bf1`. Scope: 18 files, 992 gross lines across the authorized managed owner and Apple/Android mechanics.

## Validation

Tested commit: `9195cb7b37ba0af09a1c6b7c3b58e2a0c1545293`.

The exact-head `pnpm check:affected --run` passed: 4,214 selected tests across 549 files, plus all runnable build, package, structural, typecheck, lint and Fallow checks. The explicit import-closure rerun passed all 420 cases.

All 456 focused checks pass, including 420 import-closure checks. Planted regressions exposed dispatch after admission, local readiness, deep clipboard boot, and unsupported deployment work. Native fixtures cover private transports, cancellation, fencing, and cleanup. Independent final contract/consumer review found no concrete issues.

Three scenarios moved unchanged to provider-integration. Both CI selectors caught a planted failure at the new path; all 12 focused instrumented tests passed.

Current-head CI, including Integration, Coverage and iOS smoke, is green. Live managed-device evidence remains blocked by later admission/publication wiring, so this is published, not merge-ready.

Docs and skills are unchanged because no public managed request path is activated.
