### PR TITLE
fix: repair main after the managed-allocation move landed under stale PRs

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -56,9 +56,6 @@
     // @agent-device/provider-limrun owns the source import, while the published
     // root build externalizes @limrun/api and retains runtime imports in packed chunks.
     "@limrun/api",
-    // @agent-device/managed-allocation has no root consumer yet: the managed runtime binding
-    // (ADR 0021 §3) is its first, and it lands after the package's move out of src/daemon.
-    "@agent-device/managed-allocation",
     // Oxlint resolves the shared config's JS plugins dynamically from their package names.
     "@nkzw/eslint-plugin",
     "eslint-plugin-no-only-tests",

--- a/packages/managed-allocation/src/record.ts
+++ b/packages/managed-allocation/src/record.ts
@@ -4,6 +4,15 @@ export { ALLOCATION_OPERATION_SCHEMA_VERSION };
 export { newAllocationOperation } from './record-factory.ts';
 export { decodeAllocationOperationRecord } from './record-codec.ts';
 export { bindingFenceFor } from './record-fence.ts';
+// The daemon's managed lease admission (src/daemon/managed-device-allocation/lease-admission.ts)
+// validates a grant against the same record rules the package applies internally, so these leave
+// through the record surface rather than being restated at the call site.
+export {
+  freezeLease,
+  isRequestGeneration,
+  isValidLease,
+  isVerbatimId,
+} from './record-validation.ts';
 export type {
   AllocationAllocatorOutcome,
   AllocationOperationPhase,

--- a/scripts/__tests__/eager-closure-budgets.ts
+++ b/scripts/__tests__/eager-closure-budgets.ts
@@ -128,17 +128,7 @@ export const NEW_ENTRY_CEILINGS: Readonly<Record<EntryCategory, number>> = Objec
  */
 export const APPROVED_OVER_CEILING: Readonly<
   Record<string, { issue: string; reason: string; owner: string }>
-> = Object.freeze({
-  'packages/capture-kit/src/durable-capture/index.ts': {
-    issue: '#2317',
-    reason:
-      'The entry surface is new; the weight is not. These mechanics moved out of src/daemon ' +
-      'unchanged, and their two heaviest edges are the ones that make them durable at all: the ' +
-      'store publishes through host-kit/file, and adoption validates through the envelope codec. ' +
-      'Only the daemon imports this subpath, and its own closure did not grow.',
-    owner: '@thymikee',
-  },
-});
+> = Object.freeze({});
 
 /** The category is a function of the path, never a hand-written column. */
 export function entryCategoryOf(entryFile: string): EntryCategory {

--- a/src/daemon/managed-device-allocation/__tests__/fixtures.ts
+++ b/src/daemon/managed-device-allocation/__tests__/fixtures.ts
@@ -1,0 +1,52 @@
+import type {
+  LeaseRequestInput,
+  LeaseRequestStatus,
+  ManagedIdentityRef,
+  ManagedLease,
+  ManagedShapeRequest,
+} from '@agent-device/contracts/managed-device-allocation';
+
+/**
+ * The grant shapes the daemon-side managed admission is written against, stated in contract terms
+ * only. `@agent-device/managed-allocation` keeps its own copy for the package's tests
+ * (`packages/managed-allocation/src/__tests__/fixtures.ts`), the same way both sides keep their own
+ * `managed-device-allocator.fixtures.ts`: neither tree reaches past the other's exported surface
+ * for test data.
+ */
+const ALLOCATION_SHAPE: ManagedShapeRequest = {
+  platform: 'ios',
+  deviceType: 'iPhone 16',
+  osVersion: '18.2',
+};
+
+const ALLOCATION_IDENTITY: ManagedIdentityRef = {
+  deviceId: 'device-1',
+  identityIncarnationId: 'incarnation-1',
+};
+
+export const ALLOCATION_LEASE: ManagedLease = {
+  id: 'lease-1',
+  ttlDeadline: 1_700_000_900_000,
+  device: { address: ALLOCATION_IDENTITY.deviceId },
+  environment: { SIMLOCK_IOS_DEVICE_SET: '/managed/set' },
+};
+
+export const ALLOCATION_REQUEST: LeaseRequestInput = {
+  requesterId: 'requester-a',
+  requestGeneration: 1,
+  attemptKey: 'attempt-1',
+  shape: ALLOCATION_SHAPE,
+  deadlineAtMs: 1_700_000_600_000,
+  admission: 'fail-fast',
+  activation: 'direct',
+  attribution: { tenantId: 'tenant-a' },
+};
+
+export const ALLOCATION_GRANTED_STATUS: LeaseRequestStatus = {
+  requesterId: ALLOCATION_REQUEST.requesterId,
+  requestGeneration: ALLOCATION_REQUEST.requestGeneration,
+  attemptKey: ALLOCATION_REQUEST.attemptKey,
+  identityIncarnationId: ALLOCATION_IDENTITY.identityIncarnationId,
+  state: 'granted',
+  lease: ALLOCATION_LEASE,
+};

--- a/src/daemon/managed-device-allocation/lease-admission.ts
+++ b/src/daemon/managed-device-allocation/lease-admission.ts
@@ -16,7 +16,7 @@ import {
   isRequestGeneration,
   isValidLease,
   isVerbatimId,
-} from './record-validation.ts';
+} from '@agent-device/managed-allocation/record';
 
 export type ManagedCommandHorizon = Readonly<{ deadline: Deadline; teardownTimeoutMs: number }>;
 type FenceReason = 'released' | 'replaced' | 'superseded' | 'fenced' | 'authority-unconfirmed';


### PR DESCRIPTION
`main` is red, and has been since #2308. Every open PR fails Typecheck, Repo Guards, and Integration Tests because of it — this unblocks them.

## What broke

#2316 moved managed-device allocation into `@agent-device/managed-allocation`. #2308 was authored before that move and merged after it, so the daemon files it added still import pre-move sibling paths:

```
src/daemon/managed-device-allocation/lease-admission.ts(19,8): error TS2307:
  Cannot find module './record-validation.ts'
src/daemon/managed-device-allocation/lease-admission.ts(70,5): error TS2322:
  Type 'string | undefined' is not assignable to type 'string'
src/daemon/managed-device-allocation/__tests__/lease-admission.fixtures.ts(10,61): error TS2307:
  Cannot find module './fixtures.ts'
test/integration/provider-scenarios/managed-runtime-automation.fixtures.ts(17,8): error TS2307:
  Cannot find module '.../managed-device-allocation/__tests__/fixtures.ts'
```

A semantic conflict, so neither PR's own CI could have caught it.

## Repairs

- **`lease-admission.ts`** reaches `freezeLease` / `isValidLease` / `isRequestGeneration` / `isVerbatimId` through the package's `./record` surface, which now re-exports them. `record-validation.ts` stays package-internal.
- **`TS2322` needed no separate fix.** It was a consequence of the unresolved import: with the module resolved, `isVerbatimId` narrows `grant.identityIncarnationId` to `string` again.
- **`src/daemon/managed-device-allocation/__tests__/fixtures.ts`** comes back, stated in contract terms only. Both trees keeping their own test data is the shape #2316 already chose for `managed-device-allocator.fixtures.ts`, which exists identically at both the root and package.
- **`.fallowrc.json`** drops its `@agent-device/managed-allocation` `ignoreDependencies` entry. Its comment read "no root consumer yet … it lands after the package's move" — the root consumer has now landed.

## Also failing on main, independently

`scripts/__tests__/eager-closure-budgets.test.ts > no APPROVED_OVER_CEILING row is stale` fails on pristine `origin/main`. The merge-base now carries `packages/capture-kit/src/durable-capture/index.ts` (added with #2320), so nothing can read its approval row, and the table's own staleness rule fails it — the intended outcome, just never actioned. Row removed.

## Validation

Verified failing on pristine `origin/main` first (typecheck and the closure gate, in a clean worktree), then green here:

- `pnpm typecheck` — clean
- `pnpm test:unit` — 1207 files, 9057 passed
- `managed-request-admission` + `managed-runtime-automation` provider suites — 19 passed
- `pnpm lint`, `pnpm format:check`, `pnpm check:layering`, `pnpm check:fallow`, `pnpm check:freerange` — all green
