### PR TITLE
test(ios): add a shared AX recovery conformance fixture with a host adapter

### DIFF
--- a/apple/snapshot-bridge/README.md
+++ b/apple/snapshot-bridge/README.md
@@ -63,3 +63,19 @@ use non-launch failure codes, so the route falls back without launch re-polling.
 At each native fragment boundary, an absent or invalid child count means unknown
 completeness and fails closed. Natural leaves above that boundary need no
 continuation evidence. Unchanged native dictionaries and child arrays are reused.
+
+## Recovery conformance
+
+`contracts/fixtures/ios-ax-recovery-conformance.json` is the shared, executable
+recovery contract for this bridge and the XCTest runner's private AX bridge.
+`packages/platform-apple/src/snapshot-source/fixtures/recovery-conformance.m`
+replays each case through `captureSnapshotTree`; the runner adapter that
+replays the same cases through the XCTest runner's private AX bridge is
+pending in [#2428](https://github.com/callstack/agent-device/pull/2428), so at
+this revision only the fixture's `host-bridge` column is executed. Each
+expectation names the
+outcome, the native request accounting, and the delivered tree as a canonical
+preorder signature with its retained node count, so a producer that drops,
+duplicates, reorders, or re-parents nodes cannot pass as complete. The fixture
+records each producer's expectation and documents the intentional differences
+(depth vocabulary, ladders, completeness evidence, budgets, hint lifetime).

--- a/contracts/fixtures/ios-ax-recovery-conformance.json
+++ b/contracts/fixtures/ios-ax-recovery-conformance.json
@@ -1,0 +1,567 @@
+{
+  "version": 1,
+  "description": "Shared, executable recovery contract for the two iOS Simulator accessibility producers: the host AX bridge (apple/snapshot-bridge) and the XCTest runner's private AX bridge (apple/runner). Each producer runs every case through its own adapter and interprets the synthetic native world in its own model; expectations are recorded per producer so intentional differences stay visible instead of being averaged away.",
+  "nativeModel": {
+    "tree": "A chain of `chain` nodes at levels 0..chain-1 (labels are the level number). An optional `fan` gives the last chain node `count` children at level `at + 1`, each heading a further chain of `chain` nodes; fan labels are `<level>.<branch>`.",
+    "request": "A native request rooted at level r for L node levels returns levels r..r+L-1 that exist. `rejectLevelsAbove` rejects any request asking for more node levels than that with the producer's depth-rejection code.",
+    "frontierEvidence": "`counted` gives every returned node its true child count (host only; the runner has no counts). `unknown` omits the count on the deepest level of every returned fragment.",
+    "vanishAtFrontier": "The deepest level of every returned fragment has no live accessibility element, so no continuation can be rooted there.",
+    "ownerChangesAfterRequests": "The primary foreground owner changes after that many native requests (host only).",
+    "deadlineAfterRequests": "The capture deadline is spent after that many native requests (runner only; the host deadline is the guest watchdog and the host request timeout).",
+    "signature": "`tree` is the delivered tree in preorder: every node's identity, with `<parent` appended when its parent is not the canonical one (the previous level on the same branch, or the fan's last chain node for a branch head); runs of consecutive levels on one branch collapse to `first-last` (`0-44`, `30.1-49.1`). `nodes` is the retained node count. Dropped, duplicated, reordered, or re-parented nodes change the signature."
+  },
+  "producers": {
+    "host-bridge": {
+      "recoveryOwner": "apple/snapshot-bridge/SnapshotBridgeCapture.m",
+      "hintOwner": "not yet: the host learns no accepted-depth hint (follow-up to #2424 step 1)",
+      "adapters": ["packages/platform-apple/src/snapshot-source/fixtures/recovery-conformance.m"],
+      "nativeLevelsForTraversalDepth": "depth + 1 (delivers exactly `depth` edges below the root)",
+      "frontierEvidence": "native child count at every fragment boundary; an absent or invalid count fails closed",
+      "hintIdentity": "none yet; every capture starts at the requested depth",
+      "hintExpiry": "n/a",
+      "hintLearning": "n/a"
+    },
+    "runner": {
+      "recoveryOwner": "apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerAXSnapshotBridge.m and RunnerTests+AXSnapshotFallback.swift",
+      "hintOwner": "apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift",
+      "adapters": [
+        "apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/UnitTests/RunnerTests+AXRecoveryConformanceTests.swift (stacked PR)"
+      ],
+      "nativeLevelsForTraversalDepth": "depth (node levels; delivers `depth - 1` edges below the root)",
+      "frontierEvidence": "childless nodes at the deepest observed level of a capped capture; no child counts",
+      "hintIdentity": "bundle id + process id, owned by the runner process",
+      "hintExpiry": "120 s wall clock; hinted successes never renew",
+      "hintLearning": "any lower-rung success, complete or not"
+    }
+  },
+  "differences": [
+    "Depth vocabulary: the host asks for depth + 1 native levels and delivers `depth` edges; the runner passes `depth` as native node levels and delivers `depth - 1` edges (zero-based-depth-levels, explicit-depth-honored).",
+    "Recovery ladder: the host halves the rejected depth at most twice per request; the runner walks 56/40/24/12 and has no rung below 12. A rejection at depth 8 recovers on the host and fails on the runner.",
+    "Completeness evidence: the host trusts native child counts and fails closed when a boundary count is missing; the runner infers frontiers from the deepest childless level and pays one extra call to verify a natural leaf that sits at the cap (unknown-frontier-evidence, hint-rejected-then-lower).",
+    "Delivered depth: host continuations keep the requested traversal depth and disclose deeper content as truncated; runner extension re-roots with the same native depth, so the delivered tree can exceed the requested depth and an explicit depth is not disclosed as truncated (deeper-than-requested, explicit-depth-honored).",
+    "Budgets: the host spends one continuation per withheld parent inside a 32-request budget; the runner spends one extension call per frontier node inside an 8-call budget (host-request-budget, runner-extension-budget).",
+    "Ownership and deadlines: only the host checks the foreground owner on every native request; only the runner consults the capture deadline between rungs and extension calls (owner-change-during-continuation, deadline-before-retry).",
+    "Hints: the runner remembers any lower rung per bundle id + pid with a wall-clock expiry that hinted successes never renew; the host bridge has no accepted-depth hint yet, so the hinted recovery cases and the host column of the hint cases are filled in by the follow-up that adds one."
+  ],
+  "recoveryCases": [
+    {
+      "name": "healthy-shallow",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 5
+        },
+        "rejectLevelsAbove": null,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "complete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 4,
+          "tree": "0-4",
+          "nodes": 5
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 4,
+          "tree": "0-4",
+          "nodes": 5
+        }
+      }
+    },
+    {
+      "name": "rejected-then-recovered",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "complete",
+          "requests": 3,
+          "rejected": 1,
+          "continuations": 1,
+          "deepestLevel": 44,
+          "tree": "0-44",
+          "nodes": 45
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 4,
+          "rejected": 2,
+          "continuations": 1,
+          "deepestLevel": 44,
+          "tree": "0-44",
+          "nodes": 45
+        }
+      }
+    },
+    {
+      "name": "multi-branch-recovery",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 30,
+          "fan": {
+            "at": 29,
+            "count": 3,
+            "chain": 19
+          }
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "complete",
+          "requests": 5,
+          "rejected": 1,
+          "continuations": 3,
+          "deepestLevel": 49,
+          "tree": "0-29,30.0-49.0,30.1-49.1,30.2-49.2",
+          "nodes": 90
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 6,
+          "rejected": 2,
+          "continuations": 3,
+          "deepestLevel": 49,
+          "tree": "0-29,30.0-49.0,30.1-49.1,30.2-49.2",
+          "nodes": 90
+        }
+      }
+    },
+    {
+      "name": "deeper-than-requested",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 70
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "incomplete",
+          "requests": 4,
+          "rejected": 1,
+          "continuations": 2,
+          "deepestLevel": 64,
+          "tree": "0-64",
+          "nodes": 65
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 4,
+          "rejected": 2,
+          "continuations": 1,
+          "deepestLevel": 69,
+          "tree": "0-69",
+          "nodes": 70
+        }
+      }
+    },
+    {
+      "name": "zero-based-depth-levels",
+      "request": {
+        "traversalDepth": 2,
+        "explicitDepth": true,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 3
+        },
+        "rejectLevelsAbove": null,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "complete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 2,
+          "tree": "0-2",
+          "nodes": 3
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 1,
+          "tree": "0-1",
+          "nodes": 2
+        }
+      }
+    },
+    {
+      "name": "node-budget",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 4
+      },
+      "native": {
+        "tree": {
+          "chain": 10
+        },
+        "rejectLevelsAbove": null,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "incomplete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 3,
+          "tree": "0-3",
+          "nodes": 4
+        },
+        "runner": {
+          "outcome": "incomplete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 3,
+          "tree": "0-3",
+          "nodes": 4
+        }
+      }
+    },
+    {
+      "name": "unknown-frontier-evidence",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "unknown"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "failed",
+          "failure": "boundary-evidence-missing",
+          "requests": 2,
+          "rejected": 1,
+          "continuations": 0
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 4,
+          "rejected": 2,
+          "continuations": 1,
+          "deepestLevel": 44,
+          "tree": "0-44",
+          "nodes": 45
+        }
+      }
+    },
+    {
+      "name": "missing-live-element",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted",
+        "vanishAtFrontier": true
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "failed",
+          "failure": "continuation-element-missing",
+          "requests": 2,
+          "rejected": 1,
+          "continuations": 0
+        },
+        "runner": {
+          "outcome": "incomplete",
+          "requests": 3,
+          "rejected": 2,
+          "continuations": 0,
+          "deepestLevel": 39,
+          "tree": "0-39",
+          "nodes": 40
+        }
+      }
+    },
+    {
+      "name": "owner-change-during-continuation",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted",
+        "ownerChangesAfterRequests": 2
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "failed",
+          "failure": "owner-changed",
+          "requests": 3,
+          "rejected": 1,
+          "continuations": 1
+        },
+        "runner": {
+          "outcome": "not-applicable",
+          "reason": "the runner has no foreground-owner check inside acquisition; XCTest owns system-modal resolution"
+        }
+      }
+    },
+    {
+      "name": "host-request-budget",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 15,
+          "fan": {
+            "at": 14,
+            "count": 40,
+            "chain": 1
+          }
+        },
+        "rejectLevelsAbove": 16,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "failed",
+          "failure": "request-budget-exhausted",
+          "requests": 32,
+          "rejected": 2,
+          "continuations": 29
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 6,
+          "rejected": 4,
+          "continuations": 1,
+          "deepestLevel": 16,
+          "tree": "0-14,15.0-16.0,15.1-16.1,15.2-16.2,15.3-16.3,15.4-16.4,15.5-16.5,15.6-16.6,15.7-16.7,15.8-16.8,15.9-16.9,15.10-16.10,15.11-16.11,15.12-16.12,15.13-16.13,15.14-16.14,15.15-16.15,15.16-16.16,15.17-16.17,15.18-16.18,15.19-16.19,15.20-16.20,15.21-16.21,15.22-16.22,15.23-16.23,15.24-16.24,15.25-16.25,15.26-16.26,15.27-16.27,15.28-16.28,15.29-16.29,15.30-16.30,15.31-16.31,15.32-16.32,15.33-16.33,15.34-16.34,15.35-16.35,15.36-16.36,15.37-16.37,15.38-16.38,15.39-16.39",
+          "nodes": 95
+        }
+      }
+    },
+    {
+      "name": "runner-extension-budget",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 39,
+          "fan": {
+            "at": 38,
+            "count": 12,
+            "chain": 1
+          }
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "complete",
+          "requests": 3,
+          "rejected": 1,
+          "continuations": 1,
+          "deepestLevel": 40,
+          "tree": "0-38,39.0-40.0,39.1-40.1,39.2-40.2,39.3-40.3,39.4-40.4,39.5-40.5,39.6-40.6,39.7-40.7,39.8-40.8,39.9-40.9,39.10-40.10,39.11-40.11",
+          "nodes": 63
+        },
+        "runner": {
+          "outcome": "incomplete",
+          "requests": 11,
+          "rejected": 2,
+          "continuations": 8,
+          "deepestLevel": 40,
+          "tree": "0-38,39.0-40.0,39.1-40.1,39.2-40.2,39.3-40.3,39.4-40.4,39.5-40.5,39.6-40.6,39.7-40.7,39.8,39.9,39.10,39.11",
+          "nodes": 59
+        }
+      }
+    },
+    {
+      "name": "deadline-before-retry",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted",
+        "deadlineAfterRequests": 1
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "not-applicable",
+          "reason": "the host deadline is the guest watchdog and the host request timeout, not a capture decision"
+        },
+        "runner": {
+          "outcome": "failed",
+          "failure": "deadline",
+          "requests": 1,
+          "rejected": 1,
+          "continuations": 0
+        }
+      }
+    },
+    {
+      "name": "explicit-depth-honored",
+      "request": {
+        "traversalDepth": 8,
+        "explicitDepth": true,
+        "nodeBudget": 1500
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "incomplete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 8,
+          "tree": "0-8",
+          "nodes": 9
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 1,
+          "rejected": 0,
+          "continuations": 0,
+          "deepestLevel": 7,
+          "tree": "0-7",
+          "nodes": 8
+        }
+      }
+    },
+    {
+      "name": "hinted-first-request",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500,
+        "hint": {
+          "runner": 40
+        }
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 48,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "not-applicable",
+          "reason": "the host bridge has no accepted-depth hint yet"
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 2,
+          "rejected": 0,
+          "continuations": 1,
+          "deepestLevel": 44,
+          "tree": "0-44",
+          "nodes": 45
+        }
+      }
+    },
+    {
+      "name": "hint-rejected-then-lower",
+      "request": {
+        "traversalDepth": 64,
+        "explicitDepth": false,
+        "nodeBudget": 1500,
+        "hint": {
+          "runner": 40
+        }
+      },
+      "native": {
+        "tree": {
+          "chain": 45
+        },
+        "rejectLevelsAbove": 20,
+        "frontierEvidence": "counted"
+      },
+      "expected": {
+        "host-bridge": {
+          "outcome": "not-applicable",
+          "reason": "the host bridge has no accepted-depth hint yet"
+        },
+        "runner": {
+          "outcome": "complete",
+          "requests": 7,
+          "rejected": 2,
+          "continuations": 4,
+          "deepestLevel": 44,
+          "tree": "0-44",
+          "nodes": 45
+        }
+      }
+    }
+  ]
+}

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -171,6 +171,17 @@ they run a short XCTest probe instead of the full tree slice so healthy screens 
 repeating the hostile-screen grind. The raw diagnostic plan is exempt — it keeps tree-first error
 propagation.
 
