### PR TITLE
chore(react-devtools): pin agent-react-devtools 0.5.0 for React Native 0.87+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-device",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Mobile app automation and verification for AI coding agents. CLI, MCP server, and typed Node.js API for iOS, Android, HarmonyOS, TV, web, macOS, and Linux.",
   "mcpName": "io.github.callstack/agent-device",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/callstack/agent-device",
     "source": "github"
   },
-  "version": "0.21.0",
+  "version": "0.21.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agent-device",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/cli-react-devtools.test.ts
+++ b/src/__tests__/cli-react-devtools.test.ts
@@ -43,12 +43,12 @@ afterEach(() => {
 });
 
 test('react-devtools passthrough pins agent-react-devtools package version', () => {
-  assert.equal(AGENT_REACT_DEVTOOLS_PACKAGE, 'agent-react-devtools@0.4.0');
+  assert.equal(AGENT_REACT_DEVTOOLS_PACKAGE, 'agent-react-devtools@0.5.0');
   assert.deepEqual(buildReactDevtoolsNpmExecArgs(['get', 'tree', '--depth', '3']), [
     'exec',
     '--yes',
     '--package',
-    'agent-react-devtools@0.4.0',
+    'agent-react-devtools@0.5.0',
     '--',
     'agent-react-devtools',
     'get',
@@ -221,7 +221,7 @@ test('react-devtools stop cleans up remote companion', async () => {
     'exec',
     '--yes',
     '--package',
-    'agent-react-devtools@0.4.0',
+    'agent-react-devtools@0.5.0',
     '--',
     'agent-react-devtools',
     'stop',

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -502,8 +502,8 @@ Rules:
   For cross-platform validation with explicit device selectors, use separate sessions/devices and restart react-devtools between platforms.
   Remote Android and iOS bridge runs normally through agent-device react-devtools; the CLI keeps the needed local service tunnel alive until agent-device react-devtools stop or disconnect. Expo support depends on the SDK's bundled React Native runtime.
   Remote iOS apps attempt the legacy React DevTools websocket during JavaScript startup. If the app was already open before react-devtools start, run open <bundle-id> --platform ios --relaunch, then wait --connected.
-  React Native 0.87+ needs a one-time npx agent-react-devtools init in the app project, then a rebundle, before wait --connected can succeed. Run npx agent-react-devtools uninit when the task is done unless the user wants to keep the setup.
-  If status shows 0 connected apps, nothing was observed; an empty result is not a clean pass.
+  React Native 0.87+ needs agent-react-devtools installed as a dev dependency of the app project, then a one-time npx agent-react-devtools init there and a rebundle, before wait --connected can succeed. The npm exec package this wrapper runs is temporary and does not install it into the app. Run npx agent-react-devtools uninit when the task is done unless the user wants to keep the setup.
+  Verify an attached app with status or wait --connected before trusting any result. With 0 connected apps, count, errors, and get tree return empty results that look like a clean pass.
 
 Example:
   agent-device react-devtools status

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -502,9 +502,8 @@ Rules:
   For cross-platform validation with explicit device selectors, use separate sessions/devices and restart react-devtools between platforms.
   Remote Android and iOS bridge runs normally through agent-device react-devtools; the CLI keeps the needed local service tunnel alive until agent-device react-devtools stop or disconnect. Expo support depends on the SDK's bundled React Native runtime.
   Remote iOS apps attempt the legacy React DevTools websocket during JavaScript startup. If the app was already open before react-devtools start, run open <bundle-id> --platform ios --relaunch, then wait --connected.
-  React Native 0.87+ removed the built-in DevTools websocket. The app must run agent-react-devtools init once (Metro wrapper plus an entry import) and be rebundled, or wait --connected never succeeds. On older React Native no app change is needed.
-  init edits the project's metro.config.js and entry file. When the profiling or debugging task is done, run agent-react-devtools uninit in the project and rebundle, so those edits are not left in the user's diff. Skip uninit only if the user asked to keep the setup.
-  With no app attached, status reports 0 connected and the observation commands fail; never read an empty result as a clean pass.
+  React Native 0.87+ needs a one-time npx agent-react-devtools init in the app project, then a rebundle, before wait --connected can succeed. Run npx agent-react-devtools uninit when the task is done unless the user wants to keep the setup.
+  If status shows 0 connected apps, nothing was observed; an empty result is not a clean pass.
 
 Example:
   agent-device react-devtools status

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -503,6 +503,7 @@ Rules:
   Remote Android and iOS bridge runs normally through agent-device react-devtools; the CLI keeps the needed local service tunnel alive until agent-device react-devtools stop or disconnect. Expo support depends on the SDK's bundled React Native runtime.
   Remote iOS apps attempt the legacy React DevTools websocket during JavaScript startup. If the app was already open before react-devtools start, run open <bundle-id> --platform ios --relaunch, then wait --connected.
   React Native 0.87+ removed the built-in DevTools websocket. The app must run agent-react-devtools init once (Metro wrapper plus an entry import) and be rebundled, or wait --connected never succeeds. On older React Native no app change is needed.
+  init edits the project's metro.config.js and entry file. When the profiling or debugging task is done, run agent-react-devtools uninit in the project and rebundle, so those edits are not left in the user's diff. Skip uninit only if the user asked to keep the setup.
   With no app attached, status reports 0 connected and the observation commands fail; never read an empty result as a clean pass.
 
 Example:

--- a/src/cli-schema/cli-help.ts
+++ b/src/cli-schema/cli-help.ts
@@ -502,6 +502,8 @@ Rules:
   For cross-platform validation with explicit device selectors, use separate sessions/devices and restart react-devtools between platforms.
   Remote Android and iOS bridge runs normally through agent-device react-devtools; the CLI keeps the needed local service tunnel alive until agent-device react-devtools stop or disconnect. Expo support depends on the SDK's bundled React Native runtime.
   Remote iOS apps attempt the legacy React DevTools websocket during JavaScript startup. If the app was already open before react-devtools start, run open <bundle-id> --platform ios --relaunch, then wait --connected.
+  React Native 0.87+ removed the built-in DevTools websocket. The app must run agent-react-devtools init once (Metro wrapper plus an entry import) and be rebundled, or wait --connected never succeeds. On older React Native no app change is needed.
+  With no app attached, status reports 0 connected and the observation commands fail; never read an empty result as a clean pass.
 
 Example:
   agent-device react-devtools status

--- a/src/cli/commands/react-devtools.ts
+++ b/src/cli/commands/react-devtools.ts
@@ -8,7 +8,7 @@ import { isRemoteBridgeBackend } from './remote-bridge.ts';
 import type { CliFlags } from '@agent-device/contracts/command';
 import { connectionProviderCapabilities } from '../connection/provider-policy.ts';
 
-const AGENT_REACT_DEVTOOLS_VERSION = '0.4.0';
+const AGENT_REACT_DEVTOOLS_VERSION = '0.5.0';
 export const AGENT_REACT_DEVTOOLS_PACKAGE = `agent-react-devtools@${AGENT_REACT_DEVTOOLS_VERSION}`;
 const AGENT_REACT_DEVTOOLS_BIN = 'agent-react-devtools';
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -851,7 +851,7 @@ agent-device react-devtools profile timeline --limit 20
 agent-device react-devtools profile report @c5
 ```
 
-- `react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` through npm and passes arguments through 1:1.
+- `react-devtools` dynamically runs pinned `agent-react-devtools@0.5.0` through npm and passes arguments through 1:1.
 - The first run may download the pinned package from npm; later runs can reuse the npm cache.
 - `agent-device` global flags work before or after `react-devtools`. Use `--` before downstream flags only when they intentionally share an `agent-device` global flag name.
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.


### PR DESCRIPTION
## Summary

Pins `agent-react-devtools` to 0.5.0, which restores React DevTools attachment on React Native 0.87+ ([callstackincubator/agent-react-devtools#58](https://github.com/callstackincubator/agent-react-devtools/pull/58)). React Native 0.87 removed the built-in DevTools websocket ([facebook/react-native#56897](https://github.com/facebook/react-native/pull/56897)), so `react-devtools wait --connected` could never succeed on those apps.

The `help react-devtools` topic now states the one-time `agent-react-devtools init` requirement (Metro wrapper plus an entry import, then rebundle) and that an empty observation with 0 apps connected is not a pass.

## Verification

End to end on a bare `react-native@0.87.1` app (community CLI template, Metro on 8081), driven through `agent-device react-devtools` with this pin:

| scenario | 0.5.0 (this PR) | upstream main (#59, unreleased) |
| --- | --- | --- |
| before `init`: `wait --connected --timeout 15` | times out, exit 1 | same |
| before `init`: `errors` | `No components with errors or warnings`, exit 0 | fails, exit 1 |
| after `init` + reload: `wait --connected` | attached, 149 components | same |
| `count`, `errors`, `get tree` | real data | same |
| React Native DevTools attaches alongside | count 298, `find App --exact` returns 2 | count stays 149, 1 hit |
| app killed, then `errors` | exit 0 | `No React app is attached ... app disconnected 3s ago`, exit 1 |
| `uninit` | reverts `index.js` and `metro.config.js` | same |

The help text in this PR tells agents to run `init` and `uninit`, and not to read the first-column empty results as a pass. The right-hand column arrives with the next pin bump.


- `cli-react-devtools`, `cli-help`, `cli-help-topics`, and `command-doc-coverage` tests pass; lint and typecheck clean.

## Not in this PR

The vacuous pass from #2430 (`errors` exits 0 with nothing attached) is a daemon-side defect, fixed upstream in [callstackincubator/agent-react-devtools#59](https://github.com/callstackincubator/agent-react-devtools/pull/59), pending release. Another pin bump follows once it ships.

Refs #2430

## Expo upgrade attempted and dropped

Upgrading the test-app to a React Native 0.87 Expo SDK was tried in this branch so the scenarios could run on our own app. Latest stable SDK 57 ships 0.86.3, which still has the legacy DevTools websocket. SDK 58 preview ships 0.87.1 but does not build on Xcode 26.2 / Swift 6.2.3: `expo-modules-jsi` fails first on the constructor annotations tracked in expo/expo#49667, then on Swift 6 `sending` data-race errors in `JavaScriptRuntime.swift` under `NonisolatedNonsendingByDefault`. The file is identical to Expo main, so this is a toolchain-versus-preview mismatch. The test-app stays on SDK 56 for now.
