### PR TITLE
fix(ios): budget snapshot bridge test compile from the build ceiling

### DIFF
--- a/packages/platform-apple/src/snapshot-source/cache.ts
+++ b/packages/platform-apple/src/snapshot-source/cache.ts
@@ -29,7 +29,13 @@ type SnapshotBridgeCacheManifest = Readonly<{
 const CACHE_SCHEMA_VERSION = 1 as const;
 const BRIDGE_FILENAME = 'snapshot-bridge';
 const MANIFEST_FILENAME = 'manifest.json';
-const BUILD_TIMEOUT_MS = 120_000;
+
+/**
+ * @internal Upper bound on a single snapshot-bridge clang invocation, exposed for the host bridge
+ * tests so they budget their own compile from the same ceiling instead of a stricter constant. The
+ * live build also stays under the caller's snapshot-source deadline, which can bind tighter.
+ */
+export const BUILD_TIMEOUT_MS = 120_000;
 
 export async function ensureSnapshotBridgeBinary(
   input: Readonly<{

--- a/packages/platform-apple/src/snapshot-source/native-runtime.test.ts
+++ b/packages/platform-apple/src/snapshot-source/native-runtime.test.ts
@@ -4,37 +4,48 @@ import path from 'node:path';
 import { beforeAll, describe, test } from 'vitest';
 import { runCmd } from '@agent-device/host-kit/command';
 import { mkdtempForTest } from '../__tests__/tmp-dir.ts';
+import { BUILD_TIMEOUT_MS } from './cache.ts';
+import { createSnapshotSourceDeadline, remainingSnapshotSourceMs } from './deadline.ts';
+
+// The host bridge compile is budgeted from a deadline sized to production's build ceiling, not a
+// stricter warm-host constant, so a cold runner's first `xcrun` (signature-scan stall plus clang)
+// is not tripped before the compile finishes (#2439). The hook budget leaves headroom beyond that.
+const COMPILE_HOOK_TIMEOUT_MS = BUILD_TIMEOUT_MS + 30_000;
+
+async function compileSnapshotBridgeFixture(clangArgs: readonly string[]): Promise<void> {
+  const deadline = createSnapshotSourceDeadline(BUILD_TIMEOUT_MS, undefined);
+  const compiled = await runCmd('xcrun', [...clangArgs], {
+    allowFailure: true,
+    timeoutMs: remainingSnapshotSourceMs(deadline, 'native-build-deadline'),
+  });
+  assert.equal(compiled.exitCode, 0, compiled.stderr);
+}
 
 describe.skipIf(process.platform !== 'darwin')('native snapshot capture', () => {
   let binary: string;
   beforeAll(async () => {
     binary = path.join(await mkdtempForTest('snapshot-foreground-'), 'foreground-owner');
     const nativeRoot = path.resolve(import.meta.dirname, '../../../../apple/snapshot-bridge');
-    const compiled = await runCmd(
-      'xcrun',
-      [
-        '--sdk',
-        'macosx',
-        'clang',
-        '-fobjc-arc',
-        '-Ddlopen=fixtureDlopen',
-        '-Ddlsym=fixtureDlsym',
-        '-framework',
-        'Foundation',
-        '-framework',
-        'CoreGraphics',
-        '-I',
-        nativeRoot,
-        path.join(nativeRoot, 'SnapshotBridgeRuntime.m'),
-        path.join(nativeRoot, 'SnapshotBridgeCapture.m'),
-        path.join(import.meta.dirname, 'fixtures/foreground-owner.m'),
-        '-o',
-        binary,
-      ],
-      { allowFailure: true, timeoutMs: 45_000 },
-    );
-    assert.equal(compiled.exitCode, 0, compiled.stderr);
-  }, 60_000);
+    await compileSnapshotBridgeFixture([
+      '--sdk',
+      'macosx',
+      'clang',
+      '-fobjc-arc',
+      '-Ddlopen=fixtureDlopen',
+      '-Ddlsym=fixtureDlsym',
+      '-framework',
+      'Foundation',
+      '-framework',
+      'CoreGraphics',
+      '-I',
+      nativeRoot,
+      path.join(nativeRoot, 'SnapshotBridgeRuntime.m'),
+      path.join(nativeRoot, 'SnapshotBridgeCapture.m'),
+      path.join(import.meta.dirname, 'fixtures/foreground-owner.m'),
+      '-o',
+      binary,
+    ]);
+  }, COMPILE_HOOK_TIMEOUT_MS);
 
   test.each([
     'stable',
@@ -90,26 +101,21 @@ describe.skipIf(process.platform !== 'darwin')(
     beforeAll(async () => {
       binary = path.join(await mkdtempForTest('snapshot-recovery-'), 'recovery-conformance');
       const nativeRoot = path.resolve(import.meta.dirname, '../../../../apple/snapshot-bridge');
-      const compiled = await runCmd(
-        'xcrun',
-        [
-          '--sdk',
-          'macosx',
-          'clang',
-          '-fobjc-arc',
-          '-framework',
-          'Foundation',
-          '-I',
-          nativeRoot,
-          path.join(nativeRoot, 'SnapshotBridgeCapture.m'),
-          path.join(import.meta.dirname, 'fixtures/recovery-conformance.m'),
-          '-o',
-          binary,
-        ],
-        { allowFailure: true, timeoutMs: 45_000 },
-      );
-      assert.equal(compiled.exitCode, 0, compiled.stderr);
-    }, 60_000);
+      await compileSnapshotBridgeFixture([
+        '--sdk',
+        'macosx',
+        'clang',
+        '-fobjc-arc',
+        '-framework',
+        'Foundation',
+        '-I',
+        nativeRoot,
+        path.join(nativeRoot, 'SnapshotBridgeCapture.m'),
+        path.join(import.meta.dirname, 'fixtures/recovery-conformance.m'),
+        '-o',
+        binary,
+      ]);
+    }, COMPILE_HOOK_TIMEOUT_MS);
 
     assert.equal(recoveryFixture.version, 1);
     test.each(recoveryFixture.recoveryCases.map((recoveryCase) => recoveryCase.name))(


### PR DESCRIPTION
## Summary

The host bridge unit test (`native-runtime.test.ts`) compiled the snapshot bridge under a fixed `timeoutMs: 45_000` with a `60_000` hook budget. On a cold macOS runner the first `xcrun` pays the signature-scan stall (#2422) and then clang, so the step reports `xcrun timed out after 45000ms` while every other check is green.

Both `beforeAll` compiles now budget from a deadline sized to the production build ceiling — `createSnapshotSourceDeadline(BUILD_TIMEOUT_MS)` + `remainingSnapshotSourceMs` — so the unit lane is never stricter than the preparation path it sits beside. The budget is a true `Math.min` of the same value production clamps to, not a fresh constant: `BUILD_TIMEOUT_MS` is now `@internal`-exported as the single source of truth for the compile ceiling. The hook budget leaves headroom beyond it so `runCmd`'s own timeout (not the Vitest hook) surfaces on a real hang.

Two files touched, both in `snapshot-source`. No production behavior or `BUILD_TIMEOUT_MS` value changes.

## Validation

Tested at `c394a46e59b03dc7af8a147969a48562678c4649`.

Local gates for the change pass: format, `oxlint`, `tsc`, `check:layering`, `check:fallow` (2 changed files, no issues), `check:production-exports`, `build`, `check:package`, and the full `snapshot-source` vitest family (native-runtime 46 tests green).

A broad `check:affected --run` fan-out surfaced unrelated daemon/provider failures (`daemon-entrypoint` 5 s timeout flakes that pass in isolation, a provider-integration CI lane, an xml teardown race, and two `request-router-lock-policy` real-time asserts). The lock-policy pair was reproduced failing identically on `origin/main` with this change reverted, so none are regressions here. Provider-integration, coverage, and device lanes remain GitHub-authoritative.

Cannot produce a local failing repro: the failure is cold-runner-only and this host compiles the bridge in seconds. The definitive signal is the CI step staying green; per #2439, reopen with the run URL if it fires again.

Closes #2439
