### PR TITLE
fix(aws): defer Android app launch until open

### DIFF
--- a/packages/provider-webdriver/src/aws-device-farm.test.ts
+++ b/packages/provider-webdriver/src/aws-device-farm.test.ts
@@ -126,6 +126,18 @@ test('a session that reaches RUNNING is handed on and not stopped', async () => 
   assert.deepEqual(client.stopped, []);
 });
 
+test('an Android session defers app launch until the open command', async () => {
+  const client = fakeClient({
+    status: 'RUNNING',
+    endpoints: { appium: 'https://appium.example/wd/hub' },
+  });
+  const prepare = createAwsDeviceFarmPrepareSession(baseOptions(client));
+
+  const prepared = await prepare({ lease: makeLease(), base: baseSession() });
+
+  assert.equal(prepared.webdriverCapabilities['appium:autoLaunch'], false);
+});
+
 function fakeClient(
   session: Partial<AwsDeviceFarmRemoteAccessSession>,
   onPoll?: () => void,

--- a/packages/provider-webdriver/src/aws-device-farm.ts
+++ b/packages/provider-webdriver/src/aws-device-farm.ts
@@ -239,16 +239,16 @@ export function createAwsDeviceFarmPrepareSession(
       typeof options.webdriverCapabilities === 'function'
         ? options.webdriverCapabilities(lease)
         : (options.webdriverCapabilities ?? {});
+    const awsDefaults = options.platform === 'android' ? { 'appium:autoLaunch': false } : {};
     return {
       ...base,
       endpoint,
       platform: options.platform,
       deviceName,
-      webdriverCapabilities: buildCloudWebDriverBaseCapabilities(
-        options.platform,
-        deviceName,
-        configured,
-      ),
+      webdriverCapabilities: buildCloudWebDriverBaseCapabilities(options.platform, deviceName, {
+        ...awsDefaults,
+        ...configured,
+      }),
       cleanup: async () => {
         await options.client.stopRemoteAccessSession(running.arn);
         return { awsDeviceFarmSessionArn: running.arn };


### PR DESCRIPTION
## Summary

AWS Device Farm Android sessions now create Appium with `appium:autoLaunch=false` by default. The existing `open` lifecycle still activates the requested package after allocation, but first-run system activities can no longer make WebDriver session creation fail before agent-device gains control.

This changes 2 files (+15/-1). Other providers and iOS behavior are unchanged; explicit internal capability overrides still win.

## Validation

Tested commit `fdab96c27afe40bcd5432ed110ffc6353aee4686`:

- `pnpm check:affected --run` — all runnable checks passed
- 102 related test files / 588 tests passed
- Regression test failed before the implementation (`autoLaunch` was undefined) and passes after it

GitHub remains authoritative for the listed live/device lanes.