### PR TITLE
perf(cli): keep scroll vocabulary off gesture runtime

### DIFF
--- a/src/commands/interaction/metadata.ts
+++ b/src/commands/interaction/metadata.ts
@@ -14,6 +14,7 @@ import { SCROLL_DURATION_MAX_MS } from '@agent-device/contracts/scroll-command';
 import { IS_PREDICATES } from '@agent-device/contracts/is-predicate';
 import {
   SCROLL_DIRECTIONS,
+  SCROLL_INPUT_DIRECTIONS,
   SWIPE_PATTERNS,
   SWIPE_PAUSE_MAX_MS,
   SWIPE_PRESETS,
@@ -39,7 +40,6 @@ import { readCommonInput, type CommonCommandInput } from '../common-input-fields
 import { readInputRecord } from '../input-readers.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import { postActionObservationFields } from '../post-action-observation-grammar.ts';
-import { SCROLL_INPUT_DIRECTIONS } from './runtime/gestures.ts';
 
 const FIND_ACTION_VALUES = [
   'click',


### PR DESCRIPTION
## Summary

- Import `SCROLL_INPUT_DIRECTIONS` from its owning contracts vocabulary module instead of the gesture runtime re-export.
- Keep command metadata behavior unchanged while removing the runtime edge from `src/cli.ts`.
- Touch one file and reduce the eager closure from 365 to 325 modules (-40), implementing Step A of #2374.

## Validation

Tested commit `ab05815b31c7aa5258a11c72f3ff429f52070c91`.

- focused `src/cli.ts` eager-closure test
- `pnpm exec vitest run src/commands/interaction/metadata.test.ts --maxWorkers=2`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:layering`
- `pnpm run check:fallow --base origin/main`
- `pnpm run build`

`pnpm check:affected --run` cannot complete on this Windows host: its related suites include existing POSIX/device assumptions. The target suite and structural gates above pass; GitHub CI remains authoritative for Linux, provider integration, and coverage.

Refs #2374
