### PR TITLE
fix(remote): let a plain-session client read its own failure diagnostics record

### DIFF
--- a/src/daemon/__tests__/http-server-tenant-trust.test.ts
+++ b/src/daemon/__tests__/http-server-tenant-trust.test.ts
@@ -401,14 +401,48 @@ test('aux route: no hook configured keeps the header-declared tenant unchanged (
       },
     });
     assert.equal(owner.status, 200);
+    // Nothing attested either header, so `scopeRequestSession` partitioned no
+    // session namespace and the `<tenant>:` prefix carries no ownership to check
+    // — the two RPC regressions above show the same caller may already run any
+    // command in `tenant-a:default`. The token is the gate in this mode.
     const otherTenant = await fetch(diagnosticsUrl(baseUrl, 'tenant-a:default', 'abc123'), {
       headers: {
         authorization: `Bearer ${DAEMON_TOKEN}`,
         [DAEMON_HTTP_TENANT_HEADER]: 'tenant-b',
       },
     });
-    assert.equal(otherTenant.status, 401);
+    assert.equal(otherTenant.status, 200);
   });
+});
+
+test('aux route: an attested tenant is still refused a record outside its partition', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+  const root = mkdtempForTestSync('agent-device-tenant-trust-aux-cross-');
+  try {
+    const hookPath = writeAttestingAuthHook(root);
+    await withDiagnosticsHookServer(hookPath, async ({ baseUrl, sessionsDir }) => {
+      // The hook attests `tenant-real`, so every session that caller can reach is
+      // named `tenant-real:...`. Another tenant's record, and the plain sessions
+      // outside the partition, both stay outside what it may address.
+      writeDiagnosticsRecord(sessionsDir, 'tenant-other:default', 'abc123');
+      writeDiagnosticsRecord(sessionsDir, 'cwd:9f1:default', 'abc123');
+      const auth = { authorization: `Bearer ${DAEMON_TOKEN}` };
+      for (const session of ['tenant-other:default', 'cwd:9f1:default']) {
+        const refused = await fetch(diagnosticsUrl(baseUrl, session, 'abc123'), { headers: auth });
+        assert.equal(refused.status, 401, `expected 401 for session ${session}`);
+        const body = (await refused.json()) as { error?: string; code?: string };
+        assert.equal(body.code, 'UNAUTHORIZED');
+        assert.equal(body.error, 'Session is outside this tenant');
+      }
+      writeDiagnosticsRecord(sessionsDir, `${ATTESTED_TENANT_ID}:default`, 'abc123');
+      const own = await fetch(diagnosticsUrl(baseUrl, `${ATTESTED_TENANT_ID}:default`, 'abc123'), {
+        headers: auth,
+      });
+      assert.equal(own.status, 200);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('aux route (upload): a hook configured but silent on tenant refuses a client-declared header', async (t) => {

--- a/src/daemon/__tests__/request-diagnostics-http.test.ts
+++ b/src/daemon/__tests__/request-diagnostics-http.test.ts
@@ -140,7 +140,15 @@ test('request diagnostics route rejects ids that do not name one record', async 
   });
 });
 
-test('request diagnostics route keeps a tenant inside its own session namespace', async (t) => {
+/**
+ * No auth hook is configured on this server, so every tenant here is a
+ * client-DECLARED label. `scopeRequestSession` partitions nothing for such a
+ * caller, and the same caller can already run any command in any session over
+ * `/rpc` (`http-server-tenant-trust.test.ts`, "no hook configured keeps a
+ * client-declared flags.tenant unchanged"). The prefix rule that does bite is
+ * proven against an ATTESTING hook in that file.
+ */
+test('request diagnostics route reads an unattested tenant as no session partition', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
 
   await withDiagnosticsServer(async ({ baseUrl, sessionsDir }) => {
@@ -153,7 +161,38 @@ test('request diagnostics route keeps a tenant inside its own session namespace'
     const otherTenant = await fetch(diagnosticsUrl(baseUrl, 'tenant-a:default', 'abc123'), {
       headers: { ...auth, 'x-agent-device-tenant': 'tenant-b' },
     });
-    assert.equal(otherTenant.status, 401);
-    assert.equal((await otherTenant.text()).includes('request_start'), false);
+    assert.equal(otherTenant.status, 200);
+  });
+});
+
+test('request diagnostics route serves a plain session to the tenant that ran the command', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  await withDiagnosticsServer(async ({ baseUrl, sessionsDir }) => {
+    writeRecord(sessionsDir, 'default', 'abc123');
+    const response = await fetch(diagnosticsUrl(baseUrl, 'default', 'abc123'), {
+      headers: {
+        authorization: 'Bearer daemon-secret',
+        'x-agent-device-tenant': 'tenant-a',
+      },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), RECORD);
+  });
+});
+
+test('request diagnostics route serves the cwd-scoped session its owner ran in', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  await withDiagnosticsServer(async ({ baseUrl, sessionsDir }) => {
+    writeRecord(sessionsDir, 'cwd:9f1:default', 'abc123');
+    const response = await fetch(diagnosticsUrl(baseUrl, 'cwd:9f1:default', 'abc123'), {
+      headers: {
+        authorization: 'Bearer daemon-secret',
+        'x-agent-device-tenant': 'tenant-a',
+      },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), RECORD);
   });
 });

--- a/src/daemon/request-diagnostics-http.ts
+++ b/src/daemon/request-diagnostics-http.ts
@@ -20,7 +20,10 @@ import { AppError, normalizeError, type DiagnosticsRecordRef } from '@agent-devi
 import type { DaemonRequest } from './daemon-request.ts';
 import { isSafeSessionSegment } from './session-paths.ts';
 import { decodeUriSegment } from './http-request-target.ts';
-import { isTenantOwnedSessionName } from './session-tenant-scope.ts';
+import {
+  isTenantAddressableSessionName,
+  type TenantSessionNamespace,
+} from './session-tenant-scope.ts';
 import { failStreamedHttpResponse, sendRestJsonError } from './http-errors.ts';
 
 const REQUEST_DIAGNOSTICS_CONTENT_TYPE = 'application/x-ndjson';
@@ -45,7 +48,7 @@ type RequestDiagnosticsHttpAuthorizer = (params: {
   req: http.IncomingMessage;
   res: http.ServerResponse;
   daemonRequest: Pick<DaemonRequest, 'command' | 'positionals'>;
-}) => Promise<{ tenantId?: string } | null>;
+}) => Promise<{ tenantId?: string; sessionNamespace?: TenantSessionNamespace } | null>;
 
 export type RequestDiagnosticsHttpOptions = {
   req: http.IncomingMessage;
@@ -116,7 +119,10 @@ async function handleRequestDiagnostics(
     });
     if (!auth) return;
 
-    if (auth.tenantId && !isTenantOwnedSessionName(auth.tenantId, ref.session)) {
+    if (
+      auth.sessionNamespace &&
+      !isTenantAddressableSessionName(auth.sessionNamespace, ref.session)
+    ) {
       sendRestJsonError(
         res,
         normalizeError(

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -45,6 +45,7 @@ import { tryHandleUploadHttpRoute } from '../upload-http.ts';
 import { tryHandleDownloadableArtifactHttpRoute } from '../downloadable-artifact-http.ts';
 import { tryHandleRequestDiagnosticsHttpRoute } from '../request-diagnostics-http.ts';
 import { resolveTrustedTenant, tenantTrustRejectionError } from './tenant-trust.ts';
+import type { TenantSessionNamespace } from '../session-tenant-scope.ts';
 import { tryHandleHumanControlHttpRoute } from '../human-control-http.ts';
 import type { LeaseRegistry } from '../lease-registry.ts';
 
@@ -753,7 +754,11 @@ export async function createDaemonHttpServer(options: {
         daemonRequest.meta = {
           ...daemonRequest.meta,
           tenantId: tenantTrust.tenantId,
-          sessionIsolation: authResult.tenantId
+          // Attestation is what partitions the session namespace: only an attested
+          // tenant defaults this request to tenant isolation, so only then does
+          // `scopeRequestSession` name the session `<tenant>:...`. The diagnostics
+          // route reads the same distinction back out of `authorizeAuxiliaryHttpRequest`.
+          sessionIsolation: tenantTrust.attested
             ? (daemonRequest.meta?.sessionIsolation ??
               daemonRequest.flags?.sessionIsolation ??
               'tenant')
@@ -870,13 +875,20 @@ function statusCodeForDaemonError(error: {
   return statusCodeForNormalizedError(error.code);
 }
 
+/**
+ * The token/auth-hook gate every non-RPC route shares. `sessionNamespace` is the
+ * naming precondition the session-addressed routes need: present only when the
+ * caller carries a tenant at all, and `partitioned` exactly when that tenant is
+ * attested, which is the same condition the `/rpc` handler above turns into
+ * `sessionIsolation: 'tenant'`.
+ */
 async function authorizeAuxiliaryHttpRequest(params: {
   req: http.IncomingMessage;
   res: http.ServerResponse;
   authHook: HttpAuthHook | null;
   expectedToken?: string;
   daemonRequest: Pick<DaemonRequest, 'command' | 'positionals'>;
-}): Promise<{ tenantId?: string } | null> {
+}): Promise<{ tenantId?: string; sessionNamespace?: TenantSessionNamespace } | null> {
   const { req, res, authHook, expectedToken, daemonRequest } = params;
   const token = resolveToken({}, req.headers);
   const tenantId = normalizeTenantId(readHeaderValue(req.headers, DAEMON_HTTP_TENANT_HEADER));
@@ -903,17 +915,7 @@ async function authorizeAuxiliaryHttpRequest(params: {
     },
   });
   if (!authResult.ok) {
-    res.statusCode = authResult.statusCode;
-    res.setHeader('content-type', 'application/json');
-    res.end(
-      JSON.stringify({
-        ok: false,
-        error:
-          authResult.response.error?.data?.message ??
-          authResult.response.error?.message ??
-          'Unauthorized',
-      }),
-    );
+    sendAuxiliaryAuthHookRejection(res, authResult);
     return null;
   }
 
@@ -927,7 +929,34 @@ async function authorizeAuxiliaryHttpRequest(params: {
     return null;
   }
 
-  return { tenantId: tenantTrust.tenantId };
+  const trustedTenant = tenantTrust.tenantId;
+  return {
+    tenantId: trustedTenant,
+    ...(trustedTenant
+      ? { sessionNamespace: { tenant: trustedTenant, partitioned: tenantTrust.attested } }
+      : {}),
+  };
+}
+
+/**
+ * An auth hook's own rejection, rendered as the flat REST error these routes
+ * answer with rather than the JSON-RPC envelope the hook decision carries.
+ */
+function sendAuxiliaryAuthHookRejection(
+  res: http.ServerResponse,
+  decision: Extract<HttpAuthDecision, { ok: false }>,
+): void {
+  res.statusCode = decision.statusCode;
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      ok: false,
+      error:
+        decision.response.error?.data?.message ??
+        decision.response.error?.message ??
+        'Unauthorized',
+    }),
+  );
 }
 
 function readHeaderValue(headers: IncomingHttpHeaders, name: string): string | undefined {

--- a/src/daemon/server/tenant-trust.ts
+++ b/src/daemon/server/tenant-trust.ts
@@ -1,7 +1,15 @@
 import { AppError, normalizeError } from '@agent-device/kernel/errors';
 
+/**
+ * `attested` separates the two ways a request can carry a trusted tenant, because
+ * the daemon treats them differently everywhere downstream: an ATTESTED tenant
+ * forces `sessionIsolation: 'tenant'`, so `scopeRequestSession` partitions the
+ * caller's session namespace beneath `<tenant>:`. A merely DECLARED one (no auth
+ * hook is configured, so the header is taken at face value) partitions nothing —
+ * the same caller can already reach any session over `/rpc`.
+ */
 export type TenantTrustDecision =
-  | { trusted: true; tenantId: string | undefined }
+  | { trusted: true; tenantId: string | undefined; attested: boolean }
   | { trusted: false };
 
 export function resolveTrustedTenant(params: {
@@ -10,8 +18,10 @@ export function resolveTrustedTenant(params: {
   clientDeclaredTenant: string | undefined;
 }): TenantTrustDecision {
   const { hookConfigured, hookAttestedTenant, clientDeclaredTenant } = params;
-  if (hookAttestedTenant) return { trusted: true, tenantId: hookAttestedTenant };
-  if (!hookConfigured) return { trusted: true, tenantId: clientDeclaredTenant };
+  if (hookAttestedTenant) return { trusted: true, tenantId: hookAttestedTenant, attested: true };
+  if (!hookConfigured) {
+    return { trusted: true, tenantId: clientDeclaredTenant, attested: false };
+  }
   return { trusted: false };
 }
 

--- a/src/daemon/session-tenant-scope.ts
+++ b/src/daemon/session-tenant-scope.ts
@@ -6,7 +6,32 @@
  * (`request-admission.ts`) names the session, and the request diagnostics route
  * (`request-diagnostics-http.ts`, #1801) decides from the name alone whether a
  * caller may read that session's record long after the session itself is gone.
+ *
+ * The naming side has a precondition the reading side must honor: it applies the
+ * prefix ONLY under tenant isolation, which the daemon forces exactly when the
+ * auth hook ATTESTS the tenant (`http-server.ts`). A tenant the caller merely
+ * declared — the `x-agent-device-tenant` header on a daemon with no auth hook —
+ * never scopes anything, so its sessions keep the plain names the client asked
+ * for (`default`, `cwd:<hash>:default`). Reading the prefix rule onto those names
+ * made the record read stricter than the write that produced it, and refused a
+ * caller its own record; `isTenantAddressableSessionName` is the rule with that
+ * precondition attached, so the two sides cannot disagree again.
  */
+
+/**
+ * A caller's session namespace as the daemon actually partitions it.
+ *
+ * `partitioned` is the naming precondition, not a permission level: true means
+ * `scopeRequestSession` has put every session this caller can reach beneath
+ * `<tenant>:`, so a name outside that prefix cannot be the caller's own. False
+ * means the tenant is an unattested label the daemon never partitioned by — the
+ * same caller can already run any command in any session over `/rpc` — so the
+ * prefix carries no ownership to check.
+ */
+export type TenantSessionNamespace = {
+  tenant: string;
+  partitioned: boolean;
+};
 
 export function tenantScopedSessionName(tenant: string, session: string): string {
   return isTenantOwnedSessionName(tenant, session) ? session : `${tenant}:${session}`;
@@ -14,4 +39,17 @@ export function tenantScopedSessionName(tenant: string, session: string): string
 
 export function isTenantOwnedSessionName(tenant: string, sessionName: string): boolean {
   return sessionName.startsWith(`${tenant}:`);
+}
+
+/**
+ * Whether a caller in `namespace` may address `sessionName` by name — the read
+ * counterpart of `scopeRequestSession`'s naming decision, and the only tenant
+ * rule the diagnostics route applies.
+ */
+export function isTenantAddressableSessionName(
+  namespace: TenantSessionNamespace,
+  sessionName: string,
+): boolean {
+  if (!namespace.partitioned) return true;
+  return isTenantOwnedSessionName(namespace.tenant, sessionName);
 }

--- a/test/integration/provider-scenarios/remote-proxy-request-diagnostics.test.ts
+++ b/test/integration/provider-scenarios/remote-proxy-request-diagnostics.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A client behind `agent-device proxy` must get the SAME failure envelope a
+ * client on the daemon host gets (#1801), including for the plain sessions
+ * `scopeRequestSession` leaves unscoped.
+ *
+ * The proxy forwards `x-agent-device-tenant` verbatim, so a caller that carries
+ * a tenant identity reaches the diagnostics route with that identity even
+ * though its command ran in a plain session such as `cwd:<hash>:default`. The
+ * record read must not be stricter than the write that produced it: on a daemon
+ * with no auth hook that same caller can already run any command in any session
+ * over `/rpc`.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+import { createDaemonHttpServer } from '../../../src/daemon/server/http-server.ts';
+import { createDaemonProxyServer } from '../../../src/remote/daemon-proxy.ts';
+import { localizeRemoteDaemonError } from '../../../src/remote/remote-request-diagnostics.ts';
+import { resolveSessionRequestLogPath } from '../../../src/daemon/session-artifact-paths.ts';
+import { safeSessionName } from '../../../src/daemon/session-paths.ts';
+import type { DaemonError } from '@agent-device/kernel/errors';
+import type { DaemonResponse } from '../../../src/daemon/daemon-request.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../../src/__tests__/test-utils/loopback.ts';
+import { mkdtempForTestSync } from '../../../src/__tests__/test-utils/tmp-dir.ts';
+
+const UPSTREAM_TOKEN = 'upstream-token';
+const PROXY_TOKEN = 'proxy-token';
+const TENANT = 'local-proxy-tenant';
+/** What `resolveEffectiveSessionName` names an implicit session outside tenant isolation. */
+const PLAIN_SESSION = 'cwd:9f1:default';
+const REQUEST_ID = 'abc123';
+const RECORD = '{"phase":"request_start"}\n{"phase":"request_failed"}\n';
+
+function remoteError(): DaemonError {
+  return {
+    code: 'COMMAND_FAILED',
+    message: 'wait timed out',
+    logPath: '/Users/daemon-host/.agent-device/sessions/cwd_9f1_default/requests/abc123.ndjson',
+    diagnosticsRecord: { session: PLAIN_SESSION, requestId: REQUEST_ID },
+  };
+}
+
+test('Provider-backed integration local proxy serves a plain-session diagnostics record', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t, 'local proxy request diagnostics coverage')) return;
+
+  const stateDir = mkdtempForTestSync('agent-device-proxy-request-diagnostics-');
+  const sessionsDir = path.join(stateDir, 'sessions');
+  const recordPath = resolveSessionRequestLogPath(
+    path.join(sessionsDir, safeSessionName(PLAIN_SESSION)),
+    REQUEST_ID,
+  );
+  fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+  fs.writeFileSync(recordPath, RECORD);
+
+  const upstream = await createDaemonHttpServer({
+    token: UPSTREAM_TOKEN,
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+    resolveRequestDiagnosticsPath: (ref) =>
+      resolveSessionRequestLogPath(
+        path.join(sessionsDir, safeSessionName(ref.session)),
+        ref.requestId,
+      ),
+  });
+  const upstreamBaseUrl = `http://127.0.0.1:${await listenOnLoopback(upstream)}`;
+  const proxy = createDaemonProxyServer({
+    upstreamBaseUrl,
+    upstreamToken: UPSTREAM_TOKEN,
+    clientToken: PROXY_TOKEN,
+  });
+
+  try {
+    const proxyBaseUrl = `http://127.0.0.1:${await listenOnLoopback(proxy)}/agent-device`;
+
+    const throughProxy = await localizeRemoteDaemonError(remoteError(), {
+      endpoint: { baseUrl: proxyBaseUrl, token: PROXY_TOKEN, tenantId: TENANT },
+      stateDir: path.join(stateDir, 'proxy-client'),
+    });
+    assert.equal(throughProxy.logPathUnavailable, undefined, 'the proxy must serve the record');
+    assert.notEqual(throughProxy.logPath, undefined);
+    assert.equal(fs.readFileSync(throughProxy.logPath!, 'utf8'), RECORD);
+
+    // Parity: the client on the daemon host localizes byte-identical content.
+    const direct = await localizeRemoteDaemonError(remoteError(), {
+      endpoint: { baseUrl: upstreamBaseUrl, token: UPSTREAM_TOKEN, tenantId: TENANT },
+      stateDir: path.join(stateDir, 'direct-client'),
+    });
+    assert.equal(direct.logPathUnavailable, undefined);
+    assert.equal(fs.readFileSync(direct.logPath!, 'utf8'), RECORD);
+  } finally {
+    await closeLoopbackServer(proxy);
+    await closeLoopbackServer(upstream);
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/test/wire-compat/ledger.json
+++ b/test/wire-compat/ledger.json
@@ -80,9 +80,9 @@
     "src/daemon/http-errors.ts#statusCodeForNormalizedError": "sha256:20ad272162e28425920bd2dcb4da5ec104bd7e8be2028b902b05bfa4da3df966",
     "src/daemon/http-request-target.ts#decodeUriSegment": "sha256:b37622771ea4e61d1a9820169dbdc5809b5c38889bfad79277d7b22f3c3f1ef1",
     "src/daemon/request-diagnostics-http.ts#REQUEST_DIAGNOSTICS_CONTENT_TYPE": "sha256:16bbd9ae7eaeaaa8c8cbd6e65c4ce786a6c5230c5351288228bbf1a6f11bdcdc",
-    "src/daemon/request-diagnostics-http.ts#RequestDiagnosticsHttpAuthorizer": "sha256:20761c39f434c675bb3405838dded5640bb623737957257e0452ebd46035eef1",
+    "src/daemon/request-diagnostics-http.ts#RequestDiagnosticsHttpAuthorizer": "sha256:24b0fa6b1d965e5cf6503a4665148dc6360c56bf5a0ae710eeaa76a73a62c52a",
     "src/daemon/request-diagnostics-http.ts#RequestDiagnosticsHttpOptions": "sha256:cd2c0dda77d2bc434857aea07206a5491ce5f0b82cb86628569f607d6c2cebcf",
-    "src/daemon/request-diagnostics-http.ts#handleRequestDiagnostics": "sha256:83d80f1386028ee56e8954949206dbb723d8411e5c13d25565d32ce3ee84dd9e",
+    "src/daemon/request-diagnostics-http.ts#handleRequestDiagnostics": "sha256:32c3d100176dd99ecbb61f8050d05b1cda64b7be1944a2cd16633e83fa78660b",
     "src/daemon/request-diagnostics-http.ts#resolveRequestDiagnosticsHttpRoute": "sha256:4ff07623b27a6f7461e1addb87aabd149904da63f7462149ae4114d14336cde0",
     "src/daemon/request-progress-protocol.ts#DaemonProgressEnvelope": "sha256:16162d01cfc43fc6a0198dbba3358981c1a278a70f7494ebe70d051f517cfb22",
     "src/daemon/request-progress-protocol.ts#DaemonResponseEnvelope": "sha256:202ae64836af890549a1d95963903f9a506294b80bd0862c1b708e72d7f286d0",
@@ -105,7 +105,7 @@
     "src/daemon/server/http-server.ts#MAX_HTTP_RPC_BODY_BYTES": "sha256:3cb06e12b3110fa27e390d5c6473578b3f13c93b9f2b571e0e8e42d7ce29d48a",
     "src/daemon/server/http-server.ts#RELEASE_MATERIALIZED_PATHS_RPC_METHODS": "sha256:75a18d3496894309dd6042b16c4dcc241c16ec6336783e6310eddd6db7437ccb",
     "src/daemon/server/http-server.ts#SUPPORTED_RPC_METHODS": "sha256:4d5ed730dcb669b0dacca3bb4977f35686bab9b7fb464c0590fd50f838e6c243",
-    "src/daemon/server/http-server.ts#authorizeAuxiliaryHttpRequest": "sha256:f74f2fc70313a4cc048bcd531f9831970cab75c2b098688e846c44b3c37a7185",
+    "src/daemon/server/http-server.ts#authorizeAuxiliaryHttpRequest": "sha256:1c323f97c3cefec8f95633b6abd127342bf75494bfb109d1cc6eadf3ceacaeae",
     "src/daemon/server/http-server.ts#createRpcError": "sha256:1921762129636afc7772937d48e8afb8f09047b343e3a27d18b49c1c4385bbe8",
     "src/daemon/server/http-server.ts#enforceDaemonToken": "sha256:60036cffc34388b33fc0dad39c905d9cb3fc18c9ed0cf24255bb7105f5d444c7",
     "src/daemon/server/http-server.ts#isCommandRpcMethod": "sha256:9922102ba9c72c3032f205717d772ab7c3506c6f3012f55b8e7e5636b672ed7e",
@@ -121,6 +121,8 @@
     "src/daemon/server/http-server.ts#toReleaseMaterializedPathsDaemonRequest": "sha256:708736ca03d6a3fc449bb408382dbd509e490de1f84ecc8771fd77d4adda0154",
     "src/daemon/server/http-server.ts#writeProgressEnvelope": "sha256:ca661f6dd2de6e517c520dbd1e20b59b24b58d925157ed06123149ed2bc0fa3b",
     "src/daemon/server/http-server.ts#writeRpcResponseEnvelope": "sha256:7a8155e9fcbb53485489728250a85109b5dab0d96cdd4aa8b7e7eb87a4898ddb",
+    "src/daemon/session-tenant-scope.ts#TenantSessionNamespace": "sha256:a6613d22933caa053e479f05b7f016664f6be8d0afdbbf81e578ff497fc1b13d",
+    "src/daemon/session-tenant-scope.ts#isTenantAddressableSessionName": "sha256:cc8ae18094b7f57d4bb694678f84ba767637b1087fd28058ffd6a3c92c79f05d",
     "src/daemon/session-tenant-scope.ts#isTenantOwnedSessionName": "sha256:c3cff883507d462548846554b89779cb815ceb265714575e57bee022b57c4bd1",
     "src/daemon/upload-http.ts#AuxiliaryHttpAuthorizer": "sha256:6521ffa355c57af97bfc8095699f2a2b38745a6ef8d61a34c8cfc80ee690b6b5",
     "src/daemon/upload-http.ts#DIRECT_UPLOAD_PATH_PREFIX": "sha256:6fe7d42a65baceb595d96b6aa83fe9aa84527d9aa2e448d7ef47882d31a03276",
@@ -213,11 +215,6 @@
       "rationale": "#2110 reads the optional providerApp lease-allocation parameter into the existing flags bag. Released protocol-2 clients omit it and follow the unchanged allocation path; no existing field is required or reinterpreted."
     },
     {
-      "declaration": "src/daemon/server/http-server.ts#authorizeAuxiliaryHttpRequest",
-      "digest": "sha256:f74f2fc70313a4cc048bcd531f9831970cab75c2b098688e846c44b3c37a7185",
-      "rationale": "#2095 adds one new rejection condition (a configured-but-tenant-silent auth hook plus a client-declared tenant) that answers with the same 401 `{ok:false,error,code}` REST shape `sendRestJsonError` already sends for the token-error and hook-rejected cases on this route. An older client already parses that shape; nothing new appears on the wire, only a request that used to be silently trusted now gets an error it already knows how to read."
-    },
-    {
       "declaration": "packages/kernel/src/errors.ts#DaemonError",
       "digest": "sha256:ae49c9c9c8fb93bb6b31ab865f37cc8b0db6c1b6ff026cc2791425b772c162a6",
       "rationale": "#1801 and #1862 add optional error fields, most recently the structured `cause`. A peer on protocol 2 that does not send them is unchanged, and one that does not read them keeps parsing every field it read before."
@@ -271,6 +268,21 @@
       "declaration": "src/daemon-client/daemon-client-transport.ts#readRemoteDaemonHealth",
       "digest": "sha256:d833b61b242d0f594d69282b2de2362066c1bcfee2f0c687bd2394d585550c22",
       "rationale": "#2198 slice B: the ADR 0006 refusal now covers every link a command RPC crosses, so a proxy whose daemon speaks another protocol version fails at health, before the RPC, exactly like a skewed proxy. The comparison against DAEMON_RPC_PROTOCOL_VERSION is unchanged and strictly wider; a compatible chain passes as before."
+    },
+    {
+      "declaration": "src/daemon/server/http-server.ts#authorizeAuxiliaryHttpRequest",
+      "digest": "sha256:1c323f97c3cefec8f95633b6abd127342bf75494bfb109d1cc6eadf3ceacaeae",
+      "rationale": "#2198 context: adds one optional field to the value this DAEMON-INTERNAL gate hands its own route handlers — sessionNamespace, the caller's tenant plus whether the daemon partitioned that caller's session names. Nothing about it is serialized: no request header is read that was not read before, no response field is added, and a refusal keeps the same 401 {ok:false,error,code} REST body sendRestJsonError already sent. What it enables is a refusal DROPPED, never one added — an unattested (client-declared) tenant no longer has the <tenant>: prefix rule applied to it, because scopeRequestSession never applied that prefix to its sessions either. A released peer that now gets 200 where it got 401 is getting the ndjson record it asked for and already parses."
+    },
+    {
+      "declaration": "src/daemon/request-diagnostics-http.ts#RequestDiagnosticsHttpAuthorizer",
+      "digest": "sha256:24b0fa6b1d965e5cf6503a4665148dc6360c56bf5a0ae710eeaa76a73a62c52a",
+      "rationale": "#2198 context: widens the authorizer callback's result by the same optional sessionNamespace field, so the route can put its tenant question to session-tenant-scope instead of re-deriving the rule locally. The callback is supplied by createDaemonHttpServer inside this process and never crosses the wire; a caller of the route sends and parses exactly the bytes it did before."
+    },
+    {
+      "declaration": "src/daemon/request-diagnostics-http.ts#handleRequestDiagnostics",
+      "digest": "sha256:32c3d100176dd99ecbb61f8050d05b1cda64b7be1944a2cd16633e83fa78660b",
+      "rationale": "#2198 context: asks isTenantAddressableSessionName instead of applying the prefix rule locally. Same UNAUTHORIZED code, same 'Session is outside this tenant' message and same 401 body for the attested-tenant case the rule still refuses; the only difference a peer can observe is that an unattested tenant now gets the 200 + ndjson record it already knows how to read instead of a 401 it could not act on."
     }
   ]
 }

--- a/test/wire-compat/surface.ts
+++ b/test/wire-compat/surface.ts
@@ -48,6 +48,7 @@ const HTTP_SERVER = 'src/daemon/server/http-server.ts';
 const UPLOAD_HTTP = 'src/daemon/upload-http.ts';
 const ARTIFACT_HTTP = 'src/daemon/downloadable-artifact-http.ts';
 const REQUEST_DIAGNOSTICS_HTTP = 'src/daemon/request-diagnostics-http.ts';
+const SESSION_TENANT_SCOPE = 'src/daemon/session-tenant-scope.ts';
 const HTTP_REQUEST_TARGET = 'src/daemon/http-request-target.ts';
 const REMOTE_REQUEST_DIAGNOSTICS = 'src/remote/remote-request-diagnostics.ts';
 const PROGRESS_PROTOCOL = 'src/daemon/request-progress-protocol.ts';
@@ -150,9 +151,16 @@ export const WIRE_SURFACE: readonly WireSurfaceGroup[] = [
       ...from(ARTIFACT_HTTP, 'DownloadableArtifactHttpAuthorizer'),
       // The diagnostics route's authorization: the same token/auth-hook gate as
       // the artifact routes, plus the tenant rule that decides which sessions a
-      // caller may read a record from (#1801).
+      // caller may read a record from (#1801). `isTenantAddressableSessionName`
+      // is that rule; the namespace it takes says whether the caller's sessions
+      // were partitioned at all, which is what the naming side keys off.
       ...from(REQUEST_DIAGNOSTICS_HTTP, 'RequestDiagnosticsHttpAuthorizer'),
-      ...from('src/daemon/session-tenant-scope.ts', 'isTenantOwnedSessionName'),
+      ...from(
+        SESSION_TENANT_SCOPE,
+        'TenantSessionNamespace',
+        'isTenantOwnedSessionName',
+        'isTenantAddressableSessionName',
+      ),
     ],
   },
   {


### PR DESCRIPTION
**This is an additional improvement, not retroactive acceptance of #2198.** #2198 is referenced only as context for where this route's authorization landed; nothing here re-opens or endorses that review.

## The defect

`GET /sessions/<session>/requests/<requestId>/diagnostics` (#1801) refused a caller its own failure record whenever the caller carried a tenant identity but its command had run in a plain, un-prefixed session.

The route applied the `<tenant>:` prefix rule to every caller with a tenant:

```ts
// src/daemon/request-diagnostics-http.ts (before)
if (auth.tenantId && !isTenantOwnedSessionName(auth.tenantId, ref.session)) -> UNAUTHORIZED
```

But the session-naming owner only writes that prefix under tenant isolation:

```ts
// src/daemon/request-admission.ts:35
if (isolation !== 'tenant') return req;   // session stays plain
```

and the daemon forces tenant isolation for exactly one class of caller — one whose tenant the auth hook **attested** (`http-server.ts`, the `/rpc` handler). A client that merely **declares** a tenant (`x-agent-device-tenant` on a daemon with no auth hook, which `resolveTrustedTenant` trusts at face value) runs in a plain session — `default`, or the `cwd:<hash>:default` that `resolveEffectiveSessionName` produces for any implicit session — gets a `diagnosticsRecord.session` naming that plain session, and is then answered 401 fetching it. Directly, and through `agent-device proxy`, which forwards the tenant header verbatim.

The read was stricter than the write. On that same daemon the same caller can already run **any** command in **any** session over `/rpc` — the two "no hook configured keeps a client-declared tenant unchanged" regressions in `http-server-tenant-trust.test.ts` prove it — so the prefix refusal denied an attacker nothing and denied honest callers their own records.

## The seam, and why it belongs to the authorization owner

`src/daemon/session-tenant-scope.ts` exists so the naming side and the record-reading side cannot disagree (its header comment says so). The disagreement was that the naming rule has a **precondition** the reading side did not carry: the prefix applies only where the namespace is actually partitioned. So the precondition now lives in that module, next to the rule:

```ts
export type TenantSessionNamespace = { tenant: string; partitioned: boolean };

export function isTenantAddressableSessionName(
  namespace: TenantSessionNamespace,
  sessionName: string,
): boolean {
  if (!namespace.partitioned) return true;
  return isTenantOwnedSessionName(namespace.tenant, sessionName);
}
```

The signal is threaded from the place that already computes it. `resolveTrustedTenant` (`server/tenant-trust.ts`) is the one function that distinguishes an attested tenant from a declared one, so its decision now reports `attested`, and `authorizeAuxiliaryHttpRequest` — the shared token/auth-hook gate for every non-RPC route — hands the route a `sessionNamespace` built from it. The `/rpc` handler's own `authResult.tenantId ? … : …` isolation default now reads `tenantTrust.attested`: same value, named for what it means. No new wire field, header, route, or public flag.

**The attested case is untouched.** An attested tenant is still refused every session outside its `<tenant>:` prefix, with the same typed `UNAUTHORIZED` / `Session is outside this tenant` error.

### One thing that differs from the reported diagnosis

The sketch suggested keeping the prefix refusal for tenant-prefixed names in the unpartitioned mode and relaxing only "plain" names. That is not decidable, and trying it would have left the main real case broken. A plain implicit session is named `cwd:<hash>:default`, so "plain" cannot mean "has no `<segment>:` prefix" — a leading-segment heuristic refuses exactly the session a CLI client actually runs in, and `cwd` is itself a reserved prefix indistinguishable from a tenant id. The route has no tenant registry and records outlive their sessions, so there is no other oracle.

So the implemented rule is the fully general one: **the prefix rule is applied only where the daemon partitioned the namespace.** Consequence, stated plainly: on a daemon with no auth hook, a caller declaring tenant B can now read a record from `tenant-a:default`. That is not a weakening — in that mode the same caller can already `POST /rpc` a command into `tenant-a:default` — but it does flip two existing assertions, so both are updated with the reason, and the cross-tenant refusal is now asserted where it is actually enforceable (under an attesting hook), which it previously was not.

### Adjacent finding, deliberately not fixed here

Even with an attested tenant, a client that sends `sessionIsolation: 'none'` keeps isolation `none` (the `/rpc` handler defers to the client's value), so it writes to a plain session and is then refused reading that record. The right fix is on the *write* side — attestation should force partitioning rather than defer — and it is a cross-tenant write-visibility question, not a read one. Left alone rather than weakening the attested read rule.

## Tests

1. **Direct retrieval** — `request-diagnostics-http.test.ts`, "serves a plain session to the tenant that ran the command": a caller with a declared tenant reads the record for session `default`.
2. **Proxy retrieval** — new `test/integration/provider-scenarios/remote-proxy-request-diagnostics.test.ts`: real daemon + `createDaemonProxyServer` + the real client (`localizeRemoteDaemonError` with `endpoint.tenantId`), asserting the localized record through the proxy and byte-identical parity with the direct fetch.
3. **Owning-client access** — `request-diagnostics-http.test.ts`, "serves the cwd-scoped session its owner ran in": the `cwd:9f1:default` shape a real implicit session actually gets.
4. **Cross-tenant refusal intact** — `http-server-tenant-trust.test.ts`, "an attested tenant is still refused a record outside its partition": under an attesting hook, `tenant-real` is refused both `tenant-other:default` and the plain `cwd:9f1:default`, each with `code: UNAUTHORIZED` / `Session is outside this tenant`, while its own `tenant-real:default` still serves 200.

Two existing assertions changed, both the unattested cross-tenant half described above: `request-diagnostics-http.test.ts`'s tenant test (renamed to say what it now proves) and the `otherTenant` half of `http-server-tenant-trust.test.ts`'s "no hook configured keeps the header-declared tenant unchanged".

## Red-then-green evidence

Cases 1, 2 and 3 were written first and run against unmodified `main`.

Cases 1 and 3, `vitest --project unit-core src/daemon/__tests__/request-diagnostics-http.test.ts`:

```
FAIL  |unit-core| ... > request diagnostics route serves a plain session to the tenant that ran the command
AssertionError: Expected values to be strictly equal:
401 !== 200
- 200
+ 401
 ❯ src/daemon/__tests__/request-diagnostics-http.test.ts:172:12

FAIL  |unit-core| ... > request diagnostics route serves the cwd-scoped session its owner ran in
AssertionError: Expected values to be strictly equal:
401 !== 200
 ❯ src/daemon/__tests__/request-diagnostics-http.test.ts:188:12

 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

Case 2, `vitest --project provider-integration test/integration/provider-scenarios/remote-proxy-request-diagnostics.test.ts`:

```
FAIL  |provider-integration| ... > Provider-backed integration local proxy serves a plain-session diagnostics record
AssertionError: the proxy must serve the record
+ 'remote daemon http://127.0.0.1:57696/agent-device, request abc123: HTTP 401'
- undefined
 ❯ test/integration/provider-scenarios/remote-proxy-request-diagnostics.test.ts:84:12

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Case 4 was planted red twice against the finished fix — once per side of the seam — to prove it watches the rule and the threading, not just the route.

Plant A, the rule (`isTenantAddressableSessionName` short-circuited to `return true`):

```
FAIL  |unit-core| ... > aux route: an attested tenant is still refused a record outside its partition
AssertionError: expected 401 for session tenant-other:default
200 !== 401
 ❯ src/daemon/__tests__/http-server-tenant-trust.test.ts:432:16
      Tests  1 failed | 14 skipped (15)
```

Plant B, the threading (`http-server.ts` hard-coding `partitioned: false`):

```
AssertionError: expected 401 for session tenant-other:default
      Tests  1 failed | 14 skipped (15)
```

Both plants reverted; all four cases green.

## Wire ledger

`isTenantOwnedSessionName` was already listed in `test/wire-compat/surface.ts`; `TenantSessionNamespace` and `isTenantAddressableSessionName` join it (the closure walk demands the type, since the listed authorizer signatures reach it). Five digests pasted into `ledger.json`, and `compatibleChanges` acks added for the three declarations that moved — `authorizeAuxiliaryHttpRequest` (its stale #2095 ack dropped, per the "an ack expires with its digest" rule), `RequestDiagnosticsHttpAuthorizer`, `handleRequestDiagnostics`. All three are additive: the new field is an in-process value, never serialized, and the only observable difference is a 401 that becomes the 200 + ndjson the caller already parses. No `wire-mutations.test.ts` `from:` snippet touched; no new break class, so no new mutation case.

## Gates

Run from the worktree:

- `pnpm format` (oxfmt) — clean
- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm check:layering` — OK
- `pnpm check:daemon-wire-compat` — `checked against v0.20.10 (protocol unchanged): 176 declarations, 18 changed, 0 removed, 14 added, 18 moved`
- `pnpm check:affected --run` — **all runnable checks passed**: format, lint, typecheck, layering, fallow (`✓ No issues in 9 changed files`), build, vitest-related (204 files / 1259 tests passed), daemon-wire-compat

`fallow` initially flagged one new finding: `authorizeAuxiliaryHttpRequest` crossed the 60-LOC "very high" threshold. Fixed by extracting `sendAuxiliaryAuthHookRejection` — the one place these routes render a hook rejection as a flat REST error rather than the JSON-RPC envelope the decision carries — rather than by suppressing it.

Two runs died to local memory pressure before the clean one (~13.4G of 14.3G swap in use): a vitest teardown race in the unrelated `session-devices-batch-runtime.test.ts` (passes in isolation; the apple/xml import-after-teardown signature), and one silent worker death. Both cleared on re-run; the recorded results above are from clean runs. No pre-existing host-kit code-signature failures were hit.
