### PR TITLE
refactor(commands): declare a command option once and derive its surfaces

### DIFF
--- a/packages/contracts/src/cli-flags.ts
+++ b/packages/contracts/src/cli-flags.ts
@@ -23,6 +23,12 @@ import type { ScreenshotRequestFlags } from './screenshot.ts';
 import type { RecordingScope } from './recording-scope.ts';
 import type { ReplayRequestFields } from './replay-request-fields.ts';
 
+// This is the flag KEY vocabulary, not where an option is described: an
+// option's prose belongs to its one declaration (its `FlagDefinition`, which
+// carries both the `--help` and the tool/SDK audience), so a doc comment
+// repeated here would be a second copy that drifts. Comments below state only
+// facts this type alone knows — that a key has no CLI token, or how two keys
+// interact.
 export type CliFlags = CloudProviderProfileFields &
   RemoteConfigMetroOptions &
   ScreenshotRequestFlags &
@@ -120,11 +126,6 @@ export type CliFlags = CloudProviderProfileFields &
     saveScript?: boolean | string;
     shutdown?: boolean;
     relaunch?: boolean;
-    /**
-     * Include the initial interactive snapshot in a fresh open response. With
-     * no app argument, iOS can discover the sole running app on the sole booted
-     * simulator and fails closed when that environment is ambiguous.
-     */
     foreground?: boolean;
     surface?: SessionSurface;
     headless?: boolean;

--- a/packages/contracts/src/client-app.ts
+++ b/packages/contracts/src/client-app.ts
@@ -68,8 +68,16 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
     relaunch?: boolean;
     /** Startup budget in milliseconds: bounds the Simulator boot wait on a cold device. */
     timeoutMs?: number;
-    // `foreground` is described once on its option declaration (the `--foreground`
-    // FlagDefinition), which feeds both `--help` and the tool/SDK field.
+    // Editor documentation for a public type: a `.d.ts` is read where no
+    // FlagDefinition resolves, and nothing generates these docs. It is not a second
+    // statement of what the option does — it is the option's ONE declaration (the
+    // `--foreground` FlagDefinition's `inputDescription`) verbatim, pinned to it by
+    // `commands/command-input-option-field.test.ts`.
+    /**
+     * Include an initial interactive snapshot in a fresh open response. With no
+     * app argument, discover the sole running app on the sole booted iOS
+     * simulator; ambiguous environments fail closed.
+     */
     foreground?: boolean;
     saveScript?: boolean | string;
     /** #1258: overwrite an existing --save-script target instead of refusing. Alias: --overwrite. */

--- a/packages/contracts/src/client-app.ts
+++ b/packages/contracts/src/client-app.ts
@@ -68,11 +68,8 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
     relaunch?: boolean;
     /** Startup budget in milliseconds: bounds the Simulator boot wait on a cold device. */
     timeoutMs?: number;
-    /**
-     * Include the initial interactive snapshot in a fresh open response. With
-     * no app argument, iOS can discover the sole running app on the sole booted
-     * simulator and fails closed when that environment is ambiguous.
-     */
+    // `foreground` is described once on its option declaration (the `--foreground`
+    // FlagDefinition), which feeds both `--help` and the tool/SDK field.
     foreground?: boolean;
     saveScript?: boolean | string;
     /** #1258: overwrite an existing --save-script target instead of refusing. Alias: --overwrite. */

