### PR TITLE
docs(adr-0011): narrow the offscreen rescue comment to the per-request surface policy

### DIFF
--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -171,12 +171,14 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
   // hook, refuses on the visibility resolver's verdict unchanged — this is a
   // rescue-only override, never a way to relax a genuine refusal.
   // The live read is a SEPARATE runner request (the direct querySelector), so
-  // only the per-request selection policy is shared: capture and rescue each
-  // resolve their own active surface through the runner's single
-  // prepareActiveCommandContext seam, in-place system surfaces included (the
-  // web sign-in sheet, #2448). That is not a same-instant guarantee — no
-  // captured surface identity crosses the two requests, so a surface that
-  // appears or dismisses between them is undetected.
+  // it shares the runner's prepareActiveCommandContext surface policy only with
+  // a RUNNER-ROUTED capture: eligible simulator captures go to the host AX
+  // bridge (packages/platform-apple/src/snapshot-route.ts), and a bridge-served
+  // capture never reaches that seam. #2448 puts the system-surface case (the
+  // web sign-in sheet) back on the runner, where both reads do share it. Either
+  // way this is not a same-instant guarantee — no captured surface identity
+  // crosses the two requests, so a surface that appears or dismisses between
+  // them is undetected.
   offscreen: {
     kind: 'runtime',
     via: 'src/commands/interaction/runtime/resolution.ts#throwIfOffscreenInteractionTarget',

--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -170,11 +170,13 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
   // not the bulk one. Every other platform, and any backend that omits the
   // hook, refuses on the visibility resolver's verdict unchanged — this is a
   // rescue-only override, never a way to relax a genuine refusal.
-  // The live read is the runner's direct querySelector, which runs against the
-  // single activeApp that prepareActiveCommandContext resolved for the snapshot
-  // tree as well — including an in-place system surface (the web sign-in sheet,
-  // #2448). Tree and rescue therefore read the SAME surface: a confirmation can
-  // never come from a different app than the refusal was computed on.
+  // The live read is a SEPARATE runner request (the direct querySelector), so
+  // only the per-request selection policy is shared: capture and rescue each
+  // resolve their own active surface through the runner's single
+  // prepareActiveCommandContext seam, in-place system surfaces included (the
+  // web sign-in sheet, #2448). That is not a same-instant guarantee — no
+  // captured surface identity crosses the two requests, so a surface that
+  // appears or dismisses between them is undetected.
   offscreen: {
     kind: 'runtime',
     via: 'src/commands/interaction/runtime/resolution.ts#throwIfOffscreenInteractionTarget',

--- a/packages/contracts/src/interaction-guarantees.ts
+++ b/packages/contracts/src/interaction-guarantees.ts
@@ -170,6 +170,11 @@ const RUNTIME_TREE_SHARED_GUARANTEES = {
   // not the bulk one. Every other platform, and any backend that omits the
   // hook, refuses on the visibility resolver's verdict unchanged — this is a
   // rescue-only override, never a way to relax a genuine refusal.
+  // The live read is the runner's direct querySelector, which runs against the
+  // single activeApp that prepareActiveCommandContext resolved for the snapshot
+  // tree as well — including an in-place system surface (the web sign-in sheet,
+  // #2448). Tree and rescue therefore read the SAME surface: a confirmation can
+  // never come from a different app than the refusal was computed on.
   offscreen: {
     kind: 'runtime',
     via: 'src/commands/interaction/runtime/resolution.ts#throwIfOffscreenInteractionTarget',


### PR DESCRIPTION
## Summary

Comment-only change to the `offscreen` cell in the ADR 0011 guarantee matrix
(`packages/contracts/src/interaction-guarantees.ts`, 1 file, +8/-6 lines). No behavior change.

The cell already documents the iOS live rescue (`confirmOffscreenTargetVisible` re-checks a
would-be refusal against a tree-independent read and retargets at the live rect). What it did not
record is how that read picks its surface, and how little it shares with the capture.

The rescue is its own runner request: `confirmIosOffscreenTargetVisible` →
`queryDirectIosSelector` → the Apple runner's `querySelector`, with no bridge alternative, and in
the runner `querySelector` reaches `executeOnMainPrepared` only through
`prepareActiveCommandContext`. The bulk capture has a second route: `createAppleSnapshotRoute`
serves an eligible iOS simulator capture from the host AX bridge and only falls back to XCTest on
failure, a disabled generation, or target-resolution failure. So a bridge-served capture never
touches that seam, and the comment now limits the shared-policy claim to a **runner-routed**
capture. #2448 is what puts the system-surface case (the `ASWebAuthenticationSession` sign-in
sheet) back on the runner — the bridge would serve the occluded app tree — which is where the two
reads do share the seam.

The comment still does not claim the two requests observe the same surface instant: the probe
carries only the node's id/label plus the guard's own `rootViewport`, no captured surface
identity, so a surface that appears or dismisses between capture and rescue is undetected.
(Revision `a4e639d2` overclaimed a same-surface guarantee; `2a52a4d3` overclaimed a universally
shared seam. Enforcing cross-request surface identity would be a behavior change, out of scope.)

Depends on #2448 for the system-surface clause; merge after it. Nothing #2448 touches is modified
here.

Closes #2452

## Validation

Tested at `e905700fff`. `pnpm format` (oxfmt, repo-wide) produced no further diff; `pnpm lint`,
`pnpm typecheck`, and `pnpm check:affected --run` all pass — the latter covering format, lint,
typecheck, layering, fallow, build, and `vitest related` on the changed file (2 files, 12 tests:
the ADR 0011 honesty/completeness gate and the interaction contract coverage test). The changed
file was staged before the layering scan, which reads tracked files only.

No runtime validation applies: the diff is a source comment, so no device, simulator, or runner
path changes. The honesty gate only checks that referenced `via` symbols exist, and those are
untouched.