+## Recovery conformance and depth hints
+
+The host AX bridge and the XCTest runner's private AX bridge recover rejected deep requests with
+different native representations, ladders, and completeness evidence, and they stay separate
+implementations. `contracts/fixtures/ios-ax-recovery-conformance.json` is their shared, executable
+recovery contract: each producer replays every case through its own adapter (the host adapter
+first; the runner adapter is pending in #2428), and the fixture records per-producer expectations
+plus the intentional differences, so a change to either recovery path is measured against the same
+synthetic native world. Common executable policy is extracted only
+where the fixture proves equivalence; a shared engine is not a goal.
+
 ## Consequences
 
 Regular snapshots remain the right tool for agents and Maestro compatibility because they describe

--- a/packages/platform-apple/src/snapshot-source/fixtures/recovery-conformance.m
+++ b/packages/platform-apple/src/snapshot-source/fixtures/recovery-conformance.m
@@ -1,0 +1,257 @@
+// Host-bridge adapter for contracts/fixtures/ios-ax-recovery-conformance.json: replays one
+// recovery case through captureSnapshotTree with a scripted native reader and compares the
+// producer-neutral outcome against the fixture's `host-bridge` expectation.
+#import "SnapshotBridgeCapture.h"
+
+#import <Foundation/Foundation.h>
+
+static NSString *const kAttributes = @"UIAccessibilitySnapshotKeyAttributes";
+static NSString *const kChildren = @"UIAccessibilitySnapshotKeyChildren";
+static NSString *const kChildCount = @"UIAccessibilitySnapshotKeyChildrenCount";
+static NSString *const kElement = @"UIAccessibilitySnapshotKeyElement";
+static NSString *const kIdentity = @"identity";
+
+@interface FixtureNode : NSObject
+@property(nonatomic) NSUInteger level;
+@property(nonatomic, copy) NSString *identity;
+@property(nonatomic, weak) FixtureNode *parent;
+@property(nonatomic, strong) NSMutableArray<FixtureNode *> *children;
+@end
+@implementation FixtureNode
+@end
+
+static FixtureNode *makeNode(NSUInteger level, NSString *identity)
+{
+  FixtureNode *node = [FixtureNode new];
+  node.level = level;
+  node.identity = identity;
+  node.children = [NSMutableArray array];
+  return node;
+}
+
+static void buildChain(FixtureNode *parent, NSUInteger count, NSString *branch)
+{
+  FixtureNode *current = parent;
+  for (NSUInteger index = 0; index < count; index++) {
+    NSUInteger level = current.level + 1;
+    FixtureNode *next = makeNode(level, branch ? [NSString stringWithFormat:@"%lu.%@", (unsigned long)level, branch]
+                                              : @(level).stringValue);
+    next.parent = current;
+    [current.children addObject:next];
+    current = next;
+  }
+}
+
+static FixtureNode *buildTree(NSDictionary *tree, NSMutableDictionary<NSString *, FixtureNode *> *index)
+{
+  FixtureNode *root = makeNode(0, @"0");
+  buildChain(root, [tree[@"chain"] unsignedIntegerValue] - 1, nil);
+  NSDictionary *fan = tree[@"fan"];
+  if ([fan isKindOfClass:NSDictionary.class]) {
+    FixtureNode *at = root;
+    while (at.children.count) at = at.children.firstObject;
+    for (NSUInteger branch = 0; branch < [fan[@"count"] unsignedIntegerValue]; branch++) {
+      NSString *name = @(branch).stringValue;
+      FixtureNode *head = makeNode(at.level + 1, [NSString stringWithFormat:@"%lu.%@", (unsigned long)at.level + 1, name]);
+      head.parent = at;
+      [at.children addObject:head];
+      buildChain(head, [fan[@"chain"] unsignedIntegerValue], name);
+    }
+  }
+  void (^visit)(FixtureNode *) = ^(FixtureNode *node) {
+    index[node.identity] = node;
+  };
+  NSMutableArray<FixtureNode *> *queue = [NSMutableArray arrayWithObject:root];
+  while (queue.count) {
+    FixtureNode *node = queue.firstObject;
+    [queue removeObjectAtIndex:0];
+    visit(node);
+    [queue addObjectsFromArray:node.children];
+  }
+  return root;
+}
+
+static NSDictionary *fragment(FixtureNode *node, NSUInteger remainingLevels, BOOL unknownAtBoundary, BOOL vanishAtBoundary)
+{
+  BOOL boundary = remainingLevels == 1;
+  NSMutableArray *children = [NSMutableArray array];
+  if (!boundary) {
+    for (FixtureNode *child in node.children) {
+      [children addObject:fragment(child, remainingLevels - 1, unknownAtBoundary, vanishAtBoundary)];
+    }
+  }
+  NSMutableDictionary *result = [@{kAttributes: @{kIdentity: node.identity}, kChildren: children} mutableCopy];
+  if (!(boundary && unknownAtBoundary)) result[kChildCount] = @(node.children.count);
+  if (!(boundary && vanishAtBoundary)) result[kElement] = node.identity;
+  return result;
+}
+
+static NSUInteger identityLevel(NSString *identity)
+{
+  return (NSUInteger)[[identity componentsSeparatedByString:@"."].firstObject integerValue];
+}
+
+static NSString *identityBranch(NSString *identity)
+{
+  NSArray *parts = [identity componentsSeparatedByString:@"."];
+  return parts.count > 1 ? parts[1] : @"";
+}
+
+/// Bounded by the bridge's node limit: a producer that emits a cyclic or shared subtree must read
+/// as an oversized signature, not as a hang.
+static const NSUInteger maximumSignatureNodes = 10000;
+
+static void collectPreorder(NSDictionary *node, NSString *parent, NSMutableArray<NSArray<NSString *> *> *out)
+{
+  if (out.count >= maximumSignatureNodes) return;
+  NSString *identity = node[kAttributes][kIdentity];
+  [out addObject:@[identity, parent ?: @""]];
+  for (NSDictionary *child in node[kChildren]) collectPreorder(child, identity, out);
+}
+
+/// The canonical signature described by the fixture's `nativeModel.signature`: preorder identities,
+/// `<parent` when a node hangs off a non-canonical parent, and `first-last` for a run of consecutive
+/// levels on one branch.
+static NSString *treeSignature(NSDictionary *tree, NSDictionary<NSString *, FixtureNode *> *index, NSUInteger *count)
+{
+  NSMutableArray<NSArray<NSString *> *> *preorder = [NSMutableArray array];
+  collectPreorder(tree, nil, preorder);
+  *count = preorder.count;
+  NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+  __block NSString *runStart = nil;
+  __block NSString *runLast = nil;
+  void (^flush)(void) = ^{
+    if (!runStart) return;
+    [tokens addObject:[runStart isEqual:runLast] ? runStart : [NSString stringWithFormat:@"%@-%@", runStart, runLast]];
+  };
+  for (NSArray<NSString *> *entry in preorder) {
+    NSString *identity = entry[0];
+    NSString *observedParent = entry[1];
+    NSString *canonicalParent = index[identity].parent.identity ?: @"";
+    if (![observedParent isEqual:canonicalParent]) {
+      flush();
+      runStart = runLast = nil;
+      [tokens addObject:[NSString stringWithFormat:@"%@<%@", identity, observedParent]];
+      continue;
+    }
+    BOOL extends = runLast && [observedParent isEqual:runLast] &&
+        [identityBranch(identity) isEqual:identityBranch(runLast)] && identityLevel(identity) == identityLevel(runLast) + 1;
+    if (extends) {
+      runLast = identity;
+      continue;
+    }
+    flush();
+    runStart = runLast = identity;
+  }
+  flush();
+  return [tokens componentsJoinedByString:@","];
+}
+
+static NSUInteger deepestLevel(NSDictionary *node)
+{
+  NSUInteger deepest = identityLevel(node[kAttributes][kIdentity]);
+  for (NSDictionary *child in node[kChildren]) deepest = MAX(deepest, deepestLevel(child));
+  return deepest;
+}
+
+static NSString *failureName(NSError *error)
+{
+  if ([error.domain isEqualToString:@"agent-device.snapshot"]) {
+    switch (error.code) {
+      case 1: return @"request-budget-exhausted";
+      case 3: return @"continuation-element-missing";
+      case 5: return @"owner-changed";
+      case 6: return @"boundary-evidence-missing";
+      default: return [NSString stringWithFormat:@"capture-%ld", (long)error.code];
+    }
+  }
+  return @"rejected";
+}
+
+static int fail(NSString *caseName, NSString *message)
+{
+  fprintf(stderr, "%s: %s\n", caseName.UTF8String, message.UTF8String);
+  return 1;
+}
+
+int main(int argc, const char *argv[])
+{
+  @autoreleasepool {
+    if (argc != 3) {
+      fprintf(stderr, "usage: recovery-conformance <fixture.json> <case-name>\n");
+      return 2;
+    }
+    NSData *data = [NSData dataWithContentsOfFile:@(argv[1])];
+    NSDictionary *fixture = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+    NSString *caseName = @(argv[2]);
+    NSDictionary *recoveryCase = nil;
+    for (NSDictionary *candidate in fixture[@"recoveryCases"]) {
+      if ([candidate[@"name"] isEqual:caseName]) recoveryCase = candidate;
+    }
+    if (!recoveryCase) return fail(caseName, @"unknown recovery case");
+    NSDictionary *expected = recoveryCase[@"expected"][@"host-bridge"];
+    if ([expected[@"outcome"] isEqual:@"not-applicable"]) {
+      fprintf(stdout, "%s: not applicable to host-bridge (%s)\n", caseName.UTF8String, [expected[@"reason"] UTF8String]);
+      return 0;
+    }
+
+    NSDictionary *request = recoveryCase[@"request"];
+    NSDictionary *native = recoveryCase[@"native"];
+    NSMutableDictionary<NSString *, FixtureNode *> *index = [NSMutableDictionary dictionary];
+    FixtureNode *root = buildTree(native[@"tree"], index);
+    NSNumber *rejectAbove = [native[@"rejectLevelsAbove"] isKindOfClass:NSNumber.class] ? native[@"rejectLevelsAbove"] : nil;
+    NSNumber *ownerChangesAfter = [native[@"ownerChangesAfterRequests"] isKindOfClass:NSNumber.class] ? native[@"ownerChangesAfterRequests"] : nil;
+    BOOL unknownAtBoundary = [native[@"frontierEvidence"] isEqual:@"unknown"];
+    BOOL vanishAtBoundary = [native[@"vanishAtFrontier"] boolValue];
+    __block NSUInteger requests = 0;
+    __block NSUInteger rejected = 0;
+
+    BOOL truncated = NO;
+    NSError *error = nil;
+    NSDictionary *result = captureSnapshotTree(root.identity, [request[@"traversalDepth"] unsignedIntegerValue],
+        [request[@"nodeBudget"] unsignedIntegerValue],
+        ^id(id element, NSUInteger levels, NSUInteger nodes, NSError **readError) {
+          requests++;
+          if (ownerChangesAfter && requests > ownerChangesAfter.unsignedIntegerValue) {
+            *readError = [NSError errorWithDomain:@"agent-device.snapshot" code:5 userInfo:nil];
+            return nil;
+          }
+          if (rejectAbove && levels > rejectAbove.unsignedIntegerValue) {
+            rejected++;
+            *readError = [NSError errorWithDomain:@"AX" code:-25201 userInfo:@{@"accessibility-error": @(-25201)}];
+            return nil;
+          }
+          FixtureNode *node = index[element];
+          if (!node) {
+            *readError = [NSError errorWithDomain:@"fixture" code:0 userInfo:nil];
+            return nil;
+          }
+          return fragment(node, levels, unknownAtBoundary, vanishAtBoundary);
+        }, &truncated, &error);
+
+    // Continuations are the native requests beyond the root's accepted request: every request
+    // that reached the reader, minus the rejected ones, minus the root read that produced a tree.
+    NSMutableDictionary *actual = [NSMutableDictionary dictionary];
+    actual[@"requests"] = @(requests);
+    actual[@"rejected"] = @(rejected);
+    actual[@"continuations"] = @(requests - rejected - (requests > rejected ? 1 : 0));
+    if (result) {
+      NSUInteger nodes = 0;
+      actual[@"outcome"] = truncated ? @"incomplete" : @"complete";
+      actual[@"deepestLevel"] = @(deepestLevel(result));
+      actual[@"tree"] = treeSignature(result, index, &nodes);
+      actual[@"nodes"] = @(nodes);
+    } else {
+      actual[@"outcome"] = @"failed";
+      actual[@"failure"] = failureName(error);
+    }
+    int status = 0;
+    for (NSString *key in expected) {
+      if ([key isEqual:@"reason"]) continue;
+      if (![expected[key] isEqual:actual[key]]) {
+        status = fail(caseName, [NSString stringWithFormat:@"%@ expected %@ but observed %@", key, expected[key], actual[key] ?: @"(absent)"]);
+      }
+    }
+    return status;
+  }
+}

--- a/packages/platform-apple/src/snapshot-source/native-runtime.test.ts
+++ b/packages/platform-apple/src/snapshot-source/native-runtime.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { beforeAll, describe, test } from 'vitest';
 import { runCmd } from '@agent-device/host-kit/command';
@@ -72,3 +73,54 @@ describe.skipIf(process.platform !== 'darwin')('native snapshot capture', () => 
     assert.equal(result.exitCode, 0, result.stderr);
   });
 });
