### PR TITLE
refactor(commands): declare project-config admission and recorder sanitization on the flag declaration

### DIFF
--- a/docs/agents/cli-flags.md
+++ b/docs/agents/cli-flags.md
@@ -8,9 +8,12 @@ Thread a flag only through the layers that consume it:
    flag; find the owner with
    `rg -n "<command>|supportedFlags|allowedFlags" src/commands src/cli-schema src/cli/parser`. For
    schema-only CLI commands, the owner is `SCHEMA_ONLY_CLI_COMMAND_SCHEMAS` in
-   `src/cli-schema/command-overrides.ts`. New flags are operator-only by default. Add a flag to `PROJECT_CONFIG_FLAG_KEYS` in
-   `src/cli-schema/cli-config.ts` only when repository control is safe; this positive allowlist is
-   the completeness gate.
+   `src/cli-schema/command-overrides.ts`. Every flag declaration states `projectConfig`
+   (may be set from a project `agent-device.json`) and `recorded` (the session recorder
+   copies it into `SessionAction.flags`). Both are required, so a new declaration that
+   omits either does not compile — that, not an allowlist, is the completeness gate. Set
+   `projectConfig: true` only when repository control is safe; a new flag is otherwise
+   operator-only. Set `recorded: true` only when a `.ad` recording must carry the flag.
 2. `src/commands/cli-grammar/*`: read the CLI flag into command input.
 3. `src/commands/command-projection.ts` and command-family projection helpers: write the input into
    the daemon request only if the flag affects daemon execution.

--- a/packages/contracts/src/screenshot.ts
+++ b/packages/contracts/src/screenshot.ts
@@ -97,6 +97,8 @@ type ScreenshotSpecificFlagDefinition = {
   max?: number;
   usageLabel: string;
   usageDescription: string;
+  projectConfig: boolean;
+  recorded: boolean;
 };
 
 export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFlagDefinition[] = [
@@ -107,6 +109,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--crop-on <selector-expression>',
     usageDescription:
       'Screenshot: crop the capture to the frame of the selector resolved on the same screen',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'screenshotPixelDensity',
@@ -116,6 +120,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--pixel-density <n>',
     usageDescription:
       'Screenshot: output PNG pixel density in pixels per logical point (currently supported on iOS simulators)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'screenshotFullscreen',
@@ -124,6 +130,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--fullscreen, --full, -f',
     usageDescription:
       'Screenshot: on web capture the full page; on macOS app sessions capture the full desktop instead of the app window',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'screenshotScale',
@@ -134,6 +142,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--scale <0.01-1>',
     usageDescription:
       'Screenshot: resize both dimensions by this factor (or use AGENT_DEVICE_SCREENSHOT_SCALE)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'screenshotNoStabilize',
@@ -142,6 +152,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--no-stabilize',
     usageDescription:
       'Screenshot: skip Android demo-mode/status-bar stabilization and settle delay for low-latency capture loops',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'screenshotNormalizeStatusBar',
@@ -150,6 +162,8 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageLabel: '--normalize-status-bar',
     usageDescription:
       'Screenshot: on iOS simulators temporarily normalize status-bar chrome for deterministic screenshot diffs',
+    projectConfig: true,
+    recorded: true,
   },
 ];
 

--- a/src/cli-schema/cli-config.ts
+++ b/src/cli-schema/cli-config.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
 import { mergeDefinedFlags } from './merge-flags.ts';
 import { type FlagKey } from '../commands/cli-grammar/flag-types.ts';
