### PR TITLE
refactor(daemon): separate open-target policy from platform mechanics

### DIFF
--- a/docs/adr/0022-daemon-platform-runtime-coupling.md
+++ b/docs/adr/0022-daemon-platform-runtime-coupling.md
@@ -58,9 +58,10 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
      neutral open plan/result surface (`resolveRequestedOpenSurface`, `validateOpenRelaunchTarget`,
      `resolveSessionAppBundleIdForTarget`); Android package resolution
      (`resolveAndroidPackageForOpen`, `inferAndroidPackageAfterOpen`) moved behind the Android
-     owning seam in `packages/platform-android`. `session-open-prepare.ts` and
-     `session-selector-dispatch.ts` are daemon-policy-essential over the neutral resolver, which
-     stays the one construction path for the open plan.
+     owning seam in `packages/platform-android`. `session-open-prepare.ts` consumes surface and
+     relaunch-target policy, `session-selector-dispatch.ts` consumes the app-bundle-identity
+     resolver; both edges are daemon-policy-essential, and the resolver stays the one
+     construction path for the open plan.
    - **#2273/#2274** (existing) — `direct-ios-selector.ts` → `queryAppleRuntimeSelector` is the
      selector seam those issues own; coordination was posted there rather than opening a second
      selector producer.

--- a/docs/adr/0022-daemon-platform-runtime-coupling.md
+++ b/docs/adr/0022-daemon-platform-runtime-coupling.md
@@ -54,9 +54,13 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
      the Apple runner owner, the Android snapshot-helper and Web orphan cleanups, and legacy
      app-log marker recovery. The `resource-cleanup` edge stays, reclassified
      composition-essential and carrying only `platformResourceCleanup`.
