### PR TITLE
fix(ios): serve regular --depth from every snapshot backend

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -241,7 +241,8 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCustomActionCoverageParsesOnlyCompletePairs \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPartialCustomActionPassIsDisclosedAndCompleteOneIsNot \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testActionNamesAreCappedPerElementAndReported \
-            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testHungCustomActionReadIsContainedAndRecovers 2>&1 | tee /tmp/agent-device-runner-regressions.log
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testHungCustomActionReadIsContainedAndRecovers \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testPrivateAXPinnedRegularDepthReachesAcquisitionAndPresentation 2>&1 | tee /tmp/agent-device-runner-regressions.log
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const log = readFileSync("/tmp/agent-device-runner-regressions.log", "utf8");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Fixed: iOS `--depth` on `snapshot`, `is`, `wait`, `get`, and `find` no longer fails with
+  `regular iOS snapshot presentation requires a valid viewport` when the runner plan is pinned or
+  deferred to the private AX backend (custom actions, a private AX verdict on the session, or the
+  XCTest channel penalty). The runner refused a regular depth-capped request on every backend but
+  the recursive tree, fell through to its synthetic sparse root, and the daemon rejected that root
+  as a missing viewport. Presentation applies the presented-depth cut to whatever hierarchy a
+  backend acquired, so every backend serves the request; the private AX declaration is now
+  `regular-depth=presentation-cut` and an acquisition that stopped short of the cut keeps
+  disclosing that through `truncated`/`effectiveDepth` as it does unscoped.
 - Added: `replay export` supports flows that switch apps and return, preserving each
   `open <appId>` target as an explicit Maestro `launchApp.appId`.
 - Added: `replay export` converts recorded `home` actions to Maestro `pressKey: Home`, allowing

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotBackendCapabilities.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotBackendCapabilities.swift
@@ -5,14 +5,19 @@ enum SnapshotBackendEnvironment {
   case physicalDevice
 }
 
+/// How a backend's acquisition relates to a regular `--depth` request. Every backend serves the
+/// request: `SnapshotPresentation` applies the presented-depth cut to whatever hierarchy was
+/// acquired, and an acquisition that stopped short of the cut discloses that through its own
+/// truncation verdict. The capability only says how much acquisition work the request bounds.
 enum SnapshotRegularDepthCapability: String {
-  /// The backend can stop acquisition at the requested regular presented-depth frontier.
+  /// Acquisition stops at the requested regular presented-depth frontier.
   case presentedFrontier = "presented-frontier"
-  /// The backend is flat; it can answer the root and one presented level, but has no hierarchy
-  /// from which to prove deeper regular depth.
+  /// The backend is flat: it acquires the root and one presented level, so a cut past depth 1
+  /// returns the sweep unchanged.
   case flat
-  /// The backend can return raw traversal depth, but cannot prove regular presented depth.
-  case rawOnly = "raw-only"
+  /// Acquisition walks its raw-depth ladder regardless of the request; the presented cut happens
+  /// in presentation and the ladder's cap is disclosed as `effectiveDepth`.
+  case presentationCut = "presentation-cut"
 }
 
 enum SnapshotBackendKind: String, CaseIterable {
@@ -62,19 +67,7 @@ enum SnapshotBackendKind: String, CaseIterable {
     case .querySweep:
       return .flat
     case .privateAX:
-      return .rawOnly
-    }
-  }
-
-  func canServeRegularPresentedDepth(_ requestedDepth: Int?) -> Bool {
-    guard let requestedDepth else { return true }
-    switch regularDepthCapability {
-    case .presentedFrontier:
-      return true
-    case .flat:
-      return requestedDepth <= 1
-    case .rawOnly:
-      return false
+      return .presentationCut
     }
   }
 
@@ -170,15 +163,6 @@ extension RunnerTests {
         "physical-device availability: \(expected.name)"
       )
     }
