### PR TITLE
docs: fix phantom specifiers, the duplicate ADR 0019, and the Node floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,8 @@ Read the declaration rather than maintaining a prose copy:
   `src/commands/common-input-fields.ts` and `src/commands/input-audience.ts`
 
 Shared selector parsing and matching belongs in `@agent-device/selectors`; request cancellation
-and progress in `@agent-device/capture-kit` (`request-cancel`, `request-progress`); cross-layer
-contracts in `@agent-device/contracts`; CLI flags in `src/commands/cli-grammar`; cross-surface schema
-composition in `src/cli-schema`.
+and progress in `@agent-device/host-kit/request`; cross-layer contracts in `packages/contracts/src`;
+CLI flags in `src/commands/cli-grammar`; cross-surface schema composition in `src/cli-schema`.
 
 Resolve registry completeness failures at the missing declaration. Diagnose other gate failures
 at their reported invariant; do not suppress them or add an allowlist to get a pass. Build interaction
@@ -87,8 +86,6 @@ under `contracts/fixtures/`.
 - Tests mirror source topology one-to-one. Split a source module and its test together; do not add to
   the legacy `interaction.test.ts` or platform `index.test.ts` aggregations. Pure moves carry their
   tests unchanged; rename-only hunks owe no new coverage.
-- `src/daemon/handlers/session.ts` is already over budget; extract the relevant platform-specific
-  concept before adding behavior.
 
 ## Toolchain and worktree traps
 
@@ -104,7 +101,7 @@ under `contracts/fixtures/`.
 
 ## Runtime and diagnostics seams
 
-Diagnostics use `@agent-device/capture-kit/diagnostics`. Request diagnostics belong in the session request log;
+Diagnostics use `@agent-device/host-kit/diagnostics`. Request diagnostics belong in the session request log;
 session artifact paths come from `src/daemon/session-artifact-paths.ts`. App/device logs remain in `app.log`;
 Apple runner and xcodebuild output remains in `runner.log`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ reviewable change. Detailed testing and device procedures live in the linked foc
 
 Requirements:
 
-- Node.js 22 or newer
+- Node.js 22.13 or newer — the pinned pnpm requires it. The published package keeps a lower
+  `engines.node` floor of 22.12, which CI verifies separately on the installed tarball.
 - pnpm at the version pinned in `package.json`
 - Android SDK tools (`adb`) for Android work
 - Xcode (`simctl`/`devicectl`) for Apple-platform work

--- a/docs/adr/0019-request-bound-platform-runtime.md
+++ b/docs/adr/0019-request-bound-platform-runtime.md
@@ -877,7 +877,7 @@ there, not about retiring the directory.
 
 **Entry-to-platform hop count.** Corrected 2026-09-03, re-measured for #2278 at `27a97ee619`:
 the counting definition, ordered chains, hop roles, and commit for this measurement are in
-[`0019-end-state-hop-trace.md`](./0019-end-state-hop-trace.md), which supersedes the numbers
+[`0023-end-state-hop-trace.md`](./0023-end-state-hop-trace.md), which supersedes the numbers
 below. A file-by-file re-trace at HEAD measured 41 hops for `press`/Android and 47/49 hops
 (shared 30 plus 17/19 per arm) for `snapshot`/iOS, which is now a dual-arm route (in-simulator
 AX bridge primary, XCTest runner fallback). The previously stated 38/29 named no ordered chain,

--- a/docs/adr/0022-daemon-platform-runtime-coupling.md
+++ b/docs/adr/0022-daemon-platform-runtime-coupling.md
@@ -79,7 +79,7 @@ or owning issue. #2278 audited all four concerns at `27a97ee619`.
 4. **The entry-to-platform hop trace was re-run with hop roles**
     (policy / orchestration / translation / adapter / pass-through + terminal) and a deletion
     test per pass-through/translation hop. The updated artifact is
