### PR TITLE
fix(capture): export durable resource record type

### DIFF
--- a/packages/capture-kit/src/durable-capture/index.ts
+++ b/packages/capture-kit/src/durable-capture/index.ts
@@ -22,4 +22,4 @@ export type {
   DurableCaptureRecoverySummary,
 } from './recovery.ts';
 export type { DurableCaptureRecoveryControl } from './recovery-authority.ts';
-export type { DurableCaptureResourceStore } from './store.ts';
+export type { DurableCaptureResourceRecord, DurableCaptureResourceStore } from './store.ts';

--- a/packages/capture-kit/src/durable-capture/store.test.ts
+++ b/packages/capture-kit/src/durable-capture/store.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'vitest';
+import type { DurableCaptureResourceRecord } from '@agent-device/capture-kit/durable-capture';
 import { localRuntimeOwner } from '@agent-device/contracts/platform-runtime';
 import { createDurableResourceEnvelope } from '../durable-resource-envelope.ts';
 import { mkdtempForTestSync } from '../tmp-dir.fixtures.ts';
@@ -18,7 +19,8 @@ test('publishes typed resource records atomically with owner-only permissions', 
   );
   store.write(resourcePath, envelope('session'));
 
-  expect(store.read(resourcePath)).toMatchObject({
+  const record: DurableCaptureResourceRecord<'screen-recording'> = store.read(resourcePath);
+  expect(record).toMatchObject({
     status: 'decoded',
     envelope: { resourceKind: 'screen-recording', lifecycle: 'open' },
   });


### PR DESCRIPTION
## Summary

Export the durable capture store's existing result type through its package
entry point. Consumers can name inferred `read()` return values during
declaration emit without referencing a private node_modules path.

## Scope

Two files: the package type export and an existing store regression consuming
that public type. No runtime behavior, native runner, capture timing or build
configuration changes. The separate compiler-child exit-status issue is not
addressed here.

## Validation

- Commit `d41bf53d8`, base `bd08e6e0f`.
- Unmodified base: direct declaration emit failed with nine TS2883 errors.
  With the export: identical invocation passed and all nine previously missing
  declarations were generated using public package specifiers.
- Public-type regression: `pnpm exec tsc -b packages/capture-kit` failed with
  TS2724 without the export and passed with it. Three focused store tests pass.
- Repository-wide `pnpm format` and exact-head `pnpm check:affected --run`
  passed: typecheck, build, layering, lint, fallow, and 230 related files /
  1,518 tests.
- Remote checks are terminal: Android smoke failed; all other checks passed
  or were intentionally skipped. [Failure evidence](https://github.com/callstack/agent-device/actions/runs/34056468073/job/101549174607)
  shows the fixture swipe overshot `automation-press`. A separate harness
  repair is in progress. This PR is not merge-ready.

## Verification

No device QA performed; this is a type-only package-boundary repair.

## Automated Test Plan

Device/simulator automation: not applicable; runtime implementation is unchanged.
After `pnpm install --frozen-lockfile && pnpm build`, run
`pnpm check:affected --run` and `pnpm exec tsc -b packages/capture-kit`.
Require no TS2883 errors and successful type/store regressions. No accounts,
device mutations or production services are needed.