-  }
-
-  func testRegularDepthCapabilityDoesNotClaimFlatOrRawOnlyParity() {
-    XCTAssertTrue(SnapshotBackendKind.recursiveTree.canServeRegularPresentedDepth(8))
-    XCTAssertTrue(SnapshotBackendKind.querySweep.canServeRegularPresentedDepth(0))
-    XCTAssertTrue(SnapshotBackendKind.querySweep.canServeRegularPresentedDepth(1))
-    XCTAssertFalse(SnapshotBackendKind.querySweep.canServeRegularPresentedDepth(2))
-    XCTAssertFalse(SnapshotBackendKind.privateAX.canServeRegularPresentedDepth(1))
-    XCTAssertTrue(SnapshotBackendKind.privateAX.canServeRegularPresentedDepth(nil))
   }
 }
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -415,22 +415,6 @@ extension RunnerTests {
   ) throws -> SnapshotBackendAttempt {
     let hint = SnapshotPresentation.captureHint(for: options)
     var timer = SnapshotPhaseTimer()
-    // Scoped depth is relative to a presentation-selected root, so its hint stays broad and the
-    // backend capability gate applies only to an unscoped regular frontier.
-    let requestedRegularDepth = options.raw || SnapshotScopePolicy.isActive(options.scope)
-      ? nil
-      : options.depth
-    guard kind.canServeRegularPresentedDepth(requestedRegularDepth) else {
-      NSLog(
-        "AGENT_DEVICE_RUNNER_SNAPSHOT_BACKEND_DEPTH_UNSUPPORTED backend=%@ depth=%ld",
-        kind.rawValue,
-        requestedRegularDepth ?? -1
-      )
-      return SnapshotBackendAttempt(
-        outcome: .noCapture,
-        timing: timer.timing
-      )
-    }
     let acquisition: SnapshotAcquisition?
     do {
       acquisition = try timer.measure(.acquisition) {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -1176,5 +1176,52 @@ extension RunnerTests {
       )
     )
   }
+
+#if os(iOS)
+  /// #2403: a plan pinned to private AX serves a regular `--depth` request through acquisition
+  /// and presentation. With a backend depth gate in `captureWithBackend`, private AX returns no
+  /// capture, the plan falls through to the synthetic sparse root, and the daemon rejects that
+  /// zero-rect root as a missing viewport.
+  func testPrivateAXPinnedRegularDepthReachesAcquisitionAndPresentation() throws {
+    app.launchArguments = ["--agent-device-selector-read-regression"]
+    app.launch()
+    currentApp = app
+    currentBundleId = nil
+    defer {
+      currentApp = nil
+      clearPrivateAXAcceptedDepth(reason: "test-cleanup")
+      app.terminate()
+    }
+    func capture(depth: Int?) throws -> DataPayload {
+      try runSnapshotCapturePlan(
+        Self.regularVisiblePlan,
+        app: app,
+        options: PresentationOptions(
+          interactiveOnly: false,
+          depth: depth,
+          scope: nil,
+          raw: false,
+          preferredBackend: SnapshotBackendKind.privateAX.rawValue
+        ),
+        terminal: .sparseWithFatalOnAXFailure
+      )
+    }
+
+    let capped = try capture(depth: 1)
+
+    let quality = try XCTUnwrap(capped.snapshotQuality)
+    XCTAssertEqual(quality.backend, SnapshotBackendKind.privateAX.rawValue)
+    XCTAssertNotEqual(quality.state, "sparse")
+    let nodes = try XCTUnwrap(capped.nodes)
+    XCTAssertGreaterThan(nodes.count, 1)
+    XCTAssertEqual(nodes.map(\.depth).max(), 1)
+    XCTAssertNotEqual(nodes[0].rect, SnapshotRect(x: 0, y: 0, width: 0, height: 0))
+    XCTAssertTrue(nodes.contains { $0.label == "Readable target" })
+
+    // The presented cut only ever narrows the unscoped capture from the same backend.
+    let unscoped = try XCTUnwrap(try capture(depth: nil).nodes)
+    XCTAssertLessThanOrEqual(nodes.count, unscoped.count)
+  }
+#endif
 }
 #endif

