### PR TITLE
perf(ios): settle the first interaction on a deadline, not a fixed sleep

### DIFF
--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
@@ -108,7 +108,7 @@ extension RunnerTests {
     // old PID before refreshCachedTargetIfProcessChanged can observe it.
     clearSnapshotXCTestChannelPenalty(reason: "external_app_relaunch")
     clearPrivateAXAcceptedDepth(reason: "external_app_relaunch")
-    needsFirstInteractionDelay = true
+    beginFirstInteractionStabilization()
     return Response(ok: true, data: DataPayload(message: "target reset"))
   }
 
@@ -132,7 +132,7 @@ extension RunnerTests {
     clearSnapshotXCTestChannelPenalty(reason: "target_process_changed")
     clearPrivateAXAcceptedDepth(reason: "target_process_changed")
     snapshotXCTestPenaltyWarmupExemptionPending = true
-    needsFirstInteractionDelay = true
+    beginFirstInteractionStabilization()
   }
 
   static func processIdentifier(of target: XCUIApplication) -> Int? {
@@ -205,7 +205,7 @@ extension RunnerTests {
     currentAppProcessIdentifier = Self.processIdentifier(of: target)
     clearRememberedTextEntryTap()
     snapshotXCTestPenaltyWarmupExemptionPending = false
-    needsFirstInteractionDelay = true
+    beginFirstInteractionStabilization()
     return target
   }
 
@@ -320,10 +320,17 @@ extension RunnerTests {
       sleepFor(postSnapshotInteractionDelay)
       needsPostSnapshotInteractionDelay = false
     }
-    if needsFirstInteractionDelay {
-      sleepFor(firstInteractionAfterActivateDelay)
-      needsFirstInteractionDelay = false
+    if let readyUptime = firstInteractionReadyUptime {
+      sleepFor(readyUptime - ProcessInfo.processInfo.systemUptime)
+      firstInteractionReadyUptime = nil
     }
+  }
+
+  /// Start the post-activation settling window. Measured from now, so the time the caller spends
+  /// getting back to us counts towards it instead of being charged twice.
+  func beginFirstInteractionStabilization() {
+    firstInteractionReadyUptime =
+      ProcessInfo.processInfo.systemUptime + firstInteractionAfterActivateDelay
   }
 
   func sleepFor(_ delay: TimeInterval) {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -66,7 +66,11 @@ final class RunnerTests: XCTestCase {
   let minRecordingFps = 1
   let maxRecordingFps = 120
   var needsPostSnapshotInteractionDelay = false
-  var needsFirstInteractionDelay = false
+  /// When the first interaction after an activation may run, on the monotonic uptime clock.
+  /// The guarantee is a minimum gap *since the activation*, not a pause at the interaction:
+  /// a caller that already spent that gap elsewhere (an agent's round trip is 190-260 ms)
+  /// has satisfied it and waits for nothing. `nil` = no activation is pending stabilization.
+  var firstInteractionReadyUptime: TimeInterval?
   var runnerAccessibilityHealth: RunnerAccessibilityHealth = .unknown
   var activeRecording: ScreenRecorder?
   let commandJournal = RunnerCommandJournal()

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+LifecycleCacheTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+LifecycleCacheTests.swift
@@ -133,7 +133,7 @@ extension RunnerTests {
     currentBundleId = "com.example.app"
     currentAppProcessIdentifier = 42
     snapshotXCTestPenaltyWarmupExemptionPending = true
-    needsFirstInteractionDelay = false
+    firstInteractionReadyUptime = nil
     penalizeSnapshotXCTestChannel(bundleId: "com.example.app", reason: "test")
     XCTAssertTrue(isSnapshotXCTestChannelPenalized(bundleId: "com.example.app"))
 
@@ -145,7 +145,35 @@ extension RunnerTests {
     XCTAssertNil(currentAppProcessIdentifier)
     XCTAssertFalse(snapshotXCTestPenaltyWarmupExemptionPending)
     XCTAssertFalse(isSnapshotXCTestChannelPenalized(bundleId: "com.example.app"))
-    XCTAssertTrue(needsFirstInteractionDelay)
+    XCTAssertNotNil(firstInteractionReadyUptime)
+  }
+
+  /// The settling window is a deadline measured from the activation, not a pause charged at the
+  /// interaction. A caller that already spent the window elsewhere waits for nothing; one that
+  /// arrives immediately still waits. Without the deadline both cases sleep the full delay.
+  func testFirstInteractionStabilizationWaitsOnlyForTheRemainderOfTheWindow() {
+    needsPostSnapshotInteractionDelay = false
+
+    // An activation whose window has already elapsed: the caller spent it getting back to us.
+    firstInteractionReadyUptime = ProcessInfo.processInfo.systemUptime - 1
+    let elapsedAfterSatisfiedWindow = measureStabilizationDuration()
+    XCTAssertLessThan(elapsedAfterSatisfiedWindow, firstInteractionAfterActivateDelay / 2)
+    XCTAssertNil(firstInteractionReadyUptime)
+
+    // A fresh activation still gets the whole guard.
+    beginFirstInteractionStabilization()
+    let elapsedAfterFreshActivation = measureStabilizationDuration()
+    XCTAssertGreaterThanOrEqual(
+      elapsedAfterFreshActivation,
+      firstInteractionAfterActivateDelay * 0.8
+    )
+    XCTAssertNil(firstInteractionReadyUptime)
+  }
+
+  private func measureStabilizationDuration() -> TimeInterval {
+    let startedAt = ProcessInfo.processInfo.systemUptime
+    applyInteractionStabilizationIfNeeded()
+    return ProcessInfo.processInfo.systemUptime - startedAt
   }
 #endif
 }


### PR DESCRIPTION
Implements the one candidate from #2381 worth landing. Swift only; no TypeScript, no wire, no public flag.

## The defect

The runner guarantees a settling gap between activating a target and the first interaction on it. It implemented that as a 250 ms sleep taken **at the interaction**:

```swift
// RunnerTests+Lifecycle.swift, before
if needsFirstInteractionDelay {
  sleepFor(firstInteractionAfterActivateDelay)   // 0.25
  needsFirstInteractionDelay = false
}
```

The invariant is "at least 250 ms **since the activation**". Charging it at the interaction pays it again however much of it has already passed — and in an agent-driven flow essentially all of it has, because the client round trip alone is 190–260 ms (measured for #2381; the repo already records "a ~245ms invocation" in `code-signature-cache.ts`).

`sleepFor` pumps the runloop in 20 ms slices, so this is real wall clock, not a nominal delay. It is roughly 36 % of the ~690 ms first-tap cost.

The flag is set at three points — `activateTarget`, `resetTargetAfterExternalRelaunch`, and `refreshCachedTargetIfProcessChanged`. All three now stamp a deadline instead.

## The change

`needsFirstInteractionDelay: Bool` becomes `firstInteractionReadyUptime: TimeInterval?`, stamped from `ProcessInfo.processInfo.systemUptime` — the monotonic clock this runner already uses in four other files, so a wall-clock adjustment cannot make the window wrong. The interaction waits for the remainder only:

```swift
if let readyUptime = firstInteractionReadyUptime {
  sleepFor(readyUptime - ProcessInfo.processInfo.systemUptime)   // sleepFor guards <= 0
  firstInteractionReadyUptime = nil
}
```

A caller that already spent the window waits for nothing; a tight loop still gets the whole guard. The guarantee is unchanged, and this is a real saving rather than a relocation — nothing downstream re-pays the wait.

## Validation, on device

Built with `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1` and run on Simulator `ad-bench-2198` (iOS 26.2, arm64).

**Full runner suite: `Executed 226 tests, with 0 failures (0 unexpected)`.**

New regression `testFirstInteractionStabilizationWaitsOnlyForTheRemainderOfTheWindow` asserts both directions — an already-elapsed window waits under half the delay, a fresh activation still waits at least 80 % of it — and was verified by name rather than assumed to be in the 226:

```
Test Case '…testFirstInteractionStabilizationWaitsOnlyForTheRemainderOfTheWindow' passed (0.266 seconds).
```

That 0.266 s is itself the evidence: the test performs two stabilizations, so a correct deadline costs ≈ 0 + 0.25 s. 

**Planted red.** Restoring the unconditional sleep and rebuilding:

```
RunnerTests+LifecycleCacheTests.swift:160: error: XCTAssertLessThan failed:
  ("0.2502417915966362") is not less than ("0.125")
Test Case '…' failed (0.559 seconds).
```

0.559 s versus 0.266 s — two full sleeps instead of one — and the already-elapsed case measurably paid 250 ms it did not owe. Plant reverted and rebuilt green.

`testTargetResetInvalidatesProcessBoundStateWithoutRestartingRunner` carries with the field it asserts (`XCTAssertNotNil(firstInteractionReadyUptime)`).

## Scope and what is not claimed

I am **not** claiming an end-to-end first-interaction improvement number here. The mechanism-level saving is deterministic and measured above; converting it into a corpus delta needs the #2189 benchmark on a quiet host, which this box has not been. The bounded claim is: up to 250 ms of unearned sleep is removed from the first interaction after any activation, and 0 ms is removed when the guard is genuinely needed.

One related over-charge is left alone deliberately: `activateTarget` stamps the window even when `activate()` was **skipped** because the app was already foreground. Under a deadline that now costs only the remainder, and removing it is a behavioral question about whether a foreground app needs settling at all — separate from this change.

Refs #2381.
