### PR TITLE
fix(test): keep the working directory literal during glob discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed: `test` expands relative globs from the caller's literal working directory, so directory
+  names containing glob characters no longer cause missing suites or select a different directory.
+  Missing non-glob inputs also retain their not-found error in these directories.
 - Fixed: JUnit reports remain readable when replay results contain characters forbidden by XML 1.0,
   replacing them with U+FFFD while preserving legal Unicode and whitespace. Original suite values
   remain available in JSON and other reporters.

--- a/src/__tests__/cli-replay-script-sources.test.ts
+++ b/src/__tests__/cli-replay-script-sources.test.ts
@@ -92,3 +92,40 @@ test('a Maestro replay against a remote daemon sends its runFlow includes too', 
     [path.join(cwd, 'flows/shared/login.yaml')]: included,
   });
 });
+
+test.each(['native', 'maestro'])(
+  'test globs send %s sources from a literal cwd',
+  async (backend) => {
+    const maestro = backend === 'maestro';
+    const name = maestro ? 'flow.yaml' : 'flow.ad';
+    const source = maestro ? 'appId: demo\n---\n- runFlow: shared/child.yaml\n' : 'open "Demo"\n';
+    const child = '---\n- back\n';
+    const root = makeFlowsCheckout({
+      [`[workspace]/${name}`]: source,
+      '[workspace]/shared/child.yaml': child,
+    });
+    const cwd = path.join(root, '[workspace]');
+
+    const result = await runCliCapture(
+      ['test', maestro ? './*.yaml' : './*.ad', '--json', ...(maestro ? ['--maestro'] : [])],
+      {
+        cwd,
+        env: REMOTE_DAEMON_ENV,
+        defaultResponse: { ok: true, data: { tests: [], total: 0, passed: 0, failed: 0 } },
+      },
+    );
+
+    assert.equal(result.calls.length, 1);
+    assert.equal(result.calls[0]?.command, 'test');
+    const entry = path.join(cwd, name);
+    assert.deepEqual(result.calls[0]?.flags?.replayScriptSources, [
+      {
+        entry,
+        files: {
+          [entry]: source,
+          ...(maestro ? { [path.join(cwd, 'shared/child.yaml')]: child } : {}),
+        },
+      },
+    ]);
+  },
+);

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -246,7 +246,7 @@ export const testCommandFacet = defineCommandFacet({
   text: {
     summary: 'Run replay test suites',
     cliDetail:
-      'JUnit reports (--reporter junit:<path>) replace characters forbidden by XML 1.0 with U+FFFD and preserve legal Unicode and whitespace. JSON and other reporters retain the original suite values.',
+      'Relative globs are expanded on the caller from its working directory, whose name is treated literally. Quote glob inputs to defer expansion to test. JUnit reports (--reporter junit:<path>) replace characters forbidden by XML 1.0 with U+FFFD and preserve legal Unicode and whitespace. JSON and other reporters retain the original suite values.',
   },
   metadata: testCommandMetadata,
   run: (client, input) => client.replay.test(withCommandRuntimeHints(input)),

--- a/src/commands/replay/source-discovery.test.ts
+++ b/src/commands/replay/source-discovery.test.ts
@@ -1,6 +1,7 @@
 import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
 import { discoverReplaySourcePaths } from './source-discovery.ts';
@@ -12,6 +13,66 @@ import { mkdtempForTestSync } from '../../__tests__/test-utils/tmp-dir.ts';
 // filtering policy is pinned in the replay-test package.
 const discover = (inputs: string[], cwd: string, replayBackend?: string) =>
   discoverReplaySourcePaths({ inputs, cwd, replayBackend });
+
+test.each(['[ab]', '{a,b}'])('relative suite globs treat cwd %s literally', (directoryName) => {
+  const root = mkdtempForTestSync('agent-device-discovery-literal-cwd-');
+  const cwd = path.join(root, directoryName);
+  for (const directory of [cwd, path.join(root, 'a')]) {
+    fs.mkdirSync(path.join(directory, 'flows'), { recursive: true });
+  }
+  for (const name of ['01-native.ad', '02-flow.yaml', '03-flow.yml', 'ignored.txt']) {
+    fs.writeFileSync(path.join(cwd, 'flows', name), '');
+  }
+  fs.writeFileSync(path.join(root, 'a', 'flows', 'wrong-checkout.ad'), '');
+
+  const pattern = './flows/*.{ad,yaml,yml}';
+  assert.deepEqual(discover([pattern], cwd), [path.join(cwd, 'flows', '01-native.ad')]);
+  assert.deepEqual(discover([pattern], cwd, 'maestro'), [
+    path.join(cwd, 'flows', '02-flow.yaml'),
+    path.join(cwd, 'flows', '03-flow.yml'),
+    path.join(cwd, 'flows', '01-native.ad'),
+  ]);
+  assert.deepEqual(discover(['./flows/absent*.ad'], cwd), []);
+});
+
+test.each(['plain', '[ab]', '{a,b}'])(
+  'a missing literal suite input is rejected from cwd %s',
+  (directoryName) => {
+    const root = mkdtempForTestSync('agent-device-discovery-missing-');
+    const cwd = path.join(root, directoryName);
+    fs.mkdirSync(cwd);
+
+    assert.throws(
+      () => discover(['missing.ad'], cwd),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message === 'test input not found: missing.ad',
+    );
+  },
+);
+
+test('absolute and home suite globs preserve authored patterns', () => {
+  const root = mkdtempForTestSync('agent-device-discovery-glob-paths-');
+  const cwd = path.join(root, '[workspace]');
+  fs.mkdirSync(cwd);
+  for (const name of ['a.ad', 'b.ad', 'c.ad', '[literal].ad']) {
+    fs.writeFileSync(path.join(root, name), '');
+  }
+  const homedir = vi.spyOn(os, 'homedir').mockReturnValue(root);
+
+  try {
+    const expected = [path.join(root, 'a.ad'), path.join(root, 'b.ad')];
+    assert.deepEqual(discover(['../{a,b}.ad'], cwd), expected);
+    assert.deepEqual(discover([path.join(root, '[ab].ad')], cwd), expected);
+    assert.deepEqual(discover(['~/{a,b}.ad'], cwd), expected);
+    assert.deepEqual(discover([path.join(root, '[literal].ad')], cwd), [
+      path.join(root, '[literal].ad'),
+    ]);
+  } finally {
+    homedir.mockRestore();
+  }
+});
 
 test('replay source discovery discovers nested .ad suites through native DFS traversal', () => {
   const root = mkdtempForTestSync('agent-device-test-discovery-');

--- a/src/commands/replay/source-discovery.ts
+++ b/src/commands/replay/source-discovery.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { AppError } from '@agent-device/kernel/errors';
-import { resolveUserPath } from '@agent-device/host-kit/file';
+import { expandUserHomePath, resolveUserPath } from '@agent-device/host-kit/file';
 import { isMaestroYamlPath, maestroBackendRequiredMessage } from '@agent-device/ad-script';
 
 const GLOB_PATTERN_CHARS = /[*?[\]{}]/;
@@ -63,14 +63,11 @@ function expandReplayInput(
     return { paths: [], source: 'file' };
   }
 
-  if (!looksLikeGlob(input) && !looksLikeGlob(expandedInput)) {
+  if (!looksLikeGlob(input)) {
     throw new AppError('INVALID_ARGS', `test input not found: ${input}`);
   }
 
-  const pattern = path.isAbsolute(expandedInput) ? expandedInput : input;
-  const matches = fs.globSync(pattern, {
-    cwd: path.isAbsolute(expandedInput) ? undefined : cwd,
-  });
+  const matches = fs.globSync(expandUserHomePath(input), { cwd });
   return {
     source: 'glob',
     paths: matches

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -114,6 +114,7 @@ agent-device test ./workflows --reporter default --reporter junit:./tmp/junit.xm
 ```
 
 - `test` discovers `.ad` files from files, directories, or globs and runs them serially.
+- Quote relative globs to expand them on the caller from its working directory, including when the directory name contains glob characters such as `[` or `{`. A missing file input without glob characters reports an error.
 - `context platform=...` inside each `.ad` file is the target source of truth for suite execution.
 - `--platform` is a filter for suite discovery; files without platform metadata are skipped when a filter is present.
 - `context timeout=...` and `context retries=...` can be declared per script; CLI flags override metadata. Retries are capped at `3`, and duplicate keys in the context header fail fast instead of silently overriding each other.


### PR DESCRIPTION
## Summary

Completes caller-side suite discovery established in #1810. From a checkout named `[workspace]`, `agent-device test './*.ad'` currently sends no sources; when the directory name matches a sibling, it can select that sibling's scripts instead. Missing literal files also lose their `INVALID_ARGS` error.

Pass the authored glob and literal working directory separately to Node's glob API. Keep home expansion, explicit-file precedence, directory DFS, and YAML-first glob ordering. Six files: discovery, behavioral and CLI regressions, command help, user docs, and changelog.

## Validation

Tested `cdf39a5bd79683c922362ae2ded18f2946347ea9` with Node 24.13.1 and pnpm 11.17.0, using `AGENT_DEVICE_VITEST_MAX_WORKERS=1`.

- Six regression cases failed before the fix; all 68 focused discovery/source-bundle/writer/CLI/startup tests pass.
- `pnpm build`, `pnpm test:maestro-compat` (363 tests), and `pnpm check:command-docs` (12 tests) pass.
- Built CLI against an owned HTTP fixture: all nine native/Maestro/missing-file cases pass across plain, bracketed, and braced working directories. Valid requests contain the exact source/include bundles; missing files fail before transport. The upstream build fails six of these cases.
- `pnpm check:affected --run` passes every runnable gate: 2,823 tests across 385 files, plus formatting, lint, types, layering, Fallow, and build. CI is pending.

No device execution was used: the changed boundary is caller filesystem discovery and request preparation. Upstream CI remains authoritative.

<!-- plasma-agent-device-lane:b -->
<!-- plasma-agent-device-campaign:four-more-20260910 -->
<!-- plasma-agent-device-candidate:test-glob-literal-cwd -->
