### PR TITLE
fix(check): honor Vitest worker configuration

### DIFF
--- a/packages/platform-apple/src/readiness/runtime.test.ts
+++ b/packages/platform-apple/src/readiness/runtime.test.ts
@@ -196,11 +196,17 @@ test('a boot confirmed only after the deadline is a boot_timeout, and the confir
 });
 
 test('without a startup deadline the boot wait keeps its default budget', async () => {
-  const { host, calls } = coldSimulatorHost({});
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(1_000_000);
+    const { host, calls } = coldSimulatorHost({});
 
-  await ensureAppleReady(host, simulator(), new AbortController().signal);
+    await ensureAppleReady(host, simulator(), new AbortController().signal);
 
-  expect(calls.find((call) => call.args.includes('bootstatus'))?.timeoutMs).toBe(120_000);
+    expect(calls.find((call) => call.args.includes('bootstatus'))?.timeoutMs).toBe(120_000);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('physical readiness forwards the request signal to the focused host port', async () => {

--- a/scripts/check-affected/checks.ts
+++ b/scripts/check-affected/checks.ts
@@ -10,7 +10,6 @@
 // agent reads before skipping a check locally cannot go stale.
 
 import { ALL_CHECKS, type CheckId } from './model.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 
 export type CheckKind =
   | { readonly type: 'script'; readonly script: string }
@@ -183,16 +182,7 @@ export function resolveCommand(
   changedFiles: readonly string[] = [],
 ): string[] {
   if (spec.kind.type === 'vitest-related') {
-    return [
-      'pnpm',
-      'exec',
-      'vitest',
-      'related',
-      '--run',
-      '--passWithNoTests',
-      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
-      ...changedFiles,
-    ];
+    return ['pnpm', 'exec', 'vitest', 'related', '--run', '--passWithNoTests', ...changedFiles];
   }
   const { script } = spec.kind;
   if (!(script in scripts)) {

--- a/scripts/check-affected/model.test.ts
+++ b/scripts/check-affected/model.test.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { assertCatalogComplete, CHECK_CATALOG, resolveCommand } from './checks.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { ALL_CHECKS, selectChecks, type CheckId, type SelectInput } from './model.ts';
 
 function plan(changedFiles: string[], extra: Partial<SelectInput> = {}) {
@@ -347,10 +346,16 @@ test('vitest-related delegates changed paths to Vitest instead of modeling proje
     'related',
     '--run',
     '--passWithNoTests',
-    `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
     'src/a.ts',
     'test/fixture.ts',
   ]);
+  assert.equal(
+    resolveCommand(related, {}, 'origin/main', ['src/a.ts']).some((arg) =>
+      arg.startsWith('--maxWorkers='),
+    ),
+    false,
+    'worker sizing belongs to vitest.config.ts',
+  );
 });
 
 // Guards the catalog against reality, not fixtures: the self-test above uses a

--- a/scripts/check-affected/run.test.ts
+++ b/scripts/check-affected/run.test.ts
@@ -11,7 +11,6 @@ import { test } from 'node:test';
 import { runCmdSync } from '@agent-device/host-kit/command';
 import { STALE_NODE_MODULES_MESSAGE } from './lockfile-install-sync.ts';
 import { CHECK_CATALOG } from './checks.ts';
-import { DEFAULT_VITEST_MAX_WORKERS } from '../lib/vitest-concurrency.ts';
 import { selectChecks } from './model.ts';
 import { type CommandExecutor, readChangedFiles, runChecks } from './run.ts';
 
@@ -161,16 +160,7 @@ test('runChecks passes the selector change set to Vitest related', async () => {
   assert.equal(code, 0);
   assert.deepEqual(
     executed.find((command) => command.includes('related')),
-    [
-      'pnpm',
-      'exec',
-      'vitest',
-      'related',
-      '--run',
-      '--passWithNoTests',
-      `--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`,
-      ...changedFiles,
-    ],
+    ['pnpm', 'exec', 'vitest', 'related', '--run', '--passWithNoTests', ...changedFiles],
   );
 });
 
@@ -205,7 +195,7 @@ test('runChecks skips GitHub-authoritative checks and passes when locals succeed
   }
 });
 
-test('runChecks leaves coverage to CI and runs capped related tests once', async () => {
+test('runChecks leaves coverage to CI and runs related tests once through Vitest config', async () => {
   const executed: string[][] = [];
   const execute: CommandExecutor = async (command) => {
     executed.push(command);
@@ -222,7 +212,11 @@ test('runChecks leaves coverage to CI and runs capped related tests once', async
     !related[0]?.includes('--coverage'),
     'coverage instrumentation stays GitHub-authoritative; the local run must not add it',
   );
-  assert.ok(related[0]?.includes(`--maxWorkers=${DEFAULT_VITEST_MAX_WORKERS}`));
+  assert.equal(
+    related[0]?.some((arg) => arg.startsWith('--maxWorkers=')),
+    false,
+    'worker sizing belongs to vitest.config.ts',
+  );
   assert.ok(
     executed.findIndex((command) => command.includes('test:integration:node')) <
       executed.findIndex((command) => command.includes('related')),


### PR DESCRIPTION
## Summary

`AGENT_DEVICE_VITEST_MAX_WORKERS` configures Vitest, but `check:affected` appended `--maxWorkers=4`, overriding it. Delegate worker sizing to `vitest.config.ts` so its default, validated local override, CPU clamp, and CI policy apply. This completes the propagation boundary introduced in #1964.

Also address the [maintainer's Coverage request](https://github.com/callstack/agent-device/pull/2437#issuecomment-5615398156) by freezing the default readiness-budget test's clock. Its exact 120,000 ms assertion was racing real time across async mock calls. The test now uses the same clock discipline as its neighboring deadline cases.

Four files, +24/−29; the review follow-up adds only the readiness test fix.

## Validation

Tested commit: `704b15b87e47b72765bd18bc5aafb269abdf0d53` (Node 24.13.1, pnpm 11.17.0, Linux).

- Current-main real-clock probe observed 119,998 ms. Controlled clock perturbation failed before the fix and passed after it.
- Readiness and hermetic worker-policy suites: 14 passed.
- `pnpm check:affected:test`: 65 passed.
- `AGENT_DEVICE_VITEST_MAX_WORKERS=1 pnpm check:affected --run`: all runnable gates passed, including build, lint, types, package, integration, and compatibility checks.
- Full local coverage: 10,033 passed; two failures reproduced on unchanged `main` (umask `0077` masks file mode; fabricated PID 101 is live here). Readiness: eight passed under instrumentation.
- Authoritative upstream Coverage and Integration Tests: pending on this head.

<!-- plasma-agent-device-lane:a -->
<!-- plasma-agent-device-campaign:four-more-20260910 -->
<!-- plasma-agent-device-candidate:affected-worker-override -->
