### PR TITLE
fix(selectors): resolve a wrapper chain's control for uniqueness reads

### DIFF
--- a/docs/adr/0011-interaction-guarantee-contract.md
+++ b/docs/adr/0011-interaction-guarantee-contract.md
@@ -260,6 +260,36 @@ classifier. Reads (`querySelector`, and so `get`/`is`/`wait`) keep the prior rul
 decorative duplicate into an error. Maestro's explicit expected-point /
 non-hittable compatibility path remains intentionally separate.
 
+### 2026-09-11 amendment: one collapse for one control, at both doors
+
+Two clauses of the amendment above went stale as the read paths moved, and the
+structural rule never reached the read door.
+
+- `querySelector` no longer backs `get`/`is`/`wait`. Those reads resolve against a
+  capture, through the `readUnique`/`readAny`/`readText` rows of
+  `packages/selectors/src/selector-pipeline.ts`, so the runner's hittable-preference
+  rule governs only the direct XCTest paths that still query it: the direct-iOS
+  touch fast path and the off-screen target probe.
+- A control reported through its own accessibility wrapper answers a selector
+  twice. A regular iOS snapshot omits unverified hittability, so the ladder that
+  relates a wrapper to its control cannot fire, and #2482 collapsed that chain for
+  mutating resolution only: `is visible` and `get attrs` refused the same screen
+  as ambiguous while `press` tapped it. The collapse now sits beside the
+  classification that asks for it (`resolveUnverifiedWrapperControl`) and applies
+  where a refusal was the answer: the uniqueness rows — `is <predicate>`,
+  `get attrs`, `screenshot --crop-on` — resolve the control instead of reporting
+  no match. A row that resolves before any refusal is untouched by it, and a
+  wrapper chain always resolves before one: depth separates a wrapper from its
+  control, so `get text` ranks onto the control and `wait`/`is exists` answer from
+  the document-order head without asking which element was meant. A candidate set
+  the rule does not recognize as one control — a cell and the button inside it, or
+  matches in distinct subtrees — still refuses.
+- Replay verifies a recorded target by resolving its recorded selector again under
+  the same row's refusal rules, so the screen dispatch had resolved read as an
+  identity mismatch on the step's first replay. Verification names the collapsed
+  control too, which is the node dispatch acted on and the node the recorded
+  identity carries.
+
 ### Synthesized iOS gesture policy
 
 Synthesized iOS gestures (`scroll`, synthesized coordinate `tap`, synthesized

--- a/packages/selectors/src/interaction-targeting.fixtures.ts
+++ b/packages/selectors/src/interaction-targeting.fixtures.ts
@@ -191,11 +191,42 @@ export const INDEXED_PARITY_POLICY_NODES: RawSnapshotNode[] = [
 ];
 
 /**
+ * A cell and the button inside it, both reporting one identifier with no
+ * hittability evidence and rects within wrapper slack. Both are actionable
+ * targets, so this is two controls rather than one control and its wrapper: the
+ * collapse has to refuse it.
+ */
+export const TWO_ACTIONABLE_WRAPPER_CHAIN_NODES: RawSnapshotNode[] = [
+  {
+    index: 0,
+    depth: 1,
+    parentIndex: 2,
+    type: 'XCUIElementTypeCell',
+    identifier: 'profile',
+    rect: { x: 20, y: 63, width: 36, height: 36 },
+  },
+  {
+    index: 1,
+    depth: 2,
+    parentIndex: 0,
+    type: 'XCUIElementTypeButton',
+    identifier: 'profile',
+    rect: { x: 20.666666666666668, y: 63, width: 35, height: 36 },
+  },
+  {
+    index: 2,
+    depth: 0,
+    type: 'XCUIElementTypeApplication',
+    rect: { x: 0, y: 0, width: 393, height: 852 },
+  },
+];
+
+/**
  * The SwiftUI toolbar shape on a regular iOS snapshot: a wrapper and its
  * control share one identifier, the platform reports NO hittability evidence
  * (so neither node is `hittable: true`), and the wrapper's rect carries the
- * union of the control's sub-pixel layout, beyond the 0.5 pt rectangle
- * tolerance. Captured from a live simulator with resolved sub-pixel values.
+ * union of the control's sub-pixel layout. Captured from a live simulator with
+ * resolved sub-pixel values.
  */
 export const UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES: RawSnapshotNode[] = [
   {

--- a/packages/selectors/src/interaction-targeting.test.ts
+++ b/packages/selectors/src/interaction-targeting.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fc from 'fast-check';
 import { test } from 'vitest';
+import type { SnapshotNode } from '@agent-device/kernel/snapshot';
 import {
   distinctRectPairArb,
   makeSnapshotState,
@@ -11,11 +12,13 @@ import {
   classifyActionableTouchCandidates,
   createActionableTouchResolver,
   resolveActionableTouchResolution,
+  resolveUnverifiedWrapperControl,
 } from './interaction-targeting.ts';
 import {
   ELEMENT14_DISTINCT_SUBTREE_NODES,
   EQUIVALENT_WRAPPER_CHAIN_NODES,
   INDEXED_PARITY_POLICY_NODES,
+  TWO_ACTIONABLE_WRAPPER_CHAIN_NODES,
   UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES,
 } from './interaction-targeting.fixtures.ts';
 
@@ -436,4 +439,91 @@ test('refuses a wrapper chain whose deepest candidate is not a touch target', ()
   ]);
 
   assert.equal(classifyActionableTouchCandidates(snapshot.nodes, snapshot.nodes).kind, 'ambiguous');
+});
+
+/**
+ * The candidate set a uniqueness read hands the rule: every node reporting one
+ * identifier. The acting classifier refuses a set that is not one chain before
+ * it asks, so the rule carries its own chain check for the reads that ask
+ * directly.
+ */
+function identifierReports(
+  snapshot: ReturnType<typeof makeSnapshotState>,
+  identifier: string,
+): SnapshotNode[] {
+  return snapshot.nodes.filter((node) => node.identifier === identifier);
+}
+
+test('resolves the control of one ancestry chain through the rule on its own', () => {
+  const snapshot = makeSnapshotState(UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES);
+  const reports = identifierReports(snapshot, 'scoring_home_button');
+  assert.deepEqual(
+    reports.map((node) => node.type),
+    ['XCUIElementTypeOther', 'XCUIElementTypeButton'],
+  );
+
+  const control = resolveUnverifiedWrapperControl(snapshot.nodes, reports);
+
+  assert.equal(control?.type, 'XCUIElementTypeButton');
+  assert.equal(control?.index, 1);
+});
+
+test('refuses a candidate set that is one report, not a pair to collapse', () => {
+  // Reachable through the rect-requiring rows: a refused set can hold a single
+  // candidate once matches without a rect are dropped.
+  const snapshot = makeSnapshotState(UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES);
+  const reports = identifierReports(snapshot, 'scoring_home_button');
+
+  assert.equal(resolveUnverifiedWrapperControl(snapshot.nodes, [reports[1]!]), null);
+});
+
+test('refuses one ancestry chain of two real controls through the rule on its own', () => {
+  const snapshot = makeSnapshotState(TWO_ACTIONABLE_WRAPPER_CHAIN_NODES);
+  const reports = identifierReports(snapshot, 'profile');
+  assert.deepEqual(
+    reports.map((node) => node.type),
+    ['XCUIElementTypeCell', 'XCUIElementTypeButton'],
+  );
+
+  assert.equal(resolveUnverifiedWrapperControl(snapshot.nodes, reports), null);
+});
+
+test('refuses reports that sit in two separate ancestry chains', () => {
+  // No hittability evidence, rects agree within slack, one deepest control under
+  // non-actionable wrappers — every condition but the chain holds. Two subtrees
+  // each reporting one control are two controls, not one reported twice.
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 2,
+      parentIndex: 2,
+      type: 'XCUIElementTypeOther',
+      identifier: 'profile',
+      rect: { x: 20, y: 63, width: 36, height: 36 },
+    },
+    {
+      index: 1,
+      depth: 3,
+      parentIndex: 3,
+      type: 'XCUIElementTypeButton',
+      identifier: 'profile',
+      rect: { x: 20.666666666666668, y: 63, width: 35, height: 36 },
+    },
+    { index: 2, depth: 1, parentIndex: 4, type: 'XCUIElementTypeGroup' },
+    { index: 3, depth: 2, parentIndex: 4, type: 'XCUIElementTypeGroup' },
+    {
+      index: 4,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      rect: { x: 0, y: 0, width: 393, height: 852 },
+    },
+  ]);
+  const reports = identifierReports(snapshot, 'profile');
+  assert.deepEqual(
+    reports.map((node) => node.type),
+    ['XCUIElementTypeOther', 'XCUIElementTypeButton'],
+  );
+
+  assert.equal(resolveUnverifiedWrapperControl(snapshot.nodes, reports), null);
+  assert.equal(classifyActionableTouchCandidates(snapshot.nodes, reports).kind, 'ambiguous');
 });

