### PR TITLE
fix(orientation): disclose an unconfirmed rotation instead of asserting it

### DIFF
--- a/packages/contracts/src/navigation.ts
+++ b/packages/contracts/src/navigation.ts
@@ -31,11 +31,20 @@ export type BackCommandResult = {
   settle?: SettleObservation;
 };
 
-/** `orientation` — `{ action: 'orientation', orientation, message: 'Rotated to <orientation>' }`. */
+/**
+ * `orientation` — `{ action: 'orientation', orientation, message: 'Rotated to <orientation>' }`.
+ *
+ * An owner that reports no resulting rotation is not evidence that the device
+ * rotated. That case keeps the requested `orientation` for compatibility, but
+ * discloses `confirmed: false` plus a `warning`, and names the request in
+ * `message` (`Rotation requested: <orientation> (unconfirmed)`).
+ */
 export type OrientationCommandResult = {
   action: 'orientation';
   orientation: DeviceRotation;
   message: string;
+  confirmed?: boolean;
+  warning?: string;
 };
 
 /** `app-switcher` — `{ action: 'app-switcher', message: 'Opened app switcher' }`. */

--- a/packages/session-journal/src/__tests__/session-event-action.test.ts
+++ b/packages/session-journal/src/__tests__/session-event-action.test.ts
@@ -192,6 +192,18 @@ test('structural action events preserve navigation, viewport, keyboard, and gest
 
   assert.equal(buildActionSummary(back), 'Went back using system navigation');
   assert.equal(buildActionSummary(orientation), 'Rotated to landscape-left');
+
+  // An owner that reported no resulting rotation keeps the requested value, so
+  // the recorded action must not claim the device rotated.
+  const unconfirmedOrientation = action('orientation', {
+    action: 'orientation',
+    orientation: 'portrait',
+    confirmed: false,
+    warning:
+      'Requested portrait; the device owner reported no resulting orientation, so the rotation is unconfirmed.',
+    message: 'Rotation requested: portrait (unconfirmed)',
+  });
+  assert.equal(buildActionSummary(unconfirmedOrientation), 'Requested portrait (unconfirmed)');
   assert.equal(buildActionSummary(viewport), 'Set viewport to 402×874');
   assert.equal(buildActionSummary(keyboard), 'Dismissed keyboard');
   assert.equal(buildActionSummary(gesture), 'Ran pan gesture');

--- a/packages/session-journal/src/session-event-action-presentation.ts
+++ b/packages/session-journal/src/session-event-action-presentation.ts
@@ -174,7 +174,13 @@ function buildBackActionSummary(result: Record<string, unknown>): string {
 
 function buildOrientationActionSummary(result: Record<string, unknown>): string {
   const orientation = readEnum(result.orientation, DEVICE_ROTATIONS);
-  return orientation ? `Rotated to ${orientation}` : 'Changed orientation';
+  if (!orientation) return 'Changed orientation';
+  // An unconfirmed rotation is not a rotation: the daemon keeps the requested
+  // value for compatibility, so the recorded action must disclose it instead of
+  // asserting that the device rotated.
+  return readBoolean(result.confirmed) === false
+    ? `Requested ${orientation} (unconfirmed)`
+    : `Rotated to ${orientation}`;
 }
 
 function buildViewportActionSummary(result: Record<string, unknown>): string {

--- a/src/daemon/__tests__/orientation-runtime.test.ts
+++ b/src/daemon/__tests__/orientation-runtime.test.ts
@@ -142,7 +142,7 @@ test('resolves one admitted binding and reports the owner-observed rotation', as
   });
 });
 
