### PR TITLE
refactor(cli): take the CLI's vocabulary off runtime barrels

### DIFF
--- a/packages/provider-webdriver/package.json
+++ b/packages/provider-webdriver/package.json
@@ -14,6 +14,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./providers": {
+      "types": "./src/providers.ts",
+      "default": "./src/providers.ts"
     }
   }
 }

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -656,10 +656,10 @@ test('the real tree parses, declares, and passes R11', () => {
     (pkg) => pkg.name === '@agent-device/provider-webdriver',
   );
   assert.ok(providerWebDriverPackage, 'provider-webdriver package must exist');
-  assert.deepEqual(
-    [...providerWebDriverPackage.exportTargets.keys()],
-    ['@agent-device/provider-webdriver'],
-  );
+  assert.deepEqual([...providerWebDriverPackage.exportTargets.keys()].sort(), [
+    '@agent-device/provider-webdriver',
+    '@agent-device/provider-webdriver/providers',
+  ]);
   assert.deepEqual([...providerWebDriverPackage.workspaceDependencies].sort(), [
     '@agent-device/capture-kit',
     '@agent-device/contracts',

--- a/src/cli/connection/provider-policy.ts
+++ b/src/cli/connection/provider-policy.ts
@@ -2,7 +2,7 @@ import {
   CLOUD_WEBDRIVER_PROVIDERS,
   isCloudWebDriverProviderName,
   type CloudWebDriverKnownProviderName,
-} from '@agent-device/provider-webdriver';
+} from '@agent-device/provider-webdriver/providers';
 
 export type DirectDeviceConnectProvider = CloudWebDriverKnownProviderName | 'limrun';
 export type ConnectProvider = 'cloud' | 'proxy' | DirectDeviceConnectProvider;


### PR DESCRIPTION
## Summary

Steps A and B of #2374. `src/cli.ts` eager closure **365 → 295 modules (−19%)**, measured with the eager-closure gate's own walker.

Both are the same defect: a module that needs *vocabulary* reached it through a *runtime* barrel and paid for the runtime.

**A — `interaction/metadata.ts` (−40, 365 → 325).** Every import in that metadata module is vocabulary except one, which took `SCROLL_INPUT_DIRECTIONS` from `./runtime/gestures.ts` and dragged 40 modules of gesture runtime into every CLI invocation to read a six-string constant. `gestures.ts` does not own it — it re-exports it from `@agent-device/contracts/scroll-gesture`, with a comment saying the vocabulary lives there precisely so the public API needn't depend on the command runtime. This file already imported from that module five lines earlier.

**B — `provider-policy.ts` (−30, 325 → 295).** It asks three questions of `@agent-device/provider-webdriver`: the known-provider map, the predicate over it, one type. All three live in `providers.ts`, a leaf with **zero imports**. The package predates the subpath-per-file rule and published only `"."`, so answering "is this string a known provider name" loaded 31 modules of WebDriver session handling, capture and XML. It now also publishes `./providers`. `provider-policy.ts` was the only in-closure consumer of the barrel, so the whole 30 comes back.

**C is not here, deliberately.** #2374 scoped it as "a design task, not a mechanical one" and said to split it out if it grew past one PR. It does. `commands/family/registry.ts` still dominates 82 modules and remains the largest single prize, but only 2 of the 12 families expose metadata separately; the other 10 declare `metadata` and `run` together per command (`family/types.ts:31`), so separating them changes how commands are authored across ten families. That belongs in its own PR against #2374 rather than bolted onto two one-line fixes.

## One change here is not mine

`APPROVED_OVER_CEILING` still named `packages/command-registry/src/planned-operations.ts` from #2198. The merge-base carries that entry now, so the row is stale and the gate's own staleness check fails on it. **Verified red on a clean `8299d5b` checkout with none of this branch applied.** Removing the row is exactly what the gate's message asks for, and it is one line in this PR's own subject area — but it is unrelated to the closure work and is trivially droppable if you would rather it went separately.

## Validation

At `775035d`: `pnpm check:tooling` exits 0 (format, lint, typecheck, layering, depgraph, gate-manifest, production-exports, tmpdir-leaks, xctest-selection, mcp-metadata, build, bundle-owner-files, package). `pnpm check:fallow` — no issues across the 5 changed files. `pnpm check:affected --run` passed. `eager-closure-budgets.test.ts` 480/480 (477/478 on main before the stale-row removal). Interaction and cli-connection unit tests: 29 files, 258 tests green.

Closure verified by the gate's own `eagerClosureGraphOf`: 365 at the merge-base, 295 here.

**Wall clock is not claimed.** Module count is a proxy for parse-and-evaluate cost, not a linear one; today's size report reads `--version` 27 ms and `--help` ~79 ms. Whatever the size report says on this PR is the real number.

Refs #2374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jqfa11D8QsCMuL17SsLvDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqfa11D8QsCMuL17SsLvDz)_