### PR TITLE
perf(apple): gate the launch-observation probe on the snapshot circuit breaker

### DIFF
--- a/packages/platform-apple/src/snapshot-observability.test.ts
+++ b/packages/platform-apple/src/snapshot-observability.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createLaunchObservationProbe } from './snapshot-observability.ts';
 import type { SnapshotSourceFailure, SnapshotSourceOutcome } from './snapshot-source-facade.ts';
+import type { SimulatorSnapshotTarget } from './snapshot-target.ts';
 
 const simulator = {
   platform: 'apple',
@@ -42,16 +43,19 @@ const acquired = (): SnapshotSourceOutcome => ({
 function probe(
   outcomes: readonly SnapshotSourceOutcome[],
   clock: { now(): number; sleep(ms: number): Promise<void> },
+  isBridgeDisabled: (probed: SimulatorSnapshotTarget) => boolean = () => false,
 ) {
   let index = 0;
   const acquire = vi.fn(async () => outcomes[Math.min(index++, outcomes.length - 1)]!);
   const sleep = vi.fn(clock.sleep);
+  const gate = vi.fn(isBridgeDisabled);
   const observe = createLaunchObservationProbe({
     source: { acquire, close: async () => {} },
     resolveTarget: async () => target,
     clock: { now: clock.now, sleep },
+    isBridgeDisabled: gate,
   });
-  return { observe, acquire, sleep };
+  return { observe, acquire, sleep, gate };
 }
 
 test('a launched app is observable as soon as the bridge publishes it', async () => {
@@ -138,15 +142,30 @@ test('a failure outside the launch transition ends the wait at once', async () =
   expect(sleep).not.toHaveBeenCalled();
 });
 
+test('a generation whose bridge circuit is open is unobservable without a bridge round trip', async () => {
+  const { observe, acquire, sleep, gate } = probe(
+    [acquired()],
+    { now: () => 0, sleep: async () => {} },
+    () => true,
+  );
+  await expect(observe.awaitObservable(simulator, 'com.example.app', signal())).resolves.toBe(
+    'unobservable',
+  );
+  expect(gate).toHaveBeenCalledWith(target);
+  expect(acquire).not.toHaveBeenCalled();
+  expect(sleep).not.toHaveBeenCalled();
+});
+
 test.each([
   ['a physical iOS device', { ...simulator, kind: 'device' as const }],
   ['a tvOS Simulator', { ...simulator, appleOs: 'tvos' as const, target: 'tv' as const }],
 ])('%s has no bridge and is not eligible', async (_name, device) => {
-  const { observe, acquire } = probe([acquired()], { now: () => 0, sleep: async () => {} });
+  const { observe, acquire, gate } = probe([acquired()], { now: () => 0, sleep: async () => {} });
   await expect(observe.awaitObservable(device, 'com.example.app', signal())).resolves.toBe(
     'not-eligible',
   );
   expect(acquire).not.toHaveBeenCalled();
+  expect(gate).not.toHaveBeenCalled();
 });
 
 function signal(): AbortSignal {

--- a/packages/platform-apple/src/snapshot-observability.test.ts
+++ b/packages/platform-apple/src/snapshot-observability.test.ts
@@ -1,4 +1,8 @@
 import { expect, test, vi } from 'vitest';
+import {
+  countDiagnosticEventsByPhase,
+  withDiagnosticsScope,
+} from '@agent-device/host-kit/diagnostics';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import { createLaunchObservationProbe } from './snapshot-observability.ts';
 import type { SnapshotSourceFailure, SnapshotSourceOutcome } from './snapshot-source-facade.ts';
@@ -154,6 +158,30 @@ test('a generation whose bridge circuit is open is unobservable without a bridge
   expect(gate).toHaveBeenCalledWith(target);
   expect(acquire).not.toHaveBeenCalled();
   expect(sleep).not.toHaveBeenCalled();
+});
+
+test('the skip is reported, so a live run can tell it from an unresolvable target', async () => {
+  // Both verdicts are `unobservable` with zero acquisitions; only the diagnostic separates a
+  // circuit skip from a target that never resolved.
+  await withDiagnosticsScope({ command: 'open' }, async () => {
+    const skipped = probe([acquired()], { now: () => 0, sleep: async () => {} }, () => true);
+    await skipped.observe.awaitObservable(simulator, 'com.example.app', signal());
+    expect(countDiagnosticEventsByPhase(['ios_launch_observation_skipped'])).toBe(1);
+  });
+  await withDiagnosticsScope({ command: 'open' }, async () => {
+    const unresolvable = createLaunchObservationProbe({
+      source: { acquire: vi.fn(), close: async () => {} },
+      resolveTarget: async () => {
+        throw new Error('no target');
+      },
+      clock: { now: () => 0, sleep: async () => {} },
+      isBridgeDisabled: () => true,
+    });
+    await expect(
+      unresolvable.awaitObservable(simulator, 'com.example.app', signal()),
+    ).resolves.toBe('unobservable');
+    expect(countDiagnosticEventsByPhase(['ios_launch_observation_skipped'])).toBe(0);
+  });
 });
 
 test.each([

--- a/packages/platform-apple/src/snapshot-observability.ts
+++ b/packages/platform-apple/src/snapshot-observability.ts
@@ -5,7 +5,10 @@ import {
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { SimulatorSnapshotSource } from './snapshot-source-facade.ts';
-import type { SimulatorSnapshotTargetResolver } from './snapshot-target.ts';
+import type {
+  SimulatorSnapshotTarget,
+  SimulatorSnapshotTargetResolver,
+} from './snapshot-target.ts';
 
 /**
  * What an `open` learned about the app it just launched on a local Simulator: `observable` means
@@ -51,6 +54,7 @@ export function createLaunchObservationProbe(
     source: SimulatorSnapshotSource;
     resolveTarget: SimulatorSnapshotTargetResolver;
     clock: PlatformRuntimeHost['clock'];
+    isBridgeDisabled: (target: SimulatorSnapshotTarget) => boolean;
   }>,
 ): LaunchObservationPort {
   const hint = deriveIosCaptureHint(createIosSnapshotRequest({ depth: 1, interactiveOnly: true }));
@@ -62,6 +66,10 @@ export function createLaunchObservationProbe(
         const target = await deps.resolveTarget(device, appBundleId, signal).catch(() => undefined);
         signal.throwIfAborted();
         if (!target) return 'unobservable';
+        // A generation whose bridge already failed a capture fails this probe the same way, and
+        // the codes it fails with are the ones this loop re-reads for seconds. Ask the circuit
+        // first; a relaunch carries a new generation, which rebaselines and observes as usual.
+        if (deps.isBridgeDisabled(target)) return 'unobservable';
         const outcome = await deps.source.acquire({ target, hint, signal });
         if (outcome.stage !== 'failed') return 'observable';
         signal.throwIfAborted();

--- a/packages/platform-apple/src/snapshot-observability.ts
+++ b/packages/platform-apple/src/snapshot-observability.ts
@@ -2,6 +2,7 @@ import {
   createIosSnapshotRequest,
   deriveIosCaptureHint,
 } from '@agent-device/capture-kit/ios-snapshot-planning';
+import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { SimulatorSnapshotSource } from './snapshot-source-facade.ts';
@@ -69,7 +70,20 @@ export function createLaunchObservationProbe(
         // A generation whose bridge already failed a capture fails this probe the same way, and
         // the codes it fails with are the ones this loop re-reads for seconds. Ask the circuit
         // first; a relaunch carries a new generation, which rebaselines and observes as usual.
-        if (deps.isBridgeDisabled(target)) return 'unobservable';
+        // A skip is reported, because an unresolvable target reaches the same verdict by a
+        // different route and only the diagnostic tells the two apart on a live device.
+        if (deps.isBridgeDisabled(target)) {
+          emitDiagnostic({
+            level: 'debug',
+            phase: 'ios_launch_observation_skipped',
+            data: {
+              reason: 'circuit-disabled',
+              deviceId: device.id,
+              generation: target.generation,
+            },
+          });
+          return 'unobservable';
+        }
         const outcome = await deps.source.acquire({ target, hint, signal });
         if (outcome.stage !== 'failed') return 'observable';
         signal.throwIfAborted();

--- a/packages/platform-apple/src/snapshot-route.test.ts
+++ b/packages/platform-apple/src/snapshot-route.test.ts
@@ -269,6 +269,64 @@ test('a slow app discovery yields to a live runner within its wait slice, then s
   }
 });
 
+test('an open whose generation already failed the bridge skips the launch-observation poll', async () => {
+  // #2199: `application-server-unavailable` is a launch-transition code, so an ungated probe would
+  // re-read the bridge every 150 ms for its whole 5 s window on a generation the circuit already
+  // gave up on — ~33 acquisitions per `open`, each a fresh connect.
+  const source = sourceReturning({
+    stage: 'failed',
+    failure: { kind: 'transport-failure', code: 'application-server-unavailable' },
+  });
+  const route = createAppleSnapshotRoute(
+    { ...platformRuntimeHostFixture(), clock: steppingClock() },
+    { source, resolveTarget: vi.fn(async () => target) },
+  );
+
+  await route.capture(ios, input, signal(), async () => runnerResult());
+  expect(source.acquire).toHaveBeenCalledOnce();
+
+  await expect(route.awaitObservable(ios, input.options.appBundleId, signal())).resolves.toBe(
+    'unobservable',
+  );
+  expect(source.acquire).toHaveBeenCalledOnce();
+});
+
+test('a relaunched generation rebaselines the circuit and observes the launch', async () => {
+  const outcomes: SnapshotSourceOutcome[] = [
+    { stage: 'failed', failure: { kind: 'transport-failure', code: 'bridge-disconnected' } },
+    bridgeAcquisition(),
+  ];
+  let acquisitions = 0;
+  const source = {
+    acquire: vi.fn(async () => outcomes[Math.min(acquisitions++, outcomes.length - 1)]!),
+    close: vi.fn(async () => {}),
+  };
+  const relaunched = { ...target, pid: 84, generation: '84:launch-b' };
+  const resolveTarget = vi.fn().mockResolvedValueOnce(target).mockResolvedValue(relaunched);
+  const route = createAppleSnapshotRoute(
+    { ...platformRuntimeHostFixture(), clock: steppingClock() },
+    { source, resolveTarget },
+  );
+
+  await route.capture(ios, input, signal(), async () => runnerResult());
+
+  await expect(route.awaitObservable(ios, input.options.appBundleId, signal())).resolves.toBe(
+    'observable',
+  );
+  expect(source.acquire).toHaveBeenCalledTimes(2);
+});
+
+/** A clock the launch-observation loop can run to its deadline instead of spinning forever. */
+function steppingClock() {
+  let now = 0;
+  return {
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
 function bridgeAcquisition(): Extract<SnapshotSourceOutcome, { stage: 'acquired' }> {
   return {
     stage: 'acquired',

--- a/packages/platform-apple/src/snapshot-route.ts
+++ b/packages/platform-apple/src/snapshot-route.ts
@@ -57,7 +57,22 @@ export function createAppleSnapshotRoute(
   const resolveTarget = options.resolveTarget ?? createSimulatorSnapshotTargetResolver();
   const disabledGenerations = new Set<string>();
   const latestGeneration = new Map<string, string>();
-  const observation = createLaunchObservationProbe({ source, resolveTarget, clock: host.clock });
+  /**
+   * Records `target` as the newest generation of its app — which clears the circuit an earlier
+   * generation opened — and reports whether the bridge is disabled for it. Both a capture and the
+   * launch-observation probe ask before they spend a bridge round trip, so one generation's
+   * failure is paid once rather than once per route (#2198, #2199).
+   */
+  const isBridgeDisabled = (target: SimulatorSnapshotTarget): boolean => {
+    rebaselineGeneration(target, latestGeneration, disabledGenerations);
+    return disabledGenerations.has(generationKey(target));
+  };
+  const observation = createLaunchObservationProbe({
+    source,
+    resolveTarget,
+    clock: host.clock,
+    isBridgeDisabled,
+  });
 
   return Object.freeze({
     awaitObservable: observation.awaitObservable,
@@ -79,9 +94,7 @@ export function createAppleSnapshotRoute(
           [unknownGenerationResidue()],
         );
       }
-      rebaselineGeneration(target, latestGeneration, disabledGenerations);
-      const circuitKey = generationKey(target);
-      if (disabledGenerations.has(circuitKey)) {
+      if (isBridgeDisabled(target)) {
         return await runFallback(input, fallback, target, requestFor(input), 'circuit-disabled');
       }
 

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
@@ -604,8 +604,6 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
     expect.objectContaining({ platform: 'apple', id: 'sim-1' }),
     expect.objectContaining({
       cleanStaleBundles: true,
-      buildTimeoutMs: 240000,
-      healthTimeoutMs: 240000,
       logPath: expect.stringMatching(/runner\.log$/),
       prepareDeadline: expect.objectContaining({
         elapsedMs: expect.any(Function),
@@ -613,9 +611,21 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
         remainingMs: expect.any(Function),
       }),
       requestId: 'prepare-request',
-      startupTimeoutMs: 240000,
     }),
   );
+  // `prepareAppleRunner` spends one budget across the boot wait and the runner, so what reaches
+  // the runner is `--timeout` minus whatever readiness already used. Asserting the exact request
+  // asserts that zero wall-clock time passed, which is an accident of scheduling rather than a
+  // property of the system; the guarantee is that each budget is wired and never re-spent.
+  const [, prepareOptions] = mockPrepareIosRunner.mock.calls[0]!;
+  for (const field of ['buildTimeoutMs', 'healthTimeoutMs', 'startupTimeoutMs'] as const) {
+    expect
+      .soft(prepareOptions[field], `${field} carries the unspent remainder of --timeout`)
+      .toBeGreaterThan(239_000);
+    expect
+      .soft(prepareOptions[field], `${field} never exceeds --timeout`)
+      .toBeLessThanOrEqual(240_000);
+  }
   if (response.ok) {
     expect(response.data).toMatchObject({
       action: 'ios-runner',


### PR DESCRIPTION
## What

The Simulator AX-bridge launch-observation probe never consulted the generation circuit breaker that the snapshot capture route opens on a typed bridge failure. `createAppleSnapshotRoute` re-exported `observation.awaitObservable` straight through, and the probe's own loop had no way to ask.

Route and probe now share one `isBridgeDisabled(target)` predicate that rebaselines the generation and reads the circuit. The probe asks right after it resolves its target, so a generation the circuit already gave up on is answered without a bridge round trip.

## Why

`application-element-missing` and `application-server-unavailable` each carry a 5 s launch-transition window at a 150 ms poll. Re-opening an app that is already running produces those codes on a generation whose circuit is already open, so such an `open` could spend up to ~33 `source.acquire` round trips learning what the circuit already knew — each retrying again inside `connectUntilReady`.

`rebaselineGeneration` only clears the circuit when the pid/label/start-time generation changes, and `awaitObservable` never called it, so nothing broke the loop.

Production path: `settleAppleOpen` (`open-policy.ts`) via `lifecycle.ts`.

## Design note

The obvious shape — wrapping `awaitObservable` in the route so it resolves the target, gates, then delegates — was rejected. `resolveTarget` re-checks a cached target's identity with a `ps` spawn, so a route wrapper would charge **every** happy-path `open` an extra subprocess to speed up the unhappy path. Passing the predicate into the probe adds zero work when the circuit is closed.

## Live Simulator receipt

Requested in review. iPhone 17 Pro (`F7D6F9A4`), iOS 26.2, `com.apple.Preferences`, built `dist` on this branch, one paired run against `origin/main` on the same simulator. The circuit is opened for real by stealing foreground accessibility ownership (`simctl launch com.apple.MobileSMS`) and then capturing, which the bridge rejects with `foreground-owner-unverified`.

Because a skipped probe and an unresolvable target both end at `unobservable` with zero acquisitions, `0 acquisitions` alone proves nothing. Commit `ea79a2d` adds `ios_launch_observation_skipped`, and the receipt reads that diagnostic rather than inferring from counts.

| Step | `origin/main` | this PR |
| --- | --- | --- |
| 1 — fresh launch, circuit closed | 2 acq · `observable` · 3255 ms | 0 acq · `unobservable` · 1814 ms |
| 2 — capture → circuit opens | `foreground-owner-unverified` on `88580:…Preferences[e45e]` | same |
| 3 — re-open **same** generation | 1 acq · `observable` · 62 ms | **0 acq · skip diagnostic · 312 ms** |
| 4 — `--relaunch`, new generation | 1 acq · `observable` · 1450 ms | **1 acq · `observable` · 1501 ms** |

Step 3's diagnostic names the exact generation the circuit refused:

```json
{"reason":"circuit-disabled","deviceId":"F7D6F9A4-…","generation":"88580:UIKitApplication:com.apple.Preferences[e45e][rb-legacy]:Wed Sep  9 10:48:54 2026"}
```

Step 4 carries no skip diagnostic and one acquisition, so the new generation rebaselined the circuit and observed normally.

## What the receipt does *not* show, and one tradeoff worth your call

Two honest limits:

1. **The ~5 s saving is not demonstrated live.** It needs a generation whose bridge failure *persists*. I could not force one: `application-server-unavailable` and `application-element-missing` did not reproduce on this simulator, and the three no-UI system apps I tried (`AegirProxyApp`, `VoiceOverTouch`, `Bridge`) all served the bridge fine. The 36 → 1 acquisition count is proven only by the unit test.

2. **In the transient case the receipt captures, this PR is ~250 ms slower** — step 3, 62 ms → 312 ms. `open` itself restores foreground ownership, so on `origin/main` the probe's first poll succeeded and skipped the fixed settle; here the probe declines and pays `POST_OPEN_SETTLE_MS`.

That second point is the real tension: the circuit does not distinguish a transient failure from a persistent one, so gating the probe bets that an open circuit means a slow probe. For the motivating case that bet is right; for a self-healing failure it costs a quarter second. Worth noting that on `origin/main` the probe's `observable` verdict was not actionable anyway — the next capture for that generation still takes the XCTest fallback, so the round trip only bought the settle skip.

If you would rather not pay that, the natural follow-up is to skip the settle when the probe skipped (the capture is going to XCTest, which does its own readiness), which would make step 3 both 0-acquisition and ~60 ms. I did not do it here: it changes settle semantics beyond this PR's ask.

## Reviewer notes

Both halves of the gate are mutation-proven, as is the diagnostic:

| Mutation | Test that catches it |
| --- | --- |
| Remove the probe's gate | `an open whose generation already failed the bridge skips the launch-observation poll` — `expected "vi.fn()" to be called once, but got 36 times` |
| Gate without rebaselining | `a relaunched generation rebaselines the circuit and observes the launch`, plus the pre-existing `a new app generation re-enables the bridge` |
| Drop the skip diagnostic | `the skip is reported, so a live run can tell it from an unresolvable target` |

The two route tests inject a stepping clock; the shared host fixture's clock is a frozen `now: () => 10` with a no-op `sleep`, under which an ungated probe spins forever rather than failing.

## CI

`8b170ed` fixes the Coverage failure you flagged. It is unrelated to this change and was a real flake, not noise: `prepareAppleRunner` spends one budget across the boot wait and the runner, so the runner receives `--timeout` minus elapsed time, and the test asserted exactly `240000` — true only when both `Date.now()` reads land in the same millisecond. CI observed `239999`. It now asserts each budget carries the unspent remainder and never exceeds the request; forcing the remainder to `1` fails the lower bound and re-spending the full budget fails the upper.

Rebased onto `e7d97f7`. `pnpm check:affected --run` green: 285 files, 1904 tests, format/lint/typecheck clean.

Refs #2198, #2199.