--- a/packages/contracts/src/client-capture.ts
+++ b/packages/contracts/src/client-capture.ts
@@ -4,6 +4,7 @@ import type { SessionSurface } from './session-surface.ts';
 import type { PublicSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
 import type { SnapshotDiagnosticsSummary } from './snapshot-diagnostics.ts';
 import type {
+  SnapshotCommandOptionFields,
   SnapshotNode,
   SnapshotUnchanged,
   SnapshotVisibility,
@@ -16,15 +17,12 @@ import type {
   DeviceCommandBaseOptions,
 } from './client-connection.ts';
 
+// The snapshot capture keys come from the one snapshot option declaration
+// (`SnapshotCommandOptionFields`); their prose lives on the owning option
+// declaration, not on a second copy here.
 export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
-  AgentDeviceSelectionOptions & {
-    interactiveOnly?: boolean;
-    depth?: number;
-    scope?: string;
-    raw?: boolean;
-    /** List accessibility custom actions on merged elements (iOS simulator). */
-    customActions?: boolean;
-    forceFull?: boolean;
+  AgentDeviceSelectionOptions &
+  SnapshotCommandOptionFields & {
     timeoutMs?: number;
     /**
      * #1271 stage 2 (ADR 0012 amendment): `snapshot` is observation-only and

--- a/packages/contracts/src/client-capture.ts
+++ b/packages/contracts/src/client-capture.ts
@@ -17,12 +17,26 @@ import type {
   DeviceCommandBaseOptions,
 } from './client-connection.ts';
 
-// The snapshot capture keys come from the one snapshot option declaration
-// (`SnapshotCommandOptionFields`); their prose lives on the owning option
-// declaration, not on a second copy here.
+// The snapshot capture keys and their value types come from the one snapshot
+// option declaration (`SnapshotCommandOptionFields`). `customActions` is lifted
+// out of that spread only to carry its editor documentation — a `.d.ts` is read
+// where no FlagDefinition resolves, and nothing generates these docs. Its type
+// still comes from the declaration, and the prose is the option's ONE
+// declaration (the `--actions` FlagDefinition's `inputDescription`) verbatim,
+// pinned to it by `commands/command-input-option-field.test.ts`.
 export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
   AgentDeviceSelectionOptions &
-  SnapshotCommandOptionFields & {
+  Omit<SnapshotCommandOptionFields, 'customActions'> & {
+    /**
+     * Name the affordances an element merged away (iOS UIAccessibilityCustomAction,
+     * React Native accessibilityActions) — a card whose reply/options controls are not
+     * separate elements still lists them here. The names are for PLANNING, not
+     * invocation: there is no API to trigger them, so reach the affordance through the
+     * element detail screen, through the same control exposed as a labeled element
+     * elsewhere, or by coordinates from its rect. iOS simulator only; costs one
+     * accessibility round trip per merged element.
+     */
+    customActions?: SnapshotCommandOptionFields['customActions'];
     timeoutMs?: number;
     /**
      * #1271 stage 2 (ADR 0012 amendment): `snapshot` is observation-only and

--- a/packages/contracts/src/client-request.ts
+++ b/packages/contracts/src/client-request.ts
@@ -14,24 +14,20 @@ import type {
   NetworkIncludeMode,
   SessionRuntimeHints,
 } from '@agent-device/kernel/contracts';
+import type { SnapshotCommandOptionFields } from '@agent-device/kernel/snapshot';
 import type { DaemonBatchStep } from './batch-step.ts';
 import type { ReplayRequestFields } from './replay-request-fields.ts';
 import type { AgentDeviceClientConfig, AgentDeviceSelectionOptions } from './client-connection.ts';
 
 export type CommandExecutionOptions = Partial<ScreenshotRequestFlags> &
-  ReplayRequestFields & {
+  ReplayRequestFields &
+  SnapshotCommandOptionFields & {
     positionals?: string[];
     kind?: string;
     out?: string;
     artifact?: string;
     dsym?: string;
     searchPath?: string;
-    interactiveOnly?: boolean;
-    depth?: number;
-    scope?: string;
-    raw?: boolean;
-    customActions?: boolean;
-    forceFull?: boolean;
     count?: number;
     fps?: number;
     recordingScope?: RecordingScope;

--- a/packages/contracts/src/command-flags.ts
+++ b/packages/contracts/src/command-flags.ts
@@ -51,8 +51,10 @@ export type CommandFlags = Omit<CliFlags, DaemonExcludedCliFlag> & {
 // Re-pins SNAPSHOT_OPTION_FLAGS (declared once in the kernel, which sits below contracts and
 // cannot name CommandFlags) against CommandFlags here: a renamed or misspelled flag key fails to
 // compile instead of silently reading `undefined` at every snapshotOptionsFromFlags call site.
-// fallow-ignore-next-line unused-export
-export const SNAPSHOT_OPTION_FLAGS_PINNED_TO_COMMAND_FLAGS = SNAPSHOT_OPTION_FLAGS satisfies Record<
+// This is a compile-time check, not API — it stays unexported so the command facade doesn't have
+// to widen just to carry it.
+const snapshotOptionFlagsPinnedToCommandFlags = SNAPSHOT_OPTION_FLAGS satisfies Record<
   SnapshotOptionKey,
   keyof CommandFlags
 >;
+void snapshotOptionFlagsPinnedToCommandFlags;

--- a/packages/contracts/src/command-flags.ts
+++ b/packages/contracts/src/command-flags.ts
@@ -1,6 +1,10 @@
 import type { CliFlags, DaemonExcludedCliFlag } from './cli-flags.ts';
 import type { DaemonBatchStep } from './batch-step.ts';
-import type { Point } from '@agent-device/kernel/snapshot';
+import {
+  SNAPSHOT_OPTION_FLAGS,
+  type Point,
+  type SnapshotOptionKey,
+} from '@agent-device/kernel/snapshot';
 
 // The flag vocabulary a dispatched command is stated in terms of.
 //
@@ -43,3 +47,12 @@ export type CommandFlags = Omit<CliFlags, DaemonExcludedCliFlag> & {
   shardCount?: number;
   shardIndex?: number;
 };
+
+// Re-pins SNAPSHOT_OPTION_FLAGS (declared once in the kernel, which sits below contracts and
+// cannot name CommandFlags) against CommandFlags here: a renamed or misspelled flag key fails to
+// compile instead of silently reading `undefined` at every snapshotOptionsFromFlags call site.
+// fallow-ignore-next-line unused-export
+export const SNAPSHOT_OPTION_FLAGS_PINNED_TO_COMMAND_FLAGS = SNAPSHOT_OPTION_FLAGS satisfies Record<
+  SnapshotOptionKey,
+  keyof CommandFlags
+>;

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -87,13 +87,136 @@ export type SnapshotOptions = {
   customActions?: boolean;
 };
 
-export type SnapshotPresentationFlagInput = {
-  snapshotInteractiveOnly?: boolean;
-  snapshotDepth?: number;
-  snapshotScope?: string;
-  snapshotRaw?: boolean;
-  snapshotCustomActions?: boolean;
+/**
+ * The snapshot capture family stated ONCE as option key ↔ command-flag key.
+ *
+ * The same pair (`customActions` ↔ `snapshotCustomActions`, and its seven
+ * siblings) used to be re-typed by hand at every seam that carries a snapshot
+ * request across the option/flag vocabulary line — the CLI reader, the client
+ * option projection, the daemon capture inputs, the presentation key. Each copy
+ * restated a fact already stated here and decided nothing, so a new snapshot
+ * option cost one edit per seam and a missed seam dropped the option silently.
+ *
+ * Declared in the kernel because both vocabularies are declared here
+ * ({@link SnapshotOptions}) and above (`CommandFlags` in contracts), so this is
+ * the lowest point both sides can read. This generalises the shipped
+ * `screenshotFlagsFromOptions`/`screenshotOptionsFromFlags` pair for the
+ * screenshot family.
+ *
+ * Every projection takes an EXPLICIT key list: a seam admits the options it
+ * routes and no more, so adding a pair here never silently widens a seam that
+ * cannot honour it.
+ */
+// Exported only because the exported types below say `typeof` it.
+// fallow-ignore-next-line unused-export
+export const SNAPSHOT_OPTION_FLAGS = {
+  interactiveOnly: 'snapshotInteractiveOnly',
+  depth: 'snapshotDepth',
+  scope: 'snapshotScope',
+  raw: 'snapshotRaw',
+  customActions: 'snapshotCustomActions',
+  forceFull: 'snapshotForceFull',
+  includeHiddenContentHints: 'snapshotIncludeHiddenContentHints',
+  preferredBackend: 'snapshotPreferredBackend',
+} as const;
+
+export type SnapshotOptionKey = keyof typeof SNAPSHOT_OPTION_FLAGS;
+
+type SnapshotOptionValues = {
+  interactiveOnly: boolean;
+  depth: number;
+  scope: string;
+  raw: boolean;
+  customActions: boolean;
+  forceFull: boolean;
+  includeHiddenContentHints: boolean;
+  preferredBackend: SnapshotPreferredBackend;
 };
+
+/** The option-vocabulary view of the declared pairs, narrowed to `TKeys`. */
+export type SnapshotOptionFields<TKeys extends SnapshotOptionKey = SnapshotOptionKey> = {
+  [TKey in TKeys]?: SnapshotOptionValues[TKey];
+};
+
+/** The flag-vocabulary view of the declared pairs, narrowed to `TKeys`. */
+export type SnapshotOptionFlagFields<TKeys extends SnapshotOptionKey = SnapshotOptionKey> = {
+  [TKey in TKeys as (typeof SNAPSHOT_OPTION_FLAGS)[TKey]]?: SnapshotOptionValues[TKey];
+};
+
+/**
+ * Option keys a `snapshot`/`diff` command request carries end to end. `scope` is
+ * resolved against the session before capture, so seams that resolve it spread
+ * this projection and then override that one key.
+ */
+export const SNAPSHOT_COMMAND_OPTION_KEYS = [
+  'interactiveOnly',
+  'depth',
+  'scope',
+  'raw',
+  'customActions',
+  'forceFull',
+] as const;
+
+/**
+ * The snapshot capture options a `snapshot`/`diff` request is stated in, in
+ * every vocabulary that names them: the public SDK type, the internal request
+ * bag and the command runtime options each reference THIS type instead of
+ * re-listing the same six keys.
+ */
+export type SnapshotCommandOptionFields = SnapshotOptionFields<
+  (typeof SNAPSHOT_COMMAND_OPTION_KEYS)[number]
+>;
+
+/** Option keys a daemon runtime capture input carries; `forceFull` is a command-level concern. */
+export const SNAPSHOT_CAPTURE_OPTION_KEYS = [
+  'interactiveOnly',
+  'preferredBackend',
+  'depth',
+  'scope',
+  'raw',
+  'customActions',
+  'includeHiddenContentHints',
+] as const;
+
+/** Option keys that identify a presentation; see {@link buildSnapshotPresentationKey}. */
+// fallow-ignore-next-line unused-export
+export const SNAPSHOT_PRESENTATION_OPTION_KEYS = [
+  'depth',
+  'interactiveOnly',
+  'raw',
+  'scope',
+  'customActions',
+] as const;
+
+/**
+ * Reads the declared options out of a flags bag. Every requested key is present
+ * (possibly `undefined`), matching what the hand-written copies produced.
+ */
+export function snapshotOptionsFromFlags<const TKeys extends readonly SnapshotOptionKey[]>(
+  flags: SnapshotOptionFlagFields | undefined,
+  keys: TKeys,
+): SnapshotOptionFields<TKeys[number]> {
+  return Object.fromEntries(
+    keys.map((key) => [key, flags?.[SNAPSHOT_OPTION_FLAGS[key]]]),
+  ) as SnapshotOptionFields<TKeys[number]>;
+}
+
+/** Writes the declared options back into flag vocabulary, dropping absent values. */
+export function snapshotFlagsFromOptions<const TKeys extends readonly SnapshotOptionKey[]>(
+  options: SnapshotOptionFields | undefined,
+  keys: TKeys,
+): SnapshotOptionFlagFields<TKeys[number]> {
+  return Object.fromEntries(
+    keys.flatMap((key) => {
+      const value = options?.[key];
+      return value === undefined ? [] : [[SNAPSHOT_OPTION_FLAGS[key], value]];
+    }),
+  ) as SnapshotOptionFlagFields<TKeys[number]>;
+}
+
+export type SnapshotPresentationFlagInput = SnapshotOptionFlagFields<
+  (typeof SNAPSHOT_PRESENTATION_OPTION_KEYS)[number]
+>;
 
 export type RawSnapshotNode = {
   index: number;
@@ -382,13 +505,7 @@ export function snapshotPresentationOptionsFromFlags(
   flags: SnapshotPresentationFlagInput | undefined,
 ): SnapshotOptions | undefined {
   if (!flags) return undefined;
-  return {
-    depth: flags.snapshotDepth,
-    interactiveOnly: flags.snapshotInteractiveOnly,
-    raw: flags.snapshotRaw,
-    scope: flags.snapshotScope,
-    customActions: flags.snapshotCustomActions,
-  };
+  return snapshotOptionsFromFlags(flags, SNAPSHOT_PRESENTATION_OPTION_KEYS);
 }
 
 export function centerOfRect(rect: Rect): Point {

--- a/packages/kernel/src/snapshot.ts
+++ b/packages/kernel/src/snapshot.ts
@@ -87,28 +87,29 @@ export type SnapshotOptions = {
   customActions?: boolean;
 };
 
-/**
- * The snapshot capture family stated ONCE as option key ↔ command-flag key.
- *
- * The same pair (`customActions` ↔ `snapshotCustomActions`, and its seven
- * siblings) used to be re-typed by hand at every seam that carries a snapshot
- * request across the option/flag vocabulary line — the CLI reader, the client
- * option projection, the daemon capture inputs, the presentation key. Each copy
- * restated a fact already stated here and decided nothing, so a new snapshot
- * option cost one edit per seam and a missed seam dropped the option silently.
- *
- * Declared in the kernel because both vocabularies are declared here
- * ({@link SnapshotOptions}) and above (`CommandFlags` in contracts), so this is
- * the lowest point both sides can read. This generalises the shipped
- * `screenshotFlagsFromOptions`/`screenshotOptionsFromFlags` pair for the
- * screenshot family.
- *
- * Every projection takes an EXPLICIT key list: a seam admits the options it
- * routes and no more, so adding a pair here never silently widens a seam that
- * cannot honour it.
- */
-// Exported only because the exported types below say `typeof` it.
-// fallow-ignore-next-line unused-export
+// The snapshot capture family stated ONCE as option key ↔ command-flag key.
+//
+// The same pair (`customActions` ↔ `snapshotCustomActions`, and its seven
+// siblings) used to be re-typed by hand at every seam that carries a snapshot
+// request across the option/flag vocabulary line — the CLI reader, the client
+// option projection, the daemon capture inputs, the presentation key. Each copy
+// restated a fact already stated here and decided nothing, so a new snapshot
+// option cost one edit per seam and a missed seam dropped the option silently.
+//
+// Declared in the kernel because both vocabularies are declared here
+// (SnapshotOptions) and above (`CommandFlags` in contracts), so this is
+// the lowest point both sides can read. This generalises the shipped
+// `screenshotFlagsFromOptions`/`screenshotOptionsFromFlags` pair for the
+// screenshot family.
+//
+// Every projection takes an EXPLICIT key list: a seam admits the options it
+// routes and no more, so adding a pair here never silently widens a seam that
+// cannot honour it.
+//
+// Exported only because the exported types below say `typeof` it — this const
+// is not itself public API, so the rationale stays a source comment (stripped
+// from the published .d.ts) instead of a bundled JSDoc block.
+/** The CLI/daemon flag key for each snapshot capture option, by option name. */
 export const SNAPSHOT_OPTION_FLAGS = {
   interactiveOnly: 'snapshotInteractiveOnly',
   depth: 'snapshotDepth',

--- a/src/backend-snapshot-options.ts
+++ b/src/backend-snapshot-options.ts
@@ -1,30 +1,28 @@
-import type { CommandFlags } from '@agent-device/contracts/command';
+import { snapshotFlagsFromOptions } from '@agent-device/kernel/snapshot';
 import type { BackendSnapshotOptions } from './backend.ts';
 
 type RoutedSnapshotOption = keyof Omit<BackendSnapshotOptions, 'includeRects' | 'outPath'>;
 
-const SNAPSHOT_OPTION_FLAGS = {
-  interactiveOnly: 'snapshotInteractiveOnly',
-  scope: 'snapshotScope',
-  depth: 'snapshotDepth',
-  raw: 'snapshotRaw',
-  customActions: 'snapshotCustomActions',
-  includeHiddenContentHints: 'snapshotIncludeHiddenContentHints',
-  preferredBackend: 'snapshotPreferredBackend',
-} as const satisfies Record<RoutedSnapshotOption, keyof CommandFlags>;
+/**
+ * Which backend snapshot options route as request flags. Still pinned to
+ * `BackendSnapshotOptions`, so a new backend option must decide whether it
+ * routes; the option→flag pairing itself is declared once in the kernel and is
+ * no longer restated here.
+ */
+const ROUTED_SNAPSHOT_OPTIONS = {
+  interactiveOnly: true,
+  scope: true,
+  depth: true,
+  raw: true,
+  customActions: true,
+  includeHiddenContentHints: true,
+  preferredBackend: true,
+} as const satisfies Record<RoutedSnapshotOption, true>;
 
-type SnapshotFlagOverrides = Partial<
-  Pick<CommandFlags, (typeof SNAPSHOT_OPTION_FLAGS)[RoutedSnapshotOption]>
+const ROUTED_SNAPSHOT_OPTION_KEYS = Object.keys(ROUTED_SNAPSHOT_OPTIONS) as ReadonlyArray<
+  keyof typeof ROUTED_SNAPSHOT_OPTIONS
 >;
 
-export function snapshotOptionsToFlags(
-  options: BackendSnapshotOptions | undefined,
-): SnapshotFlagOverrides {
-  if (!options) return {};
-  return Object.fromEntries(
-    Object.entries(SNAPSHOT_OPTION_FLAGS).flatMap(([optionKey, flagKey]) => {
-      const value = options[optionKey as RoutedSnapshotOption];
-      return value === undefined ? [] : [[flagKey, value]];
-    }),
-  ) as SnapshotFlagOverrides;
+export function snapshotOptionsToFlags(options: BackendSnapshotOptions | undefined) {
+  return snapshotFlagsFromOptions(options, ROUTED_SNAPSHOT_OPTION_KEYS);
 }

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -1,7 +1,11 @@
 import { PUBLIC_COMMANDS } from '@agent-device/command-registry/catalog';
 import { SNAPSHOT_BACKEND_CAPABILITIES } from '@agent-device/capture-kit/snapshot-quality-backend-capabilities';
+import {
+  SNAPSHOT_COMMAND_OPTION_KEYS,
+  snapshotOptionsFromFlags,
+} from '@agent-device/kernel/snapshot';
 import { SNAPSHOT_FLAGS } from '../cli-grammar/flag-groups.ts';
-import { booleanField, integerField, stringField } from '../command-input.ts';
+import { booleanField, integerField, optionField, stringField } from '../command-input.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -32,9 +36,7 @@ const snapshotCommandMetadata = defineFieldCommandMetadata(
     depth: integerField(),
     scope: stringField(),
     raw: booleanField(),
-    customActions: booleanField(
-      'Name the affordances an element merged away (iOS UIAccessibilityCustomAction, React Native accessibilityActions) — a card whose reply/options controls are not separate elements still lists them here. The names are for PLANNING, not invocation: there is no API to trigger them, so reach the affordance through the element detail screen, through the same control exposed as a labeled element elsewhere, or by coordinates from its rect. iOS simulator only; costs one accessibility round trip per merged element.',
-    ),
+    customActions: optionField('snapshotCustomActions'),
     forceFull: booleanField(),
     timeoutMs: integerField('Maximum wall-clock time for the snapshot command.'),
     // #1271 stage 2: `snapshot` is observation-only, so a repair-armed heal
@@ -64,12 +66,7 @@ const snapshotCliSchema = {
 export const snapshotCliReader: CliReader = (_positionals, flags) => ({
   ...commonInputFromFlags(flags),
   ...observationRecordInputFromFlags(flags),
-  interactiveOnly: flags.snapshotInteractiveOnly,
-  depth: flags.snapshotDepth,
-  scope: flags.snapshotScope,
-  raw: flags.snapshotRaw,
-  customActions: flags.snapshotCustomActions,
-  forceFull: flags.snapshotForceFull,
+  ...snapshotOptionsFromFlags(flags, SNAPSHOT_COMMAND_OPTION_KEYS),
   timeoutMs: flags.timeoutMs,
 });
 

--- a/src/commands/cli-grammar/flag-definitions-action.ts
+++ b/src/commands/cli-grammar/flag-definitions-action.ts
@@ -280,6 +280,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--foreground',
     usageDescription:
       'open: keep normal app/device selection and return an initial snapshot; without an app, resolve the sole running app on the sole booted iOS simulator',
+    inputDescription:
+      'Include an initial interactive snapshot in a fresh open response. With no app argument, discover the sole running app on the sole booted iOS simulator; ambiguous environments fail closed.',
   },
   {
     key: 'restart',

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -206,6 +206,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--actions',
     usageDescription:
       'Snapshot: name the affordances merged inside an element (iOS sim); not directly invokable — reach them via the detail screen, labeled children, or coordinates',
+    inputDescription:
+      'Name the affordances an element merged away (iOS UIAccessibilityCustomAction, React Native accessibilityActions) — a card whose reply/options controls are not separate elements still lists them here. The names are for PLANNING, not invocation: there is no API to trigger them, so reach the affordance through the element detail screen, through the same control exposed as a labeled element elsewhere, or by coordinates from its rect. iOS simulator only; costs one accessibility round trip per merged element.',
   },
   {
     key: 'snapshotForceFull',

--- a/src/commands/cli-grammar/flag-registry.ts
+++ b/src/commands/cli-grammar/flag-registry.ts
@@ -2,7 +2,7 @@ import { ACTION_FLAG_DEFINITIONS } from './flag-definitions-action.ts';
 import { CONNECTION_FLAG_DEFINITIONS } from './flag-definitions-connection.ts';
 import { TARGET_FLAG_DEFINITIONS } from './flag-definitions-target.ts';
 import { WORKFLOW_FLAG_DEFINITIONS } from './flag-definitions-workflow.ts';
-import type { FlagDefinition } from './flag-types.ts';
+import type { FlagDefinition, FlagKey } from './flag-types.ts';
 
 const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
   ...CONNECTION_FLAG_DEFINITIONS,
@@ -22,4 +22,13 @@ export function getFlagDefinition(token: string): FlagDefinition | undefined {
 
 export function getFlagDefinitions(): readonly FlagDefinition[] {
   return FLAG_DEFINITIONS;
+}
+
+/**
+ * The declarations for one flag key. A key can hold more than one when its CLI
+ * spelling is a `setValue` pair (`--record` / `--no-record`), so the caller
+ * decides which facet it needs.
+ */
+export function getFlagDefinitionsForKey(key: FlagKey): readonly FlagDefinition[] {
+  return FLAG_DEFINITIONS.filter((definition) => definition.key === key);
 }

--- a/src/commands/cli-grammar/flag-types.ts
+++ b/src/commands/cli-grammar/flag-types.ts
@@ -1,8 +1,21 @@
 import type { CliFlags } from '@agent-device/contracts/command';
 
 export type FlagKey = keyof CliFlags;
-type FlagType = 'boolean' | 'int' | 'number' | 'enum' | 'string' | 'booleanOrString';
+export type FlagType = 'boolean' | 'int' | 'number' | 'enum' | 'string' | 'booleanOrString';
 
+/**
+ * One command option, declared once.
+ *
+ * This is where an option's CLI token, value type and value bounds live, and it
+ * is also where its PROSE lives. An option has at most two audiences and they
+ * are legitimately different lengths — `usageDescription` is the one-line
+ * `--help` entry a CLI reader scans, `inputDescription` is the tool/SDK field
+ * description a model or a TypeScript caller reads — but they are one fact with
+ * one owner, stated side by side here so rewriting one is rewriting both. A
+ * command's input field derives from this declaration through `optionField`;
+ * a doc comment on `CliFlags`, on a public option type, or a second
+ * `booleanField('…')` carrying the same sentence is a copy, not a declaration.
+ */
 export type FlagDefinition = {
   key: FlagKey;
   names: readonly string[];
@@ -13,5 +26,11 @@ export type FlagDefinition = {
   max?: number;
   setValue?: CliFlags[FlagKey];
   usageLabel?: string;
+  /** The `--help` audience: one line, command-prefixed. */
   usageDescription?: string;
+  /**
+   * The tool/SDK audience. Present iff a command derives its input field from
+   * this option with `optionField`.
+   */
+  inputDescription?: string;
 };

--- a/src/commands/command-flags.ts
+++ b/src/commands/command-flags.ts
@@ -5,6 +5,10 @@ import {
   leaseScopeToCommandFlags,
 } from '@agent-device/contracts/lease-scope';
 import { stripUndefined } from '@agent-device/kernel/record';
+import {
+  SNAPSHOT_COMMAND_OPTION_KEYS,
+  snapshotFlagsFromOptions,
+} from '@agent-device/kernel/snapshot';
 import { getFlagDefinitions } from './cli-grammar/flag-registry.ts';
 import type { InternalRequestOptions } from '@agent-device/contracts/client';
 import type { CommandMetadata } from './command-contract.ts';
@@ -69,12 +73,7 @@ function buildFlags(options: InternalRequestOptions): CommandFlags {
     metroPort: options.metroPort,
     bundleUrl: options.bundleUrl,
     launchUrl: options.launchUrl,
-    snapshotInteractiveOnly: options.interactiveOnly,
-    snapshotDepth: options.depth,
-    snapshotScope: options.scope,
-    snapshotRaw: options.raw,
-    snapshotCustomActions: options.customActions,
-    snapshotForceFull: options.forceFull,
+    ...snapshotFlagsFromOptions(options, SNAPSHOT_COMMAND_OPTION_KEYS),
     ...screenshotFlagsFromOptions(options),
     appsFilter: options.appsFilter,
     kind: options.kind,

--- a/src/commands/command-input-option-field.test.ts
+++ b/src/commands/command-input-option-field.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { test, vi } from 'vitest';
 import { getFlagDefinitions, getFlagDefinitionsForKey } from './cli-grammar/flag-registry.ts';
 import type { FlagDefinition, FlagKey } from './cli-grammar/flag-types.ts';
 import { listCommandMetadata } from './command-metadata.ts';
@@ -11,6 +12,15 @@ import { optionField } from './command-input.ts';
  * two hand-written copies and can only report that they already drifted; these
  * plant a divergence in the ONE declaration and require the derived surface to
  * follow it, which a second hand-written copy could not do.
+ *
+ * The plant therefore has to land BEFORE the surfaces are built. Command
+ * metadata — and the MCP tool schema built from it — is constructed at module
+ * load, so a plant applied afterwards would only prove that `optionField` reads
+ * its own argument: a command that went back to a hand-written
+ * `booleanField('…')` would still pass. `buildWithPlantedOption` resets the
+ * module graph, writes the divergence onto the declaration, and only then
+ * imports the builders, so what these tests observe is the production
+ * derivation running over the planted declaration.
  */
 
 function declarationFor(key: FlagKey): FlagDefinition {
@@ -21,29 +31,62 @@ function declarationFor(key: FlagKey): FlagDefinition {
   return definition;
 }
 
+function propertyOf(schema: JsonSchema, property: string, label: string): JsonSchema {
+  const found = schema.properties?.[property];
+  assert.ok(found, `expected ${label} to publish the ${property} input`);
+  return found;
+}
+
 function commandProperty(command: string, property: string): JsonSchema {
   const metadata = listCommandMetadata().find((entry) => entry.name === command);
   assert.ok(metadata, `expected metadata for ${command}`);
-  const schema = metadata.inputSchema.properties?.[property];
-  assert.ok(schema, `expected ${command} to publish the ${property} input`);
-  return schema;
+  return propertyOf(metadata.inputSchema, property, command);
 }
 
-function withPlantedDivergence<T>(
-  definition: FlagDefinition,
+type PlantedSurfaces = {
+  /** The command metadata table the CLI, the Node client and `explain` read. */
+  commandProperty(command: string, property: string): JsonSchema;
+  /** The MCP tool schema, built from that same metadata. */
+  toolProperty(tool: string, property: string): JsonSchema;
+};
+
+async function buildWithPlantedOption(
+  key: FlagKey,
   plant: Partial<FlagDefinition>,
-  body: () => T,
-): T {
-  const original = { ...definition };
-  Object.assign(definition, plant);
-  try {
-    return body();
-  } finally {
-    Object.assign(definition, original);
-  }
+): Promise<PlantedSurfaces> {
+  vi.resetModules();
+
+  // Plant first: nothing in this module graph has built a command yet.
+  const registry = await import('./cli-grammar/flag-registry.ts');
+  const declaration = registry
+    .getFlagDefinitionsForKey(key)
+    .find((candidate) => candidate.inputDescription !== undefined);
+  assert.ok(declaration, `expected ${key} to declare an inputDescription`);
+  Object.assign(declaration, plant);
+
+  // Build second: importing these runs the real derivation over the planted
+  // declaration. The mutation stays inside this discarded graph — the surfaces
+  // imported statically above never see it.
+  const { listCommandMetadata: listPlantedMetadata } = await import('./command-metadata.ts');
+  const { listCommandTools } = await import('../mcp/command-tools.ts');
+  const metadata = listPlantedMetadata();
+  const tools = listCommandTools();
+
+  return {
+    commandProperty(command, property) {
+      const entry = metadata.find((candidate) => candidate.name === command);
+      assert.ok(entry, `expected metadata for ${command}`);
+      return propertyOf(entry.inputSchema, property, command);
+    },
+    toolProperty(tool, property) {
+      const entry = tools.find((candidate) => candidate.name === tool);
+      assert.ok(entry, `expected an MCP tool for ${tool}`);
+      return propertyOf(entry.inputSchema, property, `the ${tool} tool`);
+    },
+  };
 }
 
-test('a derived field publishes the option declaration itself, not a second copy of it', () => {
+test('the shipped surfaces publish the option declaration itself, not a second copy of it', () => {
   for (const [command, property, key] of [
     ['open', 'foreground', 'foreground'],
     ['snapshot', 'customActions', 'snapshotCustomActions'],
@@ -56,34 +99,40 @@ test('a derived field publishes the option declaration itself, not a second copy
   }
 });
 
-test('planted prose divergence moves the derived field; a hand-written copy could not', () => {
-  const declaration = declarationFor('foreground');
-  const published = commandProperty('open', 'foreground').description;
+test('prose planted before the build moves every surface derived from the declaration', async () => {
+  const planted = 'Planted description for the derivation test.';
+  const shipped = declarationFor('foreground').inputDescription;
+  const surfaces = await buildWithPlantedOption('foreground', { inputDescription: planted });
 
-  const derived = withPlantedDivergence(
-    declaration,
-    { inputDescription: 'Planted description for the derivation test.' },
-    () => optionField('foreground').schema,
-  );
-
-  assert.equal(derived.description, 'Planted description for the derivation test.');
-  assert.notEqual(derived.description, published);
-  assert.equal(optionField('foreground').schema.description, published);
+  // Both surfaces were BUILT from the planted declaration. An `open` command
+  // that spelled its description out by hand would publish `shipped` here.
+  assert.notEqual(planted, shipped);
+  assert.equal(surfaces.commandProperty('open', 'foreground').description, planted);
+  assert.equal(surfaces.toolProperty('open', 'foreground').description, planted);
 });
 
-test('planted value-type divergence moves the derived field shape and its bounds', () => {
-  const declaration = declarationFor('snapshotCustomActions');
+test('a value type and bounds planted before the build move the derived field shape', async () => {
+  const planted = 'Planted custom-actions description for the derivation test.';
+  const surfaces = await buildWithPlantedOption('snapshotCustomActions', {
+    type: 'int',
+    min: 1,
+    max: 4,
+    inputDescription: planted,
+  });
 
-  const derived = withPlantedDivergence(
-    declaration,
-    { type: 'int', min: 1, max: 4 },
-    () => optionField('snapshotCustomActions').schema,
-  );
-
-  assert.equal(derived.type, 'integer');
-  assert.equal(derived.minimum, 1);
-  assert.equal(derived.maximum, 4);
-  assert.equal(optionField('snapshotCustomActions').schema.type, 'boolean');
+  // A hand-written `booleanField('…')` cannot follow either half of this.
+  assert.deepEqual(surfaces.commandProperty('snapshot', 'customActions'), {
+    type: 'integer',
+    description: planted,
+    minimum: 1,
+    maximum: 4,
+  });
+  assert.deepEqual(surfaces.toolProperty('snapshot', 'customActions'), {
+    type: 'integer',
+    description: planted,
+    minimum: 1,
+    maximum: 4,
+  });
 });
 
 test('an option with no declared tool audience cannot be derived into a field', () => {
@@ -120,6 +169,48 @@ test('the two audiences of one option are declared side by side and stay distinc
       declaration.usageDescription,
       declaration.inputDescription,
       `${key} declares two audiences; collapsing them to one string is a separate decision`,
+    );
+  }
+});
+
+/**
+ * The public SDK option types keep their editor documentation: a `.d.ts` is
+ * read in an editor, where nothing resolves a `FlagDefinition`, and this repo
+ * has no step that generates those docs. That documentation is not a second
+ * declaration of the option's behaviour, but it is the same sentence in a
+ * second place — so it is pinned: the JSDoc on the SDK field must be the
+ * option's own `inputDescription`, verbatim.
+ */
+const SDK_DOCUMENTED_OPTIONS = [
+  { key: 'foreground', file: 'packages/contracts/src/client-app.ts', field: 'foreground' },
+  {
+    key: 'snapshotCustomActions',
+    file: 'packages/contracts/src/client-capture.ts',
+    field: 'customActions',
+  },
+] as const;
+
+/** The JSDoc block immediately preceding `field?:`, unwrapped onto one line. */
+function sdkFieldDocumentation(source: string, field: string): string | undefined {
+  const block = new RegExp(String.raw`/\*\*((?:(?!\*/)[\s\S])*)\*/\s*${field}\?:`).exec(source);
+  if (!block?.[1]) return undefined;
+  return block[1]
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*?/, '').trim())
+    .join(' ')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+test('each documented SDK option field carries its option declaration verbatim', () => {
+  for (const { key, file, field } of SDK_DOCUMENTED_OPTIONS) {
+    const source = readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8');
+    const documented = sdkFieldDocumentation(source, field);
+    assert.ok(documented, `expected ${file} to document ${field} with a JSDoc block`);
+    assert.equal(
+      documented,
+      declarationFor(key).inputDescription,
+      `${file} must document ${field} with the ${key} declaration verbatim`,
     );
   }
 });

--- a/src/commands/command-input-option-field.test.ts
+++ b/src/commands/command-input-option-field.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { getFlagDefinitions, getFlagDefinitionsForKey } from './cli-grammar/flag-registry.ts';
+import type { FlagDefinition, FlagKey } from './cli-grammar/flag-types.ts';
+import { listCommandMetadata } from './command-metadata.ts';
+import type { JsonSchema } from './command-contract.ts';
+import { optionField } from './command-input.ts';
+
+/**
+ * These are planted-divergence tests, not parity tests. A parity test compares
+ * two hand-written copies and can only report that they already drifted; these
+ * plant a divergence in the ONE declaration and require the derived surface to
+ * follow it, which a second hand-written copy could not do.
+ */
+
+function declarationFor(key: FlagKey): FlagDefinition {
+  const definition = getFlagDefinitionsForKey(key).find(
+    (candidate) => candidate.inputDescription !== undefined,
+  );
+  assert.ok(definition, `expected ${key} to declare an inputDescription`);
+  return definition;
+}
+
+function commandProperty(command: string, property: string): JsonSchema {
+  const metadata = listCommandMetadata().find((entry) => entry.name === command);
+  assert.ok(metadata, `expected metadata for ${command}`);
+  const schema = metadata.inputSchema.properties?.[property];
+  assert.ok(schema, `expected ${command} to publish the ${property} input`);
+  return schema;
+}
+
+function withPlantedDivergence<T>(
+  definition: FlagDefinition,
+  plant: Partial<FlagDefinition>,
+  body: () => T,
+): T {
+  const original = { ...definition };
+  Object.assign(definition, plant);
+  try {
+    return body();
+  } finally {
+    Object.assign(definition, original);
+  }
+}
+
+test('a derived field publishes the option declaration itself, not a second copy of it', () => {
+  for (const [command, property, key] of [
+    ['open', 'foreground', 'foreground'],
+    ['snapshot', 'customActions', 'snapshotCustomActions'],
+  ] as const) {
+    const declaration = declarationFor(key);
+    assert.deepEqual(commandProperty(command, property), {
+      type: 'boolean',
+      description: declaration.inputDescription,
+    });
+  }
+});
+
+test('planted prose divergence moves the derived field; a hand-written copy could not', () => {
+  const declaration = declarationFor('foreground');
+  const published = commandProperty('open', 'foreground').description;
+
+  const derived = withPlantedDivergence(
+    declaration,
+    { inputDescription: 'Planted description for the derivation test.' },
+    () => optionField('foreground').schema,
+  );
+
+  assert.equal(derived.description, 'Planted description for the derivation test.');
+  assert.notEqual(derived.description, published);
+  assert.equal(optionField('foreground').schema.description, published);
+});
+
+test('planted value-type divergence moves the derived field shape and its bounds', () => {
+  const declaration = declarationFor('snapshotCustomActions');
+
+  const derived = withPlantedDivergence(
+    declaration,
+    { type: 'int', min: 1, max: 4 },
+    () => optionField('snapshotCustomActions').schema,
+  );
+
+  assert.equal(derived.type, 'integer');
+  assert.equal(derived.minimum, 1);
+  assert.equal(derived.maximum, 4);
+  assert.equal(optionField('snapshotCustomActions').schema.type, 'boolean');
+});
+
+test('an option with no declared tool audience cannot be derived into a field', () => {
+  // `relaunch` still declares its field by hand, so the derivation refuses it
+  // rather than publishing an undescribed input.
+  assert.throws(() => optionField('relaunch'), /declares no inputDescription/);
+});
+
+test('every declared tool audience is consumed by a command; none is orphaned prose', () => {
+  const publishedDescriptions = new Set(
+    listCommandMetadata().flatMap((metadata) =>
+      Object.values(metadata.inputSchema.properties ?? {}).flatMap((schema) =>
+        schema.description === undefined ? [] : [schema.description],
+      ),
+    ),
+  );
+
+  const orphaned = getFlagDefinitions()
+    .filter(
+      (definition) =>
+        definition.inputDescription !== undefined &&
+        !publishedDescriptions.has(definition.inputDescription),
+    )
+    .map((definition) => definition.key);
+
+  assert.deepEqual(orphaned, []);
+});
+
+test('the two audiences of one option are declared side by side and stay distinct', () => {
+  for (const key of ['foreground', 'snapshotCustomActions'] as const) {
+    const declaration = declarationFor(key);
+    assert.ok(declaration.usageDescription, `${key} must keep its --help audience`);
+    assert.notEqual(
+      declaration.usageDescription,
+      declaration.inputDescription,
+      `${key} declares two audiences; collapsing them to one string is a separate decision`,
+    );
+  }
+});

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -7,7 +7,10 @@ import type {
 import {
   readOptionalInteger as optionalInteger,
   readOptionalNumber as optionalNumberValue,
+  type CliFlags,
 } from '@agent-device/contracts/command';
+import { getFlagDefinitionsForKey } from './cli-grammar/flag-registry.ts';
+import type { FlagDefinition, FlagKey } from './cli-grammar/flag-types.ts';
 import { AppError } from '@agent-device/kernel/errors';
 import type { RepeatedInput } from '@agent-device/contracts/interaction';
 import type { JsonSchema } from './command-contract.ts';
@@ -222,6 +225,79 @@ export function integerField(
 
 export function booleanField(description?: string): CommandField<boolean> {
   return optionalField(booleanSchema(description), optionalBoolean);
+}
+
+/**
+ * Builds a command's input field from the option's ONE declaration.
+ *
+ * A hand-written field — `booleanField('Include an initial interactive
+ * snapshot…')` — restates two facts the option already declared: its value type
+ * (`type: 'boolean'` on the `FlagDefinition`) and its description, as a second,
+ * differently-worded copy of the same sentence. Neither copy decides anything
+ * and both drift: `open --foreground` had one description rewritten across four
+ * files at once because no file owned it.
+ *
+ * Derived here instead:
+ *  - the JSON schema shape and its bounds come from the declaration's `type`,
+ *    `enumValues`, `min` and `max`;
+ *  - the description comes from the declaration's `inputDescription`;
+ *  - the TypeScript value type comes from `CliFlags[key]`, which is already
+ *    where that flag's type is declared.
+ *
+ * So an option's description is one edit, and a command cannot advertise an
+ * input its own CLI flag does not parse.
+ */
+export function optionField<TKey extends FlagKey>(
+  key: TKey,
+): CommandField<NonNullable<CliFlags[TKey]>> {
+  return buildOptionField(optionDeclaration(key)) as CommandField<NonNullable<CliFlags[TKey]>>;
+}
+
+/**
+ * Fails closed: a command may derive a field only from an option that actually
+ * declares a tool/SDK audience, rather than publishing an undescribed input.
+ */
+function optionDeclaration(key: FlagKey): FlagDefinition {
+  const declared = getFlagDefinitionsForKey(key).filter(
+    (definition) => definition.inputDescription !== undefined,
+  );
+  const [definition, ...extra] = declared;
+  if (!definition) {
+    throw new Error(`Flag ${key} declares no inputDescription; optionField cannot derive a field`);
+  }
+  if (extra.length > 0) {
+    throw new Error(`Flag ${key} declares inputDescription more than once`);
+  }
+  return definition;
+}
+
+function buildOptionField(definition: FlagDefinition): CommandField<unknown> {
+  const description = definition.inputDescription;
+  const bounds = { min: definition.min, max: definition.max };
+  switch (definition.type) {
+    case 'boolean':
+      return booleanField(description) as CommandField<unknown>;
+    case 'int':
+      return integerField(description, bounds) as CommandField<unknown>;
+    case 'number':
+      return numberField(description, bounds) as CommandField<unknown>;
+    case 'string':
+      return stringField(description) as CommandField<unknown>;
+    case 'enum':
+      return enumField(optionEnumValues(definition), description) as CommandField<unknown>;
+    case 'booleanOrString':
+      throw new Error(
+        `Flag ${definition.key} is booleanOrString; declare its field shape explicitly with jsonSchemaField`,
+      );
+  }
+}
+
+function optionEnumValues(definition: FlagDefinition): readonly string[] {
+  const values = definition.enumValues;
+  if (!values) {
+    throw new Error(`Flag ${definition.key} is an enum with no enumValues`);
+  }
+  return values;
 }
 
 export function enumField<const TValues extends readonly string[]>(

--- a/src/commands/management/app.ts
+++ b/src/commands/management/app.ts
@@ -10,6 +10,7 @@ import {
   enumField,
   integerField,
   jsonSchemaField,
+  optionField,
   stringArrayField,
   stringField,
   stringSchema,
@@ -53,9 +54,7 @@ const openCommandMetadata = defineFieldCommandMetadata(
       'Startup budget in milliseconds. Bounds the Simulator boot wait, so a never-booted Simulator can finish its first-boot migration; omit for the default startup behavior.',
       { min: 1 },
     ),
-    foreground: booleanField(
-      'Include an initial interactive snapshot in a fresh open response. With no app argument, discover the sole running app on the sole booted iOS simulator; ambiguous environments fail closed.',
-    ),
+    foreground: optionField('foreground'),
     saveScript: jsonSchemaField<boolean | string>({
       oneOf: [booleanSchema(), stringSchema()],
     }),

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -1,6 +1,7 @@
 import type { FileOutputRef } from '../io.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
 import type { SessionSurface } from '@agent-device/contracts/session';
+import type { SnapshotCommandOptionFields } from '@agent-device/kernel/snapshot';
 
 export type CommandResult = Record<string, unknown>;
 
@@ -57,13 +58,6 @@ export type ScreenshotCommandOptions = CommandContext & {
   surface?: SessionSurface;
 };
 
-export type SnapshotCommandOptions = CommandContext & {
-  interactiveOnly?: boolean;
-  depth?: number;
-  scope?: string;
-  raw?: boolean;
-  customActions?: boolean;
-  forceFull?: boolean;
-};
+export type SnapshotCommandOptions = CommandContext & SnapshotCommandOptionFields;
 
 export type DiffSnapshotCommandOptions = SnapshotCommandOptions;

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -2,62 +2,98 @@
 // boundary can be stated in terms of them; re-exported here because this is where consumers
 // already import them from.
 import type { ScreenshotDispatchFlags } from '@agent-device/contracts/capture';
-import type { BackMode } from '@agent-device/contracts/back-mode';
+import type { CommandFlags } from '@agent-device/contracts/command';
 import type { ClickButton } from '@agent-device/contracts/click-button';
 import type { ElementSelectorKey } from '@agent-device/contracts/interactor-types';
-import type { SwipePattern } from '@agent-device/contracts/scroll-gesture';
 import type { RunnerLogicalLeaseContext } from '@agent-device/contracts/runner-lease-context';
 import type { SessionSurface } from '@agent-device/contracts/session';
-import type { Point, SnapshotPreferredBackend } from '@agent-device/kernel/snapshot';
+import type { Point } from '@agent-device/kernel/snapshot';
 
-export type DispatchContext = ScreenshotDispatchFlags & {
-  requestId?: string;
-  signal?: AbortSignal;
-  appBundleId?: string;
-  activity?: string;
-  launchConsole?: string;
-  launchArgs?: string[];
-  // iOS simulator only: terminate the current app inside the platform open,
-  // either during `simctl launch` or immediately before `simctl openurl`.
-  terminateRunningApp?: boolean;
-  clearAppState?: boolean;
-  verbose?: boolean;
-  logPath?: string;
-  traceLogPath?: string;
-  iosXctestrunFile?: string;
-  iosXctestDerivedDataPath?: string;
-  iosXctestEnvDir?: string;
-  runnerLeaseContext?: RunnerLogicalLeaseContext;
-  screenshotCaptureBackend?: 'runner';
-  snapshotInteractiveOnly?: boolean;
-  snapshotPreferredBackend?: SnapshotPreferredBackend;
-  snapshotDepth?: number;
-  snapshotScope?: string;
-  snapshotRaw?: boolean;
-  snapshotCustomActions?: boolean;
-  snapshotIncludeRects?: boolean;
-  snapshotIncludeHiddenContentHints?: boolean;
-  skipIosSimulatorBootCheck?: boolean;
-  count?: number;
-  intervalMs?: number;
-  delayMs?: number;
-  /** Maestro replay compatibility for coordinate-resolved fill targets. */
-  allowNonHittableCoordinateFallback?: boolean;
-  durationMs?: number;
-  holdMs?: number;
-  jitterPx?: number;
-  pixels?: number;
-  doubleTap?: boolean;
-  clickButton?: ClickButton;
-  backMode?: BackMode;
-  pauseMs?: number;
-  pattern?: SwipePattern;
-  surface?: SessionSurface;
-  directElementSelector?: {
-    key: ElementSelectorKey;
-    value: string;
-    raw: string;
+/**
+ * The command flags a dispatched request carries into platform execution
+ * UNCHANGED: same key, same type, no decision on the way through.
+ *
+ * Every key here used to be written out twice — once as a field on
+ * {@link DispatchContext} and once as `key: flags?.key` in the daemon's flat
+ * mapper (`contextFromFlags`) — so an identically-named flag cost two more
+ * files, and a missed copy dropped it silently at the seam. Neither copy stated
+ * anything this list does not.
+ *
+ * The flags that DO change on the way through stay hand-written at the mapper,
+ * where the decision lives: `clickButton` (resolved from several flags), the
+ * screenshot family (`screenshotFlagsFromOptions`), and the maestro-nested
+ * capture backend. Order follows the flag order in `CliFlags`.
+ */
+// Exported only because `DispatchContextFlags` says `typeof` it.
+// fallow-ignore-next-line unused-export
+export const DISPATCH_CONTEXT_FLAG_KEYS = [
+  'activity',
+  'launchConsole',
+  'launchArgs',
+  'clearAppState',
+  'verbose',
+  'iosXctestrunFile',
+  'iosXctestDerivedDataPath',
+  'iosXctestEnvDir',
+  'snapshotInteractiveOnly',
+  'snapshotPreferredBackend',
+  'snapshotDepth',
+  'snapshotScope',
+  'snapshotRaw',
+  'snapshotCustomActions',
+  'snapshotIncludeHiddenContentHints',
+  'count',
+  'intervalMs',
+  'delayMs',
+  'durationMs',
+  'holdMs',
+  'jitterPx',
+  'pixels',
+  'doubleTap',
+  'backMode',
+  'pauseMs',
+  'pattern',
+] as const satisfies readonly (keyof CommandFlags)[];
+
+/** The dispatch-context view of {@link DISPATCH_CONTEXT_FLAG_KEYS}. */
+export type DispatchContextFlags = Pick<CommandFlags, (typeof DISPATCH_CONTEXT_FLAG_KEYS)[number]>;
+
+/**
+ * Copies exactly the declared pass-through flags. Every key is present
+ * (possibly `undefined`), matching what the hand-written mapper produced.
+ */
+export function dispatchContextFlags(flags: CommandFlags | undefined): DispatchContextFlags {
+  return Object.fromEntries(
+    DISPATCH_CONTEXT_FLAG_KEYS.map((key) => [key, flags?.[key]]),
+  ) as DispatchContextFlags;
+}
+
+// `DispatchContextFlags` carries every flag that reaches platform execution
+// unchanged; only the fields BELOW are context-owned — set by the request scope
+// rather than copied off a flag, or a flag that a decision changed on the way.
+export type DispatchContext = ScreenshotDispatchFlags &
+  DispatchContextFlags & {
+    requestId?: string;
+    signal?: AbortSignal;
+    appBundleId?: string;
+    // iOS simulator only: terminate the current app inside the platform open,
+    // either during `simctl launch` or immediately before `simctl openurl`.
+    terminateRunningApp?: boolean;
+    logPath?: string;
+    traceLogPath?: string;
+    runnerLeaseContext?: RunnerLogicalLeaseContext;
+    screenshotCaptureBackend?: 'runner';
+    snapshotIncludeRects?: boolean;
+    skipIosSimulatorBootCheck?: boolean;
+    /** Maestro replay compatibility for coordinate-resolved fill targets. */
     allowNonHittableCoordinateFallback?: boolean;
-    expectedPoint?: Point;
+    clickButton?: ClickButton;
+    surface?: SessionSurface;
+    directElementSelector?: {
+      key: ElementSelectorKey;
+      value: string;
+      raw: string;
+      allowNonHittableCoordinateFallback?: boolean;
+      expectedPoint?: Point;
+    };
   };
-};

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,5 +1,5 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
-import type { DispatchContext } from '../core/dispatch-context.ts';
+import { dispatchContextFlags, type DispatchContext } from '../core/dispatch-context.ts';
 import { resolveClickButton } from '@agent-device/contracts/click-button';
 import {
   screenshotFlagsFromOptions,
@@ -17,9 +17,10 @@ export type BoundContextFromFlags = (
   traceLogPath?: string,
 ) => DaemonCommandContext;
 
-// Flat compatibility mapper: keeping each CLI flag visible here makes request
-// context drift easier to spot than splitting the same optional fields apart.
-// fallow-ignore-next-line complexity
+// The pass-through flags come from their one declaration
+// (`DISPATCH_CONTEXT_FLAG_KEYS`); what stays written out here is what this
+// mapper actually decides — the request-scope fields, and the three flag
+// families that change vocabulary on the way through.
 export function contextFromFlags(
   logPath: string,
   flags: CommandFlags | undefined,
@@ -33,36 +34,11 @@ export function contextFromFlags(
     requestId: effectiveRequestId,
     appBundleId,
     runnerLeaseContext: resolveRunnerLogicalLeaseContext({ meta }),
-    activity: flags?.activity,
-    launchConsole: flags?.launchConsole,
-    launchArgs: flags?.launchArgs,
-    clearAppState: flags?.clearAppState,
-    verbose: flags?.verbose,
     logPath,
     traceLogPath,
-    iosXctestrunFile: flags?.iosXctestrunFile,
-    iosXctestDerivedDataPath: flags?.iosXctestDerivedDataPath,
-    iosXctestEnvDir: flags?.iosXctestEnvDir,
+    ...dispatchContextFlags(flags),
     screenshotCaptureBackend: flags?.maestro?.screenshotCaptureBackend,
-    snapshotInteractiveOnly: flags?.snapshotInteractiveOnly,
-    snapshotPreferredBackend: flags?.snapshotPreferredBackend,
-    snapshotDepth: flags?.snapshotDepth,
-    snapshotScope: flags?.snapshotScope,
-    snapshotRaw: flags?.snapshotRaw,
-    snapshotCustomActions: flags?.snapshotCustomActions,
-    snapshotIncludeHiddenContentHints: flags?.snapshotIncludeHiddenContentHints,
     ...screenshotFlagsFromOptions(flags),
-    count: flags?.count,
-    intervalMs: flags?.intervalMs,
-    delayMs: flags?.delayMs,
-    durationMs: flags?.durationMs,
-    holdMs: flags?.holdMs,
-    jitterPx: flags?.jitterPx,
-    pixels: flags?.pixels,
-    doubleTap: flags?.doubleTap,
     clickButton: resolveClickButton(flags),
-    backMode: flags?.backMode,
-    pauseMs: flags?.pauseMs,
-    pattern: flags?.pattern,
   };
 }

--- a/src/daemon/snapshot-capture.ts
+++ b/src/daemon/snapshot-capture.ts
@@ -9,6 +9,8 @@ import { publicPlatformString } from '@agent-device/kernel/device';
 import {
   findNodeByRef,
   normalizeRef,
+  SNAPSHOT_CAPTURE_OPTION_KEYS,
+  snapshotOptionsFromFlags,
   type RawSnapshotNode,
   type SnapshotCaptureProvenance,
   type SnapshotState,
@@ -115,14 +117,8 @@ export async function captureSnapshotData(params: CaptureSnapshotParams): Promis
     options: {
       appBundleId: context.appBundleId,
       signal: params.signal,
-      interactiveOnly: context.snapshotInteractiveOnly,
-      preferredBackend: context.snapshotPreferredBackend,
-      depth: context.snapshotDepth,
-      scope: context.snapshotScope,
-      raw: context.snapshotRaw,
-      customActions: context.snapshotCustomActions,
+      ...snapshotOptionsFromFlags(context, SNAPSHOT_CAPTURE_OPTION_KEYS),
       includeRects: params.includeRects,
-      includeHiddenContentHints: context.snapshotIncludeHiddenContentHints,
       surface: session?.surface,
     },
   });

--- a/src/daemon/snapshot-runtime-capture-input.ts
+++ b/src/daemon/snapshot-runtime-capture-input.ts
@@ -1,4 +1,8 @@
 import type { CommandFlags } from '@agent-device/contracts/command';
+import {
+  SNAPSHOT_CAPTURE_OPTION_KEYS,
+  snapshotOptionsFromFlags,
+} from '@agent-device/kernel/snapshot';
 import type {
   CaptureSnapshotInput,
   SnapshotRuntimeExecution,
@@ -38,13 +42,9 @@ export function buildRuntimeCaptureInput(
   return {
     options: {
       appBundleId,
-      interactiveOnly: flags?.snapshotInteractiveOnly,
-      preferredBackend: flags?.snapshotPreferredBackend,
-      depth: flags?.snapshotDepth,
+      ...snapshotOptionsFromFlags(flags, SNAPSHOT_CAPTURE_OPTION_KEYS),
+      // The session-resolved scope wins over the raw flag.
       scope: snapshotScope,
-      raw: flags?.snapshotRaw,
-      customActions: flags?.snapshotCustomActions,
-      includeHiddenContentHints: flags?.snapshotIncludeHiddenContentHints,
       includeRects: params.includeRects,
       surface,
     },

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,5 +1,9 @@
 import { stripAndroidSystemChromeProvenance } from '@agent-device/contracts/android-system-chrome';
 import { copySnapshotClickabilityEvidence } from '@agent-device/contracts/capture';
+import {
+  SNAPSHOT_COMMAND_OPTION_KEYS,
+  snapshotOptionsFromFlags,
+} from '@agent-device/kernel/snapshot';
 import { dispatchSnapshotRuntimeCommand } from './snapshot-command-runtime.ts';
 import { captureSparseFallbackScreenshot } from './sparse-fallback-screenshot.ts';
 import type { SnapshotRuntimeRouteParams } from './snapshot-runtime-binding.ts';
@@ -20,12 +24,9 @@ export async function dispatchSnapshotViaRuntime(
     }) => {
       const result = await agentRuntime.capture.snapshot({
         session: resolvedSessionName,
-        interactiveOnly: request.flags?.snapshotInteractiveOnly,
-        depth: request.flags?.snapshotDepth,
+        ...snapshotOptionsFromFlags(request.flags, SNAPSHOT_COMMAND_OPTION_KEYS),
+        // The session-resolved scope wins over the raw flag.
         scope: snapshotScope,
-        raw: request.flags?.snapshotRaw,
-        customActions: request.flags?.snapshotCustomActions,
-        forceFull: request.flags?.snapshotForceFull,
       });
       const refsGeneration = publishedSnapshotGeneration(
         request,


### PR DESCRIPTION
Closes #2410. Child 1 of #2409.

Implements the removable pass-through hops the hop trace on #2410 named, and
nothing else. An option is now declared once, and each surface reads that
declaration instead of a copy of it.

## What changed

**1 — the dispatch pass-through (trace hop group 1).**
`DISPATCH_CONTEXT_FLAG_KEYS` in `src/core/dispatch-context.ts` declares the
flags that reach platform execution unchanged. `DispatchContext` is
`Pick<CommandFlags, …>` of that list, and the daemon's `contextFromFlags` copies
exactly it. The mapper keeps only what it *decides*: the request-scope fields,
`clickButton` (resolved), the screenshot family, and the maestro-nested capture
backend. An identically-named flag costs one edit instead of two files, which is
the same collapse `screenshotFlagsFromOptions` already shipped one line below.

**2 — the snapshot flag↔option rename, nine sites (group 2).**
`SNAPSHOT_OPTION_FLAGS` in `@agent-device/kernel/snapshot` declares the eight
pairs once (`customActions` ↔ `snapshotCustomActions` and siblings) with both
projections, generalising the shipped `screenshotFlagsFromOptions` /
`screenshotOptionsFromFlags`. Every projection takes an **explicit key list**, so
declaring a pair never silently widens a seam that cannot honour it. The nine
hand-written renames — the CLI reader, the client option projection, three
daemon capture inputs, the presentation key, `SNAPSHOT_OPTION_FLAGS`' former
local copy — now read the declaration. `src/daemon/request-router.ts`'s
`--actions`/`--raw` rejection, the presentation-key decision and the replay
journal's wire key are untouched: they decide things.

**3 — the duplicate per-command option types (group 3).**
`SnapshotCommandOptionFields` is the one statement of the six snapshot capture
keys. `CaptureSnapshotOptions` (public SDK), `CommandExecutionOptions` (internal
request bag) and `SnapshotCommandOptions` (command runtime) reference it instead
of re-listing them.

**5 + 6 — one owner for an option's prose and its type (groups 5, 6).**
`FlagDefinition` now carries both audiences side by side: `usageDescription` for
`--help` and `inputDescription` for the tool/SDK field. They stay two strings —
they are legitimately two audiences with two lengths — but one owner, so a
rewrite of one is a rewrite of both. `optionField(key)` derives a command's
input field from that declaration: the JSON schema shape and bounds from `type`
/ `enumValues` / `min` / `max`, the description from `inputDescription`, the
TypeScript value type from `CliFlags[key]`. Applied to the two traced options
(`open --foreground`, `snapshot --actions`), so the copy in `cli-flags.ts` and
the hand-written `booleanField('…')` in each command are gone.

The **public SDK JSDoc stays**. `AppOpenOptions.foreground` and
`CaptureSnapshotOptions.customActions` keep their editor documentation: a
`.d.ts` is read where no `FlagDefinition` resolves, and this repo has no step
that generates those docs, so removing them would have been a silent API
documentation regression rather than a de-duplication. Documentation on a public
type is not a second statement of what the option does — but it is the same
sentence in a second place, so it is now the option's ONE declaration verbatim
(previously each field carried a third, differently-worded copy) and pinned to
it by a test, below. `CaptureSnapshotOptions` lifts `customActions` out of the
`SnapshotCommandOptionFields` spread only to carry that prose; its type is still
`SnapshotCommandOptionFields['customActions']`, so dropping the key from the
declaration fails to compile here.

No help text, MCP tool schema or wire shape changes: `pnpm check:mcp-metadata`
is clean and no CLI grammar or help test was edited.

## Proof — #1693 replayed (corrected 2026-09-09, was wrong)

The previous revision understated both replays. Corrected counts below,
verified live on this branch (edits made, tests run, then reverted — see the
review comment for the itemized packaged-size table this also required).

**#1693 added `open --foreground`** — on `origin/main` that one option costs
at least 16 files across 4 layers (#2410's own baseline). Replayed as an
addition on this shape — a new boolean option wired the same way
(`--dry-run` on `open`, added end to end and then reverted):

```
contracts type:  M packages/contracts/src/cli-flags.ts
descriptor:      M src/commands/cli-grammar/flag-definitions-action.ts
owning handler:  M src/commands/management/app.ts
tests:           a test for the option's own behaviour
```

Four files, matching #2410's acceptance criterion exactly (contracts type,
descriptor, owning handler, tests) — down from 16, none of them under
`src/cli-schema/`, none in an MCP parity test. Verified: with only the three
production files above edited (no test), `pnpm typecheck`,
`command-descriptor-parity`, `mcp/command-tools-parity` and
`sync-mcp-metadata --check` all stayed green, unedited — a real addition would
still add its own behaviour test, which is the fourth file.

**Separately — this is what the previous revision got wrong.** Rewording the
*description* of an option that already carries hand-authored SDK
documentation, such as `open --foreground`'s `inputDescription`, is not a
one-file edit on this shape:

```
before (origin/main):  4 files carry the same sentence
after  (this branch):  M src/commands/cli-grammar/flag-definitions-action.ts
                        M packages/contracts/src/client-app.ts
```

Two production files, zero test files — not one. The JSDoc-equality test
added at 79f7161 (`each documented SDK option field carries its option
declaration verbatim`) pins `client-app.ts`'s hover doc to the same
`inputDescription`, so editing the descriptor alone now fails that test.
Verified live: editing `foreground`'s `inputDescription` alone turns
`command-input-option-field.test.ts` red; it is only green again once
`client-app.ts`'s JSDoc is edited to match. This is the intended second edit,
not a regression — it is what "pinned so they cannot drift" (Tests, below)
means in practice.

That second edit is not universal: it only applies to the 2 of 156 declared
options (`foreground`, `snapshotCustomActions`) that carry a hand-authored
public SDK doc comment by design. For the other 154, a description edit is
still one file — nothing pins their (nonexistent) SDK doc to the declaration.

Both replays keep the rest of the original claim: no edit under
`src/cli-schema/`, none in an MCP parity test, none in
`src/core/dispatch-context.ts`, `src/daemon/context.ts` or
`src/commands/command-flags.ts`. `--help` output is untouched by a
description-only edit — only the MCP/SDK field description and, for the two
documented fields, the SDK hover doc move.

## Tests

Neither parity test was redundant, so neither was deleted:

- `src/mcp/__tests__/command-tools-parity.test.ts` is a behaviour test, not a
  comparison of two hand-written copies; the MCP input schema was already
  derived on `main` (trace correction 1).
- `src/__tests__/command-descriptor-parity.test.ts` is command-level only and
  has no option content (trace correction 2).

What did not exist is a test at the **option** level. Added
`src/commands/command-input-option-field.test.ts` in the planted-divergence
form: a divergence planted in the one declaration must move the derived surface
— which a second hand-written copy could not do.

The plant lands **before the surfaces are built**. Command metadata, and the MCP
tool schema built from it, are constructed at module load, so a plant applied
afterwards would only prove that `optionField` reads its own argument.
`buildWithPlantedOption` resets the module graph, writes the divergence onto the
declaration, and only then imports `command-metadata.ts` and
`mcp/command-tools.ts`, so what the assertions observe is the production
derivation running over the planted declaration. Both derived surfaces are
asserted — the command metadata property and the MCP tool's input schema
property — for a planted description (`open --foreground`) and for a planted
value type with bounds (`snapshot --actions`, `boolean` → `int` with `min`/`max`).

The guard has teeth: reverting either production use to its old hand-written
field turns the corresponding test red (both red runs are recorded in the review
comment on this PR).

Plus: each documented SDK option field's JSDoc must equal its declaration's
`inputDescription` verbatim (read out of the `.ts` source), every declared tool
audience is consumed by a command (no orphan prose), an option with no declared
tool audience cannot be derived into a field (fail-closed), and the two
audiences stay distinct.

## Named but not done here

- **Group 4, `usageOverride` on option-bearing commands.** `snapshot`'s
  generated synopsis is not byte-identical to its override (the generator
  appends `[--record]` and expands `SNAPSHOT_FLAGS` in a different order), so
  dropping the override changes `--help` output. That is a help-text decision,
  not a pass-through collapse, and this PR was required to leave the help tests
  green and unchanged. Worth its own change.
- **Moving `PROJECT_CONFIG_FLAG_KEYS` and `SANITIZED_FLAG_KEYS` onto the option
  declaration.** The trace lists these under "must NOT be collapsed — move, never
  infer". Moving them means adding a required field to ~200 flag declarations and
  saves nothing on the #1693 replay; it belongs to the #1665-shaped follow-up.

## Packaged size (added 2026-09-09)

The size gate's +3.3 kB/+2.2 kB is itemized per-file in the review comment on
this PR (same method as `scripts/size-report.mjs`: `pnpm build` +
`npm pack --dry-run --json`, diffed against `main@9d7d60c5e0`). One line item
was pure waste — an internal refactor-rationale JSDoc comment on
`SNAPSHOT_OPTION_FLAGS` (`packages/kernel/src/snapshot.ts`) that
`rolldown-plugin-dts` was bundling in full into the public `.d.ts` — fixed at
9990ea1 by moving it to a source comment with a short hover doc in its place
(no behaviour change). That cuts the growth to +2.3 kB / +1.8 kB. The rest is
the shared snapshot-option type surface itself and the two SDK JSDoc blocks
this review asked to keep verbatim-pinned; the comment explains why a smaller
design for those was rejected.

## Verification

`pnpm typecheck` ✅ · `pnpm test:unit` 9359 passed ✅ · `pnpm lint` ✅ ·
`pnpm check:layering` ✅ · `pnpm check:fallow` ✅ (no issues in changed files) ·
`pnpm check:mcp-metadata` ✅ · eager-closure budgets 577/577 ✅ ·
`pnpm check:affected --run` ✅ (770 files, 5828 tests, after the 9990ea1 fix).

`packages/host-kit/src/code-signature.test.ts` fails 3 tests on this branch and
fails the same 3 on the `origin/main` checkout — pre-existing, not from this
change.


