### PR TITLE
test(android-e2e): read the logcat tail for rotation evidence

### DIFF
--- a/test/integration/android-emulator-e2e/live-harness.ts
+++ b/test/integration/android-emulator-e2e/live-harness.ts
@@ -42,6 +42,8 @@ export function createContext(): LiveContext {
 const execFileAsync = promisify(execFile);
 
 const ROTATION_PROBE_TIMEOUT_MS = 5_000;
+/** Lines read back from logcat; the rotation decisions of the last few minutes fit comfortably. */
+const ROTATION_LOG_TAIL = 4_000;
 const ROTATION_LOG_LINES = 60;
 const ROTATION_LOG_LINE_LENGTH = 240;
 
@@ -56,7 +58,9 @@ async function readAndroidRotationEvidence(context: LiveContext): Promise<string
     ['accelerometer_rotation', ['shell', 'settings', 'get', 'system', 'accelerometer_rotation']],
     ['user_rotation', ['shell', 'settings', 'get', 'system', 'user_rotation']],
     ['display rotation', ['shell', 'dumpsys', 'display']],
-    ['logcat rotation decisions', ['logcat', '-d', '-v', 'time']],
+    // The tail, not the whole buffer: the emulator keeps 2MB and a loaded one takes seconds to
+    // dump it, which is what the group bound is for, not this read.
+    ['logcat rotation decisions', ['logcat', '-d', '-v', 'time', '-t', String(ROTATION_LOG_TAIL)]],
   ];
   const sections: string[] = [];
   for (const [title, args] of probes) {


### PR DESCRIPTION
The first CI failure carrying the rotation evidence (PR #2356, https://github.com/callstack/agent-device/actions/runs/34029660070) lost its logcat section: `(failed: Command failed: adb -s emulator-5554 logcat -d -v time)`, the 5s per-probe bound killing a full 2MB buffer dump on the loaded host. The probe now reads `logcat -d -v time -t 4000`, which holds the rotation decisions of the last minutes and returns well inside the bound (a local 2MB dump takes under a second; the tail is 290KB).

The settings and display sections of that file were intact and show the device in portrait at that failure, which is a different failure from the alert-canary one and is being handled on #2356.