### PR TITLE
test(capture): avoid coverage timeouts with a smaller crop fixture

### DIFF
--- a/src/daemon/__tests__/screenshot-crop.test.ts
+++ b/src/daemon/__tests__/screenshot-crop.test.ts
@@ -53,7 +53,7 @@ const IOS_TREE: RawSnapshotNode[] = [
     index: 0,
     depth: 0,
     type: 'XCUIElementTypeApplication',
-    rect: { x: 0, y: 0, width: 390, height: 844 },
+    rect: { x: 0, y: 0, width: 39, height: 84 },
     hittable: true,
   },
   {
@@ -62,7 +62,7 @@ const IOS_TREE: RawSnapshotNode[] = [
     parentIndex: 0,
     type: 'XCUIElementTypeButton',
     label: 'Save',
-    rect: { x: 10, y: 10, width: 100, height: 40 },
+    rect: { x: 1, y: 1, width: 10, height: 4 },
     hittable: true,
   },
 ];
@@ -149,12 +149,12 @@ test('an iOS simulator crop projects the points-space frame into the 3x capture'
     device: IOS_SIMULATOR,
     nodes: IOS_TREE,
     provenance: { backend: 'xctest', producer: 'apple-runner' },
-    png: { width: 1170, height: 2532 },
+    png: { width: 117, height: 252 },
   });
   try {
     const outcome = await seam.run();
     expect(outcome).toEqual({ partialIntersection: false });
-    expect(await readPngSize(seam.screenshotPath)).toEqual({ width: 300, height: 120 });
+    expect(await readPngSize(seam.screenshotPath)).toEqual({ width: 30, height: 12 });
   } finally {
     seam.dispose();
   }


### PR DESCRIPTION
## Summary

PR #2366's Coverage run timed out while encoding and cropping a 1170×2532 fixture solely to verify 3× coordinate scaling. Reduce the fixture to 117×252 while preserving the selector path, real PNG crop, and exact 3× result assertion. One test file changed; no timeout, threshold, or production changes.

The other reported failures were already fixed on main: eager-closure approvals in #2375 and the prewarm clock in #2385.

## Validation

Commit: `76881b9b63de7260303f49606042983fe1af02b5`.

- `pnpm check:affected --run`: all runnable checks passed.
- Instrumented crop, prewarm, and eager-closure tests: 558 passed. Crop test file fell from 1.18s to 0.10s locally; coverage unchanged at 100% lines and 94.44% branches.
- Full local coverage: 9,907 passed; three macOS `/tmp` vs `/private/tmp` code-signature assertions failed, plus one runner timeout. The runner passes in isolation; the path failures reproduce separately. These files are unchanged from main.
- [PR Coverage passed](https://github.com/callstack/agent-device/actions/runs/34217478643/job/102032556394): 88.95% statements, 90.95% lines; 1,331 test files passed. The crop file completed in 339ms on CI.
