### PR TITLE
fix(cli): declare projectConfig on the scroll --until flag

### DIFF
--- a/src/commands/cli-grammar/flag-definitions-action.ts
+++ b/src/commands/cli-grammar/flag-definitions-action.ts
@@ -147,6 +147,8 @@ export const ACTION_FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--until <selector>',
     usageDescription: 'Scroll: repeat passes until the selector is visible on screen',
+    projectConfig: true,
+    recorded: false,
   },
   {
     key: 'doubleTap',


### PR DESCRIPTION
## What broke

Main is red at 6d08de4609 (CI run https://github.com/callstack/agent-device/actions/runs/34494219071; failing jobs: Typecheck & Package, Repo Guards "Check numeric ranges", Integration Tests):

```
src/commands/cli-grammar/flag-definitions-action.ts(144,3): error TS2322: Type '{ key: "until"; names: [string]; type: "string"; usageLabel: string; usageDescription: string; }' is not assignable to type 'FlagDefinition'.
  Type '{ key: "until"; ... }' is not assignable to type 'FlagDefinitionBody & { key: RecordableFlagKey; recorded: boolean; }'.
    Property 'projectConfig' is missing in type '{ key: "until"; ... }' but required in type 'FlagDefinitionBody'.
```

## Cause

Two PRs, each green on its own base, landed in an order that broke main:

- #2436 (`feat(scroll): find off-screen targets in one command with --until`) added the `until` flag declaration without a `projectConfig`/`recorded` pair, which was valid at the time it branched.
- #2453 (`refactor(commands): declare project-config admission and recorder sanitization on the flag declaration`) made `projectConfig` (and `recorded`) required fields on every `FlagDefinition`, and merged first.

#2436 was never rebased onto #2453's stricter type, so its `until` declaration is missing both required fields.

## Fix

Add `projectConfig: true, recorded: false` to the `until` declaration in `src/commands/cli-grammar/flag-definitions-action.ts`, matching its immediate siblings in the same file — the other `Scroll:` gesture flags `durationMs` (`--duration-ms`) and `pixels` (`--pixels`), which both carry `projectConfig: true, recorded: false`.

- `projectConfig: true` matches the file's default posture for ordinary action parameters (per `flag-registry.ts`'s `projectConfigFlagKeys()` / `src/cli-schema/cli-config.ts`, this only controls whether `agent-device.json` may set the flag; `false` is reserved for one-shot/session-lifecycle flags like `--help`, `--version`, `--foreground`, `--save-script`, none of which apply to `--until`).
- `recorded: false` matches `durationMs`/`pixels` exactly: it keeps `--until` out of `SessionAction.flags` on the `.ad` recorder, consistent with how the other scroll-gesture parameters are treated.

No other change. This is the smallest possible fix for the compile error.

## Verification (in a fresh worktree off origin/main)

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm vitest run src/commands/cli-grammar/` — 3 files / 10 tests pass
- `pnpm check:layering` — OK (221/221)
- `pnpm gate freerange` (the "Check numeric ranges" CI step) — 0 findings
- `pnpm format` then `git status --short` — touches only the one changed file
