### PR TITLE
chore: drop the stale planned-operations closure approval

### DIFF
--- a/scripts/__tests__/eager-closure-budgets.ts
+++ b/scripts/__tests__/eager-closure-budgets.ts
@@ -126,16 +126,7 @@ export const NEW_ENTRY_CEILINGS: Readonly<Record<EntryCategory, number>> = Objec
  */
 export const APPROVED_OVER_CEILING: Readonly<
   Record<string, { issue: string; reason: string; owner: string }>
-> = Object.freeze({
-  'packages/command-registry/src/planned-operations.ts': {
-    issue: '#2198',
-    reason:
-      'Flattens the required runtime operations of the remaining batch steps from the registry, ' +
-      'so its closure is the registry entry itself plus the operation-name vocabulary; a lighter ' +
-      'closure would mean a second copy of the descriptors.',
-    owner: 'thymikee',
-  },
-});
+> = Object.freeze({});
 
 /** The category is a function of the path, never a hand-written column. */
 export function entryCategoryOf(entryFile: string): EntryCategory {


### PR DESCRIPTION
## Summary

`scripts/__tests__/eager-closure-budgets.test.ts › no APPROVED_OVER_CEILING row is stale` fails on main at `e7a5b8b622` and on every PR based on it (for example #2325, #2372, #2363).

The `APPROVED_OVER_CEILING` row for `packages/command-registry/src/planned-operations.ts` was consumed by #2329. Now that main carries that entry, the no-growth rule governs it and nothing reads the row again, so the probe reports it stale and asks for its removal. This does exactly that: one row deleted, no budget or ceiling changed.

## Validation

`scripts/__tests__/eager-closure-budgets.test.ts`: 478/478 green locally against `origin/main`; `tsc -p tsconfig.json` clean.
