### PR TITLE
fix(ios): refuse Simulator bridge trees that end at a web view's remote content (#2484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Fixed: iOS Simulator snapshots of Safari and of apps with a `WKWebView` stopped showing the
+  page in 0.21.0 — chrome plus empty `[webview]` nodes, no links, text, or form fields, so no ref
+  could reach the page (#2484). The host AX bridge that 0.21.0 made the Simulator's snapshot source
+  reads one process, and WebKit content lives in another; the bridge delivered the boundary as
+  an `AXRemoteElement` leaf and the tree was published as if that were the screen. The source now
+  refuses a tree whose on-screen web view ends at that leaf (`remote-content-boundary`) and the
+  route serves XCTest, which resolves remote elements, for the rest of that app generation — the
+  same path 0.20.x used. The snapshot discloses the switch through its warning, and a relaunch
+  re-enables the bridge.
 - Fixed: JUnit reports remain readable when replay results contain characters forbidden by XML 1.0,
   replacing them with U+FFFD while preserving legal Unicode and whitespace. Original suite values
   remain available in JSON and other reporters.

--- a/apple/snapshot-bridge/README.md
+++ b/apple/snapshot-bridge/README.md
@@ -48,6 +48,16 @@ resolution. Secondary owners such as the return-to-app status-bar control do
 not replace the native primary owner. The route's generation circuit remains
 disabled after fallback until that app relaunches.
 
+## Remote content
+
+The reader snapshots one process. A WebKit page — Safari's or a `WKWebView`'s —
+lives in a WebContent process and appears in that tree as an `AXRemoteElement`
+leaf under the web view. The guest returns the leaf as delivered; the host
+refuses a tree in which such a leaf sits under a web view and reaches the
+viewport, or reports no frame (`remote-content-boundary`), and routes that app
+generation to XCTest, which resolves remote elements (#2484). A zero-area or
+off-screen leaf is published: it hosts nothing the capture can miss.
+
 ## Bounded depth recovery
 
 A healthy capture uses one native request. If native acquisition rejects it,

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -42,6 +42,22 @@ fallback when bridge acquisition or presentation fails. Disable the bridge for t
 after fallback; a new app generation re-enables it. Physical devices, providers, custom-action
 captures, and interactions remain on their existing owners.
 
+A WebKit page — Safari's, or a `WKWebView`'s — lives in a WebContent process and reaches UIKit's
+tree as an `AXRemoteElement` under the web view, with its children in that other process. The
+bridge reads one process, so it delivers the element as a leaf. The source refuses a tree in which
+such a leaf sits under a `WebView`-typed ancestor and reaches the viewport (`remote-content-boundary`)
+instead of publishing a screen without its page: refs issued from it would target the host views
+around the page rather than the page. A leaf whose frame is zero-area or off screen hosts nothing
+the capture can miss and is published; one that reports no frame is refused, because nothing proves
+it empty. Remote elements outside a web view are not classified — no capture has shown one — and a
+web view truncated away by the node or depth cap stays disclosed as truncation. XCTest resolves
+remote elements, so the fallback serves the page (#2484).
+
+The refusal opens the generation circuit like any other bridge failure, so a hybrid app that showed
+one web screen takes XCTest for its remaining native screens until it relaunches — the 0.20.x path
+for every screen. Re-asking the bridge per capture would instead charge a refused bridge round trip
+to every `wait` poll on the web screen; the circuit keeps that cost to one capture per generation.
+
 Keep the two public snapshot strategies explicit:
 
 - **Regular visible strategy**: use recursive XCTest snapshots, emit the effective user-visible

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-device",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Mobile app automation and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
   "mcpName": "io.github.callstack/agent-device",
   "license": "MIT",

--- a/packages/platform-apple/src/snapshot-source/adapter.test.ts
+++ b/packages/platform-apple/src/snapshot-source/adapter.test.ts
@@ -98,6 +98,56 @@ test('the Simulator AX source returns raw acquisition facts and discloses unsupp
   }
 });
 
+test('the Simulator AX source refuses a tree that ends at content another process owns', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'agent-device-snapshot-adapter-remote-'));
+  const sourceRoot = path.join(root, 'source');
+  await (await import('@agent-device/host-kit/host-file')).ensureHostDirectory(sourceRoot);
+  for (const name of [
+    'SnapshotBridge.m',
+    'SnapshotBridgeRuntime.m',
+    'SnapshotBridgeRuntime.h',
+    'SnapshotBridgeCapture.h',
+    'SnapshotBridgeCapture.m',
+  ]) {
+    await writeFile(path.join(sourceRoot, name), 'native source');
+  }
+  const fixture = createAdapterHost();
+  fixture.remoteContent = true;
+  const source = createSimulatorSnapshotSource({
+    host: fixture.host,
+    sourceRoot,
+    cacheRoot: path.join(root, 'cache'),
+  });
+  const target = { ...targetForTest(), generation: 'generation-1', targetId: 'target-1' };
+
+  try {
+    for (const request of [
+      createIosSnapshotRequest(),
+      createIosSnapshotRequest({ acquisitionIntent: 'surface-observation' }),
+    ]) {
+      const outcome = await source.acquire({ target, hint: deriveIosCaptureHint(request) });
+      assert.equal(outcome.stage, 'failed');
+      if (outcome.stage === 'failed') {
+        assert.equal(outcome.failure.kind, 'unsupported');
+        assert.equal(outcome.failure.code, 'remote-content-boundary');
+        assert.equal(outcome.failure.details?.remoteElements, 1);
+      }
+    }
+    // A refused tree teaches no depth hint: nothing about it validated.
+    assert.deepEqual(fixture.diagnostics, []);
+
+    fixture.remoteContent = false;
+    const recovered = await source.acquire({
+      target,
+      hint: deriveIosCaptureHint(createIosSnapshotRequest()),
+    });
+    assert.equal(recovered.stage, 'acquired');
+  } finally {
+    await source.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('preparation consumes the same acquisition deadline as bridge I/O', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'agent-device-snapshot-adapter-deadline-'));
   const sourceRoot = path.join(root, 'source');