--- a/apple/snapshot-presentation/Tests/AgentDeviceSnapshotPresentationTests/RegularDepthTests.swift
+++ b/apple/snapshot-presentation/Tests/AgentDeviceSnapshotPresentationTests/RegularDepthTests.swift
@@ -1,0 +1,59 @@
+import AgentDeviceSnapshotPresentation
+import CoreGraphics
+import XCTest
+
+/// A backend that acquires past the requested frontier (private AX walks its raw ladder) still
+/// serves a regular `--depth` request: the cut is presentation's, applied to whatever hierarchy
+/// was acquired (#2403).
+final class RegularDepthTests: XCTestCase {
+  func testRegularDepthCutsAHierarchyAcquiredPastTheFrontier() throws {
+    let options = PresentationOptions(interactiveOnly: false, depth: 1, scope: nil, raw: false)
+    let viewport = CGRect(x: 0, y: 0, width: 100, height: 100)
+    // Application > Other(wrapper) > Button "Continue" > StaticText "Deep"
+    let nodes = [
+      node(0, type: "Application", label: "App", depth: 0, parentIndex: nil),
+      node(1, type: "Other", label: nil, depth: 1, parentIndex: 0),
+      node(2, type: "Button", label: "Continue", depth: 2, parentIndex: 1, hittable: true),
+      node(3, type: "StaticText", label: "Deep", depth: 3, parentIndex: 2),
+    ]
+    let acquisition = SnapshotAcquisition(
+      hint: SnapshotPresentation.captureHint(for: options),
+      nodes: nodes,
+      truncated: false,
+      effectiveDepth: nil,
+      viewport: viewport
+    )
+
+    let result = try XCTUnwrap(SnapshotPresentation.present(acquisition, options: options))
+
+    XCTAssertEqual(result.nodes.map(\.label), ["App", "Continue"])
+    XCTAssertEqual(result.nodes.map(\.depth), [0, 1])
+    XCTAssertEqual(result.nodes.map(\.parentIndex), [nil, 0])
+  }
+
+  private func node(
+    _ index: Int,
+    type: String,
+    label: String?,
+    depth: Int,
+    parentIndex: Int?,
+    hittable: Bool = false
+  ) -> RawAXNode {
+    RawAXNode(
+      index: index,
+      type: type,
+      label: label,
+      identifier: nil,
+      value: nil,
+      rect: SnapshotRect(x: 10, y: 10, width: 40, height: 20),
+      enabled: true,
+      focused: nil,
+      selected: nil,
+      hittable: hittable,
+      depth: depth,
+      parentIndex: parentIndex,
+      hiddenContentAbove: nil,
+      hiddenContentBelow: nil
+    )
+  }
+}

--- a/contracts/fixtures/ios-snapshot-backends.json
+++ b/contracts/fixtures/ios-snapshot-backends.json
@@ -39,7 +39,7 @@
       "name": "private-ax",
       "forceable": true,
       "supportsRawProjection": true,
-      "regularDepth": "raw-only",
+      "regularDepth": "presentation-cut",
       "hittable": "geometric-actionability",
       "deepExtension": "yes",
       "depthLadder": "yes",

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -273,11 +273,18 @@ fold and eligibility collapse. This keeps shallow probes bounded by the requeste
 frontier without inventing a raw-depth multiplier. Scoped captures remain broad because depth is
 relative to the scope root selected in presentation.
 
