### PR TITLE
chore(config): scope the qs override and drop dead fallow, worktree and prettier entries

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -19,7 +19,6 @@
     "src/daemon.ts",
     "packages/capture-kit/src/png-worker.ts",
     "scripts/patch-xcuitest-runner-icon.ts",
-    "scripts/runner-request-count/run.ts",
     "packages/capture-kit/src/ios-snapshot-engine/replay.ts",
     // #1596 regression fixture: runs as a real `node --experimental-strip-types`
     // subprocess (test/integration/daemon-replace-exit-flush.test.ts), so
@@ -31,7 +30,6 @@
     "examples/sdk/contracts-result.ts",
     "examples/sdk/batch-orchestration.ts",
     "examples/sdk/ai-sdk-tools.ts",
-    "test/scripts/metro-prepare-packaged-smoke.mjs",
     "test/integration/*.test.ts",
     "website/docs/404.mdx",
     "website/rspress.config.ts"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-.claude/**
-dist/**
-node_modules/**
-**/*.md
-scripts/maestro-conformance/corpus/**
-fallow-baselines/**

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,8 +10,6 @@ examples/test-app/.expo/
 DerivedData/
 android/snapshot-helper/build/
 android/snapshot-helper/dist/
-android/multitouch-helper/build/
-android/multitouch-helper/dist/
 
 # Tool caches
 .fallow/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici@7: ^7.29.0
+  undici@7: 7.29.0
   brace-expansion@5: ^5.0.9
   fast-uri: 3.1.6
   postcss: 8.5.23
-  qs: 6.15.2
+  qs@6: ^6.16.0
   react-router: 7.18.2
   react-router-dom: 7.18.2
 
@@ -168,7 +168,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       undici:
-        specifier: ^7.29.0
+        specifier: 7.29.0
         version: 7.29.0
       vite:
         specifier: ^8.2.1
@@ -473,7 +473,7 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       undici:
-        specifier: ^7.29.0
+        specifier: 7.29.0
         version: 7.29.0
 
   packages/replay-test:
@@ -3442,8 +3442,8 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -7067,8 +7067,9 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   quansync@1.0.0: {}
@@ -7500,7 +7501,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.2
+      qs: 6.16.0
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,12 +11,14 @@ minimumReleaseAgeExclude:
 # @limrun/api pins undici to an exact vulnerable version (7.24.7) even in its
 # latest release, so a direct bump can't clear the Dependabot alerts. Override
 # the transitive resolution instead; scoped to major 7 so any future undici 8
-# elsewhere in the tree is untouched.
+# elsewhere in the tree is untouched. Exact, matching the direct pin in
+# package.json: tsdown bundles undici into the published build, so a caret here
+# would let lockFileMaintenance move the shipped bytes under an unchanged pin.
 overrides:
-  undici@7: '^7.29.0'
+  undici@7: 7.29.0
   brace-expansion@5: '^5.0.9'
   fast-uri: 3.1.6
   postcss: 8.5.23
-  qs: 6.15.2
+  qs@6: ^6.16.0
   react-router: 7.18.2
   react-router-dom: 7.18.2


### PR DESCRIPTION
## Summary

Closes #2521. Config and lockfile only.

`qs: 6.15.2` overrode every major and pinned the exact version behind GHSA-x5fp-wj9c-mxmx and
GHSA-4mjr-xmp4-gh2g. `qs@6: ^6.16.0` keeps the scoped major and clears both. The caret is deliberate
here and not for undici: `qs` reaches the tree only through `@stryker-mutator/core →
typed-rest-client` and is never bundled, so a caret keeps patching itself; `undici` is bundled into
the published build by `tsdown.config.ts:109`, so its override is now the exact `7.29.0` that
`package.json:328` and `packages/provision-kit/package.json:52` already declare.

The caret had already done damage: `pnpm-lock.yaml` recorded `specifier: ^7.29.0` for **both** undici
importers, so the lockfile disagreed with their own manifests. The new lockfile records `7.29.0`,
matching them.

Deleted: two `.fallowrc.json` entry roots pointing at files removed in `26ac865c63` and `8889a17cf1`
(Fallow drops absent roots silently), two `.worktreeinclude` paths under a nonexistent
`android/multitouch-helper/`, and `.prettierignore` — its six patterns are identical to
`.oxfmtrc.json`'s `ignorePatterns` and nothing in the repo reads prettier.

The issue suggested a glob "where a directory of runners exists"; neither root sits in one.
`scripts/runner-request-count/` is gone, and `test/scripts/` holds one runner that
`test/ci/trusted-fixture-artifact.test.mjs` imports statically, so it is already in the graph. All 29
remaining `entry` paths exist with brace and glob expansion applied.

## Validation

`pnpm audit` — dev tree included — reports **no known vulnerabilities** (was 2 moderate);
`pnpm audit --prod` was already clean. `pnpm check:affected --run` at `5f48e47163` ran the full
59-check plan (a lockfile change fails open) and passed every check except `mutation-model`, which
fails identically on a clean `origin/main` tree in this worktree: its claim that
`src/commands/interaction/runtime/gestures.test.ts` reaches the `scroll-edge-state` kernel went stale
when the scroll path moved to `src/daemon/scroll-runtime.ts`. Pre-existing, advisory in CI, unrelated
to this diff.
