### PR TITLE
fix(daemon): stop an attested tenant from downgrading its own isolation

### DIFF
--- a/src/daemon/__tests__/http-server-tenant-trust.test.ts
+++ b/src/daemon/__tests__/http-server-tenant-trust.test.ts
@@ -323,6 +323,35 @@ test('RPC: no hook configured keeps a client-declared flags.tenant unchanged (re
   });
 });
 
+test('RPC: an attested tenant cannot downgrade its own session isolation', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+  const root = mkdtempForTestSync('agent-device-tenant-trust-downgrade-');
+  try {
+    const hookPath = writeAttestingAuthHook(root);
+    await withRpcServer(hookPath, async ({ baseUrl, observedRequests }) => {
+      const response = await callRpc(baseUrl, {
+        jsonrpc: '2.0',
+        id: 'rpc-downgrade',
+        method: 'agent_device.command',
+        params: {
+          command: 'session_list',
+          positionals: [],
+          // Both carriers `scopeRequestSession` reads, and both the ones downstream
+          // consumers read: neither may survive as `none` under an attested tenant.
+          meta: { tenantId: ATTESTED_TENANT_ID, sessionIsolation: 'none' },
+          flags: { sessionIsolation: 'none' },
+        },
+      });
+      assert.equal(response.status, 200);
+      assert.equal(observedRequests[0]?.meta?.tenantId, ATTESTED_TENANT_ID);
+      assert.equal(observedRequests[0]?.meta?.sessionIsolation, 'tenant');
+      assert.equal(observedRequests[0]?.flags?.sessionIsolation, 'tenant');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('aux route: a hook configured but silent on tenant refuses a client-declared header claiming another tenant', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
   const root = mkdtempForTestSync('agent-device-tenant-trust-aux-');

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -755,17 +755,23 @@ export async function createDaemonHttpServer(options: {
           ...daemonRequest.meta,
           tenantId: tenantTrust.tenantId,
           // Attestation is what partitions the session namespace: only an attested
-          // tenant defaults this request to tenant isolation, so only then does
-          // `scopeRequestSession` name the session `<tenant>:...`. The diagnostics
-          // route reads the same distinction back out of `authorizeAuxiliaryHttpRequest`.
-          sessionIsolation: tenantTrust.attested
-            ? (daemonRequest.meta?.sessionIsolation ??
-              daemonRequest.flags?.sessionIsolation ??
-              'tenant')
-            : daemonRequest.meta?.sessionIsolation,
+          // tenant gets tenant isolation, so only then does `scopeRequestSession`
+          // name the session `<tenant>:...`. The diagnostics route reads the same
+          // distinction back out of `authorizeAuxiliaryHttpRequest`.
+          //
+          // When the hook attested the tenant, isolation is the SERVER's answer and
+          // the request does not get a say: honoring a client-supplied `'none'` here
+          // dropped the prefix and dropped the caller into the `cwd:<hash>:` namespace
+          // instead, which the client names and another tenant can name too.
+          sessionIsolation: tenantTrust.attested ? 'tenant' : daemonRequest.meta?.sessionIsolation,
         };
         if (daemonRequest.flags?.tenant !== undefined) {
           daemonRequest.flags = { ...daemonRequest.flags, tenant: tenantTrust.tenantId };
+        }
+        // Consumers that read the flag rather than the meta (`session-doctor-options.ts`)
+        // must not see the isolation the meta just overrode.
+        if (tenantTrust.attested && daemonRequest.flags?.sessionIsolation !== undefined) {
+          daemonRequest.flags = { ...daemonRequest.flags, sessionIsolation: 'tenant' };
         }
         daemonRequest = restrictRemoteHttpRequest(
           daemonRequest,


### PR DESCRIPTION
Found while reviewing #2382. **Stacked on #2382** — it uses the attested-vs-declared distinction that PR introduces. Review and merge that one first; this branch is #2382 plus one commit.

## The defect

When an auth hook **attests** a tenant, session isolation is the server's answer — attestation is the whole point. The RPC handler only *defaulted* to it:

```ts
sessionIsolation: tenantTrust.attested
  ? (daemonRequest.meta?.sessionIsolation ?? daemonRequest.flags?.sessionIsolation ?? 'tenant')
  : daemonRequest.meta?.sessionIsolation,
```

A client-supplied `sessionIsolation: 'none'` wins that `??` chain. `scopeRequestSession` then returns early (`if (isolation !== 'tenant') return req`), the session never gets its `<tenant>:` prefix, and `resolveSessionScope` falls through to the **cwd scope** — a `cwd:<hash>:` namespace the client names, and that another attested tenant can name identically.

So an attested tenant could opt out of the partition that attestation exists to enforce, and share a session namespace with another tenant. This is a cross-tenant isolation hole in exactly the deployment where isolation is meant to be a boundary.

It is distinct from #2382's 401. That one was a *read* refused too strictly on a daemon with no partition at all; this is a *write* landing outside the partition on a daemon that has one.

## The fix

An attested tenant always gets tenant isolation. Both carriers are normalized, because `scopeRequestSession` reads `meta ?? flags` while `session-doctor-options.ts:160` reads the flag alone — leaving the flag at `'none'` would let a consumer see an isolation the meta had just overridden.

The declared-tenant path is untouched: with no auth hook the client's isolation is still its own, because nothing is partitioned there and the token is the gate (the reasoning #2382 documents).

## Red-then-green

New regression `RPC: an attested tenant cannot downgrade its own session isolation`, sending `'none'` on **both** carriers against an attesting hook.

- Against the unmodified parent: `AssertionError: Expected values to be strictly equal: Expected: "tenant" / Received: "none"` at the meta assertion.
- Planted red a second time against the finished fix with only the flags-side guard disabled: same failure, now on the flags assertion — so the test watches both carriers, not just the one that happened to fail first.

## Validation

- `src/daemon/__tests__/http-server-tenant-trust.test.ts` — 16 passed
- `src/daemon/__tests__/request-diagnostics-http.test.ts` — 7 passed
- `vitest related` on `http-server.ts` — 26 files, 118 passed
- `vitest related` on `request-admission.ts`, `session-tenant-scope.ts`, `session-routing.ts` — passed
- `test/integration/provider-scenarios/remote-proxy-parity.test.ts` — passed
- `test/wire-compat` — 39 passed (no surface change; `sessionIsolation` is existing request meta)
- `pnpm typecheck`, `pnpm lint`, `pnpm format` — clean

## Not fixed here

Whether an attested tenant should be able to address a session *name* outside its prefix by other routes is a wider question than this one-line decision; this change only stops the isolation mode itself from being client-chosen.
