### PR TITLE
refactor(daemon): isolate Apple session observations

### DIFF
--- a/docs/adr/0022-daemon-platform-runtime-coupling.md
+++ b/docs/adr/0022-daemon-platform-runtime-coupling.md
@@ -41,10 +41,12 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
    `device-claim-owner-recovery.ts` → `platform-runtime.ts`;
    `device-ready.ts` → `platform-runtime-device-ready.ts` — process-root assembly of the
    composed gateway, host diagnostics, owner recovery, and device readiness). The remaining
-   nine edges are leaked platform mechanics and are owned by:
-   - **#2332** — Apple runner session observation behind a semantic port
-     (`request-recording-health.ts`, `session-device-resolution.ts`, `ios-app-session-hint.ts`
-     → `inspectAppleRunnerSession` / `resolveSoleForegroundIosApp`).
+   nine edges identified as leaked platform mechanics have these owning interfaces or follow-ups:
+   - **Apple session observation** — the `AppleSessionObservation` contract supplies runner
+     liveness/session identity and the sole-foreground-app observation to recording health,
+     device refresh, and open-hint policy. Root composition supplies request-local inventory
+     and its error classifier; `packages/platform-apple` owns the probes. The three consumers
+     are daemon-policy-essential. Selector production and lifecycle participation stay separate.
    - **#2333** — lifecycle participation of platform resource owners
      (`daemon-runtime.ts` → `platform-runtime-apple-runner-owner.ts`,
      `platform-runtime-resource-cleanup.ts`, and the dynamic
@@ -77,8 +79,8 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
     ≤14 target is superseded and not reachable without folding cross-cutting request-scope
     wrappers, which the audit does not endorse.
 
-5. **Per-audit-area decisions.** Apple selector/session observation: deepen an existing
-   interface (#2332). Runtime lifecycle participation: deepen through the existing lifecycle
+5. **Per-audit-area decisions.** Apple session observation: consume the neutral
+   `AppleSessionObservation` contract. Runtime lifecycle participation: deepen through the existing lifecycle
    phases, no generic hook bag (#2333). Open-target planning: separate plan/result from
    platform mechanics, one construction path preserved (#2334). Session state/store authority:
    keep the current access shape, ratchet the handler-owned slice (R75). Route depth: record the
@@ -115,5 +117,5 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
   `scripts/layering/check.ts` (both observed red against planted violations before acceptance).
 - R7 `session-state-ownership` and the R10 merge-base ratchet for the owning-module slice.
 - R65 for the concrete-platform-import ban this audit builds on.
-- Child issues #2332, #2333, #2334 (and #2273/#2274 for the selector seam) for the category-3
+- Child issues #2333, #2334 (and #2273/#2274 for the selector seam) for the remaining category-3
   implementation work.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -72,6 +72,10 @@
       "types": "./src/apple-runner-request.ts",
       "default": "./src/apple-runner-request.ts"
     },
+    "./apple-session-observation": {
+      "types": "./src/apple-session-observation.ts",
+      "default": "./src/apple-session-observation.ts"
+    },
     "./application-lifecycle-interaction": {
       "types": "./src/application-lifecycle-interaction.ts",
       "default": "./src/application-lifecycle-interaction.ts"

--- a/packages/contracts/src/apple-session-observation.ts
+++ b/packages/contracts/src/apple-session-observation.ts
@@ -1,0 +1,20 @@
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { DeviceInventoryRequest } from './device-inventory.ts';
+
+export type AppleSessionObservation = Readonly<{
+  observeRunnerSession(
+    deviceId: string,
+  ): Promise<Readonly<{ alive: boolean; sessionId: string }> | undefined>;
+  /**
+   * Exactly one booted iOS simulator with one running app in its device set, or undefined.
+   * Ambiguous or failed probes are inconclusive; cancellation and missing context propagate.
+   */
+  resolveSoleForegroundApp(
+    options?: Readonly<{ simulatorSetPath?: string }>,
+  ): Promise<Readonly<{ device: DeviceInfo; app: Readonly<{ bundleId: string }> }> | undefined>;
+}>;
+
+export type AppleSessionObservationHost = Readonly<{
+  listLocalDevices(request: DeviceInventoryRequest): Promise<DeviceInfo[]>;
+  shouldPropagateProbeError(error: unknown): boolean;
+}>;

--- a/packages/platform-apple/package.json
+++ b/packages/platform-apple/package.json
@@ -72,6 +72,10 @@
       "types": "./src/runner-owner-facade.ts",
       "default": "./src/runner-owner-facade.ts"
     },
+    "./session-observation": {
+      "types": "./src/session-observation.ts",
+      "default": "./src/session-observation.ts"
+    },
     "./simctl": {
       "types": "./src/simctl-facade.ts",
       "default": "./src/simctl-facade.ts"

--- a/packages/platform-apple/src/__tests__/session-observation.test.ts
+++ b/packages/platform-apple/src/__tests__/session-observation.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { createAppleSessionObservation } from '../session-observation.ts';
+import { IOS_SIMULATOR } from './device-fixtures.ts';
+
+const { snapshot, runningApp } = vi.hoisted(() => ({
+  snapshot: vi.fn(),
+  runningApp: vi.fn(),
+}));
+vi.mock('../core/runner-client.ts', () => ({ getRunnerSessionSnapshot: snapshot }));
+vi.mock('../core/app-resolution.ts', () => ({ detectSoleRunningIosSimulatorApp: runningApp }));
+
+const host = {
+  listLocalDevices: vi.fn(),
+  shouldPropagateProbeError: vi.fn(),
+};
+const observation = createAppleSessionObservation(host);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test.each([true, false])(
+  'runner observation preserves liveness %s and session identity',
+  async (alive) => {
+    snapshot.mockResolvedValue({ sessionId: 'runner-1', alive, ready: false });
+
+    await expect(observation.observeRunnerSession('sim-1')).resolves.toEqual({
+      alive,
+      sessionId: 'runner-1',
+    });
+    expect(snapshot).toHaveBeenCalledWith('sim-1');
+    expect(host.listLocalDevices).not.toHaveBeenCalled();
+  },
+);
+
+test('a missing runner session has no observation', async () => {
+  snapshot.mockResolvedValue(null);
+  await expect(observation.observeRunnerSession('sim-1')).resolves.toBeUndefined();
+});
+
+test('foreground observation preserves the exact simulator set and app identity', async () => {
+  host.listLocalDevices.mockResolvedValue([IOS_SIMULATOR]);
+  runningApp.mockResolvedValue({ bundleId: 'xyz.blueskyweb.app', name: 'Bluesky' });
+
+  await expect(
+    observation.resolveSoleForegroundApp({ simulatorSetPath: '/custom/set' }),
+  ).resolves.toEqual({ device: IOS_SIMULATOR, app: { bundleId: 'xyz.blueskyweb.app' } });
+  expect(host.listLocalDevices).toHaveBeenCalledWith({
+    platform: 'ios',
+    iosSimulatorSetPath: '/custom/set',
+    kind: 'simulator',
+    booted: true,
+  });
+  expect(runningApp).toHaveBeenCalledWith(IOS_SIMULATOR);
+});
+
+test.each([{ devices: [] }, { devices: [IOS_SIMULATOR, { ...IOS_SIMULATOR, id: 'other' }] }])(
+  'an ambiguous simulator inventory never probes an app: $devices',
+  async ({ devices }) => {
+    host.listLocalDevices.mockResolvedValue(devices);
+    await expect(observation.resolveSoleForegroundApp()).resolves.toBeUndefined();
+    expect(runningApp).not.toHaveBeenCalled();
+  },
+);
+
+test('an inconclusive running-app probe never guesses', async () => {
+  host.listLocalDevices.mockResolvedValue([IOS_SIMULATOR]);
+  runningApp.mockResolvedValue(undefined);
+  await expect(observation.resolveSoleForegroundApp()).resolves.toBeUndefined();
+});
+
+test.each(['inventory', 'foreground'])(
+  '%s failures obey the host control-flow classification',
+  async (probe) => {
+    const error = new Error('probe failed');
+    host.listLocalDevices.mockResolvedValue([IOS_SIMULATOR]);
+    (probe === 'inventory' ? host.listLocalDevices : runningApp).mockRejectedValue(error);
+
+    host.shouldPropagateProbeError.mockReturnValue(false);
+    await expect(observation.resolveSoleForegroundApp()).resolves.toBeUndefined();
+    expect(host.shouldPropagateProbeError).toHaveBeenCalledWith(error);
+
+    host.shouldPropagateProbeError.mockReturnValue(true);
+    await expect(observation.resolveSoleForegroundApp()).rejects.toBe(error);
+  },
+);

--- a/packages/platform-apple/src/session-observation.ts
+++ b/packages/platform-apple/src/session-observation.ts
@@ -1,0 +1,36 @@
+import type {
+  AppleSessionObservation,
+  AppleSessionObservationHost,
+} from '@agent-device/contracts/apple-session-observation';
+
+export function createAppleSessionObservation(
+  host: AppleSessionObservationHost,
+): AppleSessionObservation {
+  return Object.freeze({
+    async observeRunnerSession(deviceId) {
+      const { getRunnerSessionSnapshot } = await import('./core/runner-client.ts');
+      const snapshot = await getRunnerSessionSnapshot(deviceId);
+      return snapshot ? { alive: snapshot.alive, sessionId: snapshot.sessionId } : undefined;
+    },
+    async resolveSoleForegroundApp(options = {}) {
+      try {
+        const booted = await host.listLocalDevices({
+          platform: 'ios',
+          iosSimulatorSetPath: options.simulatorSetPath,
+          kind: 'simulator',
+          booted: true,
+        });
+        if (booted.length !== 1) return undefined;
+        const [device] = booted;
+        if (!device) return undefined;
+
+        const { detectSoleRunningIosSimulatorApp } = await import('./core/app-resolution.ts');
+        const app = await detectSoleRunningIosSimulatorApp(device);
+        return app ? { device, app: { bundleId: app.bundleId } } : undefined;
+      } catch (error) {
+        if (host.shouldPropagateProbeError(error)) throw error;
+        return undefined;
+      }
+    },
+  });
+}

--- a/scripts/layering/contracts-exports.snapshot.json
+++ b/scripts/layering/contracts-exports.snapshot.json
@@ -15,6 +15,7 @@
   "@agent-device/contracts/app-state-runtime",
   "@agent-device/contracts/app-switcher-runtime",
   "@agent-device/contracts/apple-runner-request",
+  "@agent-device/contracts/apple-session-observation",
   "@agent-device/contracts/application-lifecycle-interaction",
   "@agent-device/contracts/application-lifecycle-runtime",
   "@agent-device/contracts/application-lifecycle-runtime-plan",

--- a/scripts/layering/daemon-platform-runtime-inventory.test.ts
+++ b/scripts/layering/daemon-platform-runtime-inventory.test.ts
@@ -30,6 +30,24 @@ test('R76 accepts a classified edge with the exact recorded symbols', () => {
   assert.deepEqual(edgeViolations(sources, 'src/daemon/device-ready.ts'), []);
 });
 
+for (const [file, target, symbol] of [
+  ['request-recording-health', 'apple-resources', 'inspectAppleRunnerSession'],
+  ['session-device-resolution', 'apple-resources', 'inspectAppleRunnerSession'],
+  ['ios-app-session-hint', 'open-target', 'resolveSoleForegroundIosApp'],
+]) {
+  test(`R76 rejects retired observation mechanics in ${file}`, () => {
+    const importer = `src/daemon/${file}.ts`;
+    const sources = {
+      [`src/platform-runtime-${target}.ts`]: `export function ${symbol}() {}\n`,
+      [importer]: `import { ${symbol} } from '../platform-runtime-${target}.ts';\nvoid ${symbol};\n`,
+    };
+    const found = edgeViolations(sources, importer);
+    assert.equal(found.length, 1);
+    assert.equal(found[0]!.rule, DAEMON_PLATFORM_RUNTIME_RULE);
+    assert.match(found[0]!.message, /unclassified daemon-to-root|classified symbols drifted/);
+  });
+}
+
 test('R76 reports every classified edge missing from the tree as stale, not the other way around', () => {
   const sources = {
     [DEVICE_READY_TARGET]: DEVICE_READY_STUB,
@@ -177,14 +195,13 @@ test('R76 rejects a namespace import alongside the recorded named binding on the
 
 test('R76 treats the import and re-export of one classified pair as one entry', () => {
   const sources = {
-    'src/platform-runtime-open-target.ts':
-      'export async function resolveSoleForegroundIosApp() { return undefined; }\n',
-    'src/daemon/ios-app-session-hint.ts':
-      "import { resolveSoleForegroundIosApp } from '../platform-runtime-open-target.ts';\n" +
-      "export { resolveSoleForegroundIosApp } from '../platform-runtime-open-target.ts';\n" +
-      'void resolveSoleForegroundIosApp;\n',
+    [DEVICE_READY_TARGET]: DEVICE_READY_STUB,
+    'src/daemon/device-ready.ts':
+      "import { ensureLocalPlatformDeviceReady } from '../platform-runtime-device-ready.ts';\n" +
+      "export { ensureLocalPlatformDeviceReady } from '../platform-runtime-device-ready.ts';\n" +
+      'void ensureLocalPlatformDeviceReady;\n',
   };
-  assert.deepEqual(edgeViolations(sources, 'src/daemon/ios-app-session-hint.ts'), []);
+  assert.deepEqual(edgeViolations(sources, 'src/daemon/device-ready.ts'), []);
 });
 
 test('R76 ignores test-shaped and non-daemon importers', () => {

--- a/scripts/layering/daemon-platform-runtime-inventory.ts
+++ b/scripts/layering/daemon-platform-runtime-inventory.ts
@@ -39,9 +39,7 @@ export function isRootPlatformRuntimeTarget(target: string): boolean {
 }
 
 /**
- * Measured on origin/main 6e22e266d7 for #2278: 14 production edges in 9 daemon files.
- * The ios-app-session-hint entry covers two edges (the import and the re-export of the
- * same symbol); every other entry is one edge.
+ * The current classified edges from the #2278 audit, ratcheted as owning interfaces land.
  */
 export const DAEMON_PLATFORM_RUNTIME_EDGES: readonly DaemonPlatformRuntimeEdge[] = [
   {
@@ -141,36 +139,30 @@ export const DAEMON_PLATFORM_RUNTIME_EDGES: readonly DaemonPlatformRuntimeEdge[]
   },
   {
     file: 'src/daemon/ios-app-session-hint.ts',
-    target: 'src/platform-runtime-open-target.ts',
-    symbols: ['resolveSoleForegroundIosApp'],
-    classification: 'leaked-platform-mechanics',
+    target: 'src/platform-runtime-apple-resources.ts',
+    symbols: ['appleSessionObservation'],
+    classification: 'daemon-policy-essential',
     rationale:
-      'the open-hint policy (daemon-owned: when to emit, length bound, never-guess) calls ' +
-      'the Apple foreground-app probe and re-exports it; the probe should arrive through ' +
-      'a semantic observation port instead of the mixed open-target module.',
-    deepenedBy: '#2332',
+      'daemon-owned hint composition and length limits consume the neutral foreground-app ' +
+      'observation; the Apple package owns ambiguity and probe mechanics.',
   },
   {
     file: 'src/daemon/request-recording-health.ts',
     target: 'src/platform-runtime-apple-resources.ts',
-    symbols: ['inspectAppleRunnerSession'],
-    classification: 'leaked-platform-mechanics',
+    symbols: ['appleSessionObservation'],
+    classification: 'daemon-policy-essential',
     rationale:
-      'recording-health refresh reads the Apple runner session mechanics directly; the ' +
-      'daemon needs a semantic runner-session observation (alive plus current session id), ' +
-      'not the runner probe.',
-    deepenedBy: '#2332',
+      'daemon-owned recording invalidation consumes only liveness and session identity ' +
+      'through the neutral observation contract; runner mechanics stay Apple-owned.',
   },
   {
     file: 'src/daemon/session-device-resolution.ts',
     target: 'src/platform-runtime-apple-resources.ts',
-    symbols: ['inspectAppleRunnerSession'],
-    classification: 'leaked-platform-mechanics',
+    symbols: ['appleSessionObservation'],
+    classification: 'daemon-policy-essential',
     rationale:
-      'device refresh uses a live runner session as simulator-boot evidence; the daemon ' +
-      'needs the same semantic runner-session observation as recording health, not the ' +
-      'runner probe.',
-    deepenedBy: '#2332',
+      'daemon-owned device refresh uses the neutral runner-session observation as boot ' +
+      'evidence; inventory selection and provider exclusions remain local policy.',
   },
   {
     file: 'src/daemon/handlers/session-selector-dispatch.ts',

--- a/scripts/layering/package-boundaries.test.ts
+++ b/scripts/layering/package-boundaries.test.ts
@@ -514,6 +514,7 @@ test('the real tree parses, declares, and passes R11', () => {
     '@agent-device/platform-apple/runner-owner',
     '@agent-device/platform-apple/runner/operations',
     '@agent-device/platform-apple/runner/test-host',
+    '@agent-device/platform-apple/session-observation',
     '@agent-device/platform-apple/simctl',
     '@agent-device/platform-apple/simulator',
     '@agent-device/platform-apple/snapshot-source',

--- a/scripts/layering/platform-package-policy.test.ts
+++ b/scripts/layering/platform-package-policy.test.ts
@@ -39,6 +39,7 @@ function declarations(): PlatformPackageDeclaration[] {
             '@agent-device/platform-apple/runner/test-host',
             '@agent-device/platform-apple/runner/operations',
             '@agent-device/platform-apple/runner-owner',
+            '@agent-device/platform-apple/session-observation',
             '@agent-device/platform-apple/simctl',
             '@agent-device/platform-apple/snapshot-source',
             '@agent-device/platform-apple/simulator',

--- a/scripts/layering/platform-package-policy.ts
+++ b/scripts/layering/platform-package-policy.ts
@@ -85,6 +85,7 @@ const MECHANICS_FACET_SUBPATHS: Readonly<Partial<Record<PlatformFamily, readonly
     '@agent-device/platform-apple/physical-device',
     '@agent-device/platform-apple/runner-owner',
     '@agent-device/platform-apple/runner/operations',
+    '@agent-device/platform-apple/session-observation',
     '@agent-device/platform-apple/snapshot-source',
     '@agent-device/platform-apple/simctl',
     '@agent-device/platform-apple/simulator',

--- a/src/__tests__/platform-runtime-apple-resources.test.ts
+++ b/src/__tests__/platform-runtime-apple-resources.test.ts
@@ -1,0 +1,53 @@
+import { expect, test, vi } from 'vitest';
+import { AppError } from '@agent-device/kernel/errors';
+import { appleSessionObservation } from '../platform-runtime-apple-resources.ts';
+import { withTestDeviceInventory } from './test-utils/device-inventory-gateways.ts';
+
+test('foreground observation uses request-local inventory without consulting a provider', async () => {
+  const local = vi.fn(async () => []);
+  const provider = { discover: vi.fn(async () => ({ kind: 'declined' as const })) };
+
+  await expect(
+    withTestDeviceInventory({ local, provider }, () =>
+      appleSessionObservation.resolveSoleForegroundApp(),
+    ),
+  ).resolves.toBeUndefined();
+  expect(local).toHaveBeenCalledOnce();
+  expect(provider.discover).not.toHaveBeenCalled();
+});
+
+test('foreground observation requires the request inventory context', async () => {
+  await expect(appleSessionObservation.resolveSoleForegroundApp()).rejects.toMatchObject({
+    code: 'COMMAND_FAILED',
+    details: { reason: 'device_inventory_context_unavailable' },
+  });
+});
+
+test.each([
+  new AppError('COMMAND_FAILED', 'probe failed', { reason: 'request_canceled' }),
+  new DOMException('probe failed', 'AbortError'),
+])('foreground observation propagates control flow: %s', async (error) => {
+  await expect(
+    withTestDeviceInventory(
+      {
+        local: async () => {
+          throw error;
+        },
+      },
+      () => appleSessionObservation.resolveSoleForegroundApp(),
+    ),
+  ).rejects.toBe(error);
+});
+
+test('the same message without a control-flow reason remains inconclusive', async () => {
+  await expect(
+    withTestDeviceInventory(
+      {
+        local: async () => {
+          throw new AppError('COMMAND_FAILED', 'probe failed');
+        },
+      },
+      () => appleSessionObservation.resolveSoleForegroundApp(),
+    ),
+  ).resolves.toBeUndefined();
+});

--- a/src/daemon/__tests__/request-recording-health.test.ts
+++ b/src/daemon/__tests__/request-recording-health.test.ts
@@ -2,17 +2,18 @@ import { test, expect, vi, beforeEach } from 'vitest';
 import type { SessionState } from '../session-state.ts';
 import { makeTestScreenRecordingResource } from '../../__tests__/test-utils/screen-recording-live-handle.ts';
 
-vi.mock('@agent-device/platform-apple/runner/operations', () => ({
-  getRunnerSessionSnapshot: vi.fn(),
+vi.mock('../../platform-runtime-apple-resources.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../platform-runtime-apple-resources.ts')>()),
+  appleSessionObservation: { observeRunnerSession: vi.fn() },
 }));
 
-import { getRunnerSessionSnapshot } from '@agent-device/platform-apple/runner/operations';
+import { appleSessionObservation } from '../../platform-runtime-apple-resources.ts';
 import { refreshRecordingHealth } from '../request-recording-health.ts';
 
-const mockGetRunnerSessionSnapshot = vi.mocked(getRunnerSessionSnapshot);
+const mockObserveRunnerSession = vi.mocked(appleSessionObservation.observeRunnerSession);
 
 beforeEach(() => {
-  mockGetRunnerSessionSnapshot.mockReset();
+  mockObserveRunnerSession.mockReset();
 });
 
 function makeIosSimulatorSession(showTouches: boolean): SessionState {
@@ -48,16 +49,51 @@ test('runner-backed iOS recordings still invalidate on runner restarts', async (
     showTouches: true,
     runnerSessionId: 'runner-before',
   });
-  mockGetRunnerSessionSnapshot.mockResolvedValue({
+  mockObserveRunnerSession.mockResolvedValue({
     alive: true,
     sessionId: 'runner-after',
-    ready: true,
   });
 
   await refreshRecordingHealth(session);
 
-  expect(mockGetRunnerSessionSnapshot).toHaveBeenCalledWith('sim-1');
+  expect(mockObserveRunnerSession).toHaveBeenCalledWith('sim-1');
   expect(session.screenRecording?.handle.inspect().invalidatedReason).toBe(
     'iOS runner session restarted during recording',
   );
+});
+
+test.each([
+  { snapshot: undefined, reason: 'iOS runner session exited during recording' },
+  {
+    snapshot: { alive: false, sessionId: 'runner-before' },
+    reason: 'iOS runner session exited during recording',
+  },
+  { snapshot: { alive: true, sessionId: 'runner-before' }, reason: undefined },
+])('recording health follows runner liveness: $snapshot', async ({ snapshot, reason }) => {
+  const session = makeIosSimulatorSession(true);
+  session.screenRecording = makeTestScreenRecordingResource(session, {
+    backend: 'runner AVAssetWriter',
+    showTouches: true,
+    runnerSessionId: 'runner-before',
+  });
+  mockObserveRunnerSession.mockResolvedValue(snapshot);
+
+  await refreshRecordingHealth(session);
+
+  expect(session.screenRecording.handle.inspect().invalidatedReason).toBe(reason);
+});
+
+test('a recording without a runner identity adopts the first live observation', async () => {
+  const session = makeIosSimulatorSession(true);
+  session.screenRecording = makeTestScreenRecordingResource(session, {
+    backend: 'runner AVAssetWriter',
+    showTouches: true,
+  });
+  mockObserveRunnerSession.mockResolvedValue({ alive: true, sessionId: 'runner-first' });
+
+  await refreshRecordingHealth(session);
+
+  const recording = session.screenRecording.handle.inspect();
+  expect(recording.runnerSessionId).toBe('runner-first');
+  expect(recording.invalidatedReason).toBeUndefined();
 });

--- a/src/daemon/__tests__/request-router-recording-health.test.ts
+++ b/src/daemon/__tests__/request-router-recording-health.test.ts
@@ -4,12 +4,12 @@ import { test, expect, vi, beforeEach } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
 
-vi.mock('@agent-device/platform-apple/runner/operations', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@agent-device/platform-apple/runner/operations')>()),
-  getRunnerSessionSnapshot: vi.fn(),
+vi.mock('../../platform-runtime-apple-resources.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../platform-runtime-apple-resources.ts')>()),
+  appleSessionObservation: { observeRunnerSession: vi.fn() },
 }));
 
-import { getRunnerSessionSnapshot } from '@agent-device/platform-apple/runner/operations';
+import { appleSessionObservation } from '../../platform-runtime-apple-resources.ts';
 import {
   createRequestHandler,
   gestureDeviceRuntimeGateway,
@@ -20,13 +20,13 @@ import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
 import { makeTestScreenRecordingResource } from '../../__tests__/test-utils/screen-recording-live-handle.ts';
 
-const mockGetRunnerSessionSnapshot = vi.mocked(getRunnerSessionSnapshot);
+const mockObserveRunnerSession = vi.mocked(appleSessionObservation.observeRunnerSession);
 
 beforeEach(() => {
   legacyDispatchCapture.mockReset();
   legacyDispatchCapture.mockResolvedValue({});
   for (const spy of Object.values(gestureRuntimeSpies)) spy.mockClear();
-  mockGetRunnerSessionSnapshot.mockReset();
+  mockObserveRunnerSession.mockReset();
 });
 
 test('router blocks non-record commands when recording was invalidated', async () => {
@@ -104,10 +104,9 @@ test('router allows canonical iOS simulator gestures during overlay recording af
     runnerSessionId: 'runner-before',
   });
   sessionStore.set('default', session);
-  mockGetRunnerSessionSnapshot.mockResolvedValue({
+  mockObserveRunnerSession.mockResolvedValue({
     alive: true,
     sessionId: 'runner-after',
-    ready: true,
   });
   const handler = createRequestHandler({
     logPath: path.join(os.tmpdir(), 'daemon.log'),
@@ -129,7 +128,7 @@ test('router allows canonical iOS simulator gestures during overlay recording af
   });
 
   expect(response.ok).toBe(true);
-  expect(mockGetRunnerSessionSnapshot).not.toHaveBeenCalled();
+  expect(mockObserveRunnerSession).not.toHaveBeenCalled();
   expect(gestureRuntimeSpies.gestureViewport).toHaveBeenCalledOnce();
   expect(gestureRuntimeSpies.performMultiTouchGesturePlan).toHaveBeenCalledOnce();
   const recording = sessionStore.get('default')?.screenRecording?.handle.inspect();

--- a/src/daemon/__tests__/session-device-resolution.test.ts
+++ b/src/daemon/__tests__/session-device-resolution.test.ts
@@ -6,13 +6,14 @@ import {
   refreshSessionDeviceIfNeeded,
   selectorTargetsSessionDevice,
 } from '../session-device-resolution.ts';
-import { getRunnerSessionSnapshot } from '@agent-device/platform-apple/runner/operations';
+import { appleSessionObservation } from '../../platform-runtime-apple-resources.ts';
 import { resolveTargetDevice } from '@agent-device/device-selection/dispatch-resolve';
 import { isActiveProviderDevice } from '../../provider-device-runtime.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 
-vi.mock('@agent-device/platform-apple/runner/operations', () => ({
-  getRunnerSessionSnapshot: vi.fn(async () => null),
+vi.mock('../../platform-runtime-apple-resources.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../platform-runtime-apple-resources.ts')>()),
+  appleSessionObservation: { observeRunnerSession: vi.fn() },
 }));
 vi.mock('@agent-device/device-selection/dispatch-resolve', () => ({
   resolveTargetDevice: vi.fn(),
@@ -24,14 +25,14 @@ vi.mock('../device-ready.ts', () => ({
   ensureDeviceReady: vi.fn(async () => {}),
 }));
 
-const mockGetRunnerSessionSnapshot = vi.mocked(getRunnerSessionSnapshot);
+const mockObserveRunnerSession = vi.mocked(appleSessionObservation.observeRunnerSession);
 const mockResolveTargetDevice = vi.mocked(resolveTargetDevice);
 const mockIsActiveProviderDevice = vi.mocked(isActiveProviderDevice);
 const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
 
 beforeEach(() => {
-  mockGetRunnerSessionSnapshot.mockReset();
-  mockGetRunnerSessionSnapshot.mockResolvedValue(null);
+  mockObserveRunnerSession.mockReset();
+  mockObserveRunnerSession.mockResolvedValue(undefined);
   mockResolveTargetDevice.mockReset();
   mockIsActiveProviderDevice.mockReset();
   mockIsActiveProviderDevice.mockReturnValue(false);
@@ -109,10 +110,9 @@ test('refreshSessionDeviceIfNeeded keeps provider-owned iOS simulators out of lo
 });
 
 test('refreshSessionDeviceIfNeeded skips re-resolve while the iOS runner session is alive', async () => {
-  mockGetRunnerSessionSnapshot.mockResolvedValue({
+  mockObserveRunnerSession.mockResolvedValue({
     sessionId: 'sim-1:1234:1',
     alive: true,
-    ready: true,
   });
 
   const device = await withMockedPlatform('darwin', async () =>
@@ -124,10 +124,9 @@ test('refreshSessionDeviceIfNeeded skips re-resolve while the iOS runner session
 });
 
 test('refreshSessionDeviceIfNeeded re-resolves when the iOS runner session is gone', async () => {
-  mockGetRunnerSessionSnapshot.mockResolvedValue({
+  mockObserveRunnerSession.mockResolvedValue({
     sessionId: 'sim-1:1234:1',
     alive: false,
-    ready: false,
   });
   const resolved = { ...iosSimulatorSession.device, booted: true, name: 'renamed' };
   mockResolveTargetDevice.mockResolvedValue(resolved);

--- a/src/daemon/ios-app-session-hint.test.ts
+++ b/src/daemon/ios-app-session-hint.test.ts
@@ -1,33 +1,21 @@
-import { AppError } from '@agent-device/kernel/errors';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-const listBootedIosSimulators = vi.hoisted(() => vi.fn());
-const detectSoleRunningIosSimulatorApp = vi.hoisted(() => vi.fn());
-
-vi.mock('@agent-device/device-selection/device-inventory-context', async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import('@agent-device/device-selection/device-inventory-context')
-  >()),
-  listLocalDeviceInventory: listBootedIosSimulators,
-}));
-vi.mock('@agent-device/platform-apple/app-resolution', () => ({
-  detectSoleRunningIosSimulatorApp,
-}));
-
 import { IOS_DEVICE, IOS_SIMULATOR } from '../__tests__/test-utils/device-fixtures.ts';
-import { buildIosOpenCommandHint, resolveSoleForegroundIosApp } from './ios-app-session-hint.ts';
+import { buildIosOpenCommandHint } from './ios-app-session-hint.ts';
+
+const resolveSoleForegroundApp = vi.hoisted(() => vi.fn());
+vi.mock('../platform-runtime-apple-resources.ts', () => ({
+  appleSessionObservation: { resolveSoleForegroundApp },
+}));
 
 beforeEach(() => {
-  listBootedIosSimulators.mockReset();
-  detectSoleRunningIosSimulatorApp.mockReset();
+  resolveSoleForegroundApp.mockReset();
 });
 
 test('an unambiguous environment gets the exact runnable open command', async () => {
   const soleBootedDevice = { ...IOS_SIMULATOR, id: 'booted-1', name: 'iPhone 16' };
-  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue({
-    bundleId: 'xyz.blueskyweb.app',
-    name: 'Bluesky',
+  resolveSoleForegroundApp.mockResolvedValue({
+    device: soleBootedDevice,
+    app: { bundleId: 'xyz.blueskyweb.app' },
   });
 
   const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
@@ -36,7 +24,7 @@ test('an unambiguous environment gets the exact runnable open command', async ()
     'One booted device found ("iPhone 16", udid booted-1) with xyz.blueskyweb.app running. ' +
       'Run: agent-device open xyz.blueskyweb.app --platform ios --udid booted-1',
   );
-  expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
+  expect(resolveSoleForegroundApp).toHaveBeenCalledWith({ simulatorSetPath: undefined });
 });
 
 test('a custom simulator set is echoed back so the printed command is the one that was run', async () => {
@@ -46,10 +34,9 @@ test('a custom simulator set is echoed back so the printed command is the one th
     name: 'iPhone 16',
     simulatorSetPath: '/tmp/agent-device sim set',
   };
-  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue({
-    bundleId: 'xyz.blueskyweb.app',
-    name: 'Bluesky',
+  resolveSoleForegroundApp.mockResolvedValue({
+    device: soleBootedDevice,
+    app: { bundleId: 'xyz.blueskyweb.app' },
   });
 
   const hint = await buildIosOpenCommandHint(soleBootedDevice);
@@ -72,144 +59,26 @@ test('a hint that would exceed the wire-redaction truncation length falls back t
     name: 'iPhone 16',
     simulatorSetPath: `/very/long/simulator/set/path/${'segment/'.repeat(30)}`,
   };
-  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue({
-    bundleId: 'xyz.blueskyweb.app',
-    name: 'Bluesky',
+  resolveSoleForegroundApp.mockResolvedValue({
+    device: soleBootedDevice,
+    app: { bundleId: 'xyz.blueskyweb.app' },
   });
 
   await expect(buildIosOpenCommandHint(soleBootedDevice)).resolves.toBeUndefined();
 });
 
-test('a rejecting probe (timeout or spawn failure) is caught, not propagated', async () => {
-  listBootedIosSimulators.mockRejectedValue(new Error('simctl timed out'));
-
+test('an inconclusive observation keeps the generic hint', async () => {
+  resolveSoleForegroundApp.mockResolvedValue(undefined);
   await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).resolves.toBeUndefined();
 });
 
-test('a rejecting foreground-app probe is caught, not propagated', async () => {
-  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
-  detectSoleRunningIosSimulatorApp.mockRejectedValue(new Error('launchctl timed out'));
-
-  await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).resolves.toBeUndefined();
-});
-
-test('request cancellation from the inventory probe is propagated', async () => {
-  const canceled = new AppError('COMMAND_FAILED', 'request canceled', {
-    reason: 'request_canceled',
-  });
-  listBootedIosSimulators.mockRejectedValue(canceled);
-
-  await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).rejects.toBe(canceled);
-});
-
-test('abort control flow from the foreground-app probe is propagated', async () => {
+test('control-flow failures from the observation port propagate', async () => {
   const canceled = new DOMException('This operation was aborted', 'AbortError');
-  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
-  detectSoleRunningIosSimulatorApp.mockRejectedValue(canceled);
-
+  resolveSoleForegroundApp.mockRejectedValue(canceled);
   await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).rejects.toBe(canceled);
-});
-
-test('missing inventory-context wiring is propagated', async () => {
-  const unavailable = new AppError(
-    'COMMAND_FAILED',
-    'Device inventory gateway is unavailable outside request execution',
-    { reason: 'device_inventory_context_unavailable' },
-  );
-  listBootedIosSimulators.mockRejectedValue(unavailable);
-
-  await expect(buildIosOpenCommandHint(IOS_SIMULATOR)).rejects.toBe(unavailable);
-});
-
-test('more than one booted simulator stays ambiguous and returns no hint', async () => {
-  listBootedIosSimulators.mockResolvedValue([
-    { ...IOS_SIMULATOR, id: 'booted-1' },
-    { ...IOS_SIMULATOR, id: 'booted-2' },
-  ]);
-
-  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
-
-  expect(hint).toBeUndefined();
-  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
-});
-
-test('no booted simulator returns no hint', async () => {
-  listBootedIosSimulators.mockResolvedValue([]);
-
-  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
-
-  expect(hint).toBeUndefined();
-  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
-});
-
-test('a failed or inconclusive running-app probe returns no hint', async () => {
-  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue(undefined);
-
-  const hint = await buildIosOpenCommandHint(IOS_SIMULATOR);
-
-  expect(hint).toBeUndefined();
 });
 
 test('a physical iOS device never probes for a hint', async () => {
-  const hint = await buildIosOpenCommandHint(IOS_DEVICE);
-
-  expect(hint).toBeUndefined();
-  expect(listBootedIosSimulators).not.toHaveBeenCalled();
-});
-
-test('resolveSoleForegroundIosApp resolves the device and app when unambiguous', async () => {
-  const soleBootedDevice = { ...IOS_SIMULATOR, id: 'booted-1', name: 'iPhone 16' };
-  const app = { bundleId: 'xyz.blueskyweb.app', name: 'Bluesky' };
-  listBootedIosSimulators.mockResolvedValue([soleBootedDevice]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue(app);
-
-  const resolved = await resolveSoleForegroundIosApp({ simulatorSetPath: '/custom/set' });
-
-  expect(resolved).toEqual({ device: soleBootedDevice, app });
-  expect(listBootedIosSimulators).toHaveBeenCalledWith({
-    platform: 'ios',
-    iosSimulatorSetPath: '/custom/set',
-    kind: 'simulator',
-    booted: true,
-  });
-  expect(detectSoleRunningIosSimulatorApp).toHaveBeenCalledWith(soleBootedDevice);
-});
-
-test('resolveSoleForegroundIosApp returns undefined for zero booted simulators', async () => {
-  listBootedIosSimulators.mockResolvedValue([]);
-
-  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
-  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
-});
-
-test('resolveSoleForegroundIosApp returns undefined for more than one booted simulator', async () => {
-  listBootedIosSimulators.mockResolvedValue([
-    { ...IOS_SIMULATOR, id: 'booted-1' },
-    { ...IOS_SIMULATOR, id: 'booted-2' },
-  ]);
-
-  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
-  expect(detectSoleRunningIosSimulatorApp).not.toHaveBeenCalled();
-});
-
-test('resolveSoleForegroundIosApp returns undefined when the running-app probe is inconclusive', async () => {
-  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
-  detectSoleRunningIosSimulatorApp.mockResolvedValue(undefined);
-
-  expect(await resolveSoleForegroundIosApp()).toBeUndefined();
-});
-
-test('resolveSoleForegroundIosApp catches a rejecting probe instead of propagating it', async () => {
-  // The hint's catch-all lives in the resolver, so an inconclusive local probe never masks the
-  // original session-not-found response.
-  listBootedIosSimulators.mockRejectedValue(new Error('simctl timed out'));
-
-  await expect(resolveSoleForegroundIosApp()).resolves.toBeUndefined();
-
-  listBootedIosSimulators.mockResolvedValue([{ ...IOS_SIMULATOR, id: 'booted-1' }]);
-  detectSoleRunningIosSimulatorApp.mockRejectedValue(new Error('launchctl timed out'));
-
-  await expect(resolveSoleForegroundIosApp()).resolves.toBeUndefined();
+  await expect(buildIosOpenCommandHint(IOS_DEVICE)).resolves.toBeUndefined();
+  expect(resolveSoleForegroundApp).not.toHaveBeenCalled();
 });

--- a/src/daemon/ios-app-session-hint.ts
+++ b/src/daemon/ios-app-session-hint.ts
@@ -1,30 +1,10 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
-import { resolveSoleForegroundIosApp } from '../platform-runtime-open-target.ts';
+import { appleSessionObservation } from '../platform-runtime-apple-resources.ts';
 import { shellQuoteIfNeeded } from '@agent-device/host-kit/command';
 
-export { resolveSoleForegroundIosApp } from '../platform-runtime-open-target.ts';
-
-/**
- * The shared ambiguity-detection probe: exactly one booted iOS simulator with
- * exactly one app running on it, or `undefined`.
- *
- * Any ambiguity — no booted simulator, more than one, no running app, more
- * than one running app, or a probe failure — returns `undefined`. This must
- * never guess: a wrong-but-confident answer is worse than failing closed.
- *
- * Probe failures (including bounded timeout/spawn failures) are best-effort
- * and treated as inconclusive. Cancellation and missing request-context
- * wiring are control-flow/composition failures and must propagate.
- *
- * `buildIosOpenCommandHint` is its only command-facing consumer; the actual bare
- * `open --foreground` probe belongs to the admitted Apple lifecycle binding.
- */
 /**
  * Enriches the generic "Run open first" SESSION_NOT_FOUND hint with the exact
- * runnable command, but only when the environment is unambiguous (see
- * `resolveSoleForegroundIosApp`, which owns the never-guess and best-effort
- * probe contract). Ambiguity or a genuine probe failure returns
- * `undefined` so the caller keeps the generic hint.
+ * runnable command when the observation port reports an unambiguous environment.
  */
 // Wire-level details are redacted before send (packages/kernel/src/redaction.ts),
 // which silently truncates any string field over 400 chars — a truncated
@@ -37,7 +17,9 @@ const MAX_HINT_LENGTH = 350;
 export async function buildIosOpenCommandHint(device: DeviceInfo): Promise<string | undefined> {
   if (!isIosFamily(device) || device.kind !== 'simulator') return undefined;
 
-  const resolved = await resolveSoleForegroundIosApp({ simulatorSetPath: device.simulatorSetPath });
+  const resolved = await appleSessionObservation.resolveSoleForegroundApp({
+    simulatorSetPath: device.simulatorSetPath,
+  });
   if (!resolved) return undefined;
 
   const command = buildOpenCommand(resolved.device, resolved.app.bundleId);

--- a/src/daemon/request-recording-health.ts
+++ b/src/daemon/request-recording-health.ts
@@ -1,5 +1,5 @@
 import { isIosFamily } from '@agent-device/kernel/device';
-import { inspectAppleRunnerSession } from '../platform-runtime-apple-resources.ts';
+import { appleSessionObservation } from '../platform-runtime-apple-resources.ts';
 import type { SessionState } from './session-state.ts';
 
 export async function refreshRecordingHealth(session: SessionState): Promise<void> {
@@ -9,7 +9,7 @@ export async function refreshRecordingHealth(session: SessionState): Promise<voi
   const recording = session.screenRecording!.handle;
   const state = recording.inspect();
 
-  const snapshot = await inspectAppleRunnerSession(session.device.id);
+  const snapshot = await appleSessionObservation.observeRunnerSession(session.device.id);
   if (!state.runnerSessionId) {
     if (snapshot?.alive) {
       recording.setRunnerSessionId(snapshot.sessionId);

--- a/src/daemon/session-device-resolution.ts
+++ b/src/daemon/session-device-resolution.ts
@@ -1,7 +1,7 @@
 import { isIosFamily, type DeviceInfo } from '@agent-device/kernel/device';
 import { AppError } from '@agent-device/kernel/errors';
 import { isActiveProviderDevice } from '../provider-device-runtime.ts';
-import { inspectAppleRunnerSession } from '../platform-runtime-apple-resources.ts';
+import { appleSessionObservation } from '../platform-runtime-apple-resources.ts';
 import { resolveTargetDevice } from '@agent-device/device-selection/dispatch-resolve';
 import type { DaemonRequest, DaemonResponse } from './daemon-request.ts';
 import type { SessionState } from './session-state.ts';
@@ -55,7 +55,7 @@ export async function refreshSessionDeviceIfNeeded(device: DeviceInfo): Promise<
   // A live XCUITest runner session is attached to this exact UDID, which
   // proves the simulator still exists and is booted — the two facts the
   // ~0.7s re-resolve inventory listing exists to establish.
-  if ((await inspectAppleRunnerSession(device.id))?.alive) {
+  if ((await appleSessionObservation.observeRunnerSession(device.id))?.alive) {
     return { ...device, booted: true };
   }
 

--- a/src/platform-runtime-apple-resources.ts
+++ b/src/platform-runtime-apple-resources.ts
@@ -1,12 +1,31 @@
 import type { AppleRunnerRequestOptions } from '@agent-device/contracts/apple-runner-request';
+import type { AppleSessionObservation } from '@agent-device/contracts/apple-session-observation';
 import type { ElementSelectorKey } from '@agent-device/contracts/interactor-types';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
-export async function inspectAppleRunnerSession(deviceId: string) {
-  const { getRunnerSessionSnapshot } =
-    await import('@agent-device/platform-apple/runner/operations');
-  return getRunnerSessionSnapshot(deviceId);
+let observation: AppleSessionObservation | undefined;
+
+async function loadAppleSessionObservation(): Promise<AppleSessionObservation> {
+  if (observation) return observation;
+  const { createAppleSessionObservation } =
+    await import('@agent-device/platform-apple/session-observation');
+  const { listLocalDeviceInventory, shouldPropagateDeviceInventoryProbeError } =
+    await import('@agent-device/device-selection/device-inventory-context');
+  observation ??= createAppleSessionObservation({
+    listLocalDevices: listLocalDeviceInventory,
+    shouldPropagateProbeError: shouldPropagateDeviceInventoryProbeError,
+  });
+  return observation;
 }
+
+export const appleSessionObservation: AppleSessionObservation = Object.freeze({
+  async observeRunnerSession(deviceId) {
+    return (await loadAppleSessionObservation()).observeRunnerSession(deviceId);
+  },
+  async resolveSoleForegroundApp(options) {
+    return (await loadAppleSessionObservation()).resolveSoleForegroundApp(options);
+  },
+});
 
 export async function queryAppleRuntimeSelector(
   device: DeviceInfo,

--- a/src/platform-runtime-open-target.ts
+++ b/src/platform-runtime-open-target.ts
@@ -10,41 +10,6 @@ import { loadAndroidMechanics } from './platform-runtime-android-mechanics.ts';
 
 const LINUX_SUPPORTED_SURFACES = new Set<SessionSurface>(['app', 'desktop', 'frontmost-app']);
 
-export type ResolvedForegroundIosApp = Readonly<{
-  device: DeviceInfo;
-  app: Readonly<{ bundleId: string }>;
-}>;
-
-/**
- * Read-only foreground discovery used solely to enrich a snapshot session-not-found hint. Actual
- * `open --foreground` target probing runs through the admitted Apple lifecycle binding instead.
- */
-export async function resolveSoleForegroundIosApp(
-  options: Readonly<{ simulatorSetPath?: string }> = {},
-): Promise<ResolvedForegroundIosApp | undefined> {
-  const { listLocalDeviceInventory, shouldPropagateDeviceInventoryProbeError } =
-    await import('@agent-device/device-selection/device-inventory-context');
-  try {
-    const booted = await listLocalDeviceInventory({
-      platform: 'ios',
-      iosSimulatorSetPath: options.simulatorSetPath,
-      kind: 'simulator',
-      booted: true,
-    });
-    if (booted.length !== 1) return undefined;
-    const [soleBootedDevice] = booted;
-    if (!soleBootedDevice) return undefined;
-
-    const { detectSoleRunningIosSimulatorApp } =
-      await import('@agent-device/platform-apple/app-resolution');
-    const app = await detectSoleRunningIosSimulatorApp(soleBootedDevice);
-    return app ? { device: soleBootedDevice, app } : undefined;
-  } catch (error) {
-    if (shouldPropagateDeviceInventoryProbeError(error)) throw error;
-    return undefined;
-  }
-}
-
 /**
  * Platform-owned surface classification for open. Daemon handlers retain only the public
  * error-response construction and session-policy choice of an existing surface.


### PR DESCRIPTION
## Summary

Closes #2332.

Recording health, simulator refresh, and missing-session hints now consume one `AppleSessionObservation` contract. The Apple package owns the liveness/session-identity and sole-foreground-app probes; root composition supplies request-local inventory and its error classifier. The daemon retains recording invalidation, device selection, and hint formatting.

22 files (+369/−282): the observation port, three consumers, behavioral coverage, ADR 0022, and package/ownership declarations. Public CLI and wire behavior is preserved.

## Validation

Head: `161c232eb1e6af80b441990e40f3fc19ee690906` (Node 24.13.1, pnpm 11.17.0).

- On unchanged `main` (`6486788359`), three ownership-retirement regressions failed; all three pass with the change.
- `pnpm exec vitest run packages/platform-apple/src/__tests__/session-observation.test.ts src/__tests__/platform-runtime-apple-resources.test.ts src/daemon/ios-app-session-hint.test.ts src/daemon/__tests__/request-recording-health.test.ts src/daemon/__tests__/session-device-resolution.test.ts src/daemon/__tests__/request-router-recording-health.test.ts`: 34 passed.
- `pnpm check:affected --run`: passed, including 1,864 related tests, 219 layering tests, build/package checks, Fallow, compatibility, and 95 Node integration tests (9 native cases skipped by the harness).

This preserves native behavior through a TypeScript seam; device/toolchain lanes, Coverage, and Integration Tests remain GitHub-authoritative. CI has not run yet.

<!-- plasma-agent-device-lane:b -->
