### PR TITLE
test(android): reveal smoke canaries by visibility

### DIFF
--- a/test/integration/android-emulator-e2e/live-assertions.ts
+++ b/test/integration/android-emulator-e2e/live-assertions.ts
@@ -22,6 +22,37 @@ export const { assertElementText, assertWaitSelector, assertWaitText, capturePng
     PUBLIC_COMMANDS.wait,
   );
 
+export async function scrollToVisibleSelector(
+  context: LiveContext,
+  selector: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const result = await runStep(
+      context,
+      `check ${selector} visibility (${attempt + 1})`,
+      ['is', 'visible', selector],
+      { allowFailure: true },
+    );
+    if (result.status === 0) {
+      assert.equal(result.json?.data?.pass, true, JSON.stringify(result.json));
+      return;
+    }
+    const reason = result.json?.error?.details?.reason;
+    assert.ok(
+      reason === 'selector_not_found' || reason === 'predicate_failed',
+      `could not observe ${selector}: ${JSON.stringify(result.json)}`,
+    );
+    if (attempt < 5) {
+      await runStep(context, `scroll toward ${selector} (${attempt + 1})`, [
+        'scroll',
+        'down',
+        '0.25',
+      ]);
+    }
+  }
+  assert.fail(`${selector} did not become visible after five scrolls`);
+}
+
 export function assertDiffLine(
   result: CliJsonResult,
   kind: SnapshotDiffLine['kind'],

--- a/test/integration/android-emulator-e2e/live-automation-scenario.ts
+++ b/test/integration/android-emulator-e2e/live-automation-scenario.ts
@@ -12,6 +12,7 @@ import {
   assertWaitText,
   capturePng,
   requireAndroidResourceId,
+  scrollToVisibleSelector,
 } from './live-assertions.ts';
 import { type LiveContext, runStep, verifyBehavior, verifyCommand } from './live-harness.ts';
 
@@ -126,19 +127,24 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
     'fixture automation-window value changed to landscape and back to portrait',
   );
 
-  await runStep(context, 'reveal input canaries', ['scroll', 'down', '0.7']);
+  await runStep(context, 'restore automation route top after rotation', ['scroll', 'top']);
+  await scrollToVisibleSelector(context, 'id="automation-press"');
   await runStep(context, 'press semantic canary', ['press', 'id="automation-press"']);
+  await scrollToVisibleSelector(context, 'id="automation-last-input"');
   await assertWaitText(context, 'Last input: press');
   verifyCommand(context, C.press, 'semantic press updates durable fixture input state');
 
+  await scrollToVisibleSelector(context, 'id="automation-longpress"');
   await runStep(context, 'long press semantic canary', [
     'longpress',
     'id="automation-longpress"',
     '800',
   ]);
+  await scrollToVisibleSelector(context, 'id="automation-longpress-count"');
   await assertWaitText(context, 'Long presses: 1');
   verifyCommand(context, C.longPress, '800ms hold increments durable fixture long-press counter');
 
+  await scrollToVisibleSelector(context, 'id="automation-open-alert"');
   await runStep(context, 'open Android native alert', ['click', 'id="automation-open-alert"']);
   await assertWaitText(context, 'Automation confirmation');
   const alertSnapshot = await runStep(context, 'capture native alert through persistent helper', [
@@ -164,6 +170,7 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
   const alert = await runStep(context, 'inspect Android native alert', ['alert', 'get']);
   assertJsonContains(alert, 'Automation confirmation', 'alert get should expose fixture dialog');
   await runStep(context, 'dismiss Android native alert', ['alert', 'dismiss']);
+  await scrollToVisibleSelector(context, 'id="automation-alert-result"');
   // The dismissal is confirmed, but the fixture's re-render after the button callback is the
   // app's own timing: wait for the outcome, then pin it to the canary element.
   await assertWaitText(context, 'Alert result: cancelled');
@@ -175,7 +182,7 @@ export async function assertAutomationSystem(context: LiveContext): Promise<void
   verifyCommand(context, C.alert, 'alert wait/get/dismiss/accept produce fixture-visible results');
 
   await assertHomeAndRecentsRestoration(context);
-  await runStep(context, 'reveal Android alert canary for diff baseline', ['scroll', 'down', '1']);
+  await scrollToVisibleSelector(context, 'id="automation-open-alert"');
   await runStep(context, 'establish automation diff baseline', ['snapshot', '-i']);
   await runStep(context, 'return from automation route with Back', ['back']);
   const diff = await runStep(context, 'observe automation-to-settings diff', [


### PR DESCRIPTION
## Summary

The Android automation smoke scrolls a fixed `0.7` after rotation and overshoots `automation-press`, then fails before dispatching input. The [repeated failure on #2362](https://github.com/callstack/agent-device/actions/runs/34058548247/attempts/2) retains `failed-step-34.png` showing the button above the viewport.

Reset the route to its top after rotation, then check semantic visibility between bounded small scrolls. Use the same positioning for input outcomes, the alert, and the diff baseline. Keep all existing outcome assertions. Two test files change; no runtime or retry-policy changes.

## Validation

At `6211bfc3f15789fbb8cf5fd5907d399a7dd58d54`, `pnpm check:affected --run` passes (format, lint, typecheck; no related Vitest tests selected). The [hosted Android smoke passes](https://github.com/callstack/agent-device/actions/runs/34061497846), including the automation-system scenario and Settings replay. CI/coverage, integration, Linux/macOS smoke and all other checks are green. Prepared separately to preserve the iOS cold-start comparison at #2362's current SHA.