-   - **#2334** — open-target planning separated from platform mechanics
-     (`session-open-prepare.ts`, `session-selector-dispatch.ts` →
-     `platform-runtime-open-target.ts`), blocked by #2332.
+   - **Open-target planning (done, #2334)** — `platform-runtime-open-target.ts` keeps only the
+     neutral open plan/result surface (`resolveRequestedOpenSurface`, `validateOpenRelaunchTarget`,
+     `resolveSessionAppBundleIdForTarget`); Android package resolution
+     (`resolveAndroidPackageForOpen`, `inferAndroidPackageAfterOpen`) moved behind the Android
+     owning seam in `packages/platform-android`. `session-open-prepare.ts` and
+     `session-selector-dispatch.ts` are daemon-policy-essential over the neutral resolver, which
+     stays the one construction path for the open plan.
    - **#2273/#2274** (existing) — `direct-ios-selector.ts` → `queryAppleRuntimeSelector` is the
      selector seam those issues own; coordination was posted there rather than opening a second
      selector producer.
@@ -85,7 +89,7 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
 5. **Per-audit-area decisions.** Apple session observation: consume the neutral
    `AppleSessionObservation` contract. Runtime lifecycle participation: deepen through the existing lifecycle
    phases, no generic hook bag (#2333). Open-target planning: separate plan/result from
-   platform mechanics, one construction path preserved (#2334). Session state/store authority:
+   platform mechanics, one construction path preserved. Session state/store authority:
    keep the current access shape, ratchet the handler-owned slice (R75). Route depth: record the
    re-traced routes; collapse only the proven pass-through hops (none undertaken in this
    change).
@@ -120,5 +124,4 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
   `scripts/layering/check.ts` (both observed red against planted violations before acceptance).
 - R7 `session-state-ownership` and the R10 merge-base ratchet for the owning-module slice.
 - R65 for the concrete-platform-import ban this audit builds on.
-- Child issue #2334 (and #2273/#2274 for the selector seam) for the remaining category-3
-  implementation work; #2333 landed (see §2.2).
+- Child issues #2333 and #2334 landed (see §2.2); #2273/#2274 remain for the selector seam.

--- a/packages/platform-android/src/app-lifecycle.ts
+++ b/packages/platform-android/src/app-lifecycle.ts
@@ -239,7 +239,7 @@ async function openAndroidAppBoundDeepLink(
     throw new AppError('INVALID_ARGS', 'Android app-bound open requires a valid URL target');
   }
   await ensureAndroidLocalhostReverse(device, deepLinkUrl);
-  const resolved = await resolveAndroidPackageForOpen(device, app, 'app-bound open');
+  const resolved = await requireAndroidPackageForOpen(device, app, 'app-bound open');
   await runAndroidAdb(device, [
     'shell',
     'am',
@@ -352,7 +352,7 @@ function buildAndroidActivityLaunchArgs(
   ];
 }
 
-async function resolveAndroidPackageForOpen(
+async function requireAndroidPackageForOpen(
   device: DeviceInfo,
   app: string,
   label: string,

--- a/packages/platform-android/src/mechanics.ts
+++ b/packages/platform-android/src/mechanics.ts
@@ -190,10 +190,22 @@ export {
   formatAndroidInstalledPackageRequiredMessage,
   type AndroidAppTargetKind,
 } from './open-target.ts';
-export {
-  inferAndroidPackageAfterOpen,
-  resolveAndroidPackageForOpen,
-} from './open-target-resolution.ts';
+export async function resolveAndroidPackageForOpen(
+  ...args: Parameters<typeof import('./open-target-resolution.ts').resolveAndroidPackageForOpen>
+): Promise<
+  Awaited<ReturnType<typeof import('./open-target-resolution.ts').resolveAndroidPackageForOpen>>
+> {
+  const { resolveAndroidPackageForOpen: load } = await import('./open-target-resolution.ts');
+  return await load(...args);
+}
+export async function inferAndroidPackageAfterOpen(
+  ...args: Parameters<typeof import('./open-target-resolution.ts').inferAndroidPackageAfterOpen>
+): Promise<
+  Awaited<ReturnType<typeof import('./open-target-resolution.ts').inferAndroidPackageAfterOpen>>
+> {
+  const { inferAndroidPackageAfterOpen: load } = await import('./open-target-resolution.ts');
+  return await load(...args);
+}
 export {
   resetAndroidFramePerfStats,
   sampleAndroidFramePerf,

--- a/packages/platform-android/src/mechanics.ts
+++ b/packages/platform-android/src/mechanics.ts
@@ -191,6 +191,10 @@ export {
   type AndroidAppTargetKind,
 } from './open-target.ts';
 export {
+  inferAndroidPackageAfterOpen,
+  resolveAndroidPackageForOpen,
+} from './open-target-resolution.ts';
+export {
   resetAndroidFramePerfStats,
   sampleAndroidFramePerf,
   type AndroidFramePerfOptions,

--- a/packages/platform-android/src/open-target-resolution.test.ts
+++ b/packages/platform-android/src/open-target-resolution.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { AppError } from '@agent-device/kernel/errors';
+
+const resolveAndroidApp = vi.hoisted(() => vi.fn());
+const getAndroidAppState = vi.hoisted(() => vi.fn());
+
+vi.mock('./app-deployment-resolution.ts', () => ({ resolveAndroidApp }));
+vi.mock('./window-state.ts', () => ({ getAndroidAppState }));
+
+const { resolveAndroidPackageForOpen, inferAndroidPackageAfterOpen } =
+  await import('./open-target-resolution.ts');
+
+const androidDevice: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel Emulator',
+  kind: 'emulator',
+  booted: true,
+};
+const appleDevice: DeviceInfo = {
+  platform: 'apple',
+  id: '00000000-0000-0000-0000-000000000000',
+  name: 'iPhone Simulator',
+  kind: 'simulator',
+  booted: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('resolveAndroidPackageForOpen returns the resolved package for a package match', async () => {
+  resolveAndroidApp.mockResolvedValue({ type: 'package', value: 'com.example.demo' });
+
+  await expect(resolveAndroidPackageForOpen(androidDevice, 'demo')).resolves.toBe(
+    'com.example.demo',
+  );
+});
+
+test('resolveAndroidPackageForOpen ignores an intent resolution', async () => {
+  resolveAndroidApp.mockResolvedValue({ type: 'intent', value: 'android.settings.SETTINGS' });
+
+  await expect(resolveAndroidPackageForOpen(androidDevice, 'settings')).resolves.toBeUndefined();
+});
+
+test('resolveAndroidPackageForOpen swallows resolution failures', async () => {
+  resolveAndroidApp.mockRejectedValue(new AppError('APP_NOT_INSTALLED', 'No package found'));
+
+  await expect(resolveAndroidPackageForOpen(androidDevice, 'demo')).resolves.toBeUndefined();
+  expect(resolveAndroidApp).toHaveBeenCalled();
+});
+
+test('resolveAndroidPackageForOpen skips non-Android devices without resolving', async () => {
+  await expect(resolveAndroidPackageForOpen(appleDevice, 'demo')).resolves.toBeUndefined();
+  expect(resolveAndroidApp).not.toHaveBeenCalled();
+});
+
+test('resolveAndroidPackageForOpen skips a deep-link target without resolving', async () => {
+  await expect(
+    resolveAndroidPackageForOpen(androidDevice, 'myapp://login'),
+  ).resolves.toBeUndefined();
+  expect(resolveAndroidApp).not.toHaveBeenCalled();
+});
+
+test('inferAndroidPackageAfterOpen reads the foreground package for a deep-link open', async () => {
+  getAndroidAppState.mockResolvedValue({
+    package: 'host.exp.exponent',
+    activity: 'host.exp.exponent.experience.ExperienceActivity',
+  });
+
+  await expect(
+    inferAndroidPackageAfterOpen(androidDevice, 'exp://127.0.0.1:8082', undefined),
+  ).resolves.toBe('host.exp.exponent');
+});
+
+test('inferAndroidPackageAfterOpen keeps an already-known bundle id without reading state', async () => {
+  await expect(
+    inferAndroidPackageAfterOpen(androidDevice, 'exp://127.0.0.1:8082', 'com.example.demo'),
+  ).resolves.toBe('com.example.demo');
+  expect(getAndroidAppState).not.toHaveBeenCalled();
+});
+
+test('inferAndroidPackageAfterOpen leaves a non-deep-link target unchanged', async () => {
+  await expect(
+    inferAndroidPackageAfterOpen(androidDevice, 'com.example.demo', undefined),
+  ).resolves.toBeUndefined();
+  expect(getAndroidAppState).not.toHaveBeenCalled();
+});
+
+test('inferAndroidPackageAfterOpen swallows a foreground-state read failure', async () => {
+  getAndroidAppState.mockRejectedValue(new Error('adb connection dropped'));
+
+  await expect(
+    inferAndroidPackageAfterOpen(androidDevice, 'exp://127.0.0.1:8082', undefined),
+  ).resolves.toBeUndefined();
+});

--- a/packages/platform-android/src/open-target-resolution.ts
+++ b/packages/platform-android/src/open-target-resolution.ts
@@ -1,0 +1,37 @@
+import { isDeepLinkTarget } from '@agent-device/contracts/command';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+import { resolveAndroidApp } from './app-deployment-resolution.ts';
+import { getAndroidAppState } from './window-state.ts';
+
+/** Resolves an `open` target to an installed package; only an exact package match counts. */
+export async function resolveAndroidPackageForOpen(
+  device: DeviceInfo,
+  openTarget: string | undefined,
+): Promise<string | undefined> {
+  if (device.platform !== 'android' || !openTarget || isDeepLinkTarget(openTarget))
+    return undefined;
+  try {
+    const resolved = await resolveAndroidApp(device, openTarget);
+    return resolved.type === 'package' ? resolved.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** A deep-link open can foreground a different package than the one requested; read it back. */
+export async function inferAndroidPackageAfterOpen(
+  device: DeviceInfo,
+  openTarget: string | undefined,
+  currentAppBundleId: string | undefined,
+): Promise<string | undefined> {
+  if (currentAppBundleId) return currentAppBundleId;
+  if (device.platform !== 'android' || !openTarget || !isDeepLinkTarget(openTarget)) {
+    return currentAppBundleId;
+  }
+  try {
+    const foreground = await getAndroidAppState(device);
+    return foreground.package?.trim() || currentAppBundleId;
+  } catch {
+    return currentAppBundleId;
+  }
+}

--- a/scripts/layering/daemon-platform-runtime-inventory.test.ts
+++ b/scripts/layering/daemon-platform-runtime-inventory.test.ts
@@ -98,6 +98,25 @@ test('R76 rejects new symbols on a classified edge', () => {
   assert.match(found[0]!.message, /ensureLocalPlatformDeviceReady, extraReadiness/);
 });
 
+test('R76 rejects a reintroduced Android-mechanics import on the selector-dispatch edge', () => {
+  const sources = {
+    'src/platform-runtime-open-target.ts':
+      'export async function resolveSessionAppBundleIdForTarget() { return undefined; }\n' +
+      'export async function resolveAndroidPackageForOpen() { return undefined; }\n',
+    'src/daemon/handlers/session-selector-dispatch.ts':
+      "import { resolveAndroidPackageForOpen, resolveSessionAppBundleIdForTarget } from '../../platform-runtime-open-target.ts';\n" +
+      'void [resolveAndroidPackageForOpen, resolveSessionAppBundleIdForTarget];\n',
+  };
+  const found = edgeViolations(sources, 'src/daemon/handlers/session-selector-dispatch.ts');
+  assert.equal(found.length, 1);
+  assert.equal(found[0]!.rule, DAEMON_PLATFORM_RUNTIME_RULE);
+  assert.match(found[0]!.message, /classified symbols drifted/);
+  assert.match(
+    found[0]!.message,
+    /resolveAndroidPackageForOpen, resolveSessionAppBundleIdForTarget/,
+  );
+});
+
 test('R76 matches a destructured dynamic import by target with the recorded bindings', () => {
   const sources = {
     'src/platform-runtime-daemon-lifecycle.ts':

--- a/scripts/layering/daemon-platform-runtime-inventory.ts
+++ b/scripts/layering/daemon-platform-runtime-inventory.ts
@@ -151,22 +151,24 @@ export const DAEMON_PLATFORM_RUNTIME_EDGES: readonly DaemonPlatformRuntimeEdge[]
   {
     file: 'src/daemon/handlers/session-selector-dispatch.ts',
     target: 'src/platform-runtime-open-target.ts',
-    symbols: ['resolveAndroidPackageForOpen', 'resolveSessionAppBundleIdForTarget'],
-    classification: 'leaked-platform-mechanics',
+    symbols: ['resolveSessionAppBundleIdForTarget'],
+    classification: 'daemon-policy-essential',
     rationale:
-      'selector dispatch consumes the mixed open-target module; Android package resolution ' +
-      'is platform mechanics that should sit behind the Android owning seam.',
-    deepenedBy: '#2334',
+      'selector dispatch reconstructs the session app-bundle identity after a trigger-app-event ' +
+      'deep link through the one neutral open-plan resolver (#2334); Android package resolution ' +
+      'moved behind the Android owning seam in packages/platform-android, so the resolver is the ' +
+      'only symbol this edge names.',
   },
   {
     file: 'src/daemon/session-lifecycle/internal/session-open-prepare.ts',
     target: 'src/platform-runtime-open-target.ts',
     symbols: ['resolveRequestedOpenSurface', 'validateOpenRelaunchTarget'],
-    classification: 'leaked-platform-mechanics',
+    classification: 'daemon-policy-essential',
     rationale:
-      'open-prepare policy consumes the mixed open-target module; the neutral open ' +
-      'plan/result should be separated from the platform mechanics that share the file.',
-    deepenedBy: '#2334',
+      'open-prepare policy consumes only the neutral open plan/result surface (#2334): surface ' +
+      'classification and relaunch-target validation. The platform mechanics that used to share ' +
+      'the file (Android package resolution) moved behind the Android owning seam, leaving this ' +
+      'edge daemon policy over a neutral resolver.',
   },
 ] as const;
 

--- a/scripts/layering/daemon-platform-runtime-inventory.ts
+++ b/scripts/layering/daemon-platform-runtime-inventory.ts
@@ -168,7 +168,7 @@ export const DAEMON_PLATFORM_RUNTIME_EDGES: readonly DaemonPlatformRuntimeEdge[]
       'open-prepare policy consumes only the neutral open plan/result surface (#2334): surface ' +
       'classification and relaunch-target validation. The platform mechanics that used to share ' +
       'the file (Android package resolution) moved behind the Android owning seam, leaving this ' +
-      'edge daemon policy over a neutral resolver.',
+      'edge daemon policy over two neutral, non-mechanics functions.',
   },
 ] as const;
 

--- a/src/__tests__/platform-runtime-android-application-tools-infer-open-target.test.ts
+++ b/src/__tests__/platform-runtime-android-application-tools-infer-open-target.test.ts
@@ -1,0 +1,24 @@
+import { expect, test, vi } from 'vitest';
+import type { DeviceInfo } from '@agent-device/kernel/device';
+
+vi.mock('../platform-runtime-android-mechanics.ts', () => ({
+  loadAndroidMechanics: vi.fn(async () => {
+    throw new Error('adb host unavailable');
+  }),
+}));
+
+import { createAndroidApplicationTools } from '../platform-runtime-android-application-tools.ts';
+
+const device: DeviceInfo = {
+  platform: 'android',
+  id: 'emulator-5554',
+  name: 'Pixel 9 Pro XL',
+  kind: 'emulator',
+  booted: true,
+};
+
+test('inferOpenedAppBundleId stays best-effort when Android mechanics fails to load for a targetless open', async () => {
+  await expect(
+    createAndroidApplicationTools().inferOpenedAppBundleId(device, undefined, undefined),
+  ).resolves.toBeUndefined();
+});

--- a/src/__tests__/platform-runtime-android-application-tools-infer-open-target.test.ts
+++ b/src/__tests__/platform-runtime-android-application-tools-infer-open-target.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
 
 vi.mock('../platform-runtime-android-mechanics.ts', () => ({
@@ -7,7 +7,14 @@ vi.mock('../platform-runtime-android-mechanics.ts', () => ({
   }),
 }));
 
+import { loadAndroidMechanics } from '../platform-runtime-android-mechanics.ts';
 import { createAndroidApplicationTools } from '../platform-runtime-android-application-tools.ts';
+
+const mockLoadAndroidMechanics = vi.mocked(loadAndroidMechanics);
+
+beforeEach(() => {
+  mockLoadAndroidMechanics.mockClear();
+});
 
 const device: DeviceInfo = {
   platform: 'android',
@@ -21,4 +28,15 @@ test('inferOpenedAppBundleId stays best-effort when Android mechanics fails to l
   await expect(
     createAndroidApplicationTools().inferOpenedAppBundleId(device, undefined, undefined),
   ).resolves.toBeUndefined();
+});
+
+test('inferOpenedAppBundleId skips loading Android mechanics when the app-bundle identity is already known', async () => {
+  await expect(
+    createAndroidApplicationTools().inferOpenedAppBundleId(
+      device,
+      'exp://127.0.0.1:8082',
+      'com.example.demo',
+    ),
+  ).resolves.toBe('com.example.demo');
+  expect(mockLoadAndroidMechanics).not.toHaveBeenCalled();
 });

--- a/src/daemon/handlers/__tests__/session-device-claims.test.ts
+++ b/src/daemon/handlers/__tests__/session-device-claims.test.ts
@@ -22,14 +22,14 @@ vi.mock('../../../platform-runtime-runtime-hints.ts', async (importOriginal) => 
     await importOriginal<typeof import('../../../platform-runtime-runtime-hints.ts')>();
   return { ...actual, applyRuntimeHintValues: vi.fn(async () => {}) };
 });
-vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
-  return { ...actual, resolveAndroidPackageForOpen: vi.fn() };
-});
 vi.mock('@agent-device/platform-android/mechanics', () => ({
   activateAndroidTestIme: vi.fn(async () => ({ activated: false })),
   restoreAndroidTestIme: vi.fn(async () => ({ restored: false, reason: 'no-record' })),
   stopAndroidSnapshotHelperSessionForDevice: vi.fn(async () => {}),
+  resolveAndroidPackageForOpen: vi.fn(),
+  inferAndroidPackageAfterOpen: vi.fn(
+    async (_device, _target, currentAppBundleId) => currentAppBundleId,
+  ),
 }));
 vi.mock('@agent-device/host-kit/process', async (importOriginal) =>
   (await import('../../../__tests__/test-utils/host-process-mock.ts')).pinOwnProcessStartTime(
@@ -40,8 +40,10 @@ vi.mock('@agent-device/host-kit/process', async (importOriginal) =>
 import { resolveTargetDevice } from '@agent-device/device-selection/dispatch-resolve';
 import { ensureDeviceReady } from '../../device-ready.ts';
 import { applyRuntimeHintValues } from '../../../platform-runtime-runtime-hints.ts';
-import { resolveAndroidPackageForOpen } from '../../../platform-runtime-open-target.ts';
-import { activateAndroidTestIme } from '@agent-device/platform-android/mechanics';
+import {
+  activateAndroidTestIme,
+  resolveAndroidPackageForOpen,
+} from '@agent-device/platform-android/mechanics';
 import {
   discoverReadyAndroidEmulators,
   dispatchApplicationLifecycleEffect,

--- a/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
+++ b/src/daemon/handlers/__tests__/session-relaunch-close.test.ts
@@ -46,8 +46,8 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
   };
 });
-vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
+vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent-device/platform-android/mechanics')>();
   return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
 });
 

--- a/src/daemon/handlers/__tests__/session-test-harness.ts
+++ b/src/daemon/handlers/__tests__/session-test-harness.ts
@@ -68,16 +68,13 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
   };
 });
-vi.mock('../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../platform-runtime-open-target.ts')>();
-  return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
-});
 vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent-device/platform-android/mechanics')>();
   return {
     ...actual,
     activateAndroidTestIme: vi.fn(async () => ({ activated: false })),
     restoreAndroidTestIme: vi.fn(async () => ({ restored: false, reason: 'no-record' })),
+    resolveAndroidPackageForOpen: vi.fn(async () => undefined),
   };
 });
 vi.mock('@agent-device/host-kit/command', async (importOriginal) => {
@@ -113,7 +110,7 @@ import {
   resolveIosApp,
   resolveIosSimulatorDeepLinkBundleId,
 } from '@agent-device/platform-apple/app-resolution';
-import { resolveAndroidPackageForOpen } from '../../../platform-runtime-open-target.ts';
+import { resolveAndroidPackageForOpen } from '@agent-device/platform-android/mechanics';
 import { runCmd } from '@agent-device/host-kit/command';
 import { dispatchApplicationLifecycleEffect } from '../../__tests__/application-lifecycle-runtime-fixture.ts';
 

--- a/src/daemon/handlers/session-selector-dispatch.ts
+++ b/src/daemon/handlers/session-selector-dispatch.ts
@@ -14,10 +14,7 @@ import { resolveBoundAppEventRuntime } from '../app-event-runtime.ts';
 import { resolveBoundKeyboardRuntime } from '../keyboard-runtime.ts';
 import { resolveRefFrameEffect } from '../daemon-command-registry.ts';
 import { expireRefFrame } from '../ref-frame.ts';
-import {
-  resolveAndroidPackageForOpen,
-  resolveSessionAppBundleIdForTarget,
-} from '../../platform-runtime-open-target.ts';
+import { resolveSessionAppBundleIdForTarget } from '../../platform-runtime-open-target.ts';
 import type { BindDeviceRuntime, InspectDeviceRuntimeFacts } from '../request-runtime-binding.ts';
 import type { DaemonCommandContext } from '../context.ts';
 import type { DeviceReadyOptions } from '../device-ready.ts';
@@ -228,7 +225,6 @@ export async function handleAppEventCommand(
             session.device,
             eventUrl,
             session.appBundleId,
-            resolveAndroidPackageForOpen,
           )) ?? session.appBundleId)
         : session.appBundleId;
       return {

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-execution-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-execution-runtime.test.ts
@@ -41,14 +41,13 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
   return { ...actual, resolveIosApp: vi.fn(async () => 'com.example.demo') };
 });
-vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
-  return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
-});
 vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent-device/platform-android/mechanics')>();
-  return { ...actual, activateAndroidTestIme: vi.fn(async () => ({ activated: false })) };
+  return {
+    ...actual,
+    activateAndroidTestIme: vi.fn(async () => ({ activated: false })),
+    resolveAndroidPackageForOpen: vi.fn(async () => undefined),
+  };
 });
 vi.mock('@agent-device/host-kit/process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent-device/host-kit/process')>();
@@ -64,7 +63,7 @@ import {
   applyRuntimeHintValues,
   clearRuntimeHintValues,
 } from '../../../../platform-runtime-runtime-hints.ts';
-import { resolveAndroidPackageForOpen } from '../../../../platform-runtime-open-target.ts';
+import { resolveAndroidPackageForOpen } from '@agent-device/platform-android/mechanics';
 import { dispatchApplicationLifecycleEffect } from '../../../__tests__/application-lifecycle-runtime-fixture.ts';
 import {
   makeAndroidEmulator,

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-runtime.test.ts
@@ -53,14 +53,13 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     await importOriginal<typeof import('@agent-device/platform-apple/app-resolution')>();
   return { ...actual, resolveIosApp: vi.fn(async () => 'com.example.demo') };
 });
-vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
-  return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
-});
 vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent-device/platform-android/mechanics')>();