+import { projectConfigFlagKeys } from './command-schema.ts';
 import { expandUserHomePath, resolveUserPath } from '@agent-device/host-kit/file';
 import {
   getConfigurableOptionSpecs,
@@ -32,95 +33,10 @@ type ConfigFileSource = 'user' | 'project' | 'explicit';
 
 type ConfigPath = { path: string; required: boolean; source: ConfigFileSource };
 
-// Project config is repository-controlled, so new flags are operator-only by default.
-// Adding a key here is the only way to make it available to ./agent-device.json.
-const PROJECT_CONFIG_FLAG_KEYS = new Set<FlagKey>([
-  'json',
-  'platform',
-  'target',
-  'device',
-  'udid',
-  'serial',
-  'session',
-  'sessionLock',
-  'activity',
-  'launchArgs',
-  'launchUrl',
-  'remote',
-  'deviceHub',
-  'testIme',
-  'appsFilter',
-  'clean',
-  'force',
-  'stale',
-  'relaunch',
-  'shutdown',
-  'surface',
-  'headless',
-  'restart',
-  'noRecord',
-  'record',
-  'recordAs',
-  'snapshotInteractiveOnly',
-  'snapshotDiff',
-  'snapshotDepth',
-  'snapshotScope',
-  'snapshotRaw',
-  'snapshotCustomActions',
-  'snapshotForceFull',
-  'screenshotPixelDensity',
-  'screenshotFullscreen',
-  'screenshotScale',
-  'screenshotNoStabilize',
-  'screenshotNormalizeStatusBar',
-  'overlayRefs',
-  'networkInclude',
-  'baseline',
-  'threshold',
-  'count',
-  'pointerCount',
-  'fps',
-  'quality',
-  'hideTouches',
-  'recordingScope',
-  'intervalMs',
-  'delayMs',
-  'durationMs',
-  'holdMs',
-  'jitterPx',
-  'pixels',
-  'doubleTap',
-  'verify',
-  'settle',
-  'settleQuietMs',
-  'clickButton',
-  'backMode',
-  'pauseMs',
-  'pattern',
-  'kind',
-  'perfTemplate',
-  'responseLevel',
-  'verbose',
-  'cost',
-  'timeoutMs',
-  'retries',
-  'failFast',
-  'recordVideo',
-  'replayUpdate',
-  'replayMaestro',
-  'replayFrom',
-  'replayPlanDigest',
-  'replayKeepSession',
-  'findFirst',
-  'findLast',
-  'batchOnError',
-  'batchMaxSteps',
-  'retainPaths',
-  'retentionMs',
-  'shardAll',
-  'shardSplit',
-  'noLogin',
-]);
+// Project config is repository-controlled, so a flag stays operator-only unless its
+// own declaration sets `projectConfig: true`. This set derives from those declarations;
+// admitting a new key to ./agent-device.json edits the declaration, not this file.
+const PROJECT_CONFIG_FLAG_KEYS = projectConfigFlagKeys();
 
 function resolveConfigPaths(
   cwd: string,

--- a/src/cli-schema/command-schema.ts
+++ b/src/cli-schema/command-schema.ts
@@ -2,7 +2,12 @@ import type { CliCommandName } from '@agent-device/command-registry/catalog';
 import { listCommandMetadata } from '../commands/command-metadata.ts';
 import type { CommandSchema } from './types.ts';
 import { getCliCommandOverride, getSchemaOnlyCliCommandSchema } from './command-overrides.ts';
-import { getFlagDefinition, getFlagDefinitions } from '../commands/cli-grammar/flag-registry.ts';
+import {
+  getFlagDefinition,
+  getFlagDefinitions,
+  projectConfigFlagKeys,
+  recordedFlagKeys,
+} from '../commands/cli-grammar/flag-registry.ts';
 import {
   COMMON_COMMAND_SUPPORTED_FLAG_KEYS,
   DEVICE_SELECTION_FLAG_KEYS,
@@ -13,7 +18,14 @@ import { AppError } from '@agent-device/kernel/errors';
 
 export type { FlagDefinition, FlagKey };
 export type { CommandSchema };
-export { DEVICE_SELECTION_FLAG_KEYS, getFlagDefinition, getFlagDefinitions, GLOBAL_FLAG_KEYS };
+export {
+  DEVICE_SELECTION_FLAG_KEYS,
+  getFlagDefinition,
+  getFlagDefinitions,
+  GLOBAL_FLAG_KEYS,
+  projectConfigFlagKeys,
+  recordedFlagKeys,
+};
 
 // Bases hold only the flags every command supports; prose arrives with the facet's schema,
 // which always carries a complete `text`.

--- a/src/commands/cli-grammar/flag-declaration-admission.test.ts
+++ b/src/commands/cli-grammar/flag-declaration-admission.test.ts
@@ -115,6 +115,20 @@ test('a flag declaration without both admission fields does not compile', () => 
   assert.ok(declaration);
 });
 
+test('a CLI-only key cannot opt into recording', () => {
+  // `help` is a CLI token that never reaches `CommandFlags`, so `recorded: true`
+  // is a type error — the guard the old `satisfies keyof CommandFlags` list held.
+  // @ts-expect-error a non-recodable key must declare `recorded: false`.
+  const declaration: FlagDefinition = {
+    key: 'help',
+    names: ['--help'],
+    type: 'boolean',
+    projectConfig: false,
+    recorded: true,
+  };
+  assert.ok(declaration);
+});
+
 function getInRegistry(
   registry: typeof import('./flag-registry.ts'),
   key: 'daemonBaseUrl' | 'overlayRefs',

--- a/src/commands/cli-grammar/flag-declaration-admission.test.ts
+++ b/src/commands/cli-grammar/flag-declaration-admission.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, vi } from 'vitest';
+import type { CliFlags } from '@agent-device/contracts/command';
+import { getFlagDefinitionsForKey } from './flag-registry.ts';
+import type { FlagDefinition } from './flag-types.ts';
+import { resolveConfigBackedFlagDefaults } from '../../cli-schema/cli-config.ts';
+import { recordActionEntry } from '../../daemon/session-action-recorder.ts';
+import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import { makeTempWorkspace } from '../../__tests__/cli-config-fixtures.ts';
+
+/**
+ * These are planted-divergence tests, not membership snapshots. A snapshot would
+ * re-list the admitted/recorded keys and drift exactly like the two hand-maintained
+ * allowlists it replaced; these plant a divergence in the ONE declaration and require
+ * the production derivation to follow it, which a second list could not do.
+ *
+ * Like #2421's `command-input-option-field.test.ts`, the plant lands BEFORE the surface
+ * is built. `cli-config.ts` freezes `PROJECT_CONFIG_FLAG_KEYS` and the recorder freezes
+ * `RECORDED_FLAG_KEYS` at their own module load, so each test resets the graph, writes
+ * the divergence onto the live declaration, and only then imports the consumer — so what
+ * it observes is the real derivation running over the planted declaration.
+ */
+
+const OPERATOR_CLI_FLAGS: CliFlags = { json: false, help: false, version: false };
+
+function writeProjectConfig(project: string, entries: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(project, 'agent-device.json'), JSON.stringify(entries), 'utf8');
+}
+
+function declarationFor(key: 'daemonBaseUrl' | 'overlayRefs'): FlagDefinition {
+  const declaration = getFlagDefinitionsForKey(key)[0];
+  assert.ok(declaration, `expected a declaration for ${key}`);
+  return declaration;
+}
+
+test('project-config admission follows the declaration: an undeclared key is refused, a planted declaration is admitted', async () => {
+  // Shipped: the declaration declines project config, so the same file the shipped
+  // derivation reads is rejected.
+  assert.equal(declarationFor('daemonBaseUrl').projectConfig, false);
+  const shipped = makeTempWorkspace();
+  try {
+    writeProjectConfig(shipped.project, { daemonBaseUrl: 'https://daemon.example.test' });
+    assert.throws(
+      () =>
+        resolveConfigBackedFlagDefaults({
+          command: 'devices',
+          cwd: shipped.project,
+          cliFlags: OPERATOR_CLI_FLAGS,
+          env: { HOME: shipped.home },
+        }),
+      /not allowed in project config file/,
+    );
+  } finally {
+    fs.rmSync(shipped.root, { recursive: true, force: true });
+  }
+
+  // Planted: flip the declaration before `cli-config` builds, and the identical file is
+  // admitted. A hand-maintained allowlist in `cli-config.ts` could not follow this.
+  vi.resetModules();
+  const registry = await import('./flag-registry.ts');
+  const planted = getInRegistry(registry, 'daemonBaseUrl');
+  Object.assign(planted, { projectConfig: true });
+  const { resolveConfigBackedFlagDefaults: derivePlanted } =
+    await import('../../cli-schema/cli-config.ts');
+  const workspace = makeTempWorkspace();
+  try {
+    writeProjectConfig(workspace.project, { daemonBaseUrl: 'https://daemon.example.test' });
+    const defaults = derivePlanted({
+      command: 'devices',
+      cwd: workspace.project,
+      cliFlags: OPERATOR_CLI_FLAGS,
+      env: { HOME: workspace.home },
+    });
+    assert.equal(defaults.daemonBaseUrl, 'https://daemon.example.test');
+  } finally {
+    fs.rmSync(workspace.root, { recursive: true, force: true });
+  }
+});
+
+test('recorder sanitization follows the declaration: an undeclared key is dropped, a planted declaration is recorded', async () => {
+  // Shipped: `overlayRefs` declines recording so it is dropped; `fps` (recorded) is the
+  // control that proves the copy itself works.
+  assert.equal(declarationFor('overlayRefs').recorded, false);
+  const shipped = recordActionEntry(makeIosSession('default'), {
+    command: 'screenshot',
+    positionals: [],
+    flags: { overlayRefs: true, fps: 5 },
+    result: {},
+  });
+  assert.equal(shipped?.flags.overlayRefs, undefined, 'overlayRefs is undeclared for recording');
+  assert.equal(shipped?.flags.fps, 5, 'fps is declared for recording');
+
+  // Planted: flip the declaration before the recorder builds, and the production
+  // `sanitizeFlags` now copies the same value.
+  vi.resetModules();
+  const registry = await import('./flag-registry.ts');
+  const planted = getInRegistry(registry, 'overlayRefs');
+  Object.assign(planted, { recorded: true });
+  const { recordActionEntry: recordPlanted } =
+    await import('../../daemon/session-action-recorder.ts');
+  const recorded = recordPlanted(makeIosSession('default'), {
+    command: 'screenshot',
+    positionals: [],
+    flags: { overlayRefs: true },
+    result: {},
+  });
+  assert.equal(recorded?.flags.overlayRefs, true, 'a planted declaration is copied');
+});
+
+test('a flag declaration without both admission fields does not compile', () => {
+  // @ts-expect-error projectConfig and recorded are required; omission is the fail-closed gate.
+  const declaration: FlagDefinition = { key: 'json', names: ['--json'], type: 'boolean' };
+  assert.ok(declaration);
+});
+
+function getInRegistry(
+  registry: typeof import('./flag-registry.ts'),
+  key: 'daemonBaseUrl' | 'overlayRefs',
+): FlagDefinition {
+  const declaration = registry.getFlagDefinitionsForKey(key)[0];
+  assert.ok(declaration, `expected a declaration for ${key}`);
+  return declaration;
+}

--- a/src/commands/cli-grammar/flag-definitions-action.ts
+++ b/src/commands/cli-grammar/flag-definitions-action.ts
@@ -11,6 +11,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 200,
     usageLabel: '--count <n>',
     usageDescription: 'Repeat count for press/swipe series',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'pointerCount',
@@ -20,6 +22,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 2,
     usageLabel: '--pointer-count <1|2>',
     usageDescription: 'Gesture pan: number of touch pointers (default 1)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'fps',
@@ -29,6 +33,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 120,
     usageLabel: '--fps <n>',
     usageDescription: 'Record: target frames per second (iOS physical device runner)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'quality',
@@ -37,6 +43,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--quality <medium|high>',
     usageDescription:
       'Record: output quality preset; Android maps this to screenrecord bitrate, Apple targets use it for export/encoding. Legacy numeric values 5-7 map to medium; 8-10 map to high',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'hideTouches',
@@ -44,6 +52,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--hide-touches',
     usageDescription: 'Record: skip touch-overlay post-processing for faster raw benchmark videos',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'recordingScope',
@@ -53,6 +63,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--scope <app|device|system>',
     usageDescription:
       'Record: app requires an active app session; device/system records the whole screen',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'intervalMs',
@@ -62,6 +74,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 10_000,
     usageLabel: '--interval-ms <ms>',
     usageDescription: 'Delay between press iterations',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'delayMs',
@@ -71,6 +85,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 10_000,
     usageLabel: '--delay-ms <ms>',
     usageDescription: 'Delay between typed characters',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'recordAs',
@@ -78,6 +94,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--record-as <VAR>',
     usageDescription: 'Fill: send the live text but publish ${VAR} in an armed .ad recording',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'durationMs',
@@ -87,6 +105,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 10_000,
     usageLabel: '--duration-ms <ms>',
     usageDescription: 'Scroll: pace the gesture over this duration when supported',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'holdMs',
@@ -96,6 +116,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 10_000,
     usageLabel: '--hold-ms <ms>',
     usageDescription: 'Press hold duration for each iteration',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'jitterPx',
@@ -105,6 +127,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 100,
     usageLabel: '--jitter-px <n>',
     usageDescription: 'Deterministic coordinate jitter radius for press',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'pixels',
@@ -114,6 +138,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 100_000,
     usageLabel: '--pixels <n>',
     usageDescription: 'Scroll: explicit gesture distance in pixels',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'doubleTap',
@@ -121,6 +147,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--double-tap',
     usageDescription: 'Use double-tap gesture per press iteration',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'verify',
@@ -129,6 +157,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--verify',
     usageDescription:
       'Capture cheap post-action evidence (AX digest, node counts, changedFromBefore) instead of a follow-up snapshot',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'settle',
@@ -137,6 +167,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--settle',
     usageDescription:
       'After the action, wait for the UI to go quiet and return the settled diff vs the pre-action tree in the same response (best-effort; never fails the action)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'settleQuietMs',
@@ -145,6 +177,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 0,
     usageLabel: '--settle-quiet <ms>',
     usageDescription: 'Settle: quiet window the UI must hold to count as settled (default 500ms)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'clickButton',
@@ -153,6 +187,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['primary', 'secondary', 'middle'],
     usageLabel: '--button primary|secondary|middle',
     usageDescription: 'Click: choose mouse button (middle reserved for future macOS support)',
+    projectConfig: true,
+    recorded: true,
   },
   // These aliases encode the value directly in the flag name so `back` reads naturally as
   // `back --in-app` or `back --system` without introducing a separate `--back-mode` flag.