-Backend capability declarations are part of the contract: recursive tree supports the presented
-frontier, the flat query sweep supports only its root and one presented level, and private AX is
-raw-depth-only for regular depth requests until it has an equivalent hierarchy-aware frontier.
-The capture plan does not claim deeper regular-depth completeness from a backend that cannot prove
-it. Raw depth remains acquisition depth for every backend.
+Backend capability declarations are part of the contract, and they describe how much acquisition
+work a regular depth request bounds — never whether the backend may answer it. Every backend
+serves a regular `--depth` request because presentation applies the presented-depth cut to
+whatever hierarchy was acquired: the recursive tree stops acquisition at the presented frontier,
+the flat query sweep has only its root and one presented level (so a cut past depth 1 returns the
+sweep unchanged), and private AX walks its raw-depth ladder and is cut afterwards
+(`presentation-cut`). Completeness below an acquisition cap is disclosed the same way it is for an
+unscoped capture — through `truncated` and `effectiveDepth` — because a depth-capped regular
+capture is a subset of the unscoped one from the same backend. Refusing the request instead
+produced no answer at all: a plan pinned or deferred to private AX fell through to the synthetic
+sparse root, which the daemon then rejected as a missing viewport (#2403). Raw depth remains
+acquisition depth for every backend.
 
 Acquisition-side limits remain explicit: raw private-AX captures still disclose their bridge-side
 node cap, the flat query sweep still drops frameless elements because it has no hierarchy to attach

--- a/packages/capture-kit/src/snapshot-quality-backend-capabilities.test.ts
+++ b/packages/capture-kit/src/snapshot-quality-backend-capabilities.test.ts
@@ -100,7 +100,7 @@ test('iOS snapshot registry classifies every backend and conformance target', ()
   expect(SNAPSHOT_BACKEND_CAPABILITIES['private-ax']).toMatchObject({
     forceable: true,
     supportsRawProjection: true,
-    regularDepth: 'raw-only',
+    regularDepth: 'presentation-cut',
     hittable: 'geometric-actionability',
     deepExtension: 'yes',
     depthLadder: 'yes',

--- a/packages/capture-kit/src/snapshot-quality-backend-capabilities.ts
+++ b/packages/capture-kit/src/snapshot-quality-backend-capabilities.ts
@@ -6,7 +6,13 @@ import type {
 /** #1933: every classified backend publishes this shared predicate in the wire `hittable` field. */
 type SnapshotBackendHittable = 'geometric-actionability';
 type SnapshotBackendSupport = 'yes' | 'no' | 'n/a';
-type SnapshotRegularDepthCapability = 'presented-frontier' | 'flat' | 'raw-only';
+/**
+ * How a backend's acquisition relates to a regular `--depth` request. Presentation applies the
+ * presented-depth cut to whatever hierarchy was acquired, so every backend serves the request;
+ * the value says whether acquisition stops at the frontier, is flat, or walks its raw ladder and
+ * is cut afterwards.
+ */
+type SnapshotRegularDepthCapability = 'presented-frontier' | 'flat' | 'presentation-cut';
 
 type SnapshotBackendCapability = {
   supportsRawProjection: boolean;
@@ -57,7 +63,7 @@ export const SNAPSHOT_BACKEND_CAPABILITIES = {
   'private-ax': {
     forceable: true,
     supportsRawProjection: true,
-    regularDepth: 'raw-only',
+    regularDepth: 'presentation-cut',
     hittable: 'geometric-actionability',
     deepExtension: 'yes',
     depthLadder: 'yes',


### PR DESCRIPTION
## Summary

Closes #2403.

On 0.21.0 every `is <selector> visible --depth <n>` on the reporter's iOS Simulator failed with `regular iOS snapshot presentation requires a valid viewport`. The cause is in the runner, not the daemon: `SnapshotBackendKind.canServeRegularPresentedDepth` (from #1947) refused a regular depth-capped request on private AX at any depth and on the query sweep past depth 1. Whenever the plan is pinned or deferred to private AX (custom actions, a private AX verdict already on the session, the XCTest channel penalty), no backend could serve, the plan fell through to its synthetic sparse root (one `Application` node, zero rect), and the daemon rejected that root as a missing viewport.

Presentation already applies the presented-depth cut to whatever hierarchy a backend acquired, and a depth-capped regular capture is a subset of the unscoped one from the same backend, so the refusal protected nothing that `truncated`/`effectiveDepth` did not already disclose. This PR deletes the gate, declares private AX as `regular-depth=presentation-cut` (fixture, TS registry, Swift enum, all parity-tested), rewrites the ADR 0004 paragraph that made the old claim, and adds a presentation test for the cut on a hierarchy acquired past the frontier.

```
agent-device snapshot --depth 20 --actions   # private AX pinned: 58 nodes, was COMMAND_FAILED
agent-device is visible "role=button label=General" --depth 20
```

8 files touched. Not changed here: a genuine sparse runner verdict (no backend could read the screen) still surfaces as the viewport-invariant error instead of the runner's own "use screenshot" message; that is a separate daemon-side seam.

## Validation

Tested commit: `bb3dfdc8a2b8627d5f16adb423c4a18ddef1af50`.

- Repro before the fix on a local iOS 26.2 Simulator (Settings): `snapshot --depth 20 --actions` returned the runner's sparse payload (`state: sparse`, one zero-rect `Application` node) and the daemon failed with the reported message; plain `--actions` worked.
- After the fix, same device: `snapshot --depth 20 --actions` returns 58 nodes; `--depth 1 --actions` returns 4. Through the test-owned `snapshotPreferredBackend: 'private-ax'` transport seam: `snapshot --depth 20` is a 58-node `recovered` private AX capture, `is visible role=button label=General` passes at depth 20 and 3, and depth 0 returns the correct `Selector did not match`.
- New runner-path regression `testPrivateAXPinnedRegularDepthReachesAcquisitionAndPresentation` (PR iOS lane): green at 1db684c239 in 4.9 s; red with the gate restored (5 assertions, runner logs `SNAPSHOT_BACKEND_DEPTH_UNSUPPORTED backend=private-ax depth=1`). Evidence in the review reply.
- Runner unit tests (`AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1`, iOS 26.2 sim): `testSnapshotBackendDeclarationsMatchCapabilityFixture`, `testSparsePayloadReasonMatrix`, `testLegacyQualityMessageStatesFallbackMeaning` pass (3 executed).
- `swift test --package-path apple/snapshot-presentation`: 3 tests pass, including the new `RegularDepthTests`.
- `pnpm check:affected --run`: green on bb3dfdc8a2 (387 files, 2827 tests). On 1db684c239 the vitest-related stage hit 7 contention timeouts on a Mac at load 125; those five files pass in isolation (68/68) and the delta is Swift test code plus one workflow line; `check:xctest-selection` passes.

Risk: the physical-device plan now also lets the query sweep answer a `--depth ≥ 2` request with its flat sweep (same payload it already returned unscoped) instead of no answer.
