### PR TITLE
fix(scroll): pace edge passes to rest and stop a stuck surface

### DIFF
--- a/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-fingerprint.test.ts
+++ b/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-fingerprint.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { capture, recycledCellSnapshot } from './scroll-edge-state-fixtures.ts';
+
+test('surface signature changes when a recycled cell keeps its slot but changes text', async () => {
+  const before = await capture(recycledCellSnapshot('First story'));
+  const after = await capture(recycledCellSnapshot('Second story'));
+  assert.ok(before.fingerprint && after.fingerprint);
+  assert.notEqual(before.fingerprint, after.fingerprint);
+});
+
+test('surface signature is stable when nothing on the container moves', async () => {
+  const first = await capture(recycledCellSnapshot('First story'));
+  const second = await capture(recycledCellSnapshot('First story'));
+  assert.ok(first.fingerprint);
+  assert.equal(first.fingerprint, second.fingerprint);
+});

--- a/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-fixtures.ts
+++ b/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-fixtures.ts
@@ -66,6 +66,32 @@ export function scrollSnapshot(hiddenContentBelow: boolean): SnapshotNode[] {
   ];
 }
 
+/**
+ * A scrolled container whose one visible cell keeps a stable identifier and slot while only its text
+ * varies — the recycled-cell shape where identity alone would hide real progress.
+ */
+export function recycledCellSnapshot(label: string): SnapshotNode[] {
+  return [
+    {
+      index: 1,
+      ref: 'e1',
+      type: 'ScrollView',
+      label: 'Feed',
+      hiddenContentBelow: true,
+      rect: { x: 0, y: 100, width: 400, height: 600 },
+    },
+    {
+      index: 2,
+      ref: 'e2',
+      parentIndex: 1,
+      type: 'StaticText',
+      identifier: 'cell-0',
+      label,
+      rect: { x: 0, y: 640, width: 400, height: 56 },
+    },
+  ];
+}
+
 export async function captureThrows(scope: string | undefined): Promise<AppError> {
   try {
     await captureScrollEdgeState({

--- a/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-pass-orchestration.test.ts
+++ b/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-pass-orchestration.test.ts
@@ -358,6 +358,34 @@ test('runScrollEdgePasses: a moving fingerprint never trips no-progress and scro
   assert.equal(result.passes, 5);
 });
 
+test('runScrollEdgePasses: a fresh surface signature continues after identical passes', async () => {
+  let scrollCalls = 0;
+  // The surface sits at `a` for three captures, then a pass finally reveals `b`. `b` is a signature
+  // the window has not seen, so the loop keeps going rather than stopping as no-progress on the pass
+  // that actually advanced.
+  const captures = [
+    { canScroll: true, fingerprint: 'a' },
+    { canScroll: true, fingerprint: 'a' },
+    { canScroll: true, fingerprint: 'a' },
+    { canScroll: true, fingerprint: 'b' },
+    { canScroll: false, fingerprint: 'b' },
+  ];
+  let index = 0;
+  const result = await runScrollEdgePasses({
+    edge: 'bottom',
+    captureState: async () => ({
+      emptySnapshot: false,
+      ...(captures[index++] ?? { canScroll: false }),
+    }),
+    scroll: async () => {
+      scrollCalls += 1;
+      return undefined;
+    },
+  });
+  assert.equal(result.passes, 4);
+  assert.equal(scrollCalls, 4);
+});
+
 test('unique container scope is retained across edge pass captures', async () => {
   const scopes: Array<string | undefined> = [];
   const snapshots = [scrollSnapshot(true), scrollSnapshot(true), scrollSnapshot(false)];

--- a/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-pass-orchestration.test.ts
+++ b/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-pass-orchestration.test.ts
@@ -284,6 +284,8 @@ test('runScrollEdgePasses: throws a COMMAND_FAILED AppError once the pass limit 
   await assert.rejects(
     runScrollEdgePasses({
       edge: 'bottom',
+      // No fingerprint on these manual captures, so no-progress detection is inert and only the
+      // 40-pass backstop can end the loop. The real capture path always sets a fingerprint.
       captureState: async () => ({
         canScroll: true,
         emptySnapshot: false,
@@ -300,13 +302,60 @@ test('runScrollEdgePasses: throws a COMMAND_FAILED AppError once the pass limit 
         error.message,
         'scroll bottom reached the safety limit before the snapshot showed the edge',
       );
-      assert.deepEqual(error.details, {
-        hint: 'The scoped scroll container still reports hidden content. Run scroll <dir> --until <selector> to stop on the element you are after, or snapshot -i to inspect the current state.',
-      });
+      assert.equal(error.details?.reason, 'scroll_edge_pass_limit');
+      assert.equal(error.details?.passes, 40);
+      assert.match(String(error.details?.hint), /--until <selector>/);
       return true;
     },
   );
   assert.equal(scrollCalls, 40);
+});
+
+test('runScrollEdgePasses: stops as no-progress after a couple of passes when the fingerprint never moves', async () => {
+  let scrollCalls = 0;
+  await assert.rejects(
+    runScrollEdgePasses({
+      edge: 'bottom',
+      // canScroll stays true but the surface fingerprint is byte-identical every capture — the
+      // stuck-container signature (the gesture is not reaching this scroll view).
+      captureState: async () => ({
+        canScroll: true,
+        emptySnapshot: false,
+        fingerprint: 'stuck-surface',
+      }),
+      scroll: async () => {
+        scrollCalls += 1;
+        return undefined;
+      },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'COMMAND_FAILED');
+      assert.equal(error.details?.reason, 'scroll_edge_no_progress');
+      assert.equal(error.details?.edge, 'bottom');
+      assert.match(String(error.details?.hint), /not reaching this container/);
+      return true;
+    },
+  );
+  // The whole point: a stuck container stops within a few flings, not 40.
+  assert.equal(scrollCalls, 3);
+});
+
+test('runScrollEdgePasses: a moving fingerprint never trips no-progress and scrolls to the edge', async () => {
+  let scrollCalls = 0;
+  const result = await runScrollEdgePasses({
+    edge: 'bottom',
+    captureState: async () => ({
+      canScroll: scrollCalls < 5,
+      emptySnapshot: false,
+      fingerprint: `surface-${scrollCalls}`,
+    }),
+    scroll: async () => {
+      scrollCalls += 1;
+      return undefined;
+    },
+  });
+  assert.equal(result.passes, 5);
 });
 
 test('unique container scope is retained across edge pass captures', async () => {

--- a/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-stuck.test.ts
+++ b/packages/capture-kit/src/snapshot/__tests__/scroll-edge-state-stuck.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { scrollSurfaceIsStuck } from '../scroll-edge-state.ts';
+
+const cases: ReadonlyArray<readonly [string, readonly string[], boolean]> = [
+  ['identical captures', ['a', 'a', 'a', 'a'], true],
+  ['rubber-band alternation', ['bottom', 'top', 'bottom', 'top'], true],
+  ['two stable signatures', ['a', 'b', 'a', 'b'], true],
+  ['parked after one detour', ['a', 'b', 'a', 'a'], true],
+  // A newest signature the window has not seen is a pass that just made progress: keep scrolling.
+  ['fresh progress after identical passes', ['a', 'a', 'a', 'b'], false],
+  ['three distinct signatures', ['a', 'b', 'c', 'a'], false],
+  ['below the minimum length', ['a', 'a', 'a'], false],
+];
+
+for (const [label, signatures, expected] of cases) {
+  test(`scrollSurfaceIsStuck: ${label}`, () => {
+    assert.equal(scrollSurfaceIsStuck(signatures), expected);
+  });
+}

--- a/packages/capture-kit/src/snapshot/scroll-edge-state.ts
+++ b/packages/capture-kit/src/snapshot/scroll-edge-state.ts
@@ -81,15 +81,19 @@ export async function scrollSurfaceFingerprint(
 
 /**
  * Has a scroll stopped making progress? True once `recentSignatures` holds at least
- * `SCROLL_EDGE_STUCK_MIN_LENGTH` captures within the last `SCROLL_EDGE_STUCK_WINDOW` and no more
- * than two of them are distinct — the signature of a container that ignores the gesture or is only
- * rubber-banding. Callers cap `recentSignatures` to the window. Exported so `scroll --until` reuses
- * the one definition of "stuck" rather than a second copy.
+ * `SCROLL_EDGE_STUCK_MIN_LENGTH` captures within the last `SCROLL_EDGE_STUCK_WINDOW`, no more than
+ * two are distinct, AND the newest capture is one the window already showed — the signature of a
+ * container that ignores the gesture or only rubber-bands. A newest signature the window has not seen
+ * is a pass that just made real progress, so `A,A,A,B` continues while `A,B,A,B` is stuck. Callers
+ * cap `recentSignatures` to the window. Exported so `scroll --until` reuses the one definition of
+ * "stuck" rather than a second copy.
  */
 export function scrollSurfaceIsStuck(recentSignatures: readonly string[]): boolean {
   if (recentSignatures.length < SCROLL_EDGE_STUCK_MIN_LENGTH) return false;
   const window = recentSignatures.slice(-SCROLL_EDGE_STUCK_WINDOW);
-  return new Set(window).size <= SCROLL_EDGE_STUCK_MAX_DISTINCT;
+  if (new Set(window).size > SCROLL_EDGE_STUCK_MAX_DISTINCT) return false;
+  const newest = window.at(-1);
+  return newest !== undefined && window.slice(0, -1).includes(newest);
 }
 
 /**

--- a/packages/capture-kit/src/snapshot/scroll-edge-state.ts
+++ b/packages/capture-kit/src/snapshot/scroll-edge-state.ts
@@ -8,6 +8,13 @@ export type ScrollEdgeState = {
   canScroll: boolean;
   emptySnapshot: boolean;
   scope?: string;
+  /**
+   * A cheap signature of what is on screen right now. Two consecutive captures with the same
+   * fingerprint but `canScroll` still true mean the scroll did not move the container — the actuator
+   * and the detector disagree, which is the stuck-container signature `runScrollEdgePasses` stops on.
+   * Optional so manual capture fixtures can opt out of no-progress detection.
+   */
+  fingerprint?: string;
 };
 
 export type ScrollEdgeTarget = {
@@ -16,6 +23,17 @@ export type ScrollEdgeTarget = {
 };
 
 const SCROLL_EDGE_PASS_LIMIT = 40;
+
+/**
+ * A stuck or rubber-banding surface revisits the same one or two on-screen signatures, while a real
+ * scroll keeps producing a new signature every pass. Once a short window has held at most two
+ * distinct signatures for enough passes, the gesture is not reaching the container and further
+ * flings only bounce — stop long before the 40-pass backstop. Rounded-pixel signatures make a real
+ * pass always look new, so this never cuts a scroll that actually moved.
+ */
+const SCROLL_EDGE_STUCK_WINDOW = 6;
+const SCROLL_EDGE_STUCK_MIN_LENGTH = 4;
+const SCROLL_EDGE_STUCK_MAX_DISTINCT = 2;
 
 export async function captureScrollEdgeState(params: {
   edge: ScrollEdge;
@@ -49,12 +67,60 @@ export async function canScrollFurtherAtEdge(
   return analyzeScrollEdgeState(nodes, edge).canScroll;
 }
 
+/**
+ * The on-screen signature the `--until` loop tracks to notice a stuck container, computed the same
+ * way `captureScrollEdgeState` derives it, so both loops read one signal. Pure: no capture happens.
+ */
+export async function scrollSurfaceFingerprint(
+  nodes: readonly (RawSnapshotNode | SnapshotNode)[],
+  edge: ScrollEdge,
+): Promise<string> {
+  const { analyzeScrollEdgeState } = await import('./scroll-edge-state/selection.ts');
+  return analyzeScrollEdgeState(nodes, edge).fingerprint ?? '';
+}
+
+/**
+ * Has a scroll stopped making progress? True once `recentSignatures` holds at least
+ * `SCROLL_EDGE_STUCK_MIN_LENGTH` captures within the last `SCROLL_EDGE_STUCK_WINDOW` and no more
+ * than two of them are distinct — the signature of a container that ignores the gesture or is only
+ * rubber-banding. Callers cap `recentSignatures` to the window. Exported so `scroll --until` reuses
+ * the one definition of "stuck" rather than a second copy.
+ */
+export function scrollSurfaceIsStuck(recentSignatures: readonly string[]): boolean {
+  if (recentSignatures.length < SCROLL_EDGE_STUCK_MIN_LENGTH) return false;
+  const window = recentSignatures.slice(-SCROLL_EDGE_STUCK_WINDOW);
+  return new Set(window).size <= SCROLL_EDGE_STUCK_MAX_DISTINCT;
+}
+
+/**
+ * Records one pass's surface signature, capped to the trailing window the stuck detector reads. An
+ * empty signature is skipped so a container with no positioned descendants stays on its edge/pass
+ * signals instead of stacking blanks. Both scroll loops push through here so "one window" has one
+ * definition rather than a copy that can drift.
+ */
+export function pushScrollSurfaceSignature(
+  recentSignatures: string[],
+  fingerprint: string | undefined,
+  window: number,
+): void {
+  if (!fingerprint) return;
+  recentSignatures.push(fingerprint);
+  if (recentSignatures.length > window) recentSignatures.shift();
+}
+
 export async function runScrollEdgePasses<TResult>(params: {
   edge: ScrollEdge;
   captureState: (scope?: string) => Promise<ScrollEdgeState>;
   scroll: () => Promise<TResult>;
+  /**
+   * Waits for the previous fling to come to rest before the next capture. A rubber-banded scroll
+   * moves back and forth for a beat after a fling; capturing mid-bounce makes every pass look new and
+   * the next fling lands on top of the bounce, compounding it. Default no-op keeps this loop
+   * device-free; the daemon supplies a real rest-wait.
+   */
+  settleAfterPass?: () => Promise<void>;
 }): Promise<{ passes: number; result?: TResult }> {
-  const { edge, captureState, scroll } = params;
+  const { edge, captureState, scroll, settleAfterPass = async () => {} } = params;
   let state = await captureState();
   if (state.scope) {
     state = await captureState(state.scope);
@@ -62,12 +128,17 @@ export async function runScrollEdgePasses<TResult>(params: {
 
   let passes = 0;
   let result: TResult | undefined;
+  const recentSignatures: string[] = [];
+  pushScrollSurfaceSignature(recentSignatures, state.fingerprint, SCROLL_EDGE_STUCK_WINDOW);
   while (state.canScroll) {
     if (passes >= SCROLL_EDGE_PASS_LIMIT) {
       throw new AppError(
         'COMMAND_FAILED',
         `scroll ${edge} reached the safety limit before the snapshot showed the edge`,
         {
+          reason: 'scroll_edge_pass_limit',
+          edge,
+          passes,
           hint: 'The scoped scroll container still reports hidden content. Run scroll <dir> --until <selector> to stop on the element you are after, or snapshot -i to inspect the current state.',
         },
       );
@@ -75,7 +146,13 @@ export async function runScrollEdgePasses<TResult>(params: {
 
     result = await scroll();
     passes += 1;
+    await settleAfterPass();
     state = await captureState(state.scope);
+
+    pushScrollSurfaceSignature(recentSignatures, state.fingerprint, SCROLL_EDGE_STUCK_WINDOW);
+    if (state.canScroll && scrollSurfaceIsStuck(recentSignatures)) {
+      throw buildScrollEdgeNoProgressError(edge, passes);
+    }
   }
 
   return { passes, result };
@@ -107,6 +184,22 @@ export function formatScrollEdgeMessage(params: {
       : `Scrolled ${direction} by ${amount} of the viewport (${honoredPixels}px)`;
   }
   return `Scrolled ${direction}`;
+}
+
+function buildScrollEdgeNoProgressError(edge: ScrollEdge, passes: number): AppError {
+  const spent = `${passes} ${passes === 1 ? 'pass' : 'passes'}`;
+  return new AppError(
+    'COMMAND_FAILED',
+    `scroll ${edge} moved nothing across ${spent}: the container still reports hidden content but its contents never shifted`,
+    {
+      reason: 'scroll_edge_no_progress',
+      edge,
+      passes,
+      hint:
+        `The scroll is not reaching this container. If a field is focused, dismiss the keyboard first; if it is nested inside another scroller, target it directly with scroll <dir> --until <selector>. ` +
+        `Some lists ignore synthesized scrolls — a raw drag moves them: swipe x1 y1 x2 y2 started inside the list.`,
+    },
+  );
 }
 
 function buildScrollEdgeVerificationError(

--- a/packages/capture-kit/src/snapshot/scroll-edge-state/selection.ts
+++ b/packages/capture-kit/src/snapshot/scroll-edge-state/selection.ts
@@ -39,6 +39,7 @@ export function analyzeScrollEdgeState(
     canScroll,
     emptySnapshot: false,
     scope: buildScrollContainerScope(container, nodes),
+    fingerprint: buildSurfaceFingerprint(container, nodes),
   };
 }
 
@@ -205,4 +206,49 @@ function containsPoint(rect: NonNullable<SnapshotNode['rect']>, point: Point): b
 
 function isUsableRect(rect: SnapshotNode['rect']): rect is NonNullable<SnapshotNode['rect']> {
   return Boolean(rect && rect.width > 0 && rect.height > 0);
+}
+
+/**
+ * A stable signature of the content the container currently shows, built from the container's own
+ * descendants (via the parent chain), each keyed by identity and rounded position. Scrolling shifts
+ * descendant rects, so a real pass always changes it; a gesture the container ignores leaves it
+ * byte-identical. Descendant scoping — not geometric overlap — is the point: it excludes the
+ * keyboard, its typing predictions, and scroll-indicator overlays, which are not under the scroller
+ * and would otherwise flicker and mask a stuck container. Rounded to whole pixels so layout jitter
+ * never fakes movement; a false "unchanged" only defers to a later pass or the pass limit. An empty
+ * string (a container with no positioned descendants) leaves both loops to their edge/pass signals.
+ */
+function buildSurfaceFingerprint(container: SnapshotNode, nodes: SnapshotNode[]): string {
+  const byIndex = new Map<number, SnapshotNode>();
+  for (const node of nodes) byIndex.set(node.index, node);
+  const descendants: string[] = [];
+  for (const node of nodes) {
+    const rect = node.rect;
+    if (!isUsableRect(rect)) continue;
+    if (node.index === container.index || !isDescendantOf(node, container.index, byIndex)) continue;
+    descendants.push(
+      `${node.type}#${surfaceIdentity(node)}@${Math.round(rect.x)},${Math.round(rect.y)}`,
+    );
+  }
+  if (descendants.length === 0) return '';
+  descendants.sort();
+  return descendants.join(';');
+}
+
+function surfaceIdentity(node: SnapshotNode): string {
+  return (node.identifier ?? node.label ?? node.value ?? '').trim();
+}
+
+function isDescendantOf(
+  node: SnapshotNode,
+  ancestorIndex: number,
+  byIndex: ReadonlyMap<number, SnapshotNode>,
+): boolean {
+  let parentIndex = node.parentIndex;
+  let guard = byIndex.size + 1;
+  while (parentIndex !== undefined && guard-- > 0) {
+    if (parentIndex === ancestorIndex) return true;
+    parentIndex = byIndex.get(parentIndex)?.parentIndex;
+  }
+  return false;
 }

--- a/packages/capture-kit/src/snapshot/scroll-edge-state/selection.ts
+++ b/packages/capture-kit/src/snapshot/scroll-edge-state/selection.ts
@@ -210,13 +210,14 @@ function isUsableRect(rect: SnapshotNode['rect']): rect is NonNullable<SnapshotN
 
 /**
  * A stable signature of the content the container currently shows, built from the container's own
- * descendants (via the parent chain), each keyed by identity and rounded position. Scrolling shifts
- * descendant rects, so a real pass always changes it; a gesture the container ignores leaves it
- * byte-identical. Descendant scoping — not geometric overlap — is the point: it excludes the
- * keyboard, its typing predictions, and scroll-indicator overlays, which are not under the scroller
- * and would otherwise flicker and mask a stuck container. Rounded to whole pixels so layout jitter
- * never fakes movement; a false "unchanged" only defers to a later pass or the pass limit. An empty
- * string (a container with no positioned descendants) leaves both loops to their edge/pass signals.
+ * descendants (via the parent chain), each keyed by its identity fields and rounded position.
+ * Scrolling shifts descendant rects, and a recycled cell that keeps its slot while its text changes
+ * re-keys, so a real pass always changes it; a gesture the container ignores leaves it byte-identical.
+ * Descendant scoping — not geometric overlap — is the point: it excludes the keyboard, its typing
+ * predictions, and scroll-indicator overlays, which are not under the scroller and would otherwise
+ * flicker and mask a stuck container. Rounded to whole pixels so layout jitter never fakes movement;
+ * a false "unchanged" only defers to a later pass or the pass limit. An empty string (a container with
+ * no positioned descendants) leaves both loops to their edge/pass signals.
  */
 function buildSurfaceFingerprint(container: SnapshotNode, nodes: SnapshotNode[]): string {
   const byIndex = new Map<number, SnapshotNode>();
@@ -236,7 +237,12 @@ function buildSurfaceFingerprint(container: SnapshotNode, nodes: SnapshotNode[])
 }
 
 function surfaceIdentity(node: SnapshotNode): string {
-  return (node.identifier ?? node.label ?? node.value ?? '').trim();
+  // All three content fields, not first-present: a recycled cell keeps its identifier and slot while
+  // its label/value change, and that text change is exactly the progress the signature must register.
+  const identifier = (node.identifier ?? '').trim();
+  const label = (node.label ?? '').trim();
+  const value = (node.value ?? '').trim();
+  return `${identifier} ${label} ${value}`;
 }
 
 function isDescendantOf(

--- a/src/daemon/__tests__/scroll-runtime.test.ts
+++ b/src/daemon/__tests__/scroll-runtime.test.ts
@@ -193,11 +193,6 @@ test('bound scroll bottom does not scroll when no hidden content is below', asyn
 test('bound scroll bottom scrolls only while a scoped capture confirms hidden content', async () => {
   const calls: ScrollCall[] = [];
   const snapshotScopes: unknown[] = [];
-  const snapshots = [
-    makeScrollSnapshot({ hiddenBelow: true, message: 'Middle message' }),
-    makeScrollSnapshot({ hiddenBelow: true, message: 'Middle message' }),
-    makeScrollSnapshot({ hiddenBelow: false, message: 'Latest message' }),
-  ];
   const result = await runScroll(
     ['bottom'],
     {},
@@ -208,7 +203,12 @@ test('bound scroll bottom scrolls only while a scoped capture confirms hidden co
       },
       captureSnapshot: async (input) => {
         snapshotScopes.push(input.options?.scope);
-        return snapshots[Math.min(snapshotScopes.length - 1, snapshots.length - 1)];
+        // Driven by scroll count, not capture count, so the rest-wait's own captures cannot move the
+        // goalposts: content is hidden until the one pass has run, then the edge is reached.
+        return makeScrollSnapshot({
+          hiddenBelow: calls.length === 0,
+          message: calls.length === 0 ? 'Middle message' : 'Latest message',
+        });
       },
     },
   );
@@ -225,32 +225,35 @@ test('bound scroll bottom scrolls only while a scoped capture confirms hidden co
   });
   assert.equal(result.passes, 1);
   assert.equal(result.lastPass, 1);
-  assert.deepEqual(snapshotScopes, [undefined, 'Messages', 'Messages']);
+  // The loop verifies against the scoped container it discovered, not the unscoped tree.
+  assert.ok(snapshotScopes.includes('Messages'));
 });
 
-test('bound scroll bottom tolerates unchanged signatures while hidden content advances', async () => {
+test('bound scroll bottom stops when the surface never shifts under hidden content', async () => {
   const calls: ScrollCall[] = [];
-  const snapshots = [
-    makeScrollSnapshot({ hiddenBelow: true, message: 'Repeated row' }),
-    makeScrollSnapshot({ hiddenBelow: true, message: 'Repeated row' }),
-    makeScrollSnapshot({ hiddenBelow: true, message: 'Repeated row' }),
-    makeScrollSnapshot({ hiddenBelow: false, message: 'Repeated row' }),
-  ];
-  let snapshotIndex = 0;
-  const result = await runScroll(
-    ['bottom'],
-    {},
-    {
-      scroll: async (direction, options) => {
-        calls.push({ direction, options });
-        return { lastPass: calls.length };
-      },
-      captureSnapshot: async () => snapshots[Math.min(snapshotIndex++, snapshots.length - 1)],
-    },
+  await assert.rejects(
+    () =>
+      runScroll(
+        ['bottom'],
+        {},
+        {
+          scroll: async (direction, options) => {
+            calls.push({ direction, options });
+            return { lastPass: calls.length };
+          },
+          // Hidden content below forever, row fixed: the surface signature is byte-identical across
+          // passes. A gesture that reports hidden content but moves nothing is the stuck-container
+          // signature, and the loop must stop on it rather than fling to the 40-pass backstop.
+          captureSnapshot: async () =>
+            makeScrollSnapshot({ hiddenBelow: true, message: 'Repeated row' }),
+        },
+      ),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'COMMAND_FAILED' &&
+      error.details?.reason === 'scroll_edge_no_progress',
   );
-
-  assert.equal(calls.length, 2);
-  assert.equal(result.passes, 2);
+  assert.equal(calls.length, 3);
 });
 
 test('bound scroll bottom keeps scoped capture failures scoped', async () => {

--- a/src/daemon/scroll-runtime.ts
+++ b/src/daemon/scroll-runtime.ts
@@ -16,11 +16,13 @@ import {
 import type { BoundDeviceRuntime } from '@agent-device/contracts/platform-runtime';
 import type { ScrollDirectionInput } from '@agent-device/contracts/scroll-runtime';
 import type { DeviceInfo } from '@agent-device/kernel/device';
+import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapshot';
 import { AppError } from '@agent-device/kernel/errors';
 import {
   captureScrollEdgeState,
   formatScrollEdgeMessage,
   runScrollEdgePasses,
+  scrollSurfaceFingerprint,
   type ScrollEdge,
   type ScrollEdgeState,
 } from '@agent-device/capture-kit/scroll-edge-state';
@@ -192,10 +194,32 @@ async function executeEdgeScroll(
   options: ResolvedScrollExecutionOptions,
   context: DaemonCommandContext,
 ): Promise<Record<string, unknown>> {
+  // The loop discovers its scope from the first capture; the rest-wait has to watch the same
+  // scoped container the loop decides on, so it reads the scope this closure records.
+  let scope: string | undefined;
   const edgeResult = await runScrollEdgePasses({
     edge,
-    captureState: async (scope) => await captureEdgeState(runtime, edge, scope, context),
+    captureState: async (stateScope) => {
+      const state = await captureEdgeState(runtime, edge, stateScope, context);
+      scope = state.scope ?? scope;
+      return state;
+    },
     scroll: async () => await scrollOnce(runtime, target, options, context),
+    settleAfterPass: async () => {
+      await pollForScrollRest(
+        async () =>
+          (
+            await runtime.operations.captureSnapshot({
+              options: {
+                ...(context.appBundleId === undefined ? {} : { appBundleId: context.appBundleId }),
+                scope,
+              },
+              execution: runtimeExecutionFromContext(context),
+            })
+          ).nodes ?? [],
+        edge,
+      );
+    },
   });
   return scrollResult(target, options, edgeResult.passes, edgeResult.result ?? {});
 }
@@ -263,6 +287,32 @@ async function scrollOnce(
   context: DaemonCommandContext,
 ): Promise<Record<string, unknown> | void> {
   return await runtime.operations.scrollDirection(scrollInput(target.direction, options, context));
+}
+
+const SCROLL_REST_TIMEOUT_MS = 1200;
+const SCROLL_REST_POLL_MS = 120;
+
+/**
+ * Wait for the last fling to come to rest before the loop decides or flings again. A rubber-band
+ * bounce keeps shifting the surface for a beat after a fling; deciding or re-scrolling mid-bounce
+ * reads a phantom new state and stacks another fling on top, which is how one stuck scroll becomes a
+ * runaway bounce. Two consecutive captures with the same surface fingerprint means the content is at
+ * rest. Bounded, so a never-settling animation cannot hang a pass.
+ */
+async function pollForScrollRest(
+  captureNodes: () => Promise<readonly (RawSnapshotNode | SnapshotNode)[]>,
+  edge: ScrollEdge,
+  timeoutMs = SCROLL_REST_TIMEOUT_MS,
+  pollMs = SCROLL_REST_POLL_MS,
+): Promise<void> {
+  let previous: string | undefined;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const fingerprint = await scrollSurfaceFingerprint(await captureNodes(), edge);
+    if (fingerprint === previous) return;
+    previous = fingerprint;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
 }
 
 /** The one response shape both executors report. Owner fields win, as the retired leaf had them. */

--- a/src/daemon/scroll-until.test.ts
+++ b/src/daemon/scroll-until.test.ts
@@ -90,6 +90,32 @@ test('a present but scrolled-out target does not end the loop', async () => {
   );
 });
 
+/**
+ * The stuck-container defect: content below the fold, so the edge analyzer says "keep going", but the
+ * gesture never moves this scroller, so every capture is identical. Without a progress check this
+ * flings the whole 12-pass budget; with it, the loop gives up after two and says why.
+ */
+test('a vertical scroll that moves nothing gives up early instead of spending the full budget', async () => {
+  let scrolls = 0;
+  await assert.rejects(
+    () =>
+      run({
+        // Same tree every pass: the Email row is below the fold (hidden content below → keeps
+        // scrolling), never becomes visible, and nothing on screen shifts between captures.
+        captures: [capture({ nodes: tree(2400) })],
+        onScroll: () => (scrolls += 1),
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.details?.reason, 'scroll_until_no_progress');
+      assert.equal(error.details?.passes, 3);
+      assert.match(String(error.details?.hint), /not reaching this container/);
+      return true;
+    },
+  );
+  assert.equal(scrolls, 3);
+});
+
 test('running out of content stops before the pass budget does', async () => {
   let scrolls = 0;
   await assert.rejects(

--- a/src/daemon/scroll-until.ts
+++ b/src/daemon/scroll-until.ts
@@ -9,6 +9,9 @@ import { resolveSelectorPipeline } from '@agent-device/selectors/selector-pipeli
 import { SELECTOR_PIPELINE_POLICIES } from '@agent-device/selectors/selector-pipeline-policy';
 import {
   canScrollFurtherAtEdge,
+  pushScrollSurfaceSignature,
+  scrollSurfaceFingerprint,
+  scrollSurfaceIsStuck,
   type ScrollEdge,
 } from '@agent-device/capture-kit/scroll-edge-state';
 
@@ -28,6 +31,12 @@ import {
  * better reached by `scroll bottom` or a search field.
  */
 export const SCROLL_UNTIL_PASS_LIMIT = 12;
+
+/**
+ * Cap for the vertical stuck-signature window fed to `scrollSurfaceIsStuck`. Matches the capture-kit
+ * edge loop so both loops notice a stuck container after the same handful of non-advancing passes.
+ */
+const SCROLL_UNTIL_STUCK_WINDOW = 6;
 
 /** Why a capture cannot answer the `--until` question at all. Never an outcome about the content. */
 type ScrollUntilCaptureRefusal = { reason: 'no-capture' | 'sparse-tree'; detail: string };
@@ -57,24 +66,71 @@ export async function runScrollUntilVisible<TResult>(params: {
   const edge = verticalEdgeFor(direction);
   let passes = 0;
   let result: TResult | undefined;
+  const recentSignatures: string[] = [];
 
   while (true) {
-    const captured = await capture();
-    const refusal = captureRefusal(captured);
-    if (refusal) throw scrollUntilCaptureError(direction, selector, refusal);
-    const nodes = (captured.nodes ?? []) as SnapshotNode[];
-    if (await isSelectorVisible(nodes, selector, platform)) {
+    const decision = await decideUntilPass({
+      captured: await capture(),
+      selector,
+      direction,
+      platform,
+      edge,
+      passes,
+      passLimit,
+      recentSignatures,
+    });
+    if (decision.visible) {
       return { passes, ...(result === undefined ? {} : { result }) };
-    }
-    if (edge && !(await canScrollFurtherAtEdge(nodes, edge))) {
-      throw scrollUntilNotFoundError(direction, selector, 'edge-reached', passes);
-    }
-    if (passes >= passLimit) {
-      throw scrollUntilNotFoundError(direction, selector, 'pass-limit', passes);
     }
     result = await scroll();
     passes += 1;
   }
+}
+
+/**
+ * What one capture tells us about the `--until` loop, answered in the order that matters: refuse an
+ * unusable read, report an arrived target, then the two ways a pass cannot usefully continue. Every
+ * terminal condition raises its own typed error; a non-terminal pass returns `{ visible: false }` so
+ * the caller flings once more and asks again. The stuck window mutates in place so the loop keeps one
+ * running history across passes.
+ */
+async function decideUntilPass(params: {
+  captured: SnapshotResult;
+  selector: string;
+  direction: ScrollDirection;
+  platform: Platform | PublicPlatform;
+  edge: ScrollEdge | undefined;
+  passes: number;
+  passLimit: number;
+  recentSignatures: string[];
+}): Promise<{ visible: boolean }> {
+  const { captured, selector, direction, platform, edge, passes, passLimit, recentSignatures } =
+    params;
+  const refusal = captureRefusal(captured);
+  if (refusal) throw scrollUntilCaptureError(direction, selector, refusal);
+  const nodes = (captured.nodes ?? []) as SnapshotNode[];
+  if (await isSelectorVisible(nodes, selector, platform)) {
+    return { visible: true };
+  }
+  if (edge && !(await canScrollFurtherAtEdge(nodes, edge))) {
+    throw scrollUntilNotFoundError(direction, selector, 'edge-reached', passes);
+  }
+  if (passes >= passLimit) {
+    throw scrollUntilNotFoundError(direction, selector, 'pass-limit', passes);
+  }
+  if (edge) {
+    // Vertical only: a stuck container revisits the same one or two signatures. Checked after the
+    // pass-limit branch so an explicit small budget still reports `scroll_until_pass_limit`.
+    pushScrollSurfaceSignature(
+      recentSignatures,
+      await scrollSurfaceFingerprint(nodes, edge),
+      SCROLL_UNTIL_STUCK_WINDOW,
+    );
+    if (scrollSurfaceIsStuck(recentSignatures)) {
+      throw scrollUntilNoProgressError(direction, selector, passes);
+    }
+  }
+  return { visible: false };
 }
 
 export function formatScrollUntilMessage(
@@ -173,6 +229,28 @@ function scrollUntilNotFoundError(
       direction,
       passes,
       hint: `Raise the step with an amount (scroll ${direction} 0.8 --until <selector>), or run snapshot -i to confirm the selector matches something on this screen.`,
+    },
+  );
+}
+
+/** The scroll was not reaching the container, not just falling short of a budget — the fix differs. */
+function scrollUntilNoProgressError(
+  direction: ScrollDirection,
+  selector: string,
+  passes: number,
+): AppError {
+  const spent = `${passes} ${passes === 1 ? 'pass' : 'passes'}`;
+  return new AppError(
+    'COMMAND_FAILED',
+    `scroll ${direction} --until ${selector} moved nothing across ${spent}: the on-screen content never shifted`,
+    {
+      reason: 'scroll_until_no_progress',
+      selector,
+      direction,
+      passes,
+      hint:
+        `The scroll is not reaching this container. If a field is focused, dismiss the keyboard first; if it is nested inside another scroller, target it directly. ` +
+        `Some lists ignore synthesized scrolls — a raw drag moves them: swipe x1 y1 x2 y2 started inside the list.`,
     },
   );
 }


### PR DESCRIPTION
## Summary
`scroll bottom` flung up to 40 times without net progress on a container that reports hidden content but does not move (focused `TextInput`, nested scroller, or a bottom that rubber-bands). The loop captured mid-bounce, so each pass looked new and another fling stacked on the bounce.

- The edge loop now waits for the scoped scroll surface to hold between passes before deciding or flinging again, and stops with a typed `scroll_edge_no_progress` when descendants never shift. The end backstop keeps its own `scroll_edge_pass_limit`.
- `scroll --until` shares the stuck-signature window and raises `scroll_until_no_progress`.
- The surface fingerprint and stuck-window bookkeeping are shared from capture-kit so both loops read one definition of "stuck".

7 files, capture-kit + daemon scroll family.

```
$ agent-device scroll bottom   # stuck checkout form, keyboard focused
Error: scroll bottom moved nothing across 3 passes: the container still reports hidden content but its contents never shifted  (reason: scroll_edge_no_progress)
```

## Validation
Commit `93de350fec`.
- `pnpm check:affected --run` → all runnable checks passed (722 tests, incl. fallow complexity on the changed files).
- `pnpm typecheck` / `pnpm build` clean.
- Live on iPhone 17 Pro (iOS 26.2), `com.callstack.agentdevicelab`:
  - Stuck Form with keyboard focused: `scroll bottom` stopped in **3 passes (~4s)** with `scroll_edge_no_progress` (was ~34s / 40 passes).
  - Home list (genuinely scrollable): `scroll bottom` reached the edge in **2 passes**, no false stop; `scroll down --until` returned on an already-visible target.