--- a/packages/selectors/src/interaction-targeting.ts
+++ b/packages/selectors/src/interaction-targeting.ts
@@ -54,7 +54,7 @@ export function classifyActionableTouchCandidates(
       resolveActionableTouchResolutionWithIndex(nodes, candidate, index).node.index !==
       actionable.index
     ) {
-      const wrapperControl = resolveUnverifiedWrapperControl(candidates);
+      const wrapperControl = resolveUnverifiedWrapperControlWithIndex(candidates, index);
       return wrapperControl
         ? { kind: 'equivalent', node: wrapperControl }
         : { kind: 'ambiguous', candidates };
@@ -64,7 +64,7 @@ export function classifyActionableTouchCandidates(
 }
 
 function candidatesFormSingleAncestryChain(
-  candidates: SnapshotNode[],
+  candidates: readonly SnapshotNode[],
   byIndex: ReadonlyMap<number, SnapshotNode>,
 ): boolean {
   for (let i = 0; i < candidates.length; i += 1) {
@@ -106,15 +106,27 @@ const WRAPPER_RECT_SLACK = 1;
  * Regular iOS snapshots omit unverified hittability, and
  * `findPreferredActionableDescendant` requires verified hittability, so a
  * SwiftUI wrapper can never relate to its own control through the resolution
- * ladder: press and wait then see two actionable elements for one toolbar
- * button. The collapse stays narrow on purpose: every candidate above the
- * control must be a non-actionable wrapper, so a chain of two real controls (a
- * cell and the button inside it) keeps the existing ambiguity refusal instead of
- * silently pressing the descendant. Candidates carrying any hittability fact
- * also keep the existing rules.
+ * ladder: `press` sees two actionable elements and a uniqueness read (`is
+ * visible`, `get attrs`) sees two matches for one toolbar button. The collapse
+ * stays narrow on purpose: every candidate above the control must be a
+ * non-actionable wrapper, so a chain of two real controls (a cell and the button
+ * inside it) keeps the existing ambiguity refusal instead of silently resolving
+ * to the descendant. Candidates carrying any hittability fact, and candidates
+ * that do not form one ancestry chain, also keep the existing rules.
  */
-function resolveUnverifiedWrapperControl(candidates: readonly SnapshotNode[]): SnapshotNode | null {
+export function resolveUnverifiedWrapperControl(
+  nodes: SnapshotNode[],
+  candidates: readonly SnapshotNode[],
+): SnapshotNode | null {
+  return resolveUnverifiedWrapperControlWithIndex(candidates, buildActionableTouchIndex(nodes));
+}
+
+function resolveUnverifiedWrapperControlWithIndex(
+  candidates: readonly SnapshotNode[],
+  index: ActionableTouchIndex,
+): SnapshotNode | null {
   if (candidates.length < 2) return null;
+  if (!candidatesFormSingleAncestryChain(candidates, index.nodesByIndex)) return null;
   if (candidates.some((candidate) => candidate.hittable !== undefined)) return null;
   const control = candidates.reduce((deepest, candidate) =>
     (candidate.depth ?? 0) > (deepest.depth ?? 0) ? candidate : deepest,

--- a/packages/selectors/src/internal/resolution-policy.ts
+++ b/packages/selectors/src/internal/resolution-policy.ts
@@ -12,7 +12,10 @@ import type { SelectorResolutionOptions } from './public-resolution-types.ts';
  * - `disambiguate` — unique match required, but the engine's visible→deepest→
  *   smallest-area tiebreak may pick a winner from an ambiguous set (`get text`).
  * - `fail-closed` — unique match required, ties reject (by design: `is`
- *   predicates and `get attrs` must never guess).
+ *   predicates and `get attrs` must never guess). A set that is one control
+ *   reported through its own accessibility wrapper is not a tie and nothing
+ *   guesses when it resolves to the control; the pipeline applies that
+ *   structural collapse after this door refuses (#2498).
  * - `first-match` — any match count accepted, first wins (existence reads and
  *   the wait loop, where presence is the question).
  * - `reject-candidates` — multiple matches stay visible to the caller, which

--- a/packages/selectors/src/selector-pipeline.test.ts
+++ b/packages/selectors/src/selector-pipeline.test.ts
@@ -4,6 +4,11 @@ import type { RawSnapshotNode, SnapshotNode } from '@agent-device/kernel/snapsho
 import { SELECTOR_RESOLUTION_POLICIES } from '@agent-device/selectors';
 import { makeSnapshotState } from './snapshot-geometry.fixtures.ts';
 import {
+  ELEMENT14_DISTINCT_SUBTREE_NODES,
+  TWO_ACTIONABLE_WRAPPER_CHAIN_NODES,
+  UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES,
+} from './interaction-targeting.fixtures.ts';
+import {
   listSelectorPipelineMatches,
   resolveSelectorPipeline,
   runNodePipelineStages,
@@ -237,6 +242,78 @@ test('a row that refuses off-screen without a refusal shape fails loudly', async
     () => runNodePipelineStages(SELECTOR_PIPELINE_POLICIES.promotedTarget, nodes, nodes[0]!),
     /supplies no refusal shape/,
   );
+});
+
+/** Captured from a live simulator: one SwiftUI toolbar button reported twice. */
+const WRAPPER_CHAIN_TREE = UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES;
+const WRAPPER_CHAIN_SELECTOR = 'id="scoring_home_button"';
+
+test('the uniqueness rows collapse one control reported through its own wrapper', async () => {
+  const nodes = nodesOf(WRAPPER_CHAIN_TREE);
+  for (const row of ['readUnique', 'cropTarget'] as const) {
+    const outcome = await resolveSelectorPipeline(
+      SELECTOR_PIPELINE_POLICIES[row],
+      nodes,
+      WRAPPER_CHAIN_SELECTOR,
+      MATCH,
+    );
+    assert.equal(outcome.kind, 'target', row);
+    if (outcome.kind !== 'target') continue;
+    assert.equal(outcome.node.type, 'XCUIElementTypeButton', row);
+    assert.equal(outcome.selector, WRAPPER_CHAIN_SELECTOR, row);
+    // The refused candidate set survives the collapse: the answer is about one
+    // control, and the read still reports that it matched twice.
+    assert.equal(outcome.matches, 2, row);
+    assert.deepEqual(
+      outcome.matchedNodes.map((node) => node.type),
+      ['XCUIElementTypeOther', 'XCUIElementTypeButton'],
+      row,
+    );
+  }
+});
+
+test('a row that resolves on its own keeps its own answer on a wrapper chain', async () => {
+  const nodes = nodesOf(WRAPPER_CHAIN_TREE);
+  // `wait`/`is exists` take the document-order head, which is the wrapper: the
+  // question is presence, and this row never reaches the collapse.
+  for (const row of ['readAny', 'wait'] as const) {
+    const outcome = await resolveSelectorPipeline(
+      SELECTOR_PIPELINE_POLICIES[row],
+      nodes,
+      WRAPPER_CHAIN_SELECTOR,
+      MATCH,
+    );
+    assert.equal(outcome.kind, 'target', row);
+    if (outcome.kind === 'target') assert.equal(outcome.node.index, 0, row);
+  }
+  // `get text` ranks visible→deepest→smallest-area, and depth separates a
+  // wrapper from its control, so the tiebreak already answers the control.
+  const readText = await resolveSelectorPipeline(
+    SELECTOR_PIPELINE_POLICIES.readText,
+    nodes,
+    WRAPPER_CHAIN_SELECTOR,
+    MATCH,
+  );
+  assert.equal(readText.kind, 'target');
+  if (readText.kind === 'target') assert.equal(readText.node.index, 1);
+});
+
+test('the uniqueness rows still refuse matches that are not one wrapper chain', async () => {
+  const cases = [
+    ['two actionable controls', nodesOf(TWO_ACTIONABLE_WRAPPER_CHAIN_NODES), 'id="profile"'],
+    ['distinct subtrees', nodesOf(ELEMENT14_DISTINCT_SUBTREE_NODES), 'label="Team Standup"'],
+  ] as const;
+  for (const [name, nodes, selector] of cases) {
+    for (const row of ['readUnique', 'cropTarget'] as const) {
+      const outcome = await resolveSelectorPipeline(
+        SELECTOR_PIPELINE_POLICIES[row],
+        nodes,
+        selector,
+        MATCH,
+      );
+      assert.equal(outcome.kind, 'ambiguous', `${name} / ${row}`);
+    }
+  }
 });
 
 test('the poll stage answers only for the rows that poll', () => {

--- a/packages/selectors/src/selector-pipeline.ts
+++ b/packages/selectors/src/selector-pipeline.ts
@@ -8,6 +8,7 @@ import { isSnapshotNodeInteractionBlocked } from '@agent-device/capture-kit/snap
 import {
   isRootInteractionContainer,
   resolveActionableTouchResolution,
+  resolveUnverifiedWrapperControl,
 } from './interaction-targeting.ts';
 import type {
   CandidateSetPipelinePolicy,
@@ -98,27 +99,75 @@ export async function resolveSelectorPipeline(
     match,
   );
   if (outcome.kind === 'none') return { kind: 'none' };
-  if (outcome.kind === 'ambiguous') {
-    return {
-      kind: 'ambiguous',
-      selector: outcome.selector,
-      selectorIndex: outcome.selectorIndex,
-      matchedNodes: outcome.matchedNodes,
-    };
+  if (outcome.kind === 'resolved') {
+    return await stageResolvedRow(
+      policy,
+      nodes,
+      {
+        node: outcome.resolution.node,
+        selector: outcome.resolution.selector,
+        selectorIndex: outcome.resolution.selectorIndex,
+        matches: outcome.resolution.matches,
+        matchedNodes: outcome.matchedNodes,
+      },
+      hooks,
+    );
   }
-  const resolution = outcome.resolution;
-  const staged = await runNodePipelineStages(policy, nodes, resolution.node, hooks);
-  if (staged.kind === 'occluded') {
-    return { kind: 'occluded', node: staged.node, selector: resolution.selector };
-  }
+  const equivalent = resolveEquivalentControlTarget(nodes, outcome);
+  return equivalent ? await stageResolvedRow(policy, nodes, equivalent, hooks) : outcome;
+}
+
+/**
+ * A resolved target plus the candidate set the engine reported with it: the
+ * first alternative that matched anything, which a uniqueness row can resolve
+ * past (`AstSelectorResolution`'s contract), so pair `selector` with
+ * `matchedNodes` before reading them as one set.
+ */
+type ResolvedRowTarget = {
+  node: SnapshotNode;
+  selector: string;
+  selectorIndex: number;
+  matches: number;
+  matchedNodes: SnapshotNode[];
+};
+
+/**
+ * Several matches refused where the candidate set is one control reported
+ * through its own accessibility wrapper: there is nothing to choose among, and
+ * `is <predicate>`/`get attrs`/`screenshot --crop-on` answer about the control
+ * instead of reporting no match for a control on screen. A row that ranks or
+ * takes the document-order head resolves on its own and never reaches here —
+ * a wrapper chain has distinct depths, which is what its tiebreak decides on —
+ * and an acting row collapses inside `classifyActionableTouchCandidates`, which
+ * additionally has to settle a touch point.
+ */
+function resolveEquivalentControlTarget(
+  nodes: SnapshotNode[],
+  refused: { selector: string; selectorIndex: number; matchedNodes: SnapshotNode[] },
+): ResolvedRowTarget | null {
+  const control = resolveUnverifiedWrapperControl(nodes, refused.matchedNodes);
+  if (!control) return null;
   return {
-    kind: 'target',
-    node: staged.node,
-    selector: resolution.selector,
-    selectorIndex: resolution.selectorIndex,
-    matches: resolution.matches,
-    matchedNodes: outcome.matchedNodes,
+    node: control,
+    selector: refused.selector,
+    selectorIndex: refused.selectorIndex,
+    matches: refused.matchedNodes.length,
+    matchedNodes: refused.matchedNodes,
   };
+}
+
+/** Every node stage this row declares, applied to a resolved target. */
+async function stageResolvedRow(
+  policy: SingleTargetPipelinePolicy,
+  nodes: SnapshotNode[],
+  resolved: ResolvedRowTarget,
+  hooks: SelectorPipelineHooks,
+): Promise<SelectorPipelineOutcome> {
+  const staged = await runNodePipelineStages(policy, nodes, resolved.node, hooks);
+  if (staged.kind === 'occluded') {
+    return { kind: 'occluded', node: staged.node, selector: resolved.selector };
+  }
+  return { ...resolved, kind: 'target', node: staged.node };
 }
 
 /**

--- a/src/commands/interaction/runtime/__tests__/selector-read-policy.test.ts
+++ b/src/commands/interaction/runtime/__tests__/selector-read-policy.test.ts
@@ -8,6 +8,7 @@ import {
   createSelectorDevice,
   observationStagesSnapshot,
   skippedAlternativeSelectorSnapshot,
+  unverifiedWrapperChainReadSnapshot,
 } from './test-utils/index.ts';
 
 /**
@@ -69,6 +70,38 @@ test('is fails closed on the same ambiguous selector (readUnique row)', async ()
   assert.ok(error instanceof AppError, 'is must refuse rather than answer about one duplicate');
   assert.equal(error.code, 'COMMAND_FAILED');
   assert.equal((error.details as { reason?: string } | undefined)?.reason, 'selector_not_found');
+});
+
+/**
+ * #2498: one control reported twice, by its own accessibility wrapper. The
+ * uniqueness rows ask which element the caller means, and there is exactly one
+ * element to mean.
+ */
+const WRAPPER_CHAIN_SELECTOR = 'id="scoring_home_button"';
+/** The button, not the wrapper that reports it. */
+const WRAPPER_CONTROL_REF = '@e2';
+
+test('is visible answers about the control a wrapper reports (readUnique row)', async () => {
+  const device = createSelectorDevice(unverifiedWrapperChainReadSnapshot());
+
+  const result = await device.selectors.is({
+    session: 'default',
+    predicate: 'visible',
+    selector: WRAPPER_CHAIN_SELECTOR,
+  });
+
+  assert.equal(result.pass, true);
+  assert.equal(`@${result.node?.ref}`, WRAPPER_CONTROL_REF);
+});
+
+test('get attrs answers about the control a wrapper reports (readUnique row)', async () => {
+  const device = createSelectorDevice(unverifiedWrapperChainReadSnapshot());
+
+  const result = await device.selectors.getAttrs(selector(WRAPPER_CHAIN_SELECTOR), {
+    session: 'default',
+  });
+
+  assert.equal(`@${result.node.ref}`, WRAPPER_CONTROL_REF);
 });
 
 test('is exists answers from the first matching alternative (readAny row)', async () => {

--- a/src/commands/interaction/runtime/__tests__/test-utils/index.ts
+++ b/src/commands/interaction/runtime/__tests__/test-utils/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../../runtime.ts';
 import { ref } from '../../selector-read-utils.ts';
 import { makeSnapshotState } from '@agent-device/selectors/snapshot-geometry-fixtures';
+import { UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES } from '@agent-device/selectors/interaction-targeting-fixtures';
 
 export function selectorSnapshot(): SnapshotState {
   return makeSnapshotState([
@@ -446,6 +447,14 @@ export function ambiguousSelectorReadSnapshot(): SnapshotState {
       hittable: true,
     },
   ]);
+}
+
+/**
+ * One control reported twice by a live iOS snapshot (`interaction-targeting.fixtures`):
+ * the uniqueness reads answer about the control instead of refusing.
+ */
+export function unverifiedWrapperChainReadSnapshot(): SnapshotState {
+  return makeSnapshotState(UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES);
 }
 
 /**

--- a/src/daemon/replay/internal/__tests__/session-replay-target-classification.test.ts
+++ b/src/daemon/replay/internal/__tests__/session-replay-target-classification.test.ts
@@ -6,6 +6,11 @@ import { computeTargetEvidence } from '../../../session-target-evidence.ts';
 import { buildSelectorChainForNode, resolveRecordedTarget } from '@agent-device/selectors';
 import { resolvePressRecordingTarget } from '@agent-device/selectors/press-retarget';
 import { classifyReplayTarget } from '../session-replay-target-classification.ts';
+import { resolveUnverifiedWrapperControl } from '@agent-device/selectors/interaction-targeting';
+import {
+  ELEMENT14_DISTINCT_SUBTREE_NODES,
+  UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES,
+} from '@agent-device/selectors/interaction-targeting-fixtures';
 import {
   bottomTabsRealCaptureFixture,
   recordArticleEvidence,
@@ -646,3 +651,54 @@ test('#1280 e2e: a retargeted press on a row container rebinds its labeled desce
 });
 
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// #2498 end-to-end mechanism: a read that resolved through the wrapper-chain
+// collapse must verify against the SAME tree it was recorded on. Dispatch
+// resolves one control reported by its own accessibility wrapper to the control;
+// verification that named no winner for that pair reported IDENTITY_MISMATCH for
+// a screen that had not changed, on the step's very first replay.
+// ---------------------------------------------------------------------------
+
+test('#2498 e2e: a read recorded on a collapsed wrapper chain verifies on the same tree', () => {
+  const nodes = toSnapshotNodes(UNVERIFIED_HITTABILITY_WRAPPER_CHAIN_NODES);
+  const reports = nodes.filter((node) => node.identifier === 'scoring_home_button');
+  const control = resolveUnverifiedWrapperControl(nodes, reports);
+  assert.ok(control, 'dispatch resolves the toolbar button, not the item host that reports it');
+  const recorded = computeTargetEvidence({ node: control, preActionNodes: nodes });
+  assert.ok(recorded);
+
+  // `is <predicate>` and `get attrs` verify without disambiguation.
+  const result = classifyReplayTarget({
+    recorded,
+    token: 'id="scoring_home_button"',
+    nodes,
+    platform: PLATFORM,
+    refLabel: undefined,
+    requireRect: false,
+    allowDisambiguation: false,
+  });
+  assertVerified(result, { winnerRef: 'e2', matchCount: 2 });
+});
+
+test('#2498 e2e: matches in distinct subtrees stay a refusal, not a collapse to one of them', () => {
+  const nodes = toSnapshotNodes(ELEMENT14_DISTINCT_SUBTREE_NODES);
+  const recordedWinner = nodes.find((node) => node.type === 'XCUIElementTypeButton');
+  assert.ok(recordedWinner);
+  const recorded = computeTargetEvidence({ node: recordedWinner, preActionNodes: nodes });
+  assert.ok(recorded);
+
+  const result = classifyReplayTarget({
+    recorded,
+    token: 'label="Team Standup"',
+    nodes,
+    platform: PLATFORM,
+    refLabel: undefined,
+    requireRect: false,
+    allowDisambiguation: false,
+  });
+  assert.equal(result.verified, false);
+  if (result.verified) throw new Error('unreachable');
+  assert.equal(result.kind, 'identity-mismatch');
+  assert.equal(result.matchCount, 4);
+});

--- a/src/daemon/replay/internal/session-replay-target-classification.ts
+++ b/src/daemon/replay/internal/session-replay-target-classification.ts
@@ -50,6 +50,7 @@ import {
   orderByViewportPosition,
 } from '../../session-target-evidence.ts';
 import { resolveRecordedTarget } from '@agent-device/selectors';
+import { resolveUnverifiedWrapperControl } from '@agent-device/selectors/interaction-targeting';
 import type { TargetAnnotationV1 } from '@agent-device/contracts/replay';
 import type { ReplayDivergenceTargetBindingKind } from '@agent-device/contracts/divergence';
 
@@ -216,7 +217,16 @@ function resolveSelectorTargetMatches(
   if (resolution.kind === 'resolved') {
     return { matchedNodes: [...resolution.matchedNodes], winnerRef: resolution.winner.ref };
   }
-  return { matchedNodes: [...resolution.matchedNodes], winnerRef: '' };
+  // A refusal is not always a changed screen. The rows that verify without
+  // disambiguation — `is <predicate>` and `get attrs` — dispatch through a
+  // pipeline that resolves one control reported by its own accessibility wrapper
+  // to the control, so naming no winner here reports a divergence for a screen
+  // that did not change.
+  const control = resolveUnverifiedWrapperControl(nodes, resolution.matchedNodes);
+  return {
+    matchedNodes: [...resolution.matchedNodes],
+    winnerRef: control?.ref ?? '',
+  };
 }
 
 type MappedVerificationFailure = Omit<ReplayTargetDivergent, 'verified'>;


### PR DESCRIPTION
## Summary

`wait` already succeeds on `main`; what still fails on the reported screen is every read that insists on one match. A SwiftUI toolbar wrapper and its button share one identifier, a regular iOS snapshot omits unverified hittability, so the ladder that relates a wrapper to its control cannot fire: `press` taps the button while `is visible` and `get attrs` report `Selector did not match` and `screenshot --crop-on` refuses with "matched 2 nodes". #2482 collapsed that chain for mutating resolution only.

This exports the collapse (`resolveUnverifiedWrapperControl`) and applies it at the read door: `readUnique` and `cropTarget` resolve the control instead of refusing. Rows that resolve before a refusal are untouched, and a candidate set the rule does not recognise as one control - a cell and the button inside it, matches in distinct subtrees - still refuses.

Replay was the second door. Verification re-resolves a recorded selector under the same row's refusal rules, so a step whose screen had not changed verified as `IDENTITY_MISMATCH` on its first replay; it now names the collapsed control, the node dispatch acted on.

ADR 0011 is amended: its 2026-08-07 clause still described `get`/`is`/`wait` as runner `querySelector` reads. 11 files, +431/-31.

Closes #2498

## Validation

- `pnpm check:affected --run` at `bab4435` (rebased onto `origin/main` d80fb35): 563 files / 4084 tests pass. An earlier run at the pre-rebase commit had one failure under concurrent load from other worktrees on this host and passed on rerun.
- Live iOS Simulator (iOS 26.2) with a SwiftUI fixture whose toolbar wrapper shares its button's identifier. Before: `is visible` and `get attrs` selector-not-matched, `screenshot --crop-on` matched 2 nodes. After: `is visible` passes, `get attrs`/`get text` resolve the Button, crop is 35x36, `wait` and `press` unchanged, `is hidden` fails with `actual={"visible":true}`, `find … list` still lists both nodes, and a distinct-subtree duplicate still refuses.
- Mutation-checked: disabling the collapse or its ancestry-chain guard fails the new tests.
- Unresolved scope: on XCTest-backed captures where the wrapper reports `hittable: true`, reads and acts both refuse. That is #2482's existing boundary and is unchanged here.
