### PR TITLE
refactor(commands): author each executable command once in its facet

### DIFF
--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -570,29 +570,17 @@ function readCommandContractBlocks(text) {
   for (const match of text.matchAll(/\bconst\s+([A-Z0-9_]+)\s*=\s*['"]([^'"]+)['"]/g)) {
     constants.set(match[1], match[2]);
   }
-
-  const metadataNames = new Map();
-  for (const match of text.matchAll(
-    /\bconst\s+([A-Za-z0-9_]+CommandMetadata)\s*=\s*defineFieldCommandMetadata\(\s*([^,\s)]+)/g,
-  )) {
-    metadataNames.set(match[1], readMetadataName(match[2], constants));
-  }
+  const nameOf = (token) => token.match(/^['"]([^'"]+)['"]$/)?.[1] ?? constants.get(token);
 
   const starts = [
-    ...text.matchAll(/defineExecutableCommand\(\s*metadata\(\s*['"]([^'"]+)['"]\s*\)/g),
-    ...[...text.matchAll(/defineExecutableCommand\(\s*([A-Za-z0-9_]+CommandMetadata)\b/g)].flatMap(
-      (match) => {
-        const name = metadataNames.get(match[1]);
-        return name ? [{ ...match, 1: name }] : [];
-      },
-    ),
-    ...text.matchAll(/defineFieldCommand\(\s*['"]([^'"]+)['"]/g),
-    ...text.matchAll(/defineCommand\(\s*\{[\s\S]*?\bname:\s*['"]([^'"]+)['"]/g),
+    ...text.matchAll(/defineCommandFacet\(\s*\{[\s\S]*?\bname:\s*([A-Za-z0-9_]+|['"][^'"]+['"])/g),
+    ...text.matchAll(/defineFieldCommand\(\s*(['"][^'"]+['"])/g),
+    ...text.matchAll(/defineCommand\(\s*\{[\s\S]*?\bname:\s*(['"][^'"]+['"])/g),
   ]
-    .map((match) => ({
-      index: match.index ?? 0,
-      name: match[1],
-    }))
+    .flatMap((match) => {
+      const name = nameOf(match[1]);
+      return name ? [{ index: match.index ?? 0, name }] : [];
+    })
     .sort((a, b) => a.index - b.index);
 
   return starts.map((start, index) => {
@@ -602,12 +590,6 @@ function readCommandContractBlocks(text) {
       source: text.slice(start.index, end),
     };
   });
-}
-
-function readMetadataName(token, constants) {
-  const literal = token.match(/^['"]([^'"]+)['"]$/);
-  if (literal) return literal[1];
-  return constants.get(token);
 }
 
 function extractProviderScenarioCommandReferences(text, clientCommandMethods) {

--- a/src/commands/batch/index.ts
+++ b/src/commands/batch/index.ts
@@ -3,7 +3,6 @@ import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { commonInputFromFlags } from '../cli-grammar/common.ts';
 import type { CliReader } from '../cli-grammar/types.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonToClientOptions } from '../common-input-fields.ts';
 import { batchCliOutputFormatters } from './output.ts';
 import { createBatchCommandMetadata, type BatchCommandStep, type BatchInput } from './metadata.ts';
@@ -11,10 +10,6 @@ import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../core/batch-policy.ts';
 import { createBatchDaemonWriter } from './projection.ts';
 
 const batchCommandMetadata = createBatchCommandMetadata();
-
-const batchCommandDefinition = defineExecutableCommand(batchCommandMetadata, (client, input) =>
-  client.batch.run(toBatchOptions(input)),
-);
 
 const batchCliSchema = {
   usageOverride: 'batch [--steps <json> | --steps-file <path>]',
@@ -74,7 +69,7 @@ const batchCommandFacet = defineCommandFacet({
     cliDetail: buildBatchCliDetail(),
   },
   metadata: batchCommandMetadata,
-  definition: batchCommandDefinition,
+  run: (client, input) => client.batch.run(toBatchOptions(input)),
   cliSchema: batchCliSchema,
   cliReader: batchCliReader,
   cliOutputFormatter: batchCliOutputFormatters.batch,

--- a/src/commands/capture/alert.ts
+++ b/src/commands/capture/alert.ts
@@ -3,7 +3,6 @@ import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { AlertCommandOptions } from '@agent-device/contracts/client';
 import { enumField, integerField } from '../command-input.ts';
 import { compactRecord } from '../input-readers.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -30,10 +29,6 @@ const alertCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const alertCommandDefinition = defineExecutableCommand(alertCommandMetadata, (client, input) =>
-  client.command.alert(input),
-);
-
 const alertCliSchema = {
   usageOverride: 'alert [get|accept|dismiss|wait] [timeout]',
   positionalArgs: ['action?', 'timeout?'],
@@ -54,7 +49,7 @@ export const alertCommandFacet = defineCommandFacet({
     summary: 'Inspect, accept, or dismiss a platform alert',
   },
   metadata: alertCommandMetadata,
-  definition: alertCommandDefinition,
+  run: (client, input) => client.command.alert(input),
   cliSchema: alertCliSchema,
   cliReader: alertCliReader,
   daemonWriter: alertDaemonWriter,

--- a/src/commands/capture/diff.ts
+++ b/src/commands/capture/diff.ts
@@ -8,7 +8,6 @@ import {
   requiredField,
   stringField,
 } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct, requiredDaemonString } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -27,10 +26,6 @@ const diffCommandMetadata = defineFieldCommandMetadata(DIFF_COMMAND_NAME, diffCo
   scope: stringField(),
   raw: booleanField(),
 });
-
-const diffCommandDefinition = defineExecutableCommand(diffCommandMetadata, (client, input) =>
-  client.capture.diff(input),
-);
 
 const diffCliSchema = {
   usageOverride:
@@ -66,7 +61,7 @@ export const diffCommandFacet = defineCommandFacet({
       'Live iOS simulator screenshot diffs normalize status-bar chrome by default; use screenshot --normalize-status-bar when capturing reusable baselines.',
   },
   metadata: diffCommandMetadata,
-  definition: diffCommandDefinition,
+  run: (client, input) => client.capture.diff(input),
   cliSchema: diffCliSchema,
   cliReader: diffCliReader,
   daemonWriter: diffDaemonWriter,

--- a/src/commands/capture/screenshot.ts
+++ b/src/commands/capture/screenshot.ts
@@ -18,7 +18,6 @@ import {
   retiredField,
   stringField,
 } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, optionalString, request } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -50,11 +49,6 @@ const screenshotCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const screenshotCommandDefinition = defineExecutableCommand(
-  screenshotCommandMetadata,
-  (client, input) => client.capture.screenshot(input),
-);
-
 const screenshotCliSchema = {
   positionalArgs: ['path?'],
   allowedFlags: SCREENSHOT_COMMAND_FLAG_KEYS,
@@ -83,7 +77,7 @@ export const screenshotCommandFacet = defineCommandFacet({
       'Web defaults to the viewport; use --fullscreen, --full, or -f for the entire page. iOS simulators default to 1x logical-point output; use --pixel-density to request a different screenshot density. macOS app sessions default to the app window; use --fullscreen for full desktop, --scale to downscale, --crop-on <selector> to crop the capture to the frame the selector resolves on the same screen (currently iOS simulators and Android emulators), --overlay-refs to annotate current refs, --normalize-status-bar for deterministic iOS simulator chrome, or --no-stabilize for low-latency Android capture loops.',
   },
   metadata: screenshotCommandMetadata,
-  definition: screenshotCommandDefinition,
+  run: (client, input) => client.capture.screenshot(input),
   cliSchema: screenshotCliSchema,
   cliReader: screenshotCliReader,
   daemonWriter: screenshotDaemonWriter,

--- a/src/commands/capture/settings.ts
+++ b/src/commands/capture/settings.ts
@@ -5,7 +5,6 @@ import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import type { CliFlags } from '@agent-device/contracts/command';
 import { AppError } from '@agent-device/kernel/errors';
 import { readLocationCoordinate } from '@agent-device/kernel/location-coordinates';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { enumField, numberField, requiredField, stringField } from '../command-input.ts';
 import {
   direct,
@@ -37,11 +36,6 @@ const settingsCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const settingsCommandDefinition = defineExecutableCommand(
-  settingsCommandMetadata,
-  (client, input) => client.settings.update(input as SettingsUpdateOptions),
-);
-
 const settingsCliSchema = {
   usageOverride: SETTINGS_USAGE_OVERRIDE,
   listUsageOverride: 'settings [area] [options]',
@@ -63,7 +57,7 @@ export const settingsCommandFacet = defineCommandFacet({
       'macOS supports only settings appearance <light|dark|toggle> and settings permission <grant|reset> <accessibility|screen-recording|input-monitoring>; wifi|airplane|location|animations remain unsupported on macOS. Mobile permission actions use the active session app. On Android, deny|reset of a permission the app currently holds kills a running app; the response reports priorGrantState (granted|not_granted|unknown) and warns for granted and unknown, with open <app> --relaunch to restore it. Permission changes require a resolvable foreground user and fail without mutating if adb cannot report one. Android settings airplane on|off is applied by the connectivity service (Android 11+) and reports the airplaneMode that service holds; older builds fail without changing device state.',
   },
   metadata: settingsCommandMetadata,
-  definition: settingsCommandDefinition,
+  run: (client, input) => client.settings.update(input as SettingsUpdateOptions),
   cliSchema: settingsCliSchema,
   cliReader: settingsCliReader,
   daemonWriter: settingsDaemonWriter,

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -2,7 +2,6 @@ import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import { SNAPSHOT_BACKEND_CAPABILITIES } from '@agent-device/capture-kit/snapshot-quality-backend-capabilities';
 import { SNAPSHOT_FLAGS } from '../cli-grammar/flag-groups.ts';
 import { booleanField, integerField, stringField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -49,11 +48,6 @@ const snapshotCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const snapshotCommandDefinition = defineExecutableCommand(
-  snapshotCommandMetadata,
-  (client, input) => client.capture.snapshot(input),
-);
-
 const snapshotCliSchema = {
   usageOverride:
     'snapshot [--diff] [-i] [-d <depth>] [-s <scope>] [--raw] [--actions] [--force-full] [--timeout <ms>]',
@@ -88,7 +82,7 @@ export const snapshotCommandFacet = defineCommandFacet({
     cliDetail: `For iOS raw-coordinate fallback after a no-op ref press, inspect rects with snapshot -i --json, press the rect center, then verify with diff snapshot -i or snapshot --diff. iOS backend capability contract: ${snapshotBackendCapabilityHelp}.`,
   },
   metadata: snapshotCommandMetadata,
-  definition: snapshotCommandDefinition,
+  run: (client, input) => client.capture.snapshot(input),
   cliSchema: snapshotCliSchema,
   cliReader: snapshotCliReader,
   daemonWriter: snapshotDaemonWriter,

--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -8,7 +8,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import { isValidSelectorExpression } from '@agent-device/selectors';
 import { booleanField, enumField, integerField, stringField } from '../command-input.ts';
 import { optionalEnum } from '../input-readers.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   direct,
   optionalNumber,
@@ -43,10 +42,6 @@ const waitCommandMetadata = defineFieldCommandMetadata(WAIT_COMMAND_NAME, waitCo
   raw: booleanField(),
 });
 
-const waitCommandDefinition = defineExecutableCommand(waitCommandMetadata, (client, input) =>
-  client.command.wait(waitInputToOptions(input)),
-);
-
 const waitCliSchema = {
   usageOverride:
     'wait <ms>|text <text>|@ref|<selector>|absent <selector> [timeoutMs]|stable [quietMs] [timeoutMs]',
@@ -68,7 +63,7 @@ export const waitCommandFacet = defineCommandFacet({
     summary: 'Wait for a duration, text, selector, strict absence, or stable UI',
   },
   metadata: waitCommandMetadata,
-  definition: waitCommandDefinition,
+  run: (client, input) => client.command.wait(waitInputToOptions(input)),
   cliSchema: waitCliSchema,
   cliReader: waitCliReader,
   daemonWriter: waitDaemonWriter,

--- a/src/commands/command-contract.ts
+++ b/src/commands/command-contract.ts
@@ -1,4 +1,3 @@
-import type { AgentDeviceClient } from '../client/client-types.ts';
 import type { InputAudienceMap } from './input-audience.ts';
 
 export type JsonSchema = {
@@ -51,14 +50,6 @@ export type CommandMetadata<Name extends string, Input> = {
   inputAudience: InputAudienceMap;
 };
 
-export type ExecutableCommandContract<Name extends string, Input, Result> = CommandMetadata<
-  Name,
-  Input
-> & {
-  run: (client: AgentDeviceClient, input: Input) => Promise<Result>;
-  invoke: (client: AgentDeviceClient, input: unknown) => Promise<Result>;
-};
-
 export type CliOutput = {
   data: unknown;
   jsonData?: unknown;
@@ -70,15 +61,4 @@ export function defineCommandMetadata<Name extends string, Input>(
   definition: CommandMetadata<Name, Input>,
 ): CommandMetadata<Name, Input> {
   return definition;
-}
-
-export function defineExecutableCommand<Name extends string, Input, Result>(
-  metadata: CommandMetadata<Name, Input>,
-  run: (client: AgentDeviceClient, input: Input) => Promise<Result>,
-): ExecutableCommandContract<Name, Input, Result> {
-  return {
-    ...metadata,
-    run,
-    invoke: async (client, input) => await run(client, metadata.readInput(input)),
-  };
 }

--- a/src/commands/debugging/index.test.ts
+++ b/src/commands/debugging/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
-import { debugCliReader, debugCommandDefinition, debugCommandMetadata } from './index.ts';
+import { debugCliReader, debugCommandFacet, debugCommandMetadata } from './index.ts';
 
 describe('debugging command interface', () => {
   test('owns debug public metadata', () => {
     expect(debugCommandMetadata.name).toBe('debug');
-    expect(debugCommandDefinition.name).toBe('debug');
+    expect(debugCommandFacet.definition.name).toBe('debug');
   });
 
   test('reads debug symbols crash artifact inputs', () => {

--- a/src/commands/debugging/index.ts
+++ b/src/commands/debugging/index.ts
@@ -2,7 +2,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { enumField, requiredField, stringField } from '../command-input.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import { commonInputFromFlags } from '../cli-grammar/common.ts';
 import type { CliReader } from '../cli-grammar/types.ts';
@@ -26,11 +25,6 @@ export const debugCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-export const debugCommandDefinition = defineExecutableCommand(
-  debugCommandMetadata,
-  (client, input) => client.debug.symbols(input),
-);
-
 const debugCliSchema = {
   usageOverride:
     'debug symbols --artifact <crash.ips|crash.log> (--dsym <App.dSYM> | --search-path <dir>) [--out <symbolicated>]',
@@ -48,13 +42,13 @@ export const debugCliReader: CliReader = (positionals, flags) => ({
   out: flags.out,
 });
 
-const debugCommandFacet = defineCommandFacet({
+export const debugCommandFacet = defineCommandFacet({
   name: DEBUG_COMMAND_NAME,
   text: {
     summary: 'Symbolicate Apple crash artifacts',
   },
   metadata: debugCommandMetadata,
-  definition: debugCommandDefinition,
+  run: (client, input) => client.debug.symbols(input),
   cliSchema: debugCliSchema,
   cliReader: debugCliReader,
   cliOutputFormatter: debuggingCliOutputFormatters.debug,

--- a/src/commands/family/types.ts
+++ b/src/commands/family/types.ts
@@ -28,14 +28,7 @@ export type CommandFamilyFacet<TCommandName extends string = string> = {
   cliOutputFormatters?: Readonly<Partial<Record<TCommandName, CliOutputFormatter>>>;
 };
 
-/**
- * What a command file authors: metadata plus the one function that runs the command. `run`'s
- * `Input` is inferred from `metadata.readInput`, so there is nowhere else to declare the
- * executable definition — `defineCommandFacet` derives `name`, `description`, `mcpDetail`,
- * `inputSchema`, and `invoke` from these two fields. `cliSchema` carries grammar only and may be
- * omitted entirely; `text` is required, because a command with no list line has nowhere to
- * appear in `--help`.
- */
+/** What a command file authors: metadata plus `run`; the facet derives the executable from them. */
 export type CommandFacetInput<
   TCommandName extends string = string,
   Input = unknown,
@@ -52,13 +45,7 @@ export type CommandFacetInput<
   text: FacetCommandText;
 };
 
-/**
- * What `defineCommandFacet` returns: the authored facet with its schema completed and the
- * executable `definition` derived from `metadata` and `run`. Stating this as a distinct type is
- * what lets the registry read `cliSchema` and `definition` without asserting they are populated.
- * `Result` carries the command's specific return type through to `definition.invoke`, the same way
- * `CommandExecutionResult` recovers it per command name from the family registry.
- */
+/** The authored facet with `cliSchema` completed and `definition` derived, typed per command. */
 export type CommandFacet<
   TCommandName extends string = string,
   Result = unknown,

--- a/src/commands/family/types.ts
+++ b/src/commands/family/types.ts
@@ -7,13 +7,15 @@ import { resolveFacetText, type FacetCommandText } from '../command-text.ts';
 
 export type AnyCommandMetadata<Name extends string = string> = CommandMetadata<Name, unknown>;
 
-export type AnyCommandDefinition<Name extends string = string> = {
+export type CommandDefinition<Name extends string = string, Result = unknown> = {
   name: Name;
   description: string;
   mcpDetail?: string;
   inputSchema: JsonSchema;
-  invoke: (client: AgentDeviceClient, input: unknown) => Promise<unknown>;
+  invoke: (client: AgentDeviceClient, input: unknown) => Promise<Result>;
 };
+
+export type AnyCommandDefinition<Name extends string = string> = CommandDefinition<Name, unknown>;
 
 export type CommandFamilyFacet<TCommandName extends string = string> = {
   name: string;
@@ -27,26 +29,49 @@ export type CommandFamilyFacet<TCommandName extends string = string> = {
 };
 
 /**
- * What a command file authors. `cliSchema` carries grammar only and may be omitted entirely;
- * `text` is required, because a command with no list line has nowhere to appear in `--help`.
+ * What a command file authors: metadata plus the one function that runs the command. `run`'s
+ * `Input` is inferred from `metadata.readInput`, so there is nowhere else to declare the
+ * executable definition — `defineCommandFacet` derives `name`, `description`, `mcpDetail`,
+ * `inputSchema`, and `invoke` from these two fields. `cliSchema` carries grammar only and may be
+ * omitted entirely; `text` is required, because a command with no list line has nowhere to
+ * appear in `--help`.
  */
-export type CommandFacetInput<TCommandName extends string = string> = {
+export type CommandFacetInput<
+  TCommandName extends string = string,
+  Input = unknown,
+  Result = unknown,
+  Formatter extends CliOutputFormatter | undefined = CliOutputFormatter | undefined,
+> = {
   name: TCommandName;
-  metadata: AnyCommandMetadata<TCommandName>;
-  definition: AnyCommandDefinition<TCommandName>;
+  metadata: CommandMetadata<TCommandName, Input>;
+  run: (client: AgentDeviceClient, input: Input) => Promise<Result>;
   cliSchema?: CommandSchemaOverride;
   cliReader: CliReader;
   daemonWriter?: AnyDaemonWriter;
-  cliOutputFormatter?: CliOutputFormatter;
+  cliOutputFormatter?: Formatter;
   text: FacetCommandText;
 };
 
 /**
- * What `defineCommandFacet` returns: the same facet with its schema completed. Stating this as a
- * distinct type is what lets the registry read `cliSchema` without asserting it is populated.
+ * What `defineCommandFacet` returns: the authored facet with its schema completed and the
+ * executable `definition` derived from `metadata` and `run`. Stating this as a distinct type is
+ * what lets the registry read `cliSchema` and `definition` without asserting they are populated.
+ * `Result` carries the command's specific return type through to `definition.invoke`, the same way
+ * `CommandExecutionResult` recovers it per command name from the family registry.
  */
-export type CommandFacet<TCommandName extends string = string> = CommandFacetInput<TCommandName> & {
+export type CommandFacet<
+  TCommandName extends string = string,
+  Result = unknown,
+  Formatter extends CliOutputFormatter | undefined = CliOutputFormatter | undefined,
+> = {
+  name: TCommandName;
+  metadata: AnyCommandMetadata<TCommandName>;
+  definition: CommandDefinition<TCommandName, Result>;
   cliSchema: CommandSchema;
+  cliReader: CliReader;
+  daemonWriter?: AnyDaemonWriter;
+  cliOutputFormatter?: Formatter;
+  text: FacetCommandText;
 };
 
 type CommandFacetMetadata<TCommands extends readonly CommandFacet[]> = {
@@ -61,17 +86,33 @@ type CommandFacetName<TCommands extends readonly CommandFacet[]> = TCommands[num
 
 export function defineCommandFacet<
   const TCommandName extends string,
-  const TCommand extends CommandFacetInput<TCommandName>,
->(command: TCommand): TCommand & { cliSchema: CommandSchema } {
+  Input,
+  Result,
+  Formatter extends CliOutputFormatter | undefined = undefined,
+>(
+  command: CommandFacetInput<TCommandName, Input, Result, Formatter>,
+): CommandFacet<TCommandName, Result, Formatter> {
   // The metadata already holds the canonical description, so the facet never repeats it; the
   // resolved text is what every surface renders from.
   const text = resolveFacetText(command.text, command.metadata.description);
   const mcpTail = text.mcpDetail ? { mcpDetail: text.mcpDetail } : {};
+  const metadata = { ...command.metadata, ...mcpTail };
+  const definition: CommandDefinition<TCommandName, Result> = {
+    name: metadata.name,
+    description: metadata.description,
+    inputSchema: metadata.inputSchema,
+    ...mcpTail,
+    invoke: async (client, input) => await command.run(client, metadata.readInput(input)),
+  };
   return {
-    ...command,
-    metadata: { ...command.metadata, ...mcpTail },
-    definition: { ...command.definition, ...mcpTail },
+    name: command.name,
+    metadata,
+    definition,
     cliSchema: { ...command.cliSchema, text },
+    cliReader: command.cliReader,
+    daemonWriter: command.daemonWriter,
+    cliOutputFormatter: command.cliOutputFormatter,
+    text,
   };
 }
 

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -21,7 +21,6 @@ import type {
 } from '@agent-device/contracts/client';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { REPEATED_TOUCH_FLAGS, SELECTOR_SNAPSHOT_FLAGS } from '../cli-grammar/flag-groups.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { postActionObservationCliFlags } from '../post-action-observation-grammar.ts';
 import {
   toClientElementTarget,
@@ -147,57 +146,174 @@ const interactionCliSchemas = {
 type InteractionCommandMetadata = (typeof interactionCommandMetadata)[number];
 type InteractionCommandName = InteractionCommandMetadata['name'];
 
-const clickCommandDefinition = defineExecutableCommand(metadata('click'), (client, input) =>
-  client.interactions.click(toClickOptions(input)),
-);
+const clickCommandFacet = defineCommandFacet({
+  name: 'click',
+  text: {
+    summary: 'Click or tap a UI target',
+  },
+  metadata: metadata('click'),
+  run: (client, input) => client.interactions.click(toClickOptions(input)),
+  cliSchema: interactionCliSchemas.click,
+  cliReader: interactionCliReaders.click,
+  daemonWriter: interactionDaemonWriters.click,
+  cliOutputFormatter: interactionCliOutputFormatters.click,
+});
 
-const pressCommandDefinition = defineExecutableCommand(metadata('press'), (client, input) =>
-  client.interactions.press(toPressOptions(input)),
-);
+const pressCommandFacet = defineCommandFacet({
+  name: 'press',
+  text: {
+    summary: 'Short-press a UI target',
+    cliDetail: 'The hold duration is positional on longpress, not press --hold-ms.',
+  },
+  metadata: metadata('press'),
+  run: (client, input) => client.interactions.press(toPressOptions(input)),
+  cliSchema: interactionCliSchemas.press,
+  cliReader: interactionCliReaders.press,
+  daemonWriter: interactionDaemonWriters.press,
+  cliOutputFormatter: interactionCliOutputFormatters.press,
+});
 
-const fillCommandDefinition = defineExecutableCommand(metadata('fill'), (client, input) =>
-  client.interactions.fill(toFillOptions(input)),
-);
+const fillCommandFacet = defineCommandFacet({
+  name: 'fill',
+  text: {
+    summary: 'Replace text in a UI input',
+    cliDetail:
+      'Every positional after an @ref is the replacement text, so fill @e57 good morning enters "good morning"; quote the text when the shell must preserve exact whitespace. Clear a field with an empty text argument: fill @e57 "" (the argument must be present — fill @e57 alone is a missing argument, not a clear). When visible label text also matches a non-input element, constrain the target with editable=true, for example fill \'label="Email" editable=true\' "qa@example.com".',
+  },
+  metadata: metadata('fill'),
+  run: (client, input) => client.interactions.fill(toFillOptions(input)),
+  cliSchema: interactionCliSchemas.fill,
+  cliReader: interactionCliReaders.fill,
+  daemonWriter: interactionDaemonWriters.fill,
+  cliOutputFormatter: interactionCliOutputFormatters.fill,
+});
 
-const longPressCommandDefinition = defineExecutableCommand(metadata('longpress'), (client, input) =>
-  client.interactions.longPress(toLongPressOptions(input)),
-);
+const longPressCommandFacet = defineCommandFacet({
+  name: 'longpress',
+  text: {
+    summary: 'Hold a UI target to open a context menu',
+    cliDetail: 'Duration is positional, for example longpress @e12 800 or longpress 300 500 800.',
+  },
+  metadata: metadata('longpress'),
+  run: (client, input) => client.interactions.longPress(toLongPressOptions(input)),
+  cliSchema: interactionCliSchemas.longpress,
+  cliReader: interactionCliReaders.longpress,
+  daemonWriter: interactionDaemonWriters.longpress,
+  cliOutputFormatter: interactionCliOutputFormatters.longpress,
+});
 
-const hoverCommandDefinition = defineExecutableCommand(metadata('hover'), (client, input) =>
-  client.interactions.hover(toHoverOptions(input)),
-);
+const hoverCommandFacet = defineCommandFacet({
+  name: 'hover',
+  text: {
+    summary: 'Hover the pointer over a UI target (web only)',
+    cliDetail:
+      'The pointer stays where hover left it: read the revealed UI (--settle or snapshot -i) and act on it before another click or hover moves the pointer away.',
+  },
+  metadata: metadata('hover'),
+  run: (client, input) => client.interactions.hover(toHoverOptions(input)),
+  cliSchema: interactionCliSchemas.hover,
+  cliReader: interactionCliReaders.hover,
+  daemonWriter: interactionDaemonWriters.hover,
+  cliOutputFormatter: interactionCliOutputFormatters.hover,
+});
 
-const swipeCommandDefinition = defineExecutableCommand(metadata('swipe'), (client, input) =>
-  client.interactions.swipe(input as SwipeOptions),
-);
+const swipeCommandFacet = defineCommandFacet({
+  name: 'swipe',
+  text: {
+    summary: 'Fling between coordinates',
+  },
+  metadata: metadata('swipe'),
+  run: (client, input) => client.interactions.swipe(input as SwipeOptions),
+  cliSchema: interactionCliSchemas.swipe,
+  cliReader: interactionCliReaders.swipe,
+  daemonWriter: interactionDaemonWriters.swipe,
+});
 
-const focusCommandDefinition = defineExecutableCommand(metadata('focus'), (client, input) =>
-  client.interactions.focus(input as FocusOptions),
-);
+const focusCommandFacet = defineCommandFacet({
+  name: 'focus',
+  text: {
+    summary: 'Focus input at screen coordinates',
+  },
+  metadata: metadata('focus'),
+  run: (client, input) => client.interactions.focus(input as FocusOptions),
+  cliSchema: interactionCliSchemas.focus,
+  cliReader: interactionCliReaders.focus,
+  daemonWriter: interactionDaemonWriters.focus,
+});
 
-const typeCommandDefinition = defineExecutableCommand(metadata('type'), (client, input) =>
-  client.interactions.type(input as TypeTextOptions),
-);
+const typeCommandFacet = defineCommandFacet({
+  name: 'type',
+  text: {
+    summary: 'Append text to the focused input',
+  },
+  metadata: metadata('type'),
+  run: (client, input) => client.interactions.type(input as TypeTextOptions),
+  cliSchema: interactionCliSchemas.type,
+  cliReader: interactionCliReaders.type,
+  daemonWriter: interactionDaemonWriters.type,
+});
 
-const scrollCommandDefinition = defineExecutableCommand(metadata('scroll'), (client, input) =>
-  client.interactions.scroll(input as ScrollOptions),
-);
+const scrollCommandFacet = defineCommandFacet({
+  name: 'scroll',
+  text: {
+    summary: 'Scroll in a direction or to an edge',
+  },
+  metadata: metadata('scroll'),
+  run: (client, input) => client.interactions.scroll(input as ScrollOptions),
+  cliSchema: interactionCliSchemas.scroll,
+  cliReader: interactionCliReaders.scroll,
+  daemonWriter: interactionDaemonWriters.scroll,
+  cliOutputFormatter: interactionCliOutputFormatters.scroll,
+});
 
-const getCommandDefinition = defineExecutableCommand(metadata('get'), (client, input) =>
-  client.interactions.get(toGetOptions(input)),
-);
+const getCommandFacet = defineCommandFacet({
+  name: 'get',
+  text: {
+    summary: 'Read element text or attributes',
+  },
+  metadata: metadata('get'),
+  run: (client, input) => client.interactions.get(toGetOptions(input)),
+  cliSchema: interactionCliSchemas.get,
+  cliReader: interactionCliReaders.get,
+  daemonWriter: interactionDaemonWriters.get,
+  cliOutputFormatter: interactionCliOutputFormatters.get,
+});
 
-const isCommandDefinition = defineExecutableCommand(metadata('is'), (client, input) =>
-  client.interactions.is(input as IsOptions),
-);
+const isCommandFacet = defineCommandFacet({
+  name: 'is',
+  text: {
+    summary: 'Check a UI predicate on a selector',
+  },
+  metadata: metadata('is'),
+  run: (client, input) => client.interactions.is(input as IsOptions),
+  cliSchema: interactionCliSchemas.is,
+  cliReader: selectorCliReaders.is,
+  daemonWriter: selectorDaemonWriters.is,
+  cliOutputFormatter: interactionCliOutputFormatters.is,
+});
 
-const findCommandDefinition = defineExecutableCommand(metadata('find'), (client, input) =>
-  client.interactions.find(input as FindOptions),
-);
+const findCommandFacet = defineCommandFacet({
+  name: 'find',
+  text: {
+    summary: 'Find an element and act',
+  },
+  metadata: metadata('find'),
+  run: (client, input) => client.interactions.find(input as FindOptions),
+  cliSchema: interactionCliSchemas.find,
+  cliReader: selectorCliReaders.find,
+  daemonWriter: selectorDaemonWriters.find,
+  cliOutputFormatter: interactionCliOutputFormatters.find,
+});
 
-const gestureCommandDefinition = defineExecutableCommand(
-  metadata('gesture'),
-  async (client, input) => {
+const gestureCommandFacet = defineCommandFacet({
+  name: 'gesture',
+  text: {
+    summary: 'Run pan, fling, swipe, pinch, rotate, transform, or drag gestures',
+    cliDetail:
+      'Argument shapes: pan <x> <y> <dx> <dy> [durationMs], fling <up|down|left|right> <x> <y> [distance], swipe <left|right|left-edge|right-edge>, pinch <scale> [x] [y], rotate <degrees> [x] [y], transform <x> <y> <dx> <dy> <scale> <degrees> [durationMs], or drag <source-selector|pinned-ref> <destination-selector|pinned-ref> [sourceHoldMs] [moveMs] [destinationHoldMs]. For command plans, output only command lines. Android transform verification should use all app-observable effects, for example wait text "pan changed yes", wait text "pinch changed yes", and wait text "rotate changed yes", not exact transform values.',
+  },
+  metadata: metadata('gesture'),
+  run: async (client, input) => {
     switch (input.kind) {
       case 'pan':
         return await client.interactions.pan(toPanOptions(input));
@@ -215,176 +331,6 @@ const gestureCommandDefinition = defineExecutableCommand(
         return await client.interactions.drag(toDragOptions(input));
     }
   },
-);
-
-const clickCommandFacet = defineCommandFacet({
-  name: 'click',
-  text: {
-    summary: 'Click or tap a UI target',
-  },
-  metadata: metadata('click'),
-  definition: clickCommandDefinition,
-  cliSchema: interactionCliSchemas.click,
-  cliReader: interactionCliReaders.click,
-  daemonWriter: interactionDaemonWriters.click,
-  cliOutputFormatter: interactionCliOutputFormatters.click,
-});
-
-const pressCommandFacet = defineCommandFacet({
-  name: 'press',
-  text: {
-    summary: 'Short-press a UI target',
-    cliDetail: 'The hold duration is positional on longpress, not press --hold-ms.',
-  },
-  metadata: metadata('press'),
-  definition: pressCommandDefinition,
-  cliSchema: interactionCliSchemas.press,
-  cliReader: interactionCliReaders.press,
-  daemonWriter: interactionDaemonWriters.press,
-  cliOutputFormatter: interactionCliOutputFormatters.press,
-});
-
-const fillCommandFacet = defineCommandFacet({
-  name: 'fill',
-  text: {
-    summary: 'Replace text in a UI input',
-    cliDetail:
-      'Every positional after an @ref is the replacement text, so fill @e57 good morning enters "good morning"; quote the text when the shell must preserve exact whitespace. Clear a field with an empty text argument: fill @e57 "" (the argument must be present — fill @e57 alone is a missing argument, not a clear). When visible label text also matches a non-input element, constrain the target with editable=true, for example fill \'label="Email" editable=true\' "qa@example.com".',
-  },
-  metadata: metadata('fill'),
-  definition: fillCommandDefinition,
-  cliSchema: interactionCliSchemas.fill,
-  cliReader: interactionCliReaders.fill,
-  daemonWriter: interactionDaemonWriters.fill,
-  cliOutputFormatter: interactionCliOutputFormatters.fill,
-});
-
-const longPressCommandFacet = defineCommandFacet({
-  name: 'longpress',
-  text: {
-    summary: 'Hold a UI target to open a context menu',
-    cliDetail: 'Duration is positional, for example longpress @e12 800 or longpress 300 500 800.',
-  },
-  metadata: metadata('longpress'),
-  definition: longPressCommandDefinition,
-  cliSchema: interactionCliSchemas.longpress,
-  cliReader: interactionCliReaders.longpress,
-  daemonWriter: interactionDaemonWriters.longpress,
-  cliOutputFormatter: interactionCliOutputFormatters.longpress,
-});
-
-const hoverCommandFacet = defineCommandFacet({
-  name: 'hover',
-  text: {
-    summary: 'Hover the pointer over a UI target (web only)',
-    cliDetail:
-      'The pointer stays where hover left it: read the revealed UI (--settle or snapshot -i) and act on it before another click or hover moves the pointer away.',
-  },
-  metadata: metadata('hover'),
-  definition: hoverCommandDefinition,
-  cliSchema: interactionCliSchemas.hover,
-  cliReader: interactionCliReaders.hover,
-  daemonWriter: interactionDaemonWriters.hover,
-  cliOutputFormatter: interactionCliOutputFormatters.hover,
-});
-
-const swipeCommandFacet = defineCommandFacet({
-  name: 'swipe',
-  text: {
-    summary: 'Fling between coordinates',
-  },
-  metadata: metadata('swipe'),
-  definition: swipeCommandDefinition,
-  cliSchema: interactionCliSchemas.swipe,
-  cliReader: interactionCliReaders.swipe,
-  daemonWriter: interactionDaemonWriters.swipe,
-});
-
-const focusCommandFacet = defineCommandFacet({
-  name: 'focus',
-  text: {
-    summary: 'Focus input at screen coordinates',
-  },
-  metadata: metadata('focus'),
-  definition: focusCommandDefinition,
-  cliSchema: interactionCliSchemas.focus,
-  cliReader: interactionCliReaders.focus,
-  daemonWriter: interactionDaemonWriters.focus,
-});
-
-const typeCommandFacet = defineCommandFacet({
-  name: 'type',
-  text: {
-    summary: 'Append text to the focused input',
-  },
-  metadata: metadata('type'),
-  definition: typeCommandDefinition,
-  cliSchema: interactionCliSchemas.type,
-  cliReader: interactionCliReaders.type,
-  daemonWriter: interactionDaemonWriters.type,
-});
-
-const scrollCommandFacet = defineCommandFacet({
-  name: 'scroll',
-  text: {
-    summary: 'Scroll in a direction or to an edge',
-  },
-  metadata: metadata('scroll'),
-  definition: scrollCommandDefinition,
-  cliSchema: interactionCliSchemas.scroll,
-  cliReader: interactionCliReaders.scroll,
-  daemonWriter: interactionDaemonWriters.scroll,
-  cliOutputFormatter: interactionCliOutputFormatters.scroll,
-});
-
-const getCommandFacet = defineCommandFacet({
-  name: 'get',
-  text: {
-    summary: 'Read element text or attributes',
-  },
-  metadata: metadata('get'),
-  definition: getCommandDefinition,
-  cliSchema: interactionCliSchemas.get,
-  cliReader: interactionCliReaders.get,
-  daemonWriter: interactionDaemonWriters.get,
-  cliOutputFormatter: interactionCliOutputFormatters.get,
-});
-
-const isCommandFacet = defineCommandFacet({
-  name: 'is',
-  text: {
-    summary: 'Check a UI predicate on a selector',
-  },
-  metadata: metadata('is'),
-  definition: isCommandDefinition,
-  cliSchema: interactionCliSchemas.is,
-  cliReader: selectorCliReaders.is,
-  daemonWriter: selectorDaemonWriters.is,
-  cliOutputFormatter: interactionCliOutputFormatters.is,
-});
-
-const findCommandFacet = defineCommandFacet({
-  name: 'find',
-  text: {
-    summary: 'Find an element and act',
-  },
-  metadata: metadata('find'),
-  definition: findCommandDefinition,
-  cliSchema: interactionCliSchemas.find,
-  cliReader: selectorCliReaders.find,
-  daemonWriter: selectorDaemonWriters.find,
-  cliOutputFormatter: interactionCliOutputFormatters.find,
-});
-
-const gestureCommandFacet = defineCommandFacet({
-  name: 'gesture',
-  text: {
-    summary: 'Run pan, fling, swipe, pinch, rotate, transform, or drag gestures',
-    cliDetail:
-      'Argument shapes: pan <x> <y> <dx> <dy> [durationMs], fling <up|down|left|right> <x> <y> [distance], swipe <left|right|left-edge|right-edge>, pinch <scale> [x] [y], rotate <degrees> [x] [y], transform <x> <y> <dx> <dy> <scale> <degrees> [durationMs], or drag <source-selector|pinned-ref> <destination-selector|pinned-ref> [sourceHoldMs] [moveMs] [destinationHoldMs]. For command plans, output only command lines. Android transform verification should use all app-observable effects, for example wait text "pan changed yes", wait text "pinch changed yes", and wait text "rotate changed yes", not exact transform values.',
-  },
-  metadata: metadata('gesture'),
-  definition: gestureCommandDefinition,
   cliSchema: interactionCliSchemas.gesture,
   cliReader: gestureCliReaders.gesture,
   daemonWriter: gestureDaemonWriters.gesture,

--- a/src/commands/management/app.ts
+++ b/src/commands/management/app.ts
@@ -14,7 +14,6 @@ import {
   stringField,
   stringSchema,
 } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct, optionalString } from '../cli-grammar/common.ts';
 import type { CliReader, CommandInput, DaemonWriter } from '../cli-grammar/types.ts';
 import { METRO_RELOAD_FLAGS } from '../cli-grammar/flag-groups.ts';
@@ -92,14 +91,6 @@ const closeCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const appsCommandDefinition = defineExecutableCommand(appsCommandMetadata, (client, input) =>
-  client.apps.list(input),
-);
-
-const openCommandDefinition = defineExecutableCommand(openCommandMetadata, (client, input) =>
-  client.apps.open(toAppOpenOptions(input)),
-);
-
 // The flat metro hint flags fold into the `runtime` object open already accepts.
 function toAppOpenOptions(
   input: AppOpenOptions & {
@@ -111,10 +102,6 @@ function toAppOpenOptions(
 ): AppOpenOptions {
   return withCommandRuntimeHints(input);
 }
-
-const closeCommandDefinition = defineExecutableCommand(closeCommandMetadata, (client, input) =>
-  input.app ? client.apps.close(input) : client.sessions.close(withoutApp(input)),
-);
 
 const appsCliSchema = {
   allowedFlags: ['appsFilter'],
@@ -193,7 +180,7 @@ export const appsCommandFacet = defineCommandFacet({
       'Before provider allocation, lists uploaded app assets when the selected provider exposes a catalog. On a live device, defaults to user-installed apps; use --all to include system/OEM apps.',
   },
   metadata: appsCommandMetadata,
-  definition: appsCommandDefinition,
+  run: (client, input) => client.apps.list(input),
   cliSchema: appsCliSchema,
   cliReader: appsCliReader,
   daemonWriter: appsDaemonWriter,
@@ -210,7 +197,7 @@ export const openCommandFacet = defineCommandFacet({
       "Metro and debug runtime hints given here are recorded as the session's dev-server binding, so a later reload reuses them; a fresh open without them clears any binding left by a previous same-name session.",
   },
   metadata: openCommandMetadata,
-  definition: openCommandDefinition,
+  run: (client, input) => client.apps.open(toAppOpenOptions(input)),
   cliSchema: openCliSchema,
   cliReader: openCliReader,
   daemonWriter: openDaemonWriter,
@@ -223,7 +210,8 @@ export const closeCommandFacet = defineCommandFacet({
     summary: 'Close an app or end the session',
   },
   metadata: closeCommandMetadata,
-  definition: closeCommandDefinition,
+  run: (client, input) =>
+    input.app ? client.apps.close(input) : client.sessions.close(withoutApp(input)),
   cliSchema: closeCliSchema,
   cliReader: closeCliReader,
   daemonWriter: closeDaemonWriter,

--- a/src/commands/management/artifacts.ts
+++ b/src/commands/management/artifacts.ts
@@ -1,7 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { stringField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -15,11 +14,6 @@ const artifactsCommandMetadata = defineFieldCommandMetadata(
     provider: stringField('Cloud provider name, for example browserstack or aws-device-farm.'),
     providerSessionId: stringField('Cloud provider session id or ARN.'),
   },
-);
-
-const artifactsCommandDefinition = defineExecutableCommand(
-  artifactsCommandMetadata,
-  (client, input) => client.sessions.artifacts(input),
 );
 
 const artifactsCliSchema = {
@@ -42,7 +36,7 @@ export const artifactsCommandFacet = defineCommandFacet({
     summary: 'List daemon or cloud provider session artifacts',
   },
   metadata: artifactsCommandMetadata,
-  definition: artifactsCommandDefinition,
+  run: (client, input) => client.sessions.artifacts(input),
   cliSchema: artifactsCliSchema,
   cliReader: artifactsCliReader,
   daemonWriter: artifactsDaemonWriter,

--- a/src/commands/management/device.ts
+++ b/src/commands/management/device.ts
@@ -1,7 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { booleanField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -34,24 +33,6 @@ const shutdownCommandMetadata = defineFieldCommandMetadata(
   {},
 );
 
-const devicesCommandDefinition = defineExecutableCommand(devicesCommandMetadata, (client, input) =>
-  client.devices.list(input),
-);
-
-const capabilitiesCommandDefinition = defineExecutableCommand(
-  capabilitiesCommandMetadata,
-  (client, input) => client.devices.capabilities(input),
-);
-
-const bootCommandDefinition = defineExecutableCommand(bootCommandMetadata, (client, input) =>
-  client.devices.boot(input),
-);
-
-const shutdownCommandDefinition = defineExecutableCommand(
-  shutdownCommandMetadata,
-  (client, input) => client.devices.shutdown(input),
-);
-
 const bootCliSchema = {
   allowedFlags: ['headless'],
 } as const satisfies CommandSchemaOverride;
@@ -80,7 +61,7 @@ const devicesCommandFacet = defineCommandFacet({
     summary: 'List available devices and simulators',
   },
   metadata: devicesCommandMetadata,
-  definition: devicesCommandDefinition,
+  run: (client, input) => client.devices.list(input),
   cliSchema: devicesCliSchema,
   cliReader: commonCliReader,
   daemonWriter: devicesDaemonWriter,
@@ -94,7 +75,7 @@ const capabilitiesCommandFacet = defineCommandFacet({
     cliDetail: 'Select an explicit target with --platform/--device/--udid/--serial.',
   },
   metadata: capabilitiesCommandMetadata,
-  definition: capabilitiesCommandDefinition,
+  run: (client, input) => client.devices.capabilities(input),
   cliSchema: capabilitiesCliSchema,
   cliReader: commonCliReader,
   daemonWriter: capabilitiesDaemonWriter,
@@ -107,7 +88,7 @@ const bootCommandFacet = defineCommandFacet({
     summary: 'Boot target device/simulator',
   },
   metadata: bootCommandMetadata,
-  definition: bootCommandDefinition,
+  run: (client, input) => client.devices.boot(input),
   cliSchema: bootCliSchema,
   cliReader: bootCliReader,
   daemonWriter: bootDaemonWriter,
@@ -120,7 +101,7 @@ const shutdownCommandFacet = defineCommandFacet({
     summary: 'Shutdown target simulator/emulator',
   },
   metadata: shutdownCommandMetadata,
-  definition: shutdownCommandDefinition,
+  run: (client, input) => client.devices.shutdown(input),
   cliSchema: shutdownCliSchema,
   cliReader: commonCliReader,
   daemonWriter: shutdownDaemonWriter,

--- a/src/commands/management/doctor.ts
+++ b/src/commands/management/doctor.ts
@@ -1,7 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import * as commandInput from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -19,10 +18,6 @@ const doctorCommandMetadata = defineFieldCommandMetadata(
       'Check remote connection setup instead of local device inventory.',
     ),
   },
-);
-
-const doctorCommandDefinition = defineExecutableCommand(doctorCommandMetadata, (client, input) =>
-  client.command.doctor(input),
 );
 
 const doctorCliSchema = {
@@ -49,7 +44,7 @@ export const doctorCommandFacet = defineCommandFacet({
       'On iOS simulators it also warms the XCTest runner build cache in the background when missing, so run it before the first Apple snapshot or interaction of a session.',
   },
   metadata: doctorCommandMetadata,
-  definition: doctorCommandDefinition,
+  run: (client, input) => client.command.doctor(input),
   cliSchema: doctorCliSchema,
   cliReader: doctorCliReader,
   daemonWriter: doctorDaemonWriter,

--- a/src/commands/management/install.ts
+++ b/src/commands/management/install.ts
@@ -12,7 +12,6 @@ import {
   integerField,
   stringField,
 } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -53,20 +52,6 @@ const installFromSourceCommandMetadata = defineFieldCommandMetadata(
     retainPaths: booleanField(),
     retentionMs: integerField(),
   },
-);
-
-const installCommandDefinition = defineExecutableCommand(installCommandMetadata, (client, input) =>
-  client.apps.install(input),
-);
-
-const reinstallCommandDefinition = defineExecutableCommand(
-  reinstallCommandMetadata,
-  (client, input) => client.apps.reinstall(input),
-);
-
-const installFromSourceCommandDefinition = defineExecutableCommand(
-  installFromSourceCommandMetadata,
-  (client, input) => client.apps.installFromSource(input),
 );
 
 const installCliSchema = {
@@ -121,7 +106,7 @@ const installCommandFacet = defineCommandFacet({
     summary: 'Install an app binary from a path',
   },
   metadata: installCommandMetadata,
-  definition: installCommandDefinition,
+  run: (client, input) => client.apps.install(input),
   cliSchema: installCliSchema,
   cliReader: installCliReader,
   daemonWriter: installDaemonWriter,
@@ -134,7 +119,7 @@ const reinstallCommandFacet = defineCommandFacet({
     summary: 'Replace an installed app with a new build',
   },
   metadata: reinstallCommandMetadata,
-  definition: reinstallCommandDefinition,
+  run: (client, input) => client.apps.reinstall(input),
   cliSchema: reinstallCliSchema,
   cliReader: reinstallCliReader,
   daemonWriter: reinstallDaemonWriter,
@@ -147,7 +132,7 @@ const installFromSourceCommandFacet = defineCommandFacet({
     summary: 'Install app builds from URLs or CI artifacts',
   },
   metadata: installFromSourceCommandMetadata,
-  definition: installFromSourceCommandDefinition,
+  run: (client, input) => client.apps.installFromSource(input),
   cliSchema: installFromSourceCliSchema,
   cliReader: installFromSourceCliReader,
   daemonWriter: installFromSourceDaemonWriter,

--- a/src/commands/management/prepare.ts
+++ b/src/commands/management/prepare.ts
@@ -1,7 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { enumField, integerField, requiredField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -22,10 +21,6 @@ const prepareCommandMetadata = defineFieldCommandMetadata(
     action: requiredField(enumField(PREPARE_ACTION_VALUES)),
     timeoutMs: integerField('Maximum wall-clock time for the prepare command.'),
   },
-);
-
-const prepareCommandDefinition = defineExecutableCommand(prepareCommandMetadata, (client, input) =>
-  client.command.prepare(input),
 );
 
 const prepareCliSchema = {
@@ -51,7 +46,7 @@ export const prepareCommandFacet = defineCommandFacet({
     summary: 'Pre-warm platform helpers before automation',
   },
   metadata: prepareCommandMetadata,
-  definition: prepareCommandDefinition,
+  run: (client, input) => client.command.prepare(input),
   cliSchema: prepareCliSchema,
   cliReader: prepareCliReader,
   daemonWriter: prepareDaemonWriter,

--- a/src/commands/management/push.ts
+++ b/src/commands/management/push.ts
@@ -12,7 +12,6 @@ import {
   requiredString,
 } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   jsonSchemaField,
   looseObjectField,
@@ -49,15 +48,6 @@ const triggerAppEventCommandMetadata = defineFieldCommandMetadata(
       'Structured payload passed to the event, in the shape the app documents for it.',
     ),
   },
-);
-
-const pushCommandDefinition = defineExecutableCommand(pushCommandMetadata, (client, input) =>
-  client.apps.push(input),
-);
-
-const triggerAppEventCommandDefinition = defineExecutableCommand(
-  triggerAppEventCommandMetadata,
-  (client, input) => client.apps.triggerEvent(input),
 );
 
 const pushCliSchema = {
@@ -97,7 +87,7 @@ const pushCommandFacet = defineCommandFacet({
     summary: 'Deliver a push notification payload',
   },
   metadata: pushCommandMetadata,
-  definition: pushCommandDefinition,
+  run: (client, input) => client.apps.push(input),
   cliSchema: pushCliSchema,
   cliReader: pushCliReader,
   daemonWriter: pushDaemonWriter,
@@ -109,7 +99,7 @@ const triggerAppEventCommandFacet = defineCommandFacet({
     summary: 'Invoke an app-defined automation event',
   },
   metadata: triggerAppEventCommandMetadata,
-  definition: triggerAppEventCommandDefinition,
+  run: (client, input) => client.apps.triggerEvent(input),
   cliSchema: triggerAppEventCliSchema,
   cliReader: triggerAppEventCliReader,
   daemonWriter: triggerAppEventDaemonWriter,

--- a/src/commands/management/session.ts
+++ b/src/commands/management/session.ts
@@ -1,7 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { booleanField, enumField, stringField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags } from '../cli-grammar/common.ts';
 import type { CliReader } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -18,21 +17,6 @@ const sessionCommandMetadata = defineFieldCommandMetadata(
     ),
     path: stringField('Optional .ad output path for save-script.'),
     force: booleanField('Atomically replace an existing save-script target.'),
-  },
-);
-
-const sessionCommandDefinition = defineExecutableCommand(
-  sessionCommandMetadata,
-  async (client, { action, path, force, ...input }) => {
-    const effectiveAction = action ?? 'list';
-    assertSessionActionOptions(effectiveAction, path, force);
-    if (effectiveAction === 'state-dir') {
-      return { stateDir: await client.sessions.stateDir(input) };
-    }
-    if (effectiveAction === 'save-script') {
-      return await client.sessions.saveScript({ ...input, path, force });
-    }
-    return { sessions: await client.sessions.list(input) };
   },
 );
 
@@ -56,7 +40,17 @@ export const sessionCommandFacet = defineCommandFacet({
     summary: 'List sessions, show the state dir, or publish a script',
   },
   metadata: sessionCommandMetadata,
-  definition: sessionCommandDefinition,
+  run: async (client, { action, path, force, ...input }) => {
+    const effectiveAction = action ?? 'list';
+    assertSessionActionOptions(effectiveAction, path, force);
+    if (effectiveAction === 'state-dir') {
+      return { stateDir: await client.sessions.stateDir(input) };
+    }
+    if (effectiveAction === 'save-script') {
+      return await client.sessions.saveScript({ ...input, path, force });
+    }
+    return { sessions: await client.sessions.list(input) };
+  },
   cliSchema: sessionCliSchema,
   cliReader: sessionCliReader,
   cliOutputFormatter: managementCliOutputFormatters.session,

--- a/src/commands/management/viewport.ts
+++ b/src/commands/management/viewport.ts
@@ -3,7 +3,6 @@ import type { ViewportCommandOptions } from '@agent-device/contracts/client';
 import { readViewportDimensions } from '@agent-device/contracts/capture';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { integerField, requiredField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { defineCommandFacet } from '../family/types.ts';
@@ -17,11 +16,6 @@ const viewportCommandMetadata = defineFieldCommandMetadata(
     width: requiredField(integerField('Viewport width in CSS pixels.', { min: 1 })),
     height: requiredField(integerField('Viewport height in CSS pixels.', { min: 1 })),
   },
-);
-
-const viewportCommandDefinition = defineExecutableCommand(
-  viewportCommandMetadata,
-  (client, input) => client.command.viewport(input),
 );
 
 const viewportCliSchema = {
@@ -44,7 +38,7 @@ export const viewportCommandFacet = defineCommandFacet({
     summary: 'Resize the active web viewport for the current session',
   },
   metadata: viewportCommandMetadata,
-  definition: viewportCommandDefinition,
+  run: (client, input) => client.command.viewport(input),
   cliSchema: viewportCliSchema,
   cliReader: viewportCliReader,
   daemonWriter: viewportDaemonWriter,

--- a/src/commands/metro/index.test.ts
+++ b/src/commands/metro/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
-import { metroCliReader, metroCommandDefinition, metroCommandMetadata } from './index.ts';
+import { metroCliReader, metroCommandFacet, metroCommandMetadata } from './index.ts';
 
 function flags(overrides: Partial<CliFlags> = {}): CliFlags {
   return overrides as CliFlags;
@@ -18,7 +18,7 @@ function expectInvalidArgs(fn: () => unknown, messageFragment: string) {
 describe('metro command interface', () => {
   test('owns public metadata', () => {
     expect(metroCommandMetadata.name).toBe('metro');
-    expect(metroCommandDefinition.name).toBe('metro');
+    expect(metroCommandFacet.definition.name).toBe('metro');
   });
 
   test('reads prepare input from flags', () => {

--- a/src/commands/metro/index.ts
+++ b/src/commands/metro/index.ts
@@ -17,7 +17,6 @@ import {
   stringSchema,
 } from '../command-input.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import type { CliReader } from '../cli-grammar/types.ts';
 import { METRO_PREPARE_FLAGS, METRO_RELOAD_FLAGS } from '../cli-grammar/flag-groups.ts';
@@ -69,14 +68,6 @@ export const metroCommandMetadata = defineFieldCommandMetadata(
 );
 
 type MetroInput = { action: 'prepare' | 'reload' } & MetroPrepareOptions & MetroReloadOptions;
-
-export const metroCommandDefinition = defineExecutableCommand(
-  metroCommandMetadata,
-  async (client, input): Promise<MetroPrepareResult | MetroReloadResult> =>
-    input.action === 'prepare'
-      ? await client.metro.prepare(toMetroPrepareOptions(input))
-      : await client.metro.reload(toMetroReloadOptions(input)),
-);
 
 const metroCliSchema = {
   usageOverride:
@@ -132,7 +123,7 @@ export const metroCliReader: CliReader = (positionals, flags) => {
   };
 };
 
-const metroCommandFacet = defineCommandFacet({
+export const metroCommandFacet = defineCommandFacet({
   name: METRO_COMMAND_NAME,
   text: {
     summary: 'Prepare the dev server or reload apps',
@@ -142,7 +133,10 @@ const metroCommandFacet = defineCommandFacet({
       'The binding is cleared when the session closes, and a fresh open without runtime hints also clears any leftover binding from a previous same-name session.',
   },
   metadata: metroCommandMetadata,
-  definition: metroCommandDefinition,
+  run: async (client, input): Promise<MetroPrepareResult | MetroReloadResult> =>
+    input.action === 'prepare'
+      ? await client.metro.prepare(toMetroPrepareOptions(input))
+      : await client.metro.reload(toMetroReloadOptions(input)),
   cliSchema: metroCliSchema,
   cliReader: metroCliReader,
   cliOutputFormatter: metroCliOutputFormatters.metro,

--- a/src/commands/observability/index.test.ts
+++ b/src/commands/observability/index.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
 import {
   audioCliReader,
-  audioCommandDefinition,
+  audioCommandFacet,
   audioCommandMetadata,
   audioDaemonWriter,
   eventsCliReader,
-  eventsCommandDefinition,
+  eventsCommandFacet,
   eventsCommandMetadata,
   eventsDaemonWriter,
   logsCliReader,
-  logsCommandDefinition,
+  logsCommandFacet,
   logsCommandMetadata,
   logsDaemonWriter,
   networkCliReader,
-  networkCommandDefinition,
+  networkCommandFacet,
   networkCommandMetadata,
   networkDaemonWriter,
 } from './index.ts';
@@ -34,13 +34,13 @@ function expectInvalidArgs(fn: () => unknown, messageFragment: string) {
 describe('observability command interface', () => {
   test('owns logs and network public metadata', () => {
     expect(audioCommandMetadata.name).toBe('audio');
-    expect(audioCommandDefinition.name).toBe('audio');
+    expect(audioCommandFacet.definition.name).toBe('audio');
     expect(eventsCommandMetadata.name).toBe('events');
-    expect(eventsCommandDefinition.name).toBe('events');
+    expect(eventsCommandFacet.definition.name).toBe('events');
     expect(logsCommandMetadata.name).toBe('logs');
-    expect(logsCommandDefinition.name).toBe('logs');
+    expect(logsCommandFacet.definition.name).toBe('logs');
     expect(networkCommandMetadata.name).toBe('network');
-    expect(networkCommandDefinition.name).toBe('network');
+    expect(networkCommandFacet.definition.name).toBe('network');
   });
 
   test('reads audio probe timing as compact daemon positionals', () => {

--- a/src/commands/observability/index.ts
+++ b/src/commands/observability/index.ts
@@ -10,7 +10,6 @@ import { parseStringMember } from './string-enum.ts';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
 import { booleanField, enumField, integerField, stringField } from '../command-input.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import { LOG_ACTION_VALUES, type LogAction } from './log-command-contract.ts';
 import {
@@ -78,25 +77,6 @@ export const audioCommandMetadata = defineFieldCommandMetadata(
     durationMs: integerField('Probe duration in milliseconds.'),
     bucketMs: integerField('Audio level bucket size in milliseconds.'),
   },
-);
-
-export const logsCommandDefinition = defineExecutableCommand(logsCommandMetadata, (client, input) =>
-  client.observability.logs(input),
-);
-
-export const eventsCommandDefinition = defineExecutableCommand(
-  eventsCommandMetadata,
-  (client, input) => client.observability.events(input),
-);
-
-export const networkCommandDefinition = defineExecutableCommand(
-  networkCommandMetadata,
-  (client, input) => client.observability.network(input),
-);
-
-export const audioCommandDefinition = defineExecutableCommand(
-  audioCommandMetadata,
-  (client, input) => client.observability.audio(input),
 );
 
 const logsCliSchema = {
@@ -172,52 +152,52 @@ export const networkDaemonWriter: DaemonWriter = (input) =>
 export const audioDaemonWriter: DaemonWriter = (input) =>
   request(AUDIO_COMMAND_NAME, audioPositionals(input as AudioOptions), input);
 
-const logsCommandFacet = defineCommandFacet({
+export const logsCommandFacet = defineCommandFacet({
   name: LOGS_COMMAND_NAME,
   text: {
     summary: 'Manage session app logs',
   },
   metadata: logsCommandMetadata,
-  definition: logsCommandDefinition,
+  run: (client, input) => client.observability.logs(input),
   cliSchema: logsCliSchema,
   cliReader: logsCliReader,
   daemonWriter: logsDaemonWriter,
   cliOutputFormatter: observabilityCliOutputFormatters.logs,
 });
 
-const eventsCommandFacet = defineCommandFacet({
+export const eventsCommandFacet = defineCommandFacet({
   name: EVENTS_COMMAND_NAME,
   text: {
     summary: 'Read session event timeline',
   },
   metadata: eventsCommandMetadata,
-  definition: eventsCommandDefinition,
+  run: (client, input) => client.observability.events(input),
   cliSchema: eventsCliSchema,
   cliReader: eventsCliReader,
   daemonWriter: eventsDaemonWriter,
   cliOutputFormatter: observabilityCliOutputFormatters.events,
 });
 
-const networkCommandFacet = defineCommandFacet({
+export const networkCommandFacet = defineCommandFacet({
   name: NETWORK_COMMAND_NAME,
   text: {
     summary: 'Inspect HTTP(S) traffic from session logs',
   },
   metadata: networkCommandMetadata,
-  definition: networkCommandDefinition,
+  run: (client, input) => client.observability.network(input),
   cliSchema: networkCliSchema,
   cliReader: networkCliReader,
   daemonWriter: networkDaemonWriter,
   cliOutputFormatter: observabilityCliOutputFormatters.network,
 });
 
-const audioCommandFacet = defineCommandFacet({
+export const audioCommandFacet = defineCommandFacet({
   name: AUDIO_COMMAND_NAME,
   text: {
     summary: 'Probe audio levels',
   },
   metadata: audioCommandMetadata,
-  definition: audioCommandDefinition,
+  run: (client, input) => client.observability.audio(input),
   cliSchema: audioCliSchema,
   cliReader: audioCliReader,
   daemonWriter: audioDaemonWriter,

--- a/src/commands/perf/index.test.ts
+++ b/src/commands/perf/index.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
-import {
-  perfCliReader,
-  perfCommandDefinition,
-  perfCommandMetadata,
-  perfDaemonWriter,
-} from './index.ts';
+import { perfCliReader, perfCommandFacet, perfCommandMetadata, perfDaemonWriter } from './index.ts';
 
 const NO_FLAGS = {} as CliFlags;
 
@@ -21,7 +16,7 @@ function expectInvalidArgs(fn: () => unknown, messageFragment: string) {
 describe('perf command interface', () => {
   test('owns perf public metadata', () => {
     expect(perfCommandMetadata.name).toBe('perf');
-    expect(perfCommandDefinition.name).toBe('perf');
+    expect(perfCommandFacet.definition.name).toBe('perf');
   });
 
   test('reads perf area, action, kind, and out flags', () => {

--- a/src/commands/perf/index.ts
+++ b/src/commands/perf/index.ts
@@ -3,7 +3,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { enumField, requiredField, stringField } from '../command-input.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import {
   isPerfAction,
@@ -48,10 +47,6 @@ export const perfCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-export const perfCommandDefinition = defineExecutableCommand(perfCommandMetadata, (client, input) =>
-  client.observability.perf(input),
-);
-
 const perfCliSchema = {
   usageOverride:
     'perf frames --json\n  agent-device perf memory sample --json\n  agent-device perf memory snapshot [--kind android-hprof|memgraph] [--out <path>]\n  agent-device perf cpu profile start --kind xctrace [--template <name>] --out <profile.trace>\n  agent-device perf cpu profile stop --kind xctrace --out <profile.trace>\n  agent-device perf cpu profile report --kind xctrace --out <report.json>\n  agent-device perf trace start|stop --kind xctrace [--template <name>] --out <path>\n  agent-device perf cpu profile start --kind simpleperf --out <cpu.perf.data>\n  agent-device perf cpu profile stop --kind simpleperf\n  agent-device perf cpu profile report --kind simpleperf --out <cpu-report.json>\n  agent-device perf trace start|stop --kind perfetto [--out <path>]\n\n  Aggregate perf was removed in 0.21. Use one of the explicit forms above.',
@@ -73,7 +68,7 @@ export const perfDaemonWriter: DaemonWriter = direct(PERF_COMMAND_NAME, (input) 
   perfPositionals(input as PerfOptions),
 );
 
-const perfCommandFacet = defineCommandFacet({
+export const perfCommandFacet = defineCommandFacet({
   name: PERF_COMMAND_NAME,
   text: {
     summary: 'Check frames, memory, or native profiles',
@@ -83,7 +78,7 @@ const perfCommandFacet = defineCommandFacet({
       'For CPU profiles, start and stop write the raw artifact while report writes a compact summary; request the report when the task needs readable native CPU evidence. Profiling output is evidence only: compact state, artifact path, and size.',
   },
   metadata: perfCommandMetadata,
-  definition: perfCommandDefinition,
+  run: (client, input) => client.observability.perf(input),
   cliSchema: perfCliSchema,
   cliReader: perfCliReader,
   daemonWriter: perfDaemonWriter,

--- a/src/commands/react-native/index.test.ts
+++ b/src/commands/react-native/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
 import {
   reactNativeCliReader,
-  reactNativeCommandDefinition,
+  reactNativeCommandFacet,
   reactNativeCommandMetadata,
   reactNativeDaemonWriter,
 } from './index.ts';
@@ -21,7 +21,7 @@ function expectInvalidArgs(fn: () => unknown, messageFragment: string) {
 describe('react-native command interface', () => {
   test('owns its public metadata', () => {
     expect(reactNativeCommandMetadata.name).toBe('react-native');
-    expect(reactNativeCommandDefinition.name).toBe('react-native');
+    expect(reactNativeCommandFacet.definition.name).toBe('react-native');
     expect(reactNativeCommandMetadata.description).toContain('React Native');
   });
 

--- a/src/commands/react-native/index.ts
+++ b/src/commands/react-native/index.ts
@@ -1,7 +1,6 @@
 import { AppError } from '@agent-device/kernel/errors';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { enumField, requiredField } from '../command-input.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import { commonInputFromFlags, direct, requiredDaemonString } from '../cli-grammar/common.ts';
@@ -21,11 +20,6 @@ export const reactNativeCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-export const reactNativeCommandDefinition = defineExecutableCommand(
-  reactNativeCommandMetadata,
-  (client, input) => client.command.reactNative(input),
-);
-
 const reactNativeCliSchema = {
   usageOverride: 'react-native dismiss-overlay',
   listUsageOverride: 'react-native dismiss-overlay',
@@ -41,13 +35,13 @@ export const reactNativeDaemonWriter: DaemonWriter = direct(REACT_NATIVE_COMMAND
   requiredDaemonString(input.action, 'react-native requires action'),
 ]);
 
-const reactNativeCommandFacet = defineCommandFacet({
+export const reactNativeCommandFacet = defineCommandFacet({
   name: REACT_NATIVE_COMMAND_NAME,
   text: {
     summary: 'Run React Native automation helpers',
   },
   metadata: reactNativeCommandMetadata,
-  definition: reactNativeCommandDefinition,
+  run: (client, input) => client.command.reactNative(input),
   cliSchema: reactNativeCliSchema,
   cliReader: reactNativeCliReader,
   daemonWriter: reactNativeDaemonWriter,

--- a/src/commands/recording/index.test.ts
+++ b/src/commands/recording/index.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from 'vitest';
 import type { CliFlags } from '@agent-device/contracts/command';
 import {
   recordCliReader,
-  recordCommandDefinition,
+  recordCommandFacet,
   recordCommandMetadata,
   recordDaemonWriter,
   traceCliReader,
-  traceCommandDefinition,
+  traceCommandFacet,
   traceCommandMetadata,
   traceDaemonWriter,
 } from './index.ts';
@@ -25,9 +25,9 @@ function expectInvalidArgs(fn: () => unknown, messageFragment: string) {
 describe('recording command interface', () => {
   test('owns record and trace public metadata', () => {
     expect(recordCommandMetadata.name).toBe('record');
-    expect(recordCommandDefinition.name).toBe('record');
+    expect(recordCommandFacet.definition.name).toBe('record');
     expect(traceCommandMetadata.name).toBe('trace');
-    expect(traceCommandDefinition.name).toBe('trace');
+    expect(traceCommandFacet.definition.name).toBe('trace');
   });
 
   test('reads record CLI input with recording flags', () => {

--- a/src/commands/recording/index.ts
+++ b/src/commands/recording/index.ts
@@ -11,7 +11,6 @@ import { AppError } from '@agent-device/kernel/errors';
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { commonInputFromFlags, direct, optionalString } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   booleanField,
   enumField,
@@ -54,16 +53,6 @@ export const traceCommandMetadata = defineFieldCommandMetadata(
     action: requiredField(enumField(RECORDING_ACTION_VALUES)),
     path: stringField(),
   },
-);
-
-export const recordCommandDefinition = defineExecutableCommand(
-  recordCommandMetadata,
-  (client, input) => client.recording.record(input as RecordOptions),
-);
-
-export const traceCommandDefinition = defineExecutableCommand(
-  traceCommandMetadata,
-  (client, input) => client.recording.trace(input),
 );
 
 const recordCliSchema = {
@@ -109,7 +98,7 @@ export const traceDaemonWriter: DaemonWriter = direct(TRACE_COMMAND_NAME, (input
   recordingPositionals(input as RecordOptions),
 );
 
-const recordCommandFacet = defineCommandFacet({
+export const recordCommandFacet = defineCommandFacet({
   name: RECORD_COMMAND_NAME,
   text: {
     summary: 'Start or stop screen recording',
@@ -117,21 +106,21 @@ const recordCommandFacet = defineCommandFacet({
       'The default --scope app requires an active app session from open <app>; use --scope device/system to explicitly request whole-screen recording where the selected backend supports it. Android record start publishes a durable device manifest, recordings longer than the 180s adb screenrecord limit are returned as multiple MP4 chunks while the daemon stays alive, and daemon-restart recovery uses only manifest-owned chunks. HarmonyOS supports whole-screen recording on physical devices only: use --scope device/system; --fps, --quality, and --hide-touches are unsupported. Use --quality to choose medium or high export quality on supported backends.',
   },
   metadata: recordCommandMetadata,
-  definition: recordCommandDefinition,
+  run: (client, input) => client.recording.record(input as RecordOptions),
   cliSchema: recordCliSchema,
   cliReader: recordCliReader,
   daemonWriter: recordDaemonWriter,
   cliOutputFormatter: recordingCliOutputFormatters.record,
 });
 
-const traceCommandFacet = defineCommandFacet({
+export const traceCommandFacet = defineCommandFacet({
   name: TRACE_COMMAND_NAME,
   text: {
     summary: 'Start or stop trace capture',
     cliDetail: 'Pass that path as the same positional argument to start and stop.',
   },
   metadata: traceCommandMetadata,
-  definition: traceCommandDefinition,
+  run: (client, input) => client.recording.trace(input),
   cliSchema: traceCliSchema,
   cliReader: traceCliReader,
   daemonWriter: traceDaemonWriter,

--- a/src/commands/replay/index.test.ts
+++ b/src/commands/replay/index.test.ts
@@ -5,11 +5,11 @@ import type { CliFlags } from '@agent-device/contracts/command';
 import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 import {
   replayCliReader,
-  replayCommandDefinition,
+  replayCommandFacet,
   replayCommandMetadata,
   replayDaemonWriter,
   testCliReader,
-  testCommandDefinition,
+  testCommandFacet,
   testCommandMetadata,
   testDaemonWriter,
 } from './index.ts';
@@ -51,9 +51,9 @@ afterEach(() => {
 describe('replay command interface', () => {
   test('owns replay and test public metadata', () => {
     expect(replayCommandMetadata.name).toBe('replay');
-    expect(replayCommandDefinition.name).toBe('replay');
+    expect(replayCommandFacet.definition.name).toBe('replay');
     expect(testCommandMetadata.name).toBe('test');
-    expect(testCommandDefinition.name).toBe('test');
+    expect(testCommandFacet.definition.name).toBe('test');
   });
 
   test('reads replay CLI input', () => {
@@ -195,8 +195,11 @@ describe('replay command interface', () => {
       bundleUrl: 'http://127.0.0.1:8083/index.bundle',
     });
 
-    await replayCommandDefinition.invoke(client, replayCliReader(['./flow.ad'], runtimeFlags));
-    await testCommandDefinition.invoke(client, testCliReader(['./suite'], runtimeFlags));
+    await replayCommandFacet.definition.invoke(
+      client,
+      replayCliReader(['./flow.ad'], runtimeFlags),
+    );
+    await testCommandFacet.definition.invoke(client, testCliReader(['./suite'], runtimeFlags));
 
     const runtime = {
       metroHost: '127.0.0.1',

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -1,6 +1,5 @@
 import type { CommandSchemaOverride } from '../../cli-schema/types.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import {
   booleanField,
   booleanSchema,
@@ -93,15 +92,6 @@ export const testCommandMetadata = defineFieldCommandMetadata(
     shardAll: integerField(),
     shardSplit: integerField(),
   },
-);
-
-export const replayCommandDefinition = defineExecutableCommand(
-  replayCommandMetadata,
-  (client, input) => client.replay.run(withCommandRuntimeHints(input)),
-);
-
-export const testCommandDefinition = defineExecutableCommand(testCommandMetadata, (client, input) =>
-  client.replay.test(withCommandRuntimeHints(input)),
 );
 
 const replayCliSchema = {
@@ -235,7 +225,7 @@ export const testDaemonWriter: AsyncDaemonWriter = async (input) => {
   });
 };
 
-const replayCommandFacet = defineCommandFacet({
+export const replayCommandFacet = defineCommandFacet({
   name: REPLAY_COMMAND_NAME,
   text: {
     summary: 'Replay a recorded session or Maestro flow',
@@ -243,19 +233,19 @@ const replayCommandFacet = defineCommandFacet({
       'For Maestro YAML compatibility flows, use replay <flow.yaml> --maestro and keep the target binding such as --platform ios on the replay command. A script with no terminal close leaves its session (and daemon) running until you close it or it idle-reaps — no different from a session opened interactively. For native .ad scripts, --keep-session suppresses exactly an authored terminal close so you can continue interactively.',
   },
   metadata: replayCommandMetadata,
-  definition: replayCommandDefinition,
+  run: (client, input) => client.replay.run(withCommandRuntimeHints(input)),
   cliSchema: replayCliSchema,
   cliReader: replayCliReader,
   daemonWriter: replayDaemonWriter,
 });
 
-const testCommandFacet = defineCommandFacet({
+export const testCommandFacet = defineCommandFacet({
   name: TEST_COMMAND_NAME,
   text: {
     summary: 'Run replay test suites',
   },
   metadata: testCommandMetadata,
-  definition: testCommandDefinition,
+  run: (client, input) => client.replay.test(withCommandRuntimeHints(input)),
   cliSchema: testCliSchema,
   cliReader: testCliReader,
   daemonWriter: testDaemonWriter,

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -17,7 +17,6 @@ import {
   requiredDaemonString,
 } from '../cli-grammar/common.ts';
 import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
-import { defineExecutableCommand } from '../command-contract.ts';
 import { enumField, integerField, requiredField, stringField } from '../command-input.ts';
 import { compactRecord } from '../input-readers.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
@@ -118,44 +117,6 @@ const tvRemoteCommandMetadata = defineFieldCommandMetadata(
   },
 );
 
-const appStateCommandDefinition = defineExecutableCommand(
-  appStateCommandMetadata,
-  (client, input) => client.command.appState(input),
-);
-
-const backCommandDefinition = defineExecutableCommand(backCommandMetadata, (client, input) =>
-  client.command.back(input),
-);
-
-const homeCommandDefinition = defineExecutableCommand(homeCommandMetadata, (client, input) =>
-  client.command.home(input),
-);
-
-const orientationCommandDefinition = defineExecutableCommand(
-  orientationCommandMetadata,
-  (client, input) => client.command.orientation(input),
-);
-
-const appSwitcherCommandDefinition = defineExecutableCommand(
-  appSwitcherCommandMetadata,
-  (client, input) => client.command.appSwitcher(input),
-);
-
-const keyboardCommandDefinition = defineExecutableCommand(
-  keyboardCommandMetadata,
-  (client, input) => client.command.keyboard(input),
-);
-
-const clipboardCommandDefinition = defineExecutableCommand(
-  clipboardCommandMetadata,
-  (client, input) => client.command.clipboard(input as ClipboardCommandOptions),
-);
-
-const tvRemoteCommandDefinition = defineExecutableCommand(
-  tvRemoteCommandMetadata,
-  (client, input) => client.command.tvRemote(input),
-);
-
 const appStateCliSchema = {} as const satisfies CommandSchemaOverride;
 
 const backCliSchema = {
@@ -254,7 +215,7 @@ const appStateCommandFacet = defineCommandFacet({
     summary: 'Show the foreground app and activity',
   },
   metadata: appStateCommandMetadata,
-  definition: appStateCommandDefinition,
+  run: (client, input) => client.command.appState(input),
   cliSchema: appStateCliSchema,
   cliReader: appStateCliReader,
   daemonWriter: appStateDaemonWriter,
@@ -267,7 +228,7 @@ const backCommandFacet = defineCommandFacet({
     summary: 'Navigate back in the app or system',
   },
   metadata: backCommandMetadata,
-  definition: backCommandDefinition,
+  run: (client, input) => client.command.back(input),
   cliSchema: backCliSchema,
   cliReader: backCliReader,
   daemonWriter: backDaemonWriter,
@@ -280,7 +241,7 @@ const homeCommandFacet = defineCommandFacet({
     summary: 'Go to the device home screen',
   },
   metadata: homeCommandMetadata,
-  definition: homeCommandDefinition,
+  run: (client, input) => client.command.home(input),
   cliSchema: homeCliSchema,
   cliReader: homeCliReader,
   daemonWriter: homeDaemonWriter,
@@ -293,7 +254,7 @@ const orientationCommandFacet = defineCommandFacet({
     summary: 'Set device orientation',
   },
   metadata: orientationCommandMetadata,
-  definition: orientationCommandDefinition,
+  run: (client, input) => client.command.orientation(input),
   cliSchema: orientationCliSchema,
   cliReader: orientationCliReader,
   daemonWriter: orientationDaemonWriter,
@@ -306,7 +267,7 @@ const appSwitcherCommandFacet = defineCommandFacet({
     summary: 'Open the device app switcher',
   },
   metadata: appSwitcherCommandMetadata,
-  definition: appSwitcherCommandDefinition,
+  run: (client, input) => client.command.appSwitcher(input),
   cliSchema: appSwitcherCliSchema,
   cliReader: appSwitcherCliReader,
   daemonWriter: appSwitcherDaemonWriter,
@@ -319,7 +280,7 @@ const keyboardCommandFacet = defineCommandFacet({
     summary: 'Inspect, press, or dismiss the device keyboard',
   },
   metadata: keyboardCommandMetadata,
-  definition: keyboardCommandDefinition,
+  run: (client, input) => client.command.keyboard(input),
   cliSchema: keyboardCliSchema,
   cliReader: keyboardCliReader,
   daemonWriter: keyboardDaemonWriter,
@@ -332,7 +293,7 @@ const clipboardCommandFacet = defineCommandFacet({
     summary: 'Read or write device clipboard text',
   },
   metadata: clipboardCommandMetadata,
-  definition: clipboardCommandDefinition,
+  run: (client, input) => client.command.clipboard(input as ClipboardCommandOptions),
   cliSchema: clipboardCliSchema,
   cliReader: clipboardCliReader,
   daemonWriter: clipboardDaemonWriter,
@@ -346,7 +307,7 @@ const tvRemoteCommandFacet = defineCommandFacet({
     cliDetail: 'longpress holds for 500ms by default; --duration-ms overrides the preset.',
   },
   metadata: tvRemoteCommandMetadata,
-  definition: tvRemoteCommandDefinition,
+  run: (client, input) => client.command.tvRemote(input),
   cliSchema: tvRemoteCliSchema,
   cliReader: tvRemoteCliReader,
   daemonWriter: tvRemoteDaemonWriter,


### PR DESCRIPTION
## Summary

Before: each command was declared
twice — a standalone `*CommandDefinition` built via `defineExecutableCommand(metadata, run)`, then
repeated inside `defineCommandFacet({ ..., definition, ... })`. After: a command file authors
`metadata` plus a typed `run(client, input)` once; `defineCommandFacet` derives `name`,
`description`, `mcpDetail`, `inputSchema`, and `invoke` internally, still exposing the derived
`definition` that `family/registry.ts`/`system/index.ts` consume. `defineExecutableCommand` and
`ExecutableCommandContract` are deleted (no remaining references).

Every `text`, `cliSchema`, `cliReader`, `daemonWriter`, `cliOutputFormatter`, and `clientMethod` is
unchanged; existing input casts (clipboard, swipe, focus, settings, etc.) are kept. `CommandFacet`
gained `Result`/`Formatter` type params so each facet's `definition.invoke`/`cliOutputFormatter`
keep per-command types — otherwise `CommandExecutionResult<Name>` and a sync `cliOutputFormatter`
test both collapsed to `unknown`.

57 sites, one commit per family plus one foundation commit. One `chore(gates)` commit follows: the integration-progress scanner now reads facets instead of executables. The R6 `commands -> client` count drops by one on its own (the deleted contract was that type import); #2299 ratchets it against the merge-base.

## Validation

Tested commit: 6a8c155fc282d02bfd636d7d53af74dea9aeb88b — `pnpm check:affected --run` green locally (scripts/ changed, so the full check set ran).

- Parity: `agent-device help commands` and `listCommandTools()`'s MCP tool schemas dumped from
  this head and from a temp worktree of `origin/main`. Both
  diffs empty — CLI help and all 56 MCP tool schemas byte-identical before/after.
- `pnpm vitest run --project unit-core src/commands`: 69 files, 569 tests passed.
- `pnpm check:quick` (oxlint + full `tsc -b`/`tsc -p`): clean. `pnpm format`: no residual diff.

