### PR TITLE
test(android): reveal automation controls semantically

### DIFF
--- a/scripts/check-affected/device-lanes.test.ts
+++ b/scripts/check-affected/device-lanes.test.ts
@@ -116,6 +116,23 @@ test('another family owns only its own lanes, so an Android-only change carries 
   assert.deepEqual(lanes('packages/platform-vega/src/index.ts'), []);
 });
 
+test('Maestro replay YAML owns its platform lane without narrowing other fixture data', () => {
+  for (const extension of ['yaml', 'yml']) {
+    assert.deepEqual(
+      lanes(`test/integration/replays/android/fixture/reveal-press-canary.${extension}`),
+      ['replay-android'],
+    );
+    assert.deepEqual(lanes(`test/integration/replays/ios/fixture/reveal.${extension}`), [...IOS]);
+    for (const file of [
+      `test/integration/android-emulator-e2e/capture.${extension}`,
+      'test/integration/replays/android/fixture/capture.json',
+    ]) {
+      assert.equal(isDeviceLaneSurface(file), false, file);
+      assert.equal(selectChecks({ changedFiles: [file] }).failOpen, true, file);
+    }
+  }
+});
+
 test('the fixture app owns the mobile lanes whichever subtree changes', () => {
   assert.deepEqual(lanes('examples/test-app/app/index.tsx'), [
     'replay-ios',

--- a/scripts/check-affected/device-lanes.ts
+++ b/scripts/check-affected/device-lanes.ts
@@ -128,7 +128,13 @@ const RUNTIME_SURFACE: ReadonlyArray<{ root: string; owns: (file: string) => boo
     owns: (file) => /^packages\/[^/]+\/src\//.test(file) && isProductionTs(file),
   },
   // Integration tests, their support modules, and the replay scripts the lanes execute.
-  { root: 'test/integration/', owns: (file) => file.endsWith('.ts') || file.endsWith('.ad') },
+  {
+    root: 'test/integration/',
+    owns: (file) =>
+      file.endsWith('.ts') ||
+      file.endsWith('.ad') ||
+      (file.startsWith('test/integration/replays/') && /\.ya?ml$/.test(file)),
+  },
   // The Expo fixture app the iOS/Android smoke drives (same extension class as own:test-app).
   { root: 'examples/test-app/', owns: (file) => /\.(?:[cm]?[jt]sx?|json)$/.test(file) },
   // Native runner and helper sources — build inputs of the lanes that boot them.

--- a/test/integration/android-emulator-e2e/live-automation-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-automation-scenario.ts
@@ -126,7 +126,12 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
     'fixture automation-window value changed to landscape and back to portrait',
   );
 
-  await runStep(context, 'reveal input canaries', ['scroll', 'down', '0.7']);
+  await runStep(context, 'restore automation top before revealing input canaries', [
+    'scroll',
+    'top',
+  ]);
+  await revealAutomationControl(context, 'automation-press');
+  await assertElementText(context, 'id="automation-press"', 'Press canary');
   await runStep(context, 'press semantic canary', ['press', 'id="automation-press"']);
   await assertWaitText(context, 'Last input: press');
   verifyCommand(context, C.press, 'semantic press updates durable fixture input state');
@@ -139,6 +144,7 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
   await assertWaitText(context, 'Long presses: 1');
   verifyCommand(context, C.longPress, '800ms hold increments durable fixture long-press counter');
 
+  await revealAutomationControl(context, 'automation-open-alert');
   await runStep(context, 'open Android native alert', ['click', 'id="automation-open-alert"']);
   await assertWaitText(context, 'Automation confirmation');
   const alertSnapshot = await runStep(context, 'capture native alert through persistent helper', [
@@ -175,7 +181,7 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
   verifyCommand(context, C.alert, 'alert wait/get/dismiss/accept produce fixture-visible results');
 
   await assertHomeAndRecentsRestoration(context);
-  await runStep(context, 'reveal Android alert canary for diff baseline', ['scroll', 'down', '1']);
+  await revealAutomationControl(context, 'automation-open-alert');
   await runStep(context, 'establish automation diff baseline', ['snapshot', '-i']);
   await runStep(context, 'return from automation route with Back', ['back']);
   const diff = await runStep(context, 'observe automation-to-settings diff', [
@@ -193,6 +199,18 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
     'safe-back-navigation',
     'Back returned from the automation route to the fixture Settings tab without opening system navigation',
   );
+}
+
+async function revealAutomationControl(context: LiveContext, identifier: string): Promise<void> {
+  await runStep(context, `reveal ${identifier}`, [
+    'replay',
+    path.resolve('test/integration/replays/android/fixture/reveal-automation-control.yaml'),
+    '--maestro',
+    '--env',
+    `APP_ID=${context.appId}`,
+    '--env',
+    `CONTROL_ID=${identifier}`,
+  ]);
 }
 
 async function assertOrientationFixtureState(

--- a/test/integration/replays/android/fixture/reveal-automation-control.yaml
+++ b/test/integration/replays/android/fixture/reveal-automation-control.yaml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+---
+- scrollUntilVisible:
+    element:
+      id: ${CONTROL_ID}
+    direction: DOWN
+    timeout: 10000


### PR DESCRIPTION
## Summary
Reveal Android smoke controls semantically instead of assuming fixed swipes leave them onscreen.

## Scope
Four files: harness, replay fixture, and required CI ownership rule/test. Use bounded Maestro `scrollUntilVisible` before press, alert activation and diff baseline. Preserve semantic actions and durable outcome assertions. No driver runtime change, action retry, timeout increase or declaration-export fix. Repository rules require implementation followed by a final enforcement commit.

## Validation
At `507209f3`, `pnpm check:affected --run` exits 0: 95 Node integration passes, 9 live skips. Routing regression failed before correction; 13 cases and manifest pass. [Exact-head Android CI](https://github.com/callstack/agent-device/actions/runs/34058790224/job/101555455877) passes the live fixture E2E, including automation-system (122.6s). macOS fails native listener startup with address-in-use; iOS remains pending after prior-head long-press visibility failure. Not merge-ready. Baseline nine declaration errors are separately addressed by #2365; no clean-build claim.

## Verification
Automatic Android smoke selects this scenario. Failed-step screenshot, snapshot and history establish the overscroll/offscreen failures. No product UI changed.

## Automated Test Plan
Run `.github/workflows/android.yml`: API 36 x86_64 Pixel 7, fixture APK from `setup-fixture-app`. Confirm cold link, modal close, rotations, reveal → press → `Last input: press`, long-press count, alert actions, Home/Recents, diff and Back. Harness restores portrait and closes its session. Retain coverage/failure artifacts. No account, funds or external delivery required.