@@ -164,6 +200,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     setValue: 'in-app',
     usageLabel: '--in-app',
     usageDescription: 'Back: use app-provided back UI when available',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'backMode',
@@ -173,6 +211,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     setValue: 'system',
     usageLabel: '--system',
     usageDescription: 'Back: use system back input or gesture when available',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'pauseMs',
@@ -182,6 +222,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 10_000,
     usageLabel: '--pause-ms <ms>',
     usageDescription: 'Delay between swipe iterations',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'pattern',
@@ -190,6 +232,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['one-way', 'ping-pong'],
     usageLabel: '--pattern one-way|ping-pong',
     usageDescription: 'Swipe repeat pattern',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'verbose',
@@ -198,6 +242,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--debug, --verbose, -v',
     usageDescription:
       'Enable debug diagnostics; test --verbose prints per-test step timings without debug logs',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'cost',
@@ -205,6 +251,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--cost',
     usageDescription: 'Include per-command wall-clock latency (cost.wallClockMs) in the response',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'responseLevel',
@@ -214,6 +262,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--level digest|default|full',
     usageDescription:
       'Response detail level: digest (token-cheap), default (today), or full. Default keeps the wire shape unchanged.',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'json',
@@ -221,6 +271,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--json',
     usageDescription: 'JSON output',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'help',
@@ -228,6 +280,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--help, -h',
     usageDescription: 'Print help and exit',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'version',
@@ -235,6 +289,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--version, -V',
     usageDescription: 'Print version and exit',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'snapshotDiff',
@@ -242,6 +298,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--diff',
     usageDescription: 'Snapshot: show structural diff against the previous session baseline',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'saveScript',
@@ -250,6 +308,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--save-script [path]',
     usageDescription:
       'Arm evidence capture on open, publish the armed recording on close; close --save-script alone (without an armed open) is rejected — start with open --save-script, or use session save-script mid-session. Optional custom output path.',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'networkInclude',
@@ -258,6 +318,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['summary', 'headers', 'body', 'all'],
     usageLabel: '--include summary|headers|body|all',
     usageDescription: 'Network: include headers, bodies, or both in output',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'shutdown',
@@ -265,6 +327,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--shutdown',
     usageDescription: 'close: shutdown associated simulator/emulator after ending session',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'relaunch',
@@ -272,6 +336,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--relaunch',
     usageDescription: 'open: terminate app process before launching it',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'foreground',
@@ -282,6 +348,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
       'open: keep normal app/device selection and return an initial snapshot; without an app, resolve the sole running app on the sole booted iOS simulator',
     inputDescription:
       'Include an initial interactive snapshot in a fresh open response. With no app argument, discover the sole running app on the sole booted iOS simulator; ambiguous environments fail closed.',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'restart',
@@ -289,6 +357,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--restart',
     usageDescription: 'logs clear: stop active stream, clear logs, then start streaming again',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'retainPaths',
@@ -296,6 +366,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--retain-paths',
     usageDescription: 'install-from-source: keep materialized artifact paths after install',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'retentionMs',
@@ -304,6 +376,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 1,
     usageLabel: '--retention-ms <ms>',
     usageDescription: 'install-from-source: retention TTL for materialized artifact paths',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'noRecord',
@@ -311,6 +385,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--no-record',
     usageDescription: 'Do not record this action',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'record',
@@ -319,5 +395,7 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--record',
     usageDescription:
       'Force-record this action even though its command is observation-only and would otherwise be excluded from a repair-armed heal by default (mutually exclusive with --no-record)',
+    projectConfig: true,
+    recorded: true,
   },
 ];

--- a/src/commands/cli-grammar/flag-definitions-connection.ts
+++ b/src/commands/cli-grammar/flag-definitions-connection.ts
@@ -9,6 +9,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--config <path>',
     usageDescription:
       'Load CLI defaults from a specific config file (required for connection/provider defaults outside user config)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'remoteConfig',
@@ -16,6 +18,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--remote-config <path>',
     usageDescription: 'Load remote host + Metro workflow settings from a specific profile file',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'stateDir',
