### PR TITLE
fix(ios): stop charging every capture for a slow Simulator app discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fixed: the iOS Simulator AX snapshot route no longer charges every capture for a slow app
+  discovery. Discovery (`simctl launchctl list` through xcrun) takes seconds on a loaded host; a
+  capture now waits a bounded slice for it, takes the XCTest fallback, and the discovery keeps
+  running so the next capture joins or reuses it instead of paying the probe again. A `wait`
+  issued right after `open` could previously lose its whole budget to repeated 3s probe timeouts
+  and report `wait_capture_stalled` with the app already on screen.
 - Fixed: iOS snapshots no longer report `truncated: true` merely because a later backend produced
   them. The runner stamped every recovered capture as truncated — including a complete private-AX
   tree taken while the XCTest channel was penalized as slow — so a strict `is absent` / `wait absent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-- Fixed: the iOS Simulator AX snapshot route no longer charges every capture for a slow app
-  discovery. Discovery (`simctl launchctl list` through xcrun) takes seconds on a loaded host; a
-  capture now waits a bounded slice for it, takes the XCTest fallback, and the discovery keeps
-  running so the next capture joins or reuses it instead of paying the probe again. A `wait`
-  issued right after `open` could previously lose its whole budget to repeated 3s probe timeouts
-  and report `wait_capture_stalled` with the app already on screen.
+- Fixed: the iOS Simulator AX snapshot route bounds how long a capture waits for app discovery
+  and stops starting a discovery per capture. Discovery (`simctl launchctl list` through xcrun)
+  takes seconds on a loaded host; a capture now waits at most 1.5s for the one in-flight
+  discovery, takes the XCTest fallback, and the discovery keeps running under its own 15s
+  deadline for the captures that follow. Previously each capture ran its own probe with a 3s
+  timeout on its critical path, so a `wait` issued right after `open` could spend its budget on
+  probe timeouts and report `wait_capture_stalled` with the app already on screen.
 - Fixed: iOS snapshots no longer report `truncated: true` merely because a later backend produced
   them. The runner stamped every recovered capture as truncated — including a complete private-AX
   tree taken while the XCTest channel was penalized as slow — so a strict `is absent` / `wait absent`

--- a/packages/platform-apple/src/snapshot-route.test.ts
+++ b/packages/platform-apple/src/snapshot-route.test.ts
@@ -1,8 +1,10 @@
 import { expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { areIosSnapshotComparisonIdentitiesEqual } from '@agent-device/capture-kit/ios-snapshot-planning';
+import { createLocalAppleToolProvider, withAppleToolProvider } from './core/tool-provider.ts';
 import { platformRuntimeHostFixture } from './runtime.fixtures.ts';
 import { createAppleSnapshotRoute } from './snapshot-route.ts';
+import { createSimulatorSnapshotTargetResolver } from './snapshot-target.ts';
 import type { SimulatorSnapshotSource, SnapshotSourceOutcome } from './snapshot-source-facade.ts';
 
 const ios = {
@@ -200,6 +202,68 @@ test('cancelled acquisition does not start a fallback after the request aborts',
     'request ended',
   );
   expect(fallback).not.toHaveBeenCalled();
+});
+
+test('a slow app discovery yields to the XCTest fallback within its wait slice, then serves the bridge', async () => {
+  // The production resolver over a simctl whose `launchctl list` answers only when released,
+  // the shape of a loaded CI host: the first capture must not sit on that probe.
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const run = vi.fn(async (args: string[]) => {
+    if (args[0] === 'spawn') await released;
+    return {
+      stdout:
+        args[0] === 'spawn'
+          ? `42\t0\tUIKitApplication:${input.options.appBundleId}[launch-a][rb-legacy]`
+          : JSON.stringify({
+              devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-26-0': [{ udid: ios.id }] },
+            }),
+      stderr: '',
+      exitCode: 0,
+    };
+  });
+  const runCommand = vi.fn(async () => ({ stdout: 'start-a', stderr: '', exitCode: 0 }));
+  const fallback = vi.fn(async () => runnerResult());
+  const source = sourceReturning(bridgeAcquisition());
+  const presentIosAcquisition = vi.fn(async () => ({
+    backend: 'xctest' as const,
+    producer: 'simulator-ax-bridge' as const,
+    nodes: [{ index: 0, type: 'Application' }],
+  }));
+  const route = createAppleSnapshotRoute(
+    {
+      ...platformRuntimeHostFixture(),
+      snapshot: { captureSurface: vi.fn(), presentIosAcquisition },
+    },
+    { source, resolveTarget: createSimulatorSnapshotTargetResolver() },
+  );
+  vi.useFakeTimers();
+  try {
+    await withAppleToolProvider(
+      createLocalAppleToolProvider({ simctl: { run }, runCommand }),
+      async () => {
+        const first = route.capture(ios, input, signal(), fallback);
+        await vi.advanceTimersByTimeAsync(1_500);
+        const result = await first;
+        expect(fallback).toHaveBeenCalledOnce();
+        expect(result.warnings).toEqual([
+          'Simulator AX snapshot unavailable (target-resolution-failed); used XCTest for an unverified app generation.',
+        ]);
+        expect(source.acquire).not.toHaveBeenCalled();
+
+        release();
+        await vi.advanceTimersByTimeAsync(0);
+        const second = await route.capture(ios, input, signal(), fallback);
+        expect(second.producer).toBe('simulator-ax-bridge');
+        expect(fallback).toHaveBeenCalledOnce();
+        expect(run.mock.calls.filter(([args]) => args[0] === 'spawn')).toHaveLength(1);
+      },
+    );
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 function bridgeAcquisition(): Extract<SnapshotSourceOutcome, { stage: 'acquired' }> {

--- a/packages/platform-apple/src/snapshot-target.test.ts
+++ b/packages/platform-apple/src/snapshot-target.test.ts
@@ -17,7 +17,7 @@ const signal = () => new AbortController().signal;
 
 function targetFixture() {
   const state = { pid: 42, launch: 'launch-a', start: 'start-a' as string | null };
-  const run = vi.fn(async (args: string[]) => ({
+  const run = vi.fn(async (args: string[], _options?: { timeoutMs?: number }) => ({
     stdout:
       args[0] === 'spawn'
         ? `90\t0\tUIKitApplication:com.example.app.beta[wrong][rb-legacy]\n${state.pid}\t0\tUIKitApplication:${app}[${state.launch}][rb-legacy]`
@@ -27,11 +27,13 @@ function targetFixture() {
     stderr: '',
     exitCode: 0,
   }));
-  const runCommand = vi.fn(async () => ({
-    stdout: state.start ?? '',
-    stderr: '',
-    exitCode: state.start ? 0 : 1,
-  }));
+  const runCommand = vi.fn(
+    async (_tool: string, _args: string[], _options?: { timeoutMs?: number }) => ({
+      stdout: state.start ?? '',
+      stderr: '',
+      exitCode: state.start ? 0 : 1,
+    }),
+  );
   const provider = createLocalAppleToolProvider({ simctl: { run }, runCommand });
   const resolve = createSimulatorSnapshotTargetResolver();
   return {
@@ -201,4 +203,29 @@ test('a cancelled caller leaves discovery running for the next capture', async (
     expect(await fixture.resolve(ios, app, signal())).toMatchObject({ pid: 42 });
     expect(fixture.discoveryCount()).toBe(1);
   });
+});
+
+test('one discovery shares a single deadline across its simctl probes and the identity read', async () => {
+  const fixture = targetFixture();
+  const release = deferredSpawn(fixture);
+  vi.useFakeTimers();
+  try {
+    await withAppleToolProvider(fixture.provider, async () => {
+      const pending = fixture.resolve(ios, app, signal());
+      pending.catch(() => undefined);
+      // The spawn ran 13s of the 15s discovery deadline before answering.
+      await vi.advanceTimersByTimeAsync(13_000);
+      release();
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(fixture.resolve(ios, app, signal())).resolves.toMatchObject({ pid: 42 });
+
+      const spawnOptions = fixture.run.mock.calls.find(([args]) => args[0] === 'spawn')?.[1];
+      expect(spawnOptions?.timeoutMs).toBe(15_000);
+      const identityOptions = fixture.runCommand.mock.calls[0]?.[2];
+      expect(identityOptions?.timeoutMs).toBeGreaterThan(0);
+      expect(identityOptions?.timeoutMs).toBeLessThanOrEqual(2_000);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/platform-apple/src/snapshot-target.test.ts
+++ b/packages/platform-apple/src/snapshot-target.test.ts
@@ -137,3 +137,68 @@ test('an aborted request cannot reuse a cached target', async () => {
     expect(fixture.runCommand).toHaveBeenCalledTimes(1);
   });
 });
+
+function deferredSpawn(fixture: ReturnType<typeof targetFixture>) {
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const respond = fixture.run.getMockImplementation()!;
+  fixture.run.mockImplementation(async (args: string[]) =>
+    args[0] === 'spawn' ? await released.then(() => respond(args)) : await respond(args),
+  );
+  return release;
+}
+
+test('a slow discovery yields to the fallback after its wait budget and finishes in the background', async () => {
+  const fixture = targetFixture();
+  const release = deferredSpawn(fixture);
+  vi.useFakeTimers();
+  try {
+    await withAppleToolProvider(fixture.provider, async () => {
+      const pending = fixture.resolve(ios, app, signal());
+      const rejected = expect(pending).rejects.toMatchObject({
+        details: { reason: 'simulator-target-discovery-pending' },
+      });
+      await vi.advanceTimersByTimeAsync(1_500);
+      await rejected;
+      expect(fixture.discoveryCount()).toBe(1);
+
+      release();
+      await vi.advanceTimersByTimeAsync(0);
+      // The finished discovery serves the next capture without a second simctl spawn.
+      expect(await fixture.resolve(ios, app, signal())).toMatchObject({ pid: 42 });
+      expect(fixture.discoveryCount()).toBe(1);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('captures that arrive during discovery join it instead of spawning their own', async () => {
+  const fixture = targetFixture();
+  const release = deferredSpawn(fixture);
+  await withAppleToolProvider(fixture.provider, async () => {
+    const first = fixture.resolve(ios, app, signal());
+    const second = fixture.resolve(ios, app, signal());
+    release();
+    const targets = await Promise.all([first, second]);
+    expect(targets[1]).toBe(targets[0]);
+    expect(fixture.discoveryCount()).toBe(1);
+  });
+});
+
+test('a cancelled caller leaves discovery running for the next capture', async () => {
+  const fixture = targetFixture();
+  const release = deferredSpawn(fixture);
+  await withAppleToolProvider(fixture.provider, async () => {
+    const controller = new AbortController();
+    const cancelled = fixture.resolve(ios, app, controller.signal);
+    controller.abort(new Error('request-ended'));
+    await expect(cancelled).rejects.toThrow('request-ended');
+
+    release();
+    expect(await fixture.resolve(ios, app, signal())).toMatchObject({ pid: 42 });
+    expect(fixture.discoveryCount()).toBe(1);
+  });
+});

--- a/packages/platform-apple/src/snapshot-target.test.ts
+++ b/packages/platform-apple/src/snapshot-target.test.ts
@@ -229,3 +229,37 @@ test('one discovery shares a single deadline across its simctl probes and the id
     vi.useRealTimers();
   }
 });
+
+test('a failed runtime probe does not release the slot while the launch-job probe still runs', async () => {
+  const fixture = targetFixture();
+  const release = deferredSpawn(fixture);
+  const respond = fixture.run.getMockImplementation()!;
+  fixture.run.mockImplementation(async (args: string[], options) =>
+    args[0] === 'list'
+      ? { stdout: '', stderr: 'simctl list failed', exitCode: 1 }
+      : await respond(args, options),
+  );
+  vi.useFakeTimers();
+  try {
+    await withAppleToolProvider(fixture.provider, async () => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const pending = fixture.resolve(ios, app, signal());
+        const rejected = expect(pending).rejects.toMatchObject({
+          details: { reason: 'simulator-target-discovery-pending' },
+        });
+        await vi.advanceTimersByTimeAsync(1_500);
+        await rejected;
+      }
+      expect(fixture.discoveryCount()).toBe(1);
+
+      release();
+      await vi.advanceTimersByTimeAsync(0);
+      // The settled discovery reports the runtime failure and frees the slot for a fresh probe.
+      await expect(fixture.resolve(ios, app, signal())).rejects.toMatchObject({
+        details: { reason: 'simulator-runtime-probe-failed' },
+      });
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/platform-apple/src/snapshot-target.ts
+++ b/packages/platform-apple/src/snapshot-target.ts
@@ -6,15 +6,13 @@ import { readSnapshotTargetProcessStartTime } from './snapshot-process.ts';
 /** Identity re-check of a cached target: one local `ps`, never CoreSimulator IPC. */
 const TARGET_IDENTITY_TIMEOUT_MS = 3_000;
 /**
- * Discovery spawns `simctl launchctl list` through xcrun, which takes ~1s on an idle Mac and
- * several seconds on a loaded CI host. One capture waits this long for it and then takes the
- * XCTest fallback while discovery keeps running; the next capture joins the same discovery
- * instead of starting another, so a slow host pays the probe once per app generation, never
- * once per capture. Sized for the healthy case so the first capture after `open` still reaches
- * the bridge on a responsive host.
+ * How long one capture waits for an in-flight discovery before taking the XCTest fallback.
+ * Discovery spawns `simctl launchctl list` through xcrun: ~1s on an idle Mac, several seconds
+ * on a loaded CI host. The wait is per capture, so captures that keep arriving while the probe
+ * runs each spend up to this long; the probe itself is shared and outlives them.
  */
 const TARGET_DISCOVERY_WAIT_MS = 1_500;
-/** The budget of the discovery itself, detached from the capture that started it. */
+/** Overall deadline of one discovery (both simctl probes and the `ps` identity read). */
 const TARGET_DISCOVERY_TIMEOUT_MS = 15_000;
 
 export type SimulatorSnapshotTarget = Readonly<{
@@ -51,8 +49,9 @@ export function createSimulatorSnapshotTargetResolver(): SimulatorSnapshotTarget
     targets.delete(key);
     let discovery = discoveries.get(key);
     if (!discovery) {
-      // Detached from the caller's signal: a capture that gives up on the probe, or is
-      // cancelled, must not take the probe down with it.
+      // One discovery per target at a time, detached from the caller's signal: a capture that
+      // gives up on it, or is cancelled, must not take it down. A discovery that fails is
+      // forgotten, so the next capture starts a new one.
       discovery = resolveSimulatorSnapshotTarget(device, appBundleId, runtimeByDevice)
         .then((target) => {
           targets.set(key, target);
@@ -95,12 +94,13 @@ async function resolveSimulatorSnapshotTarget(
   appBundleId: string,
   runtimeByDevice: Map<string, Promise<string>>,
 ): Promise<SimulatorSnapshotTarget> {
+  const deadline = Date.now() + TARGET_DISCOVERY_TIMEOUT_MS;
   const [jobs, runtime] = await Promise.all([
     runSimctl(device, ['spawn', device.id, 'launchctl', 'list'], {
       allowFailure: true,
-      timeoutMs: TARGET_DISCOVERY_TIMEOUT_MS,
+      timeoutMs: remainingMs(deadline),
     }),
-    readSimulatorRuntime(device, runtimeByDevice),
+    readSimulatorRuntime(device, runtimeByDevice, deadline),
   ]);
   if (jobs.exitCode !== 0) {
     throw targetError('simulator-target-probe-failed', device, appBundleId);
@@ -110,7 +110,7 @@ async function resolveSimulatorSnapshotTarget(
     throw targetError('simulator-target-unavailable', device, appBundleId);
   }
   const processStartTime = await readSnapshotTargetProcessStartTime(job.pid, {
-    timeoutMs: TARGET_IDENTITY_TIMEOUT_MS,
+    timeoutMs: Math.min(TARGET_IDENTITY_TIMEOUT_MS, remainingMs(deadline)),
   });
   if (!processStartTime) {
     throw targetError('simulator-target-identity-unavailable', device, appBundleId);
@@ -128,12 +128,13 @@ async function resolveSimulatorSnapshotTarget(
 async function readSimulatorRuntime(
   device: DeviceInfo,
   runtimeByDevice: Map<string, Promise<string>>,
+  deadline: number,
 ): Promise<string> {
   const existing = runtimeByDevice.get(device.id);
   if (existing) return await existing;
   const pending = runSimctl(device, ['list', 'devices', '-j'], {
     allowFailure: true,
-    timeoutMs: TARGET_DISCOVERY_TIMEOUT_MS,
+    timeoutMs: remainingMs(deadline),
   }).then((result) => {
     if (result.exitCode !== 0) throw targetError('simulator-runtime-probe-failed', device, '');
     const payload = JSON.parse(result.stdout) as {
@@ -165,6 +166,10 @@ function readApplicationJob(
     if (Number.isSafeInteger(pid) && pid > 0) return { pid, label };
   }
   return undefined;
+}
+
+function remainingMs(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
 }
 
 function targetError(reason: string, device: DeviceInfo, appBundleId: string): AppError {

--- a/packages/platform-apple/src/snapshot-target.ts
+++ b/packages/platform-apple/src/snapshot-target.ts
@@ -95,13 +95,20 @@ async function resolveSimulatorSnapshotTarget(
   runtimeByDevice: Map<string, Promise<string>>,
 ): Promise<SimulatorSnapshotTarget> {
   const deadline = Date.now() + TARGET_DISCOVERY_TIMEOUT_MS;
-  const [jobs, runtime] = await Promise.all([
+  // Both probes settle before this discovery does: a discovery that gave up on the first
+  // failure would release its single-flight slot while the other probe still runs, and every
+  // capture after it would start a probe of its own.
+  const [jobsProbe, runtimeProbe] = await Promise.allSettled([
     runSimctl(device, ['spawn', device.id, 'launchctl', 'list'], {
       allowFailure: true,
       timeoutMs: remainingMs(deadline),
     }),
     readSimulatorRuntime(device, runtimeByDevice, deadline),
   ]);
+  if (jobsProbe.status === 'rejected') throw jobsProbe.reason;
+  if (runtimeProbe.status === 'rejected') throw runtimeProbe.reason;
+  const jobs = jobsProbe.value;
+  const runtime = runtimeProbe.value;
   if (jobs.exitCode !== 0) {
     throw targetError('simulator-target-probe-failed', device, appBundleId);
   }

--- a/packages/platform-apple/src/snapshot-target.ts
+++ b/packages/platform-apple/src/snapshot-target.ts
@@ -3,7 +3,19 @@ import { AppError } from '@agent-device/kernel/errors';
 import { runSimctl } from './core/apps-simctl.ts';
 import { readSnapshotTargetProcessStartTime } from './snapshot-process.ts';
 
-const TARGET_PROBE_TIMEOUT_MS = 3_000;
+/** Identity re-check of a cached target: one local `ps`, never CoreSimulator IPC. */
+const TARGET_IDENTITY_TIMEOUT_MS = 3_000;
+/**
+ * Discovery spawns `simctl launchctl list` through xcrun, which takes ~1s on an idle Mac and
+ * several seconds on a loaded CI host. One capture waits this long for it and then takes the
+ * XCTest fallback while discovery keeps running; the next capture joins the same discovery
+ * instead of starting another, so a slow host pays the probe once per app generation, never
+ * once per capture. Sized for the healthy case so the first capture after `open` still reaches
+ * the bridge on a responsive host.
+ */
+const TARGET_DISCOVERY_WAIT_MS = 1_500;
+/** The budget of the discovery itself, detached from the capture that started it. */
+const TARGET_DISCOVERY_TIMEOUT_MS = 15_000;
 
 export type SimulatorSnapshotTarget = Readonly<{
   udid: string;
@@ -23,6 +35,7 @@ export type SimulatorSnapshotTargetResolver = (
 
 export function createSimulatorSnapshotTargetResolver(): SimulatorSnapshotTargetResolver {
   const targets = new Map<string, SimulatorSnapshotTarget>();
+  const discoveries = new Map<string, Promise<SimulatorSnapshotTarget>>();
   const runtimeByDevice = new Map<string, Promise<string>>();
   return async (device, appBundleId, signal, refresh) => {
     signal.throwIfAborted();
@@ -31,35 +44,63 @@ export function createSimulatorSnapshotTargetResolver(): SimulatorSnapshotTarget
     if (cached && refresh !== 'refresh') {
       const observed = await readSnapshotTargetProcessStartTime(cached.pid, {
         signal,
-        timeoutMs: TARGET_PROBE_TIMEOUT_MS,
+        timeoutMs: TARGET_IDENTITY_TIMEOUT_MS,
       });
       if (observed === cached.processStartTime) return cached;
     }
     targets.delete(key);
-    const target = await resolveSimulatorSnapshotTarget(
-      device,
-      appBundleId,
-      signal,
-      runtimeByDevice,
-    );
-    targets.set(key, target);
-    return target;
+    let discovery = discoveries.get(key);
+    if (!discovery) {
+      // Detached from the caller's signal: a capture that gives up on the probe, or is
+      // cancelled, must not take the probe down with it.
+      discovery = resolveSimulatorSnapshotTarget(device, appBundleId, runtimeByDevice)
+        .then((target) => {
+          targets.set(key, target);
+          return target;
+        })
+        .finally(() => discoveries.delete(key));
+      discovery.catch(() => undefined);
+      discoveries.set(key, discovery);
+    }
+    return await awaitDiscovery(discovery, signal, device, appBundleId);
   };
+}
+
+async function awaitDiscovery(
+  discovery: Promise<SimulatorSnapshotTarget>,
+  signal: AbortSignal,
+  device: DeviceInfo,
+  appBundleId: string,
+): Promise<SimulatorSnapshotTarget> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  const bound = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(targetError('simulator-target-discovery-pending', device, appBundleId)),
+      TARGET_DISCOVERY_WAIT_MS,
+    );
+    onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([discovery, bound]);
+  } finally {
+    clearTimeout(timer);
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
 }
 
 async function resolveSimulatorSnapshotTarget(
   device: DeviceInfo,
   appBundleId: string,
-  signal: AbortSignal,
   runtimeByDevice: Map<string, Promise<string>>,
 ): Promise<SimulatorSnapshotTarget> {
   const [jobs, runtime] = await Promise.all([
     runSimctl(device, ['spawn', device.id, 'launchctl', 'list'], {
       allowFailure: true,
-      signal,
-      timeoutMs: TARGET_PROBE_TIMEOUT_MS,
+      timeoutMs: TARGET_DISCOVERY_TIMEOUT_MS,
     }),
-    readSimulatorRuntime(device, signal, runtimeByDevice),
+    readSimulatorRuntime(device, runtimeByDevice),
   ]);
   if (jobs.exitCode !== 0) {
     throw targetError('simulator-target-probe-failed', device, appBundleId);
@@ -69,8 +110,7 @@ async function resolveSimulatorSnapshotTarget(
     throw targetError('simulator-target-unavailable', device, appBundleId);
   }
   const processStartTime = await readSnapshotTargetProcessStartTime(job.pid, {
-    signal,
-    timeoutMs: TARGET_PROBE_TIMEOUT_MS,
+    timeoutMs: TARGET_IDENTITY_TIMEOUT_MS,
   });
   if (!processStartTime) {
     throw targetError('simulator-target-identity-unavailable', device, appBundleId);
@@ -87,15 +127,13 @@ async function resolveSimulatorSnapshotTarget(
 
 async function readSimulatorRuntime(
   device: DeviceInfo,
-  signal: AbortSignal,
   runtimeByDevice: Map<string, Promise<string>>,
 ): Promise<string> {
   const existing = runtimeByDevice.get(device.id);
   if (existing) return await existing;
   const pending = runSimctl(device, ['list', 'devices', '-j'], {
     allowFailure: true,
-    signal,
-    timeoutMs: TARGET_PROBE_TIMEOUT_MS,
+    timeoutMs: TARGET_DISCOVERY_TIMEOUT_MS,
   }).then((result) => {
     if (result.exitCode !== 0) throw targetError('simulator-runtime-probe-failed', device, '');
     const payload = JSON.parse(result.stdout) as {
@@ -130,9 +168,13 @@ function readApplicationJob(
 }
 
 function targetError(reason: string, device: DeviceInfo, appBundleId: string): AppError {
-  return new AppError('COMMAND_FAILED', 'Unable to resolve the running iOS Simulator app.', {
-    reason,
-    deviceId: device.id,
-    appBundleId,
-  });
+  return new AppError(
+    'COMMAND_FAILED',
+    `Unable to resolve the running iOS Simulator app (${reason}).`,
+    {
+      reason,
+      deviceId: device.id,
+      appBundleId,
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Removes repeated concurrent app discovery on the iOS Simulator AX-bridge route and bounds how long each capture waits for it. Resolver and route regression tests pass; loaded-host smoke validation is what this PR's own CI run will show, and it was still pending when this was written.

## The failure it targets

Since #2279 landed (09-05 21:06), the iOS Smoke lane has failed four times with one signature, the first `wait text "Agent Device Tester"` after a cold `open --relaunch` reporting `wait_capture_stalled` with `readableCaptures: 0`:

- main `80997b6b`: https://github.com/callstack/agent-device/actions/runs/33992502696
- main `f30328d0`: https://github.com/callstack/agent-device/actions/runs/34014253127
- PR #2326: https://github.com/callstack/agent-device/actions/runs/34015120372
- branch `fix/2314-memoize-platform-runtime-la`: https://github.com/callstack/agent-device/actions/runs/34016148244

The request log of the third run (artifact `ios-artifacts`, `sessions/ios-e2e-smoke-14ax/requests/45ad58af8fd6970d.ndjson`) accounts for the 10s budget:

| phase | cost |
|---|---:|
| runner `findText` on the just-launched app | 5.8s |
| AX-bridge target discovery: `xcrun simctl spawn … launchctl list`, `xcrun timed out after 3000ms` | 3.4s |
| fallback XCTest snapshot | cancelled at the deadline |

The failed-step screenshot and snapshot the harness took right after (#2315) show the home screen rendered with a healthy tree. That is consistent with the timeline, not proof the app was readable throughout the wait.

`createSimulatorSnapshotTargetResolver` (`snapshot-target.ts`) ran that spawn with a fixed 3s timeout on every cache miss, on the capture's critical path, and kept nothing on timeout, so the next capture ran its own probe again while xcrun was slow. xcrun takes about 1s on an idle Mac with simulators booted; on these CI hosts it exceeded 3s in both captures of that run, and the same hosts time out `simctl terminate` at 2s in other artifacts.

## Change

- Discovery is single-flight per target and detached from the capture that starts it. A capture waits at most 1.5s for the in-flight discovery, then takes the XCTest fallback with reason `simulator-target-discovery-pending`. Captures that keep arriving while the probe runs each wait up to that slice; the probe is shared, not repeated.
- A discovery has one 15s deadline shared by both simctl probes and the `ps` identity read.
- A cancelled caller no longer aborts the probe. A failed discovery is forgotten, so the next capture starts a new one.
- The resolver error names its reason, so the `ios_snapshot_route_fallback` diagnostic says why the fallback ran.

A responsive host still reaches the bridge on the first capture (local probe ≈ 1s < 1.5s).

## What is verified

- Resolver tests (deferred `spawn` mock, fake timers): slow discovery yields to the fallback and finishes in the background; concurrent captures join one discovery; a cancelled caller leaves it running; one deadline is shared by the probes and the identity read. The first three fail on the old code (hang, second spawn, second spawn).
- Route test with the production resolver over a simctl that answers only when released: the first capture falls back within the slice with the `target-resolution-failed` warning, the released discovery then serves the bridge without a second spawn.
- Existing resolver and route tests pass (20 total); package typecheck, oxlint, oxfmt, fallow clean.
- Live fixture E2E on a private iOS 26.2 simulator with the rebuilt dist: cold launch, `wait for Agent Device Tester` 269ms, 23 captures served by the bridge, `smoke:automation-input` green. This proves the healthy route, not the loaded-host case. (A later `keyboard dismiss` failure in that run is my local Simulator.app hardware-keyboard environment.)

## Not verified here

- A loaded-host `wait` completing through the fallback: no local way to make xcrun slow; the lane's own runs are the evidence.
- The production poll path end to end under slow discovery; the route test covers one capture, not the `wait` loop.

## Relation to open work

#2329 changes `snapshot-route.ts` (launch grace on typed bridge failures) and makes `wait` observe runner-free; it does not touch the probe, and its design needs the probe to be cheap on the critical path. #2325 covers `open` startup budgets. This PR does not change the `wait` contract.
