### PR TITLE
fix(ios): avoid duplicate alert routing queries

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -153,6 +153,8 @@ jobs:
             -xctestrun "$XCTESTRUN_PATH" \
             -destination "platform=iOS Simulator,id=${{ steps.ios-simulator.outputs.simulator-udid }}" \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSinglePointerFlingFallsBackToXCTestCoordinateDragWhenPrivateSynthesisFails \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testAlertDispatchResolvesItsOwnModalWithoutCoordinateTapRoutingProbe \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testAlertResolutionCannotBypassRequestedDeadline \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTypeWithoutResolvedInputReturnsTypedFailureBeforeDispatchingText \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testBareTypeUsesTappedInputWhenSoftwareKeyboardIsHidden \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testHardwareKeyboardResponderConfirmsItsOwnKeyboardFocus \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -825,70 +825,6 @@ extension RunnerTests {
     XCTAssertTrue(response.error?.hint?.contains("runner session will be restarted") == true)
   }
 
-#if os(iOS)
-  func testAlertResolutionCannotBypassRequestedDeadline() throws {
-    final class ResultBox {
-      var error: Error?
-      var probeDeadline: Date?
-      var observedDeadline: Date?
-      var commandStartedAt: Date?
-    }
-    let box = ResultBox()
-    let releaseResolution = DispatchSemaphore(value: 0)
-    let resolutionExited = expectation(description: "bounded alert resolution exited")
-    let commandFinished = expectation(description: "alert command respected its deadline")
-    let command = try runnerCommandFixture(
-      #"{"command":"alert","commandId":"alert-deadline","appBundleId":"com.apple.springboard","action":"get","timeoutMs":500}"#
-    )
-    currentApp = springboard
-    currentBundleId = Self.springboardBundleId
-    systemModalProbeOverrideForTesting = { deadline in
-      box.probeDeadline = deadline
-      return nil
-    }
-    alertResolutionOverrideForTesting = { deadline in
-      box.observedDeadline = deadline
-      _ = releaseResolution.wait(timeout: .now() + 1)
-      resolutionExited.fulfill()
-      return nil
-    }
-    defer {
-      releaseResolution.signal()
-      systemModalProbeOverrideForTesting = nil
-      alertResolutionOverrideForTesting = nil
-      currentApp = nil
-      currentBundleId = nil
-    }
-
-    DispatchQueue(label: "agent-device.runner.tests.alert-deadline").async {
-      box.commandStartedAt = Date()
-      do {
-        _ = try self.executeDispatched(command: command)
-      } catch {
-        box.error = error
-      }
-      commandFinished.fulfill()
-    }
-
-    wait(for: [commandFinished], timeout: 1)
-    let error = box.error as NSError?
-    XCTAssertEqual(error?.domain, RunnerErrorDomain.general)
-    XCTAssertEqual(error?.code, RunnerErrorCode.mainThreadExecutionTimedOut)
-    XCTAssertNotNil(box.probeDeadline)
-    XCTAssertNotNil(box.observedDeadline)
-    if let probeDeadline = box.probeDeadline,
-      let observedDeadline = box.observedDeadline,
-      let commandStartedAt = box.commandStartedAt
-    {
-      XCTAssertEqual(probeDeadline.timeIntervalSince(observedDeadline), 0, accuracy: 0.01)
-      XCTAssertEqual(observedDeadline.timeIntervalSince(commandStartedAt), 0.5, accuracy: 0.05)
-    }
-
-    releaseResolution.signal()
-    wait(for: [resolutionExited], timeout: 1)
-  }
-#endif
-
   func testRunMainThreadWorkExecutesOffMainCallerOnMainThread() {
     final class ResultBox {
       var observedMainThread: Bool?
@@ -1135,10 +1071,7 @@ extension RunnerTests {
       ? Date().addingTimeInterval(Self.alertCommandTimeout(timeoutMs: command.timeoutMs))
       : nil
     if Thread.isMainThread {
-      let routeToSpringboard = shouldRouteToSpringboardBlockingSystemModal(
-        command,
-        deadline: alertDeadline
-      )
+      let routeToSpringboard = shouldRouteToSpringboardBlockingSystemModal(command)
       return try executeOnMainSafely(
         command: command,
         alertDeadline: alertDeadline,
@@ -1148,10 +1081,7 @@ extension RunnerTests {
     // Resolve this before the command's outer main-thread block. If the bounded probe abandons
     // slow XCTest enumeration, return the established recoverable response instead of queueing
     // command preparation behind work that may outlive the 30-second command watchdog.
-    let routeToSpringboard = shouldRouteToSpringboardBlockingSystemModal(
-      command,
-      deadline: alertDeadline
-    )
+    let routeToSpringboard = shouldRouteToSpringboardBlockingSystemModal(command)
     if let unavailable = runnerUnavailableResponse(command: command) {
       return unavailable
     }
@@ -2652,11 +2582,10 @@ extension RunnerTests {
   }
 
   private func shouldRouteToSpringboardBlockingSystemModal(
-    _ command: Command,
-    deadline: Date? = nil
+    _ command: Command
   ) -> Bool {
 #if os(iOS)
-    guard command.command == .alert || isCoordinateOnlyTap(command) else {
+    guard isCoordinateOnlyTap(command) else {
       return false
     }
     #if AGENT_DEVICE_RUNNER_UNIT_TESTS
@@ -2664,8 +2593,7 @@ extension RunnerTests {
       return override
     }
     #endif
-    let budgetDeadline = Date().addingTimeInterval(systemModalProbeBudget)
-    let probeDeadline = deadline.map { min($0, budgetDeadline) } ?? budgetDeadline
+    let probeDeadline = Date().addingTimeInterval(systemModalProbeBudget)
     // `runMainThreadWork` executes inline for a main-thread caller, so that path cannot use its
     // timeout machinery. Direct main-thread dispatch keeps the prior synchronous modal check;
     // normal off-main command dispatch uses the bounded probe and post-probe busy recovery.

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+AlertDispatchTests.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+AlertDispatchTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS && os(iOS)
+extension RunnerTests {
+  func testAlertDispatchResolvesItsOwnModalWithoutCoordinateTapRoutingProbe() throws {
+    final class ResultBox {
+      var routingProbeCount = 0
+      var resolutionCount = 0
+      var response: Response?
+      var error: Error?
+    }
+    let box = ResultBox()
+    let finished = expectation(description: "alert dispatch finished")
+    currentApp = springboard
+    currentBundleId = Self.springboardBundleId
+    systemModalProbeOverrideForTesting = { _ in
+      box.routingProbeCount += 1
+      return nil
+    }
+    alertResolutionOverrideForTesting = { _ in
+      box.resolutionCount += 1
+      return nil
+    }
+    defer {
+      systemModalProbeOverrideForTesting = nil
+      alertResolutionOverrideForTesting = nil
+      currentApp = nil
+      currentBundleId = nil
+    }
+    let command = try runnerCommandFixture(
+      #"{"command":"alert","commandId":"alert-routing-once","appBundleId":"com.apple.springboard","action":"get","timeoutMs":1000}"#
+    )
+    DispatchQueue(label: "agent-device.runner.tests.alert-routing").async {
+      do {
+        box.response = try self.execute(command: command)
+      } catch {
+        box.error = error
+      }
+      finished.fulfill()
+    }
+    wait(for: [finished], timeout: 2)
+    XCTAssertNil(box.error)
+    XCTAssertEqual(box.response?.error?.code, "ALERT_NOT_FOUND")
+    XCTAssertEqual(box.resolutionCount, 1)
+    XCTAssertEqual(box.routingProbeCount, 0)
+  }
+
+  func testAlertResolutionCannotBypassRequestedDeadline() throws {
+    final class ResultBox {
+      var error: Error?
+      var observedDeadline: Date?
+      var commandStartedAt: Date?
+    }
+    let box = ResultBox()
+    let releaseResolution = DispatchSemaphore(value: 0)
+    let resolutionExited = expectation(description: "bounded alert resolution exited")
+    let commandFinished = expectation(description: "alert command respected its deadline")
+    let command = try runnerCommandFixture(
+      #"{"command":"alert","commandId":"alert-deadline","appBundleId":"com.apple.springboard","action":"get","timeoutMs":500}"#
+    )
+    currentApp = springboard
+    currentBundleId = Self.springboardBundleId
+    alertResolutionOverrideForTesting = { deadline in
+      box.observedDeadline = deadline
+      _ = releaseResolution.wait(timeout: .now() + 1)
+      resolutionExited.fulfill()
+      return nil
+    }
+    defer {
+      releaseResolution.signal()
+      alertResolutionOverrideForTesting = nil
+      currentApp = nil
+      currentBundleId = nil
+    }
+
+    DispatchQueue(label: "agent-device.runner.tests.alert-deadline").async {
+      box.commandStartedAt = Date()
+      do {
+        _ = try self.execute(command: command)
+      } catch {
+        box.error = error
+      }
+      commandFinished.fulfill()
+    }
+
+    wait(for: [commandFinished], timeout: 1)
+    let error = box.error as NSError?
+    XCTAssertEqual(error?.domain, RunnerErrorDomain.general)
+    XCTAssertEqual(error?.code, RunnerErrorCode.mainThreadExecutionTimedOut)
+    XCTAssertNotNil(box.observedDeadline)
+    if let observedDeadline = box.observedDeadline,
+      let commandStartedAt = box.commandStartedAt
+    {
+      XCTAssertEqual(observedDeadline.timeIntervalSince(commandStartedAt), 0.5, accuracy: 0.05)
+    }
+
+    releaseResolution.signal()
+    wait(for: [resolutionExited], timeout: 1)
+  }
+}
+#endif


### PR DESCRIPTION
## Summary

On our cold hosted iOS 26.5 simulator, `alert get` times out in a four-second routing probe and returns `RUNNER_BUSY` before its handler runs. The handler already resolves system, remote-hosted and app alerts itself.

Remove that duplicate probe for alert commands so resolution, activation and verification use the existing alert deadline. Coordinate taps retain their bounded routing probe and busy recovery. Move the deadline test beside a new actual-dispatch regression and run both in the iOS PR lane. Three files change.

This addresses a setup blocker while validating #2362; it does not fix delayed gesture delivery. [Original failure](https://github.com/thiagobrez/react-native-reorderable/actions/runs/34213575805).

## Validation

Head: `64de91773793d5a4cfdbd70c625e3fe4f3f46685`.

- `pnpm check:affected --run` and all active PR checks pass, including iOS smoke, integration and coverage.
- Native regression fails on the original code. With the fix, that regression, the requested-deadline test and coordinate-tap busy/drain regression pass (3/3).
- Fresh package/native builds pass. Actual Scenario Lab preflight passes locally on erased and previously confirmed iOS 26.5 setups.
- [Hosted diagnostic](https://github.com/thiagobrez/react-native-reorderable/actions/runs/34219362348): alerts are accepted in boots 2 and 3 without the duplicate probe. Boot 1 still times out inside alert handling; later viewport and lifecycle errors also keep the overall workflow red. This establishes the changed route, not general reliability under host load.