@@ -24,6 +28,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--state-dir <path>',
     usageDescription:
       'Daemon state directory (defaults to ~/.agent-device for packages, or a worktree-scoped dev dir from source)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'daemonBaseUrl',
@@ -31,6 +37,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--daemon-base-url <url>',
     usageDescription: 'Explicit remote HTTP daemon base URL (skip local daemon discovery/startup)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'daemonAuthToken',
@@ -39,6 +47,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--daemon-auth-token <token>',
     usageDescription:
       'Remote HTTP daemon or proxy auth token (sent as request token and bearer header)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'daemonTransport',
@@ -47,6 +57,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['auto', 'socket', 'http'],
     usageLabel: '--daemon-transport auto|socket|http',
     usageDescription: 'Daemon client transport preference',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'daemonServerMode',
@@ -55,6 +67,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['socket', 'http', 'dual'],
     usageLabel: '--daemon-server-mode socket|http|dual',
     usageDescription: 'Daemon server mode used when spawning daemon',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'proxyHost',
@@ -62,6 +76,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--host <host>',
     usageDescription: 'Proxy: host interface to bind (default: 127.0.0.1)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'proxyPort',
@@ -71,6 +87,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 65535,
     usageLabel: '--port <port>',
     usageDescription: 'Proxy: TCP port to bind (default: 0, choose a free port)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'tenant',
@@ -78,6 +96,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--tenant <id>',
     usageDescription: 'Tenant scope identifier for isolated daemon sessions',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'sessionIsolation',
@@ -86,6 +106,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['none', 'tenant'],
     usageLabel: '--session-isolation none|tenant',
     usageDescription: 'Session isolation strategy (tenant prefixes session namespace)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'runId',
@@ -93,6 +115,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--run-id <id>',
     usageDescription: 'Run identifier used for tenant lease admission checks',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'leaseId',
@@ -100,6 +124,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--lease-id <id>',
     usageDescription: 'Lease identifier bound to tenant/run admission scope',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'leaseBackend',
@@ -108,6 +134,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['ios-simulator', 'ios-instance', 'android-instance', 'harmonyos-instance'],
     usageLabel: '--lease-backend ios-simulator|ios-instance|android-instance|harmonyos-instance',
     usageDescription: 'Lease backend for remote tenant connection admission',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'provider',
@@ -115,6 +143,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider <name>',
     usageDescription: 'Cloud provider name for provider-scoped commands',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerSessionId',
@@ -122,6 +152,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-session <id>',
     usageDescription: 'Cloud provider session id or ARN',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerApp',
@@ -130,6 +162,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--provider-app <ref-or-path>',
     usageDescription:
       'Cloud provider app reference or local app path used when creating hosted WebDriver sessions',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerOsVersion',
@@ -137,6 +171,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-os-version <version>',
     usageDescription: 'Hosted cloud provider OS version, for example 17 or 14.0',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerProject',
@@ -144,6 +180,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-project <name>',
     usageDescription: 'Hosted cloud provider project label',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerBuild',
@@ -151,6 +189,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-build <name>',
     usageDescription: 'Hosted cloud provider build label',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerSessionName',
@@ -158,6 +198,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-session-name <name>',
     usageDescription: 'Hosted cloud provider session label',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerDeviceOrientation',
@@ -167,6 +209,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--provider-device-orientation portrait|landscape',
     usageDescription:
       'Screen orientation a hosted cloud provider session starts in. Set this rather than rotating after launch: a session that boots landscape renders login webviews landscape',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerGeoLocation',
@@ -174,6 +218,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-geo-location <country>',
     usageDescription: 'Hosted cloud provider IP geolocation country code, for example US',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerTimezone',
@@ -181,6 +227,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-timezone <zone>',
     usageDescription: 'Hosted cloud provider device time zone, for example New_York',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerLanguage',
@@ -188,6 +236,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-language <language>',
     usageDescription: 'Hosted cloud provider app language, for example Fr',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerLocale',
@@ -195,6 +245,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--provider-locale <locale>',
     usageDescription: 'Hosted cloud provider device locale, for example Fr',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerNetworkProfile',
@@ -203,6 +255,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--provider-network-profile <profile>',
     usageDescription:
       'Hosted cloud provider named network condition profile, for example 4g-lte-advanced-good. Mutually exclusive with --provider-custom-network',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerCustomNetwork',
@@ -211,6 +265,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--provider-custom-network <shape>',
     usageDescription:
       'Hosted cloud provider custom network shape. Mutually exclusive with --provider-network-profile',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'providerNoResignApp',
@@ -219,6 +275,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--provider-no-resign-app',
     usageDescription:
       'iOS only: keep an Enterprise-signed app as uploaded instead of letting the provider re-sign it, which strips entitlements such as push notifications',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'awsProjectArn',
@@ -226,6 +284,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--aws-project-arn <arn>',
     usageDescription: 'AWS Device Farm project ARN for hosted WebDriver sessions',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'awsDeviceArn',
@@ -233,6 +293,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--aws-device-arn <arn>',
     usageDescription: 'AWS Device Farm device ARN for hosted WebDriver sessions',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'awsAppArn',
@@ -240,6 +302,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--aws-app-arn <arn>',
     usageDescription: 'AWS Device Farm app ARN attached to hosted remote access sessions',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'awsRegion',
@@ -247,6 +311,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--aws-region <region>',
     usageDescription: 'AWS region for Device Farm API calls',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'awsInteractionMode',
@@ -255,6 +321,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['INTERACTIVE', 'NO_VIDEO', 'VIDEO_ONLY'],
     usageLabel: '--aws-interaction-mode INTERACTIVE|NO_VIDEO|VIDEO_ONLY',
     usageDescription: 'AWS Device Farm remote access interaction mode',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'force',
@@ -263,6 +331,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--force, --overwrite',
     usageDescription:
       'Force replacement of existing state (connect: replace an active connection; --save-script: overwrite an existing target instead of refusing)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'clean',
@@ -270,6 +340,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--clean',
     usageDescription: 'Daemon stop: remove retained runner processes and leases after stopping',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'noLogin',
@@ -277,6 +349,8 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--no-login',
     usageDescription: 'Connect: fail instead of starting implicit cloud login',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'sessionLock',
@@ -286,5 +360,7 @@ export const CONNECTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--session-lock reject|strip',
     usageDescription:
       'Lock bound-session device routing for this CLI invocation and nested batch steps; strip drops conflicting platform/scope selectors only, and a selector naming a different device always fails',
+    projectConfig: true,
+    recorded: false,
   },
 ];

--- a/src/commands/cli-grammar/flag-definitions-target.ts
+++ b/src/commands/cli-grammar/flag-definitions-target.ts
@@ -11,6 +11,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: PLATFORM_SELECTORS,
     usageLabel: `--platform ${PLATFORM_SELECTORS.join('|')}`,
     usageDescription: 'Platform to target (`apple` aliases the Apple automation backend)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'target',
@@ -19,6 +21,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['mobile', 'tv', 'desktop'],
     usageLabel: '--target mobile|tv|desktop',
     usageDescription: 'Device target class to match',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'device',
@@ -26,6 +30,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--device <name>',
     usageDescription: 'Device name to target (a UDID belongs in --udid, a serial in --serial)',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'udid',
@@ -34,6 +40,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--udid <udid>',
     usageDescription:
       'Apple device or simulator UDID; the only selector that pins one device when several share a --device name',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'serial',
@@ -41,6 +49,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--serial <serial>',
     usageDescription: 'Android, HarmonyOS, or Vega VVD serial',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'stale',