-  return { ...actual, activateAndroidTestIme: vi.fn(async () => ({ activated: false })) };
+  return {
+    ...actual,
+    activateAndroidTestIme: vi.fn(async () => ({ activated: false })),
+    resolveAndroidPackageForOpen: vi.fn(async () => undefined),
+  };
 });
 vi.mock('@agent-device/host-kit/process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent-device/host-kit/process')>();
@@ -73,7 +72,7 @@ import {
   mockInspectDeviceRuntimeFacts,
 } from '../../../handlers/__tests__/session-command-harness.ts';
 import { applyRuntimeHintValues } from '../../../../platform-runtime-runtime-hints.ts';
-import { resolveAndroidPackageForOpen } from '../../../../platform-runtime-open-target.ts';
+import { resolveAndroidPackageForOpen } from '@agent-device/platform-android/mechanics';
 import { dispatchApplicationLifecycleEffect } from '../../../__tests__/application-lifecycle-runtime-fixture.ts';
 import { lifecycleRuntimeFacts } from '../../../__tests__/application-lifecycle-runtime-harness.ts';
 import {

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-target.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-target.test.ts
@@ -1,23 +1,13 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '@agent-device/kernel/device';
-import { getAndroidAppState } from '@agent-device/platform-android/mechanics';
-import {
-  inferAndroidPackageAfterOpen,
-  resolveSessionAppBundleIdForTarget,
-} from '../../../../platform-runtime-open-target.ts';
+import { resolveAndroidPackageForOpen } from '@agent-device/platform-android/mechanics';
+import { resolveSessionAppBundleIdForTarget } from '../../../../platform-runtime-open-target.ts';
 
 vi.mock('@agent-device/platform-android/mechanics', () => ({
-  getAndroidAppState: vi.fn(),
+  resolveAndroidPackageForOpen: vi.fn(),
 }));
 
-const mockGetAndroidAppState = vi.mocked(getAndroidAppState);
-const androidDevice: DeviceInfo = {
-  platform: 'android',
-  id: 'emulator-5554',
-  name: 'Pixel Emulator',
-  kind: 'emulator',
-  booted: true,
-};
+const mockResolveAndroidPackage = vi.mocked(resolveAndroidPackageForOpen);
 const harmonyDevice: DeviceInfo = {
   platform: 'harmonyos',
   id: '127.0.0.1:5555',
@@ -30,41 +20,18 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('inferAndroidPackageAfterOpen reads foreground package for Android URL opens', async () => {
-  mockGetAndroidAppState.mockResolvedValue({
-    package: 'host.exp.exponent',
-    activity: 'host.exp.exponent.experience.ExperienceActivity',
-  });
-
-  await expect(
-    inferAndroidPackageAfterOpen(androidDevice, 'exp://127.0.0.1:8082', undefined),
-  ).resolves.toBe('host.exp.exponent');
-});
-
 test('HarmonyOS adopts an explicit bundle-id target for app-scoped commands', async () => {
-  const resolveAndroidPackageForOpen = vi.fn(async () => undefined);
-
   await expect(
-    resolveSessionAppBundleIdForTarget(
-      harmonyDevice,
-      'com.example.application',
-      undefined,
-      resolveAndroidPackageForOpen,
-    ),
+    resolveSessionAppBundleIdForTarget(harmonyDevice, 'com.example.application', undefined),
   ).resolves.toBe('com.example.application');
-  expect(resolveAndroidPackageForOpen).not.toHaveBeenCalled();
+  expect(mockResolveAndroidPackage).not.toHaveBeenCalled();
 });
 
 test.each(['myapp://login', 'https://example.com', 'Demo App'])(
   'HarmonyOS retains the existing app across non-bundle targets: %s',
   async (openTarget) => {
     await expect(
-      resolveSessionAppBundleIdForTarget(
-        harmonyDevice,
-        openTarget,
-        'com.example.application',
-        vi.fn(async () => undefined),
-      ),
+      resolveSessionAppBundleIdForTarget(harmonyDevice, openTarget, 'com.example.application'),
     ).resolves.toBe('com.example.application');
   },
 );

--- a/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
+++ b/src/daemon/session-lifecycle/internal/__tests__/session-open-url-prewarm.test.ts
@@ -38,9 +38,8 @@ vi.mock('@agent-device/platform-apple/app-resolution', async (importOriginal) =>
     resolveIosSimulatorDeepLinkBundleId: vi.fn(async () => undefined),
   };
 });