@@ -373,6 +423,8 @@ type AdapterFixture = {
   truncated: boolean;
   /** Whether the fake guest answers with sound counters but an unusable tree. */
   malformedTree: boolean;
+  /** Whether the fake guest's tree ends at another process's content (a remote element leaf). */
+  remoteContent: boolean;
   omitRecovery: boolean;
   diagnostics: Record<string, unknown>[];
 };
@@ -397,6 +449,7 @@ function createAdapterHost(buildDelayMs = 0): AdapterFixture {
     rejectLevelsAbove: undefined,
     truncated: false,
     malformedTree: false,
+    remoteContent: false,
     omitRecovery: false,
     diagnostics: [],
   };
@@ -542,7 +595,22 @@ class AdapterSocket extends EventEmitter implements SnapshotSourceSocket {
                   XC_kAXXCAttributeChildren:
                     request.maxDepth === 1
                       ? [{ XC_kAXXCAttributeElementType: 'Button', XC_kAXXCAttributeChildren: [] }]
-                      : [],
+                      : this.fixture.remoteContent
+                        ? [
+                            {
+                              XC_kAXXCAttributeElementType: 'WebView',
+                              XC_kAXXCAttributeFrame: { X: 0, Y: 0, Width: 390, Height: 844 },
+                              XC_kAXXCAttributeChildren: [
+                                {
+                                  XC_kAXXCAttributeElementType: 'AXRemoteElement',
+                                  XC_kAXXCAttributeElementBaseType: 'NSObject',
+                                  XC_kAXXCAttributeFrame: { X: 0, Y: 0, Width: 390, Height: 844 },
+                                  XC_kAXXCAttributeChildren: [],
+                                },
+                              ],
+                            },
+                          ]
+                        : [],
                 },
           },
           {

--- a/packages/platform-apple/src/snapshot-source/adapter.ts
+++ b/packages/platform-apple/src/snapshot-source/adapter.ts
@@ -231,6 +231,15 @@ function createAcquisition(
   if (typeof generation !== 'string' || !generation) {
     throw snapshotSourceError('malformed-tree', 'generation-invalid');
   }
+  // A tree that ends at a web view's out-of-process page would present the screen without the
+  // page, and refs issued from it would target the host views around it rather than the page.
+  // The source refuses it as a screen it cannot describe, like a missing automation mode, so the
+  // route serves the XCTest runner, which resolves remote elements (#2484).
+  if (decoded.opaqueRemoteElements > 0) {
+    throw snapshotSourceError('unsupported', 'remote-content-boundary', {
+      remoteElements: decoded.opaqueRemoteElements,
+    });
+  }
   const nodes = Object.freeze(
     decoded.nodes.map((node) => Object.freeze({ ...node, pid: target.pid })),
   );

--- a/packages/platform-apple/src/snapshot-source/tree.test.ts
+++ b/packages/platform-apple/src/snapshot-source/tree.test.ts
@@ -74,6 +74,74 @@ test('the bridge tree becomes one depth-first raw snapshot with viewport evidenc
     rect: { x: 0, y: 0, width: 390, height: 844 },
   });
   assert.equal(result.maxTraversalDepth, 2);
+  assert.equal(result.opaqueRemoteElements, 0);
+});
+
+test('the bridge tree counts web-hosted remote leaves that reach the viewport', () => {
+  const viewport = { X: 0, Y: 0, Width: 390, Height: 844 };
+  const remoteLeaf = (rect?: Record<string, number>) => ({
+    [application]: 'AXRemoteElement',
+    [baseType]: 'NSObject',
+    ...(rect ? { [frame]: rect } : {}),
+    [children]: [],
+  });
+  const decode = (host: Record<string, unknown>, root: Record<string, unknown> = {}) =>
+    decodeSnapshotBridgeTree(
+      { [application]: 'Application', [frame]: viewport, [children]: [host], ...root },
+      { truncated: false },
+      limits,
+    );
+  const webView = (content: Record<string, unknown>) => ({
+    [automationType]: 58,
+    [frame]: viewport,
+    [children]: [
+      {
+        [automationType]: 58,
+        [baseType]: 'WKContentView',
+        [frame]: viewport,
+        [children]: [content],
+      },
+    ],
+  });
+
+  const opaque = decode(webView(remoteLeaf(viewport)));
+  assert.equal(opaque.nodes[2]?.type, 'WebView');
+  assert.equal(opaque.nodes[3]?.role, 'AXRemoteElement');
+  assert.equal(opaque.opaqueRemoteElements, 1);
+
+  assert.equal(decode(webView(remoteLeaf())).opaqueRemoteElements, 1, 'frameless leaf refuses');
+  assert.equal(
+    decode(webView(remoteLeaf({ X: 0, Y: 0, Width: 0, Height: 0 }))).opaqueRemoteElements,
+    0,
+    'zero-area leaf hosts nothing',
+  );
+  assert.equal(
+    decode(webView(remoteLeaf({ X: 0, Y: 2000, Width: 390, Height: 600 }))).opaqueRemoteElements,
+    0,
+    'off-screen leaf is not on this screen',
+  );
+  assert.equal(
+    decode(webView(remoteLeaf({ X: 0, Y: 2000, Width: 390, Height: 600 })), { [frame]: undefined })
+      .opaqueRemoteElements,
+    1,
+    'without a viewport a positive-area leaf refuses',
+  );
+  assert.equal(
+    decode({ [automationType]: 0, [frame]: viewport, [children]: [remoteLeaf(viewport)] })
+      .opaqueRemoteElements,
+    0,
+    'a remote leaf outside a web view is not classified',
+  );
+  assert.equal(
+    decode(
+      webView({
+        ...remoteLeaf(viewport),
+        [children]: [{ [automationType]: 42, [label]: 'More information', [children]: [] }],
+      }),
+    ).opaqueRemoteElements,
+    0,
+    'a crossed boundary is not opaque',
+  );
 });
 
 test('the bridge tree rejects unknown fields, invalid frames, and bounded overflows', () => {

--- a/packages/platform-apple/src/snapshot-source/tree.ts
+++ b/packages/platform-apple/src/snapshot-source/tree.ts
@@ -1,4 +1,4 @@
-import { isPositiveFiniteRect } from '@agent-device/kernel/rect';
+import { isPositiveFiniteRect, isRectVisibleInViewport } from '@agent-device/kernel/rect';
 import type { RawSnapshotNode, Rect } from '@agent-device/kernel/snapshot';
 import type { IosViewportEvidence } from '@agent-device/contracts/ios-snapshot';
 import { snapshotSourceError } from './errors.ts';
@@ -110,6 +110,20 @@ const CLASS_PROMOTED_TYPES: Readonly<Record<string, string>> = {
 
 const NODE_KEYS = new Set<string>(Object.values(ATTRIBUTE));
 
+/**
+ * A WebKit page — Safari's, or a `WKWebView`'s — lives in a WebContent process and reaches UIKit's
+ * tree as an `AXRemoteElement` under the web view, with its children in that other process. The
+ * guest reader snapshots one process, so it delivers that element as a leaf (#2484). Such a leaf
+ * is opaque when it sits under a `WebView`-typed ancestor and its frame reaches the viewport: the
+ * page is on screen and the tree does not describe it. A leaf whose frame is zero-area or off
+ * screen hosts nothing the capture can miss; one that reports no frame at all is refused, because
+ * nothing proves it is empty. Remote elements outside a web view are not classified here — no
+ * capture has shown one — and content truncated away above the web view stays disclosed as
+ * truncation, not as a boundary.
+ */
+const REMOTE_ELEMENT_CLASS = 'AXRemoteElement';
+const WEB_VIEW_TYPE = 'WebView';
+
 export function decodeSnapshotBridgeTree(
   tree: unknown,
   envelope: Readonly<{ truncated: unknown }>,
@@ -120,9 +134,10 @@ export function decodeSnapshotBridgeTree(
     throw snapshotSourceError('malformed-tree', 'guest-tree-root-invalid');
   }
   const nodes: RawSnapshotNode[] = [];
+  const webHostedRemoteLeaves: (Rect | undefined)[] = [];
   let maxTraversalDepth = 0;
   for (const root of roots) {
-    visitNode(root, undefined, 0);
+    visitNode(root, undefined, 0, false);
   }
   if (nodes.length > limits.maxNodes) {
     throw snapshotSourceError('malformed-tree', 'node-limit-exceeded', {
@@ -139,18 +154,22 @@ export function decodeSnapshotBridgeTree(
   if (typeof envelope.truncated !== 'boolean') {
     throw snapshotSourceError('malformed-tree', 'truncated-invalid');
   }
+  const viewport = viewportFromRoot(
+    nodes.find((node) => node.type === 'Application' || node.type === 'Window'),
+  );
   return {
     nodes,
     maxTraversalDepth,
-    viewport: viewportFromRoot(
-      nodes.find((node) => node.type === 'Application' || node.type === 'Window'),
-    ),
+    viewport,
+    opaqueRemoteElements: webHostedRemoteLeaves.filter((rect) => isOpaqueRemoteLeaf(rect, viewport))
+      .length,
   };
 
   function visitNode(
     value: Record<string, unknown>,
     parentIndex: number | undefined,
     depth: number,
+    underWebView: boolean,
   ): void {
     if (nodes.length >= limits.maxNodes) {
       throw snapshotSourceError('malformed-tree', 'node-limit-exceeded', {
@@ -170,9 +189,13 @@ export function decodeSnapshotBridgeTree(
     const node = nodeFacts(value, index, parentIndex, depth);
     nodes.push(node);
     maxTraversalDepth = Math.max(maxTraversalDepth, depth);
+    if (isWebHostedRemoteLeaf(node, children.length, underWebView)) {
+      webHostedRemoteLeaves.push(node.rect);
+    }
+    const hostsWeb = underWebView || node.type === WEB_VIEW_TYPE;
     for (const child of children) {
       if (!isRecord(child)) throw snapshotSourceError('malformed-tree', 'child-invalid');
-      visitNode(child, index, depth + 1);
+      visitNode(child, index, depth + 1, hostsWeb);
     }
   }
 }
@@ -222,6 +245,20 @@ function elementTypeName(
   }
   if (automationType === undefined) return undefined;
   return ELEMENT_TYPE_NAMES[automationType] ?? 'Other';
+}
+
+function isWebHostedRemoteLeaf(
+  node: RawSnapshotNode,
+  childCount: number,
+  underWebView: boolean,
+): boolean {
+  return underWebView && node.role === REMOTE_ELEMENT_CLASS && childCount === 0;
+}
+
+function isOpaqueRemoteLeaf(rect: Rect | undefined, viewport: IosViewportEvidence): boolean {
+  if (rect === undefined) return true;
+  if (!isPositiveFiniteRect(rect)) return false;
+  return viewport.kind !== 'reported' || isRectVisibleInViewport(rect, viewport.rect);
 }
 
 function frameFromGuest(value: unknown): Rect | undefined {

--- a/packages/platform-apple/src/snapshot-source/types.ts
+++ b/packages/platform-apple/src/snapshot-source/types.ts
@@ -131,4 +131,9 @@ export type SnapshotSourceDecodedTree = Readonly<{
   nodes: readonly RawSnapshotNode[];
   viewport: IosViewportEvidence;
   maxTraversalDepth: number;
+  /**
+   * `AXRemoteElement` leaves under a web view whose frame reaches the viewport, or that report no
+   * frame: pages the reader could not cross into (#2484).
+   */
+  opaqueRemoteElements: number;
 }>;

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/callstack/agent-device",
     "source": "github"
   },
-  "version": "0.21.0",
+  "version": "0.21.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agent-device",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "transport": {
         "type": "stdio"
       },

--- a/test/integration/ios-simulator-e2e/behavior-coverage.ts
+++ b/test/integration/ios-simulator-e2e/behavior-coverage.ts
@@ -7,7 +7,8 @@ export type IosSimulatorBehaviorId =
   | 'modal-open-close'
   | 'permission-state-recovery'
   | 'regular-visible-depth-frontier'
-  | 'text-entry-keyboard-lifecycle';
+  | 'text-entry-keyboard-lifecycle'
+  | 'webview-remote-content';
 
 type BehaviorCoverageEntry =
   | {
@@ -60,6 +61,12 @@ export const IOS_SIMULATOR_BEHAVIOR_COVERAGE = {
       'regular depth 1 retains an independently projected child after its clipped structural parent is removed, while raw depth remains traversal-bounded',
     level: 'live',
     owner: 'smoke:regular-visible-depth-frontier',
+  },
+  'webview-remote-content': {
+    assertion:
+      'a WKWebView page keeps its link and field label in snapshots: the route refuses the bridge tree that ends at the remote element and discloses the XCTest fallback',
+    level: 'live',
+    owner: 'smoke:webview-remote-content',
   },
   'interrupted-system-ui-flow': {
     assertion: 'Home and app switcher expose distinct system pixels before fixture restoration',

--- a/test/integration/ios-simulator-e2e/live-assertions.ts
+++ b/test/integration/ios-simulator-e2e/live-assertions.ts
@@ -21,6 +21,24 @@ export const { assertElementText, assertWaitSelector, assertWaitText, capturePng
     PUBLIC_COMMANDS.wait,
   );
 
+export type LiveSnapshotNode = {
+  depth?: unknown;
+  identifier?: unknown;
+  index?: unknown;
+  label?: unknown;
+  parentIndex?: unknown;
+  type?: unknown;
+};
+
+export function snapshotNodes(result: { json?: any }): LiveSnapshotNode[] {
+  const nodes = result.json?.data?.nodes;
+  assert.ok(
+    Array.isArray(nodes),
+    `snapshot response did not contain nodes: ${JSON.stringify(result)}`,
+  );
+  return nodes as LiveSnapshotNode[];
+}
+
 const SCROLL_SEARCH_ATTEMPTS = 4;
 // A stalled capture says nothing about where the element is, so it must not consume the scroll
 // budget outright; a couple of retries absorb a slow runner without masking a real absence.

--- a/test/integration/ios-simulator-e2e/live-runner.ts
+++ b/test/integration/ios-simulator-e2e/live-runner.ts
@@ -17,6 +17,7 @@ import {
 import { assertAutomationInput } from './live-automation-scenario.ts';
 import { assertDeviceLifecycle } from './live-device-lifecycle.ts';
 import { assertRegularVisibleDepthFrontier } from './live-snapshot-depth-frontier.ts';
+import { assertWebViewRemoteContent } from './live-webview-remote-content.ts';
 import {
   assertLifecycleAndSystem,
   assertObservabilityAndArtifacts,
@@ -77,6 +78,7 @@ const LIVE_SCENARIOS = bindIosSimulatorScenarios<LiveContext>({
   lifecycleSystem: assertLifecycleAndSystem,
   observabilityArtifacts: assertObservabilityAndArtifacts,
   snapshotDepthFrontier: assertRegularVisibleDepthFrontier,
+  webviewRemoteContent: assertWebViewRemoteContent,
 });
 
 export async function runIosSimulatorE2E(): Promise<void> {

--- a/test/integration/ios-simulator-e2e/live-snapshot-depth-frontier.ts
+++ b/test/integration/ios-simulator-e2e/live-snapshot-depth-frontier.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 
-import { assertWaitSelector, assertWaitText } from './live-assertions.ts';
+import {
+  assertWaitSelector,
+  assertWaitText,
+  type LiveSnapshotNode as SnapshotNode,
+  snapshotNodes,
+} from './live-assertions.ts';
 import { acceptDeepLinkConfirmationIfPresent } from './live-automation-scenario.ts';
 import { type LiveContext, runStep, verifyBehavior } from './live-harness.ts';
 
@@ -8,14 +13,6 @@ const VISIBLE_DEPTH_DEEP_LINK = 'agent-device-test-app:///snapshot-depth';
 const CHILD_ID = 'visible-depth-projected-child';
 const MISSING_HITTABILITY_WARNING =
   'iOS snapshot acquisition does not provide hittability evidence; regular snapshots omit unverified hittability while raw snapshots preserve supplied facts.';
-
-type SnapshotNode = {
-  depth?: unknown;
-  identifier?: unknown;
-  index?: unknown;
-  label?: unknown;
-  parentIndex?: unknown;
-};
 
 export async function assertRegularVisibleDepthFrontier(context: LiveContext): Promise<void> {
   await runStep(context, 'open regular visible-depth fixture', [
@@ -94,15 +91,6 @@ export async function assertRegularVisibleDepthFrontier(context: LiveContext): P
     'regular-visible-depth-frontier',
     'public regular depth 1 keeps a raw-deep visible child at presented depth 1 while raw depth remains traversal-bounded',
   );
-}
-
-function snapshotNodes(result: { json?: any }): SnapshotNode[] {
-  const nodes = result.json?.data?.nodes;
-  assert.ok(
-    Array.isArray(nodes),
-    `snapshot response did not contain nodes: ${JSON.stringify(result)}`,
-  );
-  return nodes as SnapshotNode[];
 }
 
 function requireIdentifier(nodes: SnapshotNode[], identifier: string, description: string) {

--- a/test/integration/ios-simulator-e2e/live-webview-remote-content.ts
+++ b/test/integration/ios-simulator-e2e/live-webview-remote-content.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+
+import { assertWaitText, snapshotNodes } from './live-assertions.ts';
+import { acceptDeepLinkConfirmationIfPresent } from './live-automation-scenario.ts';
+import { type LiveContext, runStep, verifyBehavior } from './live-harness.ts';
+
+const WEBVIEW_LAB_DEEP_LINK = 'agent-device-test-app:///webview';
+// The first WebContent process of the run spawns here; a cold CI simulator needs more than the
+// shared 10 s wait budget before the page's tree exists.
+const PAGE_LOAD_WAIT_MS = '20000';
+// Page-only landmarks: the fixture's <title> equals its <h1>, and the web view node carries the
+// document title as its label before the body's tree exists, so the heading proves nothing.
+const PAGE_LINK = 'Jump to form';
+const PAGE_FIELD_LABEL = 'Email address';
+// The first capture of the generation refuses the bridge tree (`remote-content-boundary`) and opens
+// the circuit; every later capture reports `circuit-disabled`. Which one this snapshot sees depends
+// on how many observations the readiness waits above it consumed, so both prove the fallback.
+const XCTEST_FALLBACK_WARNING =
+  /^Simulator AX snapshot unavailable \((remote-content-boundary|circuit-disabled)\); used XCTest for this app generation\.$/;
+
+/**
+ * #2484: the host AX bridge reads one process and a WebKit page lives in another, so the bridge
+ * tree of this screen ends at an `AXRemoteElement` leaf under the web view. The route must refuse
+ * that tree and serve XCTest, which resolves remote elements, or the page's link, text, and form
+ * vanish from every snapshot and no ref can reach them.
+ */
+export async function assertWebViewRemoteContent(context: LiveContext): Promise<void> {
+  await runStep(context, 'open WebView accessibility lab', [
+    'open',
+    context.appId,
+    '--relaunch',
+    '--launch-url',
+    WEBVIEW_LAB_DEEP_LINK,
+  ]);
+  await acceptDeepLinkConfirmationIfPresent(context);
+  // `wait` observes through the same route as `snapshot`: page content is reachable only once the
+  // route has stopped publishing the bridge's page-less tree.
+  await runStep(context, 'wait for the WebView page to expose its link', [
+    'wait',
+    'text',
+    PAGE_LINK,
+    PAGE_LOAD_WAIT_MS,
+  ]);
+
+  const snapshot = await runStep(context, 'capture WebView lab snapshot', ['snapshot']);
+  const nodes = snapshotNodes(snapshot);
+  assert.ok(
+    nodes.some((node) => node.type === 'Link' && node.label === PAGE_LINK),
+    `WebView page link must be present with its semantic role: ${JSON.stringify(snapshot)}`,
+  );
+  // First-viewport content only: the fixture's form controls sit below the fold.
+  assert.ok(
+    nodes.some((node) => node.label === PAGE_FIELD_LABEL),
+    `WebView page field label "${PAGE_FIELD_LABEL}" is missing: ${JSON.stringify(snapshot)}`,
+  );
+  const warnings = snapshot.json?.data?.warnings;
+  assert.ok(
+    Array.isArray(warnings) &&
+      warnings.some(
+        (warning) => typeof warning === 'string' && XCTEST_FALLBACK_WARNING.test(warning),
+      ),
+    `WebView snapshot must disclose the XCTest fallback for remote content: ${JSON.stringify(snapshot)}`,
+  );
+
+  await runStep(context, 'restore fixture home after WebView lab', [
+    'open',
+    context.appId,
+    '--relaunch',
+  ]);
+  await assertWaitText(context, 'Agent Device Tester');
+  verifyBehavior(
+    context,
+    'webview-remote-content',
+    'a WKWebView page keeps its link and field label in snapshots because the route refuses the bridge tree that ends at the remote element and serves XCTest',
+  );
+}

--- a/test/integration/ios-simulator-e2e/scenarios.ts
+++ b/test/integration/ios-simulator-e2e/scenarios.ts
@@ -12,7 +12,8 @@ type ScenarioRunnerKey =
   | 'inventoryInstall'
   | 'lifecycleSystem'
   | 'observabilityArtifacts'
-  | 'snapshotDepthFrontier';
+  | 'snapshotDepthFrontier'
+  | 'webviewRemoteContent';
 
 type ScenarioDefinition = IosSimulatorScenario & {
   runner: ScenarioRunnerKey;
@@ -27,6 +28,7 @@ const SCENARIO_DEFINITIONS: readonly ScenarioDefinition[] = [
     runner: 'snapshotDepthFrontier',
     tier: 'smoke',
   },
+  { id: 'smoke:webview-remote-content', runner: 'webviewRemoteContent', tier: 'smoke' },
   { id: 'smoke:capture-close', runner: 'captureClose', tier: 'smoke' },
   { id: 'full:lifecycle-system', runner: 'lifecycleSystem', tier: 'full' },
   {


### PR DESCRIPTION
Fixes #2484.

## What broke

0.21.0 made the host AX bridge (`apple/snapshot-bridge`) the snapshot source for local iOS Simulators (#2279). The bridge snapshots one process by pid. WebKit content — a Safari page, a `WKWebView` — lives in a separate WebContent process and reaches UIKit's tree as an `AXRemoteElement` whose children are in that other process. The bridge delivered that element as a leaf, and the route published the tree as if it were the screen: Safari chrome plus three empty `webview` nodes, no links, text, fields, or buttons, so no ref could reach the page. The in-guest XCTest runner, which served these captures before 0.21.0, resolves remote elements.

Raw bridge output of the reporter's screen ends at:

```
{"type":"WebView","role":"WKContentView", ...}
  {"type":"Other","role":"AXRemoteElement","subrole":"NSObject","rect":{"x":0,"y":0,"width":402,"height":874}}   ← no children; page lives in WebViewProcessID=9153
```

## The fix

The source refuses a tree that ends at content another process owns, the way it refuses a missing automation mode, and the existing route fallback does the rest:

- `snapshot-source/tree.ts` counts `AXRemoteElement` leaves that sit under a `WebView`-typed ancestor and whose frame reaches the reported viewport (`opaqueRemoteElements`). A zero-area or off-screen leaf hosts nothing the capture can miss and is published; a leaf that reports no frame is refused, because nothing proves it empty; a remote element with children means the reader crossed the boundary. Remote elements outside a web view are not classified (no capture has shown one), and a web view truncated away by the node or depth cap stays disclosed as truncation.
- `snapshot-source/adapter.ts` throws `unsupported` / `remote-content-boundary` (`details.remoteElements`) after the protocol checks and before the acquisition is built, so no depth hint is learned from the refused tree.
- `snapshot-route.ts` is unchanged: `fallbackAfterFailure` serves XCTest, discloses it in the snapshot warning (`Simulator AX snapshot unavailable (remote-content-boundary); used XCTest for this app generation.`), and disables the bridge for that app generation. Later captures in the generation go straight to XCTest (`circuit-disabled`), as 0.20.x did; a relaunch re-enables the bridge.

The guest ObjC reader is untouched: the class name it already delivers is the fact, and the host owns the decision (ADR 0004).

## Evidence

Live, iPhone 17 Pro simulator (iOS 26.2), Safari on a local page with a sign-in form, CLI from this branch:

| step | before (0.21.0) | after |
| --- | --- | --- |
| `snapshot -i` | chrome + 3 empty `webview` nodes | heading `Sign in`, `text-field "Email"`, `securetextfield "Password"`, `button "Log in"`; warning `remote-content-boundary`; `snapshotQuality.backend: tree` |
| second `snapshot -i` | same | same content; warning `circuit-disabled` |
| `fill @e8 "probe@example.com"` | no ref to fill | `Filled 17 chars`; next snapshot shows the value |

The fixture app's WebView lab (`agent-device-test-app:///webview`) shows the same shape: page heading, `Link "Jump to form"`, `Email address` label present, `backend: tree`.

Observed but not in scope: the first `fill` after the fallback once failed with `no text input found at the provided coordinates to clear` and succeeded on retry; that is the runner's text-entry path on a web field, unchanged by this PR.

## Gates

- Unit: `tree.test.ts` (counting rules: on-screen, frameless, zero-area, off-screen, no viewport, outside a web view, crossed), `adapter.test.ts` (refusal for both acquisition intents, no hint learned, recovers when content is native). The route's fallback + circuit are already pinned by the existing `snapshot-route.test.ts` cases; this change adds no route branch.
- Live: new smoke scenario `smoke:webview-remote-content` in the fixture-backed iOS E2E lane (behavior `webview-remote-content`) — opens the WebView lab, `wait`s 20 s for a page-only landmark (the `Jump to form` link; the heading equals the document title, which the web view node carries before the body exists), asserts the semantic `Link` node and the `Email address` label, and that the snapshot discloses the XCTest fallback (`remote-content-boundary` or, once the circuit is open, `circuit-disabled`). No WebView went through the bridge route in any gate before.
- `snapshotNodes` moved to `live-assertions.ts` and shared with the depth-frontier scenario.
- ADR 0004 amended; bridge README gains a "Remote content" section; CHANGELOG entry.

## Review

Two adversarial review passes (core mechanics; gates and docs). Applied: scope the detector to viewport-visible, web-hosted leaves instead of any remote leaf in the tree (an off-screen prewarm or analytics `WKWebView` would otherwise have disabled the bridge for the run); state the exact frameless rule and drop an unverified "extension-hosted view" claim from ADR/README; write the per-generation circuit trade-off into ADR 0004; gate the live scenario on page-only content with a 20 s budget; drop a route test that only re-stated an existing one; reuse the kernel rect helpers. Declined: re-asking the bridge per capture instead of opening the circuit (it would charge a refused round trip to every `wait` poll on a web screen).

## Follow-ups (not here)

Scoped and ranked in #2492 after a design consultation (content-class gate, probe opens the circuit, help text, bounded WebContent spike, truncation policy).

- Bridge-native remote content: read the remote element's pid and graft a second `snapshotForProcess:` for WebContent. Needs a spike; unknown whether WebContent serves AX to a host remote-access client.
- The launch-observation probe reads the full tree, so on a web-first app it answers `unobservable` and `open` pays the fixed 300 ms settle plus one refused bridge capture before the first fallback; the probe does not open the circuit itself.
- `open <http url>` on a simulator with no app opens the URL but does not bind Safari to the session (`platform-runtime-open-target.ts` gates that fallback to physical devices), so a following `snapshot` answers `SESSION_NOT_FOUND`.