@@ -48,6 +58,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--stale',
     usageDescription: 'Device status: show only claims with a provably stale owner',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'surface',
@@ -56,6 +68,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: SESSION_SURFACES,
     usageLabel: '--surface app|frontmost-app|desktop|menubar',
     usageDescription: 'macOS session surface for open (defaults to app)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'headless',
@@ -63,6 +77,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--headless',
     usageDescription: 'Boot: launch Android emulator without a GUI window',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'targetApp',
@@ -70,6 +86,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--app <id-or-name>',
     usageDescription: 'Doctor: verify an installed target app without opening a session',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroHost',
@@ -77,6 +95,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--metro-host <host>',
     usageDescription: 'Session-scoped Metro/debug host hint',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'metroPort',
@@ -87,6 +107,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--metro-port <port>',
     usageDescription:
       'Session-scoped Metro/debug port hint; on an emulator/simulator the host defaults to the loopback alias, physical devices still need --metro-host',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'metroProjectRoot',
@@ -94,6 +116,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--project-root <path>',
     usageDescription: 'metro prepare: React Native project root (default: cwd)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'kind',
@@ -103,6 +127,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--kind <kind>',
     usageDescription:
       'Kind selector for commands that support it, such as metro prepare or perf artifact collectors',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'perfTemplate',
@@ -110,6 +136,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--template <name>',
     usageDescription: 'Perf xctrace template name, for example Time Profiler',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'metroKind',
@@ -118,6 +146,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['auto', 'react-native', 'expo', 'repack'],
     usageLabel: '--metro-kind auto|react-native|expo|repack',
     usageDescription: 'metro prepare: detect or force the React Native dev-server launcher kind',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroPublicBaseUrl',
@@ -125,6 +155,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--public-base-url <url>',
     usageDescription: 'metro prepare: public base URL used for direct dev-server bundle hints',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroProxyBaseUrl',
@@ -132,6 +164,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--proxy-base-url <url>',
     usageDescription: 'metro prepare: optional bridge origin for remote dev-server access',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroBearerToken',
@@ -140,6 +174,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--bearer-token <token>',
     usageDescription:
       'metro prepare: host bridge bearer token (or AGENT_DEVICE_METRO_BEARER_TOKEN; falls back to AGENT_DEVICE_DAEMON_AUTH_TOKEN)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroPreparePort',
@@ -149,6 +185,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 65535,
     usageLabel: '--port <port>',
     usageDescription: 'metro prepare: local dev-server port (default: 8081)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroListenHost',
@@ -156,6 +194,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--listen-host <host>',
     usageDescription: 'metro prepare: host dev server listens on (default: 0.0.0.0)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroStatusHost',
@@ -164,6 +204,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--status-host <host>',
     usageDescription:
       'metro prepare: host used for local dev-server /status polling (default: 127.0.0.1)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroStartupTimeoutMs',
@@ -172,6 +214,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 1,
     usageLabel: '--startup-timeout-ms <ms>',
     usageDescription: 'metro prepare: timeout while waiting for the dev server to become ready',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroProbeTimeoutMs',
@@ -180,6 +224,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 1,
     usageLabel: '--probe-timeout-ms <ms>',
     usageDescription: 'metro prepare: timeout for /status and proxy bridge calls',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroRuntimeFile',
@@ -187,6 +233,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--runtime-file <path>',
     usageDescription: 'metro prepare: optional file path to persist the JSON result',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroNoReuseExisting',
@@ -194,6 +242,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--no-reuse-existing',
     usageDescription: 'metro prepare: always start a fresh Metro process',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'metroNoInstallDeps',
@@ -201,6 +251,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--no-install-deps',
     usageDescription: 'metro prepare: skip package-manager install when node_modules is missing',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'bundleUrl',
@@ -208,6 +260,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--bundle-url <url>',
     usageDescription: 'Session-scoped bundle URL hint',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'launchUrl',
@@ -215,6 +269,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--launch-url <url>',
     usageDescription: 'Session-scoped deep link / launch URL hint',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'iosSimulatorDeviceSet',
@@ -222,6 +278,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--ios-simulator-device-set <path>',
     usageDescription: 'Scope iOS simulator discovery/commands to this simulator device set',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'iosXctestrunFile',
@@ -229,6 +287,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--ios-xctestrun-file <path>',
     usageDescription: 'Use an externally built iOS XCTest runner .xctestrun artifact',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'iosXctestDerivedDataPath',
@@ -236,6 +296,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--ios-xctest-derived-data-path <path>',
     usageDescription: 'Derived data path for external iOS XCTest runner execution',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'iosXctestEnvDir',
@@ -243,6 +305,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--ios-xctest-env-dir <path>',
     usageDescription: 'Writable directory for per-session iOS XCTest runner env overlays',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'deviceHub',
@@ -250,6 +314,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--device-hub',
     usageDescription: 'open: use Xcode Device Hub when surfacing Apple simulators',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'testIme',
@@ -258,6 +324,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--test-ime',
     usageDescription:
       'open: activate the headless Android test IME for deterministic Unicode text entry (default on for emulators; opt-in on real devices)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'testIme',
@@ -267,6 +335,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--no-test-ime',
     usageDescription:
       'open: keep the real Android keyboard even on emulators (opt out of the headless test IME)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'androidDeviceAllowlist',
@@ -274,6 +344,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--android-device-allowlist <serials>',
     usageDescription: 'Comma/space separated Android serial allowlist for discovery/selection',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'remote',
@@ -281,6 +353,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--remote',
     usageDescription: 'Doctor: check remote connection setup instead of local device inventory',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'activity',
@@ -288,6 +362,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--activity <component>',
     usageDescription: 'Android app launch activity (package/Activity); not for URL opens',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'launchConsole',
@@ -295,6 +371,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--launch-console <path>',
     usageDescription: 'open: capture the initial iOS simulator launch console window to a file',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'launchArgs',
@@ -304,6 +382,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--launch-args <arg>',
     usageDescription:
       'open: repeatable launch argument forwarded verbatim to the platform launch command (iOS app process args; Android adb shell am start args). Linux and macOS reject the flag.',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'header',
@@ -312,6 +392,8 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     multiple: true,
     usageLabel: '--header <name:value>',
     usageDescription: 'install-from-source: repeatable HTTP header for URL downloads',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'githubActionsArtifact',
@@ -319,12 +401,16 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--github-actions-artifact <owner/repo:artifact>',
     usageDescription: 'install-from-source: GitHub Actions artifact resolved by a remote daemon',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'installSource',
     // Config-only virtual option; parsed explicitly from JSON before generic string options.
     names: [],
     type: 'string',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'session',
@@ -332,5 +418,7 @@ export const TARGET_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--session <name>',
     usageDescription: 'Named session',
+    projectConfig: true,
+    recorded: false,
   },
 ];

--- a/src/commands/cli-grammar/flag-definitions-workflow.ts
+++ b/src/commands/cli-grammar/flag-definitions-workflow.ts
@@ -10,6 +10,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription:
       'Replay: retired as a rewrite (ADR 0012) — never edits the .ad file; every divergence already ' +
       'carries ranked selector suggestions, --update or not',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'replayFrom',
@@ -20,6 +22,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription:
       'Replay: resume at 1-based plan step n, skipping 1..n-1 without executing them (requires ' +
       "--plan-digest; see a divergence report's resume field). replay only, not test",
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'replayPlanDigest',
@@ -29,6 +33,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription:
       'Replay: the plan digest a --from resume must match (from a prior divergence report); mismatch, ' +
       'edits, or include/platform-expansion changes fail INVALID_ARGS before any action',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'replayKeepSession',