-vi.mock('../../../../platform-runtime-open-target.ts', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../../../platform-runtime-open-target.ts')>();
+vi.mock('@agent-device/platform-android/mechanics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent-device/platform-android/mechanics')>();
   return { ...actual, resolveAndroidPackageForOpen: vi.fn(async () => undefined) };
 });
 

--- a/src/platform-runtime-android-application-tools.ts
+++ b/src/platform-runtime-android-application-tools.ts
@@ -25,7 +25,7 @@ export function createAndroidApplicationTools(): AndroidApplicationTools {
   return Object.freeze({
     resolveOpenTarget: async (device, input) => await resolveAndroidOpenTarget(device, input),
     inferOpenedAppBundleId: async (device, target, currentAppBundleId) => {
-      const { inferAndroidPackageAfterOpen } = await loadOpenTarget();
+      const { inferAndroidPackageAfterOpen } = await loadAndroidMechanics();
       return await inferAndroidPackageAfterOpen(device, target, currentAppBundleId);
     },
     resetFramePerfStats: async (device, appBundleId) => {
@@ -96,14 +96,12 @@ async function resolveAndroidOpenTarget(
   device: DeviceInfo,
   input: OpenTargetResolutionInput,
 ): Promise<OpenTargetResolution> {
-  const { resolveAndroidPackageForOpen, resolveSessionAppBundleIdForTarget } =
-    await loadOpenTarget();
+  const { resolveSessionAppBundleIdForTarget } = await loadOpenTarget();
   return {
     appBundleId: await resolveSessionAppBundleIdForTarget(
       device,
       input.target,
       input.currentAppBundleId,
-      resolveAndroidPackageForOpen,
     ),
     appName: input.target,
   };

--- a/src/platform-runtime-android-application-tools.ts
+++ b/src/platform-runtime-android-application-tools.ts
@@ -25,6 +25,7 @@ export function createAndroidApplicationTools(): AndroidApplicationTools {
   return Object.freeze({
     resolveOpenTarget: async (device, input) => await resolveAndroidOpenTarget(device, input),
     inferOpenedAppBundleId: async (device, target, currentAppBundleId) => {
+      if (currentAppBundleId) return currentAppBundleId;
       try {
         const { inferAndroidPackageAfterOpen } = await loadAndroidMechanics();
         return await inferAndroidPackageAfterOpen(device, target, currentAppBundleId);

--- a/src/platform-runtime-android-application-tools.ts
+++ b/src/platform-runtime-android-application-tools.ts
@@ -25,8 +25,12 @@ export function createAndroidApplicationTools(): AndroidApplicationTools {
   return Object.freeze({
     resolveOpenTarget: async (device, input) => await resolveAndroidOpenTarget(device, input),
     inferOpenedAppBundleId: async (device, target, currentAppBundleId) => {
-      const { inferAndroidPackageAfterOpen } = await loadAndroidMechanics();
-      return await inferAndroidPackageAfterOpen(device, target, currentAppBundleId);
+      try {
+        const { inferAndroidPackageAfterOpen } = await loadAndroidMechanics();
+        return await inferAndroidPackageAfterOpen(device, target, currentAppBundleId);
+      } catch {
+        return currentAppBundleId;
+      }
     },
     resetFramePerfStats: async (device, appBundleId) => {
       const { resetAndroidFramePerfStats } = await loadAndroidMechanics();

--- a/src/platform-runtime-apple-application-tools.ts
+++ b/src/platform-runtime-apple-application-tools.ts
@@ -145,12 +145,7 @@ async function resolveAppleOpenTarget(
   return {
     appBundleId:
       macOsSurface.appBundleId ??
-      (await resolveSessionAppBundleIdForTarget(
-        device,
-        input.target,
-        input.currentAppBundleId,
-        async () => undefined,
-      )),
+      (await resolveSessionAppBundleIdForTarget(device, input.target, input.currentAppBundleId)),
     appName: macOsSurface.appName ?? input.target,
   };
 }

--- a/src/platform-runtime-open-target.ts
+++ b/src/platform-runtime-open-target.ts
@@ -179,6 +179,10 @@ async function tryResolveAndroidPackageForOpen(
   openTarget: string | undefined,
 ): Promise<string | undefined> {
   if (device.platform !== 'android' || !openTarget) return undefined;
-  const { resolveAndroidPackageForOpen } = await loadAndroidMechanics();
-  return await resolveAndroidPackageForOpen(device, openTarget);
+  try {
+    const { resolveAndroidPackageForOpen } = await loadAndroidMechanics();
+    return await resolveAndroidPackageForOpen(device, openTarget);
+  } catch {
+    return undefined;
+  }
 }

--- a/src/platform-runtime-open-target.ts
+++ b/src/platform-runtime-open-target.ts
@@ -145,39 +145,6 @@ async function tryResolveIosAppBundleId(
   }
 }
 
-export async function resolveAndroidPackageForOpen(
-  device: DeviceInfo,
-  openTarget: string | undefined,
-): Promise<string | undefined> {
-  if (device.platform !== 'android' || !openTarget || isDeepLinkTarget(openTarget))
-    return undefined;
-  try {
-    const { resolveAndroidApp } = await loadAndroidMechanics();
-    const resolved = await resolveAndroidApp(device, openTarget);
-    return resolved.type === 'package' ? resolved.value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-export async function inferAndroidPackageAfterOpen(
-  device: DeviceInfo,
-  openTarget: string | undefined,
-  currentAppBundleId: string | undefined,
-): Promise<string | undefined> {
-  if (currentAppBundleId) return currentAppBundleId;
-  if (device.platform !== 'android' || !openTarget || !isDeepLinkTarget(openTarget)) {
-    return currentAppBundleId;
-  }
-  try {
-    const { getAndroidAppState } = await loadAndroidMechanics();
-    const foreground = await getAndroidAppState(device);
-    return foreground.package?.trim() || currentAppBundleId;
-  } catch {
-    return currentAppBundleId;
-  }
-}
-
 function shouldPreserveAndroidPackageContext(
   device: DeviceInfo,
   openTarget: string | undefined,
@@ -196,17 +163,22 @@ export async function resolveSessionAppBundleIdForTarget(
   device: DeviceInfo,
   openTarget: string | undefined,
   currentAppBundleId: string | undefined,
-  resolveAndroidPackageForOpenFn: (
-    device: DeviceInfo,
-    openTarget: string | undefined,
-  ) => Promise<string | undefined>,
 ): Promise<string | undefined> {
   if (device.platform === 'harmonyos') {
     return bundleIdFromOpenTarget(openTarget) ?? currentAppBundleId;
   }
   return (
     (await resolveIosBundleIdForOpen(device, openTarget, currentAppBundleId)) ??
-    (await resolveAndroidPackageForOpenFn(device, openTarget)) ??
+    (await tryResolveAndroidPackageForOpen(device, openTarget)) ??
     (shouldPreserveAndroidPackageContext(device, openTarget) ? currentAppBundleId : undefined)
   );
+}
+
+async function tryResolveAndroidPackageForOpen(
+  device: DeviceInfo,
+  openTarget: string | undefined,
+): Promise<string | undefined> {
+  if (device.platform !== 'android' || !openTarget) return undefined;
+  const { resolveAndroidPackageForOpen } = await loadAndroidMechanics();
+  return await resolveAndroidPackageForOpen(device, openTarget);
 }


### PR DESCRIPTION
## Summary

Closes #2334.

`src/platform-runtime-open-target.ts` mixed neutral open-plan policy with Android
platform mechanics (real adb-backed package resolution). This moves
`resolveAndroidPackageForOpen` / `inferAndroidPackageAfterOpen` behind the Android
owning seam in `packages/platform-android`, and simplifies
`resolveSessionAppBundleIdForTarget` to lazily reach Android mechanics itself
instead of taking an injected resolver callback — removing a dead-code stub
(`async () => undefined`) at the Apple/macOS call site and keeping exactly one
construction path for the open plan.

`session-open-prepare.ts` and `session-selector-dispatch.ts` now import only the
neutral plan/policy surface from `platform-runtime-open-target.ts`. The two R76
inventory edges are reclassified from `leaked-platform-mechanics` to
`daemon-policy-essential`, dropping the daemon-to-root platform-runtime edge count
from 14 to 13. ADR 0022 is updated to record the outcome.

## Changes

- New `packages/platform-android/src/open-target-resolution.ts` (+ colocated test)
  owns `resolveAndroidPackageForOpen` / `inferAndroidPackageAfterOpen`, exported via
  `mechanics.ts`.
- `platform-runtime-open-target.ts`: Android mechanics removed;
  `resolveSessionAppBundleIdForTarget` drops its injected-callback parameter and
  lazily loads Android mechanics itself (still swallows a load/resolution failure,
  matching prior behavior).
- `platform-runtime-android-application-tools.ts` / `platform-runtime-apple-application-tools.ts`
  / `session-selector-dispatch.ts` updated to the simplified call signature.
- `scripts/layering/daemon-platform-runtime-inventory.ts` (+ test): reclassified
  both edges, added a planted-violation regression test proving a reintroduced
  Android-mechanics import on the selector-dispatch edge stays red.
- ~7 daemon test files migrated their `resolveAndroidPackageForOpen` mock from
  `platform-runtime-open-target.ts` to `@agent-device/platform-android/mechanics`.
- Renamed an unrelated private helper in `packages/platform-android/src/app-lifecycle.ts`
  (`resolveAndroidPackageForOpen` → `requireAndroidPackageForOpen`) to remove a
  same-name/different-contract collision with the newly exported function.

## Validation

- `pnpm check:layering` — green (13 daemon-to-root edges, R76 holds; new planted
  Android-mechanics-reintroduction test passes).
- `pnpm check:di-seams` — green.
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` — green.
- `pnpm check:affected --run` — unit project: 2118/2118 tests pass; `replay-compat`
  fails only because this sandbox is a shallow clone with no tags (pre-existing
  environment limitation, unrelated to this change).
- Full `unit-core` sweep of `src/daemon/**` + `packages/platform-android/**`:
  3298/3300 pass; the 2 failures (`app-log-session-resource.test.ts`,
  `durable-capture-resource.test.ts`) reproduce identically on unmodified `main`.
- Adversarial review pass (fable model): no correctness bugs found; addressed its
  low-severity findings (exception-swallowing parity, the naming collision above,
  and the planted-violation test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167UVzrdzVMCZqXgxtzWoTD

---
_Generated by [Claude Code](https://claude.ai/code/session_0167UVzrdzVMCZqXgxtzWoTD)_