-    [`0019-end-state-hop-trace.md`](0019-end-state-hop-trace.md): 41 hops for `press`/Android and
+    [`0023-end-state-hop-trace.md`](0023-end-state-hop-trace.md): 41 hops for `press`/Android and
     47/49 per arm for the now dual-arm `snapshot`/iOS route (shared 30 + AX bridge 17 / runner
     fallback 19). The deletion test proves a single distinct removable hop
     (`commands/runtime-types.ts`); the request-spine guards (auth comparison, cancellation gate,

--- a/docs/adr/0023-end-state-hop-trace.md
+++ b/docs/adr/0023-end-state-hop-trace.md
@@ -1,4 +1,4 @@
-# ADR-0019 end-state: entry-to-platform hop trace
+# ADR-0023: end-state entry-to-platform hop trace
 
 Backs the "Entry-to-platform hop count" paragraph in
 [0019-request-bound-platform-runtime.md](./0019-request-bound-platform-runtime.md#end-state-proposed-2026-09-02-maintainer-decision-pending).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@
 | [0020 Composable Recorded Fragments (Proposed)](0020-composable-recorded-fragments.md) | lifecycle-free recorded fragment capture/composition, entry guards, fragment-local addresses/digests, staleness, and native `.ad`/Maestro composition |
 | [0021 Host — Simlock-Backed Managed Device Allocation and the Host Supervisor](0021-host-simlock-managed-device-allocation.md) | local-first Simlock-managed execution, Host identity/admin boundaries, shape allocation, durable managed-device lease mapping, lifecycle ownership, and supervised maintenance |
 | [0022 Daemon — Platform Runtime Coupling Audit and Ownership Ratchets](0022-daemon-platform-runtime-coupling.md) | daemon imports of root `platform-runtime-*` modules, the R76 edge classification inventory, R75 session-authority ratchet, entry-to-platform hop routes and roles |
+| [0023 End-State Entry-to-Platform Hop Trace](0023-end-state-hop-trace.md) | the hop counting definition, the ordered `press`/Android and dual-arm `snapshot`/iOS chains, per-hop roles, and the deletion test behind the numbers ADR 0019 and ADR 0022 quote |
 
 ADRs record *why*; the registries and gates they describe are the living source of truth — when
 prose and a registry disagree, the registry wins and the ADR needs a follow-up.

--- a/scripts/__tests__/agent-guidance-contract.test.ts
+++ b/scripts/__tests__/agent-guidance-contract.test.ts
@@ -12,6 +12,11 @@ const BYTE_BUDGETS = {
 const FOCUSED_DOC_BUDGET = 10_000;
 const AGENT_DOCS_TOTAL_BUDGET = 40_000;
 
+type PackageManifest = {
+  name: string;
+  exports?: Record<string, unknown>;
+};
+
 async function read(relativePath: string): Promise<string> {
   return readFile(path.join(ROOT, relativePath), 'utf8');
 }
@@ -54,6 +59,46 @@ test('CONTEXT.md remains a glossary rather than an architecture or workflow docu
 
   assert.deepEqual(levelTwoHeadings, ['Language']);
   assert.doesNotMatch(content, /(?:^|\s)(?:docs|packages|scripts|src|test)\//);
+});
+
+test('AGENTS.md routes each shared primitive to a package that publishes it', async () => {
+  const content = await read('AGENTS.md');
+  const specifiers = [
+    ...new Set(
+      [...content.matchAll(/@agent-device\/[a-z0-9-]+(?:\/[a-z0-9-]+)*/g)].map((match) => match[0]),
+    ),
+  ];
+  assert.ok(specifiers.length > 0, 'AGENTS.md must route shared primitives by workspace specifier');
+
+  const published = new Map<string, Set<string>>();
+  for (const directory of await readdir(path.join(ROOT, 'packages'))) {
+    const manifest = JSON.parse(
+      await read(path.join('packages', directory, 'package.json')),
+    ) as PackageManifest;
+    published.set(manifest.name, new Set(Object.keys(manifest.exports ?? {})));
+  }
+
+  for (const specifier of specifiers) {
+    const [scope = '', name = '', ...segments] = specifier.split('/');
+    const packageName = `${scope}/${name}`;
+    const subpaths = published.get(packageName);
+    assert.ok(
+      subpaths,
+      `${specifier}: AGENTS.md names a workspace package that packages/ does not publish`,
+    );
+    if (segments.length === 0) {
+      assert.ok(
+        subpaths.has('.'),
+        `${specifier}: AGENTS.md imports a package root ${packageName} does not export`,
+      );
+      continue;
+    }
+    const subpath = `./${segments.join('/')}`;
+    assert.ok(
+      subpaths.has(subpath),
+      `${specifier}: AGENTS.md names a subpath ${packageName} does not export`,
+    );
+  }
 });
 
 test('the AGENTS.md task router points only at files that exist', async () => {

--- a/website/docs/docs/installation.md
+++ b/website/docs/docs/installation.md
@@ -65,7 +65,10 @@ One-off `npx` usage is fine for humans and scripts that intentionally fetch from
 
 ## Requirements
 
-- Node.js 22+
+- Node.js 22.12 or newer
+- Node.js 24 or newer for web automation, which hard-fails below it. The rest of the CLI keeps the
+  22.12 floor, so check `node --version` in the shell that runs `agent-device web setup` and
+  `agent-device doctor` before trusting a web result.
 - Xcode for iOS simulator/device automation (`simctl` + `devicectl`)
 - Android SDK / ADB for Android
 - HarmonyOS Command Line Tools for HarmonyOS (`hdc` available through `HDC_SDK_PATH`, `DEVECO_SDK_HOME`, or `HARMONYOS_COMMAND_LINE_TOOLS`)


### PR DESCRIPTION
## Summary

Closes #2520.

AGENTS.md routed request cancellation/progress and diagnostics to `@agent-device/capture-kit`
subpaths no package exports. Real homes: `@agent-device/host-kit/request` (40 importers) and
`@agent-device/host-kit/diagnostics` (106 importers, 0 for the capture-kit spelling). It also claimed
`src/daemon/handlers/session.ts` was over budget; that extraction already landed and the file is 242
lines, so the bullet is gone.

`0019-end-state-hop-trace.md` becomes **ADR 0023**: it is indexed in `docs/adr/README.md` and both
links to it (from ADR 0019 and ADR 0022) follow the rename.

**I did not raise `engines`.** The issue reads `pnpm@11.17.0`'s `>=22.13` as the runtime floor, but that
is a dev-tooling constraint: `ci.yml` runs `scripts/check-package.ts` on the installed tarball at
Node 22.12 precisely to verify "what a user on `engines.node` floor actually installs", and says so.
Raising `engines` to 22.13 would drop users CI proves work and make that job's stated purpose false.
So the floor stays 22.12 and the *contributor* requirement is what gets documented — CONTRIBUTING now
names 22.13 for the pinned pnpm, and README keeps 22.12. `installation.md` names the 22.12 floor and
the web backend's Node 24 hard fail (`agent-browser-tool.ts:280`), which it previously omitted.

`agent-guidance-contract.test.ts` now resolves every `@agent-device/*` specifier AGENTS.md names
against the owning package's `exports`, **root included**. That enforcement immediately caught a
second phantom in the same sentence: AGENTS.md listed `@agent-device/contracts` as an importable seam,
but the package publishes only subpath exports (`./interaction`, `./replay`, `./snapshot`, …) and no
`.` entry, so nothing can import it that way. Cross-layer contracts now route to
`packages/contracts/src`, which is how the rest of that section names a declaration site.

## Validation

Docs and manifest only, so no runtime test applies. `pnpm check:agent-guidance` passes (5 tests) and
names both planted violations at `a16821b661`: restoring `@agent-device/capture-kit/diagnostics` in
AGENTS.md fails with "AGENTS.md names a subpath @agent-device/capture-kit does not export", and
deleting the `.` export from `packages/selectors/package.json` fails with "AGENTS.md imports a package
root @agent-device/selectors does not export". `pnpm check:quick` passed and `pnpm check:affected
--run` at `a16821b661` passed every selected check except `mutation-model`, which fails identically on
a clean `origin/main` tree in this worktree: its claim that
`src/commands/interaction/runtime/gestures.test.ts` reaches the `scroll-edge-state` kernel went stale
when the scroll path moved to `src/daemon/scroll-runtime.ts`. Pre-existing, advisory in CI (the
workflow triggers on `scripts/mutation/**` only) and unrelated to this diff — worth its own fix.