@@ -37,6 +43,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--keep-session',
     usageDescription:
       'Replay: leave the session active by suppressing exactly an authored terminal close in a native .ad script; replay only, not test or Maestro YAML',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'replayMaestro',
@@ -46,6 +54,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription:
       'Replay: treat input as a supported Maestro YAML subset; unsupported syntax fails loudly. ' +
       'See agent-device help maestro for commands and boundaries',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'replayEnv',
@@ -55,6 +65,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '-e KEY=VALUE, --env KEY=VALUE',
     usageDescription:
       'Replay/Test: inject or override a ${KEY} variable for the script (repeatable)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'failFast',
@@ -63,6 +75,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--fail-fast',
     usageDescription:
       'Test: stop the suite after the first failing script; with sharding, each shard stops independently',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'timeoutMs',
@@ -72,6 +86,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--timeout <ms>',
     usageDescription:
       'Open/Prepare: startup budget covering the Simulator boot (and runner preparation for prepare). Replay/Snapshot/Test: maximum wall-clock time for the command or attempt. With --settle: the settle-wait deadline (default 10s)',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'retries',
@@ -81,6 +97,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 3,
     usageLabel: '--retries <n>',
     usageDescription: 'Test: retry each failed script up to n additional times',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'recordVideo',
@@ -88,6 +106,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--record-video',
     usageDescription: 'Test: record each replay attempt to recording.mp4 in its attempt artifacts',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'artifactsDir',
@@ -95,6 +115,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--artifacts-dir <path>',
     usageDescription: 'Test: root directory for suite artifacts',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'reporter',
@@ -104,6 +126,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--reporter <name-or-path>',
     usageDescription:
       'Test: add a replay suite reporter; use default, junit:<path>, or a custom reporter path (repeatable)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'reportJunit',
@@ -111,6 +135,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--report-junit <path>',
     usageDescription: 'Test: compatibility alias for --reporter junit:<path>',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'shardAll',
@@ -120,6 +146,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--shard-all <n>',
     usageDescription:
       'Test: run the full suite on each of n devices; combine with --device id1,id2 for explicit connected devices; AD_SHARD_INDEX is zero-based',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'shardSplit',
@@ -129,6 +157,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--shard-split <n>',
     usageDescription:
       'Test: split runnable suite entries across n devices; AD_SHARD_INDEX is zero-based',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'steps',
@@ -136,6 +166,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--steps <json>',
     usageDescription: 'Batch: JSON array of {"command","input"} steps',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'stepsFile',
@@ -143,6 +175,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--steps-file <path>',
     usageDescription: 'Batch: read steps JSON from file',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'batchOnError',
@@ -151,6 +185,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     enumValues: ['stop'],
     usageLabel: '--on-error stop',
     usageDescription: 'Batch: stop when a step fails',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'batchMaxSteps',
@@ -160,6 +196,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 1000,
     usageLabel: '--max-steps <n>',
     usageDescription: 'Batch: maximum number of allowed steps',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'appsFilter',
@@ -169,6 +207,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     setValue: 'all',
     usageLabel: '--all',
     usageDescription: 'Apps: include system/OEM apps',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'snapshotInteractiveOnly',
@@ -176,6 +216,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '-i',
     usageDescription: 'Snapshot: interactive elements only',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'snapshotDepth',
@@ -184,6 +226,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     min: 0,
     usageLabel: '--depth, -d <depth>',
     usageDescription: 'Snapshot: limit snapshot depth',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'snapshotScope',
@@ -191,6 +235,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--scope, -s <scope>',
     usageDescription: 'Snapshot: scope snapshot to label/identifier',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'snapshotRaw',
@@ -198,6 +244,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--raw',
     usageDescription: 'Snapshot: raw node output',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'snapshotCustomActions',
@@ -208,6 +256,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
       'Snapshot: name the affordances merged inside an element (iOS sim); not directly invokable — reach them via the detail screen, labeled children, or coordinates',
     inputDescription:
       'Name the affordances an element merged away (iOS UIAccessibilityCustomAction, React Native accessibilityActions) — a card whose reply/options controls are not separate elements still lists them here. The names are for PLANNING, not invocation: there is no API to trigger them, so reach the affordance through the element detail screen, through the same control exposed as a labeled element elsewhere, or by coordinates from its rect. iOS simulator only; costs one accessibility round trip per merged element.',
+    projectConfig: true,
+    recorded: true,
   },
   {
     key: 'snapshotForceFull',
@@ -215,6 +265,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--force-full',
     usageDescription: 'Snapshot: re-emit the full tree even when unchanged',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'findFirst',
@@ -222,6 +274,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--first',
     usageDescription: 'Find: pick the first match when ambiguous',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'findLast',
@@ -229,6 +283,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--last',
     usageDescription: 'Find: pick the last match when ambiguous',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'out',
@@ -236,6 +292,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--out <path>',
     usageDescription: 'Output path',
+    projectConfig: false,
+    recorded: true,
   },
   {
     key: 'artifact',
@@ -243,6 +301,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--artifact <path>',
     usageDescription: 'Debug symbols: Apple crash artifact path (.ips, .crash, or .log)',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'dsym',
@@ -250,6 +310,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--dsym <path>',
     usageDescription: 'Debug symbols: matching .dSYM bundle path',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'searchPath',
@@ -257,6 +319,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--search-path <dir>',
     usageDescription: 'Debug symbols: directory to scan for matching .dSYM bundles',
+    projectConfig: false,
+    recorded: false,
   },
   {
     key: 'overlayRefs',
@@ -265,6 +329,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageLabel: '--overlay-refs',
     usageDescription:
       'Screenshot: draw current snapshot refs and target rectangles onto the saved PNG; diff screenshot: also write a separate current-screen overlay guide',
+    projectConfig: true,
+    recorded: false,
   },
   ...SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,
   {
@@ -273,6 +339,8 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--baseline, -b <path>',
     usageDescription: 'Diff screenshot: path to baseline image file',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'threshold',
@@ -280,5 +348,7 @@ export const WORKFLOW_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--threshold <0-1>',
     usageDescription: 'Diff screenshot: color distance threshold (default 0.1)',
+    projectConfig: true,
+    recorded: false,
   },
 ];

--- a/src/commands/cli-grammar/flag-registry.ts
+++ b/src/commands/cli-grammar/flag-registry.ts
@@ -2,7 +2,12 @@ import { ACTION_FLAG_DEFINITIONS } from './flag-definitions-action.ts';
 import { CONNECTION_FLAG_DEFINITIONS } from './flag-definitions-connection.ts';
 import { TARGET_FLAG_DEFINITIONS } from './flag-definitions-target.ts';
 import { WORKFLOW_FLAG_DEFINITIONS } from './flag-definitions-workflow.ts';
-import type { FlagDefinition, FlagKey } from './flag-types.ts';
+import type {
+  FlagDefinition,
+  FlagKey,
+  RecordableFlagDefinition,
+  RecordableFlagKey,
+} from './flag-types.ts';
 
 const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
   ...CONNECTION_FLAG_DEFINITIONS,
