### PR TITLE
fix(scroll): keep the swipe above the keyboard, refuse when it cannot

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -165,6 +165,9 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testEmptyReplacementWithoutResolvableTargetFailsClosed \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextEntryTapWitnessIsBoundToTargetIdentity \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCoordinateTapTextInputProbeSkipsPenalizedXCTestChannel \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollViewportKeyboardClipMatchesGoldenParityTable \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollViewportPolicyUsesParityTableConstants \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSynthesizedGesturePoliciesMatchCommandContracts \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testFreshCoordinateTapContainsUnavailableTextInputProbe \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextInputProbeIssueScopeIsThreadBound \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextInputProbePreservesEnclosingRunnerWait \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,6 +167,7 @@ jobs:
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testCoordinateTapTextInputProbeSkipsPenalizedXCTestChannel \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollViewportKeyboardClipMatchesGoldenParityTable \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollViewportPolicyUsesParityTableConstants \
+            -only-testing:AgentDeviceRunnerUITests/RunnerTests/testScrollViewportDispatchKeepsTheUnclippedFrameAsItsCoordinateRotationBasis \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testSynthesizedGesturePoliciesMatchCommandContracts \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testFreshCoordinateTapContainsUnavailableTextInputProbe \
             -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTextInputProbeIssueScopeIsThreadBound \

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
@@ -1,0 +1,256 @@
+import XCTest
+
+// The scroll viewport rule the runner shares with the TS runtime (#2500).
+//
+// RULE: a directional scroll centres its swipe, so a focused field puts the swipe's lower endpoint
+// under the keyboard — the gesture lands on keys, the surface never moves, and the edge loop reads a
+// stuck container (#2499) rather than a refusal. Clipping the viewport to the band above the
+// keyboard BEFORE the gesture planner runs keeps the swipe in what is visible, and when that band is
+// too thin to hold one the rule REFUSES instead of handing back the full frame: a keyboard-struck
+// swipe and a tiny clipped swipe both read as "stuck", so failing open is what hides the failure.
+//
+// The pure rule below is geometry on purpose — no XCUIApplication — so its exact decision is proven
+// against the golden table shared with its TS twin, `clipScrollViewportAboveKeyboard` in
+// packages/contracts/src/scroll-gesture.ts, asserted in that file's test beside this one. The table
+// carries only frames representable in both languages: `CGRect` standardizes a negative extent into a
+// positive height at a moved origin, so a negative `height` is tested on the TS side alone.
+//
+// The `extension RunnerTests` below is the one impure caller: it reads the runner's own live keyboard
+// frame, because a frame threaded from the daemon would predate the keyboard.
+
+/** What an on-screen keyboard leaves of a scroll viewport. */
+enum RunnerScrollKeyboardClip: Equatable {
+  /** No keyboard, or one that does not own this surface: swipe the whole viewport. */
+  case unobstructed
+  /** The viewport trimmed above the keyboard. Report the reduced reference height honestly. */
+  case avoided(frame: CGRect, keyboardMinY: Double)
+  /** Too little surface left to swipe. The caller refuses; it never swipes under the keys. */
+  case occluded(keyboardMinY: Double, visibleHeight: Double)
+}
+
+/** Where one directional scroll may place its swipe, once the keyboard has taken its share. */
+enum RunnerScrollViewport {
+  /** The frame to plan inside, plus the keyboard top when the swipe was clipped for one. */
+  case swipe(frame: CGRect, keyboardMinY: Double?)
+  /** Nothing to swipe. The caller answers `occlusionRunnerCode` and performs no gesture. */
+  case occluded(keyboardMinY: Double, visibleHeight: Double)
+}
+
+enum ScrollViewportPolicy {
+  /** Below this fraction of the viewport, the clipped band cannot hold a reliable swipe. */
+  static let minVisibleFraction: Double = 0.15
+  /**
+   * A fixed allowance kept above the keyboard's top edge, in points. `keyboard.frame` reports the
+   * key plane, not the input accessory or composer bar riding above it, so a swipe ending exactly
+   * at the reported edge can still land on a bar.
+   */
+  static let accessoryAllowance: Double = 12
+
+  /// The runner's own wire vocabulary, not a shared policy constant: the host keeps it
+  /// `COMMAND_FAILED` and reads it back from `details.runnerErrorCode`.
+  static let occlusionRunnerCode = "SCROLL_KEYBOARD_OCCLUDES_SURFACE"
+
+  /// Clips a scroll viewport to the band above an occluding keyboard, failing open on a frame the
+  /// runner cannot measure: a missing keyboard query is not evidence that the surface is blocked.
+  static func clip(viewport: CGRect, keyboard: CGRect) -> RunnerScrollKeyboardClip {
+    guard isUsable(viewport), isUsable(keyboard) else {
+      return .unobstructed
+    }
+    // A vertical swipe runs along the viewport's centre line, which is the only part of the width
+    // the keyboard has to reach to be struck: a 320pt keyboard centred in an 834pt viewport is 38%
+    // of the width and sits exactly in the path.
+    let swipeCenterX = viewport.minX + viewport.width / 2
+    if swipeCenterX < keyboard.minX || swipeCenterX >= keyboard.maxX {
+      return .unobstructed
+    }
+    let keyboardMinY = keyboard.minY
+    if keyboardMinY >= viewport.maxY || keyboard.maxY <= viewport.minY {
+      return .unobstructed
+    }
+    let visibleHeight = max(0, keyboardMinY - accessoryAllowance - viewport.minY)
+    if visibleHeight < minVisibleFraction * viewport.height {
+      return .occluded(keyboardMinY: keyboardMinY, visibleHeight: visibleHeight)
+    }
+    return .avoided(
+      frame: CGRect(
+        x: viewport.minX,
+        y: viewport.minY,
+        width: viewport.width,
+        height: visibleHeight
+      ),
+      keyboardMinY: keyboardMinY
+    )
+  }
+
+  private static func isUsable(_ rect: CGRect) -> Bool {
+    return [rect.minX, rect.minY, rect.width, rect.height].allSatisfy(\.isFinite)
+      && rect.width > 0 && rect.height > 0
+  }
+}
+
+extension RunnerTests {
+  /// Resolves the frame one directional scroll places its swipe in, and what the keyboard leaves of
+  /// it. Never dismisses: a dismiss drops focus, breaks a `type`/`scroll`/`type` loop, and mutates
+  /// state session-action provenance does not record, so `keyboard dismiss` stays an explicit
+  /// command and this path only ever reduces the space it swipes in.
+  func resolvedScrollViewport(
+    app: XCUIApplication,
+    context: SynthesizedCoordinateContext
+  ) -> RunnerScrollViewport {
+#if os(iOS)
+    // Every scroll reports its decision, including the two ways it avoids reading the keyboard at
+    // all: a policy that forbids the probe, and a probe that finds no keyboard.
+    guard context.allowsKeyboardProbe else {
+      logScrollViewport(decision: "probeSkipped", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
+      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
+    }
+    guard let keyboardFrame = visibleKeyboardFrame(app: app) else {
+      logScrollViewport(decision: "noKeyboard", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
+      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
+    }
+    switch ScrollViewportPolicy.clip(viewport: context.referenceFrame, keyboard: keyboardFrame) {
+    case .unobstructed:
+      logScrollViewport(decision: "unobstructed", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
+      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
+    case .avoided(let frame, let keyboardMinY):
+      logScrollViewport(
+        decision: "avoided",
+        keyboardMinY: keyboardMinY,
+        swipeHeight: frame.height,
+        context: context
+      )
+      return .swipe(frame: frame, keyboardMinY: keyboardMinY)
+    case .occluded(let keyboardMinY, let visibleHeight):
+      logScrollViewport(
+        decision: "occluded",
+        keyboardMinY: keyboardMinY,
+        swipeHeight: visibleHeight,
+        context: context
+      )
+      return .occluded(keyboardMinY: keyboardMinY, visibleHeight: visibleHeight)
+    }
+#else
+    return .swipe(frame: resolvedTouchReferenceFrame(app: app, appFrame: app.frame), keyboardMinY: nil)
+#endif
+  }
+
+#if os(iOS)
+  /// The #2500 diagnostic for a scroll that reports no travel: whether the swipe was clipped, and
+  /// whether the keyboard probe was even permitted. `axHealth` is the first thing to read, because a
+  /// policy that skipped the probe looks exactly like a keyboard that was never found.
+  private func logScrollViewport(
+    decision: String,
+    keyboardMinY: Double?,
+    swipeHeight: Double,
+    context: SynthesizedCoordinateContext
+  ) {
+    NSLog(
+      "AGENT_DEVICE_RUNNER_SCROLL_VIEWPORT kind=scroll axHealth=%@ keyboardPolicy=%@ decision=%@ keyboardMinY=%@ swipeHeight=%.1f",
+      context.accessibilityHealth.rawValue,
+      context.keyboardPolicy.rawValue,
+      decision,
+      keyboardMinY.map { String(format: "%.1f", $0) } ?? "none",
+      swipeHeight
+    )
+  }
+#endif
+}
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+private struct ScrollViewportPolicyFixture: Decodable {
+  struct Frame: Decodable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    var cgRect: CGRect {
+      CGRect(x: x, y: y, width: width, height: height)
+    }
+  }
+
+  struct Constants: Decodable {
+    let minVisibleFraction: Double
+    let accessoryAllowance: Double
+  }
+
+  struct Expected: Decodable {
+    let kind: String
+    let viewport: Frame?
+    let keyboardMinY: Double?
+    let visibleHeight: Double?
+  }
+
+  struct TestCase: Decodable {
+    let name: String
+    let viewport: Frame
+    let keyboard: Frame
+    let expected: Expected
+  }
+
+  let constants: Constants
+  let cases: [TestCase]
+}
+
+extension RunnerTests {
+  /// Golden parity table (#2500): every case in contracts/fixtures/scroll-keyboard-policy.json must
+  /// agree with the vitest twin. Add cases there, never fork the rule.
+  func testScrollViewportKeyboardClipMatchesGoldenParityTable() throws {
+    let fixture = try loadScrollViewportPolicyFixture()
+    XCTAssertFalse(fixture.cases.isEmpty, "parity table must not be empty")
+    for testCase in fixture.cases {
+      let clip = ScrollViewportPolicy.clip(
+        viewport: testCase.viewport.cgRect,
+        keyboard: testCase.keyboard.cgRect
+      )
+      switch testCase.expected.kind {
+      case "unobstructed":
+        XCTAssertEqual(clip, .unobstructed, testCase.name)
+      case "avoided":
+        let expectedFrame = try XCTUnwrap(testCase.expected.viewport, testCase.name).cgRect
+        let expectedMinY = try XCTUnwrap(testCase.expected.keyboardMinY, testCase.name)
+        XCTAssertEqual(
+          clip,
+          .avoided(frame: expectedFrame, keyboardMinY: expectedMinY),
+          testCase.name
+        )
+      case "occluded":
+        let expectedMinY = try XCTUnwrap(testCase.expected.keyboardMinY, testCase.name)
+        let expectedVisibleHeight = try XCTUnwrap(testCase.expected.visibleHeight, testCase.name)
+        XCTAssertEqual(
+          clip,
+          .occluded(keyboardMinY: expectedMinY, visibleHeight: expectedVisibleHeight),
+          testCase.name
+        )
+      default:
+        XCTFail("unknown expected kind `\(testCase.expected.kind)` in \(testCase.name)")
+      }
+    }
+  }
+
+  /// The thresholds are the table's, not this file's. The refusal reason and the runner code are
+  /// each one side's own vocabulary: the reason is what the host publishes, the code is what this
+  /// runner answers with, and neither is a shared clip constant.
+  func testScrollViewportPolicyUsesParityTableConstants() throws {
+    let constants = try loadScrollViewportPolicyFixture().constants
+    XCTAssertEqual(constants.minVisibleFraction, ScrollViewportPolicy.minVisibleFraction)
+    XCTAssertEqual(constants.accessoryAllowance, ScrollViewportPolicy.accessoryAllowance)
+  }
+
+  private func loadScrollViewportPolicyFixture() throws -> ScrollViewportPolicyFixture {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent() // AgentDeviceRunnerUITests
+      .deletingLastPathComponent() // AgentDeviceRunner
+      .deletingLastPathComponent() // runner
+      .deletingLastPathComponent() // apple
+      .deletingLastPathComponent() // repo root
+      .appendingPathComponent("contracts")
+      .appendingPathComponent("fixtures")
+      .appendingPathComponent("scroll-keyboard-policy.json")
+    return try JSONDecoder().decode(
+      ScrollViewportPolicyFixture.self,
+      from: Data(contentsOf: fixtureURL)
+    )
+  }
+}
+#endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
@@ -59,6 +59,25 @@ enum ScrollGestureOutcome {
   case occluded(keyboardMinY: Double, visibleHeight: Double)
 }
 
+extension ScrollGestureDispatch {
+  /// Reports the gesture against the band its plan ran inside, beside the keyboard evidence. The
+  /// synthesis frame stays the full viewport so the coordinates rotate correctly, which leaves the
+  /// payload measured against an axis the caller never planned on: `pixels` are a fraction of the
+  /// band, so the band is what `referenceWidth` and `referenceHeight` have to name.
+  func attachingEvidence(to response: Response) -> Response {
+    guard response.ok else { return response }
+    var payload = response.data ?? DataPayload()
+    payload.referenceWidth = Double(planFrame.width)
+    payload.referenceHeight = Double(planFrame.height)
+    guard let keyboardMinY else {
+      return Response(ok: response.ok, data: payload, error: response.error)
+    }
+    payload.keyboardAvoided = true
+    payload.keyboardMinY = keyboardMinY
+    return Response(ok: response.ok, data: payload, error: response.error)
+  }
+}
+
 extension RunnerScrollViewport {
   /// Plans the swipe inside the band the keyboard left and keeps the viewport as the coordinate basis,
   /// so a clip shortens the travel without moving the gesture's lane.
@@ -337,6 +356,22 @@ extension RunnerTests {
       keyboard.minY - ScrollViewportPolicy.accessoryAllowance,
       "a landscape swipe must stay clear of the keys"
     )
+
+    let reported = gesture.attachingEvidence(
+      to: Response(
+        ok: true,
+        data: DataPayload(referenceWidth: viewport.width, referenceHeight: viewport.height),
+        error: nil
+      )
+    )
+    XCTAssertEqual(
+      reported.data?.referenceHeight,
+      band.height,
+      "the payload names the band the plan ran inside, not the synthesis frame"
+    )
+    XCTAssertEqual(reported.data?.referenceWidth, viewport.width)
+    XCTAssertEqual(reported.data?.keyboardMinY, keyboardMinY)
+    XCTAssertEqual(reported.data?.keyboardAvoided, true)
 
     let orientedStartY = gesture.planFrame.minY + gesture.plan.y1
     let dispatched = nativeSynthesizedPoint(

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerScrollViewportPolicy.swift
@@ -30,10 +30,69 @@ enum RunnerScrollKeyboardClip: Equatable {
 
 /** Where one directional scroll may place its swipe, once the keyboard has taken its share. */
 enum RunnerScrollViewport {
-  /** The frame to plan inside, plus the keyboard top when the swipe was clipped for one. */
-  case swipe(frame: CGRect, keyboardMinY: Double?)
+  /**
+   * The band to plan the swipe inside, the frame to rotate its coordinates against, and the keyboard
+   * top when the band was clipped for one. The two frames are separate on purpose: a clip shortens
+   * only the band, while `nativeSynthesizedPoint` derives a `landscapeRight` native x from the
+   * frame's HEIGHT, so rotating inside the band moves the dispatched path sideways off the planned
+   * one.
+   */
+  case swipe(planFrame: CGRect, coordinateFrame: CGRect, keyboardMinY: Double?)
   /** Nothing to swipe. The caller answers `occlusionRunnerCode` and performs no gesture. */
   case occluded(keyboardMinY: Double, visibleHeight: Double)
+}
+
+/// The gesture one directional scroll dispatches, built from a resolved viewport in one place so the
+/// band the plan was made inside and the frame its coordinates rotate against cannot be swapped.
+struct ScrollGestureDispatch {
+  let plan: RunnerScrollGesturePlan
+  let planFrame: CGRect
+  let coordinateFrame: CGRect
+  let keyboardMinY: Double?
+}
+
+/** What a resolved viewport turns into for the command: a gesture, or the reason there is none. */
+enum ScrollGestureOutcome {
+  case gesture(ScrollGestureDispatch)
+  case unusableFrame
+  case unusablePlan
+  case occluded(keyboardMinY: Double, visibleHeight: Double)
+}
+
+extension RunnerScrollViewport {
+  /// Plans the swipe inside the band the keyboard left and keeps the viewport as the coordinate basis,
+  /// so a clip shortens the travel without moving the gesture's lane.
+  func gestureDispatch(
+    direction: RunnerScrollDirection,
+    amount: Double?,
+    pixels: Double?
+  ) -> ScrollGestureOutcome {
+    switch self {
+    case .occluded(let keyboardMinY, let visibleHeight):
+      return .occluded(keyboardMinY: keyboardMinY, visibleHeight: visibleHeight)
+    case .swipe(let planFrame, let coordinateFrame, let keyboardMinY):
+      guard planFrame.width > 0, planFrame.height > 0 else {
+        return .unusableFrame
+      }
+      guard let plan = runnerScrollGesturePlan(
+        direction: direction,
+        amount: amount,
+        pixels: pixels,
+        referenceWidth: planFrame.width,
+        referenceHeight: planFrame.height
+      ) else {
+        return .unusablePlan
+      }
+      return .gesture(
+        ScrollGestureDispatch(
+          plan: plan,
+          planFrame: planFrame,
+          coordinateFrame: coordinateFrame,
+          keyboardMinY: keyboardMinY
+        )
+      )
+    }
+  }
 }
 
 enum ScrollViewportPolicy {
@@ -82,6 +141,20 @@ enum ScrollViewportPolicy {
     )
   }
 
+  /// Splits a clip verdict into the two frames a dispatch needs. The gesture planner runs inside the
+  /// clipped band; the coordinate rotation keeps the frame the viewport was resolved against, because
+  /// the rotation basis is a property of the screen, not of what the keyboard left free.
+  static func frames(referenceFrame: CGRect, clip: RunnerScrollKeyboardClip) -> RunnerScrollViewport {
+    switch clip {
+    case .unobstructed:
+      return .swipe(planFrame: referenceFrame, coordinateFrame: referenceFrame, keyboardMinY: nil)
+    case .avoided(let frame, let keyboardMinY):
+      return .swipe(planFrame: frame, coordinateFrame: referenceFrame, keyboardMinY: keyboardMinY)
+    case .occluded(let keyboardMinY, let visibleHeight):
+      return .occluded(keyboardMinY: keyboardMinY, visibleHeight: visibleHeight)
+    }
+  }
+
   private static func isUsable(_ rect: CGRect) -> Bool {
     return [rect.minX, rect.minY, rect.width, rect.height].allSatisfy(\.isFinite)
       && rect.width > 0 && rect.height > 0
@@ -102,16 +175,16 @@ extension RunnerTests {
     // all: a policy that forbids the probe, and a probe that finds no keyboard.
     guard context.allowsKeyboardProbe else {
       logScrollViewport(decision: "probeSkipped", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
-      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
+      return ScrollViewportPolicy.frames(referenceFrame: context.referenceFrame, clip: .unobstructed)
     }
     guard let keyboardFrame = visibleKeyboardFrame(app: app) else {
       logScrollViewport(decision: "noKeyboard", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
-      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
+      return ScrollViewportPolicy.frames(referenceFrame: context.referenceFrame, clip: .unobstructed)
     }
-    switch ScrollViewportPolicy.clip(viewport: context.referenceFrame, keyboard: keyboardFrame) {
+    let clip = ScrollViewportPolicy.clip(viewport: context.referenceFrame, keyboard: keyboardFrame)
+    switch clip {
     case .unobstructed:
       logScrollViewport(decision: "unobstructed", keyboardMinY: nil, swipeHeight: context.referenceFrame.height, context: context)
-      return .swipe(frame: context.referenceFrame, keyboardMinY: nil)
     case .avoided(let frame, let keyboardMinY):
       logScrollViewport(
         decision: "avoided",
@@ -119,7 +192,6 @@ extension RunnerTests {
         swipeHeight: frame.height,
         context: context
       )
-      return .swipe(frame: frame, keyboardMinY: keyboardMinY)
     case .occluded(let keyboardMinY, let visibleHeight):
       logScrollViewport(
         decision: "occluded",
@@ -127,10 +199,11 @@ extension RunnerTests {
         swipeHeight: visibleHeight,
         context: context
       )
-      return .occluded(keyboardMinY: keyboardMinY, visibleHeight: visibleHeight)
     }
+    return ScrollViewportPolicy.frames(referenceFrame: context.referenceFrame, clip: clip)
 #else
-    return .swipe(frame: resolvedTouchReferenceFrame(app: app, appFrame: app.frame), keyboardMinY: nil)
+    let fallbackFrame = resolvedTouchReferenceFrame(app: app, appFrame: app.frame)
+    return ScrollViewportPolicy.frames(referenceFrame: fallbackFrame, clip: .unobstructed)
 #endif
   }
 
@@ -235,6 +308,55 @@ extension RunnerTests {
     let constants = try loadScrollViewportPolicyFixture().constants
     XCTAssertEqual(constants.minVisibleFraction, ScrollViewportPolicy.minVisibleFraction)
     XCTAssertEqual(constants.accessoryAllowance, ScrollViewportPolicy.accessoryAllowance)
+  }
+
+  /// A clipped landscape band shortens the frame, and `nativeSynthesizedPoint` derives a
+  /// `landscapeRight` native x from the frame's HEIGHT. Rotating inside the band therefore moves the
+  /// dispatched path sideways by exactly what the keyboard took, off the lane the plan was built for,
+  /// so the plan band and the coordinate basis stay separate values through dispatch (#2500).
+  func testScrollViewportDispatchKeepsTheUnclippedFrameAsItsCoordinateRotationBasis() throws {
+    let viewport = CGRect(x: 0, y: 0, width: 1210, height: 834)
+    let keyboard = CGRect(x: 0, y: 588, width: 1210, height: 246)
+    let clip = ScrollViewportPolicy.clip(viewport: viewport, keyboard: keyboard)
+    guard case .avoided(let band, let keyboardMinY) = clip else {
+      return XCTFail("expected a landscape keyboard to be avoided, got \(clip)")
+    }
+    XCTAssertEqual(band.height, 576)
+
+    guard case .gesture(let gesture) = ScrollViewportPolicy.frames(
+      referenceFrame: viewport,
+      clip: clip
+    ).gestureDispatch(direction: .up, amount: nil, pixels: nil) else {
+      return XCTFail("expected a gesture inside the clipped band")
+    }
+    XCTAssertEqual(gesture.planFrame, band)
+    XCTAssertEqual(gesture.keyboardMinY, keyboardMinY)
+    XCTAssertEqual(gesture.coordinateFrame, viewport, "the rotation basis must survive the clip")
+    XCTAssertLessThanOrEqual(
+      max(gesture.plan.y1, gesture.plan.y2),
+      keyboard.minY - ScrollViewportPolicy.accessoryAllowance,
+      "a landscape swipe must stay clear of the keys"
+    )
+
+    let orientedStartY = gesture.planFrame.minY + gesture.plan.y1
+    let dispatched = nativeSynthesizedPoint(
+      orientedX: gesture.planFrame.minX + gesture.plan.x1,
+      orientedY: orientedStartY,
+      in: gesture.coordinateFrame,
+      interfaceOrientation: RunnerInterfaceOrientation.landscapeRight
+    )
+    let clippedBasis = nativeSynthesizedPoint(
+      orientedX: gesture.planFrame.minX + gesture.plan.x1,
+      orientedY: orientedStartY,
+      in: gesture.planFrame,
+      interfaceOrientation: RunnerInterfaceOrientation.landscapeRight
+    )
+    XCTAssertEqual(
+      dispatched.x - clippedBasis.x,
+      viewport.height - band.height,
+      accuracy: 0.001,
+      "rotating inside the clipped band would shift native x by what the keyboard took"
+    )
   }
 
   private func loadScrollViewportPolicyFixture() throws -> ScrollViewportPolicyFixture {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1953,7 +1953,20 @@ extension RunnerTests {
           error: ErrorPayload(message: "scroll could not resolve a usable interaction frame")
         )
       }
-      let frame = scrollReferenceFrame(app: activeApp, context: scrollContext)
+      let viewport = resolvedScrollViewport(app: activeApp, context: scrollContext)
+      let frame: CGRect
+      let keyboardMinY: Double?
+      switch viewport {
+      case .occluded(let occlusionKeyboardMinY, let visibleHeight):
+        return scrollKeyboardOccludedResponse(
+          direction: direction.rawValue,
+          keyboardMinY: occlusionKeyboardMinY,
+          visibleHeight: visibleHeight
+        )
+      case .swipe(let swipeFrame, let clippedAboveKeyboardMinY):
+        frame = swipeFrame
+        keyboardMinY = clippedAboveKeyboardMinY
+      }
       guard frame.width > 0, frame.height > 0 else {
         return Response(
           ok: false,
@@ -1979,16 +1992,19 @@ extension RunnerTests {
       guard scrollDurationIsValid(command.durationMs) else {
         return invalidScrollDurationResponse(commandName: "scroll")
       }
-      return executeScrollDragGesture(
-        activeApp: activeApp,
-        x: frame.minX + plan.x1,
-        y: frame.minY + plan.y1,
-        x2: frame.minX + plan.x2,
-        y2: frame.minY + plan.y2,
-        durationMs: defaults.durationMs,
-        message: "scrolled",
-        context: scrollContext.withReferenceFrame(frame),
-        releaseBehavior: command.scrollReleaseBehavior
+      return attachingScrollViewportEvidence(
+        executeScrollDragGesture(
+          activeApp: activeApp,
+          x: frame.minX + plan.x1,
+          y: frame.minY + plan.y1,
+          x2: frame.minX + plan.x2,
+          y2: frame.minY + plan.y2,
+          durationMs: defaults.durationMs,
+          message: "scrolled",
+          context: scrollContext.withReferenceFrame(frame),
+          releaseBehavior: command.scrollReleaseBehavior
+        ),
+        keyboardMinY: keyboardMinY
       )
     case .desktopScroll:
       guard let rawDirection = command.direction,
@@ -2564,12 +2580,38 @@ extension RunnerTests {
     )
   }
 
-  private func scrollReferenceFrame(app: XCUIApplication, context: SynthesizedCoordinateContext) -> CGRect {
-#if os(iOS)
-    return synthesizedFrameAvoidingKeyboardWhenAllowed(app: app, context: context)
-#else
-    return resolvedTouchReferenceFrame(app: app, appFrame: app.frame)
-#endif
+  /// Adds the #2500 avoidance evidence to a scroll response. Only the frame resolver knows whether
+  /// it trimmed the swipe for a keyboard, and only `scroll` has this evidence to carry, so it is
+  /// attached where the frame was resolved rather than threaded through every gesture response.
+  private func attachingScrollViewportEvidence(_ response: Response, keyboardMinY: Double?) -> Response {
+    guard response.ok, let keyboardMinY else { return response }
+    var payload = response.data ?? DataPayload()
+    payload.keyboardAvoided = true
+    payload.keyboardMinY = keyboardMinY
+    return Response(ok: response.ok, data: payload, error: response.error)
+  }
+
+  /// The refusal a keyboard forces. It performs no gesture: swiping into the keys would leave the
+  /// surface where it was, which the daemon's no-progress fingerprint reads as a stuck container
+  /// (#2499) and an agent reads as a broken scroll. The TS owner maps the code to the
+  /// `scroll_keyboard_occludes_surface` reason and the "dismiss the keyboard" hint.
+  private func scrollKeyboardOccludedResponse(
+    direction: String,
+    keyboardMinY: Double,
+    visibleHeight: Double
+  ) -> Response {
+    return Response(
+      ok: false,
+      error: ErrorPayload(
+        code: ScrollViewportPolicy.occlusionRunnerCode,
+        message: String(
+          format:
+            "scroll %@ refused: the keyboard leaves %.0fpt of visible surface above it, too little to swipe",
+          direction,
+          visibleHeight
+        )
+      )
+    )
   }
 
   private func dragCommandName(message: String) -> String {

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1983,8 +1983,8 @@ extension RunnerTests {
         guard scrollDurationIsValid(command.durationMs) else {
           return invalidScrollDurationResponse(commandName: "scroll")
         }
-        return attachingScrollViewportEvidence(
-          executeScrollDragGesture(
+        return gesture.attachingEvidence(
+          to: executeScrollDragGesture(
             activeApp: activeApp,
             x: gesture.planFrame.minX + gesture.plan.x1,
             y: gesture.planFrame.minY + gesture.plan.y1,
@@ -1994,8 +1994,7 @@ extension RunnerTests {
             message: "scrolled",
             context: scrollContext.withReferenceFrame(gesture.coordinateFrame),
             releaseBehavior: command.scrollReleaseBehavior
-          ),
-          keyboardMinY: gesture.keyboardMinY
+          )
         )
       }
     case .desktopScroll:
@@ -2575,14 +2574,6 @@ extension RunnerTests {
   /// Adds the #2500 avoidance evidence to a scroll response. Only the frame resolver knows whether
   /// it trimmed the swipe for a keyboard, and only `scroll` has this evidence to carry, so it is
   /// attached where the frame was resolved rather than threaded through every gesture response.
-  private func attachingScrollViewportEvidence(_ response: Response, keyboardMinY: Double?) -> Response {
-    guard response.ok, let keyboardMinY else { return response }
-    var payload = response.data ?? DataPayload()
-    payload.keyboardAvoided = true
-    payload.keyboardMinY = keyboardMinY
-    return Response(ok: response.ok, data: payload, error: response.error)
-  }
-
   /// The refusal a keyboard forces. It performs no gesture: swiping into the keys would leave the
   /// surface where it was, which the daemon's no-progress fingerprint reads as a stuck container
   /// (#2499) and an agent reads as a broken scroll. The TS owner maps the code to the

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1954,33 +1954,24 @@ extension RunnerTests {
         )
       }
       let viewport = resolvedScrollViewport(app: activeApp, context: scrollContext)
-      let frame: CGRect
-      let keyboardMinY: Double?
-      switch viewport {
+      let defaults = runnerDragCommandDefaults(command)
+      switch viewport.gestureDispatch(
+        direction: direction,
+        amount: defaults.scrollAmount,
+        pixels: command.pixels
+      ) {
       case .occluded(let occlusionKeyboardMinY, let visibleHeight):
         return scrollKeyboardOccludedResponse(
           direction: direction.rawValue,
           keyboardMinY: occlusionKeyboardMinY,
           visibleHeight: visibleHeight
         )
-      case .swipe(let swipeFrame, let clippedAboveKeyboardMinY):
-        frame = swipeFrame
-        keyboardMinY = clippedAboveKeyboardMinY
-      }
-      guard frame.width > 0, frame.height > 0 else {
+      case .unusableFrame:
         return Response(
           ok: false,
           error: ErrorPayload(message: "scroll could not resolve a usable interaction frame")
         )
-      }
-      let defaults = runnerDragCommandDefaults(command)
-      guard let plan = runnerScrollGesturePlan(
-        direction: direction,
-        amount: defaults.scrollAmount,
-        pixels: command.pixels,
-        referenceWidth: frame.width,
-        referenceHeight: frame.height
-      ) else {
+      case .unusablePlan:
         return Response(
           ok: false,
           error: ErrorPayload(
@@ -1988,24 +1979,25 @@ extension RunnerTests {
             message: "scroll could not compute a gesture plan"
           )
         )
+      case .gesture(let gesture):
+        guard scrollDurationIsValid(command.durationMs) else {
+          return invalidScrollDurationResponse(commandName: "scroll")
+        }
+        return attachingScrollViewportEvidence(
+          executeScrollDragGesture(
+            activeApp: activeApp,
+            x: gesture.planFrame.minX + gesture.plan.x1,
+            y: gesture.planFrame.minY + gesture.plan.y1,
+            x2: gesture.planFrame.minX + gesture.plan.x2,
+            y2: gesture.planFrame.minY + gesture.plan.y2,
+            durationMs: defaults.durationMs,
+            message: "scrolled",
+            context: scrollContext.withReferenceFrame(gesture.coordinateFrame),
+            releaseBehavior: command.scrollReleaseBehavior
+          ),
+          keyboardMinY: gesture.keyboardMinY
+        )
       }
-      guard scrollDurationIsValid(command.durationMs) else {
-        return invalidScrollDurationResponse(commandName: "scroll")
-      }
-      return attachingScrollViewportEvidence(
-        executeScrollDragGesture(
-          activeApp: activeApp,
-          x: frame.minX + plan.x1,
-          y: frame.minY + plan.y1,
-          x2: frame.minX + plan.x2,
-          y2: frame.minY + plan.y2,
-          durationMs: defaults.durationMs,
-          message: "scrolled",
-          context: scrollContext.withReferenceFrame(frame),
-          releaseBehavior: command.scrollReleaseBehavior
-        ),
-        keyboardMinY: keyboardMinY
-      )
     case .desktopScroll:
       guard let rawDirection = command.direction,
         let direction = RunnerScrollDirection(rawValue: rawDirection)

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -11,7 +11,7 @@ private struct RunnerUnsupportedOperationError: LocalizedError {
   var errorDescription: String? { message }
 }
 
-private enum RunnerInterfaceOrientation {
+enum RunnerInterfaceOrientation {
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
   static let unknown = 0
 #endif

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -909,18 +909,6 @@ extension RunnerTests {
     return CGRect(x: 0, y: 0, width: width, height: height)
   }
 
-  func synthesizedFrameAvoidingKeyboardWhenAllowed(
-    app: XCUIApplication,
-    context: SynthesizedCoordinateContext
-  ) -> CGRect {
-#if os(iOS)
-    guard context.allowsKeyboardProbe else { return context.referenceFrame }
-    return frameAvoidingKeyboard(app: app, frame: context.referenceFrame)
-#else
-    return context.referenceFrame
-#endif
-  }
-
   func keyboardAvoidingSynthesizedDragPoints(
     app: XCUIApplication,
     x: Double,

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
@@ -268,6 +268,10 @@ struct DataPayload: Codable {
   var gestureFallback: String?
   var gestureFallbackMessage: String?
   var gestureFallbackHint: String?
+  // Scroll keyboard avoidance evidence (#2500): the swipe was clipped to the band above an
+  // on-screen keyboard, and where that band ended. `referenceHeight` already names the clipped axis.
+  var keyboardAvoided: Bool?
+  var keyboardMinY: Double?
   var maestroNonHittableCoordinateFallbackUsed: Bool?
   var textEntryRoute: String?
   var runnerFatal: Bool?

--- a/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedGesturePolicy.swift
+++ b/apple/runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SynthesizedGesturePolicy.swift
@@ -89,8 +89,14 @@ func synthesizedGesturePolicy(_ kind: SynthesizedGesturePolicyKind) -> Synthesiz
       fallbackPolicy: .xctestCoordinateAllowed
     )
   case .scroll:
+    // Scroll places a viewport-center-symmetric swipe, so it cannot tell a keyboard-struck swipe
+    // from a scroll that reached the edge without reading the live keyboard frame (#2500). The
+    // probe is not free — `visibleKeyboardFrame` resolves `app.keyboards.firstMatch` with a live AX
+    // fetch — but skipping it on `.unknown` left the first scroll of a session swiping under the
+    // keys, which is the failure this command exists to avoid. `.unavailable` still skips it: there
+    // the fetch is known not to answer, and `ScrollViewportPolicy` fails open on a missing frame.
     return SynthesizedGesturePolicy(
-      keyboardPolicy: .whenAccessibilityHealthy,
+      keyboardPolicy: .requiredWhenAvailable,
       fallbackPolicy: .privateSynthesisRequired
     )
   case .synthesizedDrag:
@@ -182,7 +188,9 @@ extension RunnerTests {
     )
   }
 
-  func testSynthesizedKeyboardPolicyKeepsUnknownDragProbeButNotUnknownScrollProbe() {
+  /// Keyboard-policy semantics only. Which command gets which policy is the table below; a probe
+  /// that is merely permitted still costs a live AX fetch, so the two questions stay separate.
+  func testSynthesizedKeyboardPolicyAllowsProbeOnlyWhenAccessibilityPermitsIt() {
     XCTAssertFalse(
       SynthesizedKeyboardPolicy.whenAccessibilityHealthy
         .allowsProbe(accessibilityHealth: .unknown)
@@ -208,7 +216,7 @@ extension RunnerTests {
     XCTAssertEqual(
       synthesizedGesturePolicy(.scroll),
       SynthesizedGesturePolicy(
-        keyboardPolicy: .whenAccessibilityHealthy,
+        keyboardPolicy: .requiredWhenAvailable,
         fallbackPolicy: .privateSynthesisRequired
       )
     )


### PR DESCRIPTION
## Summary

iOS half of #2500, stacked on #2537, where the shared rule, the golden table, the typed refusal and the response keys are stated once for every platform.

A directional `scroll` planned a viewport-center-symmetric swipe, so a focused field put the swipe's lower endpoint under the keyboard: the gesture hit keys, the surface never moved, and the edge loop reported a stuck container. The runner now reads its own live keyboard frame, clips the swipe band against the shared rule, reports `keyboardAvoided` / `keyboardMinY`, refuses with `scroll_keyboard_occludes_surface` when the keys leave under 15% of the band, and never dismisses the keyboard. The superseded scroll keyboard path was deleted, not guarded.

Closes #2500 once #2537 and #2514 land. Android goes on top of this in #2514. main now carries #2499, so both halves of the issue are in: the clip stops the wasted gesture, and #2499's no-progress stop ends the loop.

## Review pass

The width-fraction gate is gone: the clip asks whether the keyboard reaches the line the swipe runs along, not what share of the viewport's width it covers, because a vertical swipe travels the centre line and a floating keyboard straddling that line blocks it however narrow it is. The row that proves it (`centred floating keyboard under half the viewport width sits in the swipe's path`) is in the shared table landed by #2537, and the Swift lane asserts that same JSON row here.

Two things found while checking for reuse, both left alone deliberately:

- `frameAvoidingKeyboard` (`RunnerTests+Interaction.swift:789`) still gates on `intersection.width / frame.width >= 0.5`, i.e. the same defect for tap/drag reference frames. Fixing it changes the tap family, so it belongs in its own change; flagged rather than bundled.
- `keyboardAvoidingDragPoints` (same file, `:702`) keeps a local `padding: Double = 12` that names the same fact as `accessoryAllowance`, and fails open where scroll refuses. Sharing the constant means editing the drag rule, and the two failure policies differ on purpose: a drag that cannot fit still wants to happen, a scroll entirely under the keys does not.

Reused `visibleKeyboardFrame` and the iOS lane's existing `-only-testing` list.

A second pass found the clip leaking into the coordinate rotation. `resolvedScrollViewport` returned one frame and the command used it for two jobs: planning the swipe, and re-basing the touch context. `nativeSynthesizedPoint` derives a `landscapeRight` native x from that frame's HEIGHT, so clipping an 834pt landscape viewport to 576pt moved the dispatched gesture 258pt sideways off the lane the plan had just been built for. The viewport now carries `planFrame` and `coordinateFrame` separately and the gesture comes from one `gestureDispatch` decision, so the two cannot be swapped; `testScrollViewportDispatchKeepsTheUnclippedFrameAsItsCoordinateRotationBasis` runs the landscape case through that decision and fails on the swap.

A third pass found that fix had moved the reported frame too. Splitting the frames left the response naming the synthesis frame: `executeSynthesizedDragGesture` builds its `DragVisualizationFrame` from the frame the coordinates rotate in, so a swipe planned inside a 571pt band answered with `referenceHeight: 874`, and `pixels` — which is a fraction of the band — was measured against an axis the caller was never told about. The keyboard evidence now travels with the dispatch instead of being bolted on afterwards: `ScrollGestureDispatch.attachingEvidence(to:)` names `planFrame` in `referenceWidth` / `referenceHeight` and keeps `coordinateFrame` for synthesis, and the old `attachingScrollViewportEvidence` helper is gone. The regression above now asserts the assembled response as well, so reporting the synthesis frame is a red test rather than a reviewer's job.

## Validation

`pnpm check` green at `8a67c377cf` (exit 0).

Reproducing the runner tests locally needs `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1` on the build: `xcodebuild test-without-building -only-testing:` executes **0 tests and still reports the suite as passed** without it, because that env var is what defines `AGENT_DEVICE_RUNNER_UNIT_TESTS`. The iOS lane always sets it; my own earlier local runs did not and were therefore empty. With `AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest:ios` the scroll and policy tests genuinely execute (`Executed 4 tests, with 0 failures`), and each guard bites when neutered: handing the clipped band to the rotation basis fails on a `0.0` vs `258.0` shift, and dropping the two evidence lines fails with `("Optional(834.0)") is not equal to ("Optional(576.0)")` — the symptom reported in review, now pinned.

iOS, iPhone 17 Pro, Form screen, field focused:
- `scroll down --json` -> `referenceWidth: 402`, `referenceHeight: 571`, `keyboardAvoided: true`, `keyboardMinY: 583`, swipe `y1: 472 -> y2: 100`, `pixels: 371`, and the runner logged `decision=avoided keyboardMinY=583.0 swipeHeight=571.0`. Same command with no keyboard up reported `referenceHeight: 874`, `y1: 721 -> y2: 153`, `pixels: 568`, so the two answers differ exactly by what the keys took.
- `scroll top --json` on the notes field earlier in the same build returned `referenceHeight: 571`, `keyboardMinY: 583`, `y2=472`.
- First scroll after runner relaunch logs `axHealth=unknown keyboardPolicy=requiredWhenAvailable decision=avoided`; the old `whenAccessibilityHealthy` gate skipped the probe there.
- No keyboard -> no evidence keys, `referenceHeight: 874`, `decision=noKeyboard`.

iOS, iPadOS 26 windowed Safari (address bar focused): `referenceWidth: 834`, `referenceHeight: 913`, `keyboardAvoided: true`, `keyboardMinY: 925`. The window is 913pt tall inside a 1219pt display, so this is the clip reading the app window rather than the display. That simulator was created for the attempt and deleted afterwards, and the host's `ConnectHardwareKeyboard` was returned to its original value after the soft-keyboard run.

Unreproduced live: the `occluded` refusal. The app-side route was prototyped and ruled out on a device, so this is now a measured ceiling rather than an untested hypothesis.

- **iPhone 17 Pro, full screen.** The system keyboard keeps one height whatever the text size: with "Larger Accessibility Sizes" on and the slider at 100% (`UIPreferredContentSizeCategoryName = UICTContentSizeCategoryAccessibilityXXXL`, verified in the device's `com.apple.UIKit` domain, and the app layout visibly at AX5), `scroll down --json` still reported `keyboardMinY: 582.9999999999999`, `referenceHeight: 570.9999999999999`, swipe `471 -> 99`, `pixels: 371` — the same clip as the default size. Dynamic Type does not grow the keyboard, so the band above it is 571 of 874 = 65% and cannot fall under 15%.
- **iPadOS 26 windowed Safari.** Measured window 834x913 inside a 1219pt display with keyboard top 925. Even placing that window's bottom edge on the display's bottom edge leaves a 607pt band = 66%; getting under 15% needs a window no taller than ~360pt, and the window controls available on this simulator did not produce one. Dragging the window from the host desktop also timed out at the daemon budget before the drag landed.
- **App-sized custom `inputView`.** A temporary `examples/test-app` route attached an 800pt `UITextField.inputView`. It was visibly attached and the app reported the custom surface, but `snapshot --raw` exposed no `Keyboard` element and `scroll down` still returned `referenceHeight: 874` with no keyboard evidence. That is structural: `visibleKeyboardFrame` asks `app.keyboards.firstMatch`, and XCUITest models system keyboards there — not arbitrary app-provided input views. Reaching a real XCUITest keyboard with an app-controlled height would require a full custom keyboard app extension and its enablement flow, so the prototype was removed rather than merged.
- **Accessibility Keyboard.** Not reached. Settings navigation at AX sizes did not get past the Accessibility list, and the panel would have to exceed ~743pt of 874 to change the answer anyway.

No live iOS response is claimed for `decision=occluded`. The refusal remains exercised by the shared golden row, the Swift policy test, and the command's return before gesture synthesis; the measured iOS ceiling means those remain the available evidence on this platform. Device state was reverted: the accessibility category key was deleted, the temporary iPad simulators were deleted, the custom-input-view prototype and its pod changes were removed, the stim supervisor and its simulator were stopped, and host `ConnectHardwareKeyboard` was restored to `YES`.

## Size

6 files, 536 gross lines, one command family, 4 commits: the runner clip, its lane wiring, and the response evidence. The shared rule and golden table are #2537 (615 gross) and the Android helper read and clip are #2514 (612 gross), which is what the budget needed and also where those facts belong.


