### PR TITLE
fix(android): retire completed recording evidence after pid reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Fixed: Android `record start` no longer refuses to begin after a reused emulator reassigned the
+  previous recorder's pid. A completed recording's native marker is retired only once its recorder is
+  proven gone, but only an absent pid counted as proof — a pid that now names an unrelated process,
+  or a recorder that exited and waits to be reaped, did not. `record start` then failed every later
+  attempt with `Android screenrecord completed evidence cannot be safely retired`, and `record stop`
+  could not return an already-finalized recording. Proven termination now retires the marker and
+  returns the stored completion; a live or unreadable recorder still blocks, and the unrelated
+  process is never signalled (#2476).
 - Fixed: iOS Simulator snapshots of Safari and of apps with a `WKWebView` stopped showing the
   page in 0.21.0 — chrome plus empty `[webview]` nodes, no links, text, or form fields, so no ref
   could reach the page (#2484). The host AX bridge that 0.21.0 made the Simulator's snapshot source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   attempt with `Android screenrecord completed evidence cannot be safely retired`, and `record stop`
   could not return an already-finalized recording. Proven termination now retires the marker and
   returns the stored completion; a live or unreadable recorder still blocks, and the unrelated
-  process is never signalled (#2476).
+  process is never signalled. A reused pid that runs a replacement `screenrecord` on the same
+  remote path proves the old recorder gone but not that the path is free, so that marker and
+  artifact are retained until the replacement ends, and neither is signalled (#2476).
 - Fixed: iOS Simulator snapshots of Safari and of apps with a `WKWebView` stopped showing the
   page in 0.21.0 — chrome plus empty `[webview]` nodes, no links, text, or form fields, so no ref
   could reach the page (#2484). The host AX bridge that 0.21.0 made the Simulator's snapshot source

--- a/packages/contracts/src/screen-recording-runtime-host.test.ts
+++ b/packages/contracts/src/screen-recording-runtime-host.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import {
+  type AndroidScreenRecordingProcessOwnership,
+  provesAndroidScreenRecordTermination,
+} from './screen-recording-runtime-host.ts';
+
+const TERMINATION_PROOF: readonly (readonly [AndroidScreenRecordingProcessOwnership, boolean])[] = [
+  ['missing', true],
+  ['ownership-lost', true],
+  ['owned-alive', false],
+  ['uncertain', false],
+];
+
+test.each(TERMINATION_PROOF)(
+  'observation %s proves recorder termination as %s',
+  (ownership, expected) => {
+    expect(provesAndroidScreenRecordTermination(ownership)).toBe(expected);
+  },
+);

--- a/packages/contracts/src/screen-recording-runtime-host.test.ts
+++ b/packages/contracts/src/screen-recording-runtime-host.test.ts
@@ -1,19 +1,28 @@
 import { expect, test } from 'vitest';
 import {
   type AndroidScreenRecordingProcessOwnership,
+  provesAndroidScreenRecordPathUnclaimed,
   provesAndroidScreenRecordTermination,
 } from './screen-recording-runtime-host.ts';
 
-const TERMINATION_PROOF: readonly (readonly [AndroidScreenRecordingProcessOwnership, boolean])[] = [
-  ['missing', true],
-  ['ownership-lost', true],
-  ['owned-alive', false],
-  ['uncertain', false],
+type Proof = readonly [
+  ownership: AndroidScreenRecordingProcessOwnership,
+  termination: boolean,
+  pathUnclaimed: boolean,
 ];
 
-test.each(TERMINATION_PROOF)(
-  'observation %s proves recorder termination as %s',
-  (ownership, expected) => {
-    expect(provesAndroidScreenRecordTermination(ownership)).toBe(expected);
+const PROOFS: readonly Proof[] = [
+  ['missing', true, true],
+  ['ownership-lost', true, true],
+  ['foreign-writer', true, false],
+  ['owned-alive', false, false],
+  ['uncertain', false, false],
+];
+
+test.each(PROOFS)(
+  'observation %s proves termination as %s and an unclaimed path as %s',
+  (ownership, termination, pathUnclaimed) => {
+    expect(provesAndroidScreenRecordTermination(ownership)).toBe(termination);
+    expect(provesAndroidScreenRecordPathUnclaimed(ownership)).toBe(pathUnclaimed);
   },
 );

--- a/packages/contracts/src/screen-recording-runtime-host.ts
+++ b/packages/contracts/src/screen-recording-runtime-host.ts
@@ -94,19 +94,23 @@ export type AndroidScreenRecordingProcessIdentity = Readonly<{
   startTime: string;
 }>;
 
+/**
+ * `ownership-lost`: the pid is present, yet the identity readable there names something else — a
+ * reassigned pid, or an exited task whose command line is already gone. `foreign-writer`: the pid
+ * runs `screenrecord` on the recorded remote path but started at a different time, so a recorder
+ * that is not ours is writing that artifact. `uncertain` reads nothing conclusive.
+ */
 export type AndroidScreenRecordingProcessOwnership =
   | 'missing'
   | 'owned-alive'
   | 'ownership-lost'
+  | 'foreign-writer'
   | 'uncertain';
 
 /**
- * Whether an observation proves that the process named by the inspected identity is gone.
- *
- * `ownership-lost` is proof rather than doubt: the pid is present, yet the identity metadata that
- * was readable there named something else — a reassigned pid, or an exited task whose command line
- * is already gone — so the recorded process can no longer write its artifact. `uncertain` reads
- * nothing conclusive and proves nothing, and a matching identity is provably still running.
+ * Whether an observation proves that the process named by the inspected identity is gone. Both
+ * `ownership-lost` and `foreign-writer` are proof rather than doubt: the recorded process can no
+ * longer write its artifact.
  */
 export function provesAndroidScreenRecordTermination(
   ownership: AndroidScreenRecordingProcessOwnership,
@@ -114,7 +118,27 @@ export function provesAndroidScreenRecordTermination(
   switch (ownership) {
     case 'missing':
     case 'ownership-lost':
+    case 'foreign-writer':
       return true;
+    case 'owned-alive':
+    case 'uncertain':
+      return false;
+  }
+}
+
+/**
+ * Whether an observation proves that nothing writes the recorded remote path any more, which is
+ * what removing the artifact requires. A recorder proven gone is not proof of that: a
+ * `foreign-writer` has claimed the same path.
+ */
+export function provesAndroidScreenRecordPathUnclaimed(
+  ownership: AndroidScreenRecordingProcessOwnership,
+): boolean {
+  switch (ownership) {
+    case 'missing':
+    case 'ownership-lost':
+      return true;
+    case 'foreign-writer':
     case 'owned-alive':
     case 'uncertain':
       return false;

--- a/packages/contracts/src/screen-recording-runtime-host.ts
+++ b/packages/contracts/src/screen-recording-runtime-host.ts
@@ -100,6 +100,27 @@ export type AndroidScreenRecordingProcessOwnership =
   | 'ownership-lost'
   | 'uncertain';
 
+/**
+ * Whether an observation proves that the process named by the inspected identity is gone.
+ *
+ * `ownership-lost` is proof rather than doubt: the pid is present, yet the identity metadata that
+ * was readable there named something else — a reassigned pid, or an exited task whose command line
+ * is already gone — so the recorded process can no longer write its artifact. `uncertain` reads
+ * nothing conclusive and proves nothing, and a matching identity is provably still running.
+ */
+export function provesAndroidScreenRecordTermination(
+  ownership: AndroidScreenRecordingProcessOwnership,
+): boolean {
+  switch (ownership) {
+    case 'missing':
+    case 'ownership-lost':
+      return true;
+    case 'owned-alive':
+    case 'uncertain':
+      return false;
+  }
+}
+
 export type AndroidScreenRecordingStopOutcome =
   | 'stopped'
   | 'already-missing'

--- a/packages/platform-android/src/recording/chunks.ts
+++ b/packages/platform-android/src/recording/chunks.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
+import { provesAndroidScreenRecordTermination } from '@agent-device/contracts/screen-recording-runtime-host';
 import type {
   ScreenRecordingChunk,
   ScreenRecordingStartInput,
@@ -235,7 +236,7 @@ async function waitForStopped(
   for (let elapsed = 0; elapsed <= GRACEFUL_STOP_TIMEOUT_MS; elapsed += STOP_POLL_INTERVAL_MS) {
     const state = await transport.inspect(processIdentity);
     if (state === 'missing') return true;
-    if (state === 'ownership-lost') {
+    if (provesAndroidScreenRecordTermination(state)) {
       throw new Error(
         `Android screenrecord ownership could not be confirmed for pid ${processIdentity.pid}`,
       );

--- a/packages/platform-android/src/recording/launch.ts
+++ b/packages/platform-android/src/recording/launch.ts
@@ -1,7 +1,7 @@
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import type { ScreenRecordingStartInput } from '@agent-device/contracts/screen-recording-runtime';
-import { provesAndroidScreenRecordTermination } from '@agent-device/contracts/screen-recording-runtime-host';
+import { provesAndroidScreenRecordPathUnclaimed } from '@agent-device/contracts/screen-recording-runtime-host';
 import {
   cleanupChunks,
   AndroidScreenRecordingStartRollbackUnconfirmed,
@@ -168,7 +168,11 @@ async function retireCompletedEvidence(
       remotePath: chunk.remotePath,
       startTime: chunk.remoteStartTime,
     });
-    if (!provesAndroidScreenRecordTermination(state))
+    if (state === 'foreign-writer')
+      throw new Error(
+        'Android screenrecord completed evidence names an artifact another recorder is writing; it is retained until that recorder ends',
+      );
+    if (!provesAndroidScreenRecordPathUnclaimed(state))
       throw new Error('Android screenrecord completed evidence cannot be safely retired');
   }
   await cleanupChunks(transport, evidence.chunks);

--- a/packages/platform-android/src/recording/launch.ts
+++ b/packages/platform-android/src/recording/launch.ts
@@ -1,6 +1,7 @@
 import type { DeviceInfo } from '@agent-device/kernel/device';
 import type { PlatformRuntimeHost } from '@agent-device/contracts/platform-runtime-operations';
 import type { ScreenRecordingStartInput } from '@agent-device/contracts/screen-recording-runtime';
+import { provesAndroidScreenRecordTermination } from '@agent-device/contracts/screen-recording-runtime-host';
 import {
   cleanupChunks,
   AndroidScreenRecordingStartRollbackUnconfirmed,
@@ -167,7 +168,7 @@ async function retireCompletedEvidence(
       remotePath: chunk.remotePath,
       startTime: chunk.remoteStartTime,
     });
-    if (state !== 'missing')
+    if (!provesAndroidScreenRecordTermination(state))
       throw new Error('Android screenrecord completed evidence cannot be safely retired');
   }
   await cleanupChunks(transport, evidence.chunks);

--- a/packages/platform-android/src/recording/recovery.test.ts
+++ b/packages/platform-android/src/recording/recovery.test.ts
@@ -135,6 +135,56 @@ test('retains completed evidence while an exact persisted recorder identity rema
   expect(JSON.parse(manifest)).toHaveProperty('completion');
 });
 
+test('terminalizes completed evidence whose recorder pid was reassigned, touching nothing', async () => {
+  let manifest = '';
+  const removals: string[] = [];
+  const runtime = await start({
+    writeManifest: async ({ contents }: { contents: string }) => {
+      manifest = contents;
+    },
+    readManifest: async () =>
+      manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+    inspect: async () => 'ownership-lost' as const,
+    remove: async (remotePath: string) => {
+      removals.push(`artifact:${remotePath}`);
+      return true;
+    },
+    removeManifest: async (manifestPath: string) => {
+      removals.push(`marker:${manifestPath}`);
+      return true;
+    },
+  });
+  const started = await runtime.screenRecordingStart(recordingInput());
+  const native = JSON.parse(manifest);
+  manifest = JSON.stringify({
+    ...native,
+    completion: {
+      backend: 'adb screenrecord',
+      outPath: native.outputPath,
+      startedAt: native.startedAt,
+      completedAt: native.startedAt + 1,
+      scope: native.scope,
+      showTouches: native.showTouches,
+      recordOnlySession: native.recordOnlySession,
+    },
+  });
+
+  await expect(runtime.screenRecordingReattach({ envelope: started.envelope })).resolves.toEqual({
+    status: 'completed',
+    result: {
+      backend: 'adb screenrecord',
+      outPath: native.outputPath,
+      startedAt: native.startedAt,
+      completedAt: native.startedAt + 1,
+      scope: native.scope,
+      showTouches: native.showTouches,
+      recordOnlySession: native.recordOnlySession,
+    },
+  });
+  expect(removals).toEqual([]);
+  expect(JSON.parse(manifest)).toHaveProperty('completion');
+});
+
 test('makes matching pending evidence cleanup-eligible and stops discovered exact recorder pids', async () => {
   let manifest = '';
   const removed: string[] = [];

--- a/packages/platform-android/src/recording/recovery.test.ts
+++ b/packages/platform-android/src/recording/recovery.test.ts
@@ -158,55 +158,61 @@ test('retains completed evidence while an exact persisted recorder identity rema
   expect(JSON.parse(manifest)).toHaveProperty('completion');
 });
 
-test('terminalizes completed evidence whose recorder pid was reassigned, touching nothing', async () => {
-  let manifest = '';
-  const removals: string[] = [];
-  const runtime = await start({
-    writeManifest: async ({ contents }: { contents: string }) => {
-      manifest = contents;
-    },
-    readManifest: async () =>
-      manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
-    inspect: async () => 'ownership-lost' as const,
-    remove: async (remotePath: string) => {
-      removals.push(`artifact:${remotePath}`);
-      return true;
-    },
-    removeManifest: async (manifestPath: string) => {
-      removals.push(`marker:${manifestPath}`);
-      return true;
-    },
-  });
-  const started = await runtime.screenRecordingStart(recordingInput());
-  const native = JSON.parse(manifest);
-  manifest = JSON.stringify({
-    ...native,
-    completion: {
-      backend: 'adb screenrecord',
-      outPath: native.outputPath,
-      startedAt: native.startedAt,
-      completedAt: native.startedAt + 1,
-      scope: native.scope,
-      showTouches: native.showTouches,
-      recordOnlySession: native.recordOnlySession,
-    },
-  });
+test.each([
+  ['reassigned to an unrelated process', 'ownership-lost'],
+  ['reused by a replacement recorder on the same path', 'foreign-writer'],
+] as const)(
+  'terminalizes completed evidence whose recorder pid was %s, touching nothing',
+  async (_name, ownership) => {
+    let manifest = '';
+    const removals: string[] = [];
+    const runtime = await start({
+      writeManifest: async ({ contents }: { contents: string }) => {
+        manifest = contents;
+      },
+      readManifest: async () =>
+        manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+      inspect: async () => ownership,
+      remove: async (remotePath: string) => {
+        removals.push(`artifact:${remotePath}`);
+        return true;
+      },
+      removeManifest: async (manifestPath: string) => {
+        removals.push(`marker:${manifestPath}`);
+        return true;
+      },
+    });
+    const started = await runtime.screenRecordingStart(recordingInput());
+    const native = JSON.parse(manifest);
+    manifest = JSON.stringify({
+      ...native,
+      completion: {
+        backend: 'adb screenrecord',
+        outPath: native.outputPath,
+        startedAt: native.startedAt,
+        completedAt: native.startedAt + 1,
+        scope: native.scope,
+        showTouches: native.showTouches,
+        recordOnlySession: native.recordOnlySession,
+      },
+    });
 
-  await expect(runtime.screenRecordingReattach({ envelope: started.envelope })).resolves.toEqual({
-    status: 'completed',
-    result: {
-      backend: 'adb screenrecord',
-      outPath: native.outputPath,
-      startedAt: native.startedAt,
-      completedAt: native.startedAt + 1,
-      scope: native.scope,
-      showTouches: native.showTouches,
-      recordOnlySession: native.recordOnlySession,
-    },
-  });
-  expect(removals).toEqual([]);
-  expect(JSON.parse(manifest)).toHaveProperty('completion');
-});
+    await expect(runtime.screenRecordingReattach({ envelope: started.envelope })).resolves.toEqual({
+      status: 'completed',
+      result: {
+        backend: 'adb screenrecord',
+        outPath: native.outputPath,
+        startedAt: native.startedAt,
+        completedAt: native.startedAt + 1,
+        scope: native.scope,
+        showTouches: native.showTouches,
+        recordOnlySession: native.recordOnlySession,
+      },
+    });
+    expect(removals).toEqual([]);
+    expect(JSON.parse(manifest)).toHaveProperty('completion');
+  },
+);
 
 test('makes matching pending evidence cleanup-eligible and stops discovered exact recorder pids', async () => {
   let manifest = '';

--- a/packages/platform-android/src/recording/recovery.test.ts
+++ b/packages/platform-android/src/recording/recovery.test.ts
@@ -72,6 +72,29 @@ test('reattaches an ended pid with an artifact as finishable recovery and report
     });
 });
 
+test('discloses truncation when recovery proved the recorder gone before record stop', async () => {
+  let manifest = '';
+  const observations = ['ownership-lost', 'missing'] as const;
+  let observation = 0;
+  const runtime = await start({
+    writeManifest: async ({ contents }: { contents: string }) => {
+      manifest = contents;
+    },
+    readManifest: async () =>
+      manifest ? { status: 'read' as const, contents: manifest } : { status: 'missing' as const },
+    inspect: async () => observations[Math.min(observation++, observations.length - 1)],
+    stop: async () => 'uncertain' as const,
+  });
+  const started = await runtime.screenRecordingStart(recordingInput());
+  const reattached = await runtime.screenRecordingReattach({ envelope: started.envelope });
+  expect(reattached.status).toBe('active');
+  if (reattached.status === 'active')
+    await expect(reattached.handle.finish()).resolves.toMatchObject({
+      status: 'completed',
+      result: { warning: expect.stringContaining('likely after reaching the 180s platform limit') },
+    });
+});
+
 test('returns fenced native completion after a crash between native finalization and daemon terminalization', async () => {
   let manifest = '';
   const removals: string[] = [];

--- a/packages/platform-android/src/recording/recovery.ts
+++ b/packages/platform-android/src/recording/recovery.ts
@@ -176,7 +176,7 @@ async function reattachEvidence(params: {
         evidence,
         manifestPath: descriptor.manifestPath,
         recording: current,
-        reachedLimit: running === 'missing',
+        reachedLimit: provesAndroidScreenRecordTermination(running),
       });
       nativeCleanupConfirmed = true;
       return outcome;

--- a/packages/platform-android/src/recording/recovery.ts
+++ b/packages/platform-android/src/recording/recovery.ts
@@ -4,6 +4,7 @@ import type {
   ScreenRecordingRuntimeOperations,
   ScreenRecordingStartInput,
 } from '@agent-device/contracts/screen-recording-runtime';
+import { provesAndroidScreenRecordTermination } from '@agent-device/contracts/screen-recording-runtime-host';
 import { createScreenRecordingLiveHandle } from '@agent-device/capture-kit';
 import {
   androidScreenRecordingDescriptorCodec,
@@ -192,11 +193,13 @@ async function completedEvidenceIsTerminal(transport: Transport, evidence: Nativ
   try {
     for (const chunk of evidence.chunks) {
       if (
-        (await transport.inspect({
-          pid: chunk.remotePid,
-          remotePath: chunk.remotePath,
-          startTime: chunk.remoteStartTime,
-        })) !== 'missing'
+        !provesAndroidScreenRecordTermination(
+          await transport.inspect({
+            pid: chunk.remotePid,
+            remotePath: chunk.remotePath,
+            startTime: chunk.remoteStartTime,
+          }),
+        )
       )
         return false;
     }

--- a/packages/platform-android/src/recording/start-reconciliation.test.ts
+++ b/packages/platform-android/src/recording/start-reconciliation.test.ts
@@ -138,6 +138,43 @@ test.each([
   expect(calls).toEqual([]);
 });
 
+test('retains completed evidence and its marker while a replacement recorder writes the same path', async () => {
+  const marker = JSON.stringify(completedEvidence());
+  const calls: string[] = [];
+  const runtime = await start({
+    readManifest: async (path: string) =>
+      path.startsWith('/sdcard')
+        ? { status: 'read' as const, contents: marker }
+        : { status: 'missing' as const },
+    inspect: async () => 'foreign-writer' as const,
+    stop: async ({ pid }: { pid: string }) => {
+      calls.push(`signal:${pid}`);
+      return 'already-missing' as const;
+    },
+    remove: async (path: string) => {
+      calls.push(`artifact:${path}`);
+      return true;
+    },
+    removeManifest: async () => {
+      calls.push('manifest');
+      return true;
+    },
+    outputs: {
+      prepare: async () => {
+        calls.push('prepare');
+      },
+    },
+    start: async () => {
+      calls.push('launch');
+      return recordingProcess('77');
+    },
+  });
+  await expect(runtime.screenRecordingStart(newInput())).rejects.toThrow(
+    'another recorder is writing',
+  );
+  expect(calls).toEqual([]);
+});
+
 test('retirement failure blocks launch and can succeed on a later retry', async () => {
   let marker = JSON.stringify(completedEvidence());
   let allowRemoval = false;

--- a/packages/platform-android/src/recording/start-reconciliation.test.ts
+++ b/packages/platform-android/src/recording/start-reconciliation.test.ts
@@ -56,6 +56,88 @@ test('reconciles coherent completed evidence before output preparation or launch
   await started.pendingHandle.transfer().forceCleanup();
 });
 
+test('retires completed evidence whose recorder pid was reassigned, signaling nothing', async () => {
+  let marker = JSON.stringify(completedEvidence());
+  const calls: string[] = [];
+  const runtime = await start({
+    readManifest: async (path: string) =>
+      path.startsWith('/sdcard') && marker
+        ? { status: 'read' as const, contents: marker }
+        : { status: 'missing' as const },
+    inspect: async () => 'ownership-lost' as const,
+    stop: async ({ pid }: { pid: string }) => {
+      calls.push(`signal:${pid}`);
+      return 'already-missing' as const;
+    },
+    remove: async (path: string) => {
+      calls.push(`artifact:${path}`);
+      return true;
+    },
+    removeManifest: async () => {
+      calls.push('manifest');
+      marker = '';
+      return true;
+    },
+    outputs: {
+      prepare: async () => {
+        calls.push('prepare');
+      },
+    },
+    start: async () => {
+      calls.push('launch');
+      return recordingProcess('77');
+    },
+  });
+  const started = await runtime.screenRecordingStart(newInput());
+  expect(calls).toEqual([
+    'artifact:/sdcard/agent-device-recording-1.mp4',
+    'manifest',
+    'prepare',
+    'launch',
+  ]);
+  await started.pendingHandle.transfer().forceCleanup();
+});
+
+test.each([
+  ['an unconfirmed recorder identity', 'uncertain'],
+  ['a live recorder', 'owned-alive'],
+])('refuses completed evidence named by %s', async (_name, ownership) => {
+  const marker = JSON.stringify(completedEvidence());
+  const calls: string[] = [];
+  const runtime = await start({
+    readManifest: async (path: string) =>
+      path.startsWith('/sdcard')
+        ? { status: 'read' as const, contents: marker }
+        : { status: 'missing' as const },
+    inspect: async () => ownership,
+    stop: async ({ pid }: { pid: string }) => {
+      calls.push(`signal:${pid}`);
+      return 'already-missing' as const;
+    },
+    remove: async () => {
+      calls.push('artifact');
+      return true;
+    },
+    removeManifest: async () => {
+      calls.push('manifest');
+      return true;
+    },
+    outputs: {
+      prepare: async () => {
+        calls.push('prepare');
+      },
+    },
+    start: async () => {
+      calls.push('launch');
+      return recordingProcess('77');
+    },
+  });
+  await expect(runtime.screenRecordingStart(newInput())).rejects.toThrow(
+    'cannot be safely retired',
+  );
+  expect(calls).toEqual([]);
+});
+
 test('retirement failure blocks launch and can succeed on a later retry', async () => {
   let marker = JSON.stringify(completedEvidence());
   let allowRemoval = false;

--- a/src/platform-runtime-screen-recording-android-host.test.ts
+++ b/src/platform-runtime-screen-recording-android-host.test.ts
@@ -196,12 +196,19 @@ test('retains an interrupted empty-stderr manifest probe as unavailable', async 
   }
 });
 
-test('proves termination for a reassigned pid and an exited task, and never for an unreadable one', async () => {
+test('proves termination from each ownership-lost producer without signalling', async () => {
   const commands: string[] = [];
-  let identity: { stat: string; cmdline: string } = {
-    stat: procStat(4004, '5432'),
+  const recorded = { pid: '4004', remotePath: '/sdcard/capture.mp4', startTime: '3766' };
+  const reassignedPid = {
+    stat: procStat(4004, '3766'),
     cmdline: ['/system/bin/servicemanager', ''].join('\0'),
   };
+  const otherArtifact = {
+    stat: procStat(4004, '3766'),
+    cmdline: ['/system/bin/screenrecord', '--bit-rate', '8000000', '/other.mp4', ''].join('\0'),
+  };
+  const exitedTask = { stat: procStat(4004, '3766'), cmdline: '' };
+  let identity = reassignedPid;
   await withAndroidAdbProvider(
     {
       exec: async (args) => {
@@ -215,16 +222,11 @@ test('proves termination for a reassigned pid and an exited task, and never for 
     { serial: android.id },
     async () => {
       const transport = await createAndroidScreenRecordingTransport(android);
-      const recorded = { pid: '4004', remotePath: '/sdcard/capture.mp4', startTime: '3766' };
-      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
-      identity = {
-        stat: procStat(4004, '3766'),
-        cmdline: ['/system/bin/screenrecord', '--bit-rate', '8000000', '/other.mp4', ''].join('\0'),
-      };
-      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
-      identity = { stat: procStat(4004, '3766'), cmdline: '' };
-      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
-      identity = { stat: procStat(4004, '3766'), cmdline: '' };
+      for (const replacement of [reassignedPid, otherArtifact, exitedTask]) {
+        identity = replacement;
+        await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
+      }
+      identity = exitedTask;
       await expect(transport.stop(recorded)).resolves.toBe('ownership-lost');
       expect(commands.some((command) => command.startsWith('kill '))).toBe(false);
     },

--- a/src/platform-runtime-screen-recording-android-host.test.ts
+++ b/src/platform-runtime-screen-recording-android-host.test.ts
@@ -233,6 +233,35 @@ test('proves termination from each ownership-lost producer without signalling', 
   );
 });
 
+test('classifies a replacement recorder on the same path as a foreign writer and never signals it', async () => {
+  const commands: string[] = [];
+  const recorded = { pid: '4004', remotePath: '/sdcard/capture.mp4', startTime: '3766' };
+  const replacementRecorder = {
+    stat: procStat(4004, '9911'),
+    cmdline: ['/system/bin/screenrecord', '--bit-rate', '8000000', recorded.remotePath, ''].join(
+      '\0',
+    ),
+  };
+  await withAndroidAdbProvider(
+    {
+      exec: async (args) => {
+        const command = args[1] ?? '';
+        commands.push(command);
+        if (command.endsWith('/stat')) return result(replacementRecorder.stat);
+        if (command.endsWith('/cmdline')) return result(replacementRecorder.cmdline);
+        return result('');
+      },
+    },
+    { serial: android.id },
+    async () => {
+      const transport = await createAndroidScreenRecordingTransport(android);
+      await expect(transport.inspect(recorded)).resolves.toBe('foreign-writer');
+      await expect(transport.stop(recorded)).resolves.toBe('ownership-lost');
+      expect(commands.some((command) => command.startsWith('kill '))).toBe(false);
+    },
+  );
+});
+
 function procStat(pid: number, startTime: string): string {
   return `${pid} (screenrecord) S ${Array.from({ length: 18 }, () => '0').join(' ')} ${startTime}`;
 }

--- a/src/platform-runtime-screen-recording-android-host.test.ts
+++ b/src/platform-runtime-screen-recording-android-host.test.ts
@@ -196,6 +196,41 @@ test('retains an interrupted empty-stderr manifest probe as unavailable', async 
   }
 });
 
+test('proves termination for a reassigned pid and an exited task, and never for an unreadable one', async () => {
+  const commands: string[] = [];
+  let identity: { stat: string; cmdline: string } = {
+    stat: procStat(4004, '5432'),
+    cmdline: ['/system/bin/servicemanager', ''].join('\0'),
+  };
+  await withAndroidAdbProvider(
+    {
+      exec: async (args) => {
+        const command = args[1] ?? '';
+        commands.push(command);
+        if (command.endsWith('/stat')) return result(identity.stat);
+        if (command.endsWith('/cmdline')) return result(identity.cmdline);
+        return result('');
+      },
+    },
+    { serial: android.id },
+    async () => {
+      const transport = await createAndroidScreenRecordingTransport(android);
+      const recorded = { pid: '4004', remotePath: '/sdcard/capture.mp4', startTime: '3766' };
+      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
+      identity = {
+        stat: procStat(4004, '3766'),
+        cmdline: ['/system/bin/screenrecord', '--bit-rate', '8000000', '/other.mp4', ''].join('\0'),
+      };
+      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
+      identity = { stat: procStat(4004, '3766'), cmdline: '' };
+      await expect(transport.inspect(recorded)).resolves.toBe('ownership-lost');
+      identity = { stat: procStat(4004, '3766'), cmdline: '' };
+      await expect(transport.stop(recorded)).resolves.toBe('ownership-lost');
+      expect(commands.some((command) => command.startsWith('kill '))).toBe(false);
+    },
+  );
+});
+
 function procStat(pid: number, startTime: string): string {
   return `${pid} (screenrecord) S ${Array.from({ length: 18 }, () => '0').join(' ')} ${startTime}`;
 }

--- a/src/platform-runtime-screen-recording-android-host.ts
+++ b/src/platform-runtime-screen-recording-android-host.ts
@@ -50,6 +50,7 @@ export async function createAndroidScreenRecordingTransport(
     stop: async (process, options, signal) => {
       const inspected = await inspectAndroidScreenRecordingProcess(shell, process, signal);
       if (inspected.status === 'missing') return 'already-missing';
+      if (inspected.status === 'foreign-writer') return 'ownership-lost';
       if (inspected.status !== 'owned-alive') return inspected.status;
       const stopped = await shell(`kill ${options?.force ? '-9 ' : '-2 '}${process.pid}`, signal);
       return stopped.exitCode === 0 ? 'stopped' : 'uncertain';
@@ -157,7 +158,7 @@ async function inspectAndroidScreenRecordingProcess(
     return { status: 'ownership-lost' };
   }
   if (expected.startTime.length > 0 && expected.startTime !== startTime) {
-    return { status: 'ownership-lost' };
+    return { status: 'foreign-writer' };
   }
   return {
     status: 'owned-alive',

--- a/src/platform-runtime-screen-recording-android-host.ts
+++ b/src/platform-runtime-screen-recording-android-host.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type {
   AndroidScreenRecordingProcessIdentity,
+  AndroidScreenRecordingProcessOwnership,
   AndroidScreenRecordingTransport,
 } from '@agent-device/contracts/screen-recording-runtime-host';
 import type { DeviceInfo } from '@agent-device/kernel/device';
@@ -140,7 +141,7 @@ async function inspectAndroidScreenRecordingProcess(
   signal?: AbortSignal,
 ): Promise<
   Readonly<{
-    status: 'missing' | 'owned-alive' | 'ownership-lost' | 'uncertain';
+    status: AndroidScreenRecordingProcessOwnership;
     process?: AndroidScreenRecordingProcessIdentity;
   }>
 > {

--- a/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
+++ b/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { likelyPlayableMp4Container } from './harness.ts';
 import {
   manifestPath,
@@ -9,12 +10,19 @@ import type { AndroidAdbProvider } from '@agent-device/platform-android/mechanic
 
 export type PullCall = { remotePath: string; localPath: string };
 
-type NativeProcess = { remotePath: string; startTime: string; alive: boolean };
+type NativeProcess = {
+  remotePath: string;
+  startTime: string;
+  alive: boolean;
+  executable?: string;
+};
 type ProviderState = {
   manifests: Map<string, AndroidRecordingManifestFixture>;
   processes: Map<string, NativeProcess>;
   pulls: number;
 };
+/** A live, unrelated process the Android kernel placed on a previously recorded pid. */
+export type ReusedAndroidRecordingPid = { pid: string; startTime: string };
 
 export function createAndroidRecordingProvider(params: {
   manifests?: readonly AndroidRecordingManifestFixture[];
@@ -22,8 +30,9 @@ export function createAndroidRecordingProvider(params: {
   pulls?: PullCall[];
   onPull?: (remotePath: string, localPath: string, count: number) => void;
   deadPids?: readonly string[];
+  reusedPids?: readonly ReusedAndroidRecordingPid[];
 }): AndroidAdbProvider {
-  const state = createProviderState(params.manifests, params.deadPids);
+  const state = createProviderState(params.manifests, params.deadPids, params.reusedPids);
   return {
     exec: async (args) => respondToCommand(args, params, state),
   };
@@ -32,13 +41,24 @@ export function createAndroidRecordingProvider(params: {
 function createProviderState(
   initialManifests: readonly AndroidRecordingManifestFixture[] = [],
   deadPids: readonly string[] = [],
+  reusedPids: readonly ReusedAndroidRecordingPid[] = [],
 ): ProviderState {
   const state: ProviderState = { manifests: new Map(), processes: new Map(), pulls: 0 };
   for (const manifest of initialManifests) {
     state.manifests.set(manifestPath(manifest), manifest);
     addManifestProcesses(manifest, state.processes, deadPids);
   }
+  for (const reused of reusedPids) reusePid(reused, state.processes);
   return state;
+}
+
+function reusePid(reused: ReusedAndroidRecordingPid, processes: Map<string, NativeProcess>): void {
+  processes.set(reused.pid, {
+    remotePath: processes.get(reused.pid)?.remotePath ?? '',
+    startTime: reused.startTime,
+    alive: true,
+    executable: '/system/bin/servicemanager',
+  });
 }
 
 function respondToCommand(
@@ -192,14 +212,19 @@ function processResult(
 ) {
   const nativeProcess = processes.get(pid);
   if (!nativeProcess?.alive) return missing();
+  const executable = nativeProcess.executable ?? '/system/bin/screenrecord';
   return field === 'stat'
     ? ok(
-        `${pid} (screenrecord) S ${Array.from({ length: 18 }, () => '0').join(' ')} ${nativeProcess.startTime}`,
+        `${pid} (${path.posix.basename(executable)}) S ${Array.from({ length: 18 }, () => '0').join(' ')} ${nativeProcess.startTime}`,
       )
     : ok(
-        ['/system/bin/screenrecord', '--bit-rate', '8000000', nativeProcess.remotePath, ''].join(
-          '\0',
-        ),
+        [
+          executable,
+          ...(executable === '/system/bin/screenrecord'
+            ? ['--bit-rate', '8000000', nativeProcess.remotePath]
+            : []),
+          '',
+        ].join('\0'),
       );
 }
 

--- a/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
+++ b/test/integration/provider-scenarios/android-recording-provider-fixtures.ts
@@ -21,8 +21,15 @@ type ProviderState = {
   processes: Map<string, NativeProcess>;
   pulls: number;
 };
-/** A live, unrelated process the Android kernel placed on a previously recorded pid. */
-export type ReusedAndroidRecordingPid = { pid: string; startTime: string };
+/**
+ * A live process the Android kernel placed on a previously recorded pid: unrelated by default, or a
+ * replacement `screenrecord` writing the same remote path.
+ */
+export type ReusedAndroidRecordingPid = {
+  pid: string;
+  startTime: string;
+  role?: 'unrelated' | 'replacement-recorder';
+};
 
 export function createAndroidRecordingProvider(params: {
   manifests?: readonly AndroidRecordingManifestFixture[];
@@ -57,7 +64,10 @@ function reusePid(reused: ReusedAndroidRecordingPid, processes: Map<string, Nati
     remotePath: processes.get(reused.pid)?.remotePath ?? '',
     startTime: reused.startTime,
     alive: true,
-    executable: '/system/bin/servicemanager',
+    executable:
+      reused.role === 'replacement-recorder'
+        ? '/system/bin/screenrecord'
+        : '/system/bin/servicemanager',
   });
 }
 

--- a/test/integration/provider-scenarios/android-recording.test.ts
+++ b/test/integration/provider-scenarios/android-recording.test.ts
@@ -198,6 +198,72 @@ test('Provider-backed integration Android record start retires completed evidenc
   );
 });
 
+test('Provider-backed integration Android record start retains completed evidence while a replacement recorder writes its path', async () => {
+  await withAndroidRecordingScenario(
+    'agent-device-provider-scenario-android-foreign-writer-',
+    async (tmpDir) => {
+      const calls: string[][] = [];
+      const outputPath = path.join(tmpDir, 'foreign.mp4');
+      const remotePath = '/sdcard/agent-device-recording-723456789.mp4';
+      const manifest = buildAndroidRecordingManifest({
+        outPath: outputPath,
+        remotePath,
+        sessionName: 'default',
+        chunks: [{ index: 1, remotePath, remotePid: '4004', remoteStartTime: '3766' }],
+        completion: {
+          backend: 'adb screenrecord',
+          outPath: outputPath,
+          startedAt: 123456789,
+          completedAt: 123456999,
+          scope: 'device',
+          showTouches: true,
+          recordOnlySession: false,
+        },
+      });
+      const daemon = await createAndroidRecordingScenarioHarness({
+        androidAdbProvider: () =>
+          createAndroidRecordingProvider({
+            calls,
+            manifests: [manifest],
+            reusedPids: [{ pid: '4004', startTime: '9911', role: 'replacement-recorder' }],
+          }),
+        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_ANDROID],
+      });
+      try {
+        assertRpcError(
+          await daemon.callCommand('record', ['start', outputPath], {
+            platform: 'android',
+            serial: PROVIDER_SCENARIO_ANDROID.id,
+            recordingScope: 'device',
+          }),
+          'UNKNOWN',
+          /another recorder is writing/,
+        );
+        assert.equal(
+          calls.some((args) => args.join(' ') === `shell rm -f '${remotePath}'`),
+          false,
+          'the replacement recorder keeps its artifact',
+        );
+        assert.equal(
+          calls.some((args) => args.join(' ') === ANDROID_MARKER_REMOVAL),
+          false,
+          'the completed marker is retained',
+        );
+        assert.equal(
+          calls.some((args) => args[1]?.startsWith('kill ')),
+          false,
+        );
+        assert.equal(
+          calls.some((args) => args[1]?.startsWith('screenrecord --bit-rate ')),
+          false,
+        );
+      } finally {
+        await daemon.close();
+      }
+    },
+  );
+});
+
 test('Provider-backed integration Android record start refuses completed evidence whose recorder is alive', async () => {
   await withAndroidRecordingScenario(
     'agent-device-provider-scenario-android-pid-alive-',

--- a/test/integration/provider-scenarios/android-recording.test.ts
+++ b/test/integration/provider-scenarios/android-recording.test.ts
@@ -134,6 +134,129 @@ test('Provider-backed integration Android record stop returns fenced completed n
   );
 });
 
+const ANDROID_MARKER_REMOVAL = "shell rm -f '/sdcard/agent-device-recording-active.json'";
+
+test('Provider-backed integration Android record start retires completed evidence after the emulator reassigns its recorder pid', async () => {
+  await withAndroidRecordingScenario(
+    'agent-device-provider-scenario-android-pid-reuse-',
+    async (tmpDir) => {
+      const calls: string[][] = [];
+      const previousPath = path.join(tmpDir, 'previous.mp4');
+      const outputPath = path.join(tmpDir, 'reused.mp4');
+      const remotePath = '/sdcard/agent-device-recording-523456789.mp4';
+      const manifest = buildAndroidRecordingManifest({
+        outPath: previousPath,
+        remotePath,
+        sessionName: 'default',
+        chunks: [{ index: 1, remotePath, remotePid: '4004', remoteStartTime: '3766' }],
+        completion: {
+          backend: 'adb screenrecord',
+          outPath: previousPath,
+          startedAt: 123456789,
+          completedAt: 123456999,
+          scope: 'device',
+          showTouches: true,
+          recordOnlySession: false,
+        },
+      });
+      fs.writeFileSync(previousPath, 'saved recording');
+      const daemon = await createAndroidRecordingScenarioHarness({
+        androidAdbProvider: () =>
+          createAndroidRecordingProvider({
+            calls,
+            manifests: [manifest],
+            reusedPids: [{ pid: '4004', startTime: '5432' }],
+          }),
+        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_ANDROID],
+      });
+      try {
+        const started = await daemon.callCommand('record', ['start', outputPath], {
+          platform: 'android',
+          serial: PROVIDER_SCENARIO_ANDROID.id,
+          recordingScope: 'device',
+        });
+        assert.equal(assertRpcOk<{ recording?: unknown }>(started).recording, 'started');
+        assert.ok(
+          calls.some((args) => args.join(' ') === `shell rm -f '${remotePath}'`),
+          'retired the completed chunk artifact',
+        );
+        assert.ok(
+          calls.some((args) => args.join(' ') === ANDROID_MARKER_REMOVAL),
+          'retired the completed native marker',
+        );
+        assert.equal(
+          calls.some((args) => args[1]?.startsWith('kill ')),
+          false,
+          'the reassigned pid must never be signalled',
+        );
+        assert.ok(calls.some((args) => args[1]?.startsWith('screenrecord --bit-rate ')));
+        assert.equal(fs.existsSync(previousPath), true, 'retirement is device-side only');
+      } finally {
+        await daemon.close();
+      }
+    },
+  );
+});
+
+test('Provider-backed integration Android record start refuses completed evidence whose recorder is alive', async () => {
+  await withAndroidRecordingScenario(
+    'agent-device-provider-scenario-android-pid-alive-',
+    async (tmpDir) => {
+      const calls: string[][] = [];
+      const outputPath = path.join(tmpDir, 'alive.mp4');
+      const remotePath = '/sdcard/agent-device-recording-623456789.mp4';
+      const manifest = buildAndroidRecordingManifest({
+        outPath: outputPath,
+        remotePath,
+        sessionName: 'default',
+        chunks: [{ index: 1, remotePath, remotePid: '4004', remoteStartTime: '3766' }],
+        completion: {
+          backend: 'adb screenrecord',
+          outPath: outputPath,
+          startedAt: 123456789,
+          completedAt: 123456999,
+          scope: 'device',
+          showTouches: true,
+          recordOnlySession: false,
+        },
+      });
+      const daemon = await createAndroidRecordingScenarioHarness({
+        androidAdbProvider: () => createAndroidRecordingProvider({ calls, manifests: [manifest] }),
+        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_ANDROID],
+      });
+      try {
+        assertRpcError(
+          await daemon.callCommand('record', ['start', outputPath], {
+            platform: 'android',
+            serial: PROVIDER_SCENARIO_ANDROID.id,
+            recordingScope: 'device',
+          }),
+          'UNKNOWN',
+          /cannot be safely retired/,
+        );
+        assert.equal(
+          calls.some((args) => args[1]?.startsWith('kill ')),
+          false,
+        );
+        assert.equal(
+          calls.some((args) => args[1]?.startsWith('screenrecord --bit-rate ')),
+          false,
+        );
+        assert.equal(
+          calls.some((args) => args.join(' ') === ANDROID_MARKER_REMOVAL),
+          false,
+        );
+        assert.equal(
+          calls.some((args) => args.join(' ') === `shell rm -f '${remotePath}'`),
+          false,
+        );
+      } finally {
+        await daemon.close();
+      }
+    },
+  );
+});
+
 test('Provider-backed integration Android corrupt descriptor is retained without native cleanup', async () => {
   await withAndroidRecordingScenario(
     'agent-device-provider-scenario-android-corrupt-',


### PR DESCRIPTION
## Summary

On a reused emulator the pid a completed Android recording named can be reassigned. The transport
proves that with `ownership-lost`, but completed-evidence retirement and reattach accepted only
`missing`, so they read proven termination as an uncertain live recorder: every later `record start`
died on `Android screenrecord completed evidence cannot be safely retired`, and `record stop` could
not return an already-finalized recording. Closes #2476.

The four ownership observations are now classified once, in the contract that declares them
(`provesAndroidScreenRecordTermination`), and the completed-evidence decisions ask that question
instead of comparing to `missing`. Retirement still refuses a live or unreadable recorder; it removes
device-side files only and never signals a pid it proved is not its own. A recovered recording whose
recorder was already proven gone now discloses that its MP4 may be truncated. 11 files, two commits.

Deferred, matching the issue's conservatism instruction for live and incomplete recordings:
`stopChunk` and `waitForStopped` still refuse to read `ownership-lost` as stopped, so an open
recording whose recorder died and whose pid was reused needs its own decision — as does a typed
reason for this refusal, which surfaces as `UNKNOWN` today.

## Validation

Tested `204e447fec4` on Node 26.8.1.

- Mapping `ownership-lost` back to "not gone" fails the new start test, the new provider scenario and
  the truncation-warning test; the alive-recorder test passes with and without the fix.
- The transport test attributes each producer: reassigned executable, foreign remote path, exited
  task with no command line.
- 72 unit tests and 7 provider scenarios pass; the reuse case runs end to end against a fake `adb`.
- `pnpm check:affected --run` passes every runnable gate: 1,551 tests / 253 files plus format, lint,
  types, layering, Fallow and build. GitHub CI is pending.