@@ -51,12 +56,14 @@ export function projectConfigFlagKeys(): ReadonlySet<FlagKey> {
 /**
  * The keys the session recorder copies into `SessionAction.flags`, derived from each
  * declaration's `recorded` field. Recomputed per call for the same reason as
- * `projectConfigFlagKeys`.
+ * `projectConfigFlagKeys`. A `recorded: true` declaration can only exist for a
+ * `RecordableFlagKey` (the type forbids it otherwise), so the filter narrows to
+ * keys the recorder can index on `CommandFlags`.
  */
-export function recordedFlagKeys(): ReadonlySet<FlagKey> {
+export function recordedFlagKeys(): ReadonlySet<RecordableFlagKey> {
   return new Set(
-    FLAG_DEFINITIONS.filter((definition) => definition.recorded).map(
-      (definition) => definition.key,
-    ),
+    FLAG_DEFINITIONS.filter(
+      (definition): definition is RecordableFlagDefinition => definition.recorded,
+    ).map((definition) => definition.key),
   );
 }

--- a/src/commands/cli-grammar/flag-registry.ts
+++ b/src/commands/cli-grammar/flag-registry.ts
@@ -53,12 +53,10 @@ export function projectConfigFlagKeys(): ReadonlySet<FlagKey> {
  * declaration's `recorded` field. Recomputed per call for the same reason as
  * `projectConfigFlagKeys`.
  */
-export function recordedFlagKeys(): readonly FlagKey[] {
-  return [
-    ...new Set(
-      FLAG_DEFINITIONS.filter((definition) => definition.recorded).map(
-        (definition) => definition.key,
-      ),
+export function recordedFlagKeys(): ReadonlySet<FlagKey> {
+  return new Set(
+    FLAG_DEFINITIONS.filter((definition) => definition.recorded).map(
+      (definition) => definition.key,
     ),
-  ];
+  );
 }

--- a/src/commands/cli-grammar/flag-registry.ts
+++ b/src/commands/cli-grammar/flag-registry.ts
@@ -32,3 +32,33 @@ export function getFlagDefinitions(): readonly FlagDefinition[] {
 export function getFlagDefinitionsForKey(key: FlagKey): readonly FlagDefinition[] {
   return FLAG_DEFINITIONS.filter((definition) => definition.key === key);
 }
+
+/**
+ * The keys a project `agent-device.json` may set, derived from each declaration's
+ * `projectConfig` field. Recomputed per call over the live declarations rather than
+ * cached here, so a consumer that builds its admission set at its own module load
+ * observes the current declarations — which is what lets a planted declaration move
+ * the surface a divergence test reads.
+ */
+export function projectConfigFlagKeys(): ReadonlySet<FlagKey> {
+  return new Set(
+    FLAG_DEFINITIONS.filter((definition) => definition.projectConfig).map(
+      (definition) => definition.key,
+    ),
+  );
+}
+
+/**
+ * The keys the session recorder copies into `SessionAction.flags`, derived from each
+ * declaration's `recorded` field. Recomputed per call for the same reason as
+ * `projectConfigFlagKeys`.
+ */
+export function recordedFlagKeys(): readonly FlagKey[] {
+  return [
+    ...new Set(
+      FLAG_DEFINITIONS.filter((definition) => definition.recorded).map(
+        (definition) => definition.key,
+      ),
+    ),
+  ];
+}

--- a/src/commands/cli-grammar/flag-types.ts
+++ b/src/commands/cli-grammar/flag-types.ts
@@ -33,4 +33,18 @@ export type FlagDefinition = {
    * this option with `optionField`.
    */
   inputDescription?: string;
+  /**
+   * Whether the key may be set from a project `agent-device.json`. Fail-closed by
+   * declaration, not by a list: a repository-controlled config may set a flag only
+   * when this says so, so the compiler holds the property a hand-maintained
+   * allowlist used to hold by omission. Omit it and the declaration will not
+   * compile.
+   */
+  projectConfig: boolean;
+  /**
+   * Whether the session recorder copies this key into `SessionAction.flags`. Also
+   * fail-closed by declaration: a recorded action carries only what a flag
+   * explicitly opts into.
+   */
+  recorded: boolean;
 };

--- a/src/commands/cli-grammar/flag-types.ts
+++ b/src/commands/cli-grammar/flag-types.ts
@@ -1,23 +1,19 @@
-import type { CliFlags } from '@agent-device/contracts/command';
+import type { CliFlags, CommandFlags } from '@agent-device/contracts/command';
 
 export type FlagKey = keyof CliFlags;
 export type FlagType = 'boolean' | 'int' | 'number' | 'enum' | 'string' | 'booleanOrString';
 
 /**
- * One command option, declared once.
- *
- * This is where an option's CLI token, value type and value bounds live, and it
- * is also where its PROSE lives. An option has at most two audiences and they
- * are legitimately different lengths — `usageDescription` is the one-line
- * `--help` entry a CLI reader scans, `inputDescription` is the tool/SDK field
- * description a model or a TypeScript caller reads — but they are one fact with
- * one owner, stated side by side here so rewriting one is rewriting both. A
- * command's input field derives from this declaration through `optionField`;
- * a doc comment on `CliFlags`, on a public option type, or a second
- * `booleanField('…')` carrying the same sentence is a copy, not a declaration.
+ * Keys a CLI token can carry but a dispatched command's `flags` never does, so a
+ * recorded action has nowhere to put them. `recorded` is therefore locked to
+ * `false` for these; the recorder indexes `CommandFlags`, and widening a CLI-only
+ * key there would leak an uncarrable value (a `daemonAuthToken`, say) into a `.ad`.
  */
-export type FlagDefinition = {
-  key: FlagKey;
+export type NonRecordableFlagKey = Exclude<FlagKey, keyof CommandFlags>;
+/** The complement: a key the session recorder may copy into `SessionAction.flags`. */
+export type RecordableFlagKey = Extract<FlagKey, keyof CommandFlags>;
+
+type FlagDefinitionBody = {
   names: readonly string[];
   type: FlagType;
   multiple?: boolean;
@@ -41,10 +37,40 @@ export type FlagDefinition = {
    * compile.
    */
   projectConfig: boolean;
-  /**
-   * Whether the session recorder copies this key into `SessionAction.flags`. Also
-   * fail-closed by declaration: a recorded action carries only what a flag
-   * explicitly opts into.
-   */
-  recorded: boolean;
 };
+
+/**
+ * One command option, declared once.
+ *
+ * This is where an option's CLI token, value type and value bounds live, and it
+ * is also where its PROSE lives. An option has at most two audiences and they
+ * are legitimately different lengths — `usageDescription` is the one-line
+ * `--help` entry a CLI reader scans, `inputDescription` is the tool/SDK field
+ * description a model or a TypeScript caller reads — but they are one fact with
+ * one owner, stated side by side here so rewriting one is rewriting both. A
+ * command's input field derives from this declaration through `optionField`;
+ * a doc comment on `CliFlags`, on a public option type, or a second
+ * `booleanField('…')` carrying the same sentence is a copy, not a declaration.
+ *
+ * The union is the recorder's `recorded` constraint stated as a type: only a
+ * `RecordableFlagKey` may set `recorded: true`, so the guard the old
+ * `satisfies readonly (keyof CommandFlags)[]` list held lives on the declaration.
+ */
+export type FlagDefinition =
+  | (FlagDefinitionBody & {
+      key: RecordableFlagKey;
+      /**
+       * Whether the session recorder copies this key into `SessionAction.flags`.
+       * Fail-closed by declaration: a recorded action carries only what a flag
+       * explicitly opts into.
+       */
+      recorded: boolean;
+    })
+  | (FlagDefinitionBody & {
+      key: NonRecordableFlagKey;
+      /** A CLI-only key never reaches `CommandFlags`, so it is never recorded. */
+      recorded: false;
+    });
+
+/** A declaration whose key the session recorder can carry, i.e. one that may set `recorded: true`. */
+export type RecordableFlagDefinition = Extract<FlagDefinition, { key: RecordableFlagKey }>;

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -366,7 +366,7 @@ function sanitizeFlags(flags: CommandFlags | undefined): SessionAction['flags'] 
   if (!flags) return {};
   const result: Record<string, unknown> = {};
   for (const key of RECORDED_FLAG_KEYS) {
-    const value = flags[key as keyof CommandFlags];
+    const value = flags[key];
     if (value !== undefined) {
       result[key] = value;
     }

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -1,6 +1,6 @@
 import type { SessionAction } from '@agent-device/contracts/session';
 import type { CommandFlags } from '@agent-device/contracts/command';
-import { SCREENSHOT_ACTION_FLAG_KEYS } from '@agent-device/contracts/capture';
+import { recordedFlagKeys } from '../cli-schema/command-schema.ts';
 import { emitDiagnostic } from '@agent-device/host-kit/diagnostics';
 import type { DaemonRequest } from './daemon-request.ts';
 import type { SessionRuntimeHints, SessionState } from './session-state.ts';
@@ -357,49 +357,18 @@ function isExcludedRepairSegmentObservation(
   return entry.flags?.record !== true;
 }
 
-const SANITIZED_FLAG_KEYS = [
-  'platform',
-  'device',
-  'udid',
-  'serial',
-  'out',
-  'verbose',
-  'metroHost',
-  'metroPort',
-  'bundleUrl',
-  'launchUrl',
-  'snapshotInteractiveOnly',
-  'snapshotDepth',
-  'snapshotScope',
-  'snapshotRaw',
-  'snapshotCustomActions',
-  ...SCREENSHOT_ACTION_FLAG_KEYS,
-  'relaunch',
-  'saveScript',
-  'force',
-  'noRecord',
-  'record',
-  'fps',
-  'quality',
-  'hideTouches',
-  'count',
-  'pointerCount',
-  'intervalMs',
-  'delayMs',
-  'holdMs',
-  'jitterPx',
-  'doubleTap',
-  'clickButton',
-  'pauseMs',
-  'pattern',
-] as const satisfies readonly (keyof CommandFlags)[];
+// The keys a recorded action carries derive from each flag declaration's `recorded`
+// field, never from a list maintained here; opting a flag into recording edits the
+// declaration, not this file.
+const RECORDED_FLAG_KEYS = recordedFlagKeys();
 
 function sanitizeFlags(flags: CommandFlags | undefined): SessionAction['flags'] {
   if (!flags) return {};
   const result: Record<string, unknown> = {};
-  for (const key of SANITIZED_FLAG_KEYS) {
-    if (flags[key] !== undefined) {
-      result[key] = flags[key];
+  for (const key of RECORDED_FLAG_KEYS) {
+    const value = flags[key as keyof CommandFlags];
+    if (value !== undefined) {
+      result[key] = value;
     }
   }
   return result as SessionAction['flags'];


### PR DESCRIPTION
## What

A flag's two fail-closed properties — *may it be set from a project `agent-device.json`* and *does the session recorder copy it into `SessionAction.flags`* — move off their hand-maintained allowlists and onto each `FlagDefinition` as required `projectConfig` / `recorded` fields. Omitting either is now a type error, so the compiler holds the fail-closed property a list held by omission.

Closes #2445 (Wave 2 child of #2409; the "#1665-shaped follow-up" named in #2421).

## Changes

- `FlagDefinition` gains required `projectConfig: boolean` and `recorded: boolean`. All 156 declarations plus the 6 `ScreenshotSpecificFlagDefinition` entries carry both.
- **`recorded` is constrained to `CommandFlags` keys by the type**: `FlagDefinition` is a union that pins `recorded` to `false` for a `NonRecordableFlagKey = Exclude<FlagKey, keyof CommandFlags>` (json / help / version / replayMaestro / daemonAuthToken). This preserves the `satisfies readonly (keyof CommandFlags)[]` guard the old list carried, so `recorded: true` on a CLI-only key does not compile and cannot leak into a recorded action.
- `cli-config.ts` and `session-action-recorder.ts` derive their sets from the registry and no longer list keys (`PROJECT_CONFIG_FLAG_KEYS` / `SANITIZED_FLAG_KEYS` literals deleted). `SCREENSHOT_ACTION_FLAG_KEYS` stays (`screenshot-options.test.ts` still consumes it).
- Derivations (`projectConfigFlagKeys()` / `recordedFlagKeys()` in `flag-registry.ts`) recompute per call so each consumer freezes its set at its own module load — which is what lets a planted declaration move the surface. `recordedFlagKeys()` returns `ReadonlySet<RecordableFlagKey>` via a narrowing predicate, so `sanitizeFlags` needs no cast.
- The recorder reaches the derivation through the `cli-schema/command-schema.ts` seam: R2 `commands-floor` forbids `daemon/ -> commands/`.
- Planted-divergence tests per the #2421 pattern, plus two `@ts-expect-error` compile-time pins (missing fields; a CLI-only key cannot opt into recording).
- `docs/agents/cli-flags.md` points at the declaration fields, not the deleted allowlist.

## Acceptance (from the issue)

- **Re-doing #1665 edits the declaration, no allowlist**: both consumer files now derive; re-adding a flag touches only the declaration.
- **Derived sets equal the deleted sets** — one-off diff is **empty** (verified against `HEAD`):
  - PROJECT_CONFIG: derived 85 = original 85; only-derived `[]`, only-orig `[]`
  - RECORDED: derived 39 = original 39; only-derived `[]`, only-orig `[]`
  - `cli-config-trust.test.ts` (19) and `session-action-recorder.test.ts` (27) stay green **with no edits**.
- **A declaration without both fields does not compile**: enforced by the required fields + `@ts-expect-error` pins; full `pnpm typecheck` green.

## Size & design tradeoff

The size bot reports roughly **+3 kB unpacked** (the exact figure drifts run to run — it has shown +3.0 to +3.3 kB; download is slightly negative; startup within noise). The growth is the two required booleans repeated across all 162 declarations in the emitted bundles — inherent to stating the property per declaration rather than in one list.

The smaller alternative is to keep the two sets as standalone allowlists and not touch the declarations: near-zero bundle cost, but it is exactly the "fail-closed by omission, so a new flag edits a second file anyway" shape #2410/#2445 retire, and it cannot express the `CommandFlags` guard on a per-declaration basis. Retaining **required** declarations (so omission is a type error, not a silent drop) over another allowlist is the deliberate tradeoff here: +3 kB unpacked, one file per flag instead of two, and the guard moves onto the declaration.

## Verification

`pnpm build`, `pnpm typecheck` (all packages + examples), `pnpm lint`, `pnpm format:check`, `pnpm check:layering`, `check:production-exports`, `check:mcp-metadata`, `check:gate-manifest`, `check:bundle-owner-files`, `check:package` — all green. Targeted suites: `src/daemon` (2639), `packages/contracts` + `src/commands/capture` + `src/cli/parser` (447), plus cli-schema/commands/cli-grammar and the new test. Rebased onto `main` (`3bbeb61917`); no upstream change touched these files.

## Notes

- `docs/adr/0012-interactive-replay.md` still names `SANITIZED_FLAG_KEYS` in a point-in-time record; left unchanged (ADRs are historical and the described behavior — `--settle`/`--verify` dropped from recordings — is unchanged).