-test('falls back to the requested rotation when the owner reports nothing', async () => {
+test('keeps the requested rotation but discloses that the owner reported nothing', async () => {
   const harness = runtimeHarness();
 
   const resolved = await resolveBoundOrientationRuntime({
@@ -156,7 +156,10 @@ test('falls back to the requested rotation when the owner reports nothing', asyn
   expect(await resolved.execute(orientationExecutionParams(['portrait']))).toEqual({
     action: 'orientation',
     orientation: 'portrait',
-    message: 'Rotated to portrait',
+    confirmed: false,
+    warning:
+      'Requested portrait; the device owner reported no resulting orientation, so the rotation is unconfirmed.',
+    message: 'Rotation requested: portrait (unconfirmed)',
   });
 });
 

--- a/src/daemon/orientation-runtime.ts
+++ b/src/daemon/orientation-runtime.ts
@@ -63,6 +63,21 @@ async function executeSetOrientation(
   const result = await runtime.operations.setOrientation(
     setOrientationInput(requestedRotation, context),
   );
-  const orientation = result?.orientation ?? requestedRotation;
-  return { action: 'orientation', orientation, ...successText(`Rotated to ${orientation}`) };
+  const reported = result?.orientation;
+  if (reported) {
+    return {
+      action: 'orientation',
+      orientation: reported,
+      ...successText(`Rotated to ${reported}`),
+    };
+  }
+  // An owner that reports no resulting rotation is not evidence the device rotated: keep the
+  // requested rotation for compatibility, but disclose the unconfirmed claim instead of asserting it.
+  return {
+    action: 'orientation',
+    orientation: requestedRotation,
+    confirmed: false,
+    warning: `Requested ${requestedRotation}; the device owner reported no resulting orientation, so the rotation is unconfirmed.`,
+    ...successText(`Rotation requested: ${requestedRotation} (unconfirmed)`),
+  };
 }

--- a/src/mcp/__tests__/command-tools-navigation-schemas.test.ts
+++ b/src/mcp/__tests__/command-tools-navigation-schemas.test.ts
@@ -33,6 +33,8 @@ const NAVIGATION_DISPATCH_SHAPES: Readonly<
         enum: ['portrait', 'portrait-upside-down', 'landscape-left', 'landscape-right'],
       },
       message: { type: 'string' },
+      confirmed: { type: 'boolean' },
+      warning: { type: 'string' },
     },
     required: ['action', 'orientation', 'message'],
   },

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -491,6 +491,8 @@ const BASE_COMMAND_OUTPUT_SCHEMAS = {
       action: constSchema('orientation'),
       orientation: enumSchema(DEVICE_ROTATIONS),
       message: stringSchema(),
+      confirmed: booleanSchema(),
+      warning: stringSchema(),
     },
     ['action', 'orientation', 'message'],
   ),


### PR DESCRIPTION
# Disclose an unconfirmed rotation instead of asserting it

Fixes #2481

## What changes

`executeSetOrientation` did:

```ts
const orientation = result?.orientation ?? requestedRotation;
return { action: 'orientation', orientation, ...successText(`Rotated to ${orientation}`) };
```

When the owner reported no resulting orientation, the response asserted `Rotated to <request>` from the request alone. A pinned test ("falls back to the requested rotation when the owner reports nothing") encoded that.

Now the requested rotation is kept for compatibility, but the claim is disclosed:

- `confirmed: false`
- `warning: "Requested portrait; the device owner reported no resulting orientation, so the rotation is unconfirmed."`
- `message: "Rotation requested: portrait (unconfirmed)"`

The owner-confirmed path is unchanged.

## Tests

`src/daemon/__tests__/orientation-runtime.test.ts`: the updated test fails on the base with `Received: "Rotated to portrait"` and passes after.

## Gates

`pnpm check:affected --run`: **130 files / 646 tests, all runnable checks passed.**

## Device-lane scope (honest note)

On an iPhone 15 simulator the Apple owner either reports the observed rotation or throws (`packages/platform-apple/src/interactor.ts` verifies the runner-reported orientation), so `result?.orientation` is never empty there and this branch is defensive. On device I confirmed that the existing claim is truthful for iOS: `orientation landscape-left` really rotates the device (`simctl` screenshot 2556x1179; back to `portrait` -> 1179x2556). An app that stays portrait is a portrait-only app, not a failed rotation. So: robustness for owners that report nothing, with unit coverage only.

## Open question

Prefer a hard failure (typed error) when the owner reports nothing, or this disclosed-warning shape?