+
+const recoveryFixturePath = path.resolve(
+  import.meta.dirname,
+  '../../../../contracts/fixtures/ios-ax-recovery-conformance.json',
+);
+const recoveryFixture = JSON.parse(readFileSync(recoveryFixturePath, 'utf8')) as {
+  version: number;
+  recoveryCases: readonly { name: string }[];
+};
+
+describe.skipIf(process.platform !== 'darwin')(
+  'shared AX recovery conformance (host bridge)',
+  () => {
+    let binary: string;
+    beforeAll(async () => {
+      binary = path.join(await mkdtempForTest('snapshot-recovery-'), 'recovery-conformance');
+      const nativeRoot = path.resolve(import.meta.dirname, '../../../../apple/snapshot-bridge');
+      const compiled = await runCmd(
+        'xcrun',
+        [
+          '--sdk',
+          'macosx',
+          'clang',
+          '-fobjc-arc',
+          '-framework',
+          'Foundation',
+          '-I',
+          nativeRoot,
+          path.join(nativeRoot, 'SnapshotBridgeCapture.m'),
+          path.join(import.meta.dirname, 'fixtures/recovery-conformance.m'),
+          '-o',
+          binary,
+        ],
+        { allowFailure: true, timeoutMs: 45_000 },
+      );
+      assert.equal(compiled.exitCode, 0, compiled.stderr);
+    }, 60_000);
+
+    assert.equal(recoveryFixture.version, 1);
+    test.each(recoveryFixture.recoveryCases.map((recoveryCase) => recoveryCase.name))(
+      'host bridge recovery matches the shared fixture: %s',
+      async (name) => {
+        const result = await runCmd(binary, [recoveryFixturePath, name], {
+          allowFailure: true,
+          timeoutMs: 5_000,
+        });
+        assert.equal(result.exitCode, 0, result.stderr);
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Adds `contracts/fixtures/ios-ax-recovery-conformance.json`, a shared executable recovery contract for the host AX bridge and the XCTest runner's private AX bridge. Fifteen recovery cases (569 fixture lines; hint cases arrive with the runner adapter in #2428) cover zero-based depth versus native levels, node budgets, complete/withheld/unknown frontier evidence, missing live elements, owner change, request exhaustion, deadline, explicit raw depth, hinted first requests, and multi-branch recovery. Every expectation names the outcome, the native request accounting, the deepest level, and the delivered tree as a canonical preorder signature with its retained node count, so a producer that drops, duplicates, reorders, or re-parents nodes cannot pass as complete. Expectations are per producer, and the fixture documents the intentional differences instead of averaging them away.

This PR carries the host adapter: an Objective-C driver over `captureSnapshotTree`, compiled and run per case by `native-runtime.test.ts`. The runner adapter and the accepted-depth memory characterization follow in #2428, which executes the fixture's `runner` column and adds the hint cases; README and ADR 0004 mark the runner adapter as pending until then.

First step of #2424, stacked on #2414; no runtime behaviour change. Five files, 903 lines (569 fixture).

## Validation

Tested head: `d9a3c2afa9`.

- `pnpm check:affected --run --base origin/fix/ios-ax-depth-recovery` passed.
- Native: 46 compiled cases (31 existing + 15 fixture cases) pass via `native-runtime.test.ts`.
- Planted red in the host materializer, each restored afterwards: keep only the first sibling → `multi-branch-recovery`, `runner-extension-budget` red; duplicate the last sibling → 8 cases red (signature and node count); reverse siblings → 2 red. Also: missing boundary child count accepted → 7 red; request budget 33 → 3 red; native levels off by one → 8 red.
- Review follow-ups: structural signatures and the multi-branch case added (P1); hint characterization moved to #2428 (P2/scope), diff reduced from 1,551 to 903 lines; docs mark the runner adapter as pending; the fixture no longer restates code constants (ladder, budgets, retries) that the cases pin behaviourally.